### PR TITLE
set useCustomCSS to true

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1198,7 +1198,7 @@ class NoteTextComponent extends React.Component {
 		const previousTheme = Setting.value('theme');
 		Setting.setValue('theme', Setting.THEME_LIGHT);
 		this.lastSetHtml_ = '';
-		await this.updateHtml(this.state.note.markup_language, tempBody, { useCustomCss: false });
+		await this.updateHtml(this.state.note.markup_language, tempBody);
 		this.forceUpdate();
 
 		const restoreSettings = async () => {


### PR DESCRIPTION
Printing to pdf respects the userstyle.css from now on, except for the background settings, which gets overriden by `restoreSettings()` (that's by design?)
