### PR TITLE
Desktop, Mobile: add typographer support

### DIFF
--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -303,6 +303,7 @@ class Setting extends BaseModel {
 				},
 			},
 			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable soft breaks') },
+			'markdown.typographer': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable typographer support') },
 			'markdown.plugin.katex': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable math expressions') },
 			'markdown.plugin.mark': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax') },
 			'markdown.plugin.footnote': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes') },

--- a/ReactNativeClient/lib/renderers/MdToHtml.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml.js
@@ -60,6 +60,7 @@ class MdToHtml {
 		}
 
 		const breaks_ = Setting.value('markdown.softbreaks') ? false : true;
+		const typographer_ = Setting.value('markdown.typographer') ? true : false;
 
 		const cacheKey = md5(escape(body + JSON.stringify(options) + JSON.stringify(style)));
 		const cachedOutput = this.cachedOutputs_[cacheKey];
@@ -75,6 +76,7 @@ class MdToHtml {
 
 		const markdownIt = new MarkdownIt({
 			breaks: breaks_,
+			typographer: typographer_,
 			linkify: true,
 			html: true,
 			highlight: (str, lang) => {

--- a/readme/markdown.md
+++ b/readme/markdown.md
@@ -118,6 +118,7 @@ Joplin supports a number of plugins that can be toggled on top the standard Mark
 
 | Plugin | Syntax | Description | Enabled |
 |--------|--------|-------------|---------|
+| Typographer | See [typographer](https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%23%20Typographic%20replacements%5Cn%5Cn%28c%29%20%28C%29%20%28r%29%20%28R%29%20%28tm%29%20%28TM%29%20%28p%29%20%28P%29%20%2B-%5Cn%5Cntest..%20test...%20test.....%20test%3F.....%20test!....%5Cn%5Cn!!!!!!%20%3F%3F%3F%3F%20%2C%2C%20%20--%20---%5Cn%5Cn%5C%22Smartypants%2C%20double%20quotes%5C%22%20and%20%27single%20quotes%27%5Cn%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D) markdown-it demo | Does typographic replacements, (c) -&gt; © and so on | no |
 | [Katex](https://katex.org) | `$$math expr$$` or `$math$` | [See above](#math-notation) | yes |
 | [Mark](https://github.com/markdown-it/markdown-it-mark) | `==marked==` | Transforms into `<mark>marked</mark>` (highlighted) | yes |
 | [Footnote](https://github.com/markdown-it/markdown-it-footnote) | `Simples inline footnote ^[I'm inline!]` | See [plugin page](https://github.com/markdown-it/markdown-it-footnote) for full description | yes |


### PR DESCRIPTION
New plugin `Enable typographer support`.

# disabled (default)

![image](https://user-images.githubusercontent.com/223439/66781315-f25efc00-eea0-11e9-8276-73da8fba6d7a.png)

# enabled

![image](https://user-images.githubusercontent.com/223439/66781336-f9860a00-eea0-11e9-8ee9-2107773c794b.png)
