### PR TITLE
Add --css command line option for userstyle.css

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -848,7 +848,11 @@ class Application extends BaseApplication {
 			ids: Setting.value('collapsedFolderIds'),
 		});
 
-		const cssString = await this.loadCustomCss(Setting.value('profileDir') + '/userstyle.css');
+		var css = Setting.value('usercss');
+		if ( !css.startsWith('/') ) {
+		    css = Setting.value('profileDir') + '/' + css;
+		}
+		const cssString = await this.loadCustomCss(css);
 
 		this.store().dispatch({
 			type: 'LOAD_CUSTOM_CSS',

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -148,7 +148,14 @@ class BaseApplication {
 				continue;
 			}
 
-			if (arg.indexOf('-psn') === 0) {
+			if (arg == '--css') {
+				if (!nextArg) throw new JoplinError(_('Usage: %s', '--css <filename>'), 'flagError');
+			        Setting.setConstant('usercss', nextArg);
+				argv.splice(0, 2);
+				continue;
+			}
+
+		        if (arg.indexOf('-psn') === 0) {
 				// Some weird flag passed by macOS - can be ignored.
 				// https://github.com/laurent22/joplin/issues/480
 				// https://stackoverflow.com/questions/10242115

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -612,6 +612,7 @@ Setting.constants_ = {
 	profileDir: '',
 	tempDir: '',
 	openDevTools: false,
+	usercss: 'userstyle.css'
 }
 
 Setting.autoSaveEnabled = true;


### PR DESCRIPTION
This PR adds command line option `--css` to Joplin.
This option can be used to select an alternative `userstyle.css` upon startup.
If the value specified is an absolute path name, this file is used instead of the default `userstyle.css`. Otherwise it is considered to be the name of a file in the profile folder.
The default value is `userstyle.css`.