### PR TITLE
Desktop: removed gaps between NoteList and vertical resizers.

### DIFF
--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -334,6 +334,8 @@ class MainScreenComponent extends React.Component {
 			height: rowHeight,
 			display: 'inline-block',
 			verticalAlign: 'top',
+			marginLeft: -5,
+			marginRight: -5,
 		};
 
 		this.styles_.noteText = {


### PR DESCRIPTION
This change is based on proposed design updates I posted in the forums. [This is the related thread](https://discourse.joplinapp.org/t/some-design-suggestions-is-this-worth-implementing/2212).

I'm posting this as a different PR because I think it's the only change that could behave different in other operating systems than the one tested (I tested on MacOS 10.13.6).


