### PR TITLE
Headless webclipper to convert notes with only URLs body shared from mobile apps into clipped simplied page content

### DIFF
--- a/CliClient/app/command-mknote.js
+++ b/CliClient/app/command-mknote.js
@@ -6,7 +6,7 @@ const Note = require('lib/models/Note.js');
 class Command extends BaseCommand {
 
 	usage() {
-		return 'mknote <new-note>';
+		return 'mknote <new-title> [new-body]';
 	}
 
 	description() {
@@ -17,7 +17,8 @@ class Command extends BaseCommand {
 		if (!app().currentFolder()) throw new Error(_('Notes can only be created within a notebook.'));
 
 		let note = {
-			title: args['new-note'],
+			title: args['new-title'],
+			body: args['new-body'] || args['new-title'],
 			parent_id: app().currentFolder().id,
 		};
 

--- a/Clipper/joplin-webclipper/content_scripts/webclipper.js
+++ b/Clipper/joplin-webclipper/content_scripts/webclipper.js
@@ -1,0 +1,124 @@
+(function() {
+
+    function baseUrl() {
+        let output = location.origin + location.pathname;
+        if (output[output.length - 1] !== '/') {
+            output = output.split('/');
+            output.pop();
+            output = output.join('/');
+        }
+        return output;
+    };
+
+    const clippedContentResponse = (title, html) => {
+        return {
+            name: 'clippedContent',
+            title: title,
+            html: html,
+            base_url: baseUrl(),
+            url: location.origin + location.pathname + location.search,
+        };
+    };
+
+    async function readabilityProcess() {
+        var uri = {
+            spec: location.href,
+            host: location.host,
+            prePath: location.protocol + "//" + location.host,
+            scheme: location.protocol.substr(0, location.protocol.indexOf(":")),
+            pathBase: location.protocol + "//" + location.host + location.pathname.substr(0, location.pathname.lastIndexOf("/") + 1)
+        };
+
+        // Readability directly change the passed document so clone it so as
+        // to preserve the original web page.
+        const documentClone = document.cloneNode(true);
+        const readability = new Readability(documentClone); // new window.Readability(uri, documentClone);
+        const article = readability.parse();
+
+        if (!article) throw new Error('Could not parse HTML document with Readability');
+
+        return {
+            title: article.title,
+            body: article.content,
+        }
+    };
+
+    const ipcProxySendToHost = (methodName, arg) => {
+        window.postMessage({ target: 'main', name: methodName, args: [ arg ] }, location.origin);
+    };
+
+    const prepareCommandResponse = async (command) => {
+        let article = null;
+        try {
+            article = await readabilityProcess();
+        } catch (error) {
+            console.warn(error);
+            console.warn('Sending full page HTML instead');
+            const cleanDocument = document.body.cloneNode(true);
+            cleanUpElement(cleanDocument);
+            article = clippedContentResponse(pageTitle(), cleanDocument.innerHTML);
+            response.warning = 'Could not retrieve simplified version of page - full page has been saved instead.';
+            return response;
+        }
+        return clippedContentResponse(article.title, article.body);
+    };
+
+    /*
+    const commandState = {}
+    window.addEventListener('message', (event) => {
+        if (event.source === window) {
+            const data = event.data ? event.data : {};
+            if (data.target === 'webclipper') {
+                const state = commandState[data.iid];
+                if (data.result) {
+                    state.result = data.result;
+                    state.done = true;
+                } else if (data.reason) {
+                    state.reason = data.result;
+                    state.error = true;
+                }
+            }
+        }
+    });
+
+    const prepareCommandResponse = (command) => {
+        return new Promise((resolve, reject) => {
+			const state = {done: false, error: false};
+			const iid = setInterval(() => {
+				if (state.done) {
+					clearInterval(iid);
+					delete commandState[iid];
+					resolve(state.result);
+				} else if (state.error) {
+					clearInterval(iid);
+                    delete commandState[iid];
+					reject(state.reason);
+				}
+			});
+            commandState[iid] = state;
+            console.log('prepareCommandResponse', command);
+            window.postMessage({
+                target: 'readability',
+                command: command,
+                iid: iid
+            }, location.origin);
+		});
+    };
+    */
+
+	prepareCommandResponse({
+        name: "simplifiedPageHtml"
+	}).then((result) => {
+	    console.log('simplifiedPageHtml', result.title);
+        console.log('simplifiedPageHtml', result.html);
+        ipcProxySendToHost('clipHtml', {
+            title: result.title,
+            html: result.html,
+            base_url: document.baseURI,
+            source_url: document.location.href,
+        });
+	}, (reason) => {
+	    console.log(reason);
+    });
+
+})();

--- a/HeadlessClient/Dockerfile
+++ b/HeadlessClient/Dockerfile
@@ -1,0 +1,25 @@
+FROM library/ubuntu
+
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends curl ca-certificates curl software-properties-common \
+&& add-apt-repository ppa:ubuntu-toolchain-r/test \
+&& apt-get update \
+&& apt-get install -y build-essential gnome-keyring libsecret-1-dev python-keyring clang \
+&& curl -L https://yarnpkg.com/latest.tar.gz | tar xvz && mv yarn-* /yarn \
+&& curl -sL https://deb.nodesource.com/setup_8.x | bash - && apt-get install -y nodejs && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+&& apt-get install -y libgtk2.0-0 libgconf-2-4 libasound2 libxtst6 libxss1 libnss3 xvfb \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH "/yarn/bin:$PATH"
+ENV CC=clang
+ENV CXX=clang++
+ENV npm_config_clang=1
+
+RUN mkdir /home/user && useradd user && chown -R user:user /home/user && su - user
+WORKDIR /home/user
+USER user
+ENV DISPLAY=0
+ENV SCREEN=0
+ENV DISPLAY_MODE=1280x800x16
+CMD /usr/bin/xvfb-run /data/linux-unpacked/joplin server

--- a/HeadlessClient/app/app.js
+++ b/HeadlessClient/app/app.js
@@ -1,0 +1,488 @@
+const { BaseApplication } = require('lib/BaseApplication');
+const { createStore, applyMiddleware } = require('redux');
+const { reducer, defaultState } = require('lib/reducer.js');
+const { JoplinDatabase } = require('lib/joplin-database.js');
+const { Database } = require('lib/database.js');
+const { FoldersScreenUtils } = require('lib/folders-screen-utils.js');
+const { DatabaseDriverNode } = require('lib/database-driver-node.js');
+const ResourceService = require('lib/services/ResourceService');
+const BaseModel = require('lib/BaseModel.js');
+const Folder = require('lib/models/Folder.js');
+const BaseItem = require('lib/models/BaseItem.js');
+const Note = require('lib/models/Note.js');
+const Tag = require('lib/models/Tag.js');
+const Setting = require('lib/models/Setting.js');
+const { Logger } = require('lib/logger.js');
+const { sprintf } = require('sprintf-js');
+const { reg } = require('lib/registry.js');
+const { fileExtension } = require('lib/path-utils.js');
+const { shim } = require('lib/shim.js');
+const { _, setLocale, defaultLocale, closestSupportedLocale } = require('lib/locale.js');
+const os = require('os');
+const fs = require('fs-extra');
+const { cliUtils } = require('./cli-utils.js');
+const Cache = require('lib/Cache');
+
+class Application extends BaseApplication {
+
+	constructor() {
+		super();
+
+		this.showPromptString_ = true;
+		this.commands_ = {};
+		this.commandMetadata_ = null;
+		this.activeCommand_ = null;
+		this.allCommandsLoaded_ = false;
+		this.showStackTraces_ = false;
+		this.gui_ = null;
+		this.cache_ = new Cache();
+	}
+
+	gui() {
+		return this.gui_;
+	}
+
+	commandStdoutMaxWidth() {
+		return this.gui().stdoutMaxWidth();
+	}
+
+	generalMiddlewareFn() {
+		const middleware = store => next => (action) => {
+			return this.generalMiddleware(store, next, action);
+		};
+
+		return middleware;
+	}
+
+	async generalMiddleware(store, next, action) {
+		const result = await super.generalMiddleware(store, next, action);
+		if(action.type === 'SYNC_CREATED_NOTE') {
+			const content = action.content;
+			const noteBody = content && content.body ? content.body : content.local ? content.local.body || '' : '';
+			const isUrl = require('valid-url').isWebUri;
+			if (isUrl(noteBody)) {
+				const WebClipService = require('lib/services/WebClipService.js')
+				WebClipService.instance().queueWebClipTask(content);
+			}
+		}
+		if (action.type === 'NOTE_UPDATE_ONE') {
+			reg.scheduleSync(1000);
+		}
+		return result;
+	}
+
+	async guessTypeAndLoadItem(pattern, options = null) {
+		let type = BaseModel.TYPE_NOTE;
+		if (pattern.indexOf('/') === 0) {
+			type = BaseModel.TYPE_FOLDER;
+			pattern = pattern.substr(1);
+		}
+		return this.loadItem(type, pattern, options);
+	}
+
+	async loadItem(type, pattern, options = null) {
+		let output = await this.loadItems(type, pattern, options);
+
+		if (output.length > 1) {
+			// output.sort((a, b) => { return a.user_updated_time < b.user_updated_time ? +1 : -1; });
+
+			// let answers = { 0: _('[Cancel]') };
+			// for (let i = 0; i < output.length; i++) {
+			// 	answers[i + 1] = output[i].title;
+			// }
+
+			// Not really useful with new UI?
+			throw new Error(_('More than one item match "%s". Please narrow down your query.', pattern));
+
+			// let msg = _('More than one item match "%s". Please select one:', pattern);
+			// const response = await cliUtils.promptMcq(msg, answers);
+			// if (!response) return null;
+
+			return output[response - 1];
+		} else {
+			return output.length ? output[0] : null;
+		}
+	}
+
+	async loadItems(type, pattern, options = null) {
+		if (type === 'folderOrNote') {
+			const folders = await this.loadItems(BaseModel.TYPE_FOLDER, pattern, options);
+			if (folders.length) return folders;
+			return await this.loadItems(BaseModel.TYPE_NOTE, pattern, options);
+		}
+
+		pattern = pattern ? pattern.toString() : '';
+
+		if (type == BaseModel.TYPE_FOLDER && (pattern == Folder.conflictFolderTitle() || pattern == Folder.conflictFolderId())) return [Folder.conflictFolder()];
+
+		if (!options) options = {};
+
+		const parent = options.parent ? options.parent : app().currentFolder();
+		const ItemClass = BaseItem.itemClass(type);
+
+		if (type == BaseModel.TYPE_NOTE && pattern.indexOf('*') >= 0) { // Handle it as pattern
+			if (!parent) throw new Error(_('No notebook selected.'));
+			return await Note.previews(parent.id, { titlePattern: pattern });
+		} else { // Single item
+			let item = null;
+			if (type == BaseModel.TYPE_NOTE) {
+				if (!parent) throw new Error(_('No notebook has been specified.'));
+				item = await ItemClass.loadFolderNoteByField(parent.id, 'title', pattern);
+			} else {
+				item = await ItemClass.loadByTitle(pattern);
+			}
+			if (item) return [item];
+
+			item = await ItemClass.load(pattern); // Load by id
+			if (item) return [item];
+
+			if (pattern.length >= 2) {
+				return await ItemClass.loadByPartialId(pattern);
+			}
+		}
+
+		return [];
+	}
+
+	stdout(text) {
+		return this.gui().stdout(text);
+	}
+
+	setupCommand(cmd) {
+		cmd.setStdout((text) => {
+			return this.stdout(text);
+		});
+
+		cmd.setDispatcher((action) => {
+			if (this.store()) {
+				return this.store().dispatch(action);
+			} else {
+				return (action) => {};
+			}
+		});
+
+		cmd.setPrompt(async (message, options) => {
+			if (!options) options = {};
+			if (!options.type) options.type = 'boolean';
+			if (!options.booleanAnswerDefault) options.booleanAnswerDefault = 'y';
+			if (!options.answers) options.answers = options.booleanAnswerDefault === 'y' ? [_('Y'), _('n')] : [_('N'), _('y')];
+
+			if (options.type == 'boolean') {
+				message += ' (' + options.answers.join('/') + ')';
+			}
+
+			let answer = await this.gui().prompt('', message + ' ', options);
+
+			if (options.type === 'boolean') {
+				if (answer === null) return false; // Pressed ESCAPE
+				if (!answer) answer = options.answers[0];
+				let positiveIndex = options.booleanAnswerDefault == 'y' ? 0 : 1;
+				return answer.toLowerCase() === options.answers[positiveIndex].toLowerCase();
+			} else {
+				return answer;
+			}
+		});
+
+		return cmd;
+	}
+
+	async exit(code = 0) {
+		const superExit = super.exit; //prevent Unhandled promise rejection Promise
+		const doExit = async () => {
+			this.gui().exit();
+			await super.exit(code);
+		};
+
+		// Give it a few seconds to cancel otherwise exit anyway
+		setTimeout(async () => {
+			await doExit();
+		}, 5000);
+
+		const WebClipService = require('lib/services/WebClipService.js')
+		await WebClipService.instance().exit();
+		if (await reg.syncTarget().syncStarted()) {
+			this.stdout(_('Cancelling background synchronisation... Please wait.'));
+			const sync = await reg.syncTarget().synchronizer();
+			await sync.cancel();
+		}
+
+		await doExit();
+	}
+
+	commands(uiType = null) {
+		if (!this.allCommandsLoaded_) {
+			fs.readdirSync(__dirname).forEach((path) => {
+				if (path.indexOf('command-') !== 0) return;
+				const ext = fileExtension(path)
+				if (ext != 'js') return;
+
+				let CommandClass = require('./' + path);
+				let cmd = new CommandClass();
+				if (!cmd.enabled()) return;
+				cmd = this.setupCommand(cmd);
+				this.commands_[cmd.name()] = cmd;
+			});
+
+			this.allCommandsLoaded_ = true;
+		}
+
+		if (uiType !== null) {
+			let temp = [];
+			for (let n in this.commands_) {
+				if (!this.commands_.hasOwnProperty(n)) continue;
+				const c = this.commands_[n];
+				if (!c.supportsUi(uiType)) continue;
+				temp[n] = c;
+			}
+			return temp;
+		}
+
+		return this.commands_;
+	}
+
+	async commandNames() {
+		const metadata = await this.commandMetadata();
+		let output = [];
+		for (let n in metadata) {
+			if (!metadata.hasOwnProperty(n)) continue;
+			output.push(n);
+		}
+		return output;
+	}
+
+	async commandMetadata() {
+		if (this.commandMetadata_) return this.commandMetadata_;
+
+		let output = await this.cache_.getItem('metadata');
+		if (output) {
+			this.commandMetadata_ = output;
+			return Object.assign({}, this.commandMetadata_);
+		}
+
+		const commands = this.commands();
+
+		output = {};
+		for (let n in commands) {
+			if (!commands.hasOwnProperty(n)) continue;
+			const cmd = commands[n];
+			output[n] = cmd.metadata();
+		}
+
+		await this.cache_.setItem('metadata', output, 1000 * 60 * 60 * 24);
+
+		this.commandMetadata_ = output;
+		return Object.assign({}, this.commandMetadata_);
+	}
+
+	hasGui() {
+		return this.gui() && !this.gui().isDummy();
+	}
+
+	findCommandByName(name) {
+		if (this.commands_[name]) return this.commands_[name];
+
+		let CommandClass = null;
+		try {
+			CommandClass = require(__dirname + '/command-' + name + '.js');
+		} catch (error) {
+			if (error.message && error.message.indexOf('Cannot find module') >= 0) {
+				let e = new Error(_('No such command: %s', name));
+				e.type = 'notFound';
+				throw e;
+			} else {
+				throw error;
+			}
+		}
+
+		let cmd = new CommandClass();
+		cmd = this.setupCommand(cmd);
+		this.commands_[name] = cmd;
+		return this.commands_[name];
+	}
+
+	dummyGui() {
+		return {
+			isDummy: () => { return true; },
+			prompt: (initialText = '', promptString = '', options = null) => { return cliUtils.prompt(initialText, promptString, options); },
+			showConsole: () => {},
+			maximizeConsole: () => {},
+			stdout: (text) => { console.info(text); },
+			fullScreen: (b=true) => {},
+			exit: () => {},
+			showModalOverlay: (text) => {},
+			hideModalOverlay: () => {},
+			stdoutMaxWidth: () => { return 100; },
+			forceRender: () => {},
+			termSaveState: () => {},
+			termRestoreState: (state) => {},
+		};
+	}
+
+	async execCommand(argv) {
+		if (!argv.length) return this.execCommand(['help']);
+		// reg.logger().debug('execCommand()', argv);
+		const commandName = argv[0];
+		this.activeCommand_ = this.findCommandByName(commandName);
+
+		let outException = null;
+		try {
+			if (this.gui().isDummy() && !this.activeCommand_.supportsUi('cli')) throw new Error(_('The command "%s" is only available in GUI mode', this.activeCommand_.name()));			
+			const cmdArgs = cliUtils.makeCommandArgs(this.activeCommand_, argv);
+			await this.activeCommand_.action(cmdArgs);
+		} catch (error) {
+			outException = error;
+		}
+		this.activeCommand_ = null;
+		if (outException) throw outException;
+	}
+
+	currentCommand() {
+		return this.activeCommand_;
+	}
+
+	async loadKeymaps() {
+		const defaultKeyMap = [
+			{ "keys": [":"], "type": "function", "command": "enter_command_line_mode" },
+			{ "keys": ["TAB"], "type": "function", "command": "focus_next" },
+			{ "keys": ["SHIFT_TAB"], "type": "function", "command": "focus_previous" },
+			{ "keys": ["UP"], "type": "function", "command": "move_up" },
+			{ "keys": ["DOWN"], "type": "function", "command": "move_down" },
+			{ "keys": ["PAGE_UP"], "type": "function", "command": "page_up" },
+			{ "keys": ["PAGE_DOWN"], "type": "function", "command": "page_down" },
+			{ "keys": ["ENTER"], "type": "function", "command": "activate" },
+			{ "keys": ["DELETE", "BACKSPACE"], "type": "function", "command": "delete" },
+			{ "keys": [" "], "command": "todo toggle $n" },
+			{ "keys": ["tc"], "type": "function", "command": "toggle_console" },
+			{ "keys": ["tm"], "type": "function", "command": "toggle_metadata" },
+			{ "keys": ["/"], "type": "prompt", "command": "search \"\"", "cursorPosition": -2 },
+			{ "keys": ["mn"], "type": "prompt", "command": "mknote \"\"", "cursorPosition": -2 },
+			{ "keys": ["mt"], "type": "prompt", "command": "mktodo \"\"", "cursorPosition": -2 },
+			{ "keys": ["mb"], "type": "prompt", "command": "mkbook \"\"", "cursorPosition": -2 },
+			{ "keys": ["yn"], "type": "prompt", "command": "cp $n \"\"", "cursorPosition": -2 },
+			{ "keys": ["dn"], "type": "prompt", "command": "mv $n \"\"", "cursorPosition": -2 }
+		];
+
+		// Filter the keymap item by command so that items in keymap.json can override
+		// the default ones.
+		const itemsByCommand = {};
+
+		for (let i = 0; i < defaultKeyMap.length; i++) {
+			itemsByCommand[defaultKeyMap[i].command] = defaultKeyMap[i]
+		}
+
+		const filePath = Setting.value('profileDir') + '/keymap.json';
+		if (await fs.pathExists(filePath)) {
+			try {
+				let configString = await fs.readFile(filePath, 'utf-8');
+				configString = configString.replace(/^\s*\/\/.*/, ''); // Strip off comments
+				const keymap = JSON.parse(configString);
+				for (let keymapIndex = 0; keymapIndex < keymap.length; keymapIndex++) {
+					const item = keymap[keymapIndex];
+					itemsByCommand[item.command] = item;
+				}
+			} catch (error) {
+				let msg = error.message ? error.message : '';
+				msg = 'Could not load keymap ' + filePath + '\n' + msg;
+				error.message = msg;
+				throw error;
+			}
+		}
+
+		const output = [];
+		for (let n in itemsByCommand) {
+			if (!itemsByCommand.hasOwnProperty(n)) continue;
+			output.push(itemsByCommand[n]);
+		}
+
+		return output;
+	}
+
+	async start(argv) {
+		process.on('unhandledRejection', (reason, p) => {
+			console.error('Unhandled promise rejection', p, 'reason:', reason);
+			process.exit(1);
+		});
+
+		if (argv.length > 1 && argv[1].startsWith('--inspect-brk='))
+			argv.splice(1, 1);
+
+		// If running inside a package, the command line, instead of being "node.exe <path> <flags>" is "joplin.exe <flags>" so
+		// insert an extra argument so that they can be processed in a consistent way everywhere.
+		const isElectron = require('is-electron');
+		if (isElectron()) {
+			const electronIsDev = require('electron-is-dev');
+			if (!electronIsDev) {
+				console.info('cmd: ', process.argv)
+				argv.splice(1, 0, '.');
+			}
+		}
+
+		argv = await super.start(argv);
+
+		cliUtils.setStdout((object) => {
+			return this.stdout(object);
+		});
+
+		// If we have some arguments left at this point, it's a command
+		// so execute it.
+		if (argv.length) {
+			this.gui_ = this.dummyGui();
+
+			this.currentFolder_ = await Folder.load(Setting.value('activeFolderId'));
+
+			try {
+				await this.execCommand(argv);
+			} catch (error) {
+				if (this.showStackTraces_) {
+					console.error(error);
+				} else {
+					console.info(error.message);
+				}
+				process.exit(1);
+			}
+		} else { // Otherwise open the GUI
+			this.initRedux();
+
+			const keymap = await this.loadKeymaps();
+
+			const AppGui = require('./app-gui.js');
+			this.gui_ = new AppGui(this, this.store(), keymap);
+			this.gui_.setLogger(this.logger_);
+			await this.gui_.start();
+
+			// Since the settings need to be loaded before the store is created, it will never
+			// receive the SETTING_UPDATE_ALL even, which mean state.settings will not be
+			// initialised. So we manually call dispatchUpdateAll() to force an update.
+			Setting.dispatchUpdateAll();
+
+			await FoldersScreenUtils.refreshFolders();
+
+			const tags = await Tag.allWithNotes();
+
+			ResourceService.runInBackground();
+
+			this.dispatch({
+				type: 'TAG_UPDATE_ALL',
+				items: tags,
+			});
+
+			this.store().dispatch({
+				type: 'FOLDER_SELECT',
+				id: Setting.value('activeFolderId'),
+			});
+		}
+
+		if (!this.store()) this.exit(0);
+	}
+
+}
+
+let application_ = null;
+
+function app() {
+	if (application_) return application_;
+	application_ = new Application();
+	return application_;
+}
+
+module.exports = { app };

--- a/HeadlessClient/app/app.js
+++ b/HeadlessClient/app/app.js
@@ -58,7 +58,13 @@ class Application extends BaseApplication {
 		const result = await super.generalMiddleware(store, next, action);
 		if(action.type === 'SYNC_CREATED_NOTE') {
 			const content = action.content;
-			const noteBody = content && content.body ? content.body : content.local ? content.local.body || '' : '';
+			let noteBody = content ? (content.body || (content.local ? content.local.body : '')) : '';
+			if (noteBody === '' || !noteBody) {
+				const noteTitle = content ? (content.title || (content.local ? content.local.title : '')) : '';
+				if (noteTitle) {
+					content.body = noteBody = noteTitle;
+				}
+			}
 			const isUrl = require('valid-url').isWebUri;
 			if (isUrl(noteBody)) {
 				const WebClipService = require('lib/services/WebClipService.js')

--- a/HeadlessClient/app/command-server.js
+++ b/HeadlessClient/app/command-server.js
@@ -1,0 +1,83 @@
+const { BaseCommand } = require('./base-command.js');
+const { _ } = require('lib/locale.js');
+const Setting = require('lib/models/Setting.js');
+const SyncTargetRegistry = require('lib/SyncTargetRegistry');
+const { Logger } = require('lib/logger.js');
+const { shim } = require('lib/shim');
+const fs = require('fs');
+
+class Command extends BaseCommand {
+
+	usage() {
+		return 'server [command]';
+	}
+
+	description() {
+		return _('Start, stop or check the API server. To specify on which port it should run, set the api.port config variable. Commands are (start|stop|status).');
+	}
+
+	async action(args) {
+		const command = args.command;
+
+		const ClipperServer = require('lib/ClipperServer');
+		const stdoutFn = (s) => this.stdout(s);
+		const clipperLogger = new Logger();
+		clipperLogger.addTarget('file', { path: Setting.value('profileDir') + '/log-clipper.txt' });
+		clipperLogger.addTarget('console', { console: {
+			info: stdoutFn,
+			warn: stdoutFn,
+			error: stdoutFn,
+		}});
+		ClipperServer.instance().setDispatch(action => {});
+		ClipperServer.instance().setLogger(clipperLogger);
+
+		const pidPath = Setting.value('profileDir') + '/clipper-pid.txt';
+		const runningOnPort = await ClipperServer.instance().isRunning();
+
+		if (command === 'start' || command === undefined) {
+			if (runningOnPort) {
+				this.stdout(_('Server is already running on port %d', runningOnPort));
+			} else {
+				const { app } = require('./app.js');
+				app().initRedux();
+				const handleSignal = (signal) => {
+					this.logger().info('Received ' + signal + ', going to exit.');
+					app().exit();
+				};
+				process.on('SIGTERM', () => handleSignal('SIGTERM'));
+				process.on('SIGINT',  () => handleSignal('SIGINT'));
+				const ResourceService = require('lib/services/ResourceService');
+				ResourceService.runInBackground();
+				await shim.fsDriver().writeFile(pidPath, process.pid.toString(), 'utf-8');
+				await ClipperServer.instance().start();
+				const WebClipService = require('lib/services/WebClipService.js')
+				this.webclipService_ = WebClipService.instance();
+				this.webclipService_.start();
+				const { reg } = require('lib/registry.js');
+				reg.scheduleSync(0);
+				const filesystemSyncTargetId = SyncTargetRegistry.nameToId('filesystem');
+				if (Setting.value('sync.target') === filesystemSyncTargetId) {
+					const syncPath = Setting.value('sync.' + filesystemSyncTargetId + '.path');
+					fs.watch(syncPath, {recursive: true}, (eventType, filename) => {
+						if (!filename.endsWith('.md')) return;
+						this.logger().info('scheduleSync triggered by sync.target file change: ' + eventType + ' on ' + filename);
+						reg.scheduleSync(1000);
+					})
+				}
+			}
+		} else if (command === 'status') {
+			this.stdout(runningOnPort ? _('Server is running on port %d', runningOnPort) : _('Server is not running.'));
+		} else if (command === 'stop') {
+			if (!runningOnPort) {
+				this.stdout(_('Server is not running'));
+				return;
+			}
+			const pid = await shim.fsDriver().readFile(pidPath);
+			if (!pid) return;
+			process.kill(pid, 'SIGTERM');
+		}
+	}
+
+}
+
+module.exports = Command;

--- a/HeadlessClient/build.sh
+++ b/HeadlessClient/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_DIR="$ROOT_DIR/build"
+
+rsync -a --exclude node_modules/ --exclude lib/ --exclude locales/ "$ROOT_DIR/../CliClient/app/" "$BUILD_DIR"
+rsync -a --delete "$ROOT_DIR/../ReactNativeClient/"{lib,locales} "$BUILD_DIR"
+rsync -a --delete "$ROOT_DIR/../Clipper/joplin-webclipper/content_scripts" "$BUILD_DIR/lib"
+rsync -a "$ROOT_DIR/app/" "$BUILD_DIR"
+cp -a "$ROOT_DIR/package.json" "$ROOT_DIR/package-lock.json" "$BUILD_DIR"
+if [ ! -d "$BUILD_DIR/node_modules" ]; then
+	cd "$BUILD_DIR" && npm install && npm run pack
+	cd "$ROOT_DIR"
+fi
+chmod 755 "$BUILD_DIR/headless.js"

--- a/HeadlessClient/build.sh
+++ b/HeadlessClient/build.sh
@@ -8,8 +8,8 @@ rsync -a --delete "$ROOT_DIR/../ReactNativeClient/"{lib,locales} "$BUILD_DIR"
 rsync -a --delete "$ROOT_DIR/../Clipper/joplin-webclipper/content_scripts" "$BUILD_DIR/lib"
 rsync -a "$ROOT_DIR/app/" "$BUILD_DIR"
 cp -a "$ROOT_DIR/package.json" "$ROOT_DIR/package-lock.json" "$BUILD_DIR"
+chmod 755 "$BUILD_DIR/main.js"
 if [ ! -d "$BUILD_DIR/node_modules" ]; then
 	cd "$BUILD_DIR" && npm install && npm run pack
 	cd "$ROOT_DIR"
 fi
-chmod 755 "$BUILD_DIR/headless.js"

--- a/HeadlessClient/builddocker.sh
+++ b/HeadlessClient/builddocker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+CLIENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bash "$CLIENT_DIR/build.sh" && cd build && npm run appimage && mv dist .. && cd .. && docker build .
+
+# bash $CLIENT_DIR/build.sh && NODE_PATH="$CLIENT_DIR/build/" node build/main.js --profile ~/.config/joplin --stack-trace-enabled --log-level debug "$@"

--- a/HeadlessClient/cli.sh
+++ b/HeadlessClient/cli.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+CLIENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bash "$CLIENT_DIR/build.sh" && node "$CLIENT_DIR/build/main.js" --profile ~/Temp/TestNotes2 --stack-trace-enabled --log-level debug --env dev "$@"
+
+# bash $CLIENT_DIR/build.sh && NODE_PATH="$CLIENT_DIR/build/" node build/main.js --profile ~/.config/joplin --stack-trace-enabled --log-level debug "$@"

--- a/HeadlessClient/package-lock.json
+++ b/HeadlessClient/package-lock.json
@@ -1,0 +1,3839 @@
+{
+  "name": "joplin",
+  "version": "1.0.117",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "8.10.37",
+      "resolved": "http://registry.npm.taobao.org/@types/node/download/@types/node-8.10.37.tgz",
+      "integrity": "sha1-0ttJ3GpOCHwyRfIrkgYfIklHceU=",
+      "dev": true
+    },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+    },
+    "acorn-globals": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+      "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+      "requires": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
+          "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg=="
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.0.1.tgz",
+      "integrity": "sha512-PqVQ8c6a3kyqdsUZlC7nljp3FFuxipBRHKu+7C1h8QygBFlzTaDX5HD383jej3Peed+1aDG8HwkfB1Z1HMNPkw=="
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ansi-escape-sequences": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "requires": {
+        "array-back": "^2.0.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
+      }
+    },
+    "array-back": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "requires": {
+        "typical": "^2.6.1"
+      }
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/array-find-index/download/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async-kit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/async-kit/-/async-kit-2.2.3.tgz",
+      "integrity": "sha1-JkdRonndxfWbQZY4uAWuLEmFj7c=",
+      "requires": {
+        "nextgen-events": "^0.9.0",
+        "tree-kit": "^0.5.26"
+      },
+      "dependencies": {
+        "nextgen-events": {
+          "version": "0.9.9",
+          "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-0.9.9.tgz",
+          "integrity": "sha1-OaivxKK4RTiMV+LGu5cWcRmGo6A="
+        }
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "async-mutex": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.1.3.tgz",
+      "integrity": "sha1-Cq0hEjaXlas/F+M3RFVtLs9UdWY="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/builtin-modules/download/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/camelcase-keys/download/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "clean-css": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+      "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+      "requires": {
+        "source-map": "0.5.x"
+      }
+    },
+    "cliss": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.2.tgz",
+      "integrity": "sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==",
+      "requires": {
+        "command-line-usage": "^4.0.1",
+        "deepmerge": "^2.0.0",
+        "get-stdin": "^5.0.1",
+        "inspect-parameters-declaration": "0.0.9",
+        "object-to-arguments": "0.0.8",
+        "pipe-functions": "^1.3.0",
+        "strip-ansi": "^4.0.0",
+        "yargs-parser": "^7.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
+      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "requires": {
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "table-layout": "^0.4.2",
+        "typical": "^2.6.1"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "http://registry.npm.taobao.org/concat-stream/download/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.x.x"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
+      }
+    },
+    "cssom": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
+    },
+    "cssstyle": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
+      "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "http://registry.npm.taobao.org/currently-unhandled/download/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "requires": {
+        "uniq": "^1.0.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz",
+      "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo="
+    },
+    "data-urls": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
+      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "deep-is": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
+      "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg="
+    },
+    "deepmerge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
+      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "electron": {
+      "version": "1.8.8",
+      "resolved": "http://registry.npm.taobao.org/electron/download/electron-1.8.8.tgz",
+      "integrity": "sha1-qQzdsHUpH0lXaZPm9ci7RDkwHK4=",
+      "dev": true,
+      "requires": {
+        "@types/node": "^8.0.24",
+        "electron-download": "^3.0.1",
+        "extract-zip": "^1.0.3"
+      }
+    },
+    "electron-download": {
+      "version": "3.3.0",
+      "resolved": "http://registry.npm.taobao.org/electron-download/download/electron-download-3.3.0.tgz",
+      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "fs-extra": "^0.30.0",
+        "home-path": "^1.0.1",
+        "minimist": "^1.2.0",
+        "nugget": "^2.0.0",
+        "path-exists": "^2.1.0",
+        "rc": "^1.1.2",
+        "semver": "^5.3.0",
+        "sumchecker": "^1.2.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "http://registry.npm.taobao.org/fs-extra/download/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://registry.npm.taobao.org/jsonfile/download/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "electron-is-dev": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/electron-is-dev/download/electron-is-dev-1.0.1.tgz",
+      "integrity": "sha1-bgoYRzb+eup30YIQsLD2oCQCxLw="
+    },
+    "emphasize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/emphasize/-/emphasize-1.5.0.tgz",
+      "integrity": "sha1-48WvLdzLSYKCKjNJtHFhPMfOzJI=",
+      "requires": {
+        "chalk": "^1.1.3",
+        "highlight.js": "~9.12.0",
+        "lowlight": "~1.9.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "http://registry.npm.taobao.org/error-ex/download/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "http://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "http://registry.npm.taobao.org/es6-promise/download/es6-promise-4.2.5.tgz",
+      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ=",
+      "dev": true
+    },
+    "es6-promise-pool": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
+      "integrity": "sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-template": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "http://registry.npm.taobao.org/extract-zip/download/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fault": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
+      "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/fd-slicer/download/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "file-type": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "requires": {
+        "debug": "^2.6.9"
+      }
+    },
+    "for-each-property": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/for-each-property/-/for-each-property-0.0.4.tgz",
+      "integrity": "sha1-z6hXrsFCLh0Sb/CHhPz2Jim8g/Y=",
+      "requires": {
+        "get-prototype-chain": "^1.0.1"
+      }
+    },
+    "for-each-property-deep": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/for-each-property-deep/-/for-each-property-deep-0.0.3.tgz",
+      "integrity": "sha1-MTCaSvw4qcygbxsiP1PWSm0IP60=",
+      "requires": {
+        "for-each-property": "0.0.4"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-copy-file-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fs-copy-file-sync/-/fs-copy-file-sync-1.1.1.tgz",
+      "integrity": "sha512-2QY5eeqVv4m2PfyMiEuy9adxNP+ajf+8AR05cEi+OAzPcOj90hvFImeZhTmKLBgSd9EvG33jsD7ZRxsx9dThkQ=="
+    },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "get-pixels": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.0.tgz",
+      "integrity": "sha1-jZeVvq4YhQuED3SVgbrcBdPjbkE=",
+      "requires": {
+        "data-uri-to-buffer": "0.0.3",
+        "jpeg-js": "^0.1.1",
+        "mime-types": "^2.0.1",
+        "ndarray": "^1.0.13",
+        "ndarray-pack": "^1.1.1",
+        "node-bitmap": "0.0.1",
+        "omggif": "^1.0.5",
+        "parse-data-uri": "^0.2.0",
+        "pngjs": "^2.0.0",
+        "request": "^2.44.0",
+        "through": "^2.3.4"
+      }
+    },
+    "get-prototype-chain": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-prototype-chain/-/get-prototype-chain-1.0.1.tgz",
+      "integrity": "sha1-oXGhFeoeSQbG7ThDofABwYUQQW8="
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "home-path": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/home-path/download/home-path-1.0.6.tgz",
+      "integrity": "sha1-1UncJGU4in+GZyQsWzFYjSmvKfw=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "http://registry.npm.taobao.org/hosted-git-info/download/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
+    "html-minifier": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
+      "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.1.x",
+        "commander": "2.15.x",
+        "he": "1.1.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.3.x"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.1",
+      "resolved": "http://registry.npm.taobao.org/http-errors/download/http-errors-1.7.1.tgz",
+      "integrity": "sha1-ak/+XTUYjhw5+HJTRpBYWFLh8Cc=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "image-data-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/image-data-uri/-/image-data-uri-2.0.0.tgz",
+      "integrity": "sha512-PhIJxgfSQai/Xy8Nij1lWgK6++Y6x/ga2FKQTd8F71Nz2ArqtFr1F1UAREK0twrfp7mcEqidgGSF06No14/m+Q==",
+      "requires": {
+        "fs-extra": "^0.26.7",
+        "magicli": "0.0.8",
+        "mime-types": "^2.1.18",
+        "request": "^2.88.0"
+      },
+      "dependencies": {
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "requires": {
+            "mime-db": "~1.36.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "image-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-3.0.0.tgz",
+      "integrity": "sha1-FQKvMTX5BuEiyHfDHpSve3qRRsU=",
+      "requires": {
+        "file-type": "^4.1.0"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/indent-string/download/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inspect-function": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+      "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+      "requires": {
+        "split-skip": "0.0.1",
+        "unpack-string": "0.0.2"
+      },
+      "dependencies": {
+        "split-skip": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+          "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+        }
+      }
+    },
+    "inspect-parameters-declaration": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.9.tgz",
+      "integrity": "sha512-c3jrKKA1rwwrsjdGMAo2hFWV0vNe3/RKHxpE/OBt41LP3ynOVI1qmgxpZYK5SQu3jtWCyaho8L7AZzCjJ4mEUw==",
+      "requires": {
+        "magicli": "0.0.5",
+        "split-skip": "0.0.2",
+        "stringify-parameters": "0.0.4",
+        "unpack-string": "0.0.2"
+      },
+      "dependencies": {
+        "magicli": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+          "requires": {
+            "commander": "^2.9.0",
+            "get-stdin": "^5.0.1",
+            "inspect-function": "^0.2.1",
+            "pipe-functions": "^1.2.0"
+          }
+        }
+      }
+    },
+    "inspect-property": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz",
+      "integrity": "sha512-LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==",
+      "requires": {
+        "for-each-property": "0.0.4",
+        "for-each-property-deep": "0.0.3",
+        "inspect-function": "^0.3.1"
+      },
+      "dependencies": {
+        "inspect-function": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.3.4.tgz",
+          "integrity": "sha512-s0RsbJqK/sNZ+U1mykGoTickog3ea1A9Qk4mXniogOBu4PgkkZ56elScO7QC/r8D94lhGmJ2NyDI1ipOA/uq/g==",
+          "requires": {
+            "inspect-parameters-declaration": "0.0.8",
+            "magicli": "0.0.8",
+            "split-skip": "0.0.1",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          }
+        },
+        "inspect-parameters-declaration": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.8.tgz",
+          "integrity": "sha512-W4QzN1LgFmasKOM+NoLlDd2OAZM3enNZlVUOXoGQKmYBDFgxoPDOyebF55ALaf8avyM9TavNwibXxg347RrzCg==",
+          "requires": {
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+              "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+              "requires": {
+                "split-skip": "0.0.1",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "split-skip": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+                  "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+                }
+              }
+            },
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "split-skip": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+              "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+            }
+          }
+        },
+        "split-skip": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+          "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+        }
+      }
+    },
+    "iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+    },
+    "is-absolute": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "requires": {
+        "is-relative": "^0.2.1",
+        "is-windows": "^0.2.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-builtin-module/download/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/is-finite/download/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-relative": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "requires": {
+        "is-unc-path": "^0.1.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "requires": {
+        "unc-path-regex": "^0.1.0"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/is-utf8/download/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+    },
+    "is2": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-0.0.9.tgz",
+      "integrity": "sha1-EZVW0dFlGkG6EFr4AyZ8gLKZ9ik=",
+      "requires": {
+        "deep-is": "0.1.2"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jasmine": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+      "dev": true,
+      "requires": {
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.8.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "dev": true
+    },
+    "joplin-turndown": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/joplin-turndown/-/joplin-turndown-4.0.9.tgz",
+      "integrity": "sha512-8MOxX4t5Ai22muHhXPMGNoKc/AB7gSo0eUvNh6dyd6b3vcSiMIRZE8UHpMjS9ruJQ+8e+8TtJXc0nfbexeHwrA==",
+      "requires": {
+        "jsdom": "^11.9.0"
+      }
+    },
+    "joplin-turndown-plugin-gfm": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/joplin-turndown-plugin-gfm/-/joplin-turndown-plugin-gfm-1.0.7.tgz",
+      "integrity": "sha512-z0SveNcchtWwglkO7SgvDzPnVHYk1WumD0QRcWvUchIihqXwDVlve3G8AHkIhM69LY1YdC0HCZJlSMp2spBe/g=="
+    },
+    "jpeg-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
+      "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsdom": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "aws4": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
+          }
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "requires": {
+            "mime-db": "~1.36.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "request": {
+          "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.4.3",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+              "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+              "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jssha": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-2.3.1.tgz",
+      "integrity": "sha1-FHshJTaQNcpLL30hDcU58Amz3po="
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
+    "levenshtein": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/levenshtein/-/levenshtein-1.0.5.tgz",
+      "integrity": "sha1-ORFzepy1baNF0Aj1V4LG8TiXm6M="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/load-json-file/download/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash-es": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/loud-rejection/download/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lowlight": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "requires": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.12.0"
+      }
+    },
+    "magicli": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.8.tgz",
+      "integrity": "sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==",
+      "requires": {
+        "cliss": "0.0.2",
+        "find-up": "^2.1.0",
+        "for-each-property": "0.0.4",
+        "inspect-property": "0.0.6"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/map-obj/download/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "http://registry.npm.taobao.org/meow/download/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug=="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "~1.30.0"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+      "requires": {
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "moment": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multiparty": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npm.taobao.org/multiparty/download/multiparty-4.2.1.tgz",
+      "integrity": "sha1-2bbEbYuN6rHucMc0sK93HdRuCxM=",
+      "requires": {
+        "fd-slicer": "1.1.0",
+        "http-errors": "~1.7.0",
+        "safe-buffer": "5.1.2",
+        "uid-safe": "2.1.5"
+      },
+      "dependencies": {
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/fd-slicer/download/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "http://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        }
+      }
+    },
+    "nan": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+    },
+    "ndarray": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
+      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+      "requires": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "ndarray-pack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "requires": {
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
+      }
+    },
+    "needle": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
+      "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      }
+    },
+    "nextgen-events": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-0.11.3.tgz",
+      "integrity": "sha512-dC4v/dOF6m8/M05eU712KXjRJ0e/187rx5CMS/fTnulv2QGPps1U/c/J1D3wtegEhK+EE7LuJc3jly3pyfV46g=="
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node-abi": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.4.tgz",
+      "integrity": "sha512-DQ9Mo2mf/XectC+s6+grPPRQ1Z9gI3ZbrGv6nyXRkjwT3HrE0xvtvrfnH7YHYBLgC/KLadg+h3XHnhZw1sv88A==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-bitmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-bitmap/-/node-bitmap-0.0.1.tgz",
+      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE="
+    },
+    "node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "requires": {
+        "lodash.toarray": "^4.4.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-persist": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-2.1.0.tgz",
+      "integrity": "sha1-5lK784haBNrWo1PXQXYXfIORRwc=",
+      "requires": {
+        "is-absolute": "^0.2.6",
+        "mkdirp": "~0.5.1",
+        "q": "~1.1.1"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz",
+      "integrity": "sha512-16lql9QTqs6KsB9fl3neWyZm02KxIKdI9FlJjrB0y7eMTP5Nyz+xalwPbOlw3iw7EejllJPmlJSnY711PLD1ug==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "detect-libc": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+        }
+      }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
+    },
+    "npm-packlist": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "nugget": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/nugget/download/nugget-2.0.1.tgz",
+      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.3",
+        "minimist": "^1.1.0",
+        "pretty-bytes": "^1.0.2",
+        "progress-stream": "^1.1.0",
+        "request": "^2.45.0",
+        "single-line-log": "^1.1.2",
+        "throttleit": "0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "nwsapi": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
+      "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.taobao.org/object-keys/download/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "dev": true
+    },
+    "object-to-arguments": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.0.8.tgz",
+      "integrity": "sha512-BfWfuAwuhdH1bhMG5EG90WE/eckkBhBvnke8eSEkCDXoLE9Jk5JwYGTbCx1ehGwV48HvBkn62VukPBdlMUOY9w==",
+      "requires": {
+        "inspect-parameters-declaration": "0.0.10",
+        "magicli": "0.0.5",
+        "split-skip": "0.0.2",
+        "stringify-parameters": "0.0.4",
+        "unpack-string": "0.0.2"
+      },
+      "dependencies": {
+        "inspect-parameters-declaration": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.10.tgz",
+          "integrity": "sha512-L8/Bvt9iDXQTZ63xY5/MAyvzz+FagR/qGh1kIXvUpsno3AAE0Z95d6QO51zrcMGaEGpwh/57idfMxTxbvRmytg==",
+          "requires": {
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          }
+        },
+        "magicli": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+          "requires": {
+            "commander": "^2.9.0",
+            "get-stdin": "^5.0.1",
+            "inspect-function": "^0.2.1",
+            "pipe-functions": "^1.2.0"
+          }
+        }
+      }
+    },
+    "omggif": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
+      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "parse-data-uri": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-data-uri/-/parse-data-uri-0.2.0.tgz",
+      "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
+      "requires": {
+        "data-uri-to-buffer": "0.0.3"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/pend/download/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "http://registry.npm.taobao.org/pinkie/download/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pipe-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pipe-functions/-/pipe-functions-1.3.0.tgz",
+      "integrity": "sha512-6Rtbp7criZRwedlvWbUYxqlqJoAlMvYHo2UcRWq79xZ54vZcaNHpVBOcWkX3ErT2aUA69tv+uiv4zKJbhD/Wgg=="
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+    },
+    "pngjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-2.3.1.tgz",
+      "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
+    },
+    "prebuild-install": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "pretty-bytes": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/pretty-bytes/download/pretty-bytes-1.0.4.tgz",
+      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1",
+        "meow": "^3.1.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.taobao.org/get-stdin/download/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress-stream": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/progress-stream/download/progress-stream-1.2.0.tgz",
+      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+      "dev": true,
+      "requires": {
+        "speedometer": "~0.1.2",
+        "through2": "~0.2.3"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "proper-lockfile": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.1.tgz",
+      "integrity": "sha1-FZ+wYZPTIAP0s2kd0uwaY0qoDR0=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      }
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+      "integrity": "sha1-Y1fikSBnAdmfGXq4TlforRlvKok="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "querystringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/random-bytes/download/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "read-chunk": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+      "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+      "requires": {
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/read-pkg/download/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/redent/download/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/repeating/download/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.0.tgz",
+      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+    },
+    "sharp": {
+      "version": "0.20.8",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.20.8.tgz",
+      "integrity": "sha512-A8NaPGWRDKpmHTi8sl2xzozYXhTQWBb/GaJ8ZPU7L/vKW8wVvd4Yq+isJ0c7p9sX5gnjPQcM3eOfHuvvnZ2fOQ==",
+      "requires": {
+        "color": "^3.0.0",
+        "detect-libc": "^1.0.3",
+        "fs-copy-file-sync": "^1.1.1",
+        "nan": "^2.11.0",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^4.0.0",
+        "semver": "^5.5.1",
+        "simple-get": "^2.8.1",
+        "tar": "^4.4.6",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+          "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "semver": {
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+        },
+        "tar": {
+          "version": "4.4.6",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+          "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "single-line-log": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/single-line-log/download/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "spdx-correct": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/spdx-correct/download/spdx-correct-3.0.2.tgz",
+      "integrity": "sha1-GbtAnpG0exrVQVkkP3MSqFjbPC4=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/spdx-exceptions/download/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/spdx-expression-parse/download/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/spdx-license-ids/download/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha1-pZ78CXhMKlutoTz+r1x13SFARNI=",
+      "dev": true
+    },
+    "speedometer": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npm.taobao.org/speedometer/download/speedometer-0.1.4.tgz",
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
+      "dev": true
+    },
+    "split-skip": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+      "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "sqlite3": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.1.tgz",
+      "integrity": "sha512-i8LtU2fdEGFEt4Kcs7eNjYdGmnAQ8zWlaOv6Esbq/jfVfR0Qbn/1dgVyKebrMc2zN7h3oHsqla9zq7AJ0+34ZA==",
+      "requires": {
+        "nan": "~2.10.0",
+        "node-pre-gyp": "~0.10.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "http://registry.npm.taobao.org/statuses/download/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-kit": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.6.14.tgz",
+      "integrity": "sha512-Sz9Q98Q4JKLaOaXUYLSO8ScWhO9z/itJ53GJOLl+w/wR9XXFt82MzN4Q5pwXN9QZCN1/aCnZhOe67ANK8Vs6Vw==",
+      "requires": {
+        "xregexp": "^3.2.0"
+      }
+    },
+    "string-padding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-padding/-/string-padding-1.0.2.tgz",
+      "integrity": "sha1-OqrYVbPpc1xeQS3+chmMz5nH9I4="
+    },
+    "string-to-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.0.tgz",
+      "integrity": "sha1-rPLJ6tHEGOFIUJoS0su0afMzohg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-parameters": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+      "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+      "requires": {
+        "magicli": "0.0.5",
+        "unpack-string": "0.0.2"
+      },
+      "dependencies": {
+        "magicli": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+          "requires": {
+            "commander": "^2.9.0",
+            "get-stdin": "^5.0.1",
+            "inspect-function": "^0.2.1",
+            "pipe-functions": "^1.2.0"
+          }
+        }
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/strip-bom/download/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/strip-indent/download/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.taobao.org/get-stdin/download/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "sumchecker": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.taobao.org/sumchecker/download/sumchecker-1.3.1.tgz",
+      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es6-promise": "^4.0.5"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+    },
+    "syswide-cas": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/syswide-cas/-/syswide-cas-5.2.0.tgz",
+      "integrity": "sha512-I81xC4l8ECPonkPyYPYUw+IO1ebE4W3fMV9KeavvF/5Snlg3T1DLhWFTm9C32YVOHU70VdONPlGCotaBMG2cFA=="
+    },
+    "table-layout": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
+      "requires": {
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.6.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
+      }
+    },
+    "tar": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
+      "integrity": "sha512-gJlTiiErwo96K904FnoYWl+5+FBgS+FimU6GMh66XLdLa55al8+d4jeDfPoGwSNHdtWI5FJP6xurmVqhBuGJpQ==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.3",
+        "minipass": "^2.2.1",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "yallist": "^3.0.2"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "tcp-port-used": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-0.1.2.tgz",
+      "integrity": "sha1-lFDodoyDtBb9TRpqlEnuzL9JbCk=",
+      "requires": {
+        "debug": "0.7.4",
+        "is2": "0.0.9",
+        "q": "0.9.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "q": {
+          "version": "0.9.7",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
+        }
+      }
+    },
+    "terminal-kit": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.15.1.tgz",
+      "integrity": "sha512-nk0+wDRfcvjnBXW6b2X2SFBzCMbT5ZJX56rRvmq/CFaimMYfWHU1eooy33RmzWByXWkkI71zx17q3vlp71OUNA==",
+      "requires": {
+        "async-kit": "^2.2.3",
+        "get-pixels": "^3.3.0",
+        "ndarray": "^1.0.18",
+        "nextgen-events": "^0.11.2",
+        "string-kit": "^0.6.9",
+        "tree-kit": "^0.5.26"
+      }
+    },
+    "throttleit": {
+      "version": "0.0.2",
+      "resolved": "http://registry.npm.taobao.org/throttleit/download/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "http://registry.npm.taobao.org/through2/download/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "http://registry.npm.taobao.org/isarray/download/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "http://registry.npm.taobao.org/xtend/download/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
+    "tkwidgets": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/tkwidgets/-/tkwidgets-0.5.26.tgz",
+      "integrity": "sha512-zxhwsBpxD5fglnqHYZ9ZjunC8Hc67u/7QXzxHmhAIzzSr4a/Cq5PbzCeHsBZ7WL99uBUa6xgVLfjmGxnFU8XMg==",
+      "requires": {
+        "chalk": "^2.1.0",
+        "emphasize": "^1.5.0",
+        "node-emoji": "git+https://github.com/laurent22/node-emoji.git#9fa01eac463e94dde1316ef8c53089eeef4973b5",
+        "slice-ansi": "^1.0.0",
+        "string-width": "^2.1.1",
+        "terminal-kit": "^1.13.11",
+        "wrap-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "node-emoji": {
+          "version": "git+https://github.com/laurent22/node-emoji.git#9fa01eac463e94dde1316ef8c53089eeef4973b5",
+          "from": "git+https://github.com/laurent22/node-emoji.git",
+          "requires": {
+            "lodash.toarray": "^4.4.0"
+          }
+        }
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
+    "tree-kit": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/tree-kit/-/tree-kit-0.5.26.tgz",
+      "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8="
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/trim-newlines/download/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "http://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+    },
+    "uc.micro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
+    },
+    "uglify-js": {
+      "version": "3.3.25",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+      "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
+      "requires": {
+        "commander": "~2.15.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "http://registry.npm.taobao.org/uid-safe/download/uid-safe-2.1.5.tgz",
+      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "unidecode": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
+      "integrity": "sha1-77swFTi8RSRqmsjFWdcvAVMFBT4="
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "unpack-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/unpack-string/-/unpack-string-0.0.2.tgz",
+      "integrity": "sha1-MC7PCCOLATm9Q0pNf9Z83zPKJ10="
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "url-parse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+      "requires": {
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "http://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+      "integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
+      "requires": {
+        "iconv-lite": "0.4.23"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
+      "integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw=="
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "wordwrapjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "requires": {
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xregexp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+      "integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "http://registry.npm.taobao.org/yauzl/download/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/HeadlessClient/package.json
+++ b/HeadlessClient/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "joplin",
+  "description": "Joplin CLI Client",
+  "license": "MIT",
+  "author": "Laurent Cozic",
+  "bugs": {
+    "url": "https://github.com/laurent22/joplin/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/laurent22/joplin"
+  },
+  "copyright": {
+    "title": "Joplin CLI",
+    "years": [
+      2016,
+      2017,
+      2018
+    ],
+    "owner": "Laurent Cozic"
+  },
+  "version": "1.0.117",
+  "main": "./main.js",
+  "bin": {
+    "joplin-cli": "./main.js"
+  },
+  "engines": {
+    "node": ">=8.7.0"
+  },
+  "dependencies": {
+    "app-module-path": "^2.2.0",
+    "async-mutex": "^0.1.3",
+    "base-64": "^0.1.0",
+    "compare-version": "^0.1.2",
+    "electron-is-dev": "^1.0.1",
+    "es6-promise-pool": "^2.5.0",
+    "follow-redirects": "^1.2.4",
+    "form-data": "^2.1.4",
+    "fs-extra": "^5.0.0",
+    "html-entities": "^1.2.1",
+    "html-minifier": "^3.5.15",
+    "image-data-uri": "^2.0.0",
+    "image-type": "^3.0.0",
+    "is-electron": "^2.2.0",
+    "joplin-turndown": "^4.0.9",
+    "joplin-turndown-plugin-gfm": "^1.0.7",
+    "jssha": "^2.3.0",
+    "levenshtein": "^1.0.5",
+    "lodash": "^4.17.4",
+    "markdown-it": "^8.4.2",
+    "md5": "^2.2.1",
+    "mime": "^2.0.3",
+    "moment": "^2.18.1",
+    "multiparty": "^4.2.1",
+    "node-emoji": "^1.8.1",
+    "node-fetch": "^1.7.1",
+    "node-persist": "^2.1.0",
+    "promise": "^7.1.1",
+    "proper-lockfile": "^2.0.1",
+    "query-string": "4.3.4",
+    "read-chunk": "^2.1.0",
+    "redux": "^3.7.2",
+    "sax": "^1.2.2",
+    "server-destroy": "^1.0.1",
+    "sharp": "^0.20.8",
+    "sprintf-js": "^1.1.1",
+    "sqlite3": "^4.0.1",
+    "string-padding": "^1.0.2",
+    "string-to-stream": "^1.1.0",
+    "strip-ansi": "^4.0.0",
+    "syswide-cas": "^5.2.0",
+    "tar": "^4.4.0",
+    "tcp-port-used": "^0.1.2",
+    "tkwidgets": "^0.5.26",
+    "unidecode": "^0.1.8",
+    "url-parse": "^1.2.0",
+    "uuid": "^3.0.1",
+    "valid-url": "^1.0.9",
+    "word-wrap": "^1.2.3",
+    "xml2js": "^0.4.19",
+    "yargs-parser": "^7.0.0"
+  },
+  "devDependencies": {
+    "jasmine": "^2.6.0",
+    "electron": "^1.8.7",
+    "electron-builder": "20.14.7"
+  },
+  "scripts": {
+    "test": "jasmine",
+    "pack": "node_modules/.bin/electron-builder --dir",
+    "dist": "node_modules/.bin/electron-builder",
+    "appimage": "node_modules/.bin/electron-builder --linux AppImage",
+    "publish": "build -p always"
+  }
+}

--- a/HeadlessClient/run.sh
+++ b/HeadlessClient/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+CLIENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bash "$CLIENT_DIR/build.sh" && $CLIENT_DIR/build/node_modules/electron/dist/electron "$CLIENT_DIR/build/main.js" --profile ~/Temp/TestNotes2 --stack-trace-enabled --log-level debug --env dev "$@"
+
+# bash $CLIENT_DIR/build.sh && NODE_PATH="$CLIENT_DIR/build/" node build/main.js --profile ~/.config/joplin --stack-trace-enabled --log-level debug "$@"

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -95,7 +95,7 @@ class BaseApplication {
 	async handleStartFlags_(argv, setDefaults = true) {
 		let matched = {};
 		argv = argv.slice(0);
-		argv.splice(0, 2); // First arguments are the node executable, and the node JS file
+		argv.splice(0, argv.length > 1 && argv[1].endsWith('.js') ? 2 :1); // First arguments are the node executable, and the node JS file
 
 		while (argv.length) {
 			let arg = argv[0];

--- a/ReactNativeClient/lib/locale.js
+++ b/ReactNativeClient/lib/locale.js
@@ -188,7 +188,7 @@ function defaultLocale() {
 }
 
 function supportedLocales() {
-	if (!supportedLocales_) supportedLocales_ = require('../locales/index.js').locales;
+	if (!supportedLocales_) supportedLocales_ = require('locales/index.js').locales;
 
 	let output = [];
 	for (let n in supportedLocales_) {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -156,6 +156,8 @@ class Setting extends BaseModel {
 			'net.ignoreTlsErrors': { value: false, type: Setting.TYPE_BOOL, show: (settings) => { return [SyncTargetRegistry.nameToId('nextcloud'), SyncTargetRegistry.nameToId('webdav')].indexOf(settings['sync.target']) >= 0 }, public: true, appTypes: ['desktop', 'cli'], label: () => _('Ignore TLS certificate errors') },
 		
 			'api.token': { value: null, type: Setting.TYPE_STRING, public: false },
+			'api.port': { value: null, type: Setting.TYPE_INT, public: true, appTypes: ['cli'], description: () => _('Specify the port that should be used by the API server. If not set, a default will be used.') },
+			'api.host': { value: '127.0.0.1', type: Setting.TYPE_STRING, public: true, appTypes: ['cli'], description: () => _('Specify the host that should be used by the API server. If not set, 127.0.0.1 will be used.') },
 		};
 
 		return this.metadata_;

--- a/ReactNativeClient/lib/randomClipperPort.js
+++ b/ReactNativeClient/lib/randomClipperPort.js
@@ -1,20 +1,22 @@
 function randomClipperPort(state, env) {
-	const startPorts = {
-		prod: 41184,
-		dev: 27583,
-	};
-
-	const startPort = env === 'prod' ? startPorts.prod : startPorts.dev;
-
 	if (!state) {
 		state = { offset: 0 };
 	} else {
 		state.offset++;
 	}
 
-	state.port = startPort + state.offset;
+	state.port = startPort(env) + state.offset;
 
 	return state;
 }
 
-module.exports = randomClipperPort;
+function startPort(env) {
+	const startPorts = {
+		prod: 41184,
+		dev: 27583,
+	};
+
+	return env === 'prod' ? startPorts.prod : startPorts.dev;
+}
+
+module.exports = { randomClipperPort, startPort };

--- a/ReactNativeClient/lib/services/WebClipService.js
+++ b/ReactNativeClient/lib/services/WebClipService.js
@@ -160,17 +160,18 @@ class WebClipService extends BaseService {
 		this.addingNotes_ = true;
 
 		let count = 0;
-		const options = { conditions: ['title = body'] };
+		const options = { conditions: ['(title = body OR body = "")'] };
 		if (limit) options.limit = limit;
 		const notes = await Note.previews(null, options);
 		for (let i = 0; i < notes.length; i++) {
 			const note = notes[i]
+			if (note.body === '' && isUrl(note.title)) note.body = note.title;
 			if (isUrl(note.body)) {
 				const added = this.queueWebClipTask(note);
 				if (added) count++;
 			} else {
 				this.logger().debug("not queueWebClipTask for" + note.title);
-				//Note.save({ id: note.id, body: '\n'+note.body });
+				Note.save({ id: note.id, body: note.body + '\n' });
 			}
 		}
 

--- a/ReactNativeClient/lib/services/WebClipService.js
+++ b/ReactNativeClient/lib/services/WebClipService.js
@@ -1,0 +1,212 @@
+const Note = require('lib/models/Note');
+const Resource = require('lib/models/Resource');
+const ResourceFetcher = require('lib/services/ResourceFetcher');
+const BaseService = require('lib/services/BaseService');
+const WebClipper = require('lib/services/WebClipper');
+const BaseSyncTarget = require('lib/BaseSyncTarget');
+const { Logger } = require('lib/logger.js');
+const EventEmitter = require('events');
+const isUrl = require('valid-url').isWebUri;
+const HtmlToMd = require('lib/HtmlToMd');
+const markdownUtils = require('lib/markdownUtils');
+const Api = require('lib/services/rest/Api');
+const api = new Api(() => {
+	return Setting.value('api.token');
+});
+
+class WebClipService extends BaseService {
+
+	constructor(dispatch = null) {
+		super();
+		
+		this.logger_ = new Logger();
+		this.queue_ = [];
+		this.dispatch = dispatch;
+		this.fetchingItems_ = {};
+		this.maxWebClipTasks_ = 3;
+		this.addingNotes_ = false;
+		this.eventEmitter_ = new EventEmitter();
+	}
+
+	static instance() {
+		if (this.instance_) return this.instance_;
+		this.instance_ = new WebClipService();
+		return this.instance_;
+	}
+
+	on(eventName, callback) {
+		return this.eventEmitter_.on(eventName, callback);
+	}
+
+	off(eventName, callback) {
+		return this.eventEmitter_.removeListener(eventName, callback);
+	}
+
+	setLogger(logger) {
+		this.logger_ = logger;
+	}
+
+	logger() {
+		return this.logger_;
+	}
+
+	clipper() {
+		if (!this.clipper_)
+			this.clipper_ = new WebClipper(this);
+		return this.clipper_;
+	}
+
+	htmlToMdParser() {
+		if (this.htmlToMdParser_) return this.htmlToMdParser_;
+		this.htmlToMdParser_ = new HtmlToMd();
+		return this.htmlToMdParser_;
+	}
+
+	queuedItemIndex_(noteId) {
+		for (let i = 0; i < this.fetchingItems_.length; i++) {
+			const item = this.fetchingItems_[i];
+			if (item.id === noteId) return i;
+		}
+		return -1;
+	}
+
+	queueWebClipTask(note, priority = null) {
+		if (!note.id || !isUrl(note.body)) return false;
+		if (priority === null) priority = 'normal';
+
+		const index = this.queuedItemIndex_(note.id);
+		if (index >= 0) return false;
+
+		const item = {id: note.id, url: note.body};
+
+		if (priority === 'high') {
+			this.queue_.splice(0, 0, item);
+		} else {
+			this.queue_.push(item);
+		}
+
+		this.scheduleQueueProcess();
+		return true;
+	}
+
+	async startWebClipTask_(noteId, url) {
+		if (this.fetchingItems_[noteId]) return;
+		this.fetchingItems_[noteId] = true;
+
+		const completeWebClipTask = (emit = true) => {
+			delete this.fetchingItems_[noteId];
+			this.scheduleQueueProcess();
+			if (emit) this.eventEmitter_.emit('webClipTaskComplete', { id: noteId });
+		}
+
+		try {
+			const clipper = this.clipper();
+			const newNote = await clipper.clipSimplifiedPage(noteId, url);
+			const htmlToMdParser = this.htmlToMdParser();
+			const newBody = await htmlToMdParser.parse('<div>' + newNote.html + '</div>', {
+				baseUrl: newNote.base_url ? newNote.base_url : '',
+			});
+			const imageUrls = markdownUtils.extractImageUrls(newBody);
+
+			this.logger().debug('clipHtml (' + noteId + '): Downloading images: ', imageUrls);
+
+			let result = await api.downloadImages_(imageUrls);
+
+			this.logger().debug('clipHtml (' + noteId + '): Creating resources from paths: ', result);
+
+			result = await api.createResourcesFromPaths_(result);
+			await api.removeTempFiles_(result);
+			const noteBody = api.replaceImageUrlsByResources_(newBody, result);
+			Note.save({
+				id: noteId,
+				body: noteBody,
+				title: newNote.title,
+				source_url: newNote.source_url,
+			});
+			this.logger().info("completeWebClipTask" + noteId + " " + newNote.title);
+			completeWebClipTask();
+		} catch(error) {
+			this.logger().error('WebClipService: Could not download note: ' + noteId, error);
+			completeWebClipTask();
+		}
+	}
+
+	async processQueue_() {
+		while (this.queue_.length && !this.clipper().loading_) {
+			const item = this.queue_.splice(0, 1)[0];
+			await this.startWebClipTask_(item.id, item.url);
+		}
+
+		if (!this.queue_.length) {
+			this.autoAddNotes(10);
+		}
+	}
+
+	async waitForAllFinished() {
+		return new Promise((resolve, reject) => {
+			const iid = setInterval(() => {
+				if (!this.queue_.length && !Object.getOwnPropertyNames(this.fetchingItems_).length) {
+					clearInterval(iid);
+					resolve();
+				}
+			}, 100);
+		});
+	}
+
+	async autoAddNotes(limit) {
+		if (this.addingNotes_) return;
+		this.addingNotes_ = true;
+
+		let count = 0;
+		const options = { conditions: ['title = body'] };
+		if (limit) options.limit = limit;
+		const notes = await Note.previews(null, options);
+		for (let i = 0; i < notes.length; i++) {
+			const note = notes[i]
+			if (isUrl(note.body)) {
+				const added = this.queueWebClipTask(note);
+				if (added) count++;
+			} else {
+				this.logger().debug("not queueWebClipTask for" + note.title);
+				//Note.save({ id: note.id, body: '\n'+note.body });
+			}
+		}
+
+		this.logger().info('WebClipService: Auto-added notes: ' + count);
+		this.addingNotes_ = false;
+	}
+
+	async exit() {
+		await this.waitForAllFinished();
+		if (this.scheduleQueueProcessIID_) {
+			clearTimeout(this.scheduleQueueProcessIID_);
+			this.scheduleQueueProcessIID_ = null;
+		}
+		this.clipper().stop();
+		this.clipper_ =null;
+	}
+
+	async start() {
+		this.autoAddNotes(10);
+	}
+
+	scheduleQueueProcess() {
+		if (this.scheduleQueueProcessIID_) {
+			clearTimeout(this.scheduleQueueProcessIID_);
+			this.scheduleQueueProcessIID_ = null;
+		}
+
+		let scheduleIID = setTimeout(() => {
+			this.processQueue_(scheduleIID);
+			this.scheduleQueueProcessIID_ = null;
+		}, 100);
+		this.scheduleQueueProcessIID_ = scheduleIID;
+	}
+
+	async fetchAll() {
+		this.autoAddNotes(null);
+	}
+
+}
+
+module.exports = WebClipService;

--- a/ReactNativeClient/lib/services/WebClipService.js
+++ b/ReactNativeClient/lib/services/WebClipService.js
@@ -2,7 +2,6 @@ const Note = require('lib/models/Note');
 const Resource = require('lib/models/Resource');
 const ResourceFetcher = require('lib/services/ResourceFetcher');
 const BaseService = require('lib/services/BaseService');
-const WebClipper = require('lib/services/WebClipper');
 const BaseSyncTarget = require('lib/BaseSyncTarget');
 const { Logger } = require('lib/logger.js');
 const EventEmitter = require('events');
@@ -51,8 +50,11 @@ class WebClipService extends BaseService {
 	}
 
 	clipper() {
-		if (!this.clipper_)
+		if (!this.clipper_) {
+			// lazy load for electron, so that this module can be required by nodejs
+			const WebClipper = require('lib/services/WebClipper');
 			this.clipper_ = new WebClipper(this);
+		}
 		return this.clipper_;
 	}
 

--- a/ReactNativeClient/lib/services/WebClipper.js
+++ b/ReactNativeClient/lib/services/WebClipper.js
@@ -20,8 +20,8 @@ class WebClipper extends BaseService {
 			this.win_ = new BrowserWindow({
 				width: 1280,
 				height: 720,
-				show: true,
-				offscreen: false,
+				show: false,
+				offscreen: true,
 				nodeIntegration: false,
 				webPreferences: {
 					preload: 'clipper-preload.js',

--- a/ReactNativeClient/lib/services/WebClipper.js
+++ b/ReactNativeClient/lib/services/WebClipper.js
@@ -1,0 +1,221 @@
+const fs = require('fs');
+const { reg } = require('lib/registry.js');
+const { _ } = require('lib/locale.js');
+const BaseService = require('lib/services/BaseService');
+const { BrowserWindow, ipcMain } = require('electron');
+const url = require('url');
+const path = require('path');
+
+function getContentScript(name) {
+    const scriptPath = path.join(__dirname, '..', 'content_scripts', name + '.js');
+    return fs.readFileSync(scriptPath).toString('utf-8');
+}
+const JSDOMParser_js = getContentScript('JSDOMParser');
+const Readablility_js= getContentScript('Readability');
+const webclipper_js = getContentScript('webclipper');
+
+class WebClipper extends BaseService {
+
+	constructor() {
+		super();
+		this.win_ = null;
+		this.browserDomReady = false;
+		this.loading_ = null;
+	}
+
+	webview() {
+		if (!this.win_) {
+			this.win_ = new BrowserWindow({
+				width: 1280,
+				height: 720,
+				show: true,
+				offscreen: false,
+				nodeIntegration: false,
+				webPreferences: {
+					preload: 'clipper-preload.js',
+				}
+			});
+			this.win_.loadURL(url.format({
+				pathname: path.join(__dirname, 'webclipper.html'),
+				protocol: 'file:',
+				slashes: true
+			}));
+			const webContents = this.win_.webContents;
+			//webContents.setFrameRate(1);
+			//webContents.stopPainting();
+			webContents.on('dom-ready', this.browser_domReady.bind(this));
+			webContents.on('will-attach-webview', this.browser_willAttachWebview.bind(this));
+			webContents.on('did-attach-webview', this.browser_didAttachWebview.bind(this));
+			ipcMain.on('clipHtml', this.clipHtml.bind(this));
+		}
+		return this.win_;
+	}
+
+	stop() {
+		if (this.win_) {
+			//this.win_.close();
+			this.win_ = null;
+		}
+	}
+
+	startWebview_(url) {
+		if (this.loading_) {
+			this.loading_.url = url;
+		} else {
+			this.loading_ = {url: url};
+		}
+		if(this.browserDomReady) {
+			const webContents = this.win_.webContents;
+			const loadURL = () => {
+				webContents.send('webclipper', {
+					type: 'loadURL',
+					id: this.loading_.id,
+					value: url,
+				});
+			};
+			const openDevTools = false;
+			if (openDevTools) {
+				webContents.openDevTools();
+				webContents.on('devtools-opened', loadURL);
+			} else {
+				loadURL();
+			}
+		} else {
+			this.webview();
+		}
+	}
+
+	stopWebview_() {
+		if (this.win_)
+			this.win_.webContents.send('webclipper', {
+				type: 'stopWebview',
+				id: this.loading_.id,
+				value: this.loading_.url,
+			});
+		this.loading_ = null;
+	}
+
+	resolve(note) {
+		const resolve = this.loading_ ? this.loading_.resolve : null;
+		this.stopWebview_();
+		if (resolve) {
+			//this.win_.close();
+			resolve(note);
+		} else {
+			this.logger().warn('WebClipping resolve failed for ', note);
+		}
+	}
+
+	reject(reason) {
+		const reject = this.loading_ ? this.loading_.reject : null;
+		this.stopWebview_();
+		if (reject) {
+			this.win_.close();
+			reject(reason);
+		} else {
+			this.logger().warn('WebClipping reject failed for ', reason);
+		}
+	}
+
+	browser_domReady(event) {
+		this.browserDomReady = true;
+		this.startWebview_(this.loading_.url);
+		const webContents = this.win_.webContents;
+		webContents.on('console-message', this.browser_consoleMessage.bind(this));
+	}
+
+	browser_willAttachWebview(event, webPreference, params) {
+		this.logger().info('browser_willAttachWebview', this.loading_.id, params.src);
+	}
+
+	browser_didAttachWebview(event, guestContents) {
+		this.logger().info('browser_didAttachWebview', this.loading_.id, this.loading_.url);
+		const webContents = this.win_.webContents;
+		webContents.send('webclipper', {
+			type: 'attachIpcMessage',
+			id: this.loading_.id,
+			value: this.loading_.url,
+		});
+		//this.loading_.webContents = guestContents;
+		//guestContents.on('dom-ready', this.webview_domReady.bind(this));
+		//guestContents.on('ipc-message', this.webview_ipcMessage.bind(this));
+		//guestContents.on('message', this.webview_message.bind(this));
+		guestContents.on('console-message', this.webview_consoleMessage.bind(this));
+	}
+	browser_consoleMessage(event, level, message, line, sourceId, args) {
+		this.logger().debug("webclipper console.log: " + message);
+	}
+
+	clipHtml(event, args) {
+		const data = args && args.length ? args[0] : {};
+		try {
+			if (data.title && data.html) {
+				this.resolve(data);
+			} else {
+				this.reject(Error('Web clipping failed without html'));
+			}
+		} catch (error) {
+			this.reject(error);
+		}
+	}
+
+	webview_domReady() {
+        const webContents = this.loading_.webContents;
+
+		webContents.on('did-navigate', (event) => {
+			const url = event.url;
+            this.logger().debug("did-navigate' for ", this.loading_.id || 'not_loading_', url);
+			//this.props.updateMdClipping(HtmlToMd(htmlBody));
+		});
+        webContents.on('devtools-opened', (event) => {
+            webContents.executeJavaScript('console.debug("executeJavascript ok __dirname=' +
+                __dirname + '");');
+        });
+		//webContents.openDevTools();
+	}
+
+	webview_consoleMessage(event, level, message, line, sourceId, args) {
+		if (sourceId.startsWith('/') || sourceId === '')
+		this.logger().debug("webclipper console.log from ", event.sender.history[0], message);
+	}
+
+	webview_message(event, args) {
+		this.logger.debug('webview_message');
+	}
+
+    webview_ipcMessage(channel, args) {
+        const arg0 = args && args.length >= 1 ? args[0] : null;
+        const arg1 = args && args.length >= 2 ? args[1] : null;
+
+        //reg.logger().debug('Got ipc-message: ' + msg, args);
+
+        if (channel === 'clipHtml') {
+            const newNote = arg0;
+			this.resolve(newNote);
+        } else if (channel === "log") {
+            this.logger().debug(...args);
+        } else if (channel.indexOf('#') === 0) {
+            // This is an internal anchor, which is handled by the WebView so skip this case
+        } else {
+            this.logger().error(_('Unsupported link or message: %s', channel));
+        }
+    }
+
+	clipSimplifiedPage(id, url) {
+		if (this.loading_) {
+			return new Promise((resolve, reject) => {
+				reject(new Error("WebClipper loading another url: "
+					+ this.loading_.url + ' for ' + this.loading_.id));
+			});
+		}
+		this.loading_ = { id: id, url: url, };
+
+		this.startWebview_(url);
+		return new Promise((resolve, reject) => {
+			this.loading_.resolve = resolve;
+			this.loading_.reject = reject;
+		});
+	}
+}
+
+module.exports = WebClipper;

--- a/ReactNativeClient/lib/services/WebClipper.js
+++ b/ReactNativeClient/lib/services/WebClipper.js
@@ -1,18 +1,8 @@
-const fs = require('fs');
 const { reg } = require('lib/registry.js');
 const { _ } = require('lib/locale.js');
 const BaseService = require('lib/services/BaseService');
-const { BrowserWindow, ipcMain } = require('electron');
 const url = require('url');
 const path = require('path');
-
-function getContentScript(name) {
-    const scriptPath = path.join(__dirname, '..', 'content_scripts', name + '.js');
-    return fs.readFileSync(scriptPath).toString('utf-8');
-}
-const JSDOMParser_js = getContentScript('JSDOMParser');
-const Readablility_js= getContentScript('Readability');
-const webclipper_js = getContentScript('webclipper');
 
 class WebClipper extends BaseService {
 
@@ -25,6 +15,8 @@ class WebClipper extends BaseService {
 
 	webview() {
 		if (!this.win_) {
+			// lazy load for electron, so that this module can be required by nodejs
+			const { BrowserWindow, ipcMain } = require('electron');
 			this.win_ = new BrowserWindow({
 				width: 1280,
 				height: 720,

--- a/ReactNativeClient/lib/services/clipper-main.js
+++ b/ReactNativeClient/lib/services/clipper-main.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const {ipcRenderer} = require('electron');
+
+function getContentScript(name) {
+	const scriptPath = path.join(__dirname, '..', 'content_scripts', name + '.js');
+	return fs.readFileSync(scriptPath).toString('utf-8');
+}
+const JSDOMParser_js = getContentScript('JSDOMParser');
+const Readablility_js= getContentScript('Readability');
+const webclipper_js = getContentScript('webclipper');
+
+function attachWebviewIpcMessage(webview, url) {
+	if (!webview) webview = document.getElementById("webview");
+	const URL = url;
+	const ipcEventHandler = (event) => {
+		console.log("on ipc-message: " + event.channel + " " + event.args);
+		ipcRenderer.send(event.channel, event.args);
+	};
+	webview.addEventListener("ipc-message", ipcEventHandler);
+}
+function attachWebviewDOMReadyEvent(webview, url) {
+	if (!webview) webview = document.getElementById("webview");
+	const webContents = webview.getWebContents();
+	webview.addEventListener("did-start-loading", (event) => {
+		console.log("on did-start-loading " + url);
+		const webContents = webview.getWebContents();
+		//webContents.openDevTools();
+	});
+	webview.addEventListener("dom-ready", (event) => {
+		console.log("on dom-ready " + url);
+		const webContents = webview.getWebContents();
+		webContents.executeJavaScript('console.log("start JSDOMParser");');
+		webContents.executeJavaScript(''
+			+ 'console.debug("start JSDOMParser");' + JSDOMParser_js + '\n'
+			+ 'console.debug("start Readablility");' + Readablility_js + '\n'
+			+ 'console.debug("start webclipper");' + webclipper_js + '\n'
+			+ 'console.debug("done  webclipper");' , () => {
+					console.debug('executeJavaScript done for ' + url );
+		});
+	});
+}
+
+ipcRenderer.on('webclipper', (event, args) => {
+	console.log("ipcRenderer on webclipper " + args.type
+		+ ' ' + args.id + ' ' + args.value, event);
+	if (args.type === 'loadURL') {
+		const url = args.value;
+		document.body.innerHTML = '<webview id=webview style="width:100%; height:100%" src="' + url + '" preload="clipper-preload.js" />'
+		attachWebviewIpcMessage(webview, url);
+		attachWebviewDOMReadyEvent(webview, url);
+	} else if (args.type === 'attachIpcMessage') {
+		const webview = document.getElementById("webview");
+	} if (args.type === 'stopWebview') {
+		document.body.innerHTML = '';
+	}
+});
+

--- a/ReactNativeClient/lib/services/clipper-preload.js
+++ b/ReactNativeClient/lib/services/clipper-preload.js
@@ -1,0 +1,54 @@
+// In order to give access to the webview to certain functions of the main process, we need
+// this bridge which listens from the main process and sends to the webview and the other
+// way around. This is necessary after having enabled the "contextIsolation" option, which
+// prevents the webview from accessing low-level methods in the main process.
+
+const ipcRenderer = require('electron').ipcRenderer;
+const isUrl = require('valid-url').isWebUri;
+
+ipcRenderer.on('setHtml', (event, html) => {
+    if (isUrl(html))
+    	html = '<iframe style="width:100%; height:100%; padding:0; margin:0" src="'+html+'"></iframe>';
+    window.postMessage({ target: 'webview', name: 'setHtml', data: { html: html } }, '*');
+});
+
+ipcRenderer.on('clipHtml', (event, result) => {
+    window.postMessage({
+		target: 'webview',
+		name: 'setHtml',
+		data: {
+            title: result.title,
+            html: result.html,
+            base_url: result.base_url,
+		}
+    }, '*');
+});
+
+ipcRenderer.on('setPercentScroll', (event, percent) => {
+	window.postMessage({ target: 'webview', name: 'setPercentScroll', data: { percent: percent } }, '*');
+});
+
+ipcRenderer.on('setMarkers', (event, keywords) => {
+	window.postMessage({ target: 'webview', name: 'setMarkers', data: { keywords: keywords } }, '*');
+});
+
+window.addEventListener('message', (event) => {
+	// Here we only deal with messages that are sent from the webview to the main Electron process
+	if (event.origin !== location.origin) return;
+	console.debug("window.on message from " + event.origin, event);
+	if (!event.data || event.data.target !== 'main') return;
+
+	const callName = event.data.name;
+	const args = event.data.args;
+	console.log("window.on message to main: " + callName, args );
+
+	if (args.length === 0) {
+		ipcRenderer.sendToHost(callName);
+	} else if (args.length === 1) {
+		ipcRenderer.sendToHost(callName, args[0]);
+	} else if (args.length === 2) {
+		ipcRenderer.sendToHost(callName, args[1]);
+	} else {
+		throw new Error('Unsupported number of args');
+	}
+});

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -5,6 +5,7 @@ const Tag = require('lib/models/Tag');
 const BaseItem = require('lib/models/BaseItem');
 const BaseModel = require('lib/BaseModel');
 const Setting = require('lib/models/Setting');
+const Resource = require('lib/models/Resource');
 const markdownUtils = require('lib/markdownUtils');
 const mimeUtils = require('lib/mime-utils.js').mime;
 const { Logger } = require('lib/logger.js');

--- a/ReactNativeClient/lib/services/webclipper.html
+++ b/ReactNativeClient/lib/services/webclipper.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html style="width:100%; height:100%">
+	<head>
+		<meta charset="UTF-8">
+		<title>WebClipper</title>
+		<script src='clipper-main.js'></script>
+	</head>
+	<body style="width:100%; height:100%; margin:0px">
+	</body>
+</html>

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -238,7 +238,7 @@ function shimInit() {
 			host: url.hostname,
 			port: url.port,
 			method: method,
-			path: url.path + (url.query ? '?' + url.query : ''),
+			path: url.pathname + (url.query ? '?' + url.query : ''),
 			headers: headers,
 		};
 

--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -580,6 +580,10 @@ class Synchronizer {
 
 							if (creatingNewResource) this.dispatch({ type: "SYNC_CREATED_RESOURCE", id: content.id });
 
+							if (content.type_ === BaseModel.TYPE_NOTE) {
+								this.dispatch({ type: 'SYNC_CREATED_NOTE', content: content });
+							}
+
 							if (!hasAutoEnabledEncryption && content.type_ === BaseModel.TYPE_MASTER_KEY && !masterKeysBefore) {
 								hasAutoEnabledEncryption = true;
 								this.logger().info("One master key was downloaded and none was previously available: automatically enabling encryption");

--- a/readme/headless-clipper.md
+++ b/readme/headless-clipper.md
@@ -1,0 +1,19 @@
+HeadlessClient contains a headless clipper server.
+
+This service can help joplin mobile app to convert URLs shared from other apps into clipped simplied page.
+
+When this headless client sync from various sync target periosely, it watches created and updated notes with only URL in body, and converts such notes into clipped simplied page, just like what joplin-clipper + ClipperServer is doing on browser webExtention and ElectronClient.
+
+This service will perform best when it's running on a NAS (maybe from a docker container with xvfb) and use local filesystem as the sync.target. Note sync action will be triggered instantly when the files in the target directory get changed. After web page loading and clipping finished in a few second, updated note body in markdown format will be sync back to sync target in a second.
+
+Most files in this directory are just build scripts, the actual logic will copy from ReactNativeCient/lib, CliClient and Clipper/joplin-clipper/content_scripts in build time.
+
+To start a headless clipper:
+> ./run.sh server
+
+To start a cli client:
+> ./cli.sh
+
+To build a docker image:
+> builddocker.sh
+It just prepare every thing for electron, but joplin headless client is not contained in this docker image. This docker image will start /data/linux-unpacked/joplin by default, you can copy it from HeadlessClient/build/dist/linux-unpacked.


### PR DESCRIPTION
I have implemented a headless clipper server in HeadlessClient directory.

Most files in this directory are just build scripts, the actual logic will copy from ReactNativeCient/lib, CliClient and Clipper/joplin-clipper/content_scripts in build time. I think I have made these codes compatible with those three clients.

This service can help joplin mobile app to convert URLs shared from other apps into clipped simplied page.

When this headless client sync from various sync target periosely, it watches created and updated notes with only URL in body, and converts such notes into clipped simplied page, just like what joplin-clipper + ClipperServer is doing on browser webExtention and ElectronClient.

This service will perform best when it's running on a NAS (maybe from a docker container with xvfb) and use local filesystem as the sync.target. Note sync action will be triggered instantly when the files in the target directory get changed. After web page loading and clipping finished in a few second, updated note body in markdown format will be sync back to sync target in a second.

