### PR TITLE
Desktop: Optional open dev tools in Developer Mode

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -81,6 +81,11 @@ class ElectronAppWrapper {
 			slashes: true,
 		}));
 
+		// Early parsing of command line option in Developer mode to open DevTools if the application does not start
+		if (this.env_ === 'dev' && process.argv.indexOf('--open-dev-tools') !== -1) {
+			this.win_.webContents.openDevTools();
+		}
+
 		this.win_.on('close', (event) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)
 			// otherwise the window is simply hidden, and will be re-open once the app is "activated" (which happens when the

--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -81,9 +81,6 @@ class ElectronAppWrapper {
 			slashes: true,
 		}));
 
-		// Uncomment this to view errors if the application does not start
-		if (this.env_ === 'dev') this.win_.webContents.openDevTools();
-
 		this.win_.on('close', (event) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)
 			// otherwise the window is simply hidden, and will be re-open once the app is "activated" (which happens when the


### PR DESCRIPTION
When running in Developer mode (--env=dev) the Chrome Dev Tools are always opened during the pre-Renderer Process. The prevents use of any other Node debugging tool. 

This commit makes automatic opening of Dev Tools optional by checking for the --open-dev-tools flag in addition to --env=dev.