### PR TITLE
Mobile: Set background colour for iOS Safe Areas

### DIFF
--- a/ReactNativeClient/lib/components/side-menu-content.js
+++ b/ReactNativeClient/lib/components/side-menu-content.js
@@ -32,9 +32,7 @@ class SideMenuContentComponent extends Component {
 		let styles = {
 			menu: {
 				flex: 1,
-				backgroundColor: theme.backgroundColor,
-				borderTopWidth: 1,
-				borderTopColor: theme.dividerColor,
+				backgroundColor: theme.backgroundColor
 			},
 			button: {
 				flex: 1,

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -54,6 +54,7 @@ const ShareExtension = require('react-native-share-extension').default;
 const ResourceFetcher = require('lib/services/ResourceFetcher');
 const SearchEngine = require('lib/services/SearchEngine');
 const WelcomeUtils = require('lib/WelcomeUtils');
+const { themeStyle } = require('lib/components/global-style.js');
 
 const SyncTargetRegistry = require('lib/SyncTargetRegistry.js');
 const SyncTargetOneDrive = require('lib/SyncTargetOneDrive.js');
@@ -642,8 +643,9 @@ class AppComponent extends React.Component {
 
 	render() {
 		if (this.props.appState != 'ready') return null;
+		const theme = themeStyle(this.props.theme);
 
-		const sideMenuContent = <SafeAreaView style={{flex:1}}><SideMenuContent/></SafeAreaView>;
+		const sideMenuContent = <SafeAreaView style={{flex:1, backgroundColor: theme.backgroundColor}}><SideMenuContent/></SafeAreaView>;
 
 		const appNavInit = {
 			Welcome: { screen: WelcomeScreen },
@@ -671,7 +673,8 @@ class AppComponent extends React.Component {
 				}}
 				>
 				<MenuContext style={{ flex: 1 }}>
-					<SafeAreaView style={{flex:1}}>
+					<SafeAreaView style={{flex:0, backgroundColor: theme.raisedBackgroundColor}} />
+					<SafeAreaView style={{flex:1, backgroundColor: theme.backgroundColor}}>
 						<AppNav screens={appNavInit} />
 					</SafeAreaView>
 					<DropdownAlert ref={ref => this.dropdownAlert_ = ref} tapToCloseEnabled={true} />
@@ -689,6 +692,7 @@ const mapStateToProps = (state) => {
 		appState: state.appState,
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		selectedFolderId: state.selectedFolderId,
+		theme: state.settings.theme
 	};
 };
 


### PR DESCRIPTION
Minor style update: set background colour (both light & dark theme) for iOS Safe Areas to respect iOS style guideline.

Dark theme:
[menu closed - iphone x](https://user-images.githubusercontent.com/17232523/52448073-05137b00-2b33-11e9-81a0-6ace21b2682a.png)
[menu open - iphone x](https://user-images.githubusercontent.com/17232523/52448074-05137b00-2b33-11e9-81b0-11ccb2da1728.png)
[menu closed - iphone 7](https://user-images.githubusercontent.com/17232523/52448818-5cb2e600-2b35-11e9-9aff-fde05eab0cda.png)
[menu open - iphone 7](https://user-images.githubusercontent.com/17232523/52448819-5cb2e600-2b35-11e9-8b77-d0ea8238564b.png)


Light theme:
[menu closed - iphone x](https://user-images.githubusercontent.com/17232523/52448076-05ac1180-2b33-11e9-97d1-a96314bde5f6.png)
[menu open- iphone x](https://user-images.githubusercontent.com/17232523/52448075-05ac1180-2b33-11e9-97b5-0f14f1fdfeab.png)
[menu closed - iphone 7](https://user-images.githubusercontent.com/17232523/52448815-5c1a4f80-2b35-11e9-9a5b-e5903a638994.png)
[menu open - iphone 7](https://user-images.githubusercontent.com/17232523/52448814-5c1a4f80-2b35-11e9-8a2f-f315701a8465.png)
