### PR TITLE
Desktop: Confirm encryption password (#1656)

### DIFF
--- a/ElectronClient/app/gui/EncryptionConfigScreen.jsx
+++ b/ElectronClient/app/gui/EncryptionConfigScreen.jsx
@@ -112,6 +112,14 @@ class EncryptionConfigScreenComponent extends React.Component {
 				answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			} else {
 				answer = await dialogs.prompt(_('Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target. Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below.'), '', '', { type: 'password' });
+				if (answer) {
+					// Verify password
+					const answer2 = await dialogs.prompt(_('Verify your password by entering it again.'), '', '', { type: 'password' });
+					if (answer !== answer2) {
+						await dialogs.alert('Passwords did not match!');
+						return;
+					}
+				}
 			}
 
 			if (!answer) return;


### PR DESCRIPTION
https://github.com/laurent22/joplin/issues/1656

Gif of the "confirm password" flow:
https://gyazo.com/0921ecb141fba342ac23dfaa12b1e838

I chose to implement this via 2 prompts in a row because showing two boxes would require us to change the underlying prompt library or use a different one. See usage:
https://github.com/coderaiser/smalltalk/blob/master/README.md#smalltalkprompttitle-message-value--options

---

UI Screenshots:

_Step 1_
<img width="489" alt="Joplin_-_Options" src="https://user-images.githubusercontent.com/102242/66019031-5abbdf80-e496-11e9-85ac-f448002cd2c7.png">

_Step 2_
<img width="479" alt="Joplin_-_Options" src="https://user-images.githubusercontent.com/102242/66019042-6a3b2880-e496-11e9-8688-956f34e48442.png">

_Step 3_

On success, works as before. It exits without notification the new encryption key gets added.

On failure, shows this error pop-up.
<img width="404" alt="Joplin_-_Options" src="https://user-images.githubusercontent.com/102242/66019060-863eca00-e496-11e9-9405-35c71dc0ef41.png">
