### PR TITLE
fix: better handling of adding the title to print and export to PDF

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1097,13 +1097,18 @@ class NoteTextComponent extends React.Component {
 		});
 	}
 
+	// helper function to style the title for printing
+	title_(title) {
+		return '<div style="font-size: 2em; font-weight: bold; border-bottom: 1px solid rgb(230,230,230); padding-bottom: .3em;">' + title + '</div><br>';
+	}
+
 	async printTo_(target, options) {
 		if (this.props.selectedNoteIds.length !== 1 || !this.webviewRef_.current) {
 			throw new Error(_('Only one note can be printed or exported to PDF at a time.'));
 		}
 
 		const previousBody = this.state.note.body;
-		const tempBody = "# " + this.state.note.title + "\n\n" + previousBody;
+		const tempBody = this.title_(this.state.note.title) + "\n\n" + previousBody;
 
 		const previousTheme = Setting.value('theme');
 		Setting.setValue('theme', Setting.THEME_LIGHT);


### PR DESCRIPTION
fixes #1743

---

When a document is printed or exported to PDF, a header 1 is prepended to the document with the title (internally adding a `# Title`).

This also adds an additional entry to the TOC with the title of the document. This PR fixes this behavior. I've also added a helper function to change the appearance in the future.