### PR TITLE
CLI: Add --export, --import, and --import-file flags to joplin config

### DIFF
--- a/CliClient/app/command-config.js
+++ b/CliClient/app/command-config.js
@@ -1,6 +1,7 @@
 const { BaseCommand } = require('./base-command.js');
 const { _, setLocale } = require('lib/locale.js');
 const { app } = require('./app.js');
+const fs = require('fs-extra');
 const Setting = require('lib/models/Setting.js');
 
 class Command extends BaseCommand {
@@ -13,18 +14,48 @@ class Command extends BaseCommand {
 	}
 
 	options() {
-		return [['-v, --verbose', _('Also displays unset and hidden config variables.')]];
+		return [['-v, --verbose', _('Also displays unset and hidden config variables.')],
+			['--export', _('Writes the variables to STDOUT in plain text including secure variables.')],
+			['--import', _('Reads the variables from STDIN in plain text in the format [name]=[value] and sets them as if you had individually called config [name] [value].')],
+			['--import-file <file>', _('Reads the variables from <file> in plain text in the format [name]=[value] and sets them as if you had individually called config [name] [value].')]];
 	}
+	async __importSettings(fileStream) {
+		return new Promise((resolve) => {
+			const readline = require('readline');
 
+			const rl = readline.createInterface({
+				input: fileStream,
+			});
+
+			rl.on('line', (line) => {
+				line = line ? line.trim() : '';
+				if (!line) {
+					return;
+				}
+				const [name, value] = line.split('=');
+				Setting.setValue(name, value);
+			})
+				.on('close', () => {
+					resolve();
+				});
+		});
+	}
 	async action(args) {
 		const verbose = args.options.verbose;
+		const isExport = args.options.export;
+		const isImport = args.options.import || args.options.importFile;
+		const importFile = args.options.importFile;
 
 		const renderKeyValue = name => {
 			const md = Setting.settingMetadata(name);
 			let value = Setting.value(name);
 			if (typeof value === 'object' || Array.isArray(value)) value = JSON.stringify(value);
-			if (md.secure && value) value = '********';
+			if (md.secure && value && !isExport) value = '********';
 
+			if (isExport) {
+				// No spaces as this will cause problems
+				return _('%s=%s', name, value);
+			}
 			if (Setting.isEnum(name)) {
 				return _('%s = %s (%s)', name, value, Setting.enumOptionsDoc(name));
 			} else {
@@ -32,7 +63,7 @@ class Command extends BaseCommand {
 			}
 		};
 
-		if (!args.name && !args.value) {
+		if (!isImport && !args.name && !args.value) {
 			let keys = Setting.keys(!verbose, 'cli');
 			keys.sort();
 			for (let i = 0; i < keys.length; i++) {
@@ -49,7 +80,7 @@ class Command extends BaseCommand {
 			return;
 		}
 
-		if (args.name && !args.value) {
+		if (!isImport && args.name && !args.value) {
 			this.stdout(renderKeyValue(args.name));
 			app()
 				.gui()
@@ -60,7 +91,16 @@ class Command extends BaseCommand {
 			return;
 		}
 
-		Setting.setValue(args.name, args.value);
+		if (isImport) {
+			let fileStream = process.stdin;
+			if (importFile) {
+				fileStream = fs.createReadStream(importFile, {autoClose: true});
+			}
+			await this.__importSettings(fileStream);
+		} else {
+			Setting.setValue(args.name, args.value);
+		}
+
 
 		if (args.name == 'locale') {
 			setLocale(Setting.value('locale'));

--- a/CliClient/app/command-config.js
+++ b/CliClient/app/command-config.js
@@ -71,7 +71,7 @@ class Command extends BaseCommand {
 			const md = Setting.settingMetadata(name);
 			let value = Setting.value(name);
 			if (typeof value === 'object' || Array.isArray(value)) value = JSON.stringify(value);
-			if (md.secure && value && !isExport) value = '********';
+			if (md.secure && value) value = '********';
 
 			if (Setting.isEnum(name)) {
 				return _('%s = %s (%s)', name, value, Setting.enumOptionsDoc(name));


### PR DESCRIPTION
Added three options to the `joplin config` command. These options are intended to be used with the command only , not with the CLI GUI.

- `joplin config --export [-v]`: This is the normal `joplin config` command, except modified to:
    1. Write to stdout without any of the beautification done for the CLI Client `<name>=<value`
    2. Write out secrets in plaintext
- `joplin config --import`: This reads settings from STDIN line by line in the format `<name>=<value>`
- `joplin config --import-file <file-path>`: Same as `joplin config --import`, but from a file.

This even seems to work with encryption, though that's more of a pleasant side effect.

Use cases:
- Bootstrapping a new machine. You could run these commands to create/update the profile before starting the Desktop app or CLI app.
- Could also be used to bootstrap a completely headless setup (definitely works for unencrypted, encrypted might have some bugs).
- Create docker/Kubernetes/whatever secrets which can be used to reconfigure a joplin instance running as a service if it has to be restarted.

Forum threads:
- https://discourse.joplinapp.org/t/conf-file-to-store-backup-configurations/879
- https://discourse.joplinapp.org/t/webclipper-port-with-joplin-terminal/3440/7 