### PR TITLE
Desktop: Prevent horizontal scrolling on Linux when a scrollbar is present in note list

### DIFF
--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -29,12 +29,14 @@ class NoteListComponent extends React.Component {
 		const theme = themeStyle(this.props.theme);
 
 		const itemHeight = 34;
+		const itemWidth = '100%';
 
 		let style = {
 			root: {
 				backgroundColor: theme.backgroundColor,
 			},
 			listItem: {
+				maxwidth: itemWidth,
 				height: itemHeight,
 				boxSizing: 'border-box',
 				display: 'flex',

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -29,6 +29,9 @@ class NoteListComponent extends React.Component {
 		const theme = themeStyle(this.props.theme);
 
 		const itemHeight = 34;
+
+		// Note: max-width is used to specifically prevent horizontal scrolling on Linux when the scrollbar is present in the note list.
+		// Pull request: https://github.com/laurent22/joplin/pull/2062
 		const itemWidth = '100%';
 
 		let style = {
@@ -36,7 +39,7 @@ class NoteListComponent extends React.Component {
 				backgroundColor: theme.backgroundColor,
 			},
 			listItem: {
-				maxwidth: itemWidth,
+				maxWidth: itemWidth,
 				height: itemHeight,
 				boxSizing: 'border-box',
 				display: 'flex',


### PR DESCRIPTION
Bug fix for [#1570](https://github.com/laurent22/joplin/issues/1570).

Before the fix:

![Bug #1570 Before](https://user-images.githubusercontent.com/35600612/68226672-6da75f80-ffc0-11e9-895d-9c383d316726.gif)

After the fix:

![Bug #1570 After](https://user-images.githubusercontent.com/35600612/68226896-d7c00480-ffc0-11e9-81a9-a69ccc44fb47.gif)
