### PR TITLE
All: 1383 Clear selected Notes when switching Notebook

### DIFF
--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -218,6 +218,7 @@ function changeSelectedFolder(state, action, options = null) {
 	if (newState.selectedFolderId === state.selectedFolderId && newState.notesParentType === state.notesParentType) return state;
 
 	if (options.clearNoteHistory) newState.historyNotes = [];
+	if (options.clearSelectedNoteIds) newState.selectedNoteIds = [];
 
 	return newState;
 }
@@ -348,7 +349,7 @@ const reducer = (state = defaultState, action) => {
 
 			case 'FOLDER_SELECT':
 
-				newState = changeSelectedFolder(state, action);
+				newState = changeSelectedFolder(state, action, { clearSelectedNoteIds: true });
 				break;
 
 			case 'FOLDER_AND_NOTE_SELECT':


### PR DESCRIPTION
This commit will fix #1383.

Tried several fixes, but I think this kind of quick-n-dirty fix is the most reasonable. Debugging shows that the root issue surrounds that the render method at NoteTest.jsx is run frequently, and a timing issue in the state can occur. Pausing on a break point actually "fixed" the issue.
