### PR TITLE
fix typo on encryption options screen

### DIFF
--- a/CliClient/locales/ar.po
+++ b/CliClient/locales/ar.po
@@ -935,7 +935,7 @@ msgstr ""
 "فيما بعد عبر المزامنة."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "يرجى الرجوع إلى التوثيق للمزيد من المعلومات عن التشفير من الطرف للطرف (E2EE) "

--- a/CliClient/locales/bg_BG.po
+++ b/CliClient/locales/bg_BG.po
@@ -958,7 +958,7 @@ msgstr ""
 "ще бъдат свалени тепърва чрез синхронизация."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "За повече информация относно криптирането от край до край (E2EE) и за съвети "

--- a/CliClient/locales/ca.po
+++ b/CliClient/locales/ca.po
@@ -971,7 +971,7 @@ msgstr ""
 "sincrontizació."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Per a més informació sobre el xifratge d'extrem a extrem (E2EE) i consells "

--- a/CliClient/locales/cs_CZ.po
+++ b/CliClient/locales/cs_CZ.po
@@ -950,7 +950,7 @@ msgstr ""
 "staženy při synchronizaci."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Pro více informací o End-To-End šifrování (E2EE) a návod jak je povolit "

--- a/CliClient/locales/da_DK.po
+++ b/CliClient/locales/da_DK.po
@@ -950,7 +950,7 @@ msgstr ""
 "(på et eller andet tidspunkt) via synkroniseringen."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Se dokumentationen for nærmere oplysninger om End-To-End-kryptering (E2EE) "

--- a/CliClient/locales/de_DE.po
+++ b/CliClient/locales/de_DE.po
@@ -973,7 +973,7 @@ msgstr ""
 "Die Hauptschlüssel dieser IDs werden für die Verschlüsselung einiger ..."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Weitere Informationen zur Ende-zu-Ende-Verschlüsselung (E2EE) und Hinweise "

--- a/CliClient/locales/en_GB.po
+++ b/CliClient/locales/en_GB.po
@@ -856,7 +856,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/en_US.po
+++ b/CliClient/locales/en_US.po
@@ -874,7 +874,7 @@ msgstr ""
 "they will eventually be downloaded via synchronization."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/es_ES.po
+++ b/CliClient/locales/es_ES.po
@@ -961,7 +961,7 @@ msgstr ""
 "través de la sincronización."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Para más información acerca del cifrado extremo a extremo (E2EE) y "

--- a/CliClient/locales/eu.po
+++ b/CliClient/locales/eu.po
@@ -957,7 +957,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/fa.po
+++ b/CliClient/locales/fa.po
@@ -866,7 +866,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/fr_FR.po
+++ b/CliClient/locales/fr_FR.po
@@ -961,7 +961,7 @@ msgstr ""
 "probable qu'elle vont être prochainement disponible via la synchronisation."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Pour plus d'informations sur le chiffrement de bout en bout, ainsi que des "

--- a/CliClient/locales/gl_ES.po
+++ b/CliClient/locales/gl_ES.po
@@ -950,7 +950,7 @@ msgstr ""
 "descargados pola sincronización."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/hr_HR.po
+++ b/CliClient/locales/hr_HR.po
@@ -943,7 +943,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/it_IT.po
+++ b/CliClient/locales/it_IT.po
@@ -964,7 +964,7 @@ msgstr ""
 "ad essi. È probabile che verranno scaricati tramite la sincronizzazione."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Per ulteriori informazioni sulla crittografia end-to-end (E2EE) e consigli "

--- a/CliClient/locales/ja_JP.po
+++ b/CliClient/locales/ja_JP.po
@@ -941,7 +941,7 @@ msgstr ""
 "ロードしてきたのでしょう。"
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "エンドツーエンド暗号化(E2EE)に関する詳細な情報とどのように有効化するのかのア"

--- a/CliClient/locales/joplin.pot
+++ b/CliClient/locales/joplin.pot
@@ -856,7 +856,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/ko.po
+++ b/CliClient/locales/ko.po
@@ -936,7 +936,7 @@ msgstr ""
 "될 가능성이 있습니다."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "종단간 암호화(E2EE)에 관한 정보, 사용법 및 조언은 다음 문서에서 확인해주세요:"

--- a/CliClient/locales/nb_NO.po
+++ b/CliClient/locales/nb_NO.po
@@ -946,7 +946,7 @@ msgstr ""
 "vil siden bli lastet ned via synkronisering."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "For mer informasjon om ende-til-ende-kryptering (E2EE) og råd om hvordan du "

--- a/CliClient/locales/nl_BE.po
+++ b/CliClient/locales/nl_BE.po
@@ -959,7 +959,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/nl_NL.po
+++ b/CliClient/locales/nl_NL.po
@@ -958,7 +958,7 @@ msgstr ""
 "items. Waarschijnlijk worden ze uiteindelijk gedownload via synchronisatie."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Bekijk, voor meer informatie over End-To-End-versleuteling (E2EE) en hulp "

