### PR TITLE
Desktop: Add starred items [WIP]

### DIFF
--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -693,6 +693,12 @@ class SideBarComponent extends React.Component {
 				{folderItems}</div>);
 		}
 
+		items.push(this.makeHeader("starredHeader", _("Starred"), "fa-star", {
+			onDrop: this.onFolderDrop_,
+			folderid: '',
+			toggleblock: 1
+		}));
+
 		items.push(this.makeHeader("tagHeader", _("Tags"), "fa-tags", {
 			toggleblock: 1
 		}));


### PR DESCRIPTION
Right now the killing feature that prevents me from actively using Joplin is the "starred notes" or "quick access" area.

Unfortunately, it's not clear to me where should I add the "star" property. I would be happy if I could hear some thoughts and get some guidance on how to do that.

So far, that's what I could get:

![image](https://user-images.githubusercontent.com/14880710/60684176-849f3f00-9e72-11e9-806a-ef3385ed3e08.png)
