### PR TITLE
Desktop: Added zoom controls to the application menu

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -118,7 +118,6 @@ class Application extends BaseApplication {
 					const zoomFactor = Math.max(MIN, Math.min(MAX, action.zoomFactor));
 					newState = Object.assign({}, state);
 					newState.windowContentZoomFactor = zoomFactor;
-					webFrame.setZoomFactor(zoomFactor);
 				}
 				break;
 
@@ -292,6 +291,10 @@ class Application extends BaseApplication {
 		if (action.type === 'NOTE_DEVTOOLS_TOGGLE') {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 			menuItem.checked = newState.noteDevToolsVisible;
+		}
+
+		if (action.type === 'WINDOW_CONTENT_ZOOM_FACTOR_SET') {
+			webFrame.setZoomFactor(newState.windowContentZoomFactor);
 		}
 
 		return result;

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -115,7 +115,8 @@ class Application extends BaseApplication {
 				{
 					const MIN = 0.3;
 					const MAX = 3;
-					const zoomFactor = Math.max(MIN, Math.min(MAX, action.zoomFactor));
+					const zoomFactor = Math.round(Math.max(MIN, Math.min(MAX, action.zoomFactor)) * 100) / 100;
+
 					newState = Object.assign({}, state);
 					newState.windowContentZoomFactor = zoomFactor;
 				}
@@ -261,6 +262,17 @@ class Application extends BaseApplication {
 			this.updateEditorFont();
 		}
 
+		if (action.type == 'SETTING_UPDATE_ONE' && action.key == 'windowContentZoomFactor' || action.type == 'SETTING_UPDATE_ALL') {
+			const zoomFactor = (action.value || action.settings.windowContentZoomFactor) / 100;
+
+			if (zoomFactor !== store.getState().windowContentZoomFactor) {
+				this.store().dispatch({
+					type: 'WINDOW_CONTENT_ZOOM_FACTOR_SET',
+					zoomFactor: zoomFactor,
+				});
+			}
+		}
+
 		if (['EVENT_NOTE_ALARM_FIELD_CHANGE', 'NOTE_DELETE'].indexOf(action.type) >= 0) {
 			await AlarmService.updateNoteNotification(action.id, action.type === 'NOTE_DELETE');
 		}
@@ -295,6 +307,7 @@ class Application extends BaseApplication {
 
 		if (action.type === 'WINDOW_CONTENT_ZOOM_FACTOR_SET') {
 			webFrame.setZoomFactor(newState.windowContentZoomFactor);
+			Setting.setValue('windowContentZoomFactor', newState.windowContentZoomFactor * 100);
 		}
 
 		return result;

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1001,18 +1001,20 @@ class Application extends BaseApplication {
 				}, {
 					label: _('Zoom In'),
 					click: () => {
+						const currentZoomFactor = this.store().getState().windowContentZoomFactor;
 						this.store().dispatch({
 							type: 'WINDOW_CONTENT_ZOOM_FACTOR_SET',
-							zoomFactor: webFrame.getZoomFactor() + 0.1,
+							zoomFactor: currentZoomFactor + 0.1,
 						});
 					},
 					accelerator: 'CommandOrControl+=',
 				}, {
 					label: _('Zoom Out'),
 					click: () => {
+						const currentZoomFactor = this.store().getState().windowContentZoomFactor;
 						this.store().dispatch({
 							type: 'WINDOW_CONTENT_ZOOM_FACTOR_SET',
-							zoomFactor: webFrame.getZoomFactor() - 0.1,
+							zoomFactor: currentZoomFactor - 0.1,
 						});
 					},
 					accelerator: 'CommandOrControl+-',

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -75,6 +75,17 @@ class HeaderComponent extends React.Component {
 		if (nextProps.windowCommand) {
 			this.doCommand(nextProps.windowCommand);
 		}
+
+		if (nextProps.zoomFactor !== this.props.zoomFactor || nextProps.size !== this.props.size) {
+			const mediaQuery = window.matchMedia(`(max-width: ${550 * nextProps.zoomFactor}px)`);
+			const showButtonLabels = !mediaQuery.matches;
+
+			if (this.state.showButtonLabels !== showButtonLabels) {
+				this.setState({
+					showButtonLabels: !mediaQuery.matches,
+				});
+			}
+		}
 	}
 
 	componentDidUpdate(prevProps) {
@@ -150,7 +161,9 @@ class HeaderComponent extends React.Component {
 				}}
 			>
 				{icon}
-				<span className="title">{title}</span>
+				<span className="title" style={{
+					display: this.state.showButtonLabels ? 'inline-block' : 'none',
+				}}>{title}</span>
 			</a>
 		);
 	}
@@ -167,7 +180,7 @@ class HeaderComponent extends React.Component {
 			paddingTop: 1, // vertical alignment with buttons
 			paddingBottom: 0, // vertical alignment with buttons
 			height: style.fontSize * 2,
-			width: 300,
+			maxWidth: 300,
 			color: style.color,
 			fontSize: style.fontSize,
 			fontFamily: style.fontFamily,
@@ -193,6 +206,7 @@ class HeaderComponent extends React.Component {
 		const containerStyle = {
 			display: 'flex',
 			flexDirection: 'row',
+			flexGrow: 1,
 			alignItems: 'center',
 		};
 
@@ -274,6 +288,8 @@ const mapStateToProps = state => {
 		theme: state.settings.theme,
 		windowCommand: state.windowCommand,
 		notesParentType: state.notesParentType,
+		size: state.windowContentSize,
+		zoomFactor: state.windowContentZoomFactor,
 	};
 };
 

--- a/ElectronClient/app/gui/Header.jsx
+++ b/ElectronClient/app/gui/Header.jsx
@@ -75,9 +75,15 @@ class HeaderComponent extends React.Component {
 		if (nextProps.windowCommand) {
 			this.doCommand(nextProps.windowCommand);
 		}
+	}
 
-		if (nextProps.zoomFactor !== this.props.zoomFactor || nextProps.size !== this.props.size) {
-			const mediaQuery = window.matchMedia(`(max-width: ${550 * nextProps.zoomFactor}px)`);
+	componentDidUpdate(prevProps) {
+		if (prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
+			this.resetSearch();
+		}
+
+		if (this.props.zoomFactor !== prevProps.zoomFactor || this.props.size !== prevProps.size) {
+			const mediaQuery = window.matchMedia(`(max-width: ${550 * this.props.zoomFactor}px)`);
 			const showButtonLabels = !mediaQuery.matches;
 
 			if (this.state.showButtonLabels !== showButtonLabels) {
@@ -85,12 +91,6 @@ class HeaderComponent extends React.Component {
 					showButtonLabels: !mediaQuery.matches,
 				});
 			}
-		}
-	}
-
-	componentDidUpdate(prevProps) {
-		if (prevProps.notesParentType !== this.props.notesParentType && this.props.notesParentType !== 'Search' && this.state.searchQuery) {
-			this.resetSearch();
 		}
 	}
 

--- a/ElectronClient/app/gui/Root.jsx
+++ b/ElectronClient/app/gui/Root.jsx
@@ -81,8 +81,8 @@ class RootComponent extends React.Component {
 
 	render() {
 		const navigatorStyle = {
-			width: this.props.size.width,
-			height: this.props.size.height,
+			width: this.props.size.width / this.props.zoomFactor,
+			height: this.props.size.height / this.props.zoomFactor,
 		};
 
 		const screens = {
@@ -101,6 +101,7 @@ class RootComponent extends React.Component {
 const mapStateToProps = state => {
 	return {
 		size: state.windowContentSize,
+		zoomFactor: state.windowContentZoomFactor,
 		appState: state.appState,
 	};
 };

--- a/ElectronClient/app/style.css
+++ b/ElectronClient/app/style.css
@@ -139,12 +139,6 @@ a {
 	opacity: 0.6;
 }
 
-@media screen and (max-width:550px){    
-	.header .title {
-		display: none;
-	}
-}
-
 .config-menu-bar button:focus {
 	outline: 0 none;
 }

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -513,6 +513,16 @@ class Setting extends BaseModel {
 
 			'camera.type': { value: 0, type: Setting.TYPE_INT, public: false, appTypes: ['mobile'] },
 			'camera.ratio': { value: '4:3', type: Setting.TYPE_STRING, public: false, appTypes: ['mobile'] },
+
+			windowContentZoomFactor: {
+				value: 100,
+				type: Setting.TYPE_INT,
+				public: false,
+				appTypes: ['desktop'],
+				minimum: 30,
+				maximum: 300,
+				step: 10,
+			},
 		};
 
 		return this.metadata_;


### PR DESCRIPTION
This adds "Actual Size", "Zoom In", and "Zoom Out" options to the View menu, along with keyboard shortcuts:

<img width="258" alt="Screen Shot 2019-12-08 at 11 20 57 AM" src="https://user-images.githubusercontent.com/1136332/70392321-cf4f5500-19d6-11ea-83f9-29b636c76692.png">

This behaves the same as how browsers usually handle zooming, by scaling the entire page.

Resolves #2162 