### PR TITLE
version info changes

### DIFF
--- a/CliClient/locales/ca.po
+++ b/CliClient/locales/ca.po
@@ -755,11 +755,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Hi ha disponible una actualització. Voleu baixar-la ara?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/cs_CZ.po
+++ b/CliClient/locales/cs_CZ.po
@@ -737,11 +737,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Je k dispozici update, chcete jej stáhnout?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/da_DK.po
+++ b/CliClient/locales/da_DK.po
@@ -742,11 +742,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Opdatering er til rådighed, vil du hente den nu?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/de_DE.po
+++ b/CliClient/locales/de_DE.po
@@ -18,7 +18,7 @@ msgstr ""
 
 msgid "To delete a tag, untag the associated notes."
 msgstr ""
-"Um ein Tag zu löschen, entferne es bei allen damit verbundenen Notizen."
+"Um ein Schlagwort zu löschen, entferne es bei allen damit verbundenen Notizen."
 
 msgid "Please select the note or notebook to be deleted first."
 msgstr ""

--- a/CliClient/locales/de_DE.po
+++ b/CliClient/locales/de_DE.po
@@ -755,12 +755,12 @@ msgstr ""
 "Es ist eine Aktualisierung verfügbar. Soll sie jetzt heruntergeladen werden?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Deine Version: v%s"
+msgid "Your version: %s"
+msgstr "Deine Version: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Neue Version: v%s"
+msgid "New version: %s"
+msgstr "Neue Version: %s"
 
 msgid "Yes"
 msgstr "Ja"

--- a/CliClient/locales/en_GB.po
+++ b/CliClient/locales/en_GB.po
@@ -664,11 +664,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/es_ES.po
+++ b/CliClient/locales/es_ES.po
@@ -744,12 +744,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Hay disponible una actualización. ¿Quiere descargarla ahora?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Tu versión: v%s"
+msgid "Your version: %s"
+msgstr "Tu versión: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Nueva versión: v%s"
+msgid "New version: %s"
+msgstr "Nueva versión: %s"
 
 msgid "Yes"
 msgstr "Sí"

--- a/CliClient/locales/eu.po
+++ b/CliClient/locales/eu.po
@@ -749,11 +749,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/fr_FR.po
+++ b/CliClient/locales/fr_FR.po
@@ -740,12 +740,12 @@ msgstr ""
 "Une mise à jour est disponible, souhaitez vous la télécharger maintenant ?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Votre version : v%s"
+msgid "Your version: %s"
+msgstr "Votre version : %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Nouvelle version : v%s"
+msgid "New version: %s"
+msgstr "Nouvelle version : %s"
 
 msgid "Yes"
 msgstr "Oui"

--- a/CliClient/locales/gl_ES.po
+++ b/CliClient/locales/gl_ES.po
@@ -742,11 +742,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Hai unha actualización dispoñíbel, desexa descargala agora?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/hr_HR.po
+++ b/CliClient/locales/hr_HR.po
@@ -748,11 +748,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/it_IT.po
+++ b/CliClient/locales/it_IT.po
@@ -753,11 +753,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "È disponibile un aggiornamento, vuoi scaricarlo ora?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/ja_JP.po
+++ b/CliClient/locales/ja_JP.po
@@ -735,11 +735,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "アップデートがあります。すぐにダウンロードしますか？"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/joplin.pot
+++ b/CliClient/locales/joplin.pot
@@ -664,11 +664,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/ko.po
+++ b/CliClient/locales/ko.po
@@ -732,12 +732,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "업데이트가 있습니다. 지금 다운로드할까요?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "현재 버전: v%s"
+msgid "Your version: %s"
+msgstr "현재 버전: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "새 버전: v%s"
+msgid "New version: %s"
+msgstr "새 버전: %s"
 
 msgid "Yes"
 msgstr "예"

--- a/CliClient/locales/nb_NO.po
+++ b/CliClient/locales/nb_NO.po
@@ -741,12 +741,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "En oppdatering er tilgjengelig, vil du laste den ned nå?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Din versjon: v%s"
+msgid "Your version: %s"
+msgstr "Din versjon: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Ny versjon: v%s"
+msgid "New version: %s"
+msgstr "Ny versjon: %s"
 
 msgid "Yes"
 msgstr "Ja"