--- a/CliClient/locales/pl_PL.po
+++ b/CliClient/locales/pl_PL.po
@@ -965,7 +965,7 @@ msgstr ""
 "pobrane przy synchonizacji."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Aby uzyskać informacje o szyfrowaniu po stronie klienta (E2EE) i przykłady "

--- a/CliClient/locales/pt_BR.po
+++ b/CliClient/locales/pt_BR.po
@@ -955,7 +955,7 @@ msgstr ""
 "elas serão baixadas via sincronização."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Para mais informações sobre Encriptação ponto-a-ponto (E2EE) e recomendações "

--- a/CliClient/locales/ro.po
+++ b/CliClient/locales/ro.po
@@ -879,7 +879,7 @@ msgid ""
 msgstr ""
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/ru_RU.po
+++ b/CliClient/locales/ru_RU.po
@@ -960,7 +960,7 @@ msgstr ""
 "загрузятся при синхронизации."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Для получения дополнительной информации о сквозном шифровании (E2EE) и "

--- a/CliClient/locales/sl_SI.po
+++ b/CliClient/locales/sl_SI.po
@@ -958,7 +958,7 @@ msgstr ""
 "da bodo sčasoma preneseni s sinhronizacijo."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 

--- a/CliClient/locales/sr_RS.po
+++ b/CliClient/locales/sr_RS.po
@@ -959,7 +959,7 @@ msgstr ""
 "преузети путем синхронизације."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "За више информација о End-To-End Шифровању (Е2ЕЕ) и саветима о томе како да "

--- a/CliClient/locales/sv.po
+++ b/CliClient/locales/sv.po
@@ -965,7 +965,7 @@ msgstr ""
 "småningom kommer att hämtas via synkronisering."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "För mer information om End-to-End Encryption (E2EE) och råd om hur du "

--- a/CliClient/locales/tr_TR.po
+++ b/CliClient/locales/tr_TR.po
@@ -934,7 +934,7 @@ msgstr ""
 "senkronizasyon yoluyla indirilmeleri sağlanacaktır."
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr ""
 "Uçtan Uca Şifreleme (E2EE) hakkında bilgi ve nasıl aktif edilebileceğine "

--- a/CliClient/locales/zh_CN.po
+++ b/CliClient/locales/zh_CN.po
@@ -908,7 +908,7 @@ msgstr ""
 "能通过同步下载。"
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr "有关端到端加密（E2EE）的更多信息，以及如何启用它的建议，请查看文档："
 

--- a/CliClient/locales/zh_TW.po
+++ b/CliClient/locales/zh_TW.po
@@ -921,7 +921,7 @@ msgstr ""
 "可能最終會通過同步下載。"
 
 msgid ""
-"For more information about End-To-End Encryption (E2EE) and advices on how "
+"For more information about End-To-End Encryption (E2EE) and advice on how "
 "to enable it please check the documentation:"
 msgstr "有關端到端加密 (E2EE) 的詳細資訊以及該如何啟用它，請參考線上文檔:"
 

--- a/ElectronClient/app/gui/EncryptionConfigScreen.jsx
+++ b/ElectronClient/app/gui/EncryptionConfigScreen.jsx
@@ -205,7 +205,7 @@ class EncryptionConfigScreenComponent extends React.Component {
 					{
 						<div style={{ backgroundColor: theme.warningBackgroundColor, paddingLeft: 10, paddingRight: 10, paddingTop: 2, paddingBottom: 2 }}>
 							<p style={theme.textStyle}>
-								<span>{_('For more information about End-To-End Encryption (E2EE) and advices on how to enable it please check the documentation:')}</span>{' '}
+								<span>{_('For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:')}</span>{' '}
 								<a
 									onClick={() => {
 										bridge().openExternal('https://joplinapp.org/e2ee/');

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -243,7 +243,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				<ScrollView style={this.styles().container}>
 					{
 						<View style={{ backgroundColor: theme.warningBackgroundColor, paddingTop: 5, paddingBottom: 5, paddingLeft: 10, paddingRight: 10 }}>
-							<Text>{_('For more information about End-To-End Encryption (E2EE) and advices on how to enable it please check the documentation:')}</Text>
+							<Text>{_('For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:')}</Text>
 							<TouchableOpacity
 								onPress={() => {
 									Linking.openURL('https://joplinapp.org/e2ee/');


### PR DESCRIPTION
fixes #1798

- changed all `.po` files and `Joplin.pot`
- fixed the occurences of that string in

```
ElectronClient/app/gui/EncryptionConfigScreen.jsx
ReactNativeClient/lib/components/screens/encryption-config.js
``` 

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
