### PR TITLE
Fix extra space (2 rows) on top of note

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1408,7 +1408,7 @@ class NoteTextComponent extends React.Component {
 			height: 30
 		};
 
-		const bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - tagStyle.height - tagStyle.marginBottom;
+		const bottomRowHeight = (this.state.noteTags.length !== 0) ? rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - tagStyle.height - tagStyle.marginBottom : rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - tagStyle.height;
 
 		const viewerStyle = {
 			width: Math.floor(innerWidth / 2),
@@ -1422,6 +1422,7 @@ class NoteTextComponent extends React.Component {
 		const paddingTop = 14;
 
 		const editorStyle = {
+			marginTop: this.state.noteTags.length === 0 && tagStyle.marginBottom,
 			width: innerWidth - viewerStyle.width,
 			height: bottomRowHeight - paddingTop,
 			overflowY: 'hidden',
@@ -1493,10 +1494,10 @@ class NoteTextComponent extends React.Component {
 			placeholder={ this.props.newNote ? _('Creating new %s...', isTodo ? _('to-do') : _('note')) : '' }
 		/>
 
-		const tagList = <TagList
+		const tagList = this.state.noteTags.length !== 0 ? <TagList
 			style={tagStyle}
 			items={this.state.noteTags}
-		/>;
+		/> : null;
 
 		const titleBarMenuButton = <IconButton style={{
 			display: 'flex',


### PR DESCRIPTION
<!--
PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md
-->

Fix for https://github.com/laurent22/joplin/issues/993. Removes tag bar if note doesn't have any tags and adds light top margin.

With tags:
![joplin-with-tags](https://user-images.githubusercontent.com/4237724/48903491-f682c500-ee5b-11e8-9d82-4531880e471d.PNG)

Without tags:
![joplin-without-tags](https://user-images.githubusercontent.com/4237724/48903494-f8e51f00-ee5b-11e8-9516-3b4b4760d8ab.PNG)
