### PR TITLE
Add the toggle sidebar option to the View app menu bar.

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -395,6 +395,16 @@ class Application extends BaseApplication {
 			}, {
 				label: _('View'),
 				submenu: [{
+					label: _('Toggle sidebar'),
+					screens: ['Main'],
+					accelerator: 'F10',
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'toggleSidebar',
+						});
+					}
+				}, {
 					label: _('Toggle editor layout'),
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+L',


### PR DESCRIPTION
Towards #183

**Off Topic** - Got this error a couple of times while pushing my code,

```
remote: /data/github/releases/deploy-b/vendor/gems/2.4.2/ruby/2.4.0/gems/statsd-ruby-0.3.0.github.3.38.gd478cc7/lib/github/statsd.rb:23:in `ip': getaddrinfo: Name or service not known (SocketError)
remote: 	from /data/github/releases/deploy-b/vendor/gems/2.4.2/ruby/2.4.0/gems/statsd-ruby-0.3.0.github.3.38.gd478cc7/lib/github/statsd.rb:23:in `initialize'
remote: 	from /data/github/releases/deploy-b/vendor/gems/2.4.2/ruby/2.4.0/gems/statsd-ruby-0.3.0.github.3.38.gd478cc7/lib/github/statsd.rb:106:in `new'
remote: 	from /data/github/releases/deploy-b/vendor/gems/2.4.2/ruby/2.4.0/gems/statsd-ruby-0.3.0.github.3.38.gd478cc7/lib/github/statsd.rb:106:in `add_shard'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:33:in `block in create_statsd'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:33:in `each'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:33:in `create_statsd'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:20:in `stats'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:244:in `<module:GitHub>'
remote: 	from /data/github/releases/deploy-b/lib/github/config/stats.rb:12:in `<top (required)>'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/lib/github/logger.rb:3:in `<top (required)>'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/lib/github.rb:137:in `<module:GitHub>'
remote: 	from /data/github/releases/deploy-b/lib/github.rb:20:in `<top (required)>'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:66:in `require'
remote: 	from /data/github/releases/deploy-b/config/basic.rb:230:in `<top (required)>'
remote: 	from /data/github/releases/deploy-b/vendor/ruby/44c51a28900fc53699489c87289294b79ee365d3/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
remote: 	from /data/github/releases/deploy-b/vendor/ruby/44c51a28900fc53699489c87289294b79ee365d3/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
To https://github.com/Abijeet/joplin.git
 ! [remote rejected]   HEAD -> master (pre-receive hook declined)
error: failed to push some refs to 'https://github.com/Abijeet/joplin.git'
```
Any ideas why I'd receive this error?

Signed-off-by: Abijeet <abijeetpatro@gmail.com>