### PR TITLE
Desktop: improve search bar text alignment

### DIFF
--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -135,8 +135,11 @@ class HeaderComponent extends React.Component {
 		const inputStyle = {
 			display: 'flex',
 			flex: 1,
-			paddingLeft: 4,
-			paddingRight: 4,
+			paddingLeft: 6,
+			paddingRight: 6,
+			paddingTop: 1,  // vertical alignment with buttons
+			paddingBottom: 0,  // vertical alignment with buttons
+			height: style.fontSize * 2,
 			color: style.color,
 			fontSize: style.fontSize,
 			fontFamily: style.fontFamily,


### PR DESCRIPTION
This makes sure the text in the search bar aligns with the texts of the buttons and makes for an overall more pleasant spacing. See screenshots below.

![alignment-wrong](https://user-images.githubusercontent.com/226708/55290337-4f4a0780-53d2-11e9-83a3-c165504afb26.png)
![alignment-fixed](https://user-images.githubusercontent.com/226708/55290338-507b3480-53d2-11e9-9c74-093113f6a23e.png)
