### PR TITLE
Desktop: Add solarized themes

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -45,6 +45,8 @@ require('brace/mode/markdown');
 // https://ace.c9.io/build/kitchen-sink.html
 // https://highlightjs.org/static/demo/
 require('brace/theme/chrome');
+require('brace/theme/solarized_light');
+require('brace/theme/solarized_dark');
 require('brace/theme/twilight');
 
 const NOTE_TAG_BAR_FEATURE_ENABLED = false;

--- a/ElectronClient/app/theme.js
+++ b/ElectronClient/app/theme.js
@@ -141,6 +141,79 @@ const darkStyle = {
 	codeThemeCss: "atom-one-dark-reasonable.css",
 };
 
+// Solarized Styles
+const solarizedLightStyle = {
+	backgroundColor: "#fdf6e3",
+	backgroundColorTransparent: "rgba(253, 246, 227, 0.9)",
+	oddBackgroundColor: "#eee8d5",
+	color: "#657b83", // For regular text
+	colorError: "#dc322f",
+	colorWarn: "#cb4b16",
+	colorFaded: "#839496", // For less important text;
+	colorBright: "#073642", // For important text;
+	dividerColor: "#eee8d5",
+	selectedColor: "#eee8d5",
+	urlColor: "#268bd2",
+
+	backgroundColor2: "#002b36",
+	color2: "#eee8d5",
+	selectedColor2: "#6c71c4",
+	colorError2: "#cb4b16",
+
+	raisedBackgroundColor: "#eee8d5",
+	raisedColor: "#073642",
+
+	warningBackgroundColor: "#b58900",
+
+	htmlColor: "#657b83",
+	htmlBackgroundColor: "#fdf6e3",
+	htmlDividerColor: "#eee8d5",
+	htmlLinkColor: "#268bd2",
+	htmlTableBackgroundColor: "#fdf6e3",
+	htmlCodeBackgroundColor: "#fdf6e3",
+	htmlCodeBorderColor: "#eee8d5",
+	htmlCodeColor: "#002b36",
+
+	editorTheme: "solarized_light",
+	codeThemeCss: "atom-one-light.css",
+};
+
+const solarizedDarkStyle = {
+	backgroundColor: "#002b36",
+	backgroundColorTransparent: "rgba(0, 43, 54, 0.9)",
+	oddBackgroundColor: "#073642",
+	color: "#93a1a1", // For regular text
+	colorError: "#dc322f",
+	colorWarn: "#cb4b16",
+	colorFaded: "#657b83", // For less important text;
+	colorBright: "#eee8d5", // For important text;
+	dividerColor: "#586e75",
+	selectedColor: "#073642",
+	urlColor: "#268bd2",
+
+	backgroundColor2: "#073642",
+	color2: "#eee8d5",
+	selectedColor2: "#6c71c4",
+	colorError2: "#cb4b16",
+
+	raisedBackgroundColor: "#073642",
+	raisedColor: "#839496",
+
+	warningBackgroundColor: "#b58900",
+
+	htmlColor: "#93a1a1",
+	htmlBackgroundColor: "#002b36",
+	htmlDividerColor: "#073642",
+	htmlLinkColor: "#268bd2",
+	htmlTableBackgroundColor: "#002b36",
+	htmlCodeBackgroundColor: "#002b36",
+	htmlCodeBorderColor: "#073642",
+	htmlCodeColor: "#fdf6e3",
+
+	editorTheme: 'solarized_dark',
+	codeThemeCss: "atom-one-dark-reasonable.css",
+};
+
 function addExtraStyles(style) {
 	style.tagStyle = {
 		fontSize: style.fontSize,
@@ -270,6 +343,12 @@ function themeStyle(theme) {
 	}
 	else if (theme == Setting.THEME_DARK) {
 		output = Object.assign({}, globalStyle, fontSizes, darkStyle);
+	}
+	else if (theme == Setting.THEME_SOLARIZED_LIGHT) {
+		output = Object.assign({}, globalStyle, fontSizes, solarizedLightStyle);
+	}
+	else if (theme == Setting.THEME_SOLARIZED_DARK) {
+		output = Object.assign({}, globalStyle, fontSizes, solarizedDarkStyle);
 	}
 
 	// Note: All the theme specific things should go in addExtraStyles

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -103,6 +103,8 @@ class Setting extends BaseModel {
 				let output = {};
 				output[Setting.THEME_LIGHT] = _('Light');
 				output[Setting.THEME_DARK] = _('Dark');
+				output[Setting.THEME_SOLARIZED_LIGHT] = _('Solarized Light');
+				output[Setting.THEME_SOLARIZED_DARK] = _('Solarized Dark');
 				return output;
 			}},
 			'uncompletedTodosOnTop': { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, appTypes: ['cli'], label: () => _('Uncompleted to-dos on top') },
@@ -627,6 +629,8 @@ Setting.TYPE_OBJECT = 5;
 
 Setting.THEME_LIGHT = 1;
 Setting.THEME_DARK = 2;
+Setting.THEME_SOLARIZED_LIGHT = 3;
+Setting.THEME_SOLARIZED_DARK = 4;
 
 Setting.DATE_FORMAT_1 = 'DD/MM/YYYY'
 Setting.DATE_FORMAT_2 = 'DD/MM/YY';


### PR DESCRIPTION
### Description

This PR adds two themes to the desktop client: Solarized Light and Solarized Dark.

Solarized homepage: https://ethanschoonover.com/solarized/


### Screenshots

#### Solarized Light

![Screenshot from 2019-07-14 09-55-15](https://user-images.githubusercontent.com/1540054/61181435-75f91a80-a61e-11e9-93b8-5ec95089c169.png)

![Screenshot from 2019-07-14 09-55-45](https://user-images.githubusercontent.com/1540054/61181437-7a253800-a61e-11e9-94fb-b90ba45edd2b.png)


#### Solarized Dark

![Screenshot from 2019-07-14 09-56-27](https://user-images.githubusercontent.com/1540054/61181440-84473680-a61e-11e9-8c51-8829e164aa38.png)

![Screenshot from 2019-07-14 09-57-04](https://user-images.githubusercontent.com/1540054/61181442-86a99080-a61e-11e9-96eb-6ad6477720bf.png)



### Testing

I've tested the desktop client, but I couldn't get the android toolchain installed to test the mobile client.

### Color Palette

For reference, this is the solarized color palette, in pseudo-css form:
```css
solarized {
    Base03:  #002b36;  // dark background
    Base02:  #073642;
    Base01:  #586e75;
    Base00:  #657b83;  // light text
    Base0:   #839496;
    Base1:   #93a1a1;  // dark text
    Base2:   #eee8d5;
    Base3:   #fdf6e3;  // light background
    Yellow:  #b58900;
    Orange:  #cb4b16;
    Red:     #dc322f;
    Magenta: #d33682;
    Violet:  #6c71c4;
    Blue:    #268bd2
    Cyan:    #2aa198
    Green:   #859900
}
```

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
