### PR TITLE
Desktop: Add external editor actions to the note context menu.

### DIFF
--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -19,7 +19,6 @@ const { bridge } = require('electron').remote.require('./bridge');
 const eventManager = require('../eventManager');
 const VerticalResizer = require('./VerticalResizer.min');
 const PluginManager = require('lib/services/PluginManager');
-const ExternalEditWatcher = require('lib/services/ExternalEditWatcher');
 
 class MainScreenComponent extends React.Component {
 	constructor() {
@@ -175,17 +174,6 @@ class MainScreenComponent extends React.Component {
 					},
 				},
 			});
-
-		} else if (command.name === 'commandStartExternalEditing') {
-			try {
-				const note = await Note.load(command.noteId);
-				await ExternalEditWatcher.instance().openAndWatch(note);
-			} catch (error) {
-				bridge().showErrorMessageBox(_('Error opening note in editor: %s', error.message));
-			}
-		} else if (command.name === 'commandStopExternalEditing') {
-			ExternalEditWatcher.instance().stopWatching(command.noteId);
-
 		} else if (command.name === 'renameFolder') {
 			const folder = await Folder.load(command.id);
 

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -19,6 +19,7 @@ const { bridge } = require('electron').remote.require('./bridge');
 const eventManager = require('../eventManager');
 const VerticalResizer = require('./VerticalResizer.min');
 const PluginManager = require('lib/services/PluginManager');
+const ExternalEditWatcher = require('lib/services/ExternalEditWatcher');
 
 class MainScreenComponent extends React.Component {
 	constructor() {
@@ -174,6 +175,17 @@ class MainScreenComponent extends React.Component {
 					},
 				},
 			});
