### PR TITLE
Minor fix to install script

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -90,7 +90,7 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
     else
       DESKTOP=$XDG_CURRENT_DESKTOP
     fi
-    DESKTOP=${desktop,,}  # convert to lower case
+    DESKTOP=${DESKTOP,,}  # convert to lower case
 
     # Create icon for Gnome
     echo 'Create Desktop icon.'


### PR DESCRIPTION
The script is currently failing to generate icons (and the .desktop file).
This is caused by a minor naming mistake.
