### PR TITLE
Onboard renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "extends": ["config:base", ":rebaseStalePrs"],
+  "packageRules": [
+    {
+      "paths": ["CliClient/package.json"],
+    },
+    {
+      "paths": ["Clipper/joplin-webclipper/package.json"],
+      "labels": ["clipper"]
+    },
+    {
+      "paths": ["Clipper/joplin-webclipper/popup/package.json"],
+      "labels": ["clipper"]
+    },
+    {
+      "paths": ["ElectronClient/app/package.json"],
+      "labels": ["desktop"]
+    },
+    {
+      "paths": ["ReactNativeClient/lib/package.json"],
+      "labels": ["mobile"]
+    },
+    {
+      "paths": ["ReactNativeClient/package.json"],
+      "labels": ["mobile"]
+    },
+    {
+      "paths": ["Tools/package.json"]
+    }
+  ]
+}


### PR DESCRIPTION
[Renovate](https://renovatebot.com/) is an automated dependency updater. This PR adds a config for renovate that includes all `package.json` files. In order to enable renovate, you'll have to [Install the GitHub App](https://renovatebot.com/docs/install-github-app/) (It's free for open source projects).

I think that renovate can help with the burden of keeping all 7 of your `package.json` files up to date (as well as your gradle dependencies, but I'll leave that for now).