### PR TITLE
CLI: improve e2ee decrypt command

### DIFF
--- a/CliClient/app/command-e2ee.js
+++ b/CliClient/app/command-e2ee.js
@@ -47,34 +47,63 @@ class Command extends BaseCommand {
 		}
 
 		if (args.command === 'decrypt') {
-			if (args.path) {
-				const plainText = await EncryptionService.instance().decryptString(args.path);
-				this.stdout(plainText);
-			} else {
-				this.stdout(_('Starting decryption... Please wait as it may take several minutes depending on how much there is to decrypt.'));
+			while (true) {
+				try {
+					if (args.path) {
+						const plainText = await EncryptionService.instance().decryptString(args.path);
+						this.stdout(plainText);
+						return;
+					} else {
+						if (process.stdin.isTTY) {
+							this.stdout(_('Starting decryption... Please wait as it may take several minutes depending on how much there is to decrypt.'));
+							await DecryptionWorker.instance().start();
+							this.stdout(_('Completed decryption.'));
+							return;
+						} else {
+							// var repl = require("repl");
+							// var r = repl.start("node> ");
 
-				while (true) {
-					try {
-						await DecryptionWorker.instance().start();
-						break;
-					} catch (error) {
-						if (error.code === 'masterKeyNotLoaded') {
-							const masterKeyId = error.masterKeyId;
-							const password = await this.prompt(_('Enter master password:'), { type: 'string', secure: true });
-							if (!password) {
-								this.stdout(_('Operation cancelled'));
-								return;
+							const text = await new Promise((accept, reject) => {
+								var buffer = '';
+								process.stdin.setEncoding('utf8');
+								process.stdin.on('data', function(chunk) {
+										buffer += chunk;
+										// process.stdout.write(chunk);
+								});
+								process.stdin.on('end', function() {
+									accept(buffer.trim());
+								});
+							});
+
+							if (text.length > 0) {
+								var cipherText = text;
+								try {
+									var item = await BaseItem.unserialize(text);
+									cipherText = item.encryption_cipher_text;
+								} catch (error) {
+									// we already got the pure cipher text
+								}
+								const plainText = await EncryptionService.instance().decryptString(cipherText);
+								this.stdout(plainText);
 							}
-							Setting.setObjectKey('encryption.passwordCache', masterKeyId, password);
-							await EncryptionService.instance().loadMasterKeysFromSettings();
-							continue;
+							return;
 						}
-
-						throw error;
 					}
-				}
+				} catch (error) {
+					if (error.code === 'masterKeyNotLoaded') {
+						const masterKeyId = error.masterKeyId;
+						const password = await this.prompt(_('Enter master password:'), { type: 'string', secure: true });
+						if (!password) {
+							this.stdout(_('Operation cancelled'));
+							return;
+						}
+						Setting.setObjectKey('encryption.passwordCache', masterKeyId, password);
+						await EncryptionService.instance().loadMasterKeysFromSettings();
+						continue;
+					}
 
-				this.stdout(_('Completed decryption.'));
+					throw error;
+				}
 			}
 
 			return;


### PR DESCRIPTION
fixes #782

This fixes and adds the following use cases to print the clear text:

* `joplin e2ee decrypt "JEDsome_encryption_cipher_text_blocks"`
* `git show commithash:encrypted-notes-file.md | joplin e2ee decrypt`
* `cat encrypted-notes-file.md | joplin e2ee decrypt`
* `echo "JEDsome_encryption_cipher_text_blocks" | joplin e2ee decrypt`