### PR TITLE
Mobile: Workaround for react-native-fs bug

### DIFF
--- a/ReactNativeClient/lib/fs-driver-rn.js
+++ b/ReactNativeClient/lib/fs-driver-rn.js
@@ -11,7 +11,7 @@ class FsDriverRN extends FsDriverBase {
 	}
 
 	writeFile(path, string, encoding = 'base64') {
-		return RNFS.writeFile(path, string, encoding);
+		return RNFS.unlink(path).then(() => { RNFS.writeFile(path, string, encoding)); });
 	}
 
 	// same as rm -rf

--- a/ReactNativeClient/lib/fs-driver-rn.js
+++ b/ReactNativeClient/lib/fs-driver-rn.js
@@ -11,7 +11,7 @@ class FsDriverRN extends FsDriverBase {
 	}
 
 	writeFile(path, string, encoding = 'base64') {
-		return RNFS.unlink(path).then(() => { RNFS.writeFile(path, string, encoding)); });
+		return RNFS.unlink(path).then(() => { RNFS.writeFile(path, string, encoding); });
 	}
 
 	// same as rm -rf


### PR DESCRIPTION
There seems to be a bug with `react-native-fs` on Android 10 which causes written files to not being properly truncated when the updated content is shorter than the previous content: https://github.com/itinance/react-native-fs/issues/700

This works around the issue by deleting the file before writing it, as suggested by @mstratiev on this comment: https://github.com/itinance/react-native-fs/issues/700#issuecomment-570650632