### PR TITLE
Desktop + Mobile: Enabled permalink anchors on headings (via module markdownItAnchor).

### DIFF
--- a/ReactNativeClient/lib/renderers/MdToHtml.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml.js
@@ -145,6 +145,8 @@ class MdToHtml {
 		markdownIt.use(rules.code_inline(context, ruleOptions));
 		markdownIt.use(markdownItAnchor, {
 			slugify: s => uslug(s),
+			permalink: true,
+			permalinkSpace: false,
 		});
 
 		for (let key in plugins) {


### PR DESCRIPTION
This makes it possible to link to sections via heading slugs - e.g.
  `[my link](#my-heading).`

This also works across notebooks
  `[my link in to notebook](:/9eda3c2ef3124727840f327268eab513#my-heading).`

I have not been able to test this on mobile platforms; I hope you will have the possibility to test it before merging.

Also, should there be a note about this in the docs somewhere? I think I saw a section regarding links, but could not find it.

Unit tests fails; but I believe it is not from my changes.