### PR TITLE
Desktop: add alternate codeblock shortcut (Ctrl+')

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -762,6 +762,18 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
+					id: 'edit:codeAlt',
+					label: _('Code'),
+					screens: ['Main'],
+					visible: false,
+					accelerator: 'CommandOrControl+\'',
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'textCode',
+						});
+					},
+				}, {
 					type: 'separator',
 					screens: ['Main'],
 				}, {


### PR DESCRIPTION
Some keybord layouts have an issue with the backtick character.
Even setting no dead keys for those layouts may not work.

See also [this topic](https://discourse.joplinapp.org/t/problem-with-the-ctrl-grave-accent-shortcut-on-german-keyboards/3687?u=tessus) on the forum.

Update: I could only find a way to do that by creating a second invisible menu item. And this won’t trigger on macOS before Electron 6. But as mentioned before, on mcOS it’s not necessary anyway, because there’s a workaround by redefining the shortcut via the OS (`System Preferences -> Keyboard -> Shortcuts -> App Shortcuts `).

Someone has to test this, because I don’t have Windows or Linux with a DE.

---

I believe something is wrong with the CI pipeline.