### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/CliClient/app/app.js
+++ b/CliClient/app/app.js
@@ -299,7 +299,7 @@ class Application extends BaseApplication {
 
 		let outException = null;
 		try {
-			if (this.gui().isDummy() && !this.activeCommand_.supportsUi('cli')) throw new Error(_('The command "%s" is only available in GUI mode', this.activeCommand_.name()));			
+			if (this.gui().isDummy() && !this.activeCommand_.supportsUi('cli')) throw new Error(_('The command "%s" is only available in GUI mode', this.activeCommand_.name()));
 			const cmdArgs = cliUtils.makeCommandArgs(this.activeCommand_, argv);
 			await this.activeCommand_.action(cmdArgs);
 		} catch (error) {
@@ -399,7 +399,7 @@ class Application extends BaseApplication {
 
 			await Setting.saveAll();
 
-			// Need to call exit() explicitely, otherwise Node wait for any timeout to complete
+			// Need to call exit() explicitly, otherwise Node wait for any timeout to complete
 			// https://stackoverflow.com/questions/18050095
 			process.exit(0);
 		} else { // Otherwise open the GUI

--- a/CliClient/app/autocompletion.js
+++ b/CliClient/app/autocompletion.js
@@ -11,7 +11,7 @@ async function handleAutocompletionPromise(line) {
 	const names = await app().commandNames();
 	let words = getArguments(line);
 	//If there is only one word and it is not already a command name then you
-	//should look for commmands it could be
+	//should look for commands it could be
 	if (words.length == 1) {
 		if (names.indexOf(words[0]) === -1) {
 			let x = names.filter((n) => n.indexOf(words[0]) === 0);

--- a/CliClient/app/command-sync.js
+++ b/CliClient/app/command-sync.js
@@ -193,7 +193,7 @@ class Command extends BaseCommand {
 
 			// When using the tool in command line mode, the ResourceFetcher service is
 			// not going to be running in the background, so the resources need to be
-			// explicitely downloaded below.
+			// explicitly downloaded below.
 			if (!app().hasGui()) {
 				this.stdout(_('Downloading resources...'));
 				await ResourceFetcher.instance().fetchAll();

--- a/CliClient/app/onedrive-api-node-utils.js
+++ b/CliClient/app/onedrive-api-node-utils.js
@@ -48,7 +48,7 @@ class OneDriveApiNodeUtils {
 
 		let authCodeUrl = this.api().authCodeUrl('http://localhost:' + port);
 
-		return new Promise((resolve, reject) => {			
+		return new Promise((resolve, reject) => {
 			this.oauthServer_ = http.createServer();
 			let errorMessage = null;
 
@@ -106,7 +106,7 @@ class OneDriveApiNodeUtils {
 
 			enableServerDestroy(this.oauthServer_);
 
-			// Rather than displaying authCodeUrl directly, we go throught the local
+			// Rather than displaying authCodeUrl directly, we go through the local
 			// server. This is just so that the URL being displayed is shorter and
 			// doesn't get cut in terminals (especially those that don't handle multi
 			// lines URLs).

--- a/CliClient/tests/html_to_md/table_no_header.html
+++ b/CliClient/tests/html_to_md/table_no_header.html
@@ -1,4 +1,4 @@
 <table>
 	<tr><td>No</td><td>header</td></tr>
-	<tr><td>And no</td><td>suprises</td></tr>
+	<tr><td>And no</td><td>surprises</td></tr>
 </table>

--- a/CliClient/tests/html_to_md/table_no_header.md
+++ b/CliClient/tests/html_to_md/table_no_header.md
@@ -1,4 +1,4 @@
 |     |     |
 | --- | --- |
 | No  | header |
-| And no | suprises |
+| And no | surprises |

--- a/CliClient/tests/markdownUtils.js
+++ b/CliClient/tests/markdownUtils.js
@@ -22,7 +22,7 @@ describe('markdownUtils', function() {
 			['![something](/img/test.png)', '![something](https://test.com/img/test.png)'],
 			['[![something](/img/test.png)](/index.html "Home page")', '[![something](https://test.com/img/test.png)](https://test.com/index.html "Home page")'],
 			['[onelink.com](/jmp/?id=123&u=http://something.com/test)', '[onelink.com](https://test.com/jmp/?id=123&u=http://something.com/test)'],
-			['[![some text](/img/test.png)](/jmp/?s=80&l=related&u=http://example.com "some decription")', '[![some text](https://test.com/img/test.png)](https://test.com/jmp/?s=80&l=related&u=http://example.com "some decription")'],
+			['[![some text](/img/test.png)](/jmp/?s=80&l=related&u=http://example.com "some description")', '[![some text](https://test.com/img/test.png)](https://test.com/jmp/?s=80&l=related&u=http://example.com "some description")'],
 		];
 
 		for (let i = 0; i < testCases.length; i++) {

--- a/CliClient/tests/services_SearchEngine.js
+++ b/CliClient/tests/services_SearchEngine.js
@@ -21,7 +21,7 @@ describe('services_SearchEngine', function() {
 
 		engine = new SearchEngine();
 		engine.setDb(db());
-		
+
 		done();
 	});
 
@@ -99,7 +99,7 @@ describe('services_SearchEngine', function() {
 		// 2
 		const n4 = await Note.save({ title: "blablablabla blabla bla abcd X efgh" });
 		// 5
-		const n5 = await Note.save({ title: "occurence many times but very abcd spread appart spread appart spread appart spread appart spread appart efgh occurence many times but very abcd spread appart spread appart spread appart spread appart spread appart efgh occurence many times but very abcd spread appart spread appart spread appart spread appart spread appart efgh occurence many times but very abcd spread appart spread appart spread appart spread appart spread appart efgh occurence many times but very abcd spread appart spread appart spread appart spread appart spread appart efgh" });
+		const n5 = await Note.save({ title: "occurrence many times but very abcd spread apart spread apart spread apart spread apart spread apart efgh occurrence many times but very abcd spread apart spread apart spread apart spread apart spread apart efgh occurrence many times but very abcd spread apart spread apart spread apart spread apart spread apart efgh occurrence many times but very abcd spread apart spread apart spread apart spread apart spread apart efgh occurrence many times but very abcd spread apart spread apart spread apart spread apart spread apart efgh" });
 
 		await engine.syncTables();
 		const rows = await engine.search('abcd efgh');

--- a/CliClient/tests/test-utils.js
+++ b/CliClient/tests/test-utils.js
@@ -134,7 +134,7 @@ async function clearDatabase(id = null) {
 		'DELETE FROM master_keys',
 		'DELETE FROM item_changes',
 		'DELETE FROM note_resources',
-		'DELETE FROM settings',		
+		'DELETE FROM settings',
 		'DELETE FROM deleted_items',
 		'DELETE FROM sync_items',
 		'DELETE FROM notes_normalized',
@@ -232,7 +232,7 @@ async function loadEncryptionMasterKey(id = null, useExisting = false) {
 		masterKey = await MasterKey.save(masterKey);
 	} else { // Use the one already available
 		materKey = await MasterKey.all();
-		if (!materKey.length) throw new Error('No mater key available');
+		if (!materKey.length) throw new Error('No master key available');
 		masterKey = materKey[0];
 	}
 

--- a/CliClient/tests/urlUtils.js
+++ b/CliClient/tests/urlUtils.js
@@ -26,7 +26,7 @@ describe('urlUtils', function() {
 		expect(urlUtils.prependBaseUrl('', 'http://example.com/something')).toBe('http://example.com/something');
 		expect(urlUtils.prependBaseUrl('testing.html', '')).toBe('testing.html');
 
-		// It shouldn't prepend anyting for these:
+		// It shouldn't prepend anything for these:
 		expect(urlUtils.prependBaseUrl('mailto:emailme@example.com', 'http://example.com')).toBe('mailto:emailme@example.com');
 		expect(urlUtils.prependBaseUrl('javascript:var%20testing=true', 'http://example.com')).toBe('javascript:var%20testing=true');
 		expect(urlUtils.prependBaseUrl('http://alreadyabsolute.com', 'http://example.com')).toBe('http://alreadyabsolute.com');

--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -88,7 +88,7 @@ class ElectronAppWrapper {
 			// user clicks on the icon in the task bar).
 
 			// On Windows and Linux, the app is closed when the window is closed *except* if the tray icon is used. In which
-			// case the app must be explicitely closed with Ctrl+Q or by right-clicking on the tray icon and selecting "Exit".
+			// case the app must be explicitly closed with Ctrl+Q or by right-clicking on the tray icon and selecting "Exit".
 
 			if (process.platform === 'darwin') {
 				if (this.willQuitApp_) {
@@ -139,7 +139,7 @@ class ElectronAppWrapper {
 	}
 
 	// This method is used in macOS only to hide the whole app (and not just the main window)
-	// including the menu bar. This follows the macOS way of hidding an app.
+	// including the menu bar. This follows the macOS way of hiding an app.
 	hide() {
 		this.electronApp_.hide();
 	}
@@ -220,7 +220,7 @@ class ElectronAppWrapper {
 		await this.waitForElectronAppReady();
 
 		const alreadyRunning = this.ensureSingleInstance();
-		if (alreadyRunning) return;		
+		if (alreadyRunning) return;
 
 		this.createWindow();
 

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -194,7 +194,7 @@ const appReducer = (state = appDefaultState, action) => {
 
 				historyGoingBack = true;
 
-				// Fall throught
+				// Fall through
 
 			case 'NAV_GO':
 

--- a/Tools/buildReactNativeInjectedJs.js
+++ b/Tools/buildReactNativeInjectedJs.js
@@ -1,5 +1,5 @@
 // React Native WebView cannot load external JS files, however it can load
-// arbitraty JS via the injectedJavaScript property. So we use this to load external
+// arbitrary JS via the injectedJavaScript property. So we use this to load external
 // files: First here we convert the JS file to a plain string, and that string
 // is then loaded by eg. the Mermaid plugin, and finally injected in the WebView.
 
@@ -18,7 +18,7 @@ async function copyJs(name, filePath) {
 
 async function main(argv) {
 	await fs.mkdirp(outputDir);
-	await copyJs('webviewLib', rnDir + '/lib/MdToHtml/webviewLib.js');	
+	await copyJs('webviewLib', rnDir + '/lib/MdToHtml/webviewLib.js');
 }
 
 main(process.argv).catch((error) => {

--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 <!--
 
-Please prefix the title with the platform you are targetting:
+Please prefix the title with the platform you are targeting:
 
 - "Desktop" for the Windows/macOS/Linux app (Electron app)
 - "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -7,7 +7,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="https://joplin.cozic.net/css/bootstrap.min.css">
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
-	<link rel="stylesheet" href="https://joplin.cozic.net/css/fontawesome-all.min.css"> 
+	<link rel="stylesheet" href="https://joplin.cozic.net/css/fontawesome-all.min.css">
 	<script src="https://joplin.cozic.net/js/jquery-3.2.1.slim.min.js"></script>
 	<style>
 	body {
@@ -73,7 +73,7 @@
 		height: 3em;
 		text-align: center;
 	}
-	table.screenshots th, 
+	table.screenshots th,
 	table.screenshots td {
 		border: 1px solid #C2C2C2;
 	}
@@ -317,7 +317,7 @@
 </tbody>
 </table>
 <h2 id="master-keys">Master Keys</h2>
-<p>The master keys are used to encrypt and decrypt data. They can be generated from the Encryption Service and are saved to the database. They are themselves encrypted via a user password using a <a href="https://github.com/laurent22/joplin/blob/fb6dee32ac035b00153106273135fb16be4b4fa5/ReactNativeClient/lib/services/EncryptionService.js#L263">strong encyption method</a>.</p>
+<p>The master keys are used to encrypt and decrypt data. They can be generated from the Encryption Service and are saved to the database. They are themselves encrypted via a user password using a <a href="https://github.com/laurent22/joplin/blob/fb6dee32ac035b00153106273135fb16be4b4fa5/ReactNativeClient/lib/services/EncryptionService.js#L263">strong encryption method</a>.</p>
 <p>These encrypted master keys are transmitted with the sync data so that they can be available to each client. Each client will need to supply the user password to decrypt each key.</p>
 <p>The application supports multiple master keys in order to handle cases where one offline client starts encrypting notes, then another offline client starts encrypting notes too, and later both sync. Both master keys will have to be decrypted separately with the user password.</p>
 <p>Only one master key can be active for encryption purposes. For decryption, the algorithm will check the Master Key ID in the header, then check if it&#39;s available to the current app and, if so, use this for decryption.</p>
@@ -341,11 +341,11 @@
 </ul>
 
 <script>
-	function stickyHeader() { 
+	function stickyHeader() {
 		return; // Disabled
 
 		if ($(window).scrollTop() > 179) {
-			$('.nav').addClass('sticky'); 
+			$('.nav').addClass('sticky');
 		} else {
 			$('.nav').removeClass('sticky');
 		}

--- a/docs/terminal/index.html
+++ b/docs/terminal/index.html
@@ -604,8 +604,8 @@ Possible keys/values:
                              Type: string.
 
     sync.target              Synchronisation target.
-                             The target to synchonise to. Each sync target may 
-                             have additional parameters which are named as 
+                             The target to synchronise to. Each sync target may 
+                             have additional parameters which are named as
                              `sync.NUM.NAME` (all documented below).
                              Type: Enum.
                              Possible values: 2 (File system), 3 (OneDrive), 4 

--- a/readme/spec.md
+++ b/readme/spec.md
@@ -32,7 +32,7 @@ Data    |  ("Length" bytes) (ASCII)
 
 ## Master Keys
 
-The master keys are used to encrypt and decrypt data. They can be generated from the Encryption Service and are saved to the database. They are themselves encrypted via a user password using a [strong encyption method](https://github.com/laurent22/joplin/blob/fb6dee32ac035b00153106273135fb16be4b4fa5/ReactNativeClient/lib/services/EncryptionService.js#L263).
+The master keys are used to encrypt and decrypt data. They can be generated from the Encryption Service and are saved to the database. They are themselves encrypted via a user password using a [strong encryption method](https://github.com/laurent22/joplin/blob/fb6dee32ac035b00153106273135fb16be4b4fa5/ReactNativeClient/lib/services/EncryptionService.js#L263).
 
 These encrypted master keys are transmitted with the sync data so that they can be available to each client. Each client will need to supply the user password to decrypt each key.
 

--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -322,10 +322,10 @@ The following commands are available in [command-line mode](#command-line-mode):
 	                             will be used to open a note. If none is provided 
 	                             it will try to auto-detect the default editor.
 	                             Type: string.
-	                             
+
 	    sync.target              Synchronisation target.
-	                             The target to synchonise to. Each sync target may 
-	                             have additional parameters which are named as 
+	                             The target to synchronise to. Each sync target may 
+	                             have additional parameters which are named as
 	                             `sync.NUM.NAME` (all documented below).
 	                             Type: Enum.
 	                             Possible values: 2 (File system), 3 (OneDrive), 4 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,./ElectronClient/app/locales,./ReactNativeClient/locales,./CliClient/locales -L adresse,ba,fonction,te,whet`