### PR TITLE
Desktop: Don't copy image from clipboard if there is also text

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -114,23 +114,33 @@ class NoteTextComponent extends React.Component {
 		this.onTodoToggle_ = (event) => { if (event.noteId === this.props.noteId) this.scheduleReloadNote(this.props); }
 
 		this.onEditorPaste_ = async (event = null) => {
+			let imageFormat;
+
 			const formats = clipboard.availableFormats();
 			for (let i = 0; i < formats.length; i++) {
 				const format = formats[i].toLowerCase();
 				const formatType = format.split('/')[0]
 
-				if (formatType === 'image') {
-					if (event) event.preventDefault();
-
-					const image = clipboard.readImage();
-
-					const fileExt = mimeUtils.toFileExtension(format);
-					const filePath = Setting.value('tempDir') + '/' + md5(Date.now()) + '.' + fileExt;
-
-					await shim.writeImageToFile(image, format, filePath);
-					await this.commandAttachFile([filePath]);
-					await shim.fsDriver().remove(filePath);
+				if (format === 'text/plain') {
+					return;
 				}
+
+				if (formatType === 'image') {
+					imageFormat = format;
+				}
+			}
+
+			if (imageFormat) {
+				if (event) event.preventDefault();
+
+				const image = clipboard.readImage();
+
+				const fileExt = mimeUtils.toFileExtension(imageFormat);
+				const filePath = Setting.value('tempDir') + '/' + md5(Date.now()) + '.' + fileExt;
+
+				await shim.writeImageToFile(image, imageFormat, filePath);
+				await this.commandAttachFile([filePath]);
+				await shim.fsDriver().remove(filePath);
 			}
 		}
 


### PR DESCRIPTION
Fix for #1291 

On Windows, some programs (e.g., OneNote) store data to the
clipboard in multiple formats. If clipboard contains data in
both text/plain and image/* formats, Joplin will paste the
data twice.

In that case, prefer text/plain to image/* as the former
is editable.

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
