### PR TITLE
Desktop: Create fileURLs via drag and drop

### DIFF
--- a/CliClient/tests/pathUtils.js
+++ b/CliClient/tests/pathUtils.js
@@ -77,7 +77,7 @@ describe('pathUtils', function() {
 		const platform = process.platform;
 		let testCases = [];
 
-		if (platform == 'win32') {
+		if (platform === 'win32') {
 			testCases = [
 				['C:\\handle\\space test', 'file:///C:/handle/space+test'],
 				['C:\\escapeplus\\+', 'file:///C:/escapeplus/%2B'],
@@ -94,7 +94,7 @@ describe('pathUtils', function() {
 
 		for (let i = 0; i < testCases.length; i++) {
 			const t = testCases[i];
-			expect(toFileProtocolPath(t[0])).toBe(t[1]);
+			expect(toFileProtocolPath(t[0], platform)).toBe(t[1]);
 		} 
 
 		done();

--- a/CliClient/tests/pathUtils.js
+++ b/CliClient/tests/pathUtils.js
@@ -74,27 +74,24 @@ describe('pathUtils', function() {
 	});
 
 	it('should create correct fileURL syntax', async (done) => {
-		const platform = process.platform;
-		let testCases = [];
+		const testCases_win32 = [
+			['C:\\handle\\space test', 'file:///C:/handle/space+test'],
+			['C:\\escapeplus\\+', 'file:///C:/escapeplus/%2B'],
+			['C:\\handle\\single quote\'', 'file:///C:/handle/single+quote%27'],				
+		];
+		const testCases_unixlike = [
+			['/handle/space test', 'file:///handle/space+test'],
+			['/escapeplus/+', 'file:///escapeplus/%2B'],
+			['/handle/single quote\'', 'file:///handle/single+quote%27'],
+		];
 
-		if (platform === 'win32') {
-			testCases = [
-				['C:\\handle\\space test', 'file:///C:/handle/space+test'],
-				['C:\\escapeplus\\+', 'file:///C:/escapeplus/%2B'],
-				['C:\\handle\\single quote\'', 'file:///C:/handle/single+quote%27'],				
-			];
-		} else {
-			testCases = [
-				['/handle/space test', 'file:///handle/space+test'],
-				['/escapeplus/+', 'file:///escapeplus/%2B'],
-				['/handle/single quote\'', 'file:///handle/single+quote%27'],
-			];
-		}
-
-
-		for (let i = 0; i < testCases.length; i++) {
-			const t = testCases[i];
-			expect(toFileProtocolPath(t[0], platform)).toBe(t[1]);
+		for (let i = 0; i < testCases_win32.length; i++) {
+			const t = testCases_win32[i];
+			expect(toFileProtocolPath(t[0], 'win32')).toBe(t[1]);
+		} 
+		for (let i = 0; i < testCases_unixlike.length; i++) {
+			const t = testCases_unixlike[i];
+			expect(toFileProtocolPath(t[0], 'linux')).toBe(t[1]);
 		} 
 
 		done();

--- a/CliClient/tests/pathUtils.js
+++ b/CliClient/tests/pathUtils.js
@@ -1,6 +1,6 @@
 require('app-module-path').addPath(__dirname);
 
-const { extractExecutablePath, quotePath, unquotePath, friendlySafeFilename } = require('lib/path-utils.js');
+const { extractExecutablePath, quotePath, unquotePath, friendlySafeFilename, toFileProtocolPath} = require('lib/path-utils.js');
 const { fileContentEqual, setupDatabase, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync } = require('test-utils.js');
 
 process.on('unhandledRejection', (reason, p) => {
@@ -68,6 +68,33 @@ describe('pathUtils', function() {
 		for (let i = 0; i < testCases.length; i++) {
 			const t = testCases[i];
 			expect(extractExecutablePath(t[0])).toBe(t[1]);
+		} 
+
+		done();
+	});
+
+	it('should create correct fileURL syntax', async (done) => {
+		const platform = process.platform;
+		let testCases = [];
+
+		if (platform == 'win32') {
+			testCases = [
+				['C:\\handle\\space test', 'file:///C:/handle/space+test'],
+				['C:\\escapeplus\\+', 'file:///C:/escapeplus/%2B'],
+				['C:\\handle\\single quote\'', 'file:///C:/handle/single+quote%27'],				
+			];
+		} else {
+			testCases = [
+				['/handle/space test', 'file:///handle/space+test'],
+				['/escapeplus/+', 'file:///escapeplus/%2B'],
+				['/handle/single quote\'', 'file:///handle/single+quote%27'],
+			];
+		}
+
+
+		for (let i = 0; i < testCases.length; i++) {
+			const t = testCases[i];
+			expect(toFileProtocolPath(t[0])).toBe(t[1]);
 		} 
 
 		done();

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -172,6 +172,7 @@ class NoteTextComponent extends React.Component {
 
 		this.onDrop_ = async (event) => {
 			const dt = event.dataTransfer;
+			const createFileURL = event.altKey;
 
 			if (dt.types.indexOf("text/x-jop-note-ids") >= 0) {
 				const noteIds = JSON.parse(dt.getData("text/x-jop-note-ids"));
@@ -195,7 +196,7 @@ class NoteTextComponent extends React.Component {
 				filesToAttach.push(file.path);
 			}
 
-			await this.commandAttachFile(filesToAttach);
+			await this.commandAttachFile(filesToAttach, createFileURL);
 		}
 
 		const updateSelectionRange = () => {
@@ -1049,7 +1050,7 @@ class NoteTextComponent extends React.Component {
 		});
 	}
 
-	async commandAttachFile(filePaths = null) {
+	async commandAttachFile(filePaths = null, createFileURL = false) {
 		if (!filePaths) {
 			filePaths = bridge().showOpenDialog({
 				properties: ['openFile', 'createDirectory', 'multiSelections'],
@@ -1066,7 +1067,7 @@ class NoteTextComponent extends React.Component {
 			const filePath = filePaths[i];
 			try {
 				reg.logger().info('Attaching ' + filePath);
-				note = await shim.attachFileToNote(note, filePath, position);
+				note = await shim.attachFileToNote(note, filePath, position, createFileURL);
 				reg.logger().info('File was attached.');
 				this.setState({
 					note: Object.assign({}, note),

--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@ Joplin was designed as a replacement for Evernote and so can import complete Eve
 
 To import Evernote data, first export your Evernote notebooks to ENEX files as described [here](https://help.evernote.com/hc/en-us/articles/209005557-How-to-back-up-export-and-restore-import-notes-and-notebooks). Then follow these steps:
 
-On the **desktop application**, open File > Import > ENEX and select your file. The notes will be imported into a new separate notebook. If needed they can then be moved to a different notebook, or the notebook can be renamed, etc.
+In the **desktop application**, open File > Import > ENEX and select your file. The notes will be imported into a new separate notebook. If needed they can then be moved to a different notebook, or the notebook can be renamed, etc.
 
-On the **terminal application**, in [command-line mode](https://joplinapp.org/terminal/#command-line-mode), type `import /path/to/file.enex`. This will import the notes into a new notebook named after the filename.
+In the **terminal application**, in [command-line mode](https://joplinapp.org/terminal/#command-line-mode), type `import /path/to/file.enex`. This will import the notes into a new notebook named after the filename.
 
 ## Importing from Markdown files
 
 Joplin can import notes from plain Markdown file. You can either import a complete directory of Markdown files or individual files.
 
-On the **desktop application**, open File > Import > MD and select your Markdown file or directory.
+In the **desktop application**, open File > Import > MD and select your Markdown file or directory.
 
-On the **terminal application**, in [command-line mode](https://joplinapp.org/terminal/#command-line-mode), type `import --format md /path/to/file.md` or `import --format md /path/to/directory/`.
+In the **terminal application**, in [command-line mode](https://joplinapp.org/terminal/#command-line-mode), type `import --format md /path/to/file.md` or `import --format md /path/to/directory/`.
 
 ## Importing from other applications
 
@@ -141,9 +141,9 @@ Currently, synchronisation is possible with Nextcloud, Dropbox (by default), One
 
 <img src="https://joplinapp.org/images/nextcloud-logo-background.png" width="100" align="left"> <a href="https://nextcloud.com/">Nextcloud</a> is a self-hosted, private cloud solution. It can store documents, images and videos but also calendars, passwords and countless other things and can sync them to your laptop or phone. As you can host your own Nextcloud server, you own both the data on your device and infrastructure used for synchronisation. As such it is a good fit for Joplin. The platform is also well supported and with a strong community, so it is likely to be around for a while - since it's open source anyway, it is not a service that can be closed, it can exist on a server for as long as one chooses.
 
-On the **desktop application** or **mobile application**, go to the config screen and select Nextcloud as the synchronisation target. Then input the WebDAV URL (to get it, click on Settings in the bottom left corner of the page, in Nextcloud), this is normally `https://example.com/nextcloud/remote.php/webdav/Joplin` (**make sure to create the "Joplin" directory in Nextcloud**), and set the username and password. If it does not work, please [see this explanation](https://github.com/laurent22/joplin/issues/61#issuecomment-373282608) for more details.
+In the **desktop application** or **mobile application**, go to the config screen and select Nextcloud as the synchronisation target. Then input the WebDAV URL (to get it, click on Settings in the bottom left corner of the page, in Nextcloud), this is normally `https://example.com/nextcloud/remote.php/webdav/Joplin` (**make sure to create the "Joplin" directory in Nextcloud**), and set the username and password. If it does not work, please [see this explanation](https://github.com/laurent22/joplin/issues/61#issuecomment-373282608) for more details.
 
-On the **terminal application**, you will need to set the `sync.target` config variable and all the `sync.5.path`, `sync.5.username` and `sync.5.password` config variables to, respectively the Nextcloud WebDAV URL, your username and your password. This can be done from the command line mode using:
+In the **terminal application**, you will need to set the `sync.target` config variable and all the `sync.5.path`, `sync.5.username` and `sync.5.password` config variables to, respectively the Nextcloud WebDAV URL, your username and your password. This can be done from the command line mode using:
 
 	:config sync.5.path https://example.com/nextcloud/remote.php/webdav/Joplin
 	:config sync.5.username YOUR_USERNAME
@@ -156,9 +156,9 @@ If synchronisation does not work, please consult the logs in the app profile dir
 
 When syncing with Dropbox, Joplin creates a sub-directory in Dropbox, in `/Apps/Joplin` and read/write the notes and notebooks from it. The application does not have access to anything outside this directory.
 
-On the **desktop application** or **mobile application**, select "Dropbox" as the synchronisation target in the config screen (it is selected by default). Then, to initiate the synchronisation process, click on the "Synchronise" button in the sidebar and follow the instructions.
+In the **desktop application** or **mobile application**, select "Dropbox" as the synchronisation target in the config screen (it is selected by default). Then, to initiate the synchronisation process, click on the "Synchronise" button in the sidebar and follow the instructions.
 
-On the **terminal application**, to initiate the synchronisation process, type `:sync`. You will be asked to follow a link to authorise the application. It is possible to also synchronise outside of the user interface by typing `joplin sync` from the terminal. This can be used to setup a cron script to synchronise at regular interval. For example, this would do it every 30 minutes:
+In the **terminal application**, to initiate the synchronisation process, type `:sync`. You will be asked to follow a link to authorise the application. It is possible to also synchronise outside of the user interface by typing `joplin sync` from the terminal. This can be used to setup a cron script to synchronise at regular interval. For example, this would do it every 30 minutes:
 
 	*/30 * * * * /path/to/joplin sync
 
@@ -185,9 +185,9 @@ WebDAV-compatible services that are known to work with Joplin:
 
 When syncing with OneDrive, Joplin creates a sub-directory in OneDrive, in /Apps/Joplin and read/write the notes and notebooks from it. The application does not have access to anything outside this directory.
 
-On the **desktop application** or **mobile application**, select "OneDrive" as the synchronisation target in the config screen. Then, to initiate the synchronisation process, click on the "Synchronise" button in the sidebar and follow the instructions.
+In the **desktop application** or **mobile application**, select "OneDrive" as the synchronisation target in the config screen. Then, to initiate the synchronisation process, click on the "Synchronise" button in the sidebar and follow the instructions.
 
-On the **terminal application**, to initiate the synchronisation process, type `:sync`. You will be asked to follow a link to authorise the application (simply input your Microsoft credentials - you do not need to register with OneDrive).
+In the **terminal application**, to initiate the synchronisation process, type `:sync`. You will be asked to follow a link to authorise the application (simply input your Microsoft credentials - you do not need to register with OneDrive).
 
 # Encryption
 
@@ -211,7 +211,8 @@ Joplin notes can be opened and edited using an external editor of your choice. I
 
 Any kind of file can be attached to a note. In Markdown, links to these files are represented as a simple ID to the resource. In the note viewer, these files, if they are images, will be displayed or, if they are other files (PDF, text files, etc.) they will be displayed as links. Clicking on this link will open the file in the default application.
 
-On the **desktop application**, images can be attached either by clicking on "Attach file" or by pasting (with Ctrl+V) an image directly in the editor, or by drag and dropping an image.
+In the **desktop application**, files can be attached either by clicking the "Attach file" icon in the editor or via drag and drop. If you prefer to create a link to a local file instead, hold the ALT key while performing the drag and drop operation.
+If the OS-clipboard contains an image you can directly paste it in the editor via Ctrl+V.
 
 Resources that are not attached to any note will be automatically deleted after 10 days (see [rationale](https://github.com/laurent22/joplin/issues/154#issuecomment-356582366)).
 
@@ -219,7 +220,7 @@ Resources that are not attached to any note will be automatically deleted after 
 
 # Notifications
 
-On the desktop and mobile apps, an alarm can be associated with any to-do. It will be triggered at the given time by displaying a notification. How the notification will be displayed depends on the operating system since each has a different way to handle this. Please see below for the requirements for the desktop applications:
+In the desktop and mobile apps, an alarm can be associated with any to-do. It will be triggered at the given time by displaying a notification. How the notification will be displayed depends on the operating system since each has a different way to handle this. Please see below for the requirements for the desktop applications:
 
 - **Windows**: >= 8. Make sure the Action Center is enabled on Windows. Task bar balloon for Windows < 8. Growl as fallback. Growl takes precedence over Windows balloons.
 - **macOS**: >= 10.8 or Growl if earlier.
@@ -237,7 +238,7 @@ Sub-notebooks allow organising multiple notebooks into a tree of notebooks. For 
 
 ![](https://joplinapp.org/images/SubNotebooks.png)
 
-- On the **desktop application**, to create a subnotebook, drag and drop it onto another notebook. To move it back to the root, drag and drop it on the "Notebooks" header. Currently only the desktop app can be used to organise the notebooks.
+- In the **desktop application**, to create a subnotebook, drag and drop it onto another notebook. To move it back to the root, drag and drop it on the "Notebooks" header. Currently only the desktop app can be used to organise the notebooks.
 - The **mobile application** supports displaying and collapsing/expanding the tree of notebooks, however it does not currently support moving the subnotebooks to different notebooks.
 - The **terminal app** supports displaying the tree of subnotebooks but it does not support collapsing/expanding them or moving the subnotebooks around.
 

--- a/ReactNativeClient/lib/path-utils.js
+++ b/ReactNativeClient/lib/path-utils.js
@@ -100,10 +100,10 @@ function friendlySafeFilename(e, maxLength = null) {
 	return output.substr(0, maxLength);
 }
 
-function toFileProtocolPath(filePathEncode) {
-	const platform = process.platform;
+function toFileProtocolPath(filePathEncode, os = null) {
+	if (os === null) os = process.platform;
 	
-	if (platform == 'win32') {
+	if (os === 'win32') {
 		filePathEncode = filePathEncode.replace(/\\/g, '/'); // replace backslash in windows pathname with slash e.g. c:\temp to c:/temp
 		filePathEncode = "/" + filePathEncode; // put slash in front of path to comply with windows fileURL syntax
 	}

--- a/ReactNativeClient/lib/path-utils.js
+++ b/ReactNativeClient/lib/path-utils.js
@@ -100,9 +100,18 @@ function friendlySafeFilename(e, maxLength = null) {
 	return output.substr(0, maxLength);
 }
 
-function toFileProtocolPath(path) {
-	const output = path.replace(/\\/g, "/");
-	return 'file://' + escape(output);
+function toFileProtocolPath(filePathEncode) {
+	const platform = process.platform;
+	
+	if (platform == 'win32') {
+		filePathEncode = filePathEncode.replace(/\\/g, '/'); // replace backslash in windows pathname with slash e.g. c:\temp to c:/temp
+		filePathEncode = "/" + filePathEncode; // put slash in front of path to comply with windows fileURL syntax
+	}
+
+	filePathEncode = encodeURI(filePathEncode);
+	filePathEncode = filePathEncode.replace(/\+/g, '%2B'); // escape '+' with unicode
+	filePathEncode = filePathEncode.replace(/%20/g, '+'); // switch space (%20) with '+'. To comply with syntax used by joplin, see urldecode_(str) in MdToHtml.js
+	return "file://" + filePathEncode.replace(/\'/g, '%27'); // escape '(single quote) with unicode, to prevent crashing the html view
 }
 
 function toSystemSlashes(path, os = null) {

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -193,6 +193,7 @@ function shimInit() {
 			const platform = process.platform;
 			if (platform == 'win32') {
 				filePathEncode = filePathEncode.replace(/\\/g, '/'); // replace backslash in windows pathname with slash e.g. c:\temp to c:/temp
+				filePathEncode = "/" + filePathEncode; // put slash in front of path to comply with windows fileURL syntax
 			} else {
 				filePathEncode = filePathEncode.replace(/\\/g, '%5C'); // replace backslash with unicode on linux and MacOS
 			}

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -198,7 +198,7 @@ function shimInit() {
 				filePathEncode = filePathEncode.replace(/\\/g, '%5C'); // replace backslash with unicode on linux and MacOS
 			}
 			let filename = markdownUtils.escapeLinkText(path.basename(filePath)); // to get same filename as standard drag and drop
-			let fileURL = "[" + filename + "](file://" + (filePathEncode) +")" // encodeURIComponent
+			let fileURL = "[" + filename + "](file://" + encodeURI(filePathEncode) +")"
 			newBody.push(fileURL);
 		}
 

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -176,7 +176,7 @@ function shimInit() {
 		const { toFileProtocolPath } = require('lib/path-utils');
 
 		let resource = [];
-		if (createFileURL == false) {
+		if (!createFileURL) {
 			resource = await shim.createResourceFromPath(filePath);
 		}
 
@@ -188,7 +188,7 @@ function shimInit() {
 
 		if (note.body && position) newBody.push(note.body.substr(0, position));
 
-		if (createFileURL == false) {
+		if (!createFileURL) {
 			newBody.push(Resource.markdownTag(resource));
 		} else {
 			let filename = escapeLinkText(basename(filePath)); // to get same filename as standard drag and drop

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -187,18 +187,19 @@ function shimInit() {
 		if (createFileURL == false) {
 			newBody.push(Resource.markdownTag(resource));
 		} else {
-			let filePathEncode = filePath.replace(/\+/g, '%2B'); // escape '+' with unicode
-			filePathEncode = filePathEncode.replace(/ /g, '+'); // escape ' ' with '+'. To comply with syntax used by joplin, see urldecode_(str) in MdToHtml.js
-			filePathEncode = filePathEncode.replace(/\'/g, '%27'); // escape '(single quote) with unicode, to prevent crashing the html view
+			let filePathEncode = filePath;
 			const platform = process.platform;
 			if (platform == 'win32') {
 				filePathEncode = filePathEncode.replace(/\\/g, '/'); // replace backslash in windows pathname with slash e.g. c:\temp to c:/temp
 				filePathEncode = "/" + filePathEncode; // put slash in front of path to comply with windows fileURL syntax
-			} else {
-				filePathEncode = filePathEncode.replace(/\\/g, '%5C'); // replace backslash with unicode on linux and MacOS
 			}
+			filePathEncode = encodeURI(filePathEncode);
+			filePathEncode = filePathEncode.replace(/\+/g, '%2B'); // escape '+' with unicode
+			filePathEncode = filePathEncode.replace(/%20/g, '+'); // switch space (%20) with '+'. To comply with syntax used by joplin, see urldecode_(str) in MdToHtml.js
+			filePathEncode = filePathEncode.replace(/\'/g, '%27'); // escape '(single quote) with unicode, to prevent crashing the html view
+			
 			let filename = markdownUtils.escapeLinkText(path.basename(filePath)); // to get same filename as standard drag and drop
-			let fileURL = "[" + filename + "](file://" + encodeURI(filePathEncode) +")"
+			let fileURL = "[" + filename + "](file://" + filePathEncode +")"
 			newBody.push(fileURL);
 		}
 


### PR DESCRIPTION
Following on some discussion in [REF1](https://discourse.joplinapp.org/t/feature-request/1408/6) and [REF2]( https://discourse.joplinapp.org/t/file-paths-with-german-umlaut-do-not-work-for-me/793), I have tried to figure out an easy way to use fileURLs without entering the link syntax by hand.

To accomplish this, I have altered the drag and drop file behaviour in Joplin slightly. If drag and drop is performed while pressing the ALT-key, a fileURL is embedded in the note text, (the file is not embedded into the Joplin resources). This can be done with a single file or multiple files (just as in the standard drag and drop feature).

![fileURL_dragndrop](https://user-images.githubusercontent.com/22592201/59491579-5340de00-8e87-11e9-840d-d3d4fb808d1a.png)

The fileURL syntax is `[NAME](file://FILEPATH)`

The FILEPATH complies with the format already used by Joplin (i.e. ‘+’ is escaped with Unicode, + sign escapes space and ‘(single quote) is escaped to prevent crashing the html view. Tested on Windows 10 and Linux/Ubuntu
