### PR TITLE
Desktop: add checkmark to menu item, if Dev Tools are on

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -197,10 +197,12 @@ class Application extends BaseApplication {
 
 			case 'NOTE_DEVTOOLS_TOGGLE':
 
-				newState = Object.assign({}, state);
-				newState.noteDevToolsVisible = !newState.noteDevToolsVisible;
-				const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
-				menuItem.checked = newState.noteDevToolsVisible;
+				{
+					newState = Object.assign({}, state);
+					newState.noteDevToolsVisible = !newState.noteDevToolsVisible;
+					const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
+					menuItem.checked = newState.noteDevToolsVisible;
+				}
 				break;
 
 			}

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -199,6 +199,8 @@ class Application extends BaseApplication {
 
 				newState = Object.assign({}, state);
 				newState.noteDevToolsVisible = !newState.noteDevToolsVisible;
+				const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
+				menuItem.checked = newState.noteDevToolsVisible;
 				break;
 
 			}
@@ -913,6 +915,8 @@ class Application extends BaseApplication {
 					type: 'separator',
 					screens: ['Main'],
 				}, {
+					id: 'help:toggleDevTools',
+					type: 'checkbox',
 					label: _('Toggle development tools'),
 					visible: true,
 					click: () => {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -196,13 +196,8 @@ class Application extends BaseApplication {
 				break;
 
 			case 'NOTE_DEVTOOLS_TOGGLE':
-
-				{
-					newState = Object.assign({}, state);
-					newState.noteDevToolsVisible = !newState.noteDevToolsVisible;
-					const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
-					menuItem.checked = newState.noteDevToolsVisible;
-				}
+				newState = Object.assign({}, state);
+				newState.noteDevToolsVisible = !newState.noteDevToolsVisible;
 				break;
 
 			}
@@ -252,6 +247,11 @@ class Application extends BaseApplication {
 
 		if (action.type.indexOf('NOTE_SELECT') === 0 || action.type.indexOf('FOLDER_SELECT') === 0) {
 			this.updateMenuItemStates();
+		}
+
+		if (action.type === 'NOTE_DEVTOOLS_TOGGLE') {
+			const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
+			menuItem.checked = newState.noteDevToolsVisible;
 		}
 
 		return result;


### PR DESCRIPTION
If one closed the dev tools window, one could think that the Dev Tools are closed.
This is not the case. After the next action, the window opens again. This can be
confusing, therefore I added a checkmark to the menu item so that it is very clear.
