### PR TITLE
Add script to launch electron app for development

### DIFF
--- a/ElectronClient/app/package.json
+++ b/ElectronClient/app/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "pack": "node_modules/.bin/electron-builder --dir",
     "dist": "node_modules/.bin/electron-builder",
+    "start": "electron .",
     "publish": "build -p always",
     "postinstall": "node compile-jsx.js && node compile-package-info.js && node ../../Tools/copycss.js --copy-fonts",
     "compile": "node compile-jsx.js && node compile-package-info.js && node ../../Tools/copycss.js --copy-fonts"


### PR DESCRIPTION
<!--
PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md
-->
Adds script to launch electron app for development. This allows to develop Joplin without the need to compile it first.