### PR TITLE
Desktop: don't count completed to-dos in note counts when they are not shown

### DIFF
--- a/CliClient/tests/models_Folder.js
+++ b/CliClient/tests/models_Folder.js
@@ -128,25 +128,42 @@ describe('models_Folder', function() {
 	}));
 
 	it('should add node counts', asyncTest(async () => {
+		let folders, foldersById;
+
 		let f1 = await Folder.save({ title: 'folder1' });
 		let f2 = await Folder.save({ title: 'folder2', parent_id: f1.id });
 		let f3 = await Folder.save({ title: 'folder3', parent_id: f2.id });
 		let f4 = await Folder.save({ title: 'folder4' });
 
 		let n1 = await Note.save({ title: 'note1', parent_id: f3.id });
-		let n2 = await Note.save({ title: 'note1', parent_id: f3.id });
-		let n3 = await Note.save({ title: 'note1', parent_id: f1.id });
+		let n2 = await Note.save({ title: 'note2', parent_id: f3.id });
+		let n3 = await Note.save({ title: 'note3', parent_id: f1.id });
+		let n4 = await Note.save({ title: 'note4', parent_id: f3.id, is_todo: true, todo_completed: 0 });
+		let n5 = await Note.save({ title: 'note5', parent_id: f3.id, is_todo: true, todo_completed: 999 });
+		let n6 = await Note.save({ title: 'note6', parent_id: f3.id, is_todo: true, todo_completed: 999 });
 
-		const folders = await Folder.all();
-		await Folder.addNoteCounts(folders);
+		folders = await Folder.all();
+		await Folder.addNoteCounts(folders, true); // count completed
 
-		const foldersById = {};
+		foldersById = {};
 		folders.forEach((f) => { foldersById[f.id] = f; });
 
 		expect(folders.length).toBe(4);
-		expect(foldersById[f1.id].note_count).toBe(3);
-		expect(foldersById[f2.id].note_count).toBe(2);
-		expect(foldersById[f3.id].note_count).toBe(2);
+		expect(foldersById[f1.id].note_count).toBe(6);
+		expect(foldersById[f2.id].note_count).toBe(5);
+		expect(foldersById[f3.id].note_count).toBe(5);
+		expect(foldersById[f4.id].note_count).toBe(0);
+
+		folders = await Folder.all();
+		await Folder.addNoteCounts(folders, false); // don't count completed
+
+		foldersById = {};
+		folders.forEach((f) => { foldersById[f.id] = f; });
+
+		expect(folders.length).toBe(4);
+		expect(foldersById[f1.id].note_count).toBe(4);
+		expect(foldersById[f2.id].note_count).toBe(3);
+		expect(foldersById[f3.id].note_count).toBe(3);
 		expect(foldersById[f4.id].note_count).toBe(0);
 	}));
 

