### PR TITLE
Watch for rename events in the external editor and re-watch file

### DIFF
--- a/ReactNativeClient/lib/services/ExternalEditWatcher.js
+++ b/ReactNativeClient/lib/services/ExternalEditWatcher.js
@@ -87,6 +87,14 @@ class ExternalEditWatcher {
 					this.logger().error(error)
 				}
 			});
+			// Hack to support external watcher on some linux applications (gedit, gvim, etc)
+			// taken from https://github.com/paulmillr/chokidar/issues/591
+			this.watcher_.on('raw', async (event, path, {watchedPath}) => {
+				if (event === 'rename') {
+					this.watcher_.unwatch(watchedPath);
+					this.watcher_.add(watchedPath);
+				}
+			});
 		} else {
 			this.watcher_.add(fileToWatch);
 		}


### PR DESCRIPTION
Fixes the [gedit issue from the forums](https://discourse.joplinapp.org/t/bug-saving-notes-in-external-editor/2673/3)
I'm a bit wary adding in a change like this, but it doesn't seem to introduce any issues on my machine.
This was added based on a [chokidar issue](https://github.com/paulmillr/chokidar/issues/591) at some point I think chokidar will be fixed and this bit of code can be removed.

I tested this with gedit and gvim, it fixes the issue for both.

I think this also fixes #1614 but it might need more testing.