### PR TITLE
Add test for newline(s) import in <code> tags

### DIFF
--- a/CliClient/tests/html_to_md/code3.html
+++ b/CliClient/tests/html_to_md/code3.html
@@ -1,0 +1,25 @@
+<p>Codeblock:</p>
+<pre><code>
+function rtrim(str, ch)
+{
+    for (i = str.length - 1; i >= 0; i--)
+    { // One newline after
+
+        if (ch != str.charAt(i))
+        { // Two newlines after
+
+
+            str = str.substring(0, i + 1);
+            break;
+        }
+        // Three newlines after
+
+
+
+        // And two lines with some spaces inside
+        
+    
+    }
+    return str;
+}
+</code></pre>

--- a/CliClient/tests/html_to_md/code3.md
+++ b/CliClient/tests/html_to_md/code3.md
@@ -1,0 +1,24 @@
+Codeblock:
+
+	function rtrim(str, ch)
+	{
+	    for (i = str.length - 1; i >= 0; i--)
+	    { // One newline after
+
+	        if (ch != str.charAt(i))
+	        { // Two newlines after
+
+
+	            str = str.substring(0, i + 1);
+	            break;
+	        }
+	        // Three newlines after
+
+
+
+	        // And two lines with some spaces inside
+	        
+	    
+	    }
+	    return str;
+	}


### PR DESCRIPTION
Hi,
This is followup of #409. It seems the simplest would be to start with Enex CodeBlock, however the recent import code modifications are very successful in merging newlines :) Unfortunately, that breaks import of preformed code. As a start I'm suggesting a new test for code import - since in the current code the test fails, the  .md part may not be the final version yet.

The problem is essentially here: https://github.com/laurent22/joplin/blob/master/ReactNativeClient/lib/import-enex-md-gen.js#L128. The `mergeMultipleNewLines` and probably also `formatMdLayout` should be skipped for code and Enex codeblock import.

At the moment I'm not sure what is the best way except for temporary removing newline merging...? What do you think?