### PR TITLE
Disable Tray Icon logic update

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -388,7 +388,7 @@ class Application extends BaseApplication {
 			if (process.env.XDG_CURRENT_DESKTOP.toLowerCase() == 'unity') {
 				// Check if the kernel version is from Ubuntu 17.04 or later
 				// https://en.wikipedia.org/wiki/Ubuntu_version_history
-				if (os.release().split('.').slice(0,2).join('.') >= 4.10) return;
+				if (os.release().split('.')[0] >= 4 && os.release.split('.')[1] >= 10) return;
 			}
 		}
 

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -383,7 +383,14 @@ class Application extends BaseApplication {
 		// Tray icon (called AppIndicator) doesn't work in Ubuntu
 		// http://www.webupd8.org/2017/04/fix-appindicator-not-working-for.html
 		// Might be fixed in Electron 18.x but no non-beta release yet.
-		if (!shim.isWindows() && !shim.isMac()) return;
+		if (!shim.isWindows() && !shim.isMac()) {
+			// Check if Desktop Environment is Unity
+			if (process.env.XDG_CURRENT_DESKTOP.toLowerCase() == 'unity') {
+				// Check if the kernel version is from Ubuntu 17.04 or later
+				// https://en.wikipedia.org/wiki/Ubuntu_version_history
+				if (os.release().split('.').slice(0,2).join('.') >= 4.10) return;
+			}
+		}
 
 		const app = bridge().electronApp();
 


### PR DESCRIPTION
<!--
PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md
-->

This is an attempted fix for #252.

Currently the Tray Icon is disabled if the host OS is detected to be Linux. However there are many Linux Distributions and Releases where the Tray Icon still works and it is therefore desirable to display it.

This pull request adds two checks. First if the host OS is detected to be Linux the environment variables are checked to see if Unity is the Desktop. If this is the case `os.release()` is used to get the kernel version and make sure that it is associated with an Ubuntu release prior to 17.04.

This fix is certainly not perfect, but it does allow a larger audience of users to get the Tray Icon.

Any comments on this implementation are most welcome.