### PR TITLE
Desktop: tray improvements

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1150,6 +1150,7 @@ class Application extends BaseApplication {
 		} else {
 			const contextMenu = Menu.buildFromTemplate([
 				{ label: _('Open %s', app.electronApp().getName()), click: () => { app.window().show(); } },
+				{ label: _('Hide %s', app.electronApp().getName()), click: () => { app.window().hide(); } },
 				{ type: 'separator' },
 				{ label: _('Exit'), click: () => { app.quit(); } },
 			]);

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1152,7 +1152,7 @@ class Application extends BaseApplication {
 				{ label: _('Open %s', app.electronApp().getName()), click: () => { app.window().show(); } },
 				{ label: _('Hide %s', app.electronApp().getName()), click: () => { app.window().hide(); } },
 				{ type: 'separator' },
-				{ label: _('Exit'), click: () => { app.quit(); } },
+				{ label: _('Quit'), click: () => { app.quit(); } },
 			]);
 			app.createTray(contextMenu);
 		}


### PR DESCRIPTION
- add `Hide Joplin` item to tray (see [this topic](https://discourse.joplinapp.org/t/hide-to-tray/5104?u=tessus))
- change `Exit` to `Quit`

It's very confusing that `Exit` is used in the tray but `Quit` in the app's menu.