### PR TITLE
Clipper: bugfix, joplin icon not show up in Firefox using 32px size.

### DIFF
--- a/Clipper/joplin-webclipper/manifest.json
+++ b/Clipper/joplin-webclipper/manifest.json
@@ -5,6 +5,7 @@
     "description": "Capture and save web pages and screenshots from your browser to Joplin.",
     "homepage_url": "https://joplin.cozic.net",
     "icons": {
+        "32": "icons/32.png",
         "48": "icons/48.png",
         "96": "icons/96.png"
     },


### PR DESCRIPTION
Put "icons/32.png" in browser_action.default_icon is not enough, need to put it in icons["32"], too.
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
