### PR TITLE
Desktop: Fix pdf export for current but unselected note.

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -461,6 +461,7 @@ class Application extends BaseApplication {
 				this.dispatch({
 					type: 'WINDOW_COMMAND',
 					name: 'exportPdf',
+					noteId: null,
 				});
 			},
 		});

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1103,9 +1103,11 @@ class NoteTextComponent extends React.Component {
 		if (!command) return;
 
 		let fn = null;
+		let args = null;
 
 		if (command.name === 'exportPdf') {
 			fn = this.commandSavePdf;
+			args = {noteId: command.noteId};
 		} else if (command.name === 'print') {
 			fn = this.commandPrint;
 		}
@@ -1155,7 +1157,7 @@ class NoteTextComponent extends React.Component {
 
 		requestAnimationFrame(() => {
 			fn = fn.bind(this);
-			fn();
+			fn(args);
 		});
 	}
 
@@ -1248,7 +1250,7 @@ class NoteTextComponent extends React.Component {
 		setTimeout(async () => {
 			if (target === 'pdf') {
 				try {
-					const pdfData = await InteropServiceHelper.exportNoteToPdf(this.state.note.id, {
+					const pdfData = await InteropServiceHelper.exportNoteToPdf(options.noteId, {
 						printBackground: true,
 						pageSize: Setting.value('export.pdfPageSize'),
 						landscape: Setting.value('export.pdfPageOrientation') === 'landscape',
@@ -1260,7 +1262,7 @@ class NoteTextComponent extends React.Component {
 				}
 			} else if (target === 'printer') {
 				try {
-					await InteropServiceHelper.printNote(this.state.note.id, {
+					await InteropServiceHelper.printNote(options.noteId, {
 						printBackground: true,
 					});
 				} catch (error) {
@@ -1274,18 +1276,20 @@ class NoteTextComponent extends React.Component {
 		}, 100);
 	}
 
-	async commandSavePdf() {
+	async commandSavePdf(args) {
 		try {
-			if (!this.state.note) throw new Error(_('Only one note can be printed or exported to PDF at a time.'));
+			if (!this.state.note && !args.noteId) throw new Error(_('Only one note can be exported to PDF at a time.'));
+
+			const note = (!args.noteId ? this.state.note : await Note.load(args.noteId));
 
 			const path = bridge().showSaveDialog({
 				filters: [{ name: _('PDF File'), extensions: ['pdf'] }],
-				defaultPath: safeFilename(this.state.note.title),
+				defaultPath: safeFilename(note.title),
 			});
 
 			if (!path) return;
 
-			await this.printTo_('pdf', { path: path });
+			await this.printTo_('pdf', { path: path, noteId: args.noteId });
 		} catch (error) {
 			bridge().showErrorMessageBox(error.message);
 		}
@@ -1293,7 +1297,9 @@ class NoteTextComponent extends React.Component {
 
 	async commandPrint() {
 		try {
-			await this.printTo_('printer');
+			if (!this.state.note) throw new Error(_('Only one note can be printed at a time.'));
+
+			await this.printTo_('printer', { noteId: this.state.note.id });
 		} catch (error) {
 			bridge().showErrorMessageBox(error.message);
 		}

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -148,6 +148,7 @@ class NoteListUtils {
 							props.dispatch({
 								type: 'WINDOW_COMMAND',
 								name: 'exportPdf',
+								noteId: noteIds[0],
 							});
 						},
 					})


### PR DESCRIPTION
Proposed fix for issue #2254 

The fix ensures the current note is used when it is not in the set of selected notes, which can happen when the user right-clicks on an unselected note in the note list.
