### PR TITLE
Prevent shared link on android from overwriting note

### DIFF
--- a/ReactNativeClient/lib/components/shared/note-screen-shared.js
+++ b/ReactNativeClient/lib/components/shared/note-screen-shared.js
@@ -157,13 +157,11 @@ shared.isModified = function(comp) {
 }
 
 shared.initState = async function(comp) {
-	let note = null;
+	let note = await Note.load(comp.props.noteId);
 	let mode = 'view';
 	if (!comp.props.noteId) {
 		note = comp.props.itemType == 'todo' ? Note.newTodo(comp.props.folderId) : Note.new(comp.props.folderId);
 		mode = 'edit';
-	} else {
-		note = await Note.load(comp.props.noteId);
 	}
 
 	const folder = Folder.byId(comp.props.folders, note.parent_id);


### PR DESCRIPTION
This fixes the issue reported in the comments of #110.
From what I can tell, the issue is a sort of race condition where `comp.props` is being changed synchronously with the running of the `initState` function (which is what I have edited here). To fix this I have simply moved the note loading outside the check for noteId meaning that anytime you open a note (whether or not it is new) the system will attempt to load something. This gives enough time for `comp.props` to properly update and a new note will be successfully created and the old one won't be lost (provided it was saved).

Things to note
1. I don't really like this solution, it feels kinda hacky to me. If someone who knows more about the code base as a whole could offer a better solution I'd happily implement it.
2. This still leaves a bug where a new note that hasn't been saved will be overwritten if the user shares something to joplin before saving the note. Clearly some sort of autosave is needed, but I might not address that here.

edit: fixes #902 