### PR TITLE
Show geolocation info on save

### DIFF
--- a/ReactNativeClient/lib/components/shared/note-screen-shared.js
+++ b/ReactNativeClient/lib/components/shared/note-screen-shared.js
@@ -45,12 +45,18 @@ shared.saveNoteButton_press = async function(comp) {
 	} else {
 		diff = Object.assign({}, note);
 	}
-
-	const savedNote = await Note.save(diff);
-
-	const stateNote = comp.state.note;
+	let savedNote= await Note.save(diff);
 	// Re-assign any property that might have changed during saving (updated_time, etc.)
 	note = Object.assign(note, savedNote);
+	if (isNew){
+		const geoNote=await Note.updateGeolocation(note.id);
+		if(geoNote){
+			note = Object.assign(note, geoNote);
+		}
+	}
+
+	const stateNote = comp.state.note;
+
 
 	if (stateNote) {
 		// But we preserve the current title and body because
@@ -69,7 +75,7 @@ shared.saveNoteButton_press = async function(comp) {
 		note: note,
 	});
 
-	if (isNew) Note.updateGeolocation(note.id);
+
 	comp.refreshNoteMetadata();
 }
 


### PR DESCRIPTION
I fix the issue that not shown geolocation info when the user saved a new note.
I have added <code>await</code> to <code>updateGeolocation</code> and then I've set the note object to state  