### PR TITLE
Desktop: Fix for wrong tags shown on note

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -689,12 +689,20 @@ class NoteTextComponent extends React.Component {
 		if (newTags.length !== oldTags.length) return true;
 
 		for (let i = 0; i < newTags.length; ++i) {
+			let found = false;
 			let currNewTag = newTags[i];
 			for (let j = 0; j < oldTags.length; ++j) {
 				let currOldTag = oldTags[j];
-				if (currOldTag.id === currNewTag.id && currOldTag.updated_time !== currNewTag.updated_time) {
-					return true;
+				if (currOldTag.id === currNewTag.id) {
+					found = true;
+					if (currOldTag.updated_time !== currNewTag.updated_time) {
+						return true;
+					}
+					break;
 				}
+			}
+			if (!found) {
+				return true;
 			}
 		}
 


### PR DESCRIPTION
This fix is for a bug in the "show tags on note" feature (new feature, created in #2217, merged onto master but not yet released).

The bug causes notes to be shown with wrong tags.

To reproduce:
1. Create three notes, say `Note1`, `Note2`, `Note3`
2. Add tag `AAA` to `Note1`
3. Add tag `BBB` to `Note2`
4. Select `Note3` in the note list
5. Select `Note1` in the note list
6. Select `Note2` in the note list

Expected result: `Note2` is shown with tag `BBB`
Observed result: `Note2` is shown with tag `AAA`

The bug is because the function that compares tag lists only checks that the tag lists contain the same number of tags, and the timestamps for matching tags are the same. The fix is to ensure that all the tag ids match as well, ie it ensures the lists actually contain the same tags.