### PR TITLE
Desktop, Cli: enex_to_md: support italic in span tags

### DIFF
--- a/CliClient/tests/enex_to_md/text_formatting_span_italic.html
+++ b/CliClient/tests/enex_to_md/text_formatting_span_italic.html
@@ -1,0 +1,8 @@
+<div><span style="font-style: italic;">singleline italic text with span style font-style: italic;.</span></div><div><br/></div>
+<div><span style="font-style: italic;">multiline italic
+ text with span style font-style: italic;.</span></div><div><br/></div>
+
+<div><span style="font-style: italic;">singleline italic text with span style font-style: italic;</span> next to normal text with leading space.</div><div><br/></div>
+<div><span style="font-style: italic;">singleline italic text with span style font-style: italic; and with trailing space </span>next to normal text.</div><div><br/></div>
+<div><span style="font-style: italic;">singleline italic text with span style font-style: italic;</span><span style="font-style: italic;"> next to more italic text with span style font-style: italic; and with leading space.</span></div><div><br/></div>
+<div><span style="font-style: italic;">singleline italic text with span style font-style: italic; and with trailing space </span><span style="font-style: italic;">next to more italic text with span style font-style: italic;.</span></div>

--- a/CliClient/tests/enex_to_md/text_formatting_span_italic.md
+++ b/CliClient/tests/enex_to_md/text_formatting_span_italic.md
@@ -1,0 +1,11 @@
+*singleline italic text with span style font-style: italic;.*
+
+*multiline italic text with span style font-style: italic;.*
+
+*singleline italic text with span style font-style: italic;* next to normal text with leading space.
+
+*singleline italic text with span style font-style: italic; and with trailing space *next to normal text.
+
+*singleline italic text with span style font-style: italic;** next to more italic text with span style font-style: italic; and with leading space.*
+
+*singleline italic text with span style font-style: italic; and with trailing space **next to more italic text with span style font-style: italic;.*

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -392,10 +392,10 @@ function isSpanStyleBold(attributes) {
 	if (style.includes('font-weight: bold;')) {
 		return true;
 	} else if (style.search(/font-family:.*,Bold.*;/) != -1) {
-		//console.debug('font-family regex matched');
+		// console.debug('font-family regex matched');
 		return true;
 	} else {
-		//console.debug('Found unsupported style(s) in span tag: %s', style);
+		// console.debug('Found unsupported style(s) in span tag: %s', style);
 		return false;
 	}
 }
@@ -700,14 +700,14 @@ function enexXmlToMdArray(stream, resources) {
 				}
 			} else if (n == 'span') {
 				if (isSpanWithStyle(nodeAttributes)) {
-					//console.debug('Found style(s) in span tag: %s', nodeAttributes.style);
+					// console.debug('Found style(s) in span tag: %s', nodeAttributes.style);
 					state.spanAttributes.push(nodeAttributes);
 					if (isSpanStyleBold(nodeAttributes)) {
-						//console.debug('Applying style found in span tag: bold')
+						// console.debug('Applying style found in span tag: bold')
 						section.lines.push('**');
 					}
 					if (isSpanStyleItalic(nodeAttributes)) {
-						//console.debug('Applying style found in span tag: italic')
+						// console.debug('Applying style found in span tag: italic')
 						section.lines.push('*');
 					}
 				}
@@ -895,11 +895,11 @@ function enexXmlToMdArray(stream, resources) {
 				let attributes = state.spanAttributes.pop();
 				if (isSpanWithStyle(attributes)) {
 					if (isSpanStyleBold(attributes)) {
-						//console.debug('Applying style found in span tag (closing): bold')
+						// console.debug('Applying style found in span tag (closing): bold')
 						section.lines.push('**');
 					}
 					if (isSpanStyleItalic(attributes)) {
-						//console.debug('Applying style found in span tag (closing): italic')
+						// console.debug('Applying style found in span tag (closing): italic')
 						section.lines.push('*');
 					}
 				}

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -395,6 +395,7 @@ function isSpanStyleBold(attributes) {
 		// console.debug('font-family regex matched');
 		return true;
 	} else {
+		// console.debug('Found unsupported style(s) in span tag: %s', style);
 		return false;
 	}
 }

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -395,6 +395,7 @@ function isSpanStyleBold(attributes) {
 		//console.debug('font-family regex matched');
 		return true;
 	} else {
+		//console.debug('Found unsupported style(s) in span tag: %s', style);
 		return false;
 	}
 }

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -395,7 +395,6 @@ function isSpanStyleBold(attributes) {
 		// console.debug('font-family regex matched');
 		return true;
 	} else {
-		// console.debug('Found unsupported style(s) in span tag: %s', style);
 		return false;
 	}
 }

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -395,9 +395,14 @@ function isSpanStyleBold(attributes) {
 		//console.debug('font-family regex matched');
 		return true;
 	} else {
-		//console.debug('Found unsupported style(s) in span tag: %s', style);
 		return false;
 	}
+}
+
+function isSpanStyleItalic(attributes) {
+	let style = attributes.style;
+	style = style.replace(/\s+/g, '');
+	return (style.toLowerCase().includes('font-style:italic;'));
 }
 
 function enexXmlToMdArray(stream, resources) {
@@ -694,10 +699,15 @@ function enexXmlToMdArray(stream, resources) {
 				}
 			} else if (n == 'span') {
 				if (isSpanWithStyle(nodeAttributes)) {
+					//console.debug('Found style(s) in span tag: %s', nodeAttributes.style);
 					state.spanAttributes.push(nodeAttributes);
 					if (isSpanStyleBold(nodeAttributes)) {
 						//console.debug('Applying style found in span tag: bold')
 						section.lines.push('**');
+					}
+					if (isSpanStyleItalic(nodeAttributes)) {
+						//console.debug('Applying style found in span tag: italic')
+						section.lines.push('*');
 					}
 				}
 			} else if (['font', 'sup', 'cite', 'abbr', 'small', 'tt', 'sub', 'colgroup', 'col', 'ins', 'caption', 'var', 'map', 'area'].indexOf(n) >= 0) {
@@ -886,6 +896,10 @@ function enexXmlToMdArray(stream, resources) {
 					if (isSpanStyleBold(attributes)) {
 						//console.debug('Applying style found in span tag (closing): bold')
 						section.lines.push('**');
+					}
+					if (isSpanStyleItalic(attributes)) {
+						//console.debug('Applying style found in span tag (closing): italic')
+						section.lines.push('*');
 					}
 				}
 			} else if (isIgnoredEndTag(n)) {


### PR DESCRIPTION
Hi, this should theoretically be a no-brainer. It is just an addition to the "span tags format conversion feature" you merged a couple of weeks ago (#1708). I also added a html and md pair test and it passes. Additionally I did a lot of testing with my old Evernote notes.

Anyway, I am experiencing an odd issue: Some tests don't pass and I think I didn't break them: 

```
Error converting file: mathjax_block.html
Error converting file: mathjax_inline.html
Error converting file: table_with_pipe.html
```

By any chance, are they currently broken or should they work?

Thanks
