### PR TITLE
Desktop (macOS): Remove separator between New Notebook and Close Window in File Menu

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -588,9 +588,6 @@ class Application extends BaseApplication {
 				newNoteItem,
 				newTodoItem,
 				newNotebookItem, {
-					type: 'separator',
-					visible: shim.isMac() ? true : false
-				}, {
 					label: _('Close Window'),
 					platforms: ['darwin'],
 					accelerator: 'Command+W',


### PR DESCRIPTION
After discussion within #1434 let's remove the separator between New Notebook and Close Window in the File Menu.
