### PR TITLE
allow to set toc depth - DO NOT MERGE

### DIFF
--- a/ReactNativeClient/lib/MdToHtml.js
+++ b/ReactNativeClient/lib/MdToHtml.js
@@ -21,7 +21,7 @@ const setupLinkify = require('./MdToHtml/setupLinkify');
 const hljs = require('highlight.js');
 const markdownItAnchor = require('markdown-it-anchor');
 // The keys must match the corresponding entry in Setting.js
-const plugins = {
+let plugins = {
 	mark: {module: require('markdown-it-mark')},
 	footnote: {module: require('markdown-it-footnote')},
 	sub: {module: require('markdown-it-sub')},
@@ -147,6 +147,13 @@ class MdToHtml {
 		markdownIt.use(rules.highlight_keywords(context, ruleOptions));
 		markdownIt.use(rules.code_inline(context, ruleOptions));
 		markdownIt.use(markdownItAnchor)
+
+		if (Setting.value('markdown.plugin.toc.depth.enabled')) {
+			const levels = [...Array(Setting.value('markdown.plugin.toc.depth'))].map((_, i) => i + 1);
+			plugins['toc'].options.level = levels;
+		} else {
+			delete plugins['toc'].options.level;
+		}
 
 		for (let key in plugins) {
 			if (Setting.value('markdown.plugin.' + key)) markdownIt.use(plugins[key].module, plugins[key].options);

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -145,6 +145,8 @@ class Setting extends BaseModel {
 			'markdown.plugin.mark': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax')},
 			'markdown.plugin.footnote': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes')},
 			'markdown.plugin.toc': {value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable table of contents extension')},
+			'markdown.plugin.toc.depth.enabled': {value: false, type: Setting.TYPE_BOOL, public: true, show: (settings) => {return settings['markdown.plugin.toc']}, section: 'plugins', label: () => _('Enable specific TOC depth') },
+			'markdown.plugin.toc.depth': {value: 3, type: Setting.TYPE_INT, public: true, show: (settings) => {return settings['markdown.plugin.toc']}, section: 'plugins', label: () => _('Max TOC levels'), minimum: 1, maximum: 10, step: 1},
 			'markdown.plugin.sub': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ~sub~ syntax')},
 			'markdown.plugin.sup': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ^sup^ syntax')},
 			'markdown.plugin.deflist': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable deflist syntax')},
@@ -152,7 +154,6 @@ class Setting extends BaseModel {
 			'markdown.plugin.emoji': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable markdown emoji')},
 			'markdown.plugin.insert': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ++insert++ syntax')},
 			'markdown.plugin.multitable': {value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable multimarkdown table extension')},
-
 
 			// Tray icon (called AppIndicator) doesn't work in Ubuntu
 			// http://www.webupd8.org/2017/04/fix-appindicator-not-working-for.html


### PR DESCRIPTION
This is just a proof of concept. It is fully functional though. But according to the discussion in the forum, we rather want to get this done upstream with an option like `[toc depth:2]`.

The reason why I opened this PR is because I have a few questions and it is easier to discuss them this way.

I played around with showing items in settings only when another item is enabled.

Without the toc extension enabled it looks like this:

<img width="218" alt="image" src="https://user-images.githubusercontent.com/223439/61101850-6a98ca00-a439-11e9-9129-06bf761bd3f5.png">

As soon as the toc extension is enabled, 2 more items show up:

<img width="216" alt="image" src="https://user-images.githubusercontent.com/223439/61101878-94ea8780-a439-11e9-8884-7767d16c4ef1.png">

Unfortunately this looks horrible. Is there any way to indent items, so that that they are easily recognizable as "sub options" of another item? How can I move the 2 items `Enable specific TOC depth` and `Max TOC levels` about 1 to 1.5 cm to the right?
Or even better, is it possible to group them so that they are shown on one line?

As I said, I only want to learn more about how things work.