### PR TITLE
Desktop,Cli: enex_to_md: support bold formatting in span tags

### DIFF
--- a/CliClient/tests/enex_to_md/text_formatting.html
+++ b/CliClient/tests/enex_to_md/text_formatting.html
@@ -1,0 +1,19 @@
+<div><strong>singleline strong text.</strong></div><div><br/></div>
+<div><b>singleline bold text.</b></div><div><br/></div>
+<div><strong>multiline strong
+ text.</strong></div><div><br/></div>
+<div><b>multiline bold
+ text.</b></div><div><br/></div>
+
+<div><em>singleline emphasized text.</em></div><div><br/></div>
+<div><i>singleline italic text.</i></div><div><br/></div>
+<div><em>multiline emphasized
+ text.</em><div><br/></div>
+<div><i>multiline italic
+ text.</i><div><br/></div>
+
+
+<div><b>singleline bold text</b> next to normal text with leading space.</div><div><br/></div>
+<div><b>singleline bold text with trailing space </b>next to normal text.</div><div><br/></div>
+<div><b>singleline bold text</b><b> next to more bold text with leading space.</b></div><div><br/></div>
+<div><b>singleline bold text with trailing space </b><b>next to more bold text.</b></div><div><br/></div>

--- a/CliClient/tests/enex_to_md/text_formatting.md
+++ b/CliClient/tests/enex_to_md/text_formatting.md
@@ -1,0 +1,23 @@
+**singleline strong text.**
+
+**singleline bold text.**
+
+**multiline strong text.**
+
+**multiline bold text.**
+
+*singleline emphasized text.*
+
+*singleline italic text.*
+
+*multiline emphasized text.*
+
+*multiline italic text.*
+
+**singleline bold text** next to normal text with leading space.
+
+**singleline bold text with trailing space **next to normal text.
+
+**singleline bold text**** next to more bold text with leading space.**
+
+**singleline bold text with trailing space ****next to more bold text.**

--- a/CliClient/tests/enex_to_md/text_formatting_span_bold.html
+++ b/CliClient/tests/enex_to_md/text_formatting_span_bold.html
@@ -1,0 +1,11 @@
+<div><span style="font-weight: bold;">singleline bold text with span style font-weight: bold;.</span></div><div><br/></div>
+<div><span style="font-family: 'TimesNewRoman,Bold';">singleline bold text with span style font-family: 'TimesNewRoman,Bold';.</span></div><div><br/></div>
+<div><span style="font-weight: bold;">multiline bold
+ text with span style font-weight: bold;.</span></div><div><br/></div>
+<div><span style="font-family: 'TimesNewRoman,Bold';">multiline bold
+ text with span style font-family: 'TimesNewRoman,Bold';.</span></div><div><br/></div>
+
+<div><span style="font-weight: bold;">singleline bold text with span style font-weight: bold;</span> next to normal text with leading space.</div><div><br/></div>
+<div><span style="font-weight: bold;">singleline bold text with span style font-weight: bold; and with trailing space </span>next to normal text.</div><div><br/></div>
+<div><span style="font-weight: bold;">singleline bold text with span style font-weight: bold;</span><span style="font-weight: bold;"> next to more bold text with span style font-weight: bold; and with leading space.</span></div><div><br/></div>
+<div><span style="font-weight: bold;">singleline bold text with span style font-weight: bold; and with trailing space </span><span style="font-weight: bold;">next to more bold text with span style font-weight: bold;.</span></div>

--- a/CliClient/tests/enex_to_md/text_formatting_span_bold.md
+++ b/CliClient/tests/enex_to_md/text_formatting_span_bold.md
@@ -1,0 +1,15 @@
+**singleline bold text with span style font-weight: bold;.**
+
+**singleline bold text with span style font-family: 'TimesNewRoman,Bold';.**
+
+**multiline bold text with span style font-weight: bold;.**
+
+**multiline bold text with span style font-family: 'TimesNewRoman,Bold';.**
+
+**singleline bold text with span style font-weight: bold;** next to normal text with leading space.
+
+**singleline bold text with span style font-weight: bold; and with trailing space **next to normal text.
+
+**singleline bold text with span style font-weight: bold;**** next to more bold text with span style font-weight: bold; and with leading space.**
+
+**singleline bold text with span style font-weight: bold; and with trailing space ****next to more bold text with span style font-weight: bold;.**

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -397,7 +397,6 @@ function attributeToLowerCase(node) {
 function isSpanWithStyle(attributes, state) {
 	if (attributes != undefined) {
 		if ('style' in attributes) {
-			state.spanAttributes.push(attributes);
 			return true;
 		} else {
 			return false;
@@ -705,7 +704,8 @@ function enexXmlToMdArray(stream, resources) {
 					section.lines = addResourceTag(section.lines, resource, nodeAttributes.alt);
 				}
 			} else if (n == "span") {
-				if (isSpanWithStyle(nodeAttributes, state)) {
+				if (isSpanWithStyle(nodeAttributes)) {
+					state.spanAttributes.push(nodeAttributes);
 					if (isSpanStyleBold(nodeAttributes)) {
 						//console.debug('Applying style found in span tag: bold')
 						section.lines.push("**");
@@ -894,7 +894,7 @@ function enexXmlToMdArray(stream, resources) {
 				// Skip
 			} else if (n == 'span') {
 				let attributes = state.spanAttributes.pop();
-				if (isSpanWithStyle(attributes, state)) {
+				if (isSpanWithStyle(attributes)) {
 					if (isSpanStyleBold(attributes)) {
 						//console.debug('Applying style found in span tag (closing): bold')
 						section.lines.push("**");


### PR DESCRIPTION
Hi, I added a draft feature to detect some styles buried inside of span tags. Evernote did that very often to my notes. E.g. most of my bold text was saved as inline styles in span tags and not  as `<b>` or `<strong>` tags. This feature is far from perfect but I wanted to discuss things further before moving on. I read the contribution guidelines and tried to follow them but I didn't write a unit test yet. I will if it is necessary.

I am aware of the following issues:
* It detects either bold or italic or monospace - bold and italic should be supported i think. monospace and bold/italic should be ignored - the most likely case is people use monospace text to show code. I think it is not possible in MD to format stuff eg bold inside of \`code\` sections? Right?
* the string comparision matches only the text "bold" and not "font-weight: bold;" for a reason:  Evernote sometimes uses the font-weight style but sometimes stuff like this: "font-family: TimesNewRoman,Bold;"
* it also has problems with something like the following correctly:

`<div><span style="font-weight: bold;">text bold blabla, </span>text normal blabla </div>`

it produces markdown that is not correct, because there is a space missing after the closing **:

`**text bold blabla, **text normal blabla `

this could happen with normal `<strong>` tag too. how did you handle it?

* should span style detection move to a new seperate function, similar to isStrongTag?
* or should isStrongTag better be extended to also support bold inside of span styles?
* which way should i go?

Please tell me which fixes/features you'd like to see to accept this.
Thanks a lot
Jojo

