### PR TITLE
Mobile: Added Front Camera toggle when taking a picture with Joplin Camera

### DIFF
--- a/ReactNativeClient/lib/components/CameraView.js
+++ b/ReactNativeClient/lib/components/CameraView.js
@@ -28,7 +28,7 @@ class CameraView extends Component {
 			this.setState({
 				camera: RNCamera.Constants.Type.front,
 			});
-		} else if (this.state.camera == RNCamera.Constants.Type.front){
+		} else if (this.state.camera == RNCamera.Constants.Type.front) {
 			this.setState({
 				camera: RNCamera.Constants.Type.back,
 			});
@@ -84,29 +84,31 @@ class CameraView extends Component {
 								</View>
 							</TouchableOpacity>
 						</View>
-						<View style={{ flex: 1, justifyContent: 'center', alignItems: 'flex-end', flexDirection: 'row' }}>
-							<TouchableOpacity onPress={this.photo_onPress}>
-								<View style={{ marginBottom: 20, borderRadius: 90, width: 90, height: 90, backgroundColor: '#ffffffaa', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-									<Icon
-										name={photoIcon}
-										style={{
-											fontSize: 60,
-											color: 'black',
-										}}
-									/>
-								</View>
-							</TouchableOpacity>
-							<TouchableOpacity onPress={this.reverse_onPress}>
-								<View style={{ marginBottom: 20, borderRadius: 90, width: 90, height: 90, backgroundColor: '#ffffffaa', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-									<Icon
-										name="md-reverse-camera"
-										style={{
-											fontSize: 60,
-											color: 'black',
-										}}
-									/>
-								</View>
-							</TouchableOpacity>
+						<View style={{ flex: 1, alignItems: 'flex-end', flexDirection: 'row', width: '100%' }}>
+							<View style={{ flex: 1, flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+								<TouchableOpacity onPress={this.reverse_onPress} style={{width: '35%', marginLeft: 20}}>
+									<View style={{borderRadius: 32, width: 60, height: 60, backgroundColor: '#ffffffaa', justifyContent: 'center', alignItems: 'center', alignSelf: 'baseline' }}>
+										<Icon
+											name="md-reverse-camera"
+											style={{
+												fontSize: 40,
+												color: 'black',
+											}}
+										/>
+									</View>
+								</TouchableOpacity>
+								<TouchableOpacity onPress={this.photo_onPress} style={{width: '65%'}}>
+									<View style={{ marginBottom: 20, borderRadius: 90, width: 90, height: 90, backgroundColor: '#ffffffaa', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+										<Icon
+											name={photoIcon}
+											style={{
+												fontSize: 60,
+												color: 'black',
+											}}
+										/>
+									</View>
+								</TouchableOpacity>
+							</View>
 						</View>
 					</View>
 				</RNCamera>

--- a/ReactNativeClient/lib/components/CameraView.js
+++ b/ReactNativeClient/lib/components/CameraView.js
@@ -11,14 +11,28 @@ class CameraView extends Component {
 
 		this.state = {
 			snapping: false,
+			camera: RNCamera.Constants.Type.back,
 		};
 
 		this.back_onPress = this.back_onPress.bind(this);
 		this.photo_onPress = this.photo_onPress.bind(this);
+		this.reverse_onPress = this.reverse_onPress.bind(this);
 	}
 
 	back_onPress() {
 		if (this.props.onCancel) this.props.onCancel();
+	}
+
+	reverse_onPress() {
+		if (this.state.camera == RNCamera.Constants.Type.back) {
+			this.setState({
+				camera: RNCamera.Constants.Type.front,
+			});
+		} else if (this.state.camera == RNCamera.Constants.Type.front){
+			this.setState({
+				camera: RNCamera.Constants.Type.back,
+			});
+		}
 	}
 
 	async photo_onPress() {
@@ -47,7 +61,7 @@ class CameraView extends Component {
 					ref={ref => {
 						this.camera = ref;
 					}}
-					type={RNCamera.Constants.Type.back}
+					type={this.state.camera}
 					captureAudio={false}
 					androidCameraPermissionOptions={{
 						title: _('Permission to use camera'),
@@ -75,6 +89,17 @@ class CameraView extends Component {
 								<View style={{ marginBottom: 20, borderRadius: 90, width: 90, height: 90, backgroundColor: '#ffffffaa', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
 									<Icon
 										name={photoIcon}
+										style={{
+											fontSize: 60,
+											color: 'black',
+										}}
+									/>
+								</View>
+							</TouchableOpacity>
+							<TouchableOpacity onPress={this.reverse_onPress}>
+								<View style={{ marginBottom: 20, borderRadius: 90, width: 90, height: 90, backgroundColor: '#ffffffaa', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+									<Icon
+										name="md-reverse-camera"
 										style={{
 											fontSize: 60,
 											color: 'black',


### PR DESCRIPTION
Added toggle switch to use front camera. React-native-camera by default uses back camera if the specified camera (front) is not found. Tested on Android and iOS(Simulator, no real images just blackscreens with the date attached).