### PR TITLE
Desktop: add support for printstyle.css

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1080,6 +1080,13 @@ class Application extends BaseApplication {
 			css: cssString
 		});
 
+		const printCssString = await this.loadCustomCss(Setting.value('profileDir') + '/printstyle.css');
+
+		this.store().dispatch({
+			type: 'LOAD_PRINT_CSS',
+			printCss: printCssString
+		});
+
 		// Note: Auto-update currently doesn't work in Linux: it downloads the update
 		// but then doesn't install it on exit.
 		if (shim.isWindows() || shim.isMac()) {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -943,16 +943,25 @@ class NoteTextComponent extends React.Component {
 	async updateHtml(body = null, options = null) {
 		if (!options) options = {};
 		if (!('useCustomCss' in options)) options.useCustomCss = true;
+		if (!('usePrintCss' in options)) options.usePrintCss = false;
 
 		let bodyToRender = body;
 		if (bodyToRender === null) bodyToRender = this.state.note && this.state.note.body ? this.state.note.body : '';
 
 		const theme = themeStyle(this.props.theme);
 
+		let userCss_ = '';
+
+		if (options.useCustomCss) {
+			userCss_ = this.props.customCss;
+		} else if (options.usePrintCss) {
+			userCss_ = this.props.printCss;
+		}
+
 		const mdOptions = {
 			codeTheme: theme.codeThemeCss,
 			postMessageSyntax: 'ipcProxySendToHost',
-			userCss: options.useCustomCss ? this.props.customCss : '',
+			userCss: userCss_,
 			resources: await shared.attachedResources(bodyToRender),
 			codeHighlightCacheKey: this.state.note ? this.state.note.id : null,
 		};
@@ -1118,7 +1127,7 @@ class NoteTextComponent extends React.Component {
 		const previousTheme = Setting.value('theme');
 		Setting.setValue('theme', Setting.THEME_LIGHT);
 		this.lastSetHtml_ = '';
-		await this.updateHtml(tempBody, { useCustomCss: false });
+		await this.updateHtml(tempBody, { useCustomCss: false, usePrintCss: true });
 		this.forceUpdate();
 
 		const restoreSettings = async () => {
@@ -1927,6 +1936,7 @@ const mapStateToProps = (state) => {
 		selectedSearchId: state.selectedSearchId,
 		watchedNoteFiles: state.watchedNoteFiles,
 		customCss: state.customCss,
+		printCss: state.printCss,
 		lastEditorScrollPercents: state.lastEditorScrollPercents,
 		historyNotes: state.historyNotes,
 	};

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -33,6 +33,7 @@ const defaultState = {
 	hasDisabledSyncItems: false,
 	newNote: null,
 	customCss: '',
+	printCss: '',
 	collapsedFolderIds: [],
 	clipperServer: {
 		startState: 'idle',
@@ -692,6 +693,12 @@ const reducer = (state = defaultState, action) => {
 
 				newState = Object.assign({}, state);
 				newState.customCss = action.css;
+				break;
+
+			case 'LOAD_PRINT_CSS':
+
+				newState = Object.assign({}, state);
+				newState.printCss = action.printCss;
 				break;
         
 			case 'SET_NOTE_TAGS':


### PR DESCRIPTION
It is now possible to use custom css when printing and exporting notes to PDF
by placing a file called `printstyle.css` to the profile directory
(e.g.: ``~/.config/joplin-desktop`). This file supports standard css syntax.

Please note that Joplin has to be restarted for changes to this file to become effective.