--- a/CliClient/tests/models_Folder.js
+++ b/CliClient/tests/models_Folder.js
@@ -128,7 +128,29 @@ describe('models_Folder', function() {
 	}));
 
 	it('should add node counts', asyncTest(async () => {
-		let folders, foldersById;
+		let f1 = await Folder.save({ title: 'folder1' });
+		let f2 = await Folder.save({ title: 'folder2', parent_id: f1.id });
+		let f3 = await Folder.save({ title: 'folder3', parent_id: f2.id });
+		let f4 = await Folder.save({ title: 'folder4' });
+
+		let n1 = await Note.save({ title: 'note1', parent_id: f3.id });
+		let n2 = await Note.save({ title: 'note1', parent_id: f3.id });
+		let n3 = await Note.save({ title: 'note1', parent_id: f1.id });
+
+		const folders = await Folder.all();
+		await Folder.addNoteCounts(folders);
+
+		const foldersById = {};
+		folders.forEach((f) => { foldersById[f.id] = f; });
+
+		expect(folders.length).toBe(4);
+		expect(foldersById[f1.id].note_count).toBe(3);
+		expect(foldersById[f2.id].note_count).toBe(2);
+		expect(foldersById[f3.id].note_count).toBe(2);
+		expect(foldersById[f4.id].note_count).toBe(0);
+	}));
+
+	it('should not count completed to-dos', asyncTest(async () => {
 
 		let f1 = await Folder.save({ title: 'folder1' });
 		let f2 = await Folder.save({ title: 'folder2', parent_id: f1.id });
@@ -142,22 +164,10 @@ describe('models_Folder', function() {
 		let n5 = await Note.save({ title: 'note5', parent_id: f3.id, is_todo: true, todo_completed: 999 });
 		let n6 = await Note.save({ title: 'note6', parent_id: f3.id, is_todo: true, todo_completed: 999 });
 
-		folders = await Folder.all();
-		await Folder.addNoteCounts(folders, true); // count completed
+		const folders = await Folder.all();
+		await Folder.addNoteCounts(folders, false);
 
-		foldersById = {};
-		folders.forEach((f) => { foldersById[f.id] = f; });
-
-		expect(folders.length).toBe(4);
-		expect(foldersById[f1.id].note_count).toBe(6);
-		expect(foldersById[f2.id].note_count).toBe(5);
-		expect(foldersById[f3.id].note_count).toBe(5);
-		expect(foldersById[f4.id].note_count).toBe(0);
-
-		folders = await Folder.all();
-		await Folder.addNoteCounts(folders, false); // don't count completed
-
-		foldersById = {};
+		const foldersById = {};
 		folders.forEach((f) => { foldersById[f.id] = f; });
 
 		expect(folders.length).toBe(4);

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -450,11 +450,16 @@ class BaseApplication {
 			refreshFolders = true;
 		}
 
-		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key.indexOf('folders.sortOrder') === 0) || action.type == 'SETTING_UPDATE_ALL')) {
+		if (this.hasGui() && action.type == 'SETTING_UPDATE_ALL')
+		{
 			refreshFolders = 'now';
 		}
 
-		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key == 'showNoteCounts') || action.type == 'SETTING_UPDATE_ALL')) {
+		if (this.hasGui() && action.type == 'SETTING_UPDATE_ONE' && (
+				action.key.indexOf('folders.sortOrder') === 0 ||
+				action.key == 'showNoteCounts' ||
+				action.key == 'showCompletedTodos' ))
+		{
 			refreshFolders = 'now';
 		}
 

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -450,16 +450,14 @@ class BaseApplication {
 			refreshFolders = true;
 		}
 
-		if (this.hasGui() && action.type == 'SETTING_UPDATE_ALL')
-		{
+		if (this.hasGui() && action.type == 'SETTING_UPDATE_ALL') {
 			refreshFolders = 'now';
 		}
 
 		if (this.hasGui() && action.type == 'SETTING_UPDATE_ONE' && (
-				action.key.indexOf('folders.sortOrder') === 0 ||
-				action.key == 'showNoteCounts' ||
-				action.key == 'showCompletedTodos' ))
-		{
+			action.key.indexOf('folders.sortOrder') === 0 ||
+			action.key == 'showNoteCounts' ||
+			action.key == 'showCompletedTodos')) {
 			refreshFolders = 'now';
 		}
 

--- a/ReactNativeClient/lib/folders-screen-utils.js
+++ b/ReactNativeClient/lib/folders-screen-utils.js
@@ -26,7 +26,8 @@ class FoldersScreenUtils {
 		}
 
 		if (Setting.value('showNoteCounts')) {
-			await Folder.addNoteCounts(folders);
+			await Folder.addNoteCounts(folders,
+				Setting.value('showCompletedTodos'));
 		}
 
 		return folders;

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -107,15 +107,18 @@ class Folder extends BaseItem {
 
 	// Calculates note counts for all folders and adds the note_count attribute to each folder
 	// Note: this only calculates the overall number of nodes for this folder and all its descendants
-	static async addNoteCounts(folders) {
+	static async addNoteCounts(folders, showDone) {
 		const foldersById = {};
 		folders.forEach((f) => {
 			foldersById[f.id] = f;
+			f.note_count = 0;
 		});
 
 		const sql = `SELECT folders.id as folder_id, count(notes.parent_id) as note_count 
-			FROM folders LEFT JOIN notes ON notes.parent_id = folders.id 
-			GROUP BY folders.id`;
+			FROM folders LEFT JOIN notes ON notes.parent_id = folders.id`
+			+ (!showDone ? ' WHERE (notes.is_todo = 0 OR notes.todo_completed = 0)' : '')
+			+ ` GROUP BY folders.id`;
+
 		const noteCounts = await this.db().selectAll(sql);
 		noteCounts.forEach((noteCount) => {
 			let parentId = noteCount.folder_id;

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -107,17 +107,18 @@ class Folder extends BaseItem {
 
 	// Calculates note counts for all folders and adds the note_count attribute to each folder
 	// Note: this only calculates the overall number of nodes for this folder and all its descendants
-	static async addNoteCounts(folders, showDone) {
+	static async addNoteCounts(folders, includeCompletedTodos = true) {
 		const foldersById = {};
 		folders.forEach((f) => {
 			foldersById[f.id] = f;
 			f.note_count = 0;
 		});
 
+		const where = !includeCompletedTodos ? 'WHERE (notes.is_todo = 0 OR notes.todo_completed = 0)' : '';
+
 		const sql = `SELECT folders.id as folder_id, count(notes.parent_id) as note_count 
-			FROM folders LEFT JOIN notes ON notes.parent_id = folders.id`
-			+ (!showDone ? ' WHERE (notes.is_todo = 0 OR notes.todo_completed = 0)' : '')
-			+ ` GROUP BY folders.id`;
+			FROM folders LEFT JOIN notes ON notes.parent_id = folders.id
+			${where} GROUP BY folders.id`;
 
 		const noteCounts = await this.db().selectAll(sql);
 		noteCounts.forEach((noteCount) => {


### PR DESCRIPTION
If completed to-dos are not shown, they should not be included in the note counts.  This makes to-do list functionality better as you can have the count show only the remaining to-dos.