### PR TITLE
ReactNativeClient: A better NAV_BACK logic to change folder or tag.

### DIFF
--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -222,11 +222,14 @@ const appReducer = (state = appDefaultState, action) => {
 					}
 				}
 
-				if (action.routeName == 'Welcome') navHistory = [];
-
 				//reg.logger().info('Route: ' + currentRouteName + ' => ' + action.routeName);
 
 				newState = Object.assign({}, state);
+
+				if (action.routeName == 'Welcome') {
+					navHistory = [];
+					newState.showSideMenu = true;
+				}
 
 				if ('noteId' in action) {
 					newState.selectedNoteIds = action.noteId ? [action.noteId] : [];
@@ -598,11 +601,19 @@ class AppComponent extends React.Component {
 
 		if (this.props.showSideMenu) {
 			this.props.dispatch({ type: 'SIDE_MENU_CLOSE' });
-			return true;
+			if (this.props.historyCanGoBack) {
+				return true;
+			} else {
+				BackHandler.exitApp();
+				return false;
+			}
 		}
 
 		if (this.props.historyCanGoBack) {
 			this.props.dispatch({ type: 'NAV_BACK' });
+			return true;
+		} else if (!this.props.showSideMenu) {
+			this.props.dispatch({ type: 'SIDE_MENU_OPEN' });
 			return true;
 		}
 


### PR DESCRIPTION
When NAV_BACK from folder or tag to the Welcome page, show side menu too. Because people are mostly going to change to a different folder or tag,  and not just seeing the useless Welcome page at such situation.
    
People used to press NAV_BACK on Welcome page to exitApp. But as is often the case now, the side menu is shown on Welcome page, and one NAV_BACK action only hide the side menu, another NAV_BACK action is needed to exitApp. This logic is better to be changed to save the extra click:
>    When BACK button is pressed on Welcome page while side menu is shown, hide the side menu and also exitApp.
>    When BACK button is pressed on Welcome page while side menu is not shown, show the side menu.