### PR TITLE
Desktop: set cancel as the default in dangerous operations

### DIFF
--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -267,14 +267,18 @@ class SideBarComponent extends React.Component {
 		if (!itemId || !itemType) throw new Error('No data on element');
 
 		let deleteMessage = '';
+		let buttonLabel = '';
 		if (itemType === BaseModel.TYPE_FOLDER) {
 			const folder = await Folder.load(itemId);
 			deleteMessage = _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', substrWithEllipsis(folder.title, 0, 32));
+			buttonLabel = _('Delete');
 		} else if (itemType === BaseModel.TYPE_TAG) {
 			const tag = await Tag.load(itemId);
 			deleteMessage = _('Remove tag "%s" from all notes?', substrWithEllipsis(tag.title, 0, 32));
+			buttonLabel = _('Remove');
 		} else if (itemType === BaseModel.TYPE_SEARCH) {
 			deleteMessage = _('Remove this search from the sidebar?');
+			buttonLabel = _('Remove');
 		}
 
 		const menu = new Menu();
@@ -286,9 +290,12 @@ class SideBarComponent extends React.Component {
 
 		menu.append(
 			new MenuItem({
-				label: _('Delete'),
+				label: buttonLabel,
 				click: async () => {
-					const ok = bridge().showConfirmMessageBox(deleteMessage);
+					const ok = bridge().showConfirmMessageBox(deleteMessage, {
+						buttons: [buttonLabel, _('Cancel')],
+						defaultId: 1,
+					});
 					if (!ok) return;
 
 					if (itemType === BaseModel.TYPE_FOLDER) {

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -267,7 +267,7 @@ class SideBarComponent extends React.Component {
 		if (!itemId || !itemType) throw new Error('No data on element');
 
 		let deleteMessage = '';
-		let buttonLabel = '';
+		let buttonLabel = _('Remove');
 		if (itemType === BaseModel.TYPE_FOLDER) {
 			const folder = await Folder.load(itemId);
 			deleteMessage = _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', substrWithEllipsis(folder.title, 0, 32));
@@ -275,10 +275,8 @@ class SideBarComponent extends React.Component {
 		} else if (itemType === BaseModel.TYPE_TAG) {
 			const tag = await Tag.load(itemId);
 			deleteMessage = _('Remove tag "%s" from all notes?', substrWithEllipsis(tag.title, 0, 32));
-			buttonLabel = _('Remove');
 		} else if (itemType === BaseModel.TYPE_SEARCH) {
 			deleteMessage = _('Remove this search from the sidebar?');
-			buttonLabel = _('Remove');
 		}
 
 		const menu = new Menu();


### PR DESCRIPTION
and rename buttons (delete, remove) and context menu (for tags)

fixes #1662 (partially, because I can't fix the upstream issue, unless we update Electron)

Please note that the reason for `Cancel` not being selected is an upstream issue. But this was already the case for the `delete note dialog` (see below).
Therefore I made everything more consistent.

## right click on tag

<img width="159" alt="image" src="https://user-images.githubusercontent.com/223439/66003689-d3aa3f80-e474-11e9-91e7-7304990cffe9.png">

## remove tag dialog

<img width="398" alt="image" src="https://user-images.githubusercontent.com/223439/66003779-07856500-e475-11e9-8857-ab0a532fed31.png">

## delete notebook dialog

<img width="399" alt="image" src="https://user-images.githubusercontent.com/223439/66003836-2be14180-e475-11e9-847a-717985414501.png">

## delete note dialog (did not change anything, only listed as a reference)

<img width="406" alt="image" src="https://user-images.githubusercontent.com/223439/66003878-49161000-e475-11e9-924a-0d06c2069e5d.png">