### PR TITLE
Desktop: Fixed filename in Markdown output during import of Evernote resources

### DIFF
--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -639,7 +639,7 @@ function enexXmlToMdArray(stream, resources) {
 				// means it's an attachement. It will be appended along with the
 				// other remaining resources at the bottom of the markdown text.
 				if (resource && !!resource.id) {
-					section.lines = addResourceTag(section.lines, resource, nodeAttributes.alt);
+					section.lines = addResourceTag(section.lines, resource, resource.filename);
 				}
 			} else if (["span", "font", 'sup', 'cite', 'abbr', 'small', 'tt', 'sub', 'colgroup', 'col', 'ins', 'caption', 'var', 'map', 'area'].indexOf(n) >= 0) {
 				// Inline tags that can be ignored in Markdown


### PR DESCRIPTION
This pull request addresses #1017, which I believe is a simple bug rather than a feature request!

I have attached a test ENEX file to this request:

[joplin_test.zip](https://github.com/laurent22/joplin/files/2955663/joplin_test.zip)

The behaviour before and after the fix is shown in the following screenshots:

Before

![before_import_fix](https://user-images.githubusercontent.com/1671065/54183581-dd278680-44e7-11e9-9452-1fd7ccb8177f.png)

After

![after_import_fix](https://user-images.githubusercontent.com/1671065/54183605-e87ab200-44e7-11e9-9b08-e4511143529e.png)

This is my first attempt at a pull request, so please shout if I've done something wrong!