### PR TITLE
Github: updated Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,42 @@
 # User support
 
-For general discussion about Joplin, user support, software development questions, and to discuss new features, please go to the [Joplin Forum](https://discourse.joplin.cozic.net/). It is possible to login with your GitHub account.
+The [Joplin Forum](https://discourse.joplin.cozic.net/) is the community driven place for user support, general discussion about Joplin, problems with installation, new features and software development questions. It is possible to login with your GitHub account.
 
 # Reporting a bug
 
-Please check first that it [has not already been reported](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). Also consider [enabling debug mode](https://github.com/laurent22/joplin/blob/master/readme/debugging.md) before reporting the issue so that you can provide as much details as possible to help fix it.
+File bugs in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). Please follow these guidelines:
 
-If possible, **please provide a screenshot**. A screenshot showing the problem is often more useful than a paragraph describing it as it can make it immediately clear what the issue is.
+- Search existing issues first, make sure yours hasn't already been reported.
+- Don't use the issue tracker for support questions.
+- Consider [enabling debug mode](https://github.com/laurent22/joplin/blob/master/readme/debugging.md) before so that you can provide as much details as possible when reporting the issue.
+- Stay on topic, but describe the issue in detail so that others can reproduce it.
+- **Provide a screenshot** if possible. A screenshot showing the problem is often more useful than a paragraph describing it.
 
 # Feature requests
 
-Again, please check that it has not already been requested. If it has, simply **up-vote the issue** - the ones with the most up-votes are likely to be implemented. "+1" comments are not tracked.
+Please check that your request has not already been posted in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). If it has, **up-voting the issue** increases the chances it'll be noticed and implemented in the future. "+1" comments are not tracked.
 
-# Creating a pull request
+As a general rule, suggestions to _improve Joplin_ should be posted first in the [Joplin Forum](https://discourse.joplin.cozic.net/) for discussion.
 
-- If you want to add a new feature, consider asking about it before implementing it or checking existing discussions to make sure it is within the scope of the project. As a rule of thumb **if your change is likely to involve more than 50 lines of code, you should discuss it in the forum**, just so that you don't spend too much time implementing something that might not be accepted.
+Avoid listing multiple requests in one report in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). One issue per request makes it easier to track and discuss it.
 
-- Bug fixes are always welcome.
+# Contribute to the project
+
+## Contributing to Joplin's translation
+
+Joplin is available in multiple languages thanks to the help of its users. You can help translate Joplin to your language or keep it up to date. Please read the documentation about [Localisation](https://github.com/laurent22/joplin#localisation).
+
+## Contributing to Joplin's code
+
+If you want to start contributing to the project's code, please follow these guidelines before creating a pull request: 
+
+- Bug fixes are always welcome. Start by reviewing the list of [essential issues](https://github.com/laurent22/joplin/issues?q=is%3Aissue+is%3Aopen+label%3Aessential)
+- Before adding a new feature, ask about it in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue) or the [Joplin Forum](https://discourse.joplin.cozic.net/), or check if existing discussions exist to make sure the new functionality is desired.
+- **Changes that will consist in more than 50 lines of code should be discussed the [Joplin Forum](https://discourse.joplin.cozic.net/)**, so that you don't spend too much time implementing something that might not be accepted.
 
 Building the apps is relatively easy - please [see the build instructions](https://github.com/laurent22/joplin/blob/master/BUILD.md) for more details.
 
-# Coding style
+## Coding style
 
 There are only two rules, but not following them means the pull request will not be accepted (it can be accepted once the issues are fixed):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # User support
 
-The [Joplin Forum](https://discourse.joplin.cozic.net/) is the community driven place for user support, general discussion about Joplin, problems with installation, new features and software development questions. It is possible to login with your GitHub account.
+The [Joplin Forum](https://discourse.joplinapp.org/) is the community driven place for user support, general discussion about Joplin, problems with installation, new features and software development questions. It is possible to login with your GitHub account.
 
 # Reporting a bug
 
@@ -8,7 +8,7 @@ File bugs in the [Github Issue Tracker](https://github.com/laurent22/joplin/issu
 
 - Search existing issues first, make sure yours hasn't already been reported.
 - Don't use the issue tracker for support questions.
-- Consider [enabling debug mode](https://github.com/laurent22/joplin/blob/master/readme/debugging.md) before so that you can provide as much details as possible when reporting the issue.
+- Consider [enabling debug mode](https://github.com/laurent22/joplin/blob/master/readme/debugging.md) so that you can provide as much details as possible when reporting the issue.
 - Stay on topic, but describe the issue in detail so that others can reproduce it.
 - **Provide a screenshot** if possible. A screenshot showing the problem is often more useful than a paragraph describing it.
 
@@ -16,7 +16,7 @@ File bugs in the [Github Issue Tracker](https://github.com/laurent22/joplin/issu
 
 Please check that your request has not already been posted in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). If it has, **up-voting the issue** increases the chances it'll be noticed and implemented in the future. "+1" comments are not tracked.
 
-As a general rule, suggestions to _improve Joplin_ should be posted first in the [Joplin Forum](https://discourse.joplin.cozic.net/) for discussion.
+As a general rule, suggestions to _improve Joplin_ should be posted first in the [Joplin Forum](https://discourse.joplinapp.org/) for discussion.
 
 Avoid listing multiple requests in one report in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue). One issue per request makes it easier to track and discuss it.
 
@@ -31,8 +31,8 @@ Joplin is available in multiple languages thanks to the help of its users. You c
 If you want to start contributing to the project's code, please follow these guidelines before creating a pull request: 
 
 - Bug fixes are always welcome. Start by reviewing the list of [essential issues](https://github.com/laurent22/joplin/issues?q=is%3Aissue+is%3Aopen+label%3Aessential)
-- Before adding a new feature, ask about it in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue) or the [Joplin Forum](https://discourse.joplin.cozic.net/), or check if existing discussions exist to make sure the new functionality is desired.
-- **Changes that will consist in more than 50 lines of code should be discussed the [Joplin Forum](https://discourse.joplin.cozic.net/)**, so that you don't spend too much time implementing something that might not be accepted.
+- Before adding a new feature, ask about it in the [Github Issue Tracker](https://github.com/laurent22/joplin/issues?utf8=%E2%9C%93&q=is%3Aissue) or the [Joplin Forum](https://discourse.joplinapp.org/), or check if existing discussions exist to make sure the new functionality is desired.
+- **Changes that will consist in more than 50 lines of code should be discussed the [Joplin Forum](https://discourse.joplinapp.org/)**, so that you don't spend too much time implementing something that might not be accepted.
 
 Building the apps is relatively easy - please [see the build instructions](https://github.com/laurent22/joplin/blob/master/BUILD.md) for more details.
 


### PR DESCRIPTION
- Added some guidelines based on suggested ideas from [the forum](https://discourse.joplinapp.org/t/contributing-md-suggestions/2317/8)
- Moved some rules to bulleted lists (for quicker reading).
- When possible, moved the main idea of sentences to the beginning of the sentences (for example: "The _Joplin Forum_ is the...place for user support", instead of "For general support, software questions...go to the _Joplin Forum_")