### PR TITLE
Fix ubuntu install script

### DIFF
--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -12,7 +12,7 @@ echo "              |_|                                                 "
 # Get the latest version to download
 version=$(curl --silent "https://api.github.com/repos/laurent22/joplin/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
 # Delete previous version
-rm ~/.joplin/*.AppImage ~/.local/share/applications/joplin.desktop
+rm -f ~/.joplin/*.AppImage ~/.local/share/applications/joplin.desktop
 # Creates the folder where the binary will be stored
 mkdir -p ~/.joplin/
 # Download the latest version


### PR DESCRIPTION
If no former version is present, the script fails since the rm commands do not succeed.
Added -f to rm in order to ignore non-existent files to be deleted.