### PR TITLE
Lib: fixes #1468, prevents notes with no title to break after synchronize.

### DIFF
--- a/CliClient/tests/models_BaseItem.js
+++ b/CliClient/tests/models_BaseItem.js
@@ -47,5 +47,20 @@ describe('models_BaseItem', function() {
 
 		expect('ignore_me' in unserialized).toBe(false);
 	}));
+	
+	it('should not modify title when unserializing', asyncTest(async () => {
+	  let folder1 = await Folder.save({ title: "" });
+	  let folder2 = await Folder.save({ title: "folder1" });
+	  
+	  let serialized1 = await Folder.serialize(folder1);
+	  let unserialized1 = await Folder.unserialize(serialized1);
+	  
+	  expect(unserialized1.title).toBe(folder1.title);
+	  
+	  let serialized2 = await Folder.serialize(folder2);
+	  let unserialized2 = await Folder.unserialize(serialized2);
+	  
+	  expect(unserialized2.title).toBe(folder2.title);
+	}));
 
 });

--- a/CliClient/tests/models_Note.js
+++ b/CliClient/tests/models_Note.js
@@ -86,5 +86,32 @@ describe('models_Note', function() {
 		expect(changedNote === note1).toBe(false);
 		expect(!!changedNote.is_todo).toBe(false);
 	}));
+	
+	it('should serialize and unserialize without modifying data', asyncTest(async () => {
+		let folder1 = await Folder.save({ title: "folder1"});
+		const testCases = [
+			[ {title: '', body:'Body and no title\nSecond line\nThird Line', parent_id: folder1.id},
+				'', 'Body and no title\nSecond line\nThird Line'],
+			[ {title: 'Note title', body:'Body and title', parent_id: folder1.id},
+				'Note title', 'Body and title'],
+			[ {title: 'Title and no body', body:'', parent_id: folder1.id},
+				'Title and no body', ''],
+		]
+		
+		for (let i = 0; i < testCases.length; i++) {
+			const t = testCases[i];
+			
+			const input = t[0];
+			const expectedTitle = t[1];
+			const expectedBody = t[1];
+			
+			let note1 = await Note.save(input);
+			let serialized = await Note.serialize(note1);
+			let unserialized = await Note.unserialize( serialized);
+			
+			expect(unserialized.title).toBe(input.title);
+			expect(unserialized.body).toBe(input.body);
+		}
+	}));
 
 });

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -279,7 +279,7 @@ class BaseItem extends BaseModel {
 
 		let temp = [];
 
-		if (output.title) temp.push(output.title);
+		if (typeof output.title === "string") temp.push(output.title);
 		if (output.body) temp.push(output.body);
 		if (output.props.length) temp.push(output.props.join("\n"));
 
@@ -644,7 +644,7 @@ class BaseItem extends BaseModel {
 
 	static displayTitle(item) {
 		if (!item) return '';
-		return !!item.encryption_applied ? '🔑 ' + _('Encrypted') : item.title + '';
+		return !!item.encryption_applied ? '🔑 ' + _('Encrypted') : (!!item.title)? item.title + '' : Note.defaultTitle(item);
 	}
 
 	static async markAllNonEncryptedForSync() {


### PR DESCRIPTION
- Fix: Serialize now leaves an empty line on .md file if title is empty.

- Possible Fix in displayTitle: if there's no title, call Note.defaultTitle(item). This is so the NoteList doesn't display an empty block when note has no title. It's for display only; it doesn't modify the original note. _I'm not sure if this can have any unintended consequences_

unserialize() could also be fixed to prevent loss of the second line as described in #1468, but if serialize works ok, it's unnecessary.