### PR TITLE
Linux install script: Fix category

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -107,7 +107,7 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
 
        # On some systems this directory doesn't exist by default
        mkdir -p ~/.local/share/applications
-       echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Application;\n$APPIMAGE_VERSION" >> ~/.local/share/applications/appimagekit-joplin.desktop 
+       echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n$APPIMAGE_VERSION" >> ~/.local/share/applications/appimagekit-joplin.desktop 
        print "${COLOR_GREEN}OK${COLOR_RESET}"
     else
        print "${COLOR_RED}NOT DONE${COLOR_RESET}"


### PR DESCRIPTION
After running the install script, Joplin is placed under "Other" in my applications menu.
This happens because the `Categories` value in `joplin.desktop` is not in [the FreeDesktop specification](https://standards.freedesktop.org/menu-spec/latest/apa.html).

This pull request fixes it, changing to the most suitable IMO: Office. Do feel free to pick other.

