### PR TITLE
add option to use soft breaks for markdown rendering

### DIFF
--- a/ReactNativeClient/lib/MdToHtml.js
+++ b/ReactNativeClient/lib/MdToHtml.js
@@ -52,6 +52,8 @@ class MdToHtml {
 		if (!options.paddingBottom) options.paddingBottom = '0';
 		if (!options.highlightedKeywords) options.highlightedKeywords = [];
 
+		const breaks_ = Setting.value('markdown.softbreaks') ? false : true;
+
 		const cacheKey = md5(escape(body + JSON.stringify(options) + JSON.stringify(style)));
 		const cachedOutput = this.cachedOutputs_[cacheKey];
 		if (cachedOutput) return cachedOutput;
@@ -63,7 +65,7 @@ class MdToHtml {
 		};
 
 		const markdownIt = new MarkdownIt({
-			breaks: true,
+			breaks: breaks_,
 			linkify: true,
 			html: true,
 			highlight: function(str, lang) {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -192,7 +192,7 @@ class Setting extends BaseModel {
 			'searchEngine.lastProcessedChangeId': { value: 0, type: Setting.TYPE_INT, public: false },
 			'searchEngine.initialIndexingDone': { value: false, type: Setting.TYPE_BOOL, public: false },
 			'welcome.wasBuilt': { value: false, type: Setting.TYPE_BOOL, public: false },
-			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks'), description: () => _('Traditional markdown line-break behavior.') },
+			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks'), description: () => _('Traditional markdown line-break behaviour.') },
 		};
 
 		return this.metadata_;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -96,6 +96,7 @@ class Setting extends BaseModel {
 					'body': _('Focus body'),
 				};
 			}},
+			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable traditional markdown line-break behaviour') },
 			'markdown.plugin.katex': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable math expressions')},
 			'markdown.plugin.mark': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax')},
 			'markdown.plugin.footnote': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes')},
@@ -192,7 +193,6 @@ class Setting extends BaseModel {
 			'searchEngine.lastProcessedChangeId': { value: 0, type: Setting.TYPE_INT, public: false },
 			'searchEngine.initialIndexingDone': { value: false, type: Setting.TYPE_BOOL, public: false },
 			'welcome.wasBuilt': { value: false, type: Setting.TYPE_BOOL, public: false },
-			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks'), description: () => _('Traditional markdown line-break behaviour.') },
 		};
 
 		return this.metadata_;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -96,7 +96,7 @@ class Setting extends BaseModel {
 					'body': _('Focus body'),
 				};
 			}},
-			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable traditional markdown line-break behaviour') },
+			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks') },
 			'markdown.plugin.katex': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable math expressions')},
 			'markdown.plugin.mark': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax')},
 			'markdown.plugin.footnote': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes')},

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -192,6 +192,7 @@ class Setting extends BaseModel {
 			'searchEngine.lastProcessedChangeId': { value: 0, type: Setting.TYPE_INT, public: false },
 			'searchEngine.initialIndexingDone': { value: false, type: Setting.TYPE_BOOL, public: false },
 			'welcome.wasBuilt': { value: false, type: Setting.TYPE_BOOL, public: false },
+			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks'), description: () => _('Traditional markdown line-break behavior.') },
 		};
 
 		return this.metadata_;


### PR DESCRIPTION
This PR adds an option to settings to use the traditional line-break behavior.

It is marked as `Work In Progress` because of the following 2 items:

- I added the option under `General` because it's a general markdown setting. We can always move it to a different section.
- I used a separate variable `breaks_`, because I thought it made the code more readable. I can remove it and use the ternary operation directly. Please advise.
