### PR TITLE
Desktop: Add loading animation to import/export

### DIFF
--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -245,7 +245,16 @@ class MainScreenComponent extends React.Component {
 		} else if (command.name === 'toggleSidebar') {
 			this.toggleSidebar();
 		} else if (command.name === 'showModalMessage') {
-			this.setState({ modalLayer: { visible: true, message: command.message } });
+			this.setState({
+				modalLayer: {
+					visible: true,
+					message:
+						<div className="modal-message">
+							<div id="loading-animation" />
+							<div className="text">{command.message}</div>
+						</div>,
+				},
+			});
 		} else if (command.name === 'hideModalMessage') {
 			this.setState({ modalLayer: { visible: false, message: '' } });
 		} else if (command.name === 'editAlarm') {

--- a/ElectronClient/app/style.css
+++ b/ElectronClient/app/style.css
@@ -149,3 +149,52 @@ a {
 	outline: 0 none;
 }
 
+.modal-message {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	color: grey;
+	font-size: 1.2em;
+	margin: 40px 20px;
+}
+
+.modal-message #loading-animation {
+	margin-right: 20px;
+  width: 20px;
+  height: 20px;
+  border: 5px solid lightgrey;
+  border-top: 4px solid white;
+  border-radius: 50%;
+  -webkit-transition-property: -webkit-transform;
+  -webkit-transition-duration: 1.2s;
+  -webkit-animation-name: rotate;
+  -webkit-animation-iteration-count: infinite;
+  -webkit-animation-timing-function: linear;
+
+  -moz-transition-property: -moz-transform;
+  -moz-animation-name: rotate;
+  -moz-animation-duration: 1.2s;
+  -moz-animation-iteration-count: infinite;
+  -moz-animation-timing-function: linear;
+
+  transition-property: transform;
+  animation-name: rotate;
+  animation-duration: 1.2s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+@-webkit-keyframes rotate {
+    from {-webkit-transform: rotate(0deg);}
+    to {-webkit-transform: rotate(360deg);}
+}
+
+@-moz-keyframes rotate {
+    from {-moz-transform: rotate(0deg);}
+    to {-moz-transform: rotate(360deg);}
+}
+
+@keyframes rotate {
+    from {transform: rotate(0deg);}
+    to {transform: rotate(360deg);}
+}

--- a/ElectronClient/app/style.css
+++ b/ElectronClient/app/style.css
@@ -160,41 +160,19 @@ a {
 
 .modal-message #loading-animation {
 	margin-right: 20px;
-  width: 20px;
-  height: 20px;
-  border: 5px solid lightgrey;
-  border-top: 4px solid white;
-  border-radius: 50%;
-  -webkit-transition-property: -webkit-transform;
-  -webkit-transition-duration: 1.2s;
-  -webkit-animation-name: rotate;
-  -webkit-animation-iteration-count: infinite;
-  -webkit-animation-timing-function: linear;
-
-  -moz-transition-property: -moz-transform;
-  -moz-animation-name: rotate;
-  -moz-animation-duration: 1.2s;
-  -moz-animation-iteration-count: infinite;
-  -moz-animation-timing-function: linear;
-
-  transition-property: transform;
-  animation-name: rotate;
-  animation-duration: 1.2s;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
-}
-
-@-webkit-keyframes rotate {
-    from {-webkit-transform: rotate(0deg);}
-    to {-webkit-transform: rotate(360deg);}
-}
-
-@-moz-keyframes rotate {
-    from {-moz-transform: rotate(0deg);}
-    to {-moz-transform: rotate(360deg);}
+	width: 20px;
+	height: 20px;
+	border: 5px solid lightgrey;
+	border-top: 4px solid white;
+	border-radius: 50%;
+	transition-property: transform;
+	animation-name: rotate;
+	animation-duration: 1.2s;
+	animation-iteration-count: infinite;
+	animation-timing-function: linear;
 }
 
 @keyframes rotate {
-    from {transform: rotate(0deg);}
-    to {transform: rotate(360deg);}
+	from {transform: rotate(0deg);}
+	to {transform: rotate(360deg);}
 }


### PR DESCRIPTION
Small upgrade to the import/export pages, per discussion in https://github.com/laurent22/joplin/issues/1862.

Here's how it looks while you're waiting for an export to complete:

![Kapture 2019-09-22 at 17 25 12--Joplin export loading animation](https://user-images.githubusercontent.com/6979755/65396732-50933600-dd5e-11e9-8bb7-cfa25a54cd8f.gif)
