### PR TITLE
Handle Nginx DAV PROPFIND responses correctly

### DIFF
--- a/ReactNativeClient/lib/file-api-driver-webdav.js
+++ b/ReactNativeClient/lib/file-api-driver-webdav.js
@@ -44,7 +44,7 @@ class FileApiDriverWebDav {
 		if (!Array.isArray(propStat)) throw new Error('Invalid WebDAV resource format: ' + JSON.stringify(resource));
 
 		const httpStatusLine = this.api().stringFromJson(resource, ['d:propstat',0,'d:status', 0]);
-		if ( typeof httpStatusLine === 'string' && httpStatusLine.split(' ')[1] === '404' ) throw  new JoplinError(resource, 404);
+		if ( typeof httpStatusLine === 'string' && httpStatusLine.indexOf('404') >= 0 ) throw  new JoplinError(resource, 404);
 
 		const resourceTypes = this.api().resourcePropByName(resource, 'array', 'd:resourcetype');
 		let isDir = false;

--- a/ReactNativeClient/lib/file-api-driver-webdav.js
+++ b/ReactNativeClient/lib/file-api-driver-webdav.js
@@ -43,8 +43,8 @@ class FileApiDriverWebDav {
 		const propStat = this.api().arrayFromJson(resource, ['d:propstat']);
 		if (!Array.isArray(propStat)) throw new Error('Invalid WebDAV resource format: ' + JSON.stringify(resource));
 
-		const httpStatusCode = parseInt(propStat[0]['d:status'][0].split(' ')[1]); // Parsing "HTTP/1.1 200 OK"
-		if ( httpStatusCode === 404 ) throw  new JoplinError(resource, 404);
+		const httpStatusLine = this.api().stringFromJson(resource, ['d:propstat',0,'d:status', 0]);
+		if ( typeof httpStatusLine === 'string' && httpStatusLine.split(' ')[1] === '404' ) throw  new JoplinError(resource, 404);
 
 		const resourceTypes = this.api().resourcePropByName(resource, 'array', 'd:resourcetype');
 		let isDir = false;

--- a/ReactNativeClient/lib/file-api-driver-webdav.js
+++ b/ReactNativeClient/lib/file-api-driver-webdav.js
@@ -43,6 +43,9 @@ class FileApiDriverWebDav {
 		const propStat = this.api().arrayFromJson(resource, ['d:propstat']);
 		if (!Array.isArray(propStat)) throw new Error('Invalid WebDAV resource format: ' + JSON.stringify(resource));
 
+		const httpStatusCode = parseInt(propStat[0]['d:status'][0].split(' ')[1]); // Parsing "HTTP/1.1 200 OK"
+		if ( httpStatusCode === 404 ) throw  new JoplinError(resource, 404);
+
 		const resourceTypes = this.api().resourcePropByName(resource, 'array', 'd:resourcetype');
 		let isDir = false;
 		if (Array.isArray(resourceTypes)) {


### PR DESCRIPTION
Parse the d:status field for d:propstat sections within a d:multistatus response to a DAV PROPFIND because Nginx returns 404 statuses wrapped in an overall 207

Proposed fix for https://github.com/laurent22/joplin/issues/523
<!--
PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md
-->
