### PR TITLE
Backtick changes

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -669,6 +669,16 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
+					label: _('Inline Code'),
+					screens: ['Main'],
+					accelerator: 'CommandOrControl+`',
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'textCode',
+						});
+					},
+				}, {
 					type: 'separator',
 					screens: ['Main'],
 				}, {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -669,7 +669,7 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
-					label: _('Inline Code'),
+					label: _('Code'),
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+`',
 					click: () => {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -896,9 +896,6 @@ class NoteTextComponent extends React.Component {
 				}
 				return output;
 			}
-			
-			//fixes #1426 but this is an Ace issue, so it can be removed if ace/brace is updated.
-			this.editor_.editor.getSession().getMode().$quotes = {'"': '"', "'": "'", "`": "`"};
 
 			// Disable Markdown auto-completion (eg. auto-adding a dash after a line with a dash.
 			// https://github.com/ajaxorg/ace/issues/2754

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1019,6 +1019,8 @@ class NoteTextComponent extends React.Component {
 				fn = this.commandStartExternalEditing;
 			} else if (command.name === 'showLocalSearch') {
 				fn = this.commandShowLocalSearch;
+			} else if (command.name === 'textCode') {
+				fn = this.commandTextCode;
 			}
 		}
 


### PR DESCRIPTION
- revert 7dee930
- add shortcut ``` cmd+` ``` / ``` ctrl+` ```
- add menu item for `Inline code`
