### PR TITLE
Clipper: Add ability to launch clipper window with shortcut

### DIFF
--- a/Clipper/joplin-webclipper/background.js
+++ b/Clipper/joplin-webclipper/background.js
@@ -128,7 +128,6 @@ async function sendClipMessage(clipType) {
 browser.commands.onCommand.addListener(function(command) {
 	// We could enumerate these twice, but since we're in here first,
 	// why not save ourselves the trouble with this convention
-	console.log('Rah');
 	if (command.startsWith('clip')) {
 		sendClipMessage(command);
 	}

--- a/Clipper/joplin-webclipper/background.js
+++ b/Clipper/joplin-webclipper/background.js
@@ -97,7 +97,7 @@ async function sendClipMessage(clipType) {
 	const tabId = tabs[0].id;
 	// send a message to the content script on the active tab (assuming it's there)
 	const message = {
-		useDefaultSettings: true,
+		shouldSendToJoplin: true,
 	};
 	switch (clipType) {
 	case 'clipCompletePage':
@@ -125,7 +125,7 @@ async function sendClipMessage(clipType) {
 	}
 }
 
-browser.commands.onCommand.addListener(function(command) {
+browser_.commands.onCommand.addListener(function(command) {
 	// We could enumerate these twice, but since we're in here first,
 	// why not save ourselves the trouble with this convention
 	if (command.startsWith('clip')) {

--- a/Clipper/joplin-webclipper/background.js
+++ b/Clipper/joplin-webclipper/background.js
@@ -91,7 +91,7 @@ async function getActiveTabs() {
 async function sendClipMessage(clipType) {
 	const tabs = await getActiveTabs();
 	if (!tabs || !tabs.length) {
-		console.warn('No active tabs');
+		console.error('No active tabs');
 		return;
 	}
 	const tabId = tabs[0].id;

--- a/Clipper/joplin-webclipper/background.js
+++ b/Clipper/joplin-webclipper/background.js
@@ -76,3 +76,60 @@ browser_.runtime.onMessage.addListener(async (command) => {
 		});
 	}
 });
+
+async function getActiveTabs() {
+	const options = { active: true, currentWindow: true };
+	if (browserSupportsPromises_) return browser_.tabs.query(options);
+
+	return new Promise((resolve) => {
+		browser_.tabs.query(options, (tabs) => {
+			resolve(tabs);
+		});
+	});
+}
+
+async function sendClipMessage(clipType) {
+	const tabs = await getActiveTabs();
+	if (!tabs || !tabs.length) {
+		console.warn('No active tabs');
+		return;
+	}
+	const tabId = tabs[0].id;
+	// send a message to the content script on the active tab (assuming it's there)
+	const message = {
+		useDefaultSettings: true,
+	};
+	switch (clipType) {
+	case 'clipCompletePage':
+		message.name = 'completePageHtml';
+		message.preProcessFor = 'markdown';
+		break;
+	case 'clipCompletePageHtml':
+		message.name = 'completePageHtml';
+		message.preProcessFor = 'html';
+		break;
+	case 'clipSimplifiedPage':
+		message.name = 'simplifiedPageHtml';
+		break;
+	case 'clipUrl':
+		message.name = 'pageUrl';
+		break;
+	case 'clipSelection':
+		message.name = 'selectedHtml';
+		break;
+	default:
+		break;
+	}
+	if (message.name) {
+		browser_.tabs.sendMessage(tabId, message);
+	}
+}
+
+browser.commands.onCommand.addListener(function(command) {
+	// We could enumerate these twice, but since we're in here first,
+	// why not save ourselves the trouble with this convention
+	console.log('Rah');
+	if (command.startsWith('clip')) {
+		sendClipMessage(command);
+	}
+});

--- a/Clipper/joplin-webclipper/content_scripts/index.js
+++ b/Clipper/joplin-webclipper/content_scripts/index.js
@@ -266,6 +266,8 @@
 
 	async function prepareCommandResponse(command) {
 		console.info(`Got command: ${command.name}`);
+		const useDefaultSettings = command.useDefaultSettings || false;
+		command.useDefaultSettings = undefined;
 
 		const convertToMarkup = command.preProcessFor ? command.preProcessFor : 'markdown';
 
@@ -283,6 +285,7 @@
 				source_command: Object.assign({}, command),
 				convert_to: convertToMarkup,
 				stylesheets: stylesheets,
+				useDefaultSettings: useDefaultSettings,
 			};
 		};
 

--- a/Clipper/joplin-webclipper/content_scripts/index.js
+++ b/Clipper/joplin-webclipper/content_scripts/index.js
@@ -266,7 +266,7 @@
 
 	async function prepareCommandResponse(command) {
 		console.info(`Got command: ${command.name}`);
-		const shouldSendToJoplin = command.shouldSendToJoplin || false;
+		const shouldSendToJoplin = !!command.shouldSendToJoplin;
 
 		const convertToMarkup = command.preProcessFor ? command.preProcessFor : 'markdown';
 

--- a/Clipper/joplin-webclipper/content_scripts/index.js
+++ b/Clipper/joplin-webclipper/content_scripts/index.js
@@ -266,14 +266,13 @@
 
 	async function prepareCommandResponse(command) {
 		console.info(`Got command: ${command.name}`);
-		const useDefaultSettings = command.useDefaultSettings || false;
-		command.useDefaultSettings = undefined;
+		const shouldSendToJoplin = command.shouldSendToJoplin || false;
 
 		const convertToMarkup = command.preProcessFor ? command.preProcessFor : 'markdown';
 
 		const clippedContentResponse = (title, html, imageSizes, anchorNames, stylesheets) => {
 			return {
-				name: 'clippedContent',
+				name: shouldSendToJoplin ? 'sendContentToJoplin' : 'clippedContent',
 				title: title,
 				html: html,
 				base_url: baseUrl(),
@@ -285,7 +284,6 @@
 				source_command: Object.assign({}, command),
 				convert_to: convertToMarkup,
 				stylesheets: stylesheets,
-				useDefaultSettings: useDefaultSettings,
 			};
 		};
 

--- a/Clipper/joplin-webclipper/manifest.json
+++ b/Clipper/joplin-webclipper/manifest.json
@@ -33,6 +33,13 @@
             ]
         }
     ],
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "Alt+Shift+J"
+            }
+        }
+    },
     "background": {
         "scripts": [
             "background.js"

--- a/Clipper/joplin-webclipper/manifest.json
+++ b/Clipper/joplin-webclipper/manifest.json
@@ -38,6 +38,34 @@
             "suggested_key": {
                 "default": "Alt+Shift+J"
             }
+        },
+        "clipCompletePage": {
+            "suggested_key": {
+                "default": "Alt+Shift+C"
+            },
+            "description": "Clip complete page (uses last selected notebook)"
+
+        },
+        "clipCompletePageHtml": {
+            "suggested_key": {
+            },
+            "description": "Clip complete page (HTML) (uses last selected notebook)"
+
+        },
+        "clipSimplifiedPage": {
+            "suggested_key": {
+            },
+            "description": "Clip simplified page (uses last selected notebook)"
+        },
+        "clipUrl": {
+            "suggested_key": {
+            },
+            "description": "Clip url (uses last selected notebook)"
+        },
+        "clipSelection": {
+            "suggested_key": {
+            },
+            "description": "Clip selection (uses last selected notebook)"
         }
     },
     "background": {

--- a/Clipper/joplin-webclipper/manifest.json
+++ b/Clipper/joplin-webclipper/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Joplin Web Clipper [DEV]",
-    "version": "1.0.24",
+    "version": "1.0.20",
     "description": "Capture and save web pages and screenshots from your browser to Joplin.",
     "homepage_url": "https://joplinapp.org",
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",

--- a/Clipper/joplin-webclipper/manifest.json
+++ b/Clipper/joplin-webclipper/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Joplin Web Clipper [DEV]",
-    "version": "1.0.19",
+    "version": "1.0.24",
     "description": "Capture and save web pages and screenshots from your browser to Joplin.",
     "homepage_url": "https://joplinapp.org",
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
@@ -44,27 +44,17 @@
                 "default": "Alt+Shift+C"
             },
             "description": "Clip complete page (uses last selected notebook)"
-
         },
         "clipCompletePageHtml": {
-            "suggested_key": {
-            },
             "description": "Clip complete page (HTML) (uses last selected notebook)"
-
         },
         "clipSimplifiedPage": {
-            "suggested_key": {
-            },
             "description": "Clip simplified page (uses last selected notebook)"
         },
         "clipUrl": {
-            "suggested_key": {
-            },
             "description": "Clip url (uses last selected notebook)"
         },
         "clipSelection": {
-            "suggested_key": {
-            },
             "description": "Clip selection (uses last selected notebook)"
         }
     },

--- a/Clipper/joplin-webclipper/popup/src/App.css
+++ b/Clipper/joplin-webclipper/popup/src/App.css
@@ -52,9 +52,11 @@
 	cursor: pointer;
 	align-items: center;
 	min-height: 31px;
+	text-decoration: none;
 }
 
