### PR TITLE
Tests: markupLanguageUtils

### DIFF
--- a/CliClient/tests/markupLanguageUtils.js
+++ b/CliClient/tests/markupLanguageUtils.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-unused-vars */
+
+require('app-module-path').addPath(__dirname);
+
+const {asyncTest} = require('test-utils.js');
+const markupLanguageUtils = require('lib/markupLanguageUtils.js');
+const Note = require('lib/models/Note');
+const markdownUtils = require('lib/markdownUtils');
+const htmlUtils = require('lib/htmlUtils');
+
+process.on('unhandledRejection', (reason, p) => {
+	console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+});
+
+describe('markupLanguageUtils', function() {
+
+	beforeEach(async (done) => {
+		done();
+	});
+
+	it('should recognise supported markup languages', function() {
+		expect(markupLanguageUtils.lib_(Note.MARKUP_LANGUAGE_MARKDOWN)).toBe(markdownUtils);
+		expect(markupLanguageUtils.lib_(Note.MARKUP_LANGUAGE_HTML)).toBe(htmlUtils);
+	});
+
+	it('should call correct handler for markup language', function() {
+
+		const imageMd = '![something](http://test.com/img.png)';
+		// eslint-disable-next-line no-undef
+		spyOn(markdownUtils, 'extractImageUrls');
+		markupLanguageUtils.extractImageUrls(Note.MARKUP_LANGUAGE_MARKDOWN, imageMd);
+		expect(markdownUtils.extractImageUrls).toHaveBeenCalled();
+
+		const imageHtml = '<img src="http://test.com/img.png"/>';
+		// eslint-disable-next-line no-undef
+		spyOn(htmlUtils, 'extractImageUrls');
+		markupLanguageUtils.extractImageUrls(Note.MARKUP_LANGUAGE_HTML, imageHtml);
+		expect(markdownUtils.extractImageUrls).toHaveBeenCalled();
+	});
+});

--- a/CliClient/tests/markupLanguageUtils.js
+++ b/CliClient/tests/markupLanguageUtils.js
@@ -1,16 +1,10 @@
-/* eslint-disable no-unused-vars */
-
+// testing ReactNativeClient/lib/markupLanguageUtils.js
 require('app-module-path').addPath(__dirname);
 
-const {asyncTest} = require('test-utils.js');
 const markupLanguageUtils = require('lib/markupLanguageUtils.js');
 const Note = require('lib/models/Note');
 const markdownUtils = require('lib/markdownUtils');
 const htmlUtils = require('lib/htmlUtils');
-
-process.on('unhandledRejection', (reason, p) => {
-	console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
-});
 
 describe('markupLanguageUtils', function() {
 
@@ -24,7 +18,6 @@ describe('markupLanguageUtils', function() {
 	});
 
 	it('should call correct handler for markup language', function() {
-
 		const imageMd = '![something](http://test.com/img.png)';
 		// eslint-disable-next-line no-undef
 		spyOn(markdownUtils, 'extractImageUrls');


### PR DESCRIPTION
Adding some test cover for lib/markupLanguageUtils.js. I expect to add functionality to markupLanguageUtils at some point so have put cover in place over the existing class.

The linter complained about spyOn as undefined and as I found no other uses of spyOn to refer to, with the tests passing correctly, eslint-disable-next-line no-undef is used to silence the warning.