### PR TITLE
[WIP] add shortcut for note properties and item in context menu

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -775,6 +775,19 @@ class Application extends BaseApplication {
 					label: _('Focus'),
 					screens: ['Main'],
 					submenu: focusItems,
+				}, {
+					type: 'separator',
+					screens: ['Main'],
+				}, {
+					label: _('Note properties'),
+					screens: ['Main'],
+					accelerator: 'CommandOrControl+Alt+I',
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'commandNoteProperties',
+						});
+					},
 				}],
 			},
 			tools: {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -783,10 +783,14 @@ class Application extends BaseApplication {
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+Alt+I',
 					click: () => {
-						this.dispatch({
-							type: 'WINDOW_COMMAND',
-							name: 'commandNoteProperties',
-						});
+						if (this.store().getState().selectedNoteIds.length === 1) {
+							this.dispatch({
+								type: 'WINDOW_COMMAND',
+								name: 'commandNoteProperties',
+								noteId: this.store().getState().selectedNoteIds[0],
+								onRevisionLinkClick: () => { this.setState({ showRevisions: true}) },
+							});
+						}
 					},
 				}],
 			},

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -81,6 +81,14 @@ class NoteListUtils {
 				clipboard.writeText(links.join(' '));
 			}}));
 
+			menu.append(new MenuItem({label: _('Note properties'), enabled: noteIds.length === 1, click: async () => {
+				props.dispatch({
+					type: 'WINDOW_COMMAND',
+					name: 'commandNoteProperties',
+					noteId: noteIds[0],
+				});
+			}}));
+
 			const exportMenu = new Menu();
 
 			const ioService = new InteropService();

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -86,6 +86,7 @@ class NoteListUtils {
 					type: 'WINDOW_COMMAND',
 					name: 'commandNoteProperties',
 					noteId: noteIds[0],
+					onRevisionLinkClick: () => { this.setState({ showRevisions: true}) },
 				});
 			}}));
 


### PR DESCRIPTION
I tried to add a shortcut to show the note properties:

<img width="234" alt="image" src="https://user-images.githubusercontent.com/223439/59163522-54ad8780-8ad0-11e9-9cd0-997518e093cb.png">

However, the following happens:

<img width="164" alt="image" src="https://user-images.githubusercontent.com/223439/59163536-76a70a00-8ad0-11e9-8776-9b2350e2076c.png">

I suspect this has something to do with the fact that the `noteId` might be needed. But how do I get the current `noteId` in `app.js`?

Then I also tried to add it to the context menu when right clicking a note:

<img width="338" alt="image" src="https://user-images.githubusercontent.com/223439/59163566-c554a400-8ad0-11e9-90fa-5aa3b994e417.png">

This works, but I was not able to get the `Previous version of this note` link working. Once again, I think something is needed which is not available in that context.


