### PR TITLE
Desktop: Optional open dev tools in Developer Mode

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -81,8 +81,10 @@ class ElectronAppWrapper {
 			slashes: true,
 		}));
 
-		// Uncomment this to view errors if the application does not start
-		if (this.env_ === 'dev') this.win_.webContents.openDevTools();
+		// Early parsing of command line option in Developer mode to open DevTools if the application does not start
+		if (this.env_ === 'dev' && process.argv.indexOf('--open-dev-tools') !== -1) {
+			this.win_.webContents.openDevTools();
+		}
 
 		this.win_.on('close', (event) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)

--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -81,10 +81,8 @@ class ElectronAppWrapper {
 			slashes: true,
 		}));
 
-		// Early parsing of command line option in Developer mode to open DevTools if the application does not start
-		if (this.env_ === 'dev' && process.argv.indexOf('--open-dev-tools') !== -1) {
-			this.win_.webContents.openDevTools();
-		}
+		// Uncomment this to view errors if the application does not start
+		// if (this.env_ === 'dev') this.win_.webContents.openDevTools();
 
 		this.win_.on('close', (event) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)


### PR DESCRIPTION
A first, very simple commit that may help development of Joplin on differing environments.

When running in Developer mode (--env dev) the Chrome Dev Tools are always opened during preparation of the Renderer Process. The prevents use of other Node debugging tools.

This commit makes automatic opening of Dev Tools optional by checking for the --open-dev-tools flag in addition to --env dev.
