### PR TITLE
Desktop: fix sub pixel rendering

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -54,6 +54,7 @@ class ElectronAppWrapper {
 			y: windowState.y,
 			width: windowState.width,
 			height: windowState.height,
+                        backgroundColor: '#fff', // required to enable sub pixel rendering, can't be in css
 			webPreferences: {
 				nodeIntegration: true,
 			},


### PR DESCRIPTION
This change improves font rendering for the electron desktop client.

For subpixel rendering to work electron requires the background to be non-transparent.  
This has to be set as an option for the BrowserWindow, see https://github.com/electron/electron/pull/16459/files

