### PR TITLE
Fix window manager icon on linux

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -58,7 +58,7 @@ class ElectronAppWrapper {
 
 		// Linux icon workaround for bug https://github.com/electron-userland/electron-builder/issues/2098
 		// Fix: https://github.com/electron-userland/electron-builder/issues/2269
-		if (shim.isLinux()) windowOptions.icon = __dirname + '/build/icons/128x128.png';
+		if (shim.isLinux()) windowOptions.icon = path.join(__dirname, '..', 'build/icons/128x128.png');
 
 		require('electron-context-menu')({
 			shouldShowMenu: (event, params) => {

--- a/ElectronClient/app/package.json
+++ b/ElectronClient/app/package.json
@@ -58,6 +58,9 @@
     "linux": {
       "asar": false,
       "category": "Office",
+      "desktop": {
+        "Icon": "joplin"
+      },
       "target": "AppImage"
     }
   },


### PR DESCRIPTION
This was a weird one that I suspect will come up again when electron-builder is updated. For some reason the resources that are specified by `extraResources` in `package.json` are placed one level up from the app directory even though they initially reside in the app directory itself. Unfortunately this fix means that the icon is messed up when running joplin in debug mode.

I also added a desktop parameter into `package.json` this makes sure that the .desktop file generated by the appimage (if used) will have the correct icon name.

Fixes #251 