### PR TITLE
release-clipper.js: create a zip file of the source (for validation)

### DIFF
--- a/Tools/release-clipper.js
+++ b/Tools/release-clipper.js
@@ -1,7 +1,8 @@
 const fs = require('fs-extra');
 const { execCommand } = require('./tool-utils.js');
 
-const clipperDir = __dirname + '/../Clipper/joplin-webclipper';
+const clipperDir   = __dirname + '/../Clipper/joplin-webclipper';
+const tmpSourceDir = __dirname + '/../Clipper/joplin-webclipper-source';
 
 async function copyDir(baseSourceDir, sourcePath, baseDestDir) {
 	await fs.mkdirp(baseDestDir + '/' + sourcePath);
@@ -75,6 +76,12 @@ async function main() {
 		console.info(await execCommand('7z a -tzip ' + dist.name + '.zip *'));
 		console.info(await execCommand('mv ' + dist.name + '.zip ..'));
 	}
+
+	console.info('Creating source tarball for code validation...');
+	process.chdir(clipperDir + '/../');
+	console.info(await execCommand("rsync -a --delete --exclude 'node_modules/' --exclude 'build/' --exclude 'dist/' " + clipperDir + '/ ' + tmpSourceDir + '/'));
+	console.info(await execCommand('7z a -tzip joplin-webclipper-source.zip joplin-webclipper-source'));
+	console.info(await execCommand('mv joplin-webclipper-source.zip ' + clipperDir + '/dist/ && rm -rf joplin-webclipper-source'));
 
 	console.info(await execCommand('git pull'));
 	console.info(await execCommand('git add -A'));


### PR DESCRIPTION
The file `joplin-webclipper-source.zip` will be in the `dist` directory of the webclipper.

As discussed earlier, I've finally modified the `release-clipper.js` script to create a source tarball for validation as required by the Mozilla add-on store.

Btw, not related to this PR, the `npm run build` command throws several warnings.
