### PR TITLE
Set locale in time-utils

### DIFF
--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -391,7 +391,8 @@ class BaseApplication {
 		// 	});
 		// }
 
-		if ((action.type == 'SETTING_UPDATE_ONE' && (action.key == 'dateFormat' || action.key == 'timeFormat')) || action.type == 'SETTING_UPDATE_ALL') {
+		if ((action.type == 'SETTING_UPDATE_ONE' && (action.key == 'dateFormat' || action.key == 'timeFormat' || action.key == 'locale')) || action.type == 'SETTING_UPDATE_ALL') {
+			time.setLocale(Setting.value('locale'));
 			time.setDateFormat(Setting.value('dateFormat'));
 			time.setTimeFormat(Setting.value('timeFormat'));
 		}

--- a/ReactNativeClient/lib/time-utils.js
+++ b/ReactNativeClient/lib/time-utils.js
@@ -4,6 +4,16 @@ class Time {
 	constructor() {
 		this.dateFormat_ = 'DD/MM/YYYY';
 		this.timeFormat_ = 'HH:mm';
+		this.locale_ = 'en-us';
+	}
+
+	locale() {
+		return this.locale_;
+	}
+
+	setLocale(v) {
+		moment.locale(v);
+		this.locale_ = v
 	}
 
 	dateFormat() {


### PR DESCRIPTION
[reference](https://discourse.joplinapp.org/t/1-0-165-timestamp-formatting-in-new-template/3219/7?u=calebjohn)

Example of template after switching the language around
![image](https://user-images.githubusercontent.com/2179547/63300748-3618f900-c296-11e9-81b8-a9a6f78fb870.png)
