### PR TITLE
Desktop: Display selected tags under a note title

### DIFF
--- a/ElectronClient/app/gui/TagList.jsx
+++ b/ElectronClient/app/gui/TagList.jsx
@@ -16,7 +16,7 @@ class TagListComponent extends React.Component {
 		style.fontSize = theme.fontSize;
 
 		const tagItems = [];
-		if (tags || tags.length > 0) {
+		if (tags && tags.length > 0) {
 			// Sort by id for now, but probably needs to be changed in the future.
 			tags.sort((a, b) => {
 				return a.title < b.title ? -1 : +1;
@@ -29,10 +29,6 @@ class TagListComponent extends React.Component {
 				};
 				tagItems.push(<TagItem {...props} />);
 			}
-		}
-
-		if (tagItems.length === 0) {
-			style.visibility = 'hidden';
 		}
 
 		return (

--- a/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
+++ b/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
@@ -28,6 +28,26 @@ const reduxSharedMiddleware = async function(store, next, action) {
 		refreshTags = true;
 	}
 
+	if (action.type === 'NOTE_SELECT' ||
+		action.type === 'NOTE_SELECT_TOGGLE' ||
+		action.type === 'NOTE_SET_NEW_ONE') {
+		let noteTags = [];
+
+		// We don't need to show tags unless only one note is selected.
+		// For new notes, the old note is still selected, but we don't want to show any tags.
+		if (action.type !== 'NOTE_SET_NEW_ONE' &&
+			newState.selectedNoteIds &&
+			newState.selectedNoteIds.length === 1) {
+			noteTags = await Tag.tagsByNoteId(newState.selectedNoteIds[0]);
+		}
+
+		store.dispatch({
+			type: 'SET_NOTE_TAGS',
+			items: noteTags,
+		});
+	}
+
+
 	if (refreshTags) {
 		store.dispatch({
 			type: 'TAG_UPDATE_ALL',
@@ -37,3 +57,4 @@ const reduxSharedMiddleware = async function(store, next, action) {
 };
 
 module.exports = reduxSharedMiddleware;
+


### PR DESCRIPTION
Follow up to #893

Now using middleware to set the tags when a note is selected

This avoids the ugly code in the NoteTextComponent where we determine
if tags are to be fetched, identify if they have been modified, fetch
them  and then dispatch an action to update the store which might
again re-render the component.

Also implements style related fixes from #1000

Fixes: #469

# Tests

- [x] Creating a new notebook should work as expeted without any issues.
- [x] Adding a tag to a new note should display the tag under the note.
- [x] Updating an existing tag, should update the tag under the note.
- [x] Deleting a tag removes it from the note.
- [x] Adding a *new* tag to a note should display the tag under the note.
- [x] Renaming a tag changes the tag in the note.
- [x] Tags should appear in the same order on the dialog box and on the note.
- [x] A new note should not display the tag bar.
- [x] Tag list order under note should be in ascending order for now.
- [x] Switching between notes updates the tag bar with tags for the respective notes.
- Proper margin between toolbars when,
   - [x] Tags are not present.
   - [x] Tags are present.
- [x] During testing the CPU usage by Joplin should not peak at 100% for one or more CPU cores.

