### PR TITLE
Restored case-sensitivity to tags upon creation and renaming

### DIFF
--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -117,7 +117,7 @@ class Tag extends BaseItem {
 		const addedTitles = [];
 
 		for (let i = 0; i < tagTitles.length; i++) {
-			const title = tagTitles[i].trim().toLowerCase();
+			const title = tagTitles[i].trim();
 			if (!title) continue;
 			let tag = await this.loadByTitle(title);
 			if (!tag) tag = await Tag.save({ title: title }, { userSideValidation: true });
@@ -126,7 +126,7 @@ class Tag extends BaseItem {
 		}
 
 		for (let i = 0; i < previousTags.length; i++) {
-			if (addedTitles.indexOf(previousTags[i].title.toLowerCase()) < 0) {
+			if (addedTitles.indexOf(previousTags[i].title) < 0) {
 				await this.removeNote(previousTags[i].id, noteId);
 			}
 		}
@@ -152,7 +152,7 @@ class Tag extends BaseItem {
 	static async save(o, options = null) {
 		if (options && options.userSideValidation) {
 			if ('title' in o) {
-				o.title = o.title.trim().toLowerCase();
+				o.title = o.title.trim();
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/651. Tags names retain case-sensitivity, both upon creation and when renamed. 

I've tested this with imported tags from Evernote. The old behavior was that only imported tags retained case sensitivity. Due to this, imported tags that had uppercase letters in them could not be assigned to any new notes that were not imported. An all-lowercase tag would be created and assigned to the new note instead. This pull request allows new notes to use all imported tags as expected.