### PR TITLE
Desktop: fix for layout conflict introduced by PR #1464

### DIFF
--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -314,6 +314,10 @@ class MainScreenComponent extends React.Component {
 			height: height,
 			display: 'inline-block',
 		};
+		
+		this.styles_.noteListResizer = Object.assign({
+			transform: 'translateX(5px)',
+		}, this.styles_.verticalResizer);
 
 		const rowHeight = height - theme.headerHeight - (messageBoxVisible ? this.styles_.messageBox.height : 0);
 
@@ -495,7 +499,7 @@ class MainScreenComponent extends React.Component {
 				<SideBar style={styles.sideBar} />
 				<VerticalResizer style={styles.verticalResizer} onDrag={this.sidebar_onDrag}/>
 				<NoteList style={styles.noteList} />
-				<VerticalResizer style={styles.verticalResizer} onDrag={this.noteList_onDrag}/>
+				<VerticalResizer style={styles.noteListResizer} onDrag={this.noteList_onDrag}/>
 				<NoteText style={styles.noteText} visiblePanes={this.props.noteVisiblePanes} />
 
 				{pluginDialog}	


### PR DESCRIPTION
I introduced an issue on PR #1464 . When the NoteList has a scrollbar, it looks normal, but it just can't be clicked on because the vertical resizer renders on top of it. So you can resize, but not scroll using the scrollbar.

![joplin-resizers](https://user-images.githubusercontent.com/6557454/56878036-8c2c0d00-6a17-11e9-9780-78cfbc399cc0.png)
The vertical resizers are transparent, shown on color here just to illustrate the issue.

Solution: Using transform:translateX("5px") moves the resizer to the right of the noteList visually, but for the code, all layout and position calculations remain the same, as if it was still on its original place.

I don't like this workaround too much. Alternatively, we could get rid of the negative rightMargin from PR #1464, leave the right vertical resizer as is, remove the vertical line from the left of NoteText and add it to the right of NoteList. This would require additional changes (decreasing the padding in NoteText, there seems to be some calculations taking the 1px border into account, those'd change). I don't know enough about the code yet, so those changes could introduce more side-effects. The other option would be to remove the changes from PR #1464 
