### PR TITLE
added support for 'tag list -l [tag]' to show long format as for 'not…

### DIFF
--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -15,11 +15,11 @@ class Command extends BaseCommand {
 		return _('<tag-command> can be "add", "remove" or "list" to assign or remove [tag] from [note], or to list the notes associated with [tag]. The command `tag list` can be used to list all the tags (use -l for long option).');
 	}
 
-    options() {
-        return [
-            ['-l, --long', _('Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, TODO_CHECKED (for to-dos), TITLE')],
-        ];
-    }
+	options() {
+		return [
+			['-l, --long', _('Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, TODO_CHECKED (for to-dos), TITLE')],
+		];
+	}
 
 	async action(args) {
 		let tag = null;
@@ -50,28 +50,28 @@ class Command extends BaseCommand {
 		} else if (command == 'list') {
 			if (tag) {
 				let notes = await Tag.notes(tag.id);
-                notes.map((note) => {
-                    let line = '';
-                    if (options.long) {
-                        line += BaseModel.shortId(note.id)
-                        line += ' '
-                        line += time.unixMsToLocalDateTime(note.user_updated_time)
-                        line += ' '
-                    }
-                    if (note.is_todo) {
-                        line += '[';
-                        if (note.todo_completed) {
-                           line += 'X';
-                        } else {
-                            line += ' ';
-                        }
-                        line += '] ';
-                    } else {
-                        line += '    ';
-                    }
-                    line += note.title;
-                    this.stdout(line);
-                });
+				notes.map((note) => {
+					let line = '';
+				if (options.long) {
+					line += BaseModel.shortId(note.id);
+					line += ' ';
+					line += time.formatMsToLocal(note.user_updated_time);
+					line += ' ';
+				}
+				if (note.is_todo) {
+					line += '[';
+					if (note.todo_completed) {
+					   line += 'X';
+					} else {
+						line += ' ';
+					}
+					line += '] ';
+				} else {
+					line += '    ';
+				}
+				line += note.title;
+				this.stdout(line);
+				});
 			} else {
 				let tags = await Tag.all();
 				tags.map((tag) => { this.stdout(tag.title); });

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -52,25 +52,25 @@ class Command extends BaseCommand {
 				let notes = await Tag.notes(tag.id);
 				notes.map((note) => {
 					let line = '';
-				if (options.long) {
-					line += BaseModel.shortId(note.id);
-					line += ' ';
-					line += time.formatMsToLocal(note.user_updated_time);
-					line += ' ';
-				}
-				if (note.is_todo) {
-					line += '[';
-					if (note.todo_completed) {
-					   line += 'X';
-					} else {
-						line += ' ';
-					}
-					line += '] ';
-				} else {
-					line += '    ';
-				}
-				line += note.title;
-				this.stdout(line);
+                    if (options.long) {
+                        line += BaseModel.shortId(note.id);
+                        line += ' ';
+                        line += time.formatMsToLocal(note.user_updated_time);
+                        line += ' ';
+                    }
+                    if (note.is_todo) {
+                        line += '[';
+                        if (note.todo_completed) {
+                           line += 'X';
+                        } else {
+                            line += ' ';
+                        }
+                        line += '] ';
+                    } else {
+                        line += '    ';
+                    }
+                    line += note.title;
+                    this.stdout(line);
 				});
 			} else {
 				let tags = await Tag.all();

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -3,6 +3,7 @@ const { app } = require('./app.js');
 const { _ } = require('lib/locale.js');
 const Tag = require('lib/models/Tag.js');
 const BaseModel = require('lib/BaseModel.js');
+const { time } = require('lib/time-utils.js');
 
 class Command extends BaseCommand {
 
@@ -11,11 +12,19 @@ class Command extends BaseCommand {
 	}
 
 	description() {
-		return _('<tag-command> can be "add", "remove" or "list" to assign or remove [tag] from [note], or to list the notes associated with [tag]. The command `tag list` can be used to list all the tags.');
+		return _('<tag-command> can be "add", "remove" or "list" to assign or remove [tag] from [note], or to list the notes associated with [tag]. The command `tag list` can be used to list all the tags (use -l for long option).');
 	}
-	
+
+    options() {
+        return [
+            ['-l, --long', _('Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, TODO_CHECKED (for to-dos), TITLE')],
+        ];
+    }
+
 	async action(args) {
 		let tag = null;
+		let options = args.options;
+
 		if (args.tag) tag = await app().loadItem(BaseModel.TYPE_TAG, args.tag);
 		let notes = [];
 		if (args.note) {
@@ -41,7 +50,28 @@ class Command extends BaseCommand {
 		} else if (command == 'list') {
 			if (tag) {
 				let notes = await Tag.notes(tag.id);
-				notes.map((note) => { this.stdout(note.title); });
+                notes.map((note) => {
+                    let line = '';
+                    if (options.long) {
+                        line += BaseModel.shortId(note.id)
+                        line += ' '
+                        line += time.unixMsToLocalDateTime(note.user_updated_time)
+                        line += ' '
+                    }
+                    if (note.is_todo) {
+                        line += '[';
+                        if (note.todo_completed) {
+                           line += 'X';
+                        } else {
+                            line += ' ';
+                        }
+                        line += '] ';
+                    } else {
+                        line += '    ';
+                    }
+                    line += note.title;
+                    this.stdout(line);
+                });
 			} else {
 				let tags = await Tag.all();
 				tags.map((tag) => { this.stdout(tag.title); });

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -52,25 +52,25 @@ class Command extends BaseCommand {
 				let notes = await Tag.notes(tag.id);
 				notes.map((note) => {
 					let line = '';
-                    if (options.long) {
-                        line += BaseModel.shortId(note.id);
-                        line += ' ';
-                        line += time.formatMsToLocal(note.user_updated_time);
-                        line += ' ';
-                    }
-                    if (note.is_todo) {
-                        line += '[';
-                        if (note.todo_completed) {
-                           line += 'X';
-                        } else {
-                            line += ' ';
-                        }
-                        line += '] ';
-                    } else {
-                        line += '    ';
-                    }
-                    line += note.title;
-                    this.stdout(line);
+					if (options.long) {
+						line += BaseModel.shortId(note.id);
+						line += ' ';
+						line += time.formatMsToLocal(note.user_updated_time);
+						line += ' ';
+					}
+					if (note.is_todo) {
+						line += '[';
+						if (note.todo_completed) {
+						   line += 'X';
+						} else {
+							line += ' ';
+						}
+						line += '] ';
+					} else {
+						line += '	';
+					}
+					line += note.title;
+					this.stdout(line);
 				});
 			} else {
 				let tags = await Tag.all();


### PR DESCRIPTION
Added support for -l option for the 'tag list' command line client app. [(see forum entry)](https://discourse.joplin.cozic.net/t/terminal-tag-list-shows-only-the-title/429/3)

eg:
```
./build.sh && ./run.sh tag list -l tag1                                                                                                                        
228ec 13/08/2018 23:17 [ ] todo_2
79ac5 13/08/2018 23:18 [X] todo_3
c8c49 13/08/2018 22:19     notiz_1
e9e05 13/08/2018 22:19     notiz_2
```

versus the default without '-l', which also got the added todo-box
```
./build.sh && ./run.sh tag list tag1                                                                                                                           1s
[ ] todo_2
[X] todo_3
    notiz_1
    notiz_2
```