### PR TITLE
fix backtick side effect in editor

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -880,9 +880,116 @@ class NoteTextComponent extends React.Component {
 				}
 				return output;
 			}
-			
-			//fixes #1426 but this is an Ace issue, so it can be removed if ace/brace is updated.
+
+			// fixes #1426 but this is an Ace issue, so it can be removed if ace/brace is updated.
+			// START of very ugly hack... (but it works)
+			var context;
+			var contextCache = {};
+			var initContext = function(editor) {
+				var id = -1;
+				if (editor.multiSelect) {
+					id = editor.selection.index;
+					if (contextCache.rangeCount != editor.multiSelect.rangeCount)
+						contextCache = {rangeCount: editor.multiSelect.rangeCount};
+				}
+				if (contextCache[id])
+					return context = contextCache[id];
+				context = contextCache[id] = {
+					autoInsertedBrackets: 0,
+					autoInsertedRow: -1,
+					autoInsertedLineEnd: "",
+					maybeInsertedBrackets: 0,
+					maybeInsertedRow: -1,
+					maybeInsertedLineStart: "",
+					maybeInsertedLineEnd: ""
+				};
+			};
+			var getWrapped = function(selection, selected, opening, closing) {
+				var rowDiff = selection.end.row - selection.start.row;
+				return {
+					text: opening + selected + closing,
+					selection: [
+							0,
+							selection.start.column + 1,
+							rowDiff,
+							selection.end.column + (rowDiff ? 0 : 1)
+						]
+				};
+			};
 			this.editor_.editor.getSession().getMode().$quotes = {'"': '"', "'": "'", "`": "`"};
+			this.editor_.editor.getSession().getMode().$behaviour.remove("string_dquotes");
+			this.editor_.editor.getSession().getMode().$behaviour.add("string_dquotes", "insertion", function(state, action, editor, session, text) {
+				var quotes = session.$mode.$quotes || defaultQuotes;
+				if (text.length == 1 && quotes[text]) {
+					if (this.lineCommentStart && this.lineCommentStart.indexOf(text) != -1)
+						return;
+					initContext(editor);
+					var quote = text;
+					var selection = editor.getSelectionRange();
+					var selected = session.doc.getTextRange(selection);
+					if (selected !== "" && (selected.length != 1 || !quotes[selected]) && editor.getWrapBehavioursEnabled()) {
+						return getWrapped(selection, selected, quote, quote);
+					} else if (!selected) {
+						var cursor = editor.getCursorPosition();
+						var line = session.doc.getLine(cursor.row);
+						var leftChar = line.substring(cursor.column-1, cursor.column);
+						var rightChar = line.substring(cursor.column, cursor.column + 1);
+
+						var token = session.getTokenAt(cursor.row, cursor.column);
+						var rightToken = session.getTokenAt(cursor.row, cursor.column + 1);
+						// We're escaped.
+						if (leftChar == "\\" && token && /escape/.test(token.type))
+							return null;
+
+						var stringBefore = token && /string|escape/.test(token.type);
+						var stringAfter = !rightToken || /string|escape/.test(rightToken.type);
+
+						var pair;
+						if (rightChar == quote) {
+							pair = stringBefore !== stringAfter;
+							if (pair && /string\.end/.test(rightToken.type))
+								pair = false;
+						} else {
+							if (stringBefore && !stringAfter)
+								return null; // wrap string with different quote
+							if (stringBefore && stringAfter)
+								return null; // do not pair quotes inside strings
+							var wordRe = session.$mode.tokenRe;
+							wordRe.lastIndex = 0;
+							var isWordBefore = wordRe.test(leftChar);
+							wordRe.lastIndex = 0;
+							var isWordAfter = wordRe.test(leftChar);
+							if (isWordBefore || isWordAfter)
+								return null; // before or after alphanumeric
+							if (rightChar && !/[\s;,.})\]\\]/.test(rightChar))
+								return null; // there is rightChar and it isn't closing
+							var charBefore = line[cursor.column - 2];
+							if (leftChar == quote &&  (charBefore == quote || wordRe.test(charBefore)))
+								return null;
+							pair = true;
+						}
+						return {
+							text: pair ? quote + quote : "",
+							selection: [1,1]
+						};
+					}
+				}
+			});
+			this.editor_.editor.getSession().getMode().$behaviour.add("string_dquotes", "deletion", function(state, action, editor, session, range) {
+				var quotes = session.$mode.$quotes || defaultQuotes;
+
+				var selected = session.doc.getTextRange(range);
+				if (!range.isMultiLine() && quotes.hasOwnProperty(selected)) {
+					initContext(editor);
+					var line = session.doc.getLine(range.start.row);
+					var rightChar = line.substring(range.start.column + 1, range.start.column + 2);
+					if (rightChar == selected) {
+						range.end.column++;
+						return range;
+					}
+				}
+			});
+			// END of very ugly hack
 
 			// Disable Markdown auto-completion (eg. auto-adding a dash after a line with a dash.
 			// https://github.com/ajaxorg/ace/issues/2754

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -883,27 +883,6 @@ class NoteTextComponent extends React.Component {
 
 			// fixes #1426 but this is an Ace issue, so it can be removed if ace/brace is updated.
 			// START of very ugly hack... (but it works)
-			var context;
-			var contextCache = {};
-			var initContext = function(editor) {
-				var id = -1;
-				if (editor.multiSelect) {
-					id = editor.selection.index;
-					if (contextCache.rangeCount != editor.multiSelect.rangeCount)
-						contextCache = {rangeCount: editor.multiSelect.rangeCount};
-				}
-				if (contextCache[id])
-					return context = contextCache[id];
-				context = contextCache[id] = {
-					autoInsertedBrackets: 0,
-					autoInsertedRow: -1,
-					autoInsertedLineEnd: "",
-					maybeInsertedBrackets: 0,
-					maybeInsertedRow: -1,
-					maybeInsertedLineStart: "",
-					maybeInsertedLineEnd: ""
-				};
-			};
 			var getWrapped = function(selection, selected, opening, closing) {
 				var rowDiff = selection.end.row - selection.start.row;
 				return {
@@ -923,7 +902,6 @@ class NoteTextComponent extends React.Component {
 				if (text.length == 1 && quotes[text]) {
 					if (this.lineCommentStart && this.lineCommentStart.indexOf(text) != -1)
 						return;
-					initContext(editor);
 					var quote = text;
 					var selection = editor.getSelectionRange();
 					var selected = session.doc.getTextRange(selection);
@@ -980,7 +958,6 @@ class NoteTextComponent extends React.Component {
 
 				var selected = session.doc.getTextRange(range);
 				if (!range.isMultiLine() && quotes.hasOwnProperty(selected)) {
-					initContext(editor);
 					var line = session.doc.getLine(range.start.row);
 					var rightChar = line.substring(range.start.column + 1, range.start.column + 2);
 					if (rightChar == selected) {


### PR DESCRIPTION
see https://github.com/laurent22/joplin/pull/1534#issuecomment-496310488 and following discussion.

This change is an ugly hack, which works. ace development will help react-ace to update ace, so I hope we can remove this soon. Until then...

I have tested it quite extensively, but I kindly ask that someone verifies the change.
