### PR TITLE
when deleting notebook or tag, display name

### DIFF
--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -13,6 +13,7 @@ const { bridge } = require("electron").remote.require("./bridge");
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
 const InteropServiceHelper = require("../InteropServiceHelper.js");
+const { substrWithEllipsis } = require('lib/string-utils');
 const { shim } = require('lib/shim');
 
 class SideBarComponent extends React.Component {
@@ -259,7 +260,7 @@ class SideBarComponent extends React.Component {
 		}
 	}
 
-	itemContextMenu(event) {
+	async itemContextMenu(event) {
 		const itemId = event.target.getAttribute("data-id");
 		if (itemId === Folder.conflictFolderId()) return;
 
@@ -268,9 +269,11 @@ class SideBarComponent extends React.Component {
 
 		let deleteMessage = "";
 		if (itemType === BaseModel.TYPE_FOLDER) {
-			deleteMessage = _("Delete notebook? All notes and sub-notebooks within this notebook will also be deleted.");
+			const folder = await Folder.load(itemId);
+			deleteMessage = _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', substrWithEllipsis(folder.title, 0, 32));
 		} else if (itemType === BaseModel.TYPE_TAG) {
-			deleteMessage = _("Remove this tag from all the notes?");
+			const tag = await Tag.load(itemId);
+			deleteMessage = _('Remove tag "%s" from all notes?', substrWithEllipsis(tag.title, 0, 32));
 		} else if (itemType === BaseModel.TYPE_SEARCH) {
 			deleteMessage = _("Remove this search from the sidebar?");
 		}


### PR DESCRIPTION
The delete dialog for notebooks and tags does not display the name of the item to be deleted.
This can lead to an undesired result.

closes #1245

The dialog now looks like this:

## delete notebook

<img width="418" alt="screen shot 2019-02-22 at 01 35 58" src="https://user-images.githubusercontent.com/223439/53224694-a0344680-3643-11e9-8d77-f75e61c068ed.png">

## delete tag

<img width="415" alt="screen shot 2019-02-22 at 01 36 47" src="https://user-images.githubusercontent.com/223439/53224692-9dd1ec80-3643-11e9-9aa1-bd13e94dec09.png">

---

Please note that I do not know how to update the `.pot` and `.po` files. Is there a script to do this? I doubt this is a manual process.