### PR TITLE
Desktop: Improved resource hover title

### DIFF
--- a/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
@@ -9,7 +9,7 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 		let href = utils.getAttr(token.attrs, 'href');
 		const resourceHrefInfo = urlUtils.parseResourceUrl(href);
 		const isResourceUrl = !!resourceHrefInfo;
-		const title = isResourceUrl ? utils.getAttr(token.attrs, 'title') : href;
+		let title = utils.getAttr(token.attrs, 'title', isResourceUrl ? '' : href);
 
 		let resourceIdAttr = '';
 		let icon = '';
@@ -19,6 +19,8 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 
 			const result = ruleOptions.resources[resourceId];
 			const resourceStatus = utils.resourceStatus(result);
+
+			if (result && result.item) title = utils.getAttr(token.attrs, 'title', result.item.title);
 
 			if (result && resourceStatus !== 'ready') {
 				const icon = utils.resourceStatusFile(resourceStatus);

--- a/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
@@ -14,13 +14,17 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 		let resourceIdAttr = '';
 		let icon = '';
 		let hrefAttr = '#';
+		let mime = '';
 		if (isResourceUrl) {
 			const resourceId = resourceHrefInfo.itemId;
 
 			const result = ruleOptions.resources[resourceId];
 			const resourceStatus = utils.resourceStatus(result);
 
-			if (result && result.item) title = utils.getAttr(token.attrs, 'title', result.item.title);
+			if (result && result.item) {
+				title = utils.getAttr(token.attrs, 'title', result.item.title);
+				mime = result.item.mime;
+			}
 
 			if (result && resourceStatus !== 'ready') {
 				const icon = utils.resourceStatusFile(resourceStatus);
@@ -39,7 +43,7 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 
 		let js = `${ruleOptions.postMessageSyntax}(${JSON.stringify(href)}); return false;`;
 		if (hrefAttr.indexOf('#') === 0 && href.indexOf('#') === 0) js = ''; // If it's an internal anchor, don't add any JS since the webview is going to handle navigating to the right place
-		return `<a data-from-md ${resourceIdAttr} title='${htmlentities(title)}' href='${hrefAttr}' onclick='${js}'>${icon}`;
+		return `<a data-from-md ${resourceIdAttr} title='${htmlentities(title)}' href='${hrefAttr}' onclick='${js}' type='${mime}'>${icon}`;
 	};
 }
 

--- a/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml/rules/link_open.js
@@ -43,7 +43,7 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 
 		let js = `${ruleOptions.postMessageSyntax}(${JSON.stringify(href)}); return false;`;
 		if (hrefAttr.indexOf('#') === 0 && href.indexOf('#') === 0) js = ''; // If it's an internal anchor, don't add any JS since the webview is going to handle navigating to the right place
-		return `<a data-from-md ${resourceIdAttr} title='${htmlentities(title)}' href='${hrefAttr}' onclick='${js}' type='${mime}'>${icon}`;
+		return `<a data-from-md ${resourceIdAttr} title='${htmlentities(title)}' href='${hrefAttr}' onclick='${js}' type='${htmlentities(mime)}'>${icon}`;
 	};
 }
 


### PR DESCRIPTION
This pull does 2 things.
1. Actually allows the user to set a markdown link title for resource URLs and internal links
e.g
`[internal link](:/51bee0f048994f81a7cbca4e7627ad13 "title")`

2. Display the stored resource title for resources on hover.
From what I can tell, this field is always the original filename, is that correct @laurent22 ? This will be useful because it will allow users to hover over a resource to get some additional info.
My other motivation for adding that is it will allow for joplin to display the filetype [instead of the resource icon](https://discourse.joplinapp.org/t/set-of-icons-for-attachments/2813) when filetypes are known. Users can do this manually using css, or if you're open to it, I can make a pull request that will make it a feature in Joplin.