### PR TITLE
Desktop: Add option to disable auto-matching braces

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -2120,6 +2120,8 @@ class NoteTextComponent extends React.Component {
 				onSelectionChange={this.aceEditor_selectionChange}
 				onFocus={this.aceEditor_focus}
 				readOnly={visiblePanes.indexOf('editor') < 0}
+				// Enable/Disable the autoclosing braces
+				setOptions={{ behavioursEnabled: Setting.value('editor.autoMatchingBraces') }}
 				// Disable warning: "Automatically scrolling cursor into view after
 				// selection change this will be disabled in the next version set
 				// editor.$blockScrolling = Infinity to disable this message"

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -289,6 +289,7 @@ class Setting extends BaseModel {
 				type: Setting.TYPE_BOOL,
 				public: true,
 				section: 'note',
+				appTypes: ['desktop'],
 				label: () => _('Auto-pair braces, parenthesis, quotations, etc.'),
 			},
 			'notes.sortOrder.reverse': { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, label: () => _('Reverse sort order'), appTypes: ['cli'] },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -284,6 +284,13 @@ class Setting extends BaseModel {
 					return options;
 				},
 			},
+			'editor.autoMatchingBraces': {
+				value: true,
+				type: Setting.TYPE_BOOL,
+				public: true,
+				section: 'note',
+				label: () => _('Auto-pair braces, parenthesis, quotations, etc.'),
+			},
 			'notes.sortOrder.reverse': { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, label: () => _('Reverse sort order'), appTypes: ['cli'] },
 			'folders.sortOrder.field': {
 				value: 'title',


### PR DESCRIPTION
This is a very simple fix, the only complexity was trying to understand the ace documentation :(

This was [requested on the forum](https://discourse.joplinapp.org/t/feature-un-request-back-tick-quote-balancing/2626/6)