### PR TITLE
Desktop: Fix for #1426, backticks added to auto-wrapping quotes.

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -864,6 +864,9 @@ class NoteTextComponent extends React.Component {
 				}
 				return output;
 			}
+			
+			//fixes #1426 but this is an Ace issue, so it can be removed if ace/brace is updated.
+			this.editor_.editor.getSession().getMode().$quotes = {'"': '"', "'": "'", "`": "`"};
 
 			// Disable Markdown auto-completion (eg. auto-adding a dash after a line with a dash.
 			// https://github.com/ajaxorg/ace/issues/2754


### PR DESCRIPTION
I'm adding the $quotes property to the Ace Mode dynamically. The code also modifies the getNextLineIndent() method for the Mode a line after my change, so I assume this is the correct place for the code. 

$quotes is undefined by default. Ace recently added this to [their markdown mode](https://github.com/ajaxorg/ace/blob/master/lib/ace/mode/markdown.js). However, they don't add single quotes. I added single quotes they work in the current editor, so not to break any functionality.

I tested with [ { " ' ( `
@tessus can you test if this works? Ace documentation is either frustrating or non-existent! so I'm just adding this based on what you posted on #1426, and it magically works.
