### PR TITLE
Linux script install: implement previous updates

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -1,52 +1,70 @@
 #!/bin/bash
 set -e
 # Title
-echo "       _             _  _         _           _        _ _           "
-echo "      | |           | |(_)       (_)         | |      | | |          "
-echo "      | | ___  _ __ | | _ _ __    _ _ __  ___| |_ __ _| | | ___ _ __ "
-echo "  _   | |/ _ \|  _ \| || |  _ \  | |  _ \ /  __|  __  | | |/ _ \ __| "
-echo " | |__| | (_) | |_) | || | | | | | | | | \__ \ || (_| | | |  __/ |   "
-echo "  \____/ \___/| .__/|_||_|_| |_| |_|_| |_|___/\__\__,_|_|_|\___|_|   "
-echo "              | |                                                    "
-echo "              |_|                                                    "
+echo "       _             _         _           _        _ _           "
+echo "      | |           (_)       (_)         | |      | | |          "
+echo "      | | ___  _ __  _ _ __    _ _ __  ___| |_ __ _| | | ___ _ __ "
+echo "  _   | |/ _ \\\| '_ \| | '_ \\  | | '_ \\\/ __| __/ _\` | | |/ _ \ '__|"
+echo " | |__| | (_) | |_) | | | | | | | | | \__ \ || (_| | | |  __/ |   "
+echo "  \____/ \___/| .__/|_|_| |_| |_|_| |_|___/\__\__,_|_|_|\___|_|   "
+echo "              | |                                                 "
+echo "              |_|                                                 "
+echo ""
+
+#-----------------------------------------------------
+# Download Joplin
+#-----------------------------------------------------
 
 # Get the latest version to download
 version=$(curl --silent "https://api.github.com/repos/laurent22/joplin/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
 
-# Delete previous version
-rm -f ~/.joplin/*.AppImage ~/.local/share/applications/*joplin.desktop
+# Check if it's in the latest version
+touch VERSION
+if [[ $(< ~/.joplin/VERSION) != "$version" ]]; then
 
-# Creates the folder where the binary will be stored
-mkdir -p ~/.joplin/
+    # Delete previous version
+    rm -f ~/.joplin/*.AppImage ~/.local/share/applications/joplin.desktop ~/.joplin/VERSION
+    
+    # Creates the folder where the binary will be stored
+    mkdir -p ~/.joplin/
+    
+    # Download the latest version
+    wget -O ~/.joplin/Joplin.AppImage https://github.com/laurent22/joplin/releases/download/v$version/Joplin-$version-x86_64.AppImage 
+    
+    # Gives execution privileges
+    chmod +x ~/.joplin/Joplin.AppImage
+    
+    #-----------------------------------------------------
+    # Icon
+    #-----------------------------------------------------
+    
+    # Download icon
+    wget -O ~/.joplin/Icon512.png https://joplin.cozic.net/images/Icon512.png
+    
+    # Detect desktop environment  
+    if [ "$XDG_CURRENT_DESKTOP" = "" ]
+    then
+      desktop=$(echo "$XDG_DATA_DIRS" | sed 's/.*\(xfce\|kde\|gnome\).*/\1/')
+    else
+      desktop=$XDG_CURRENT_DESKTOP
+    fi
+    desktop=${desktop,,}  # convert to lower case
 
-# Download the latest version
-wget -O ~/.joplin/Joplin-$version-x86_64.AppImage https://github.com/laurent22/joplin/releases/download/v$version/Joplin-$version-x86_64.AppImage
- 
-# Gives execution privileges
-chmod +x ~/.joplin/Joplin-$version-x86_64.AppImage
-
-# Download icon
-wget -O ~/.joplin/Icon512.png https://joplin.cozic.net/images/Icon512.png
-
-# Detect desktop environment  
-if [ "$XDG_CURRENT_DESKTOP" = "" ]
-then
-  desktop=$(echo "$XDG_DATA_DIRS" | sed 's/.*\(xfce\|kde\|gnome\).*/\1/')
+    # Create icon for Gnome
+    if [[ $desktop =~ .*gnome.* ]] 
+    then
+       echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nExec=/home/$USER/.joplin/Joplin-$version-x86_64.AppImage\nIcon=/home/$USER/.joplin/Icon512.png\nType=Application\nCategories=Application;" >> ~/.local/share/applications/joplin.desktop
+    fi
+    
+    #-----------------------------------------------------
+    # Finish
+    #-----------------------------------------------------
+    
+    # Informs the user that it has been installed and cleans variables
+    echo 'Joplin installed in the version' $version
+    # Add version
+    echo $version > ~/.joplin/VERSION
 else
-  desktop=$XDG_CURRENT_DESKTOP
+    echo 'You are now in the latest version.'
 fi
-desktop=${desktop,,}  # convert to lower case
-
-# Create icon for Gnome
-if [[ $desktop =~ .*gnome.* ]] 
-then
-   echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nExec=/home/$USER/.joplin/Joplin-$version-x86_64.AppImage\nIcon=/home/$USER/.joplin/Icon512.png\nType=Application\nCategories=Application;" >> ~/.local/share/applications/joplin.desktop
-fi
-
-# Informs the user that it has been installed and cleans variables
-echo 'Joplin installed in the version' $version
-
-# start Joplin:
-~/.joplin/Joplin-$version-x86_64.AppImage
-
 unset version


### PR DESCRIPTION
Avoid an erroneous update and prevent installation icon only on gnome.

<!--
PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md
-->
