### PR TITLE
Ab Initio fix for 387

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1193,6 +1193,7 @@ class NoteTextComponent extends React.Component {
 			type: 'WINDOW_COMMAND',
 			name: 'setTags',
 			noteId: this.state.note.id,
+			pendingTag: this.state.note.pendingTag || []
 		});
 	}
 

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -374,6 +374,32 @@ class SideBarComponent extends React.Component {
 					},
 				})
 			);
+			menu.append(
+				new MenuItem({
+					label: _('New Todo'),
+					click: async () => {
+						this.props.dispatch({
+							type: "WINDOW_COMMAND",
+							name: "newTagged",
+							id: itemId,
+							is_todo: true
+						});
+					},
+				})
+			);
+			menu.append(
+				new MenuItem({
+					label: _('New Note'),
+					click: async () => {
+						this.props.dispatch({
+							type: "WINDOW_COMMAND",
+							name: "newTagged",
+							id: itemId,
+							is_todo: false
+						});
+					},
+				})
+			);
 		}
 
 		menu.popup(bridge().window());

--- a/ReactNativeClient/lib/components/shared/note-screen-shared.js
+++ b/ReactNativeClient/lib/components/shared/note-screen-shared.js
@@ -7,6 +7,7 @@ const ResourceFetcher = require('lib/services/ResourceFetcher.js');
 const DecryptionWorker = require('lib/services/DecryptionWorker.js');
 const Setting = require('lib/models/Setting.js');
 const Mutex = require('async-mutex').Mutex;
+const Tag = require('lib/models/Tag.js');
 
 const shared = {};
 
@@ -196,7 +197,10 @@ shared.attachedResources = async function(noteBody) {
 }
 
 shared.refreshNoteMetadata = async function(comp, force = null) {
-	if (force !== true && !comp.state.showNoteMetadata) return;
+if (comp.state.note.pendingTag) {
+	await Tag.setNoteTagsByIds(comp.state.note.id, [comp.state.note.pendingTag]);
+}
+if (force !== true && !comp.state.showNoteMetadata) return;
 
 	let noteMetadata = await Note.serializeAllProps(comp.state.note);
 	comp.setState({ noteMetadata: noteMetadata });


### PR DESCRIPTION
Trying to fix: laurent22/joplin#387.
The way I am fixing this is a hack IMHO. I am letting you put a pending tag on the new note action. Then I am just tickling the tag edit dialog and the final refreshMetadata in order to:

- Make sure the pending tag shows up in the tag editor
- Make sure that it is added to the note in the case we save it.
- But also make sure we keep the current behavior where if the user starts a note but discards it unmodified then the note is never saved.

Also, I don’t know where/how to test this in a reasonable way.

But at least I don't see white space issues ;-)
