### PR TITLE
Desktop: Fill X primary selection from the editor on text selection

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -238,6 +238,14 @@ class NoteTextComponent extends React.Component {
 				this.selectionRange_ = null;
 			} else {
 				this.selectionRange_ = ranges[0];
+				if (process.platform === 'linux') {
+					const textRange = this.textOffsetSelection();
+					if (textRange.start != textRange.end) {
+						clipboard.writeText(this.state.note.body.slice(
+							Math.min(textRange.start, textRange.end),
+							Math.max(textRange.end, textRange.start)), 'selection');
+					}
+				}
 			}
 		};
 


### PR DESCRIPTION
This fixes the Joplin->"other apps" half of
https://github.com/laurent22/joplin/issues/215.