### PR TITLE
Desktop: Format notes using prettier markdown formatter

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1728,9 +1728,10 @@ class NoteTextComponent extends React.Component {
 				tooltip: _('Format note'),
 				iconName: 'fa-align-left',
 				onClick: () => {
-					const note = this.state.note;
+					let note = Object.assign({}, this.state.note);
 					const prettifiedBody = prettier.format(note.body, {parser: 'markdown'});
-					this.setState({note: {...note, body: prettifiedBody}});
+					note = Object.assign(note, {body: prettifiedBody});
+					this.setState({note: note});
 					this.scheduleSave();
 				},
 			});

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -41,6 +41,7 @@ const SearchEngine = require('lib/services/SearchEngine');
 const NoteTextViewer = require('./NoteTextViewer.min');
 const NoteRevisionViewer = require('./NoteRevisionViewer.min');
 const TemplateUtils = require('lib/TemplateUtils');
+const prettier = require('prettier');
 
 require('brace/mode/markdown');
 // https://ace.c9.io/build/kitchen-sink.html
@@ -1720,6 +1721,17 @@ class NoteTextComponent extends React.Component {
 				iconName: 'fa-calendar-plus-o',
 				onClick: () => {
 					return this.commandDateTime();
+				},
+			});
+
+			toolbarItems.push({
+				tooltip: _('Format note'),
+				iconName: 'fa-align-left',
+				onClick: () => {
+					const note = this.state.note;
+					const prettifiedBody = prettier.format(note.body, {parser: 'markdown'});
+					this.setState({note: {...note, body: prettifiedBody}});
+					this.scheduleSave();
 				},
 			});
 

--- a/ElectronClient/app/package-lock.json
+++ b/ElectronClient/app/package-lock.json
@@ -5512,6 +5512,11 @@
       "dev": true,
       "optional": true
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/ElectronClient/app/package.json
+++ b/ElectronClient/app/package.json
@@ -133,6 +133,7 @@
     "mustache": "^3.0.1",
     "node-fetch": "^1.7.3",
     "node-notifier": "^6.0.0",
+    "prettier": "^1.19.1",
     "promise": "^8.0.1",
     "query-string": "^5.1.1",
     "react": "^16.12.0",


### PR DESCRIPTION
Add a button to the toolbar of the notes editor, that formats the current note using `prettier`.

This adds the `prettier` dependency to the Electron App.

