### PR TITLE
Android: add version info

### DIFF
--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -46,7 +46,8 @@ public class MainApplication extends Application implements ReactApplication {
 				new RNFSPackage(),
 				new SQLitePluginPackage(),
 				new VectorIconsPackage(),
-				new SharePackage()
+				new SharePackage(),
+				new VersionInfoPackage()
 			);
 		}
 	};

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/VersionInfo.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/VersionInfo.java
@@ -1,0 +1,49 @@
+package net.cozic.joplin;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class VersionInfo extends ReactContextBaseJavaModule {
+
+	ReactApplicationContext reactContext;
+
+	public VersionInfo(ReactApplicationContext reactContext) {
+		super(reactContext);
+
+		this.reactContext = reactContext;
+	}
+
+	@Override
+	public String getName() {
+		return "VersionInfo";
+	}
+
+	@Override
+	public Map<String, Object> getConstants() {
+		HashMap<String, Object> constants = new HashMap<String, Object>();
+
+		PackageManager packageManager = this.reactContext.getPackageManager();
+		String packageName = this.reactContext.getPackageName();
+
+		constants.put("appVersion", "not available");
+
+		try {
+			PackageInfo info = packageManager.getPackageInfo(packageName, 0);
+			constants.put("appVersion", info.versionName);
+		} catch (PackageManager.NameNotFoundException e) {
+			e.printStackTrace();
+		}
+		return constants;
+	}
+
+}

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/VersionInfoPackage.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/VersionInfoPackage.java
@@ -1,0 +1,28 @@
+package net.cozic.joplin;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class VersionInfoPackage implements ReactPackage {
+
+	@Override
+	public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+		List<NativeModule> modules = new ArrayList<>();
+
+		modules.add(new VersionInfo(reactContext));
+
+		return modules;
+	}
+
+}

--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -1,5 +1,5 @@
 const React = require('react'); const Component = React.Component;
-const { Platform, TouchableOpacity, Linking, View, Switch, Slider, StyleSheet, Text, Button, ScrollView, TextInput } = require('react-native');
+const { Platform, NativeModules, TouchableOpacity, Linking, View, Switch, Slider, StyleSheet, Text, Button, ScrollView, TextInput } = require('react-native');
 const { connect } = require('react-redux');
 const { ScreenHeader } = require('lib/components/screen-header.js');
 const { _, setLocale } = require('lib/locale.js');
@@ -11,7 +11,7 @@ const shared = require('lib/components/shared/config-shared.js');
 const SyncTargetRegistry = require('lib/SyncTargetRegistry');
 
 class ConfigScreenComponent extends BaseScreenComponent {
-	
+
 	static navigationOptions(options) {
 		return { header: null };
 	}
@@ -229,7 +229,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				</TouchableOpacity>
 			</View>
 		);
-		
+
 		settingComps.push(
 			<View key="website_link" style={this.styles().settingContainer}>
 				<TouchableOpacity onPress={() => { Linking.openURL('https://joplin.cozic.net/') }}>
@@ -245,6 +245,15 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				</TouchableOpacity>
 			</View>
 		);
+
+		if (Platform.OS === 'android') {
+			var VersionInfo = NativeModules.VersionInfo;
+			settingComps.push(
+				<View key="version_info" style={this.styles().settingContainer}>
+						<Text key="version" style={this.styles().settingText}>Version {VersionInfo.appVersion}</Text>
+				</View>
+			);
+		}
 
 		return (
 			<View style={this.rootStyle(this.props.theme).root}>


### PR DESCRIPTION
This change adds the application version to the `Configuration` screen.

We can also add the Version Info somewhere else, like to the `Status` screen or create a new menu item `About`. I just added it to the `Configuration` item, because I didn't know where to put it otherwise.

As soon as I have the time, I will also implement this for iOS.


