### PR TITLE
Added 'Yandex Disk' to the list of WebDAV-compatible services known to work with Joplin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ WebDAV-compatible services that are known to work with Joplin:
 - [Stack](https://www.transip.nl/stack/)
 - [WebDAV Nav](https://www.schimera.com/products/webdav-nav-server/), a macOS server.
 - [Zimbra](https://www.zimbra.com/)
+- [Yandex Disk](https://disk.yandex.ru/download?src=Yandex.Sidebar#pc)
 
 ## OneDrive synchronisation
 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ WebDAV-compatible services that are known to work with Joplin:
 - [Seafile](https://www.seafile.com/)
 - [Stack](https://www.transip.nl/stack/)
 - [WebDAV Nav](https://www.schimera.com/products/webdav-nav-server/), a macOS server.
-- [Zimbra](https://www.zimbra.com/)
 - [Yandex Disk](https://disk.yandex.ru/download?src=Yandex.Sidebar#pc)
+- [Zimbra](https://www.zimbra.com/)
 
 ## OneDrive synchronisation
 


### PR DESCRIPTION
Yandex Disk (cloud storage by Yandex) supports WebDAV access and is known to work with Joplin.

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
