### PR TITLE
build-translation.js: hack to show en_US as 100%

### DIFF
--- a/Tools/build-translation.js
+++ b/Tools/build-translation.js
@@ -156,6 +156,11 @@ async function translationStatus(isDefault, poFile) {
 	translatorName = translatorName.replace(/ </, ' (');
 	translatorName = translatorName.replace(/>/, ')');
 
+	// hack to show en_US as 100%
+	if (poFile.endsWith("en_US.po")) {
+		isDefault = true;
+	}
+
 	return {
 		percentDone: isDefault ? 100 : percentDone,
 		translatorName: translatorName,


### PR DESCRIPTION
en_US is basically always at 100%, but since it is not necessary to translate the common words/sentences, it currently shows only 7%.
