### PR TITLE
Mobile: Bump version of multimd-tables for mobile

### DIFF
--- a/ReactNativeClient/package.json
+++ b/ReactNativeClient/package.json
@@ -28,7 +28,7 @@
     "markdown-it-ins": "^2.0.0",
     "markdown-it-katex": "^2.0.3",
     "markdown-it-mark": "^2.0.0",
-    "markdown-it-multimd-table": "^3.1.3",
+    "markdown-it-multimd-table": "^3.2.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "markdown-it-toc-done-right": "^3.0.1",


### PR DESCRIPTION
I forgot to bump the version of the table plugin when updating. One of the table options isn't supported in the older version, to my knowledge no one is using this option yet.