### PR TITLE
Customization to the scrollbars

### DIFF
--- a/ElectronClient/app/style.css
+++ b/ElectronClient/app/style.css
@@ -22,6 +22,26 @@ table td, table th {
 	border: 1px solid #ccc;
 }
 
+::-webkit-scrollbar {
+	width: 7px;
+}
+
+::-webkit-scrollbar-track {
+	border: none;
+}
+ 
+::-webkit-scrollbar-thumb {
+	background: rgba(100, 100, 100, 0.3); 
+	border-radius: 5px;
+}
+
+::-webkit-scrollbar-track:hover {
+	background: rgba(0, 0, 0, 0.1); 
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: rgba(100, 100, 100, 0.7); 
+}
 /* By default, the Ice Editor displays invalid characters, such as non-breaking spaces
    as red boxes, but since those are actually valid characters and common in imported
    Evernote data, we hide them here. */

--- a/ReactNativeClient/lib/MdToHtml.js
+++ b/ReactNativeClient/lib/MdToHtml.js
@@ -538,6 +538,22 @@ class MdToHtml {
 				/* So that, for example, highlighted text or background images are printed too, otherwise browsers tend not to print these things */
 				-webkit-print-color-adjust: exact;
 			}
+			::-webkit-scrollbar {
+				width: 7px;
+			}
+			::-webkit-scrollbar-track {
+				border: none;
+			}
+			::-webkit-scrollbar-thumb {
+				background: rgba(100, 100, 100, 0.3); 
+				border-radius: 5px;
+			}
+			::-webkit-scrollbar-track:hover {
+				background: rgba(0, 0, 0, 0.1); 
+			}
+			::-webkit-scrollbar-thumb:hover {
+				background: rgba(100, 100, 100, 0.7); 
+			}
 			p, h1, h2, h3, h4, h5, h6, ul, table {
 				margin-top: .6em;
 				margin-bottom: .65em;


### PR DESCRIPTION
This applies some styling updates to the scrollbars. Currently the webview defaults are in use which look fine for the light theme (although the side bar with notebooks etc. is a little bit lacking). But with the dark theme it's a little bit breaking. 
This replaces the scrollbar with a much simpler visual scrollbar that matches the theme much better

Note: the scrollbar will darken/lighten on hover but I couldn't get a good screenshot of that 
![image](https://user-images.githubusercontent.com/2179547/52538984-838c3a80-2d36-11e9-90ff-6fea8e30c54c.png)

![image](https://user-images.githubusercontent.com/2179547/52538988-8dae3900-2d36-11e9-85a5-a9ed4edd9481.png)
