### PR TITLE
Android: Suggest to check app perms in case of ENOENT error during FS sync

### DIFF
--- a/ReactNativeClient/lib/file-api-driver-local.js
+++ b/ReactNativeClient/lib/file-api-driver-local.js
@@ -16,9 +16,10 @@ const { basicDelta } = require('lib/file-api');
 
 class FileApiDriverLocal {
 
-	fsErrorToJsError_(error, path = null) {
+	fsErrorToJsError_(error, path = null, comment = null) {
 		let msg = error.toString();
 		if (path !== null) msg += '. Path: ' + path;
+		if (comment !== null) msg += `. ${comment}`;
 		let output = new Error(msg);
 		if (error.code) output.code = error.code;
 		return output;
@@ -151,7 +152,8 @@ class FileApiDriverLocal {
 		
 			await this.fsDriver().writeFile(path, content, 'utf8');
 		} catch (error) {
-			throw this.fsErrorToJsError_(error, path);
+			const comment = error.code === 'ENOENT' ? 'Please check application permissions.' : null;
+			throw this.fsErrorToJsError_(error, path, comment);
 		}
 
 		// if (!options) options = {};


### PR DESCRIPTION
This error can occur on Android if application doesn't have SD card permission (#1654).

Preview:

<img src="https://user-images.githubusercontent.com/1660460/59566846-3ca8ab80-906e-11e9-9bfb-32d42db7147e.png" width="300">
