### PR TITLE
Desktop: Add `escape` to go back from Dropbox Login screen

### DIFF
--- a/ElectronClient/app/gui/DropboxLoginScreen.jsx
+++ b/ElectronClient/app/gui/DropboxLoginScreen.jsx
@@ -17,6 +17,18 @@ class DropboxLoginScreenComponent extends React.Component {
 		this.shared_.refreshUrl();
 	}
 
+	componentDidMount() {
+		document.addEventListener('keydown', event => {
+			if (event.keyCode === 27) { // `escape` key
+				this.props.dispatch({ type: 'NAV_BACK' });
+			}
+		});
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener('keydown', null);
+	}
+
 	render() {
 		const style = this.props.style;
 		const theme = themeStyle(this.props.theme);


### PR DESCRIPTION
**Problem:** I habitually press <kbd>⌘</kbd> + <kbd>S</kbd> in notes, which in development mode (i.e. where I, and likely others, don't have a sync target set up) takes you to the `Dropbox Login` screen. It's annoying to have to mouse over to the `Back` button on the top left.

**Solution:** I've added a keyboard shortcut to escape out of that screen: <kbd>esc</kbd>. 
Here's a demo with the key visualizer on:

<img src="http://g.recordit.co/HJJ5PzklSm.gif" />