### PR TITLE
Desktop: add `depthColor` for solarized light and dark themes

### DIFF
--- a/ElectronClient/app/theme.js
+++ b/ElectronClient/app/theme.js
@@ -158,6 +158,7 @@ const solarizedLightStyle = {
 	urlColor: "#268bd2",
 
 	backgroundColor2: "#002b36",
+	depthColor: 'rgb(100, 182, 253, OPACITY)',
 	color2: "#eee8d5",
 	selectedColor2: "#6c71c4",
 	colorError2: "#cb4b16",
@@ -194,6 +195,7 @@ const solarizedDarkStyle = {
 	urlColor: "#268bd2",
 
 	backgroundColor2: "#073642",
+	depthColor: 'rgb(200, 200, 200, OPACITY)',
 	color2: "#eee8d5",
 	selectedColor2: "#6c71c4",
 	colorError2: "#cb4b16",


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

Following on from https://github.com/laurent22/joplin/pull/1733, this PR adds the `depthColor` property to the new Solarized Light and Dark themes.

They've basically been copied from the Light and Dark themes respectively, I think it looks pretty good:

## Screenshots

### Solarized Light

![Screenshot from 2019-07-24 21-19-13](https://user-images.githubusercontent.com/1540054/61825885-281fb600-ae59-11e9-93c8-3463146e3c89.png)


### Solarized Dark

![Screenshot from 2019-07-24 21-19-48](https://user-images.githubusercontent.com/1540054/61825900-2c4bd380-ae59-11e9-93f3-c1c8b20db6fe.png)


These could probably be tuned better, but I'm no good with color so 🤷