--- a/CliClient/locales/nl_BE.po
+++ b/CliClient/locales/nl_BE.po
@@ -751,11 +751,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/nl_NL.po
+++ b/CliClient/locales/nl_NL.po
@@ -751,11 +751,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Er is een update beschikbaar. Wil je deze nu downloaden?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/pt_BR.po
+++ b/CliClient/locales/pt_BR.po
@@ -748,11 +748,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Uma atualização está disponível, você quer baixar agora?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/ro.po
+++ b/CliClient/locales/ro.po
@@ -686,11 +686,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr ""
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/ru_RU.po
+++ b/CliClient/locales/ru_RU.po
@@ -748,12 +748,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Доступно обновление, вы хотите загрузить его сейчас?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Ваша версия: v%s"
+msgid "Your version: %s"
+msgstr "Ваша версия: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Новая версия: v%s"
+msgid "New version: %s"
+msgstr "Новая версия: %s"
 
 msgid "Yes"
 msgstr "Да"

--- a/CliClient/locales/sl_SI.po
+++ b/CliClient/locales/sl_SI.po
@@ -748,11 +748,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Posodobitev je na voljo, jo želite prenesti sedaj?"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/CliClient/locales/sv.po
+++ b/CliClient/locales/sv.po
@@ -749,12 +749,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "En uppdatering är tillgänglig, vill du hämta den nu?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Din version: v%s"
+msgid "Your version: %s"
+msgstr "Din version: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Ny version: v%s"
+msgid "New version: %s"
+msgstr "Ny version: %s"
 
 msgid "Yes"
 msgstr "Ja"

--- a/CliClient/locales/tr_TR.po
+++ b/CliClient/locales/tr_TR.po
@@ -717,12 +717,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "Güncelleme mevcut, şimdi indirmek ister misiniz?"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "Sürümün: v%s"
+msgid "Your version: %s"
+msgstr "Sürümün: %s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "Yeni sürüm: v%s"
+msgid "New version: %s"
+msgstr "Yeni sürüm: %s"
 
 msgid "Yes"
 msgstr "Evet"

--- a/CliClient/locales/zh_CN.po
+++ b/CliClient/locales/zh_CN.po
@@ -708,12 +708,12 @@ msgid "An update is available, do you want to download it now?"
 msgstr "有更新可用，是否现在进行下载？"
 
 #, javascript-format
-msgid "Your version: v%s"
-msgstr "您的版本：v%s"
+msgid "Your version: %s"
+msgstr "您的版本：%s"
 
 #, javascript-format
-msgid "New version: v%s"
-msgstr "最新版本：v%s"
+msgid "New version: %s"
+msgstr "最新版本：%s"
 
 msgid "Yes"
 msgstr "是"

--- a/CliClient/locales/zh_TW.po
+++ b/CliClient/locales/zh_TW.po
@@ -714,11 +714,11 @@ msgid "An update is available, do you want to download it now?"
 msgstr "有可用的更新，您需要立即下載嗎？"
 
 #, javascript-format
-msgid "Your version: v%s"
+msgid "Your version: %s"
 msgstr ""
 
 #, javascript-format
-msgid "New version: v%s"
+msgid "New version: %s"
 msgstr ""
 
 msgid "Yes"

--- a/ElectronClient/app/checkForUpdates.js
+++ b/ElectronClient/app/checkForUpdates.js
@@ -131,7 +131,7 @@ function checkForUpdates(inBackground, window, logFilePath, options) {
 
 			const buttonIndex = dialog.showMessageBox(parentWindow_, {
 				type: 'info',
-				message: _('An update is available, do you want to download it now?') + '\n\n' + _('Your version: v%s', packageInfo.version) + '\n' + _('New version: v%s', newVersionString) + releaseNotes,
+				message: _('An update is available, do you want to download it now?') + '\n\n' + _('Your version: %s', packageInfo.version) + '\n' + _('New version: %s', newVersionString) + releaseNotes,
 				buttons: [_('Yes'), _('No')]
 			});
 

--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -250,7 +250,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 
 		settingComps.push(
 			<View key="version_info_app" style={this.styles().settingContainer}>
-					<Text style={this.styles().settingText}>{_('Joplin v%s', VersionInfo.appVersion)}</Text>
+					<Text style={this.styles().settingText}>{"Joplin " + VersionInfo.appVersion}</Text>
 			</View>
 		);
 


### PR DESCRIPTION
- update the version info string for mobiles to be consistent with the desktop app
- show version as `X.Y.Z` in update dialog
- update `.po` files (and `.pot`) so that the previous commit won't break translations
- small update to `de_DE.po`

Please don't forget to update the translations. The `build-translation.js` script doesn't work on my system out of the box. I would have to change the script, since I'm using MacPorts. Also I'd have to install pocount.