### PR TITLE
Desktop: hide some toolbar buttons when editor hidden

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1543,7 +1543,7 @@ class NoteTextComponent extends React.Component {
 		menu.popup(bridge().window());
 	}
 
-	createToolbarItems(note) {
+	createToolbarItems(note, editorIsVisible) {
 		const toolbarItems = [];
 		if (note && this.state.folder && ['Search', 'Tag'].includes(this.props.notesParentType)) {
 			toolbarItems.push({
@@ -1578,7 +1578,7 @@ class NoteTextComponent extends React.Component {
 			});
 		}
 
-		if (note.markup_language === Note.MARKUP_LANGUAGE_MARKDOWN) {
+		if (note.markup_language === Note.MARKUP_LANGUAGE_MARKDOWN && editorIsVisible) {
 			toolbarItems.push({
 				tooltip: _('Bold'),
 				iconName: 'fa-bold',
@@ -1980,7 +1980,8 @@ class NoteTextComponent extends React.Component {
 			}
 		}
 
-		const toolbarItems = this.createToolbarItems(note);
+		const editorIsVisible = visiblePanes.indexOf('editor') >= 0;
+		const toolbarItems = this.createToolbarItems(note, editorIsVisible);
 
 		const toolbar = <Toolbar style={toolbarStyle} items={toolbarItems} />;
 


### PR DESCRIPTION
addresses issue: https://github.com/laurent22/joplin/issues/1896

_editor visible, preview visible_
<img width="1091" alt="Joplin" src="https://user-images.githubusercontent.com/102242/66023740-e6d60300-e4a6-11e9-9efe-23574cd1be65.png">

_editor visible, preview NOT visible_
<img width="1094" alt="Joplin" src="https://user-images.githubusercontent.com/102242/66023837-31f01600-e4a7-11e9-8b31-902595a3cd69.png">

_editor NOT visible, preview visible (NEW BEHAVIOR)_
<img width="1094" alt="Joplin" src="https://user-images.githubusercontent.com/102242/66023861-42a08c00-e4a7-11e9-89f3-6962f75ae4fe.png">



