### PR TITLE
Desktop: Fixes #1186, #1354. Clears search when clicking on a notebook.

### DIFF
--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -56,6 +56,18 @@ class HeaderComponent extends React.Component {
 				this.setState({ showSearchUsageLink: false });
 			}, 5000);
 		}
+		
+		this.search_keyDown = event => {
+			if (event.keyCode === 27) { // ESCAPE
+				this.setState({ searchQuery: '' });
+				triggerOnQuery('');
+			}
+		}
+		
+		this.resetSearch = () => {
+			this.setState({ searchQuery: '' });
+			triggerOnQuery('');
+		}
 
 		this.searchUsageLink_click = event => {
 			bridge().openExternal('https://joplinapp.org/#searching');
@@ -68,6 +80,12 @@ class HeaderComponent extends React.Component {
 		}
 	}
 
+	componentDidUpdate(prevProps) {
+	  if(prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
+	    this.resetSearch();
+	  }
+	}
+	
 	componentWillUnmount() {
 		if (this.hideSearchUsageLinkIID_) {
 			clearTimeout(this.hideSearchUsageLinkIID_);
@@ -190,6 +208,7 @@ class HeaderComponent extends React.Component {
 					ref={elem => this.searchElement_ = elem}
 					onFocus={this.search_onFocus}
 					onBlur={this.search_onBlur}
+					onKeyDown={this.search_keyDown}
 				/>
 				<a
 					href="#"
@@ -257,6 +276,7 @@ const mapStateToProps = (state) => {
 	return {
 		theme: state.settings.theme,
 		windowCommand: state.windowCommand,
+		notesParentType: state.notesParentType,
 	};
 };
 

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -79,9 +79,9 @@ class HeaderComponent extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-	  if(prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
+		if(prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
 			this.resetSearch();
-	  }
+		}
 	}
 	
 	componentWillUnmount() {

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -35,8 +35,7 @@ class HeaderComponent extends React.Component {
 		};
 
 		this.search_onClear = (event) => {
-			this.setState({ searchQuery: '' });
-			triggerOnQuery('');
+			this.resetSearch();
 			if (this.searchElement_) this.searchElement_.focus();
 		}
 
@@ -59,8 +58,7 @@ class HeaderComponent extends React.Component {
 		
 		this.search_keyDown = event => {
 			if (event.keyCode === 27) { // ESCAPE
-				this.setState({ searchQuery: '' });
-				triggerOnQuery('');
+				this.resetSearch();
 			}
 		}
 		
@@ -82,7 +80,7 @@ class HeaderComponent extends React.Component {
 
 	componentDidUpdate(prevProps) {
 	  if(prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
-	    this.resetSearch();
+			this.resetSearch();
 	  }
 	}
 	


### PR DESCRIPTION
When you search for notes, and then click on a notebook or tag, you effectively go out of the search UI, but I fixed the following:
1. search input should reset to show you're out of the search (#1186)
2. the search query should reset, otherwise you'll still see highlighted matches in notes (#1354)
3. Unrequested bonus: you can know hit Escape to clear the field. This mimics the behavior of the local search field.

I'm using notesParentType, which is "Search" when you're searching, or "Folder" if you have a folder selected.

It's not optimal to do this in componentDidUpdate, but the options were:
- using componentWillReceiveProps, which is deprecated and causes other small issues.
- Mess with the global data handled by lib, which could affect the other apps and cause more issues than it fixes.
