### PR TITLE
Desktop: Larger search bar

### DIFF
--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -166,6 +166,7 @@ class HeaderComponent extends React.Component {
 			paddingTop: 1, // vertical alignment with buttons
 			paddingBottom: 0, // vertical alignment with buttons
 			height: style.fontSize * 2,
+			width: 300,
 			color: style.color,
 			fontSize: style.fontSize,
 			fontFamily: style.fontFamily,

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -161,7 +161,7 @@ class HeaderComponent extends React.Component {
 		const inputStyle = {
 			display: 'flex',
 			flex: 1,
-			marginLeft: 20,
+			marginLeft: 10,
 			paddingLeft: 6,
 			paddingRight: 6,
 			paddingTop: 1, // vertical alignment with buttons

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -161,6 +161,7 @@ class HeaderComponent extends React.Component {
 		const inputStyle = {
 			display: 'flex',
 			flex: 1,
+			marginLeft: 20,
 			paddingLeft: 6,
 			paddingRight: 6,
 			paddingTop: 1, // vertical alignment with buttons


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
As per the previous discussions on the issue https://github.com/laurent22/joplin/issues/917, I've made the search bar for the desktop application a bit larger. In addition to this, I also added some margin before the search bar as I've always felt that the search bar is a bit too close to other items on the header.

![image](https://user-images.githubusercontent.com/1782292/66003742-374d6080-e4a7-11e9-90be-375358c4d483.png)

@laurent22 Happy to hear your thoughts on this.