### PR TITLE
Custom mobile editor font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ ReactNativeClient/lib/rnInjectedJs/
 ElectronClient/app/gui/note-viewer/fonts/
 ElectronClient/app/gui/note-viewer/lib.js
 Tools/commit_hook.txt
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.minimap.maxColumn": 50,
-  "editor.minimap.renderCharacters": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.minimap.maxColumn": 50,
+  "editor.minimap.renderCharacters": false
+}

--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -99,11 +99,13 @@ function addExtraStyles(style) {
 }
 
 function editorFont(fontId) {
+	// IMPORTANT: The font mapping must match the one in Setting.js
 	const fonts = {
 		[Setting.FONT_DEFAULT]: null,
 		[Setting.FONT_MENLO]: 'Menlo',
 		[Setting.FONT_COURIER_NEW]: 'Courier New',
 		[Setting.FONT_AVENIR]: 'Avenir',
+		[Setting.FONT_MONOSPACE]: 'monospace',
 	};
 	if (!fontId) {
 		console.warn('Editor font not set! Falling back to default font."');

--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -98,6 +98,20 @@ function addExtraStyles(style) {
 	return style;
 }
 
+function editorFont(fontId) {
+	const fonts = {
+		[Setting.FONT_MENLO]: 'Menlo',
+		[Setting.FONT_COURIER_NEW]: 'Courier New',
+		[Setting.FONT_AVENIR]: 'Avenir',
+	};
+	if (!fontId) {
+		const menlo = globalStyle.fonts[Setting.FONT_MENLO];
+		console.warn(`Editor font not set! Defaulting to "${menlo}"`);
+		fontId = Setting.FONT_MENLO;
+	}
+	return fonts[fontId];
+}
+
 function themeStyle(theme) {
 	if (!theme) {
 		console.warn('Theme not set!! Defaulting to Light theme');
@@ -140,4 +154,4 @@ function themeStyle(theme) {
 	return addExtraStyles(themeCache_[theme]);
 }
 
-module.exports = { globalStyle, themeStyle };
+module.exports = { globalStyle, themeStyle, editorFont };

--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -100,21 +100,21 @@ function addExtraStyles(style) {
 
 function editorFont(fontId) {
 	const fonts = {
+		[Setting.FONT_DEFAULT]: null,
 		[Setting.FONT_MENLO]: 'Menlo',
 		[Setting.FONT_COURIER_NEW]: 'Courier New',
 		[Setting.FONT_AVENIR]: 'Avenir',
 	};
 	if (!fontId) {
-		const menlo = globalStyle.fonts[Setting.FONT_MENLO];
-		console.warn(`Editor font not set! Defaulting to "${menlo}"`);
-		fontId = Setting.FONT_MENLO;
+		console.warn('Editor font not set! Falling back to default font."');
+		fontId = Setting.FONT_DEFAULT;
 	}
 	return fonts[fontId];
 }
 
 function themeStyle(theme) {
 	if (!theme) {
-		console.warn('Theme not set!! Defaulting to Light theme');
+		console.warn('Theme not set! Defaulting to Light theme.');
 		theme = Setting.THEME_LIGHT;
 	}
 

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -24,7 +24,7 @@ const { reg } = require('lib/registry.js');
 const { shim } = require('lib/shim.js');
 const ResourceFetcher = require('lib/services/ResourceFetcher');
 const { BaseScreenComponent } = require('lib/components/base-screen.js');
-const { themeStyle } = require('lib/components/global-style.js');
+const { themeStyle, editorFont } = require('lib/components/global-style.js');
 const { dialogs } = require('lib/dialogs.js');
 const DialogBox = require('react-native-dialogbox').default;
 const { NoteBodyViewer } = require('lib/components/note-body-viewer.js');
@@ -206,7 +206,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 				color: theme.color,
 				backgroundColor: theme.backgroundColor,
 				fontSize: theme.fontSize,
-				fontFamily: 'Menlo',
+				fontFamily: editorFont(this.props.editorFont),
 			},
 			noteBodyViewer: {
 				flex: 1,
@@ -912,6 +912,7 @@ const NoteScreen = connect(state => {
 		folders: state.folders,
 		searchQuery: state.searchQuery,
 		theme: state.settings.theme,
+		editorFont: [state.settings.editorFont],
 		ftsEnabled: state.settings['db.ftsEnabled'],
 		sharedData: state.sharedData,
 		showSideMenu: state.showSideMenu,

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -912,7 +912,7 @@ const NoteScreen = connect(state => {
 		folders: state.folders,
 		searchQuery: state.searchQuery,
 		theme: state.settings.theme,
-		editorFont: [state.settings.editorFont],
+		editorFont: [state.settings['style.editor.fontFamily']],
 		ftsEnabled: state.settings['db.ftsEnabled'],
 		sharedData: state.sharedData,
 		showSideMenu: state.showSideMenu,

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -206,6 +206,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 				color: theme.color,
 				backgroundColor: theme.backgroundColor,
 				fontSize: theme.fontSize,
+				fontFamily: 'Menlo',
 			},
 			noteBodyViewer: {
 				flex: 1,

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -22,6 +22,7 @@ class Setting extends BaseModel {
 		if (this.metadata_) return this.metadata_;
 
 		const platform = shim.platformName();
+		const mobilePlatform = shim.mobilePlatform();
 
 		const emptyDirWarning = _('Attention: If you change this location, make sure you copy all your content to it before syncing, otherwise all files will be removed! See the FAQ for more details: %s', 'https://joplinapp.org/faq/');
 
@@ -353,16 +354,16 @@ class Setting extends BaseModel {
 				label: () => _('Editor font'),
 				appTypes: ['mobile'],
 				section: 'appearance',
-				options: () => ({
-					/**
-					 * TODO: Check if these fonts break Android. If so, how to retrieve
-					 * info that is more detailed than the `platform` metadata (which
-					 * returns "desktop"|"mobile"|"cli", not the OS info.)
-					 */
-					[Setting.FONT_MENLO]: 'Menlo',
-					[Setting.FONT_COURIER_NEW]: 'Courier New',
-					[Setting.FONT_AVENIR]: 'Avenir',
-				}),
+				options: () => {
+					if (mobilePlatform === 'ios') {
+						return {
+							[Setting.FONT_MENLO]: 'Menlo',
+							[Setting.FONT_COURIER_NEW]: 'Courier New',
+							[Setting.FONT_AVENIR]: 'Avenir',
+						};
+					}
+					return {};
+				},
 			},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -338,7 +338,7 @@ class Setting extends BaseModel {
 			'style.editor.fontFamily':
 				(mobilePlatform === 'ios') ?
 					({
-						value: Setting.FONT_MENLO,
+						value: Setting.FONT_DEFAULT,
 						type: Setting.TYPE_STRING,
 						isEnum: true,
 						public: true,
@@ -348,12 +348,15 @@ class Setting extends BaseModel {
 						options: () => {
 							if (mobilePlatform === 'ios') {
 								return {
+									[Setting.FONT_DEFAULT]: 'Default',
 									[Setting.FONT_MENLO]: 'Menlo',
 									[Setting.FONT_COURIER_NEW]: 'Courier New',
 									[Setting.FONT_AVENIR]: 'Avenir',
 								};
 							}
-							return {};
+							return {
+								[Setting.FONT_DEFAULT]: 'Default',
+							};
 						},
 					}) : {
 						value: '',
@@ -862,6 +865,7 @@ Setting.THEME_DARK = 2;
 Setting.THEME_SOLARIZED_LIGHT = 3;
 Setting.THEME_SOLARIZED_DARK = 4;
 
+Setting.FONT_DEFAULT = 0;
 Setting.FONT_MENLO = 1;
 Setting.FONT_COURIER_NEW = 2;
 Setting.FONT_AVENIR = 3;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -336,7 +336,7 @@ class Setting extends BaseModel {
 			'style.zoom': { value: 100, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Global zoom percentage'), minimum: 50, maximum: 500, step: 10 },
 			'style.editor.fontSize': { value: 13, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Editor font size'), minimum: 4, maximum: 50, step: 1 },
 			'style.editor.fontFamily':
-				(mobilePlatform === 'ios') ?
+				(!!mobilePlatform) ?
 					({
 						value: Setting.FONT_DEFAULT,
 						type: Setting.TYPE_STRING,
@@ -346,6 +346,7 @@ class Setting extends BaseModel {
 						appTypes: ['mobile'],
 						section: 'appearance',
 						options: () => {
+							// IMPORTANT: The font mapping must match the one in global-styles.js::editorFont()
 							if (mobilePlatform === 'ios') {
 								return {
 									[Setting.FONT_DEFAULT]: 'Default',
@@ -356,6 +357,7 @@ class Setting extends BaseModel {
 							}
 							return {
 								[Setting.FONT_DEFAULT]: 'Default',
+								[Setting.FONT_MONOSPACE]: 'Monospace',
 							};
 						},
 					}) : {
@@ -869,6 +871,7 @@ Setting.FONT_DEFAULT = 0;
 Setting.FONT_MENLO = 1;
 Setting.FONT_COURIER_NEW = 2;
 Setting.FONT_AVENIR = 3;
+Setting.FONT_MONOSPACE = 4;
 
 Setting.DATE_FORMAT_1 = 'DD/MM/YYYY';
 Setting.DATE_FORMAT_2 = 'DD/MM/YY';

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -224,19 +224,6 @@ class Setting extends BaseModel {
 					return output;
 				},
 			},
-			editorFont: {
-				value: Setting.FONT_MENLO,
-				type: Setting.TYPE_STRING,
-				isEnum: true,
-				public: true,
-				label: () => _('Editor font'),
-				section: 'appearance',
-				options: () => ({
-					[Setting.FONT_MENLO]: 'Menlo',
-					[Setting.FONT_COURIER_NEW]: 'Courier New',
-					[Setting.FONT_AVENIR]: 'Avenir',
-				}),
-			},
 			uncompletedTodosOnTop: { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, appTypes: ['cli'], label: () => _('Uncompleted to-dos on top') },
 			showCompletedTodos: { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, appTypes: ['cli'], label: () => _('Show completed to-dos') },
 			'notes.sortOrder.field': {
@@ -347,7 +334,36 @@ class Setting extends BaseModel {
 			'encryption.passwordCache': { value: {}, type: Setting.TYPE_OBJECT, public: false, secure: true },
 			'style.zoom': { value: 100, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Global zoom percentage'), minimum: 50, maximum: 500, step: 10 },
 			'style.editor.fontSize': { value: 13, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Editor font size'), minimum: 4, maximum: 50, step: 1 },
-			'style.editor.fontFamily': { value: '', type: Setting.TYPE_STRING, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Editor font family'), description: () => _('This must be *monospace* font or it will not work properly. If the font is incorrect or empty, it will default to a generic monospace font.') },
+			'style.editor.fontFamily': {
+				value: '',
+				type: Setting.TYPE_STRING,
+				public: true,
+				appTypes: ['desktop'],
+				section: 'appearance',
+				label: () => _('Editor font family'),
+				description: () =>
+					_('This must be *monospace* font or it will not work properly. If the font ' +
+					'is incorrect or empty, it will default to a generic monospace font.'),
+			},
+			editorFont: {
+				value: Setting.FONT_MENLO,
+				type: Setting.TYPE_STRING,
+				isEnum: true,
+				public: true,
+				label: () => _('Editor font'),
+				appTypes: ['mobile'],
+				section: 'appearance',
+				options: () => ({
+					/**
+					 * TODO: Check if these fonts break Android. If so, how to retrieve
+					 * info that is more detailed than the `platform` metadata (which
+					 * returns "desktop"|"mobile"|"cli", not the OS info.)
+					 */
+					[Setting.FONT_MENLO]: 'Menlo',
+					[Setting.FONT_COURIER_NEW]: 'Courier New',
+					[Setting.FONT_AVENIR]: 'Avenir',
+				}),
+			},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			autoUpdateEnabled: { value: true, type: Setting.TYPE_BOOL, section: 'application', public: true, appTypes: ['desktop'], label: () => _('Automatically update the application') },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -335,36 +335,37 @@ class Setting extends BaseModel {
 			'encryption.passwordCache': { value: {}, type: Setting.TYPE_OBJECT, public: false, secure: true },
 			'style.zoom': { value: 100, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Global zoom percentage'), minimum: 50, maximum: 500, step: 10 },
 			'style.editor.fontSize': { value: 13, type: Setting.TYPE_INT, public: true, appTypes: ['desktop'], section: 'appearance', label: () => _('Editor font size'), minimum: 4, maximum: 50, step: 1 },
-			'style.editor.fontFamily': {
-				value: '',
-				type: Setting.TYPE_STRING,
-				public: true,
-				appTypes: ['desktop'],
-				section: 'appearance',
-				label: () => _('Editor font family'),
-				description: () =>
-					_('This must be *monospace* font or it will not work properly. If the font ' +
-					'is incorrect or empty, it will default to a generic monospace font.'),
-			},
-			editorFont: {
-				value: Setting.FONT_MENLO,
-				type: Setting.TYPE_STRING,
-				isEnum: true,
-				public: true,
-				label: () => _('Editor font'),
-				appTypes: ['mobile'],
-				section: 'appearance',
-				options: () => {
-					if (mobilePlatform === 'ios') {
-						return {
-							[Setting.FONT_MENLO]: 'Menlo',
-							[Setting.FONT_COURIER_NEW]: 'Courier New',
-							[Setting.FONT_AVENIR]: 'Avenir',
-						};
-					}
-					return {};
-				},
-			},
+			'style.editor.fontFamily':
+				(mobilePlatform === 'ios') ?
+					({
+						value: Setting.FONT_MENLO,
+						type: Setting.TYPE_STRING,
+						isEnum: true,
+						public: true,
+						label: () => _('Editor font'),
+						appTypes: ['mobile'],
+						section: 'appearance',
+						options: () => {
+							if (mobilePlatform === 'ios') {
+								return {
+									[Setting.FONT_MENLO]: 'Menlo',
+									[Setting.FONT_COURIER_NEW]: 'Courier New',
+									[Setting.FONT_AVENIR]: 'Avenir',
+								};
+							}
+							return {};
+						},
+					}) : {
+						value: '',
+						type: Setting.TYPE_STRING,
+						public: true,
+						appTypes: ['desktop'],
+						section: 'appearance',
+						label: () => _('Editor font family'),
+						description: () =>
+							_('This must be *monospace* font or it will not work properly. If the font ' +
+						'is incorrect or empty, it will default to a generic monospace font.'),
+					},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			autoUpdateEnabled: { value: true, type: Setting.TYPE_BOOL, section: 'application', public: true, appTypes: ['desktop'], label: () => _('Automatically update the application') },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -224,6 +224,19 @@ class Setting extends BaseModel {
 					return output;
 				},
 			},
+			editorFont: {
+				value: Setting.FONT_MENLO,
+				type: Setting.TYPE_STRING,
+				isEnum: true,
+				public: true,
+				label: () => _('Editor font'),
+				section: 'appearance',
+				options: () => ({
+					[Setting.FONT_MENLO]: 'Menlo',
+					[Setting.FONT_COURIER_NEW]: 'Courier New',
+					[Setting.FONT_AVENIR]: 'Avenir',
+				}),
+			},
 			uncompletedTodosOnTop: { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, appTypes: ['cli'], label: () => _('Uncompleted to-dos on top') },
 			showCompletedTodos: { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, appTypes: ['cli'], label: () => _('Show completed to-dos') },
 			'notes.sortOrder.field': {
@@ -830,6 +843,10 @@ Setting.THEME_LIGHT = 1;
 Setting.THEME_DARK = 2;
 Setting.THEME_SOLARIZED_LIGHT = 3;
 Setting.THEME_SOLARIZED_DARK = 4;
+
+Setting.FONT_MENLO = 1;
+Setting.FONT_COURIER_NEW = 2;
+Setting.FONT_AVENIR = 3;
 
 Setting.DATE_FORMAT_1 = 'DD/MM/YYYY';
 Setting.DATE_FORMAT_2 = 'DD/MM/YY';

--- a/ReactNativeClient/lib/shim-init-react.js
+++ b/ReactNativeClient/lib/shim-init-react.js
@@ -6,7 +6,7 @@ const { generateSecureRandom } = require('react-native-securerandom');
 const FsDriverRN = require('lib/fs-driver-rn.js').FsDriverRN;
 const urlValidator = require('valid-url');
 const { Buffer } = require('buffer');
-const { Linking } = require('react-native');
+const { Linking, Platform } = require('react-native');
 const mimeUtils = require('lib/mime-utils.js').mime;
 const { basename, fileExtension } = require('lib/path-utils.js');
 const { uuid } = require('lib/uuid.js');
@@ -143,6 +143,10 @@ function shimInit() {
 				resolve();
 			});
 		});
+	};
+
+	shim.mobilePlatform = () => {
+		return Platform.OS;
 	};
 
 	// NOTE: This is a limited version of createResourceFromPath - unlike the Node version, it

--- a/ReactNativeClient/lib/shim.js
+++ b/ReactNativeClient/lib/shim.js
@@ -39,6 +39,10 @@ shim.platformName = function() {
 	throw new Error('Cannot determine platform');
 };
 
+shim.mobilePlatform = function() {
+	return ''; // Default if we're not on mobile (React Native)
+};
+
 // https://github.com/cheton/is-electron
 shim.isElectron = () => {
 	// Renderer process


### PR DESCRIPTION
## Description
Enables user to select the font they want to use in the Joplin mobile editor. 
Partially addresses https://github.com/laurent22/joplin/issues/337.

<img width="40%" src="http://g.recordit.co/Tmse4qf8ty.gif" />

## What next?

I could add something similar for the rendered note font (i.e. the page before the editor).