### PR TITLE
Useless and error prone VERSION file removed & warn use of root

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -14,7 +14,7 @@ echo ""
 # Check and warn if running as root.
 if [[ $EUID = 0 ]] ; then
   if [[ $* != *--allow-root* ]] ; then
-    echo "Please don't run as root. Use '--allow-root' to ignore this warning."
+    echo "It is not recommended (nor necessary) to run this script as root. To do so anyway, please use '--allow-root'"
     exit 1
   fi
 fi

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -11,6 +11,14 @@ echo "              | |                                                 "
 echo "              |_|                                                 "
 echo ""
 
+# Check and warn if running as root.
+if [[ $EUID = 0 ]] ; then
+  if [[ $* != *--allow-root* ]] ; then
+    echo "Please don't run as root. Use '--allow-root' to ignore this warning."
+    exit 1
+  fi
+fi
+
 #-----------------------------------------------------
 # Download Joplin
 #-----------------------------------------------------

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -19,7 +19,6 @@ echo ""
 version=$(curl --silent "https://api.github.com/repos/laurent22/joplin/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
 
 # Check if it's in the latest version
-touch VERSION
 if [[ $(< ~/.joplin/VERSION) != "$version" ]]; then
 
     # Delete previous version


### PR DESCRIPTION
I've removed the creation of an unused VERSION file, which throws an error if the script is run from a non-writable directory.

The user is also warned when running the script as root, preventing unintended installation as root:root.