### PR TITLE
Desktop: Add menu item to toggle note list #1988

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -44,7 +44,7 @@ const appDefaultState = Object.assign({}, defaultState, {
 	windowCommand: null,
 	noteVisiblePanes: ['editor', 'viewer'],
 	sidebarVisibility: true,
-	notelistVisibility: true,
+	noteListVisibility: true,
 	windowContentSize: bridge().windowContentSize(),
 	watchedNoteFiles: [],
 	lastEditorScrollPercents: {},
@@ -157,12 +157,12 @@ class Application extends BaseApplication {
 
 			case 'NOTELIST_VISIBILITY_TOGGLE':
 				newState = Object.assign({}, state);
-				newState.notelistVisibility = !state.notelistVisibility;
+				newState.noteListVisibility = !state.noteListVisibility;
 				break;
 
 			case 'NOTELIST_VISIBILITY_SET':
 				newState = Object.assign({}, state);
-				newState.notelistVisibility = action.visibility;
+				newState.noteListVisibility = action.visibility;
 				break;
 
 			case 'NOTE_FILE_WATCHER_ADD':
@@ -257,7 +257,7 @@ class Application extends BaseApplication {
 		}
 
 		if (['NOTELIST_VISIBILITY_TOGGLE', 'NOTELIST_VISIBILITY_SET'].indexOf(action.type) >= 0) {
-			Setting.setValue('notelistVisibility', newState.notelistVisibility);
+			Setting.setValue('noteListVisibility', newState.noteListVisibility);
 		}
 
 		if (action.type.indexOf('NOTE_SELECT') === 0 || action.type.indexOf('FOLDER_SELECT') === 0) {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -865,8 +865,7 @@ class Application extends BaseApplication {
 							name: 'toggleSidebar',
 						});
 					},
-				},
-				{
+				}, {
 					label: _('Toggle note list'),
 					screens: ['Main'],
 					click: () => {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -44,6 +44,7 @@ const appDefaultState = Object.assign({}, defaultState, {
 	windowCommand: null,
 	noteVisiblePanes: ['editor', 'viewer'],
 	sidebarVisibility: true,
+	notelistVisibility: true,
 	windowContentSize: bridge().windowContentSize(),
 	watchedNoteFiles: [],
 	lastEditorScrollPercents: {},
@@ -154,6 +155,16 @@ class Application extends BaseApplication {
 				newState.sidebarVisibility = action.visibility;
 				break;
 
+			case 'NOTELIST_VISIBILITY_TOGGLE':
+				newState = Object.assign({}, state);
+				newState.notelistVisibility = !state.notelistVisibility;
+				break;
+
+			case 'NOTELIST_VISIBILITY_SET':
+				newState = Object.assign({}, state);
+				newState.notelistVisibility = action.visibility;
+				break;
+
 			case 'NOTE_FILE_WATCHER_ADD':
 
 				if (newState.watchedNoteFiles.indexOf(action.id) < 0) {
@@ -243,6 +254,10 @@ class Application extends BaseApplication {
 
 		if (['SIDEBAR_VISIBILITY_TOGGLE', 'SIDEBAR_VISIBILITY_SET'].indexOf(action.type) >= 0) {
 			Setting.setValue('sidebarVisibility', newState.sidebarVisibility);
+		}
+
+		if (['NOTELIST_VISIBILITY_TOGGLE', 'NOTELIST_VISIBILITY_SET'].indexOf(action.type) >= 0) {
+			Setting.setValue('notelistVisibility', newState.notelistVisibility);
 		}
 
 		if (action.type.indexOf('NOTE_SELECT') === 0 || action.type.indexOf('FOLDER_SELECT') === 0) {
@@ -848,6 +863,16 @@ class Application extends BaseApplication {
 						this.dispatch({
 							type: 'WINDOW_COMMAND',
 							name: 'toggleSidebar',
+						});
+					},
+				},
+				{
+					label: _('Toggle note list'),
+					screens: ['Main'],
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'toggleNoteList',
 						});
 					},
 				}, {

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -451,7 +451,7 @@ class MainScreenComponent extends React.Component {
 
 		headerItems.push({
 			title: _('Toggle note list'),
-			iconName: 'fa-bars',
+			iconName: 'fa-tasks',
 			iconRotation: noteListVisibility ? 0 : 90,
 			onClick: () => {
 				this.doCommand({ name: 'toggleNoteList' });

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -451,7 +451,7 @@ class MainScreenComponent extends React.Component {
 
 		headerItems.push({
 			title: _('Toggle note list'),
-			iconName: 'fa-tasks',
+			iconName: 'fa-align-justify',
 			iconRotation: noteListVisibility ? 0 : 90,
 			onClick: () => {
 				this.doCommand({ name: 'toggleNoteList' });

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -69,6 +69,12 @@ class MainScreenComponent extends React.Component {
 		});
 	}
 
+	toggleNoteList() {
+		this.props.dispatch({
+			type: 'NOTELIST_VISIBILITY_TOGGLE',
+		});
+	}
+
 	async doCommand(command) {
 		if (!command) return;
 
@@ -435,6 +441,15 @@ class MainScreenComponent extends React.Component {
 		});
 
 		headerItems.push({
+			title: _('Toggle note list'),
+			iconName: 'fa-bars',
+			iconRotation: this.props.notelistVisibility ? 0 : 90,
+			onClick: () => {
+				this.doCommand({ name: 'toggleNoteList' });
+			},
+		});
+
+		headerItems.push({
 			title: _('New note'),
 			iconName: 'fa-file-o',
 			enabled: !!folders.length && !onConflictFolder,
@@ -577,6 +592,7 @@ const mapStateToProps = state => {
 		windowCommand: state.windowCommand,
 		noteVisiblePanes: state.noteVisiblePanes,
 		sidebarVisibility: state.sidebarVisibility,
+		notelistVisibility: state.notelistVisibility,
 		folders: state.folders,
 		notes: state.notes,
 		hasDisabledSyncItems: state.hasDisabledSyncItems,

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -391,6 +391,7 @@ class MainScreenComponent extends React.Component {
 		if (isNoteListVisible === false) {
 			this.styles_.noteList.width = 0;
 			this.styles_.noteList.display = 'none';
+			this.styles_.verticalResizer.display = 'none';
 		}
 
 		this.styles_.noteText = {

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -389,7 +389,6 @@ class MainScreenComponent extends React.Component {
 		};
 
 		if (isNoteListVisible === false) {
-			this.styles_.noteList.width = 0;
 			this.styles_.noteList.display = 'none';
 			this.styles_.verticalResizer.display = 'none';
 		}

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -250,6 +250,8 @@ class MainScreenComponent extends React.Component {
 			this.toggleVisiblePanes();
 		} else if (command.name === 'toggleSidebar') {
 			this.toggleSidebar();
+		} else if (command.name === 'toggleNoteList') {
+			this.toggleNoteList();
 		} else if (command.name === 'showModalMessage') {
 			this.setState({
 				modalLayer: {
@@ -336,8 +338,8 @@ class MainScreenComponent extends React.Component {
 		}
 	}
 
-	styles(themeId, width, height, messageBoxVisible, isSidebarVisible, sidebarWidth, noteListWidth) {
-		const styleKey = [themeId, width, height, messageBoxVisible, +isSidebarVisible, sidebarWidth, noteListWidth].join('_');
+	styles(themeId, width, height, messageBoxVisible, isSidebarVisible, isNoteListVisible, sidebarWidth, noteListWidth) {
+		const styleKey = [themeId, width, height, messageBoxVisible, +isSidebarVisible, +isNoteListVisible, sidebarWidth, noteListWidth].join('_');
 		if (styleKey === this.styleKey_) return this.styles_;
 
 		const theme = themeStyle(themeId);
@@ -386,6 +388,11 @@ class MainScreenComponent extends React.Component {
 			verticalAlign: 'top',
 		};
 
+		if (isNoteListVisible === false) {
+			this.styles_.noteList.width = 0;
+			this.styles_.noteList.display = 'none';
+		}
+
 		this.styles_.noteText = {
 			width: Math.floor(width - this.styles_.sideBar.width - this.styles_.noteList.width - 10),
 			height: rowHeight,
@@ -426,7 +433,8 @@ class MainScreenComponent extends React.Component {
 		const notes = this.props.notes;
 		const messageBoxVisible = this.props.hasDisabledSyncItems || this.props.showMissingMasterKeyMessage;
 		const sidebarVisibility = this.props.sidebarVisibility;
-		const styles = this.styles(this.props.theme, style.width, style.height, messageBoxVisible, sidebarVisibility, this.props.sidebarWidth, this.props.noteListWidth);
+		const noteListVisibility = this.props.noteListVisibility;
+		const styles = this.styles(this.props.theme, style.width, style.height, messageBoxVisible, sidebarVisibility, noteListVisibility, this.props.sidebarWidth, this.props.noteListWidth);
 		const onConflictFolder = this.props.selectedFolderId === Folder.conflictFolderId();
 
 		const headerItems = [];
@@ -443,7 +451,7 @@ class MainScreenComponent extends React.Component {
 		headerItems.push({
 			title: _('Toggle note list'),
 			iconName: 'fa-bars',
-			iconRotation: this.props.notelistVisibility ? 0 : 90,
+			iconRotation: noteListVisibility ? 0 : 90,
 			onClick: () => {
 				this.doCommand({ name: 'toggleNoteList' });
 			},
@@ -592,7 +600,7 @@ const mapStateToProps = state => {
 		windowCommand: state.windowCommand,
 		noteVisiblePanes: state.noteVisiblePanes,
 		sidebarVisibility: state.sidebarVisibility,
-		notelistVisibility: state.notelistVisibility,
+		noteListVisibility: state.noteListVisibility,
 		folders: state.folders,
 		notes: state.notes,
 		hasDisabledSyncItems: state.hasDisabledSyncItems,

--- a/ElectronClient/app/gui/Root.jsx
+++ b/ElectronClient/app/gui/Root.jsx
@@ -56,7 +56,7 @@ async function initialize() {
 
 	store.dispatch({
 		type: 'NOTELIST_VISIBILITY_SET',
-		visibility: Setting.value('notelistVisibility'),
+		visibility: Setting.value('noteListVisibility'),
 	});
 }
 

--- a/ElectronClient/app/gui/Root.jsx
+++ b/ElectronClient/app/gui/Root.jsx
@@ -53,6 +53,11 @@ async function initialize() {
 		type: 'SIDEBAR_VISIBILITY_SET',
 		visibility: Setting.value('sidebarVisibility'),
 	});
+
+	store.dispatch({
+		type: 'NOTELIST_VISIBILITY_SET',
+		visibility: Setting.value('notelistVisibility'),
+	});
 }
 
 class RootComponent extends React.Component {

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -792,7 +792,7 @@ const mapStateToProps = state => {
 		resourceFetcher: state.resourceFetcher,
 		windowCommand: state.windowCommand,
 		sidebarVisibility: state.sidebarVisibility,
-		notelistVisibility: state.notelistVisibility,
+		noteListVisibility: state.noteListVisibility,
 	};
 };
 

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -792,6 +792,7 @@ const mapStateToProps = state => {
 		resourceFetcher: state.resourceFetcher,
 		windowCommand: state.windowCommand,
 		sidebarVisibility: state.sidebarVisibility,
+		notelistVisibility: state.notelistVisibility,
 	};
 };
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -405,7 +405,7 @@ class Setting extends BaseModel {
 			},
 			noteVisiblePanes: { value: ['editor', 'viewer'], type: Setting.TYPE_ARRAY, public: false, appTypes: ['desktop'] },
 			sidebarVisibility: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
-			notelistVisibility: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
+			noteListVisibility: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			tagHeaderIsExpanded: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			folderHeaderIsExpanded: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			editor: { value: '', type: Setting.TYPE_STRING, subType: 'file_path_and_args', public: true, appTypes: ['cli', 'desktop'], label: () => _('Text editor command'), description: () => _('The editor command (may include arguments) that will be used to open a note. If none is provided it will try to auto-detect the default editor.') },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -405,6 +405,7 @@ class Setting extends BaseModel {
 			},
 			noteVisiblePanes: { value: ['editor', 'viewer'], type: Setting.TYPE_ARRAY, public: false, appTypes: ['desktop'] },
 			sidebarVisibility: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
+			notelistVisibility: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			tagHeaderIsExpanded: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			folderHeaderIsExpanded: { value: true, type: Setting.TYPE_BOOL, public: false, appTypes: ['desktop'] },
 			editor: { value: '', type: Setting.TYPE_STRING, subType: 'file_path_and_args', public: true, appTypes: ['cli', 'desktop'], label: () => _('Text editor command'), description: () => _('The editor command (may include arguments) that will be used to open a note. If none is provided it will try to auto-detect the default editor.') },


### PR DESCRIPTION
Here's my first feature request and pull request!

***
Related forum post: https://discourse.joplinapp.org/t/feature-idea-hide-note-list/3920
Related issue: https://github.com/laurent22/joplin/issues/1988
***

# Basically I added:
- new menu item: toggle note list visibility
- new toolbar button: to toggle note list visibility
- new feature: toggle actual note list visibility

# Here's what I'm unsure about / questions:
- Is a toolbar button really needed?
  - If yes, should we use another icon from the one used for toggle sidebar?
- Should we have a keyboard shortcut for that feature too? (toggle sidebar has one)
- Is there anything locale-wise (translations) I need to do about this new feature?
- **The part in `ReactNativeClient/lib/models/Setting.js` I added the setting in `ReactNativeClient` as well. Is it okay? I'm not sure about that change.**

Otherwise it should work. Please feel free to suggest, comment and point out any way I should improve this PR.

Thanks!