### PR TITLE
Mobile: Set note webview background color

### DIFF
--- a/ReactNativeClient/lib/components/note-body-viewer.js
+++ b/ReactNativeClient/lib/components/note-body-viewer.js
@@ -108,7 +108,7 @@ class NoteBodyViewer extends Component {
 			</html>
 		`;
 
-		let webViewStyle = {}
+		let webViewStyle = {'backgroundColor': this.props.webViewStyle.backgroundColor}
 		// On iOS, the onLoadEnd() event is never fired so always
 		// display the webview (don't do the little trick
 		// to avoid the white flash).


### PR DESCRIPTION
Minor UI fix: set background color based on selected theme to note webview to avoid white background on scroll when dark theme is enabled.

Before:
![before](https://user-images.githubusercontent.com/17232523/52911302-2ba78380-32a2-11e9-8be9-ab5f7a6d506d.gif)

After:
![after](https://user-images.githubusercontent.com/17232523/52911310-4ed23300-32a2-11e9-89bc-cf485bdb4fae.gif)
