### PR TITLE
Update light theme tag remove prompt color

### DIFF
--- a/ElectronClient/app/theme.js
+++ b/ElectronClient/app/theme.js
@@ -70,7 +70,7 @@ const lightStyle = {
 	dividerColor: "#dddddd",
 	selectedColor: '#e5e5e5',
 	urlColor: '#155BDA',
-	removeColor: '#B01C2E',
+	removeColor: '#E76574',
 
 	backgroundColor2: "#162B3D",
 	color2: "#ffffff",


### PR DESCRIPTION
An example of how it looks

![tag-color](https://user-images.githubusercontent.com/2179547/53302938-ab44cd80-3821-11e9-9d98-f2a5a2150c11.png)
