### PR TITLE
Desktop: Fix #1790: Stop print command from resetting theme

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -100,6 +100,7 @@ class NoteTextComponent extends React.Component {
 		this.selectionRange_ = null;
 		this.lastComponentUpdateNoteId_ = null;
 		this.noteSearchBar_ = React.createRef();
+		this.isPrinting_ = false;
 
 		// Complicated but reliable method to get editor content height
 		// https://github.com/ajaxorg/ace/issues/2046
@@ -1195,6 +1196,12 @@ class NoteTextComponent extends React.Component {
 			throw new Error(_('Only one note can be printed or exported to PDF at a time.'));
 		}
 
+		// Concurrent print calls are disallowed to avoid incorrect settings being restored upon completion
+		if (this.isPrinting_) {
+			return;
+		}
+
+		this.isPrinting_ = true;
 		const previousBody = this.state.note.body;
 		const tempBody = `${this.title_(this.state.note.title)}\n\n${previousBody}`;
 
@@ -1226,6 +1233,7 @@ class NoteTextComponent extends React.Component {
 				this.webviewRef_.current.wrappedInstance.print({ printBackground: true });
 				restoreSettings();
 			}
+			this.isPrinting_ = false;
 		}, 100);
 	}
 


### PR DESCRIPTION
Fixes #1790.

This solution uses a simple print flag to reduce the chance of triggering the race condition. It's not as foolproof as an async lock, but I cannot reproduce the bug with the change added, and this check is much faster than a lock would be.