-.App a.Button:hover {
+.App a.Button:hover,
+.App a.Button:focus {
 	background-color: #1E89E6;
 }
 

--- a/Clipper/joplin-webclipper/popup/src/App.js
+++ b/Clipper/joplin-webclipper/popup/src/App.js
@@ -49,7 +49,7 @@ class PreviewComponent extends React.PureComponent {
 				<h2>Title:</h2>
 				<input className={'Title'} value={this.props.title} onChange={this.props.onTitleChange}/>
 				<p><span>Type:</span> {commandUserString(this.props.command)}</p>
-				<a className={'Confirm Button'} onClick={this.props.onConfirmClick}>Confirm</a>
+				<a className={'Confirm Button'} href="#" onClick={this.props.onConfirmClick}>Confirm</a>
 			</div>
 		);
 
@@ -384,12 +384,12 @@ class AppComponent extends Component {
 			<div className="App">
 				<div className="Controls">
 					<ul>
-						<li><a className="Button" onClick={this.clipSimplified_click} title={simplifiedPageButtonTooltip}>{simplifiedPageButtonLabel}</a></li>
-						<li><a className="Button" onClick={this.clipComplete_click}>Clip complete page</a></li>
-						<li><a className="Button" onClick={this.clipCompleteHtml_click}>Clip complete page (HTML) (Beta)</a></li>
-						<li><a className="Button" onClick={this.clipSelection_click}>Clip selection</a></li>
-						<li><a className="Button" onClick={this.clipScreenshot_click}>Clip screenshot</a></li>
-						<li><a className="Button" onClick={this.clipUrl_click}>Clip URL</a></li>
+						<li><a className="Button" href="#" onClick={this.clipSimplified_click} title={simplifiedPageButtonTooltip}>{simplifiedPageButtonLabel}</a></li>
+						<li><a className="Button" href="#" onClick={this.clipComplete_click}>Clip complete page</a></li>
+						<li><a className="Button" href="#" onClick={this.clipCompleteHtml_click}>Clip complete page (HTML) (Beta)</a></li>
+						<li><a className="Button" href="#" onClick={this.clipSelection_click}>Clip selection</a></li>
+						<li><a className="Button" href="#" onClick={this.clipScreenshot_click}>Clip screenshot</a></li>
+						<li><a className="Button" href="#" onClick={this.clipUrl_click}>Clip URL</a></li>
 					</ul>
 				</div>
 				{ foldersComp() }

--- a/Clipper/joplin-webclipper/popup/src/bridge.js
+++ b/Clipper/joplin-webclipper/popup/src/bridge.js
@@ -16,6 +16,22 @@ class Bridge {
 		this.clipperServerPort_ = null;
 		this.clipperServerPortStatus_ = 'searching';
 
+		function convertCommandToContent(command) {
+			return {
+				title: command.title,
+				body_html: command.html,
+				base_url: command.base_url,
+				source_url: command.url,
+				parent_id: command.parent_id,
+				tags: command.tags || '',
+				image_sizes: command.image_sizes || {},
+				anchor_names: command.anchor_names || [],
+				source_command: command.source_command,
+				convert_to: command.convert_to,
+				stylesheets: command.stylesheets,
+			};
+		}
+
 		this.browser_notify = async (command) => {
 			console.info('Popup: Got command:', command);
 
@@ -27,28 +43,18 @@ class Bridge {
 			}
 
 			if (command.name === 'clippedContent') {
-				const content = {
-					title: command.title,
-					body_html: command.html,
-					base_url: command.base_url,
-					source_url: command.url,
-					parent_id: command.parent_id,
-					tags: command.tags || '',
-					image_sizes: command.image_sizes || {},
-					anchor_names: command.anchor_names || [],
-					source_command: command.source_command,
-					convert_to: command.convert_to,
-					stylesheets: command.stylesheets,
-				};
+				const content = convertCommandToContent(command);
+				this.dispatch({ type: 'CLIPPED_CONTENT_SET', content: content });
+			}
 
+			if (command.name === 'sendContentToJoplin') {
+				const content = convertCommandToContent(command);
 				this.dispatch({ type: 'CLIPPED_CONTENT_SET', content: content });
 
-				if (command.useDefaultSettings) {
-					const state = this.store_.getState();
-					content.parent_id = state.selectedFolderId;
-					if (content.parent_id) {
-						this.sendContentToJoplin(content);
-					}
+				const state = this.store_.getState();
+				content.parent_id = state.selectedFolderId;
+				if (content.parent_id) {
+					this.sendContentToJoplin(content);
 				}
 			}
 

--- a/Clipper/joplin-webclipper/popup/src/index.js
+++ b/Clipper/joplin-webclipper/popup/src/index.js
@@ -105,7 +105,7 @@ async function main() {
 
 	console.info('Popup: Init bridge and restore state...');
 
-	await bridge().init(window.browser ? window.browser : window.chrome, !!window.browser, store.dispatch);
+	await bridge().init(window.browser ? window.browser : window.chrome, !!window.browser, store);
 
 	console.info('Popup: Creating React app...');
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->


Related forum post:
- https://discourse.joplinapp.org/t/shortcut-hotkey-for-the-web-clipper/4877

Relevant docs:
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands

Not sure if you'll want to take this given the [discussion of a new webclipper](https://discourse.joplinapp.org/t/an-alternative-web-clipper-for-joplin/4904/), but the first bit was simple and already finished so I thought I'd open the PR. 

This change adds a command to the `manifest.json` for the web clipper which launches the webclipper rather than clicking on it. Because this is a WebExtensions feature and not something homegrown, users are able to change (or remove) the shortcut using native browser functionality.

It should theoretically be possible to take the default values and add commands for each individual piece of functionality ("Clip simplified page", "Clip Selection", etc), but I left that for another PR since I ended up not having as much time to work on this as I had hoped.