### PR TITLE
Desktop: Change localeCompare functiion for tags

### DIFF
--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -134,8 +134,8 @@ class MainScreenComponent extends React.Component {
 					return { value: a.id, label: a.title };
 				})
 				.sort((a, b) => {
-          // sensitivity accent will treat accented characters as differemt
-          // but treats caps as equal
+					// sensitivity accent will treat accented characters as differemt
+					// but treats caps as equal
 					return a.label.localeCompare(b.label, undefined, {sensitivity: 'accent'});
 				});
 			const allTags = await Tag.allWithNotes();

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -134,7 +134,9 @@ class MainScreenComponent extends React.Component {
 					return { value: a.id, label: a.title };
 				})
 				.sort((a, b) => {
-					return a.label.localeCompare(b.label);
+          // sensitivity accent will treat accented characters as differemt
+          // but treats caps as equal
+					return a.label.localeCompare(b.label, undefined, {sensitivity: 'accent'});
 				});
 			const allTags = await Tag.allWithNotes();
 			const tagSuggestions = allTags.map(a => {


### PR DESCRIPTION
This makes the tag sorting function also ignore case.
In general tags are lowercase, sometimes that doesn't happen when they've been imported from enex. This keeps everything consistent. 

See [this comment](https://github.com/laurent22/joplin/pull/1806/files/c77f47ef514225540819bde18369af6819ae8175#r314447426) on some similar code.