### PR TITLE
Desktop: Add highlight_mark token to Ace editor rules

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1143,7 +1143,7 @@ class Application extends BaseApplication {
 		// The '*' and '!important' parts are necessary to make sure Russian text is displayed properly
 		// https://github.com/laurent22/joplin/issues/155
 
-		const css = `.ace_editor * { font-family: ${fontFamilies.join(', ')} !important; }  .ace_highlight_mark {background: cyan}`;
+		const css = `.ace_editor * { font-family: ${fontFamilies.join(', ')} !important; }`;
 		const styleTag = document.createElement('style');
 		styleTag.type = 'text/css';
 		styleTag.appendChild(document.createTextNode(css));

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1143,7 +1143,7 @@ class Application extends BaseApplication {
 		// The '*' and '!important' parts are necessary to make sure Russian text is displayed properly
 		// https://github.com/laurent22/joplin/issues/155
 
-		const css = `.ace_editor * { font-family: ${fontFamilies.join(', ')} !important; }`;
+		const css = `.ace_editor * { font-family: ${fontFamilies.join(', ')} !important; }  .ace_highlight_mark {background: cyan}`;
 		const styleTag = document.createElement('style');
 		styleTag.type = 'text/css';
 		styleTag.appendChild(document.createTextNode(css));

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -60,10 +60,13 @@ class CustomHighlightRules extends ace.acequire(
 	constructor() {
 		super();
 		this.$rules.start.push({
-			// This is actually a highlight `mark`, but Ace has no token name for this
-			// https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#common-tokens
+			/**
+			 * This is actually a highlight `mark`, but Ace has no token name for this
+			 * so we made up our own. Reference for common tokens here:
+			 * https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#common-tokens
+			 */
 			token: 'highlight_mark',
-			regex: '==.*?==',
+			regex: '==[^ ](?:.*?[^ ])?==',
 		});
 	}
 }

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -53,6 +53,29 @@ require('brace/theme/chaos');
 require('brace/keybinding/vim');
 require('brace/keybinding/emacs');
 
+/* eslint-disable-next-line no-undef */
+class CustomHighlightRules extends ace.acequire(
+	'ace/mode/markdown_highlight_rules'
+).MarkdownHighlightRules {
+	constructor() {
+		super();
+		this.$rules.start.push({
+			// This is actually a highlight `mark`, but Ace has no token name for this
+			// https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#common-tokens
+			token: 'highlight_mark',
+			regex: '==.*?==',
+		});
+	}
+}
+
+/* eslint-disable-next-line no-undef */
+class CustomMdMode extends ace.acequire('ace/mode/markdown').Mode {
+	constructor() {
+		super();
+		this.HighlightRules = CustomHighlightRules;
+	}
+}
+
 const NOTE_TAG_BAR_FEATURE_ENABLED = false;
 
 class NoteTextComponent extends React.Component {
@@ -443,6 +466,7 @@ class NoteTextComponent extends React.Component {
 
 		const currentNoteId = this.state.note ? this.state.note.id : null;
 		if (this.lastComponentUpdateNoteId_ !== currentNoteId && this.editor_) {
+			this.editor_.editor.getSession().setMode(new CustomMdMode());
 			const undoManager = this.editor_.editor.getSession().getUndoManager();
 			undoManager.reset();
 			this.editor_.editor.getSession().setUndoManager(undoManager);
@@ -1937,7 +1961,7 @@ class NoteTextComponent extends React.Component {
 			fontSize: `${theme.editorFontSize}px`,
 			color: theme.color,
 			backgroundColor: theme.backgroundColor,
-			editorTheme: theme.editorTheme,
+			editorTheme: theme.editorTheme, // Defined in theme.js
 		};
 
 		if (visiblePanes.indexOf('viewer') < 0) {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -59,15 +59,15 @@ class CustomHighlightRules extends ace.acequire(
 ).MarkdownHighlightRules {
 	constructor() {
 		super();
-		this.$rules.start.push({
-			/**
-			 * This is actually a highlight `mark`, but Ace has no token name for this
-			 * so we made up our own. Reference for common tokens here:
-			 * https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#common-tokens
-			 */
-			token: 'highlight_mark',
-			regex: '==[^ ](?:.*?[^ ])?==',
-		});
+		if (Setting.value('markdown.plugin.mark')) {
+			this.$rules.start.push({
+				// This is actually a highlight `mark`, but Ace has no token name for
+				// this so we made up our own. Reference for common tokens here:
+				// https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode#common-tokens
+				token: 'highlight_mark',
+				regex: '==[^ ](?:.*?[^ ])?==',
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
> NOTE: This is just a proposal. Apologies, I should've opened a thread in the forum but got a little carried away playing around with a solution here, so no pressure at all to take this one as-is. I've opened a thread now in case that's where you prefer to have the discussion: https://discourse.joplinapp.org/t/interested-in-supporting-custom-ace-tokens/4315

This PR adds support for the `highlight_mark` token specifically, and generally paves the way for additional custom tokens if we'd like to add more in the future. 

Here's the resulting html that's created when using the `==mark==` syntax:

![image](https://user-images.githubusercontent.com/6979755/69004647-bb2ea100-08cb-11ea-8992-ccc89f2c1d31.png)

This would play nicely with the proposed https://github.com/laurent22/joplin/pull/2099, which would allow for adding a custom style to associate with the custom token, for example: 

![image](https://user-images.githubusercontent.com/6979755/69004740-1745f500-08cd-11ea-8f86-501980a15a81.png)
