### PR TITLE
Desktop: Add -css command line option for userstyle.css

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -848,7 +848,11 @@ class Application extends BaseApplication {
 			ids: Setting.value('collapsedFolderIds'),
 		});
 
-		const cssString = await this.loadCustomCss(Setting.value('profileDir') + '/userstyle.css');
+		var css = Setting.value('usercss');
+		if ( !css.startsWith('/') ) {
+		    css = Setting.value('profileDir') + '/' + css;
+		}
+		const cssString = await this.loadCustomCss(css);
 
 		this.store().dispatch({
 			type: 'LOAD_CUSTOM_CSS',

--- a/ElectronClient/app/package-lock.json
+++ b/ElectronClient/app/package-lock.json
@@ -464,13 +464,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3478,13 +3480,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -5313,7 +5317,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/ElectronClient/app/package-lock.json
+++ b/ElectronClient/app/package-lock.json
@@ -464,15 +464,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -3480,15 +3478,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -5317,8 +5313,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -148,7 +148,14 @@ class BaseApplication {
 				continue;
 			}
 
-			if (arg.indexOf('-psn') === 0) {
+			if (arg == '--css') {
+				if (!nextArg) throw new JoplinError(_('Usage: %s', '--css <filename>'), 'flagError');
+			        Setting.setConstant('usercss', nextArg);
+				argv.splice(0, 2);
+				continue;
+			}
+
+		        if (arg.indexOf('-psn') === 0) {
 				// Some weird flag passed by macOS - can be ignored.
 				// https://github.com/laurent22/joplin/issues/480
 				// https://stackoverflow.com/questions/10242115

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -612,6 +612,7 @@ Setting.constants_ = {
 	profileDir: '',
 	tempDir: '',
 	openDevTools: false,
+	usercss: 'userstyle.css'
 }
 
 Setting.autoSaveEnabled = true;


### PR DESCRIPTION
This PR adds command line option `--css` to Joplin.
This option can be used to select an alternative `userstyle.css` upon startup.
If the value specified is an absolute path name, this file is used instead of the default `userstyle.css`. Otherwise it is considered to be the name of a file in the profile folder.
The default value is `userstyle.css`.