### PR TITLE
Fix image fetching error in ClipperServer for URLs with query string.

### DIFF
--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -238,7 +238,7 @@ function shimInit() {
 			host: url.hostname,
 			port: url.port,
 			method: method,
-			path: url.path + (url.query ? '?' + url.query : ''),
+			path: url.pathname + (url.query ? '?' + url.query : ''),
 			headers: headers,
 		};
 


### PR DESCRIPTION
https://github.com/laurent22/joplin/blob/b30c65dd89d46c44d534e719725909575bce47e5/ReactNativeClient/lib/shim-init-node.js#L241
Url like 
> http://example.com/favicon.ico?ver=1.0 
will be changed to
> http://example.com/favicon.ico?ver=1.0?ver=1.0
Image from some website will fail to download.
testcase
> https://static.leiphone.com/uploads/new/images/20181112/5be958706ae86.png?imageView2/2/w/740