### PR TITLE
Desktop: Resize images in Markdown

### DIFF
--- a/ElectronClient/package-lock.json
+++ b/ElectronClient/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "html-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-format/-/html-format-1.0.1.tgz",
+      "integrity": "sha512-ePp+h+akaQiLeCGPefWQ4QJXVXhWx4sU4ZxJVFlaY0AeVgh/tnHGTL27ao09JrdEEelXYMAWi4ynKKheck4tdw=="
+    },
+    "markdown-it-imsize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz",
+      "integrity": "sha1-zKBCeQXQUziiR8ucqdloxc3dUXA="
+    }
+  }
+}

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -339,7 +339,6 @@ class Setting extends BaseModel {
 			'markdown.plugin.katex': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable math expressions') },
 			'markdown.plugin.mark': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax') },
 			'markdown.plugin.footnote': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes') },
-			'markdown.plugin.imageSize': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable editing image size from editor') },
 			'markdown.plugin.toc': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable table of contents extension') },
 			'markdown.plugin.sub': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ~sub~ syntax') },
 			'markdown.plugin.sup': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ^sup^ syntax') },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -339,6 +339,7 @@ class Setting extends BaseModel {
 			'markdown.plugin.katex': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable math expressions') },
 			'markdown.plugin.mark': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ==mark== syntax') },
 			'markdown.plugin.footnote': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable footnotes') },
+			'markdown.plugin.imageSize': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable editing image size from editor') },
 			'markdown.plugin.toc': { value: true, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable table of contents extension') },
 			'markdown.plugin.sub': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ~sub~ syntax') },
 			'markdown.plugin.sup': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => _('Enable ^sup^ syntax') },

--- a/ReactNativeClient/lib/renderers/MdToHtml.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml.js
@@ -21,7 +21,6 @@ const markdownItAnchor = require('markdown-it-anchor');
 const plugins = {
 	mark: { module: require('markdown-it-mark') },
 	footnote: { module: require('markdown-it-footnote') },
-	imageSize: { module: require('markdown-it-imsize') },
 	sub: { module: require('markdown-it-sub') },
 	sup: { module: require('markdown-it-sup') },
 	deflist: { module: require('markdown-it-deflist') },
@@ -146,12 +145,12 @@ class MdToHtml {
 		markdownIt.use(rules.checkbox(context, ruleOptions));
 		markdownIt.use(rules.link_open(context, ruleOptions));
 		markdownIt.use(rules.html_image(context, ruleOptions));
-		// markdownIt.use(require('markdown-it-imsize'), { autofill: true });
 		if (Setting.value('markdown.plugin.katex')) markdownIt.use(rules.katex(context, ruleOptions));
 		if (Setting.value('markdown.plugin.fountain')) markdownIt.use(rules.fountain(context, ruleOptions));
 		markdownIt.use(rules.highlight_keywords(context, ruleOptions));
 		markdownIt.use(rules.code_inline(context, ruleOptions));
 		markdownIt.use(markdownItAnchor, { slugify: uslugify });
+		markdownIt.use(require('markdown-it-imsize'));
 
 		for (let key in plugins) {
 			if (Setting.value(`markdown.plugin.${key}`)) markdownIt.use(plugins[key].module, plugins[key].options);

--- a/ReactNativeClient/lib/renderers/MdToHtml.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml.js
@@ -21,6 +21,7 @@ const markdownItAnchor = require('markdown-it-anchor');
 const plugins = {
 	mark: { module: require('markdown-it-mark') },
 	footnote: { module: require('markdown-it-footnote') },
+	imageSize: { module: require('markdown-it-imsize') },
 	sub: { module: require('markdown-it-sub') },
 	sup: { module: require('markdown-it-sup') },
 	deflist: { module: require('markdown-it-deflist') },
@@ -145,6 +146,7 @@ class MdToHtml {
 		markdownIt.use(rules.checkbox(context, ruleOptions));
 		markdownIt.use(rules.link_open(context, ruleOptions));
 		markdownIt.use(rules.html_image(context, ruleOptions));
+		// markdownIt.use(require('markdown-it-imsize'), { autofill: true });
 		if (Setting.value('markdown.plugin.katex')) markdownIt.use(rules.katex(context, ruleOptions));
 		if (Setting.value('markdown.plugin.fountain')) markdownIt.use(rules.fountain(context, ruleOptions));
 		markdownIt.use(rules.highlight_keywords(context, ruleOptions));

--- a/ReactNativeClient/lib/renderers/MdToHtml/rules/image.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml/rules/image.js
@@ -2,7 +2,271 @@ const Resource = require('lib/models/Resource.js');
 const utils = require('../../utils');
 const htmlUtils = require('lib/htmlUtils.js');
 
+function parseNextNumber(str, pos, max) {
+	var code,
+		start = pos,
+		result = {
+			ok: false,
+			pos: pos,
+			value: '',
+		};
+
+	code = str.charCodeAt(pos);
+
+	while (pos < max && (code >= 0x30 /* 0 */ && code <= 0x39 /* 9 */) || code === 0x25 /* % */) {
+		code = str.charCodeAt(++pos);
+	}
+
+	result.ok = true;
+	result.pos = pos;
+	result.value = str.slice(start, pos);
+
+	return result;
+}
+
+function parseImageSize(str, pos, max) {
+	var code,
+		result = {
+			ok: false,
+			pos: 0,
+			width: '',
+			height: '',
+		};
+
+	if (pos >= max) { return result; }
+
+	code = str.charCodeAt(pos);
+
+	if (code !== 0x3d /* = */) { return result; }
+
+	pos++;
+
+	// size must follow = without any white spaces as follows
+	// (1) =300x200
+	// (2) =300x
+	// (3) =x200
+	code = str.charCodeAt(pos);
+	if (code !== 0x78 /* x */ && (code < 0x30 || code  > 0x39) /* [0-9] */) {
+		return result;
+	}
+
+	// parse width
+	var resultW = parseNextNumber(str, pos, max);
+	pos = resultW.pos;
+
+	// next charactor must be 'x'
+	code = str.charCodeAt(pos);
+	if (code !== 0x78 /* x */) { return result; }
+
+	pos++;
+
+	// parse height
+	var resultH = parseNextNumber(str, pos, max);
+	pos = resultH.pos;
+
+	console.log([resultW.value, resultH.value]);
+	result.width = resultW.value;
+	result.height = resultH.value;
+	result.pos = pos;
+	result.ok = true;
+	return result;
+}
+
+
+function image_with_size(md) {
+	return function(state, silent) {
+		var attrs,
+			code,
+			label,
+			labelEnd,
+			labelStart,
+			pos,
+			ref,
+			res,
+			title,
+			width = '',
+			height = '',
+			token,
+			tokens,
+			start,
+			href = '',
+			oldPos = state.pos,
+			max = state.posMax;
+
+		if (state.src.charCodeAt(state.pos) !== 0x21/* ! */) { return false; }
+		if (state.src.charCodeAt(state.pos + 1) !== 0x5B/* [ */) { return false; }
+
+		labelStart = state.pos + 2;
+		labelEnd = md.helpers.parseLinkLabel(state, state.pos + 1, false);
+
+		// parser failed to find ']', so it's not a valid link
+		if (labelEnd < 0) { return false; }
+
+		pos = labelEnd + 1;
+		if (pos < max && state.src.charCodeAt(pos) === 0x28/* ( */) {
+
+			//
+			// Inline link
+			//
+
+			// [link](  <href>  "title"  )
+			//        ^^ skipping these spaces
+			pos++;
+			for (; pos < max; pos++) {
+				code = state.src.charCodeAt(pos);
+				if (code !== 0x20 && code !== 0x0A) { break; }
+			}
+			if (pos >= max) { return false; }
+
+			// [link](  <href>  "title"  )
+			//          ^^^^^^ parsing link destination
+			start = pos;
+			res = md.helpers.parseLinkDestination(state.src, pos, state.posMax);
+			if (res.ok) {
+				href = state.md.normalizeLink(res.str);
+				if (state.md.validateLink(href)) {
+					pos = res.pos;
+				} else {
+					href = '';
+				}
+			}
+
+			// [link](  <href>  "title"  )
+			//                ^^ skipping these spaces
+			start = pos;
+			for (; pos < max; pos++) {
+				code = state.src.charCodeAt(pos);
+				if (code !== 0x20 && code !== 0x0A) { break; }
+			}
+
+			// [link](  <href>  "title"  )
+			//                  ^^^^^^^ parsing link title
+			res = md.helpers.parseLinkTitle(state.src, pos, state.posMax);
+			if (pos < max && start !== pos && res.ok) {
+				title = res.str;
+				pos = res.pos;
+
+				// [link](  <href>  "title"  )
+				//                         ^^ skipping these spaces
+				for (; pos < max; pos++) {
+					code = state.src.charCodeAt(pos);
+					if (code !== 0x20 && code !== 0x0A) { break; }
+				}
+			} else {
+				title = '';
+			}
+
+			// [link](  <href>  "title" =WxH  )
+			//                          ^^^^ parsing image size
+			if (pos - 1 >= 0) {
+				code = state.src.charCodeAt(pos - 1);
+
+				// there must be at least one white spaces
+				// between previous field and the size
+				if (code === 0x20) {
+					res = parseImageSize(state.src, pos, state.posMax);
+					if (res.ok) {
+						width = res.width;
+						height = res.height;
+						pos = res.pos;
+
+						// [link](  <href>  "title" =WxH  )
+						//                              ^^ skipping these spaces
+						for (; pos < max; pos++) {
+							code = state.src.charCodeAt(pos);
+							if (code !== 0x20 && code !== 0x0A) { break; }
+						}
+					}
+				}
+			}
+
+			if (pos >= max || state.src.charCodeAt(pos) !== 0x29/* ) */) {
+				state.pos = oldPos;
+				return false;
+			}
+			pos++;
+
+		} else {
+			//
+			// Link reference
+			//
+			if (typeof state.env.references === 'undefined') { return false; }
+
+			// [foo]  [bar]
+			//      ^^ optional whitespace (can include newlines)
+			for (; pos < max; pos++) {
+				code = state.src.charCodeAt(pos);
+				if (code !== 0x20 && code !== 0x0A) { break; }
+			}
+
+			if (pos < max && state.src.charCodeAt(pos) === 0x5B/* [ */) {
+				start = pos + 1;
+				pos = md.helpers.parseLinkLabel(state, pos);
+				if (pos >= 0) {
+					label = state.src.slice(start, pos++);
+				} else {
+					pos = labelEnd + 1;
+				}
+			} else {
+				pos = labelEnd + 1;
+			}
+
+			// covers label === '' and label === undefined
+			// (collapsed reference link and shortcut reference link respectively)
+			if (!label) { label = state.src.slice(labelStart, labelEnd); }
+
+			ref = state.env.references[md.utils.normalizeReference(label)];
+			if (!ref) {
+				state.pos = oldPos;
+				return false;
+			}
+			href = ref.href;
+			title = ref.title;
+		}
+
+		//
+		// We found the end of the link, and know for a fact it's a valid link;
+		// so all that's left to do is to call tokenizer.
+		//
+		if (!silent) {
+			state.pos = labelStart;
+			state.posMax = labelEnd;
+
+			var newState = new state.md.inline.State(
+				state.src.slice(labelStart, labelEnd),
+				state.md,
+				state.env,
+				tokens = []
+			);
+			newState.md.inline.tokenize(newState);
+
+			token          = state.push('image', 'img', 0);
+			token.attrs    = attrs = [ [ 'src', href ],
+				[ 'alt', '' ] ];
+			token.children = tokens;
+			if (title) {
+				attrs.push([ 'title', title ]);
+			}
+
+			if (width !== '') {
+				attrs.push([ 'width', width ]);
+			}
+
+			if (height !== '') {
+				attrs.push([ 'height', height ]);
+			}
+		}
+
+		state.pos = pos;
+		state.posMax = max;
+		return true;
+	};
+}
+
 function installRule(markdownIt, mdOptions, ruleOptions) {
+	// markdownIt.ruler.push('image', (x,y) => console.log({x,y}))
+	markdownIt.inline.ruler.before('emphasis', 'image', image_with_size(markdownIt, mdOptions));
+
 	const defaultRender = markdownIt.renderer.rules.image;
 
 	console.log('hello!');
@@ -11,6 +275,9 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 		const token = tokens[idx];
 		const src = utils.getAttr(token.attrs, 'src');
 		const title = utils.getAttr(token.attrs, 'title');
+		const width = utils.getAttr(token.attrs, 'width');
+		const height = utils.getAttr(token.attrs, 'height');
+		console.log(token.attrs);
 
 		// const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)>/gi;
 
@@ -25,7 +292,7 @@ function installRule(markdownIt, mdOptions, ruleOptions) {
 
 		const r = utils.imageReplacement(src, ruleOptions.resources, ruleOptions.resourceBaseUrl);
 		if (typeof r === 'string') return r;
-		if (r) return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title }))}/>`;
+		if (r) return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title, width, height }))}/>`;
 
 		return defaultRender(tokens, idx, options, env, self);
 	};

--- a/ReactNativeClient/lib/renderers/MdToHtml/rules/image.js
+++ b/ReactNativeClient/lib/renderers/MdToHtml/rules/image.js
@@ -5,17 +5,33 @@ const htmlUtils = require('lib/htmlUtils.js');
 function installRule(markdownIt, mdOptions, ruleOptions) {
 	const defaultRender = markdownIt.renderer.rules.image;
 
+	console.log('hello!');
+
 	markdownIt.renderer.rules.image = (tokens, idx, options, env, self) => {
 		const token = tokens[idx];
 		const src = utils.getAttr(token.attrs, 'src');
 		const title = utils.getAttr(token.attrs, 'title');
 
-		if (!Resource.isResourceUrl(src) || ruleOptions.plainResourceRendering) return defaultRender(tokens, idx, options, env, self);
+		// const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)>/gi;
+
+		console.log({src, split: src.split('%7C')});
+		// if (src.match(imageRegex)) {
+		// 	console.log('match!')
+		// }
+
+		if (!Resource.isResourceUrl(src) || ruleOptions.plainResourceRendering) {
+			return defaultRender(tokens, idx, options, env, self);
+		}
 
 		const r = utils.imageReplacement(src, ruleOptions.resources, ruleOptions.resourceBaseUrl);
 		if (typeof r === 'string') return r;
 		if (r) return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title }))}/>`;
 
+		return defaultRender(tokens, idx, options, env, self);
+	};
+	markdownIt.renderer.rules.foooooo = (tokens, idx, options, env, self) => {
+
+		console.log('in fooooo');
 		return defaultRender(tokens, idx, options, env, self);
 	};
 }

--- a/ReactNativeClient/lib/renderers/noteStyle.js
+++ b/ReactNativeClient/lib/renderers/noteStyle.js
@@ -210,7 +210,6 @@ module.exports = function(style, options) {
 		}
 		img {
 			max-width: 100%;
-			height: auto;
 		}
 		.inline-code {
 			border: 1px solid ${style.htmlCodeBorderColor};


### PR DESCRIPTION
Opening this just for posterity, because we decided not to go down this route after all in https://discourse.joplinapp.org/t/resize-images/708/13 but it might still be useful for other people to see how to build a `markdown-it` plugin.

This PR wasn't totally ready to merge before I put it down. There was one unresolved issue around actually loading the image that I didn't resolve.

Here's how the test file looked:

![image](https://user-images.githubusercontent.com/6979755/71485978-a4e10280-27f2-11ea-92cc-19e1e1c822c6.png)
