### PR TITLE
focus NoteText only when creating new notes

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -342,9 +342,8 @@ class NoteTextComponent extends React.Component {
 			this.editorSetScrollTop(1);
 			this.restoreScrollTop_ = 0;
 
-			// If a search is in progress we don't focus any field otherwise it will
-			// take the focus out of the search box.
-			if (note && this.props.notesParentType !== 'Search') {
+			// Only force focus on notes when creating a new note/todo
+			if (this.props.newNote) {
 				const focusSettingName = !!note.is_todo ? 'newTodoFocus' : 'newNoteFocus';
 
 				if (Setting.value(focusSettingName) === 'title') {


### PR DESCRIPTION
This changes the behaviour so that loading a note does automatically
focus the note text/title only when a new note is being created.

This reduces accidental edits and is in line with other note taking
applications such as Simplenote, Evernote and Apple Notes.