### PR TITLE
Desktop: Allow changing user agent when syncing

### DIFF
--- a/ReactNativeClient/lib/WebDavApi.js
+++ b/ReactNativeClient/lib/WebDavApi.js
@@ -5,6 +5,7 @@ const JoplinError = require('lib/JoplinError');
 const URL = require('url-parse');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const base64 = require('base-64');
+const Setting = require('lib/models/Setting.js');
 
 // Note that the d: namespace (the DAV namespace) is specific to Nextcloud. The RFC for example uses "D:" however
 // we make all the tags and attributes lowercase so we handle both the Nextcloud style and RFC. Hopefully other
@@ -350,6 +351,9 @@ class WebDavApi {
 		// finds out that no resource has this ID and simply sends the requested data.
 		// Also add a random value to make sure the eTag is unique for each call.
 		if (['GET', 'HEAD'].indexOf(method) < 0) headers['If-None-Match'] = `JoplinIgnore-${Math.floor(Math.random() * 100000)}`;
+
+		// Set user agent to value from settings
+		headers['User-Agent'] = Setting.value('sync.user_agent');
 
 		const fetchOptions = {};
 		fetchOptions.headers = headers;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -52,6 +52,19 @@ class Setting extends BaseModel {
 				},
 			},
 
+			'sync.user_agent': {
+				value: 'Joplin', // Default to using 'Joplin' as the default user agent
+				type: Setting.TYPE_STRING,
+				isEnum: false,
+				public: true,
+				show: true, // Show in the config
+				section: 'sync',
+				label: () => _('Synchronisation user agent'),
+				description: appType => {
+					return appType !== 'cli' ? null : _('The User Agent to use when syncing.');
+				},
+			},
+
 			'sync.2.path': {
 				value: '',
 				type: Setting.TYPE_STRING,


### PR DESCRIPTION
Hi hope you're all well :)

This is a pull request to allow changing the user agent used when syncing in both the CLI and Desktop versions of Joplin. The user agent default value is set to Joplin.

I wanted to add this because of the raised issue https://github.com/laurent22/joplin/issues/2042

Thank you,
Alex