+
+		} else if (command.name === 'commandStartExternalEditing') {
+			try {
+				const note = await Note.load(command.noteId);
+				await ExternalEditWatcher.instance().openAndWatch(note);
+			} catch (error) {
+				bridge().showErrorMessageBox(_('Error opening note in editor: %s', error.message));
+			}
+		} else if (command.name === 'commandStopExternalEditing') {
+			ExternalEditWatcher.instance().stopWatching(command.noteId);
+
 		} else if (command.name === 'renameFolder') {
 			const folder = await Folder.load(command.id);
 

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -87,6 +87,7 @@ class NoteListComponent extends React.Component {
 		const menu = NoteListUtils.makeContextMenu(noteIds, {
 			notes: this.props.notes,
 			dispatch: this.props.dispatch,
+			watchedNoteFiles: this.props.watchedNoteFiles,
 		});
 
 		menu.popup(bridge().window());
@@ -113,6 +114,15 @@ class NoteListComponent extends React.Component {
 				this.props.dispatch({
 					type: 'NOTE_SELECT',
 					id: item.id,
+				});
+			}
+		};
+
+		const onTitleDoubleClick = async (event, item) => {
+			if (this.props.watchedNoteFiles.indexOf(item.id) < 0) {
+				this.props.dispatch({
+					type: 'WINDOW_COMMAND',
+					name: 'commandStartExternalEditing',
 				});
 			}
 		};
@@ -238,6 +248,9 @@ class NoteListComponent extends React.Component {
 					style={listItemTitleStyle}
 					onClick={event => {
 						onTitleClick(event, item);
+					}}
+					onDoubleClick={event => {
+						onTitleDoubleClick(event, item);
 					}}
 					onDragStart={event => onDragStart(event)}
 					data-id={item.id}

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -118,15 +118,6 @@ class NoteListComponent extends React.Component {
 			}
 		};
 
-		const onTitleDoubleClick = async (event, item) => {
-			if (this.props.watchedNoteFiles.indexOf(item.id) < 0) {
-				this.props.dispatch({
-					type: 'WINDOW_COMMAND',
-					name: 'commandStartExternalEditing',
-				});
-			}
-		};
-
 		const onDragStart = event => {
 			let noteIds = [];
 
@@ -248,9 +239,6 @@ class NoteListComponent extends React.Component {
 					style={listItemTitleStyle}
 					onClick={event => {
 						onTitleClick(event, item);
-					}}
-					onDoubleClick={event => {
-						onTitleDoubleClick(event, item);
 					}}
 					onDragStart={event => onDragStart(event)}
 					data-id={item.id}

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1301,20 +1301,11 @@ class NoteTextComponent extends React.Component {
 		await this.saveIfNeeded(true, {
 			autoTitle: false,
 		});
-
-		this.props.dispatch({
-			type: 'WINDOW_COMMAND',
-			name: 'commandStartExternalEditing',
-			noteId: this.state.note.id,
-		});
+		NoteListUtils.startExternalEditing(this.state.note.id);
 	}
 
 	async commandStopExternalEditing() {
-		this.props.dispatch({
-			type: 'WINDOW_COMMAND',
-			name: 'commandStopExternalEditing',
-			noteId: this.state.note.id,
-		});
+		NoteListUtils.stopExternalEditing(this.state.note.id);
 	}
 
 	async commandSetTags() {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1119,10 +1119,6 @@ class NoteTextComponent extends React.Component {
 				fn = this.commandTextLink;
 			} else if (command.name === 'insertDateTime') {
 				fn = this.commandDateTime;
-			} else if (command.name === 'commandStartExternalEditing') {
-				fn = this.commandStartExternalEditing;
-			} else if (command.name === 'commandStopExternalEditing') {
-				fn = this.commandStopExternalEditing;
 			} else if (command.name === 'showLocalSearch') {
 				fn = this.commandShowLocalSearch;
 			} else if (command.name === 'textCode') {
@@ -1302,18 +1298,23 @@ class NoteTextComponent extends React.Component {
 	}
 
 	async commandStartExternalEditing() {
-		try {
-			await this.saveIfNeeded(true, {
-				autoTitle: false,
-			});
-			await ExternalEditWatcher.instance().openAndWatch(this.state.note);
-		} catch (error) {
-			bridge().showErrorMessageBox(_('Error opening note in editor: %s', error.message));
-		}
+		await this.saveIfNeeded(true, {
+			autoTitle: false,
+		});
+
+		this.props.dispatch({
+			type: 'WINDOW_COMMAND',
+			name: 'commandStartExternalEditing',
+			noteId: this.state.note.id,
+		});
 	}
 
 	async commandStopExternalEditing() {
-		ExternalEditWatcher.instance().stopWatching(this.state.note.id);
+		this.props.dispatch({
+			type: 'WINDOW_COMMAND',
+			name: 'commandStopExternalEditing',
+			noteId: this.state.note.id,
+		});
 	}
 
 	async commandSetTags() {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1119,6 +1119,10 @@ class NoteTextComponent extends React.Component {
 				fn = this.commandTextLink;
 			} else if (command.name === 'insertDateTime') {
 				fn = this.commandDateTime;
+			} else if (command.name === 'commandStartExternalEditing') {
+				fn = this.commandStartExternalEditing;
+			} else if (command.name === 'commandStopExternalEditing') {
+				fn = this.commandStopExternalEditing;
 			} else if (command.name === 'showLocalSearch') {
 				fn = this.commandShowLocalSearch;
 			} else if (command.name === 'textCode') {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1121,6 +1121,8 @@ class NoteTextComponent extends React.Component {
 				fn = this.commandDateTime;
 			} else if (command.name === 'commandStartExternalEditing') {
 				fn = this.commandStartExternalEditing;
+			} else if (command.name === 'commandStopExternalEditing') {
+				fn = this.commandStopExternalEditing;
 			} else if (command.name === 'showLocalSearch') {
 				fn = this.commandShowLocalSearch;
 			} else if (command.name === 'textCode') {
@@ -1817,6 +1819,7 @@ class NoteTextComponent extends React.Component {
 		const menu = NoteListUtils.makeContextMenu(this.props.selectedNoteIds, {
 			notes: this.props.notes,
 			dispatch: this.props.dispatch,
+			watchedNoteFiles: this.props.watchedNoteFiles,
 		});
 
 		const buttonStyle = Object.assign({}, theme.buttonStyle, {

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -49,6 +49,34 @@ class NoteListUtils {
 				})
 			);
 
+			if (props.watchedNoteFiles.indexOf(noteIds[0]) < 0) {
+				menu.append(
+					new MenuItem({
+						label: _('Edit in external editor'),
+						enabled: noteIds.length === 1,
+						click: async () => {
+							props.dispatch({
+								type: 'WINDOW_COMMAND',
+								name: 'commandStartExternalEditing',
+							});
+						},
+					})
+				);
+			} else {
+				menu.append(
+					new MenuItem({
+						label: _('Stop watching external editor'),
+						enabled: noteIds.length === 1,
+						click: async () => {
+							props.dispatch({
+								type: 'WINDOW_COMMAND',
+								name: 'commandStopExternalEditing',
+							});
+						},
+					})
+				);
+			}
+
 			if (noteIds.length <= 1) {
 				menu.append(
 					new MenuItem({

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -65,7 +65,7 @@ class NoteListUtils {
 			} else {
 				menu.append(
 					new MenuItem({
-						label: _('Stop watching external editor'),
+						label: _('Stop external editing'),
 						enabled: noteIds.length === 1,
 						click: async () => {
 							props.dispatch({

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -58,6 +58,7 @@ class NoteListUtils {
 							props.dispatch({
 								type: 'WINDOW_COMMAND',
 								name: 'commandStartExternalEditing',
+								noteId: noteIds[0],
 							});
 						},
 					})
@@ -71,6 +72,7 @@ class NoteListUtils {
 							props.dispatch({
 								type: 'WINDOW_COMMAND',
 								name: 'commandStopExternalEditing',
+								noteId: noteIds[0],
 							});
 						},
 					})


### PR DESCRIPTION
~Also start up external editor on note double click.~

These changes enhance user experience by placing the actions where they feel natural.
