### PR TITLE
 use correct date/time format for sync time - fix for #421

### DIFF
--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -141,7 +141,7 @@ class Synchronizer {
 
 	async cancel() {
 		if (this.cancelling_ || this.state() == 'idle') return;
-		
+
 		this.logSyncOperation('cancelling', null, null, '');
 		this.cancelling_ = true;
 

--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -74,7 +74,7 @@ class Synchronizer {
 		if (report.fetchingTotal && report.fetchingProcessed) lines.push(_("Fetched items: %d/%d.", report.fetchingProcessed, report.fetchingTotal));
 		if (!report.completedTime && report.state) lines.push(_('State: %s.', Synchronizer.stateToLabel(report.state)));
 		if (report.cancelling && !report.completedTime) lines.push(_("Cancelling..."));
-		if (report.completedTime) lines.push(_("Completed: %s", time.unixMsToLocalDateTime(report.completedTime)));
+		if (report.completedTime) lines.push(_("Completed: %s", time.formatMsToLocal(report.completedTime)));
 		if (report.errors && report.errors.length) lines.push(_("Last error: %s", report.errors[report.errors.length - 1].toString().substr(0, 500)));
 
 		return lines;


### PR DESCRIPTION
This change displays the correct date/time format (the one specified in settings) for the sync time.
(See issue #421 for more details.)

P.S.: Once again, there's an extra commit for fixing a small whitespace error in the file.