### PR TITLE
Desktop: Fix install_and_update script

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -66,7 +66,7 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
     mkdir -p ~/.joplin/
 
     # Download the latest version
-    wget -nv --show-progress -O ~/.joplin/Joplin.AppImage https://github.com/laurent22/joplin/releases/download/v$RELEASE_VERSION/Joplin-$RELEASE_VERSION-x86_64.AppImage 
+    wget -nv --show-progress -O ~/.joplin/Joplin.AppImage https://github.com/laurent22/joplin/releases/download/v$RELEASE_VERSION/Joplin-$RELEASE_VERSION.AppImage 
 
     # Gives execution privileges
     chmod +x ~/.joplin/Joplin.AppImage


### PR DESCRIPTION
AppImage files are no more post-fixed by the architecture. Changed the `wget` url to reflect that.