### PR TITLE
Add text sharing on android

### DIFF
--- a/ReactNativeClient/android/app/build.gradle
+++ b/ReactNativeClient/android/app/build.gradle
@@ -137,7 +137,7 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-file-viewer')
+	compile project(':react-native-file-viewer')
 	compile project(':react-native-securerandom')
 	compile project(':react-native-push-notification')
 	compile project(':react-native-fs')
@@ -151,6 +151,8 @@ dependencies {
 	compile project(':react-native-fetch-blob')
 	compile project(':react-native-document-picker')
 	compile project(':react-native-image-resizer')
+	compile project(':react-native-share-extension')
+	compile "com.facebook.react:react-native:+"
 }
 
 // Run this once to be able to run the application with BUCK

--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -63,5 +63,19 @@
 			</intent-filter>
 		</activity>
 		<activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+		<activity
+			android:noHistory="true"
+			android:name=".share.ShareActivity"
+			android:configChanges="orientation"
+			android:label="@string/app_name"
+			android:screenOrientation="portrait"
+			android:theme="@style/AppTheme" >
+			<intent-filter>
+				<action android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="text/plain" />
+			</intent-filter>
+		</activity>
 	</application>
+
 </manifest>

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -7,6 +7,7 @@ import com.vinzscam.reactnativefileviewer.RNFileViewerPackage;
 import net.rhogan.rnsecurerandom.RNSecureRandomPackage;
 import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 import com.imagepicker.ImagePickerPackage;
+import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -17,6 +18,8 @@ import com.RNFetchBlob.RNFetchBlobPackage;
 import com.rnfs.RNFSPackage;
 import fr.bamlab.rnimageresizer.ImageResizerPackage;
 import org.pgsqlite.SQLitePluginPackage;
+
+import com.alinz.parkerdan.shareextension.SharePackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +45,8 @@ public class MainApplication extends Application implements ReactApplication {
 				new RNFetchBlobPackage(),
 				new RNFSPackage(),
 				new SQLitePluginPackage(),
-				new VectorIconsPackage()
+				new VectorIconsPackage(),
+				new SharePackage()
 			);
 		}
 	};

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/share/ShareActivity.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/share/ShareActivity.java
@@ -1,0 +1,15 @@
+package net.cozic.joplin.share;
+
+
+// import ReactActivity
+import com.facebook.react.ReactActivity;
+
+
+public class ShareActivity extends ReactActivity {
+		@Override
+		protected String getMainComponentName() {
+			// this is the name AppRegistry will use to launch the Share View
+			return "Joplin";
+		}
+}
+

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/share/ShareApplication.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/share/ShareApplication.java
@@ -1,0 +1,38 @@
+package net.cozic.joplin.share;
+// import build config
+import net.cozic.joplin.BuildConfig;
+
+import com.alinz.parkerdan.shareextension.SharePackage;
+
+import android.app.Application;
+
+import com.facebook.react.shell.MainReactPackage;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactPackage;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class ShareApplication extends Application implements ReactApplication {
+	private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+		@Override
+		public boolean getUseDeveloperSupport() {
+			return BuildConfig.DEBUG;
+		}
+
+		@Override
+		protected List<ReactPackage> getPackages() {
+			return Arrays.<ReactPackage>asList(
+				new MainReactPackage(),
+				new SharePackage()
+			);
+		}
+	};
+
+	@Override
+	public ReactNativeHost getReactNativeHost() {
+		return mReactNativeHost;
+	}
+}

--- a/ReactNativeClient/android/settings.gradle
+++ b/ReactNativeClient/android/settings.gradle
@@ -26,3 +26,6 @@ project(':react-native-fetch-blob').projectDir = new File(rootProject.projectDir
 
 include ':react-native-document-picker'
 project(':react-native-document-picker').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-document-picker/android')
+include ':app', ':react-native-share-extension'
+
+project(':react-native-share-extension').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-share-extension/android')

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -34,6 +34,7 @@ const shared = require('lib/components/shared/note-screen-shared.js');
 const ImagePicker = require('react-native-image-picker');
 const AlarmService = require('lib/services/AlarmService.js');
 const { SelectDateTimeDialog } = require('lib/components/select-date-time-dialog.js');
+const ShareExtension = require('react-native-share-extension').default;
 
 import FileViewer from 'react-native-file-viewer';
 
@@ -57,6 +58,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 			alarmDialogShown: false,
 			heightBumpView:0,
 			noteTagDialogShown: false,
+			fromShare: false,
 		};
 
 		// iOS doesn't support multiline text fields properly so disable it
@@ -215,6 +217,10 @@ class NoteScreenComponent extends BaseScreenComponent {
 	componentWillUnmount() {
 		BackButtonService.removeHandler(this.backHandler);
 		NavService.removeHandler(this.navHandler);
+
+		if (this.state.fromShare) {
+			ShareExtension.close();
+		}
 	}
 
 	title_changeText(text) {
@@ -675,6 +681,7 @@ const NoteScreen = connect(
 			itemType: state.selectedItemType,
 			folders: state.folders,
 			theme: state.settings.theme,
+			sharedData: state.sharedData,
 			showAdvancedOptions: state.settings.showAdvancedOptions,
 		};
 	}

--- a/ReactNativeClient/lib/components/screens/notes.js
+++ b/ReactNativeClient/lib/components/screens/notes.js
@@ -1,5 +1,5 @@
 const React = require('react'); const Component = React.Component;
-const { View, Button, Text } = require('react-native');
+const { AppState, View, Button, Text } = require('react-native');
 const { stateUtils } = require('lib/reducer.js');
 const { connect } = require('react-redux');
 const { reg } = require('lib/registry.js');
@@ -25,6 +25,13 @@ class NotesScreenComponent extends BaseScreenComponent {
 
 	constructor() {
 		super();
+
+		this.onAppStateChange_ = async () => {
+			// Force an update to the notes list when app state changes
+			let newProps = Object.assign({}, this.props);
+			newProps.notesSource = '';
+			await this.refreshNotes(newProps);
+		}
 
 		this.sortButton_press = async () => {
 			const buttons = [];
@@ -67,6 +74,11 @@ class NotesScreenComponent extends BaseScreenComponent {
 
 	async componentDidMount() {
 		await this.refreshNotes();
+		AppState.addEventListener('change', this.onAppStateChange_);
+	}
+
+	async componentWillUnmount() {
+		AppState.removeEventListener('change', this.onAppStateChange_);
 	}
 
 	async UNSAFE_componentWillReceiveProps(newProps) {

--- a/ReactNativeClient/lib/components/shared/note-screen-shared.js
+++ b/ReactNativeClient/lib/components/shared/note-screen-shared.js
@@ -174,7 +174,12 @@ shared.initState = async function(comp) {
 		mode: mode,
 		folder: folder,
 		isLoading: false,
+		fromShare: comp.props.sharedData ? true : false,
 	});
+
+	if (comp.props.sharedData) {
+		this.noteComponent_change(comp, 'body', comp.props.sharedData.value);
+	}
 
 	comp.lastLoadedNoteId_ = note ? note.id : null;
 }

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -23,6 +23,7 @@ const defaultState = {
 	syncReport: {},
 	searchQuery: '',
 	settings: {},
+	sharedData: null,
 	appState: 'starting',
 	hasDisabledSyncItems: false,
 	newNote: null,

--- a/ReactNativeClient/package-lock.json
+++ b/ReactNativeClient/package-lock.json
@@ -6593,6 +6593,11 @@
         "base64-js": "*"
       }
     },
+    "react-native-share-extension": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-share-extension/-/react-native-share-extension-1.2.1.tgz",
+      "integrity": "sha512-C+WaUFhM4iMtH38N7/44lX4uW/B+XSbeJnSBZMMgKsZQIJKzJSYQklKVZdxf2/V5YOjjPaXohFwabTYclpJhtA=="
+    },
     "react-native-side-menu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/react-native-side-menu/-/react-native-side-menu-1.1.3.tgz",

--- a/ReactNativeClient/package.json
+++ b/ReactNativeClient/package.json
@@ -40,6 +40,7 @@
     "react-native-popup-menu": "^0.10.0",
     "react-native-push-notification": "^3.0.1",
     "react-native-securerandom": "^0.1.1",
+    "react-native-share-extension": "^1.2.1",
     "react-native-side-menu": "^1.1.3",
     "react-native-sqlite-storage": "3.3.*",
     "react-native-vector-icons": "^4.4.2",

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -528,8 +528,6 @@ class AppComponent extends React.Component {
 			const { type, value } = await ShareExtension.data();
 
 			if (type != "") {
-				console.log(value);
-				console.log(type)
 
 				this.props.dispatch({
 					type: 'NAV_GO',

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -50,6 +50,7 @@ const { PoorManIntervals } = require('lib/poor-man-intervals.js');
 const { reducer, defaultState } = require('lib/reducer.js');
 const { FileApiDriverLocal } = require('lib/file-api-driver-local.js');
 const DropdownAlert = require('react-native-dropdownalert').default;
+const ShareExtension = require('react-native-share-extension').default;
 
 const SyncTargetRegistry = require('lib/SyncTargetRegistry.js');
 const SyncTargetOneDrive = require('lib/SyncTargetOneDrive.js');
@@ -233,6 +234,12 @@ const appReducer = (state = appDefaultState, action) => {
 
 				if ('itemType' in action) {
 					newState.selectedItemType = action.itemType;
+				}
+
+				if ('sharedData' in action) {
+					newState.sharedData = action.sharedData;
+				} else {
+					newState.sharedData = null;
 				}
 
 				newState.route = action;
@@ -515,6 +522,27 @@ class AppComponent extends React.Component {
 				type: 'APP_STATE_SET',
 				state: 'ready',
 			});
+		}
+
+		try {
+			const { type, value } = await ShareExtension.data();
+
+			if (type != "") {
+				console.log(value);
+				console.log(type)
+
+				this.props.dispatch({
+					type: 'NAV_GO',
+					routeName: 'Note',
+					noteId: null,
+					sharedData: {type: type, value: value},
+					folderId: this.props.parentFolderId,
+					itemType: 'note',
+				});
+		}
+
+		} catch(e) {
+			console.log('Error in ShareExtension.data', e);
 		}
 
 		BackButtonService.initialize(this.backButtonHandler_);


### PR DESCRIPTION
I mostly follow the procedure given in the readme of the [react-native-share-extension](https://github.com/alinz/react-native-share-extension). I also added to the react native side so that this will actually work. 

This currently doesn't work on ios because I don't have a development environment that supports developing for ios, but in principle someone that does just needs to follow the same instructions that I did (but for ios) and it'll be good to go.

Currently I only added support for sharing plain text (not images) because it seems that the underlying extension has issues actually passing around images.

I think the only potentially contentious change I've added is hooking into the AppState change events. This is done to force the note list to refresh when re-opening the app after having shared a note to Joplin. This is because the extension technically spins up a new run of the app and saves a not there, meaning the actually running app needs to reload notes from disk.

fixes #110 