### PR TITLE
Desktop: Remove escape for title (#2085)

### DIFF
--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -7,7 +7,6 @@ const { time } = require('lib/time-utils.js');
 const { sprintf } = require('sprintf-js');
 const { _ } = require('lib/locale.js');
 const moment = require('moment');
-const markdownUtils = require('lib/markdownUtils');
 
 class BaseItem extends BaseModel {
 	static useUuid() {
@@ -761,7 +760,7 @@ class BaseItem extends BaseModel {
 
 		const output = [];
 		output.push('[');
-		output.push(markdownUtils.escapeLinkText(item.title));
+		output.push(item.title);
 		output.push(']');
 		output.push(`(:/${item.id})`);
 		return output.join('');


### PR DESCRIPTION
#2085 
The issue is not only for parenthesis but also brackets because [escapeLinkText](https://github.com/laurent22/joplin/blob/59bb1015ab8b87dcebf92e98049d5a9ab5660966/ReactNativeClient/lib/markdownUtils.js#L8) replaces brackets and parenthesis with an underscore.
Editing [markdownTag](https://github.com/laurent22/joplin/blob/59bb1015ab8b87dcebf92e98049d5a9ab5660966/ReactNativeClient/lib/models/BaseItem.js#L764) to push the note title without escaping solves the problem, but I'm note sure why markdownUtils was there in the first place @laurent22 .