### PR TITLE
Desktop: better icon size for about window

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -617,7 +617,7 @@ class Application extends BaseApplication {
 				console.info(gitInfo);
 			}
 			bridge().showInfoMessageBox(message.join('\n'), {
-				icon: `${bridge().electronApp().buildDir()}/icons/32x32.png`,
+				icon: `${bridge().electronApp().buildDir()}/icons/128x128.png`,
 			});
 		}
 


### PR DESCRIPTION
see  https://discourse.joplinapp.org/t/icon-size-for-electron-about-window/4550?u=tessus

Icon in About window is blurry. This change fixes this.