### PR TITLE
CLI: confirm encryption password

### DIFF
--- a/CliClient/app/command-e2ee.js
+++ b/CliClient/app/command-e2ee.js
@@ -50,7 +50,15 @@ class Command extends BaseCommand {
 				this.stdout(_('Operation cancelled'));
 				return;
 			}
-
+			const password2 = await this.prompt(_('Confirm master password:'), { type: 'string', secure: true });
+			if (!password2) {
+				this.stdout(_('Operation cancelled'));
+				return;
+			}
+			if (password !== password2) {
+				this.stdout(_('Passwords did not match!'));
+				return;
+			}
 			await EncryptionService.instance().generateMasterKeyAndEnableEncryption(password);
 			return;
 		}


### PR DESCRIPTION
#1656

Same idea as https://github.com/laurent22/joplin/pull/1936 except for the CLI instead of Desktop.

Successful flow:
https://gyazo.com/354ca9ea412ffe3756ee77938d544341

Flow with error (non-matching passwords):
https://gyazo.com/9adda69278e3631da33d9fb366815d04

