### PR TITLE
fix tag shortcut

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -709,11 +709,13 @@ class Application extends BaseApplication {
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+Alt+T',
 					click: () => {
-						this.dispatch({
-							type: 'WINDOW_COMMAND',
-							name: 'setTags',
-							noteId: this.store().getState().selectedNoteIds[0]
-						});
+						if (this.store().getState().selectedNoteIds.length === 1) {
+							this.dispatch({
+								type: 'WINDOW_COMMAND',
+								name: 'setTags',
+								noteId: this.store().getState().selectedNoteIds[0]
+							});
+						}
 					},
 				}, {
 					type: 'separator',

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -712,6 +712,7 @@ class Application extends BaseApplication {
 						this.dispatch({
 							type: 'WINDOW_COMMAND',
 							name: 'setTags',
+							noteId: this.store().getState().selectedNoteIds[0]
 						});
 					},
 				}, {


### PR DESCRIPTION
I fixed the tag shortcut. See [comment](https://discourse.joplinapp.org/t/version-1-0-160-shortcut-for-tags/2665/5?u=tessus) on the forum.

However, I've noticed a few other issues and I do not know how to fix them:

I wanted to only activate the menu item, when a note was selected (a single note). But when I tried to add the line `enabled: this.store().getState().selectedNoteIds.length === 1 ? true : false,` after `accelerator`, I got an error: `Cannot read property 'getState' of undefined`.
I tried to work around it by doing something like this
```
enabled: (() => {return this.store().getState().selectedNoteIds.length === 1 }) ? true : false,
```
but this doesn't work either.

So, I have no idea which noteId is picked when you are in a folder which has no notes or have multiple notes selected. During that investigation, I also noticed that `Edit in external editor` has the same problem. You can still click the menu item or use the shortcut, when you are in a folder without a note.
Weird things happen when you select multiple notes and click `Edit in external editor`.

Btw, I also found out that you can't add/remove tags when more than one note is selected. It should be easy for adding tags. For removing tags, we would have to create an intersecation of tags of the selected notes.