### PR TITLE
Desktop: Make toolbar icons responsive

### DIFF
--- a/ElectronClient/app/gui/Toolbar.jsx
+++ b/ElectronClient/app/gui/Toolbar.jsx
@@ -8,9 +8,9 @@ class ToolbarComponent extends React.Component {
 	render() {
 		const style = this.props.style;
 		const theme = themeStyle(this.props.theme);
-		style.height = theme.toolbarHeight;
 		style.display = 'flex';
 		style.flexDirection = 'row';
+		style.flexWrap = 'wrap';
 		style.borderBottom = `1px solid ${theme.dividerColor}`;
 		style.boxSizing = 'border-box';
 

--- a/ElectronClient/app/gui/ToolbarButton.jsx
+++ b/ElectronClient/app/gui/ToolbarButton.jsx
@@ -26,6 +26,7 @@ class ToolbarButton extends React.Component {
 
 		const finalStyle = Object.assign({}, style, {
 			opacity: isEnabled ? 1 : 0.4,
+			height: theme.toolbarHeight,
 		});
 
 		return (


### PR DESCRIPTION
This makes the toolbar icons become multi-line if there isn't enough horizontal space, instead of them simply falling off the screen and thus being unreachable.

I moved the theme.toolbarHeight setting to ToolbarButton.jsx to try to not break existing themes (aside from this turning the height into "height per line" effectively). I haven't however seen any themes set this so I couldn't test if setting the height on each icon has the intended effect.

<img width="733" alt="Screenshot 2020-01-08 at 17 10 08" src="https://user-images.githubusercontent.com/1885159/71995757-58a6b100-323b-11ea-86d3-f74f4449b840.png">
