### PR TITLE
Docs: Suggesting some language improvements for the Welcome page

### DIFF
--- a/readme/welcome/1_welcome_to_joplin.md
+++ b/readme/welcome/1_welcome_to_joplin.md
@@ -1,8 +1,8 @@
 # Welcome to Joplin! 🗒️
 
-Joplin is a free, open source note taking and to-do application, which helps you write and organise your notes, and synchronise them between your devices. The notes are searchable, can be copied, tagged and modified either from the applications directly or from your own text editor. The notes are in [Markdown format](https://joplin.cozic.net/#markdown). Joplin is available as **💻 desktop**, **📱 mobile** and **🔡 terminal** applications.
+Joplin is a free, open source note taking and to-do application, which helps you write and organise your notes, and synchronise them between your devices. The notes are searchable, can be copied, tagged and modified either from the applications directly or from your own text editor. The notes are in [Markdown format](https://joplin.cozic.net/#markdown). Joplin is available as a **💻 desktop**, **📱 mobile** and **🔡 terminal** application.
 
-The notes in this notebook give an overview of what Joplin can do and how to use it. In general the three applications share roughly the same functionalities, and they are not the differences will be clearly indicated.
+The notes in this notebook give an overview of what Joplin can do and how to use it. In general, the three applications share roughly the same functionalities; any differences will be clearly indicated.
 
 ![](./AllClients.png)
 
@@ -10,9 +10,9 @@ The notes in this notebook give an overview of what Joplin can do and how to use
 
 Joplin has three main columns:
 
-- **Sidebar**: It contains the list of your notebooks and tags, as well as the synchronisation status.
-- **Note List**: It contains the current list of notes - either the notes in the currently selected notebook, or the notes in the currently selected tag.
-- **Note Editor**: The note editor contains of course an actual editor, where your write your note in Markdown, and a viewer, which shows the rendered note. To edit notes, you may also use an [external editor](https://joplin.cozic.net/#external-text-editor). For example, if you like WYSIWYG editors, you can use something like Typora as an external editor and it will display the note as well as any embedded image.
+- **Sidebar** contains the list of your notebooks and tags, as well as the synchronisation status.
+- **Note List** contains the current list of notes - either the notes in the currently selected notebook, the notes in the currently selected tag, or search results.
+- **Note Editor** is the place where you write your notes in Markdown, with a viewer showing what the note will look like. You may also use an [external editor](https://joplin.cozic.net/#external-text-editor) to edit notes. For example, if you like WYSIWYG editors, you can use something like Typora as an external editor and it will display the note as well as any embedded images.
 
 ## Writing notes in Markdown
 
@@ -38,11 +38,11 @@ Or numbered lists:
 2. rinse
 3. repeat
 
-This is a [link](https://joplin.cozic.net) and, finally, below is an horizontal rule:
+This is a [link](https://joplin.cozic.net) and, finally, below is a horizontal rule:
 
 * * *
 
-A lot more is possible including adding code samples, math formulaes or checkbox lists - see the [Markdown documentation](https://joplin.cozic.net/#markdown) for more information.
+A lot more is possible including adding code samples, math formulae or checkbox lists - see the [Markdown documentation](https://joplin.cozic.net/#markdown) for more information.
 
 ## Organising your notes
 
@@ -60,7 +60,7 @@ Joplin notes are organised into a tree of notebooks and sub-notebooks.
 
 The second way to organise your notes is using tags:
 
-- On **desktop**, right-click on any note in the Note List, and select "Edit tags". You can then add the tags, separating each one by a comma.
+- On **desktop**, right-click on any note in the Note List, and select "Edit tags". You can then add the tags, separating them by commas.
 - On **mobile**, open the note and press the "⋮" button and select "Tags".
 - On **terminal**, type `:help tag` for the available commands.
 


### PR DESCRIPTION
I'm not sure about the "Joplin has three main columns" part. While it would be more correct to put articles in front of the names, I think they aren't necessary and it seems more visually clear to me this way.

(As a side note: the PR info says I should "prefix the title with the platform you are targetting [sic]" as either Desktop, Mobile or CLI. This change doesn't touch any code, though. Not sure about what to do here.)