### PR TITLE
Desktop: Allow for custom Joplin theme and Ace editor styles

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -28,6 +28,7 @@ const PluginManager = require('lib/services/PluginManager');
 const RevisionService = require('lib/services/RevisionService');
 const MigrationService = require('lib/services/MigrationService');
 const TemplateUtils = require('lib/TemplateUtils');
+const CssUtils = require('lib/CssUtils');
 
 const pluginClasses = [
 	require('./plugins/GotoAnything.min'),
@@ -1224,8 +1225,8 @@ class Application extends BaseApplication {
 			ids: Setting.value('collapsedFolderIds'),
 		});
 
-		const cssString = await this.loadCustomCss(`${Setting.value('profileDir')}/userstyle.css`);
-
+		// Loads custom Markdown preview styles
+		const cssString = await CssUtils.loadCustomCss(`${Setting.value('profileDir')}/userstyle.css`);
 		this.store().dispatch({
 			type: 'LOAD_CUSTOM_CSS',
 			css: cssString,

--- a/ElectronClient/app/gui/ConfigScreen.jsx
+++ b/ElectronClient/app/gui/ConfigScreen.jsx
@@ -426,7 +426,7 @@ class ConfigScreenComponent extends React.Component {
 						<label>{md.label()}</label>
 					</div>
 					<button style={buttonStyle} onClick={md.onClick}>
-						Edit
+						{_('Edit')}
 					</button>
 					{descriptionComp}
 				</div>

--- a/ElectronClient/app/gui/ConfigScreen.jsx
+++ b/ElectronClient/app/gui/ConfigScreen.jsx
@@ -413,6 +413,24 @@ class ConfigScreenComponent extends React.Component {
 					{descriptionComp}
 				</div>
 			);
+		} else if (md.type === Setting.TYPE_BUTTON) {
+			const theme = themeStyle(this.props.theme);
+			const buttonStyle = Object.assign({}, theme.buttonStyle, {
+				display: 'inline-block',
+				marginRight: 10,
+			});
+
+			return (
+				<div key={key} style={rowStyle}>
+					<div style={labelStyle}>
+						<label>{md.label()}</label>
+					</div>
+					<button style={buttonStyle} onClick={md.onClick}>
+						Edit
+					</button>
+					{descriptionComp}
+				</div>
+			);
 		} else {
 			console.warn(`Type not implemented: ${key}`);
 		}

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Joplin uses and renders a Github-flavoured Markdown with a few variations and ad
 
 Rendered markdown can be customized by placing a userstyle file in the profile directory `~/.config/joplin-desktop/userstyle.css` (This path might be different on your device - check at the top of the Config screen for the exact path). This file supports standard CSS syntax. Joplin ***must*** be restarted for the new css to be applied, please ensure that Joplin is not closing to the tray, but is actually exiting. Note that this file is used for both displaying the notes and printing the notes. Be aware how the CSS may look printed (for example, printing white text over a black background is usually not wanted).
 
+Editor styles can be customized by placing a custom editor style file in the profile directory `~/.config/joplin-desktop/userchrome.css`.
+
 # Note templates
 
 In the **desktop app**, templates can be used to create new notes or to insert into existing ones by creating a `templates` folder in Joplin's config folder and placing Markdown template files into it. For example creating the file `hours.md` in the `templates` directory with the contents:

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -612,7 +612,7 @@ class BaseApplication {
 
 		// Loads app-wide styles. (Markdown preview-specific styles loaded in app.js)
 		const dir = Setting.value('profileDir');
-		const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
+		const filename = Setting.custom_css_files.JOPLIN_APP;
 		await CssUtils.injectCustomStyles(`${dir}/${filename}`);
 
 		if (!Setting.value('clientId')) Setting.setValue('clientId', uuid.create());

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -39,6 +39,7 @@ const BaseService = require('lib/services/BaseService');
 const SearchEngine = require('lib/services/SearchEngine');
 const KvStore = require('lib/services/KvStore');
 const MigrationService = require('lib/services/MigrationService');
+const CssUtils = require('lib/CssUtils');
 
 SyncTargetRegistry.addClass(SyncTargetFilesystem);
 SyncTargetRegistry.addClass(SyncTargetOneDrive);
@@ -608,6 +609,11 @@ class BaseApplication {
 		BaseModel.db_ = this.database_;
 
 		await Setting.load();
+
+		// Loads app-wide styles. (Markdown preview-specific styles loaded in app.js)
+		const dir = Setting.value('profileDir');
+		const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
+		await CssUtils.injectCustomStyles(`${dir}/${filename}`);
 
 		if (!Setting.value('clientId')) Setting.setValue('clientId', uuid.create());
 

--- a/ReactNativeClient/lib/CssUtils.js
+++ b/ReactNativeClient/lib/CssUtils.js
@@ -1,0 +1,27 @@
+const fs = require('fs-extra');
+
+const loadCustomCss = async filePath => {
+	let cssString = '';
+	if (await fs.pathExists(filePath)) {
+		try {
+			cssString = await fs.readFile(filePath, 'utf-8');
+		} catch (error) {
+			let msg = error.message ? error.message : '';
+			msg = `Could not load custom css from ${filePath}\n${msg}`;
+			error.message = msg;
+			throw error;
+		}
+	}
+
+	return cssString;
+};
+
+const injectCustomStyles = async cssFilePath => {
+	const css = await loadCustomCss(cssFilePath);
+	const styleTag = document.createElement('style');
+	styleTag.type = 'text/css';
+	styleTag.appendChild(document.createTextNode(css));
+	document.head.appendChild(styleTag);
+};
+
+module.exports = {loadCustomCss, injectCustomStyles};

--- a/ReactNativeClient/lib/layout-utils.js
+++ b/ReactNativeClient/lib/layout-utils.js
@@ -1,9 +1,0 @@
-const layoutUtils = {};
-
-layoutUtils.size = function(preferred, min, max) {
-	if (preferred < min) return min;
-	if (typeof max !== 'undefined' && preferred > max) return max;
-	return preferred;
-};
-
-module.exports = layoutUtils;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -20,6 +20,7 @@ const { toTitleCase } = require('lib/string-utils.js');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const { _, supportedLocalesToLanguages, defaultLocale } = require('lib/locale.js');
 const { shim } = require('lib/shim');
+const { bridge } = require('electron').remote.require('./bridge');
 
 class Setting extends BaseModel {
 	static tableName() {
@@ -422,6 +423,37 @@ class Setting extends BaseModel {
 					},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
+
+			// TODO: Is there a better way to do this? The goal here is to simply have
+			// a way to display a link to the customizable stylesheets, not for it to
+			// serve as a customizable Setting. But because the Setting page is auto-
+			// generated from this list of settings, there wasn't a really elegant way
+			// to do that directly in the React markup.
+			'style.customCss.renderedMarkdown': {
+				onClick: () => {
+					const dir = Setting.value('profileDir');
+					const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
+					bridge().openExternal(`file://${dir}/${filename}`);
+				},
+				type: Setting.TYPE_BUTTON,
+				public: true,
+				appTypes: ['desktop'],
+				label: () => _('Custom stylesheet for rendered markdown'),
+				section: 'appearance',
+			},
+			'style.customCss.joplinApp': {
+				onClick: () => {
+					const dir = Setting.value('profileDir');
+					const filename = Setting.custom_css_files.JOPLIN_APP;
+					bridge().openExternal(`file://${dir}/${filename}`);
+				},
+				type: Setting.TYPE_BUTTON,
+				public: true,
+				appTypes: ['desktop'],
+				label: () => _('Custom stylesheet for Joplin-wide app styles'),
+				section: 'appearance',
+			},
+
 			autoUpdateEnabled: { value: true, type: Setting.TYPE_BOOL, section: 'application', public: true, appTypes: ['desktop'], label: () => _('Automatically update the application') },
 			'autoUpdate.includePreReleases': { value: false, type: Setting.TYPE_BOOL, section: 'application', public: true, appTypes: ['desktop'], label: () => _('Get pre-releases when checking for updates'), description: () => _('See the pre-release page for more details: %s', 'https://joplinapp.org/prereleases') },
 			'clipperServer.autoStart': { value: false, type: Setting.TYPE_BOOL, public: false },
@@ -978,6 +1010,12 @@ Setting.DATE_FORMAT_6 = 'DD.MM.YYYY';
 
 Setting.TIME_FORMAT_1 = 'HH:mm';
 Setting.TIME_FORMAT_2 = 'h:mm A';
+
+Setting.custom_css_files = {
+	JOPLIN_APP: 'userstyle.css',
+	RENDERED_MARKDOWN: 'userchrome.css',
+};
+
 
 // Contains constants that are set by the application and
 // cannot be modified by the user:

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -1,15 +1,3 @@
-// *********************************************************************
-// **********************************************************************
-// ***                                                               ****
-// ***  Each build regenerates                                       ****
-// ***  ElectronClient/app/lib/models/Setting.js from                ****
-// ***  ReactNativeClient/lib/models/Setting.js, so only edit the    ****
-// ***  latter and not the former, otherwise you'll be confused      ****
-// ***  about why your code keeps disappearing.                      ****
-// ***                                                               ****
-// **********************************************************************
-// *********************************************************************
-
 const BaseModel = require('lib/BaseModel.js');
 const { Database } = require('lib/database.js');
 const SyncTargetRegistry = require('lib/SyncTargetRegistry.js');
@@ -1042,15 +1030,3 @@ Setting.constants_ = {
 Setting.autoSaveEnabled = true;
 
 module.exports = Setting;
-
-// *********************************************************************
-// **********************************************************************
-// ***                                                               ****
-// ***  Each build regenerates                                       ****
-// ***  ElectronClient/app/lib/models/Setting.js from                ****
-// ***  ReactNativeClient/lib/models/Setting.js, so only edit the    ****
-// ***  latter and not the former, otherwise you'll be confused      ****
-// ***  about why your code keeps disappearing.                      ****
-// ***                                                               ****
-// **********************************************************************
-// *********************************************************************

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -20,7 +20,6 @@ const { toTitleCase } = require('lib/string-utils.js');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const { _, supportedLocalesToLanguages, defaultLocale } = require('lib/locale.js');
 const { shim } = require('lib/shim');
-const fs = require('fs');
 
 class Setting extends BaseModel {
 	static tableName() {
@@ -436,7 +435,7 @@ class Setting extends BaseModel {
 					const filepath = `${dir}/${filename}`;
 					const defaultContents = '/* For styling the rendered Markdown */';
 
-					this.openOrCreateFile(filepath, defaultContents);
+					shim.openOrCreateFile(filepath, defaultContents);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,
@@ -447,11 +446,11 @@ class Setting extends BaseModel {
 			'style.customCss.joplinApp': {
 				onClick: () => {
 					const dir = Setting.value('profileDir');
-					const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
+					const filename = Setting.custom_css_files.JOPLIN_APP;
 					const filepath = `${dir}/${filename}`;
-					const defaultContents = '/* For styling the entire Joplin app, except the rendered Markdown */';
+					const defaultContents = `/* For styling the entire Joplin app (except the rendered Markdown, which is defined in \`${Setting.custom_css_files.RENDERED_MARKDOWN}\`) */`;
 
-					this.openOrCreateFile(filepath, defaultContents);
+					shim.openOrCreateFile(filepath, defaultContents);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,
@@ -979,20 +978,6 @@ class Setting extends BaseModel {
 		// Not translated for now because only used on Welcome notes (which are not translated)
 		if (name === 'cli') return 'CLI';
 		return name[0].toUpperCase() + name.substr(1).toLowerCase();
-	}
-
-	static openOrCreateFile(filepath, defaultContents) {
-		// If the file doesn't exist, create it
-		if (!fs.existsSync(filepath)) {
-			fs.writeFile(filepath, defaultContents, 'utf-8', (error) => {
-				if (error) {
-					console.error(`error: ${error}`);
-				}
-			});
-		}
-
-		// Open the file
-		shim.openUrl(`file://${filepath}`);
 	}
 }
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -1012,8 +1012,8 @@ Setting.TIME_FORMAT_1 = 'HH:mm';
 Setting.TIME_FORMAT_2 = 'h:mm A';
 
 Setting.custom_css_files = {
-	JOPLIN_APP: 'userstyle.css',
-	RENDERED_MARKDOWN: 'userchrome.css',
+	JOPLIN_APP: 'userchrome.css',
+	RENDERED_MARKDOWN: 'userstyle.css',
 };
 
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -1,3 +1,15 @@
+// *********************************************************************
+// **********************************************************************
+// ***                                                               ****
+// ***  Each build regenerates                                       ****
+// ***  ElectronClient/app/lib/models/Setting.js from                ****
+// ***  ReactNativeClient/lib/models/Setting.js, so only edit the    ****
+// ***  latter and not the former, otherwise you'll be confused      ****
+// ***  about why your code keeps disappearing.                      ****
+// ***                                                               ****
+// **********************************************************************
+// *********************************************************************
+
 const BaseModel = require('lib/BaseModel.js');
 const { Database } = require('lib/database.js');
 const SyncTargetRegistry = require('lib/SyncTargetRegistry.js');
@@ -986,3 +998,15 @@ Setting.constants_ = {
 Setting.autoSaveEnabled = true;
 
 module.exports = Setting;
+
+// *********************************************************************
+// **********************************************************************
+// ***                                                               ****
+// ***  Each build regenerates                                       ****
+// ***  ElectronClient/app/lib/models/Setting.js from                ****
+// ***  ReactNativeClient/lib/models/Setting.js, so only edit the    ****
+// ***  latter and not the former, otherwise you'll be confused      ****
+// ***  about why your code keeps disappearing.                      ****
+// ***                                                               ****
+// **********************************************************************
+// *********************************************************************

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -20,7 +20,6 @@ const { toTitleCase } = require('lib/string-utils.js');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const { _, supportedLocalesToLanguages, defaultLocale } = require('lib/locale.js');
 const { shim } = require('lib/shim');
-const { bridge } = require('electron').remote.require('./bridge');
 
 class Setting extends BaseModel {
 	static tableName() {
@@ -433,19 +432,19 @@ class Setting extends BaseModel {
 				onClick: () => {
 					const dir = Setting.value('profileDir');
 					const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
-					bridge().openExternal(`file://${dir}/${filename}`);
+					shim.openUrl(`file://${dir}/${filename}`);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,
 				appTypes: ['desktop'],
-				label: () => _('Custom stylesheet for rendered markdown'),
+				label: () => _('Custom stylesheet for rendered Markdown'),
 				section: 'appearance',
 			},
 			'style.customCss.joplinApp': {
 				onClick: () => {
 					const dir = Setting.value('profileDir');
 					const filename = Setting.custom_css_files.JOPLIN_APP;
-					bridge().openExternal(`file://${dir}/${filename}`);
+					shim.openUrl(`file://${dir}/${filename}`);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -20,6 +20,7 @@ const { toTitleCase } = require('lib/string-utils.js');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const { _, supportedLocalesToLanguages, defaultLocale } = require('lib/locale.js');
 const { shim } = require('lib/shim');
+const fs = require('fs');
 
 class Setting extends BaseModel {
 	static tableName() {
@@ -432,7 +433,10 @@ class Setting extends BaseModel {
 				onClick: () => {
 					const dir = Setting.value('profileDir');
 					const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
-					shim.openUrl(`file://${dir}/${filename}`);
+					const filepath = `${dir}/${filename}`;
+					const defaultContents = '/* For styling the rendered Markdown */';
+
+					this.openOrCreateFile(filepath, defaultContents);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,
@@ -443,8 +447,11 @@ class Setting extends BaseModel {
 			'style.customCss.joplinApp': {
 				onClick: () => {
 					const dir = Setting.value('profileDir');
-					const filename = Setting.custom_css_files.JOPLIN_APP;
-					shim.openUrl(`file://${dir}/${filename}`);
+					const filename = Setting.custom_css_files.RENDERED_MARKDOWN;
+					const filepath = `${dir}/${filename}`;
+					const defaultContents = '/* For styling the entire Joplin app, except the rendered Markdown */';
+
+					this.openOrCreateFile(filepath, defaultContents);
 				},
 				type: Setting.TYPE_BUTTON,
 				public: true,
@@ -972,6 +979,20 @@ class Setting extends BaseModel {
 		// Not translated for now because only used on Welcome notes (which are not translated)
 		if (name === 'cli') return 'CLI';
 		return name[0].toUpperCase() + name.substr(1).toLowerCase();
+	}
+
+	static openOrCreateFile(filepath, defaultContents) {
+		// If the file doesn't exist, create it
+		if (!fs.existsSync(filepath)) {
+			fs.writeFile(filepath, defaultContents, 'utf-8', (error) => {
+				if (error) {
+					console.error(`error: ${error}`);
+				}
+			});
+		}
+
+		// Open the file
+		shim.openUrl(`file://${filepath}`);
 	}
 }
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -949,6 +949,7 @@ Setting.TYPE_STRING = 2;
 Setting.TYPE_BOOL = 3;
 Setting.TYPE_ARRAY = 4;
 Setting.TYPE_OBJECT = 5;
+Setting.TYPE_BUTTON = 6;
 
 Setting.THEME_LIGHT = 1;
 Setting.THEME_DARK = 2;

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -363,6 +363,20 @@ function shimInit() {
 		return bridge().openExternal(url);
 	};
 
+	shim.openOrCreateFile = (filepath, defaultContents) => {
+		// If the file doesn't exist, create it
+		if (!fs.existsSync(filepath)) {
+			fs.writeFile(filepath, defaultContents, 'utf-8', (error) => {
+				if (error) {
+					console.error(`error: ${error}`);
+				}
+			});
+		}
+
+		// Open the file
+		return shim.openUrl(`file://${filepath}`);
+	};
+
 	shim.waitForFrame = () => {};
 }
 

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -358,7 +358,9 @@ function shimInit() {
 
 	shim.openUrl = url => {
 		const { bridge } = require('electron').remote.require('./bridge');
-		bridge().openExternal(url);
+		// Returns true if it opens the file successfully; returns false if it could
+		// not find the file.
+		return bridge().openExternal(url);
 	};
 
 	shim.waitForFrame = () => {};

--- a/ReactNativeClient/lib/shim.js
+++ b/ReactNativeClient/lib/shim.js
@@ -190,6 +190,9 @@ shim.Buffer = null;
 shim.openUrl = () => {
 	throw new Error('Not implemented');
 };
+shim.openOrCreateFile = () => {
+	throw new Error('Not implemented');
+};
 shim.waitForFrame = () => {
 	throw new Error('Not implemented');
 };


### PR DESCRIPTION
_Discussed in https://discourse.joplinapp.org/t/custom-stylessheets/384/12?u=devonzuegel_

This allows users to define custom Ace editor styles in `editor.css`, similar to how they can define custom styles for the rendered Markdown pane in `userstyle.css`.

For example, I've added this to my `~/.config/joplindev-desktop/editor.css`:

![image](https://user-images.githubusercontent.com/6979755/69004281-ab13c300-08c5-11ea-86db-ef8ec5fc15b7.png)

... which in this case italicizes and bolds the `emphasis` tokens in the Ace editor and puts an ugly orange background in place of the default blue sidebar color:

![image](https://user-images.githubusercontent.com/6979755/69004398-6db03500-08c7-11ea-895a-48094ed185b8.png)

I'd be curious to get @laurent22's perspective though before I go further with this. Three things I'd want to improve if you are interested in this general concept before this is a real PR ready for review:
1. [FIXED] ~The naming I went with is not very elegant alongside the `userstyle.css` file. If I were starting from scratch I'd make them something like `joplin-theme.css` and `rendered-markdown.css` to make it more clear to users which is which. It might be too late to do that though since `userstyle.css` has been in use for a while, and there may be an even better option.~
2. ~It would be ideal if users could update both css files from inside the Preferences tabs, rather than having to dig around `~/.config/joplin-desktop/`. Ideally this would be direct editing from inside there for minimum navigation required, but an incremental step towards this would be to add a link from in there that when clicked opens up your default text editor to that file + a quick description of what adding to each file does.~
 
   Done! Here's how it looks: 
   <img width="50%" src="https://user-images.githubusercontent.com/6979755/69761351-fb87ed80-111b-11ea-830f-344f3c2ea11c.png" />

3. [FIXED] ~Right now, [`await this.loadCustomAceStyles`](https://github.com/laurent22/joplin/pull/2099/files#diff-00b0e649e4e574cdf55197c857ccadefR236) is called on every ACTION, rather than handled properly by the reducer. This means the styles are reloaded on every action, which is not good. I'll fix this of course.~