### PR TITLE
Desktop: Ability to auto hide menubar

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -73,6 +73,8 @@ class ElectronAppWrapper {
 		});
 
 		this.win_ = new BrowserWindow(windowOptions)
+		
+		this.win_.setAutoHideMenuBar(true)
 
 		this.win_.loadURL(url.format({
 			pathname: path.join(__dirname, 'index.html'),


### PR DESCRIPTION
Sets whether the window menu bar should hide itself automatically. Once set the menu bar will only show when users press the single Alt key, from https://electronjs.org/docs/api/browser-window#winsetautohidemenubarhide

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
