### PR TITLE
Desktop: Code button now detects multiline

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1444,7 +1444,19 @@ class NoteTextComponent extends React.Component {
 	}
 
 	commandTextCode() {
-		this.wrapSelectionWithStrings('`', '`');
+		const selection = this.textOffsetSelection();
+		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
+
+		// Look for newlines
+		let match = string.match(/\r?\n/);
+
+		if (match && match.length > 0) {
+			// Follow the same newline style
+			this.wrapSelectionWithStrings(`\`\`\`${match[0]}`, `${match[0]}\`\`\``);
+		}
+		else {
+			this.wrapSelectionWithStrings('`', '`');
+		}
 	}
 
 	commandTemplate(value) {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1369,9 +1369,16 @@ class NoteTextComponent extends React.Component {
 
 			const r = this.selectionRange_;
 
+			// Because some insertion strings will have newlines, we'll need to account for them
+			const str1Split = string1.split(/\r?\n/);
+
+			// Add the number of newlines to the row
+			// and add the length of the final line to the column (for strings with no newlines this is the string length)
 			const newRange = {
-				start: { row: r.start.row, column: r.start.column + string1.length },
-				end: { row: r.end.row, column: r.end.column + string1.length },
+				start: { row: r.start.row + str1Split.length - 1,
+					column: r.start.column + str1Split[str1Split.length - 1].length },
+				end: { row: r.end.row + str1Split.length - 1,
+					column: r.end.column + str1Split[str1Split.length - 1].length },
 			};
 
 			if (replacementText) {


### PR DESCRIPTION
The new linter changed the string formatting a bit, but it still works.

fixes #1606 which was closed by the stale bot.