### PR TITLE
Mobile: show alarm in correct date and time format

### DIFF
--- a/ReactNativeClient/lib/components/select-date-time-dialog.js
+++ b/ReactNativeClient/lib/components/select-date-time-dialog.js
@@ -4,6 +4,7 @@ import PopupDialog, { DialogTitle, DialogButton } from 'react-native-popup-dialo
 import DatePicker from 'react-native-datepicker';
 import moment from 'moment';
 import { _ } from 'lib/locale.js';
+const { time } = require('lib/time-utils.js');
 
 class SelectDateTimeDialog extends React.PureComponent {
 
@@ -41,7 +42,7 @@ class SelectDateTimeDialog extends React.PureComponent {
 	}
 
 	dateTimeFormat() {
-		return 'MM/DD/YYYY HH:mm';
+		return time.dateTimeFormat();
 	}
 
 	stringToDate(s) {


### PR DESCRIPTION
see https://discourse.joplinapp.org/t/alarm-does-not-display-the-date-in-the-system-format/4070?u=tessus

It now shows the date and time formats which are chosen in settings:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/223439/67626545-b02ba800-f81a-11e9-9624-f601b42a7b72.png">

