### PR TITLE
Add joplin.desktop file for xfce and mate desktops

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -70,11 +70,13 @@ if [[ $(< ~/.joplin/VERSION) != "$version" ]]; then
 
     # Create icon for Gnome
     echo 'Create Desktop icon.'
-    if [[ $desktop =~ .*gnome.* ]] || [[ $desktop =~ .*kde.* ]] 
+    if [[ $desktop =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.* ]]
     then
        echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=/home/$USER/.joplin/Icon512.png\nType=Application\nCategories=Application;" >> ~/.local/share/applications/joplin.desktop
+       echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+       echo "${COLOR_RED}NOT DONE${COLOR_RESET}"
     fi
-    echo "${COLOR_GREEN}OK${COLOR_RESET}"
     
     #-----------------------------------------------------
     # Finish


### PR DESCRIPTION
Fairly simple pull since the mate and xfce environments also use desktop files, this writes desktop files for those environments. Additionally it adds a note if a file was not created.