### PR TITLE
Android: Allow User-added CAs

### DIFF
--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -37,7 +37,9 @@
 		android:allowBackup="true"
 		android:label="@string/app_name"
 		android:icon="@mipmap/ic_launcher"
-		android:theme="@style/AppTheme">
+		android:theme="@style/AppTheme"
+		android:networkSecurityConfig="@xml/network_security_config"
+		>
 
 		<!-- ============================= -->
 		<!-- START RN-push-notitication    -->

--- a/ReactNativeClient/android/app/src/main/res/xml/network_security_config.xml
+++ b/ReactNativeClient/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/readme/faq.md
+++ b/readme/faq.md
@@ -93,3 +93,7 @@ Joplin relies on Firebase to enable reliable notifications on Android. Since F-D
 # Why is it named Joplin?
 
 The name comes from the composer and pianist [Scott Joplin](https://en.wikipedia.org/wiki/Scott_Joplin), which I often listen to. His name is also easy to remember and type so it fell like a good choice. And, to quote a user on Hacker News, "though Scott Joplin's ragtime musical style has a lot in common with some very informal music, his own approach was more educated, sophisticated, and precise. Every note was in its place for a reason, and he was known to prefer his pieces to be performed exactly as written. So you could say that compared to the people who came before him, his notes were more organized".
+
+# How can I use self-signed SSL certificates on Android?
+
+If you want to serve using https but can't or don't want to use SSL certificates signed by trusted certificate authorities (like "Let's Encrypt"), it's possible to generate a custom CA and sign your certificates with it. You can generate the CA and certificates using [openssl](https://gist.github.com/fntlnz/cf14feb5a46b2eda428e000157447309), but I like to use a tool called [mkcert](https://github.com/FiloSottile/mkcert) for it's simplicity. Finally, you have to add your CA certificate to Android settings so that Android can recognize the certificates you signed with your CA as valid ([link](https://support.google.com/nexus/answer/2844832?hl=en-GB)).


### PR DESCRIPTION
This will enable connecting to servers with self-signed certificates on
android as per issue #680.
Users are required to install their generated root CA in android settings: https://support.google.com/nexus/answer/2844832?hl=en-GB

Implemented as per:
- https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html
- https://github.com/facebook/react-native/issues/20488

I've tested this on an emulator and my android device with a server running on certificates generated with [mkcert](https://github.com/FiloSottile/mkcert)

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
