### PR TITLE
Clarify Windows build dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -37,8 +37,6 @@ yarn dist
 
 If there's an error `while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory`, run `sudo apt-get install libgconf-2-4`
 
-For node-gyp to work, you might need to install the `windows-build-tools` using `npm install --global windows-build-tools`.
-
 That will create the executable file in the `dist` directory.
 
 From `/ElectronClient` you can also run `run.sh` to run the app for testing.
@@ -53,6 +51,10 @@ xcopy /C /I /H /R /Y /S ..\..\ReactNativeClient\lib lib
 npm install
 yarn dist
 ```
+
+If node-gyp does not works (MSBUILD: error MSB3428: Could not load the Visual C++ component "VCBuild.exe"), you might need to install the `windows-build-tools` using `npm install --global windows-build-tools`.
+
+If `yarn dist` fails, it may need administrative rights.
 
 # Building the Mobile application
 


### PR DESCRIPTION
Notes about `npm install -g windows-build-tools` was in "Building the Electron application" section instead of "Building Electron application on Windows" thus it wasn't unequivocal.