### PR TITLE
Desktop: Allow Electron debugging flag 

### DIFF
--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -170,11 +170,9 @@ class BaseApplication {
 				continue;
 			}
 
-			// Electron-specific flag used for debugging - ignore it
-			if (arg.includes('--remote-debugging-port')) {
-				// If port number passed also ignore it
-				const argsToIgnore = (nextArg && /^\d+$/.test(nextArg)) ? 2 : 1;
-				argv.splice(0, argsToIgnore);
+			if (arg.indexOf('--remote-debugging-port=') === 0) {
+				// Electron-specific flag used for debugging - ignore it. Electron expects this flag in '--x=y' form, a single string.
+				argv.splice(0, 1);
 				continue;
 			}
 

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -175,6 +175,7 @@ class BaseApplication {
 				// If port number passed also ignore it
 				const argsToIgnore = (nextArg && /^\d+$/.test(nextArg)) ? 2 : 1;
 				argv.splice(0, argsToIgnore);
+				continue;
 			}
 
 			if (arg.length && arg[0] == '-') {

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -170,6 +170,13 @@ class BaseApplication {
 				continue;
 			}
 
+			// Electron-specific flag used for debugging - ignore it
+			if (arg.includes('--remote-debugging-port')) {
+				// If port number passed also ignore it
+				const argsToIgnore = (nextArg && /^\d+$/.test(nextArg)) ? 2 : 1;
+				argv.splice(0, argsToIgnore);
+			}
+
 			if (arg.length && arg[0] == '-') {
 				throw new JoplinError(_('Unknown flag: %s', arg), 'flagError');
 			} else {


### PR DESCRIPTION
To allow debuggers other than Chrome DevTools it may be necessary to pass command line arguments directly to Electron. Specifically [--remote-debugging-port](https://electronjs.org/docs/api/chrome-command-line-switches#--remote-debugging-portport). The cli argument parser implementation raises an exception against any unrecognized flag. This patch allows the flag and its argument to be ignored. 