### PR TITLE
allow the app to be installed on external storage (SD card) 

### DIFF
--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -15,12 +15,12 @@
 	<!-- START react-native-push-notification -->
 	<!-- ==================================== -->
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
-    <permission
-        android:name="${applicationId}.permission.C2D_MESSAGE"
-        android:protectionLevel="signature" />
-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+	<permission
+		android:name="${applicationId}.permission.C2D_MESSAGE"
+		android:protectionLevel="signature" />
+	<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+	<uses-permission android:name="android.permission.VIBRATE" />
+	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 	<!-- ================================== -->
 	<!-- END react-native-push-notification -->
 	<!-- ================================== -->
@@ -40,13 +40,13 @@
 		<!-- START react-native-push-notification -->
 		<!-- ==================================== -->
 
-        <receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationPublisher" />
-        <receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationBootEventReceiver">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
-        <service android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationRegistrationService"/>
+		<receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationPublisher" />
+		<receiver android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationBootEventReceiver">
+			<intent-filter>
+				<action android:name="android.intent.action.BOOT_COMPLETED" />
+			</intent-filter>
+		</receiver>
+		<service android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationRegistrationService"/>
 		<!-- ================================== -->
 		<!-- END react-native-push-notification -->
 		<!-- ================================== -->

--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
+	android:installLocation="auto"
 	package="net.cozic.joplin"
 	android:versionCode="2"
 	android:versionName="0.8.0">


### PR DESCRIPTION
This change allows the app to be installed on an SD card.

Info on `android:installLocation`:

When your application is installed on the external storage:

- There is no effect on the application performance so long as the external storage is mounted on the device.
- The .apk file is saved on the external storage, but all private user data, databases, optimized .dex files, and extracted native code are saved on the internal device memory.
- The unique container in which your application is stored is encrypted with a randomly generated key that can be decrypted only by the device that originally installed it. Thus, an application installed on an SD card works for only one device.
- The user can move your application to the internal storage through the system settings.

P.S.: I also fixed a few whitespace errors in a separate commit.