### PR TITLE
enable file-URLs in note html view

### DIFF
--- a/ReactNativeClient/lib/MdToHtml.js
+++ b/ReactNativeClient/lib/MdToHtml.js
@@ -395,6 +395,40 @@ class MdToHtml {
 			html: true,
 		});
 
+		// Add `file:` protocol in linkify to allow text in the format of "file://..." to translate into
+		// file-URL links in html view
+		md.linkify.add('file:', {
+
+		  validate: function (text, pos, self) {
+		    var tail = text.slice(pos);
+
+		    if (!self.re.file) {
+		      self.re.file =  new RegExp(
+			'^[\\/]{2,3}[\\S]+' // matches all local file URI on Win/Unix/MacOS systems including reserved characters in some OS (i.e. no OS specific sanity check)
+		      );
+		    }
+		    if (self.re.file.test(tail)) {
+		      return tail.match(self.re.file)[0].length;
+		    }
+		    return 0;
+		}
+			
+		});
+
+		// enable file link URLs in MarkdownIt. Keeps other URL restrictions of MarkdownIt untouched.
+		// Format [link name](file://...)		
+		md.validateLink = function (url) {
+
+			var BAD_PROTO_RE = /^(vbscript|javascript|data):/;
+			var GOOD_DATA_RE = /^data:image\/(gif|png|jpeg|webp);/;
+
+	    		// url should be normalized at this point, and existing entities are decoded
+			var str = url.trim().toLowerCase();
+
+			return BAD_PROTO_RE.test(str) ? (GOOD_DATA_RE.test(str) ? true : false) : true;
+
+		}
+
 		// This is currently used only so that the $expression$ and $$\nexpression\n$$ blocks are translated
 		// to math_inline and math_block blocks. These blocks are then processed directly with the Katex
 		// library.  It is better this way as then it is possible to conditionally load the CSS required by


### PR DESCRIPTION
following up the discussion in [forum](https://discourse.joplin.cozic.net/t/support-for-links-to-local-file/279/9) I would like to propose some code that enables file URL links in the notes html view.

* Add `file:` protocol in linkify to allow text in the format of "file:///..." to translate into file-URL links in html view
* enable file link URLs in MarkdownIt. Keeps all other URL restrictions of MarkdownIt untouched. Format [link name](file:///...)	

![joplin_screenshot_file_url](https://user-images.githubusercontent.com/22592201/44298010-6a508700-a2db-11e8-84b5-f4d947ed7bb1.png)


