### PR TITLE
Mobile: confirm encryption password

### DIFF
--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -23,6 +23,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 		this.state = {
 			passwordPromptShow: false,
 			passwordPromptAnswer: '',
+			passwordPromptConfirmAnswer: '',
 		};
 
 		shared.constructor(this);
@@ -131,6 +132,9 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 			try {
 				const password = this.state.passwordPromptAnswer;
 				if (!password) throw new Error(_('Password cannot be empty'));
+				const password2 = this.state.passwordPromptConfirmAnswer;
+				if (!password2) throw new Error(_('Confirm password cannot be empty'));
+				if (password !== password2) throw new Error(_('Passwords do not match'));
 				await EncryptionService.instance().generateMasterKeyAndEnableEncryption(password);
 				this.setState({ passwordPromptShow: false });
 			} catch (error) {
@@ -141,6 +145,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 		return (
 			<View style={{ flex: 1, borderColor: theme.dividerColor, borderWidth: 1, padding: 10, marginTop: 10, marginBottom: 10 }}>
 				<Text style={{ fontSize: theme.fontSize, color: theme.color }}>{_('Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target. Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below.')}</Text>
+				<Text>Password: </Text>
 				<TextInput
 					selectionColor={theme.textSelectionColor}
 					style={{ margin: 10, color: theme.color, borderWidth: 1, borderColor: theme.dividerColor }}
@@ -148,6 +153,16 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 					value={this.state.passwordPromptAnswer}
 					onChangeText={text => {
 						this.setState({ passwordPromptAnswer: text });
+					}}
+				></TextInput>
+				<Text>Confirm Password: </Text>
+				<TextInput
+					selectionColor={theme.textSelectionColor}
+					style={{ margin: 10, color: theme.color, borderWidth: 1, borderColor: theme.dividerColor }}
+					secureTextEntry={true}
+					value={this.state.passwordPromptConfirmAnswer}
+					onChangeText={text => {
+						this.setState({ passwordPromptConfirmAnswer: text });
 					}}
 				></TextInput>
 				<View style={{ flexDirection: 'row' }}>
@@ -203,6 +218,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				this.setState({
 					passwordPromptShow: true,
 					passwordPromptAnswer: '',
+					passwordPromptConfirmAnswer: '',
 				});
 				return;
 			}

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -83,6 +83,12 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				fontSize: theme.fontSize,
 				color: theme.color,
 			},
+			normalTextInput: {
+				margin: 10,
+				color: theme.color,
+				borderWidth: 1,
+				borderColor: theme.dividerColor,
+			},
 			container: {
 				flex: 1,
 				padding: theme.margin,
@@ -134,7 +140,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				if (!password) throw new Error(_('Password cannot be empty'));
 				const password2 = this.state.passwordPromptConfirmAnswer;
 				if (!password2) throw new Error(_('Confirm password cannot be empty'));
-				if (password !== password2) throw new Error(_('Passwords do not match'));
+				if (password !== password2) throw new Error(_('Passwords did not match!'));
 				await EncryptionService.instance().generateMasterKeyAndEnableEncryption(password);
 				this.setState({ passwordPromptShow: false });
 			} catch (error) {
@@ -144,21 +150,24 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 
 		return (
 			<View style={{ flex: 1, borderColor: theme.dividerColor, borderWidth: 1, padding: 10, marginTop: 10, marginBottom: 10 }}>
-				<Text style={{ fontSize: theme.fontSize, color: theme.color }}>{_('Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target. Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below.')}</Text>
-				<Text>Password: </Text>
+				<Text style={{ fontSize: theme.fontSize, color: theme.color, marginBottom: 10 }}>{_('Enabling encryption means *all* your notes and attachments are going to be re-synchronised and sent encrypted to the sync target. Do not lose the password as, for security purposes, this will be the *only* way to decrypt the data! To enable encryption, please enter your password below.')}</Text>
+				<Text style={this.styles().normalText}>{_('Password:')}</Text>
 				<TextInput
+					placeholder={_('Password')}
 					selectionColor={theme.textSelectionColor}
-					style={{ margin: 10, color: theme.color, borderWidth: 1, borderColor: theme.dividerColor }}
+					style={this.styles().normalTextInput}
 					secureTextEntry={true}
 					value={this.state.passwordPromptAnswer}
 					onChangeText={text => {
 						this.setState({ passwordPromptAnswer: text });
 					}}
 				></TextInput>
-				<Text>Confirm Password: </Text>
+
+				<Text style={this.styles().normalText}>{_('Confirm password:')}</Text>
 				<TextInput
+					placeholder={_('Confirm password')}
 					selectionColor={theme.textSelectionColor}
-					style={{ margin: 10, color: theme.color, borderWidth: 1, borderColor: theme.dividerColor }}
+					style={this.styles().normalTextInput}
 					secureTextEntry={true}
 					value={this.state.passwordPromptConfirmAnswer}
 					onChangeText={text => {

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -140,7 +140,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				if (!password) throw new Error(_('Password cannot be empty'));
 				const password2 = this.state.passwordPromptConfirmAnswer;
 				if (!password2) throw new Error(_('Confirm password cannot be empty'));
-				if (password !== password2) throw new Error(_('Passwords did not match!'));
+				if (password !== password2) throw new Error(_('Passwords do not match!'));
 				await EncryptionService.instance().generateMasterKeyAndEnableEncryption(password);
 				this.setState({ passwordPromptShow: false });
 			} catch (error) {


### PR DESCRIPTION
Issue: #1656

Same idea as #1936 except for Mobile

--

_Before_

<img width="371" alt="iPhone_X_—_12_2" src="https://user-images.githubusercontent.com/102242/66025777-1e937980-e4ac-11e9-8cd8-7e7aeb3e1b29.png">

_New UI:_

(Verified that it sets up encryption as normal if passwords match)

<img width="366" alt="iPhone_X_—_12_2" src="https://user-images.githubusercontent.com/102242/66025417-42a28b00-e4ab-11e9-932e-50b591a3020b.png">

**Error cases**

_Errors if passwords don't match_

<img width="370" alt="iPhone_X_—_12_2" src="https://user-images.githubusercontent.com/102242/66025582-acbb3000-e4ab-11e9-9f62-fc1383cc038e.png">

_Errors if either field is empty and you click "enable"_

<img width="364" alt="iPhone_X_—_12_2" src="https://user-images.githubusercontent.com/102242/66025479-6fef3900-e4ab-11e9-9e3c-af3c1ab17431.png">

<img width="379" alt="iPhone_X_—_12_2" src="https://user-images.githubusercontent.com/102242/66025524-8b5a4400-e4ab-11e9-8e91-30f91fb330e5.png">
