### PR TITLE
ru_RU translation updated and unified

### DIFF
--- a/CliClient/locales/ru_RU.po
+++ b/CliClient/locales/ru_RU.po
@@ -19,12 +19,11 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/app-gui.js:445
 msgid "To delete a tag, untag the associated notes."
-msgstr "Для удаления метки, открепите ее от связанных с ней заметок."
+msgstr "Для удаления метки открепите ее от всех связанных с ней заметок."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/app-gui.js:455
 msgid "Please select the note or notebook to be deleted first."
-msgstr ""
-"Пожалуйста, выберите заметку или блокнот, которые будут удалены первыми."
+msgstr "Пожалуйста, сначала выберите заметку или блокнот для удаления."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/app-gui.js:719
 msgid "Press Ctrl+D or type \"exit\" to exit the application"
@@ -34,7 +33,8 @@ msgstr "Для выхода из приложения нажмите Ctrl+D ил
 #, javascript-format
 msgid "More than one item match \"%s\". Please narrow down your query."
 msgstr ""
-"Более одного элемента соответствуют \"%s\". Пожалуйста, уточните ваш запрос."
+"Более одного элемента соответствуют выражению \"%s\". Пожалуйста, уточните "
+"ваш запрос."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/app.js:91
 msgid "No notebook selected."
@@ -149,25 +149,29 @@ msgid ""
 "value of [name]. If neither [name] nor [value] is provided, it will list the "
 "current configuration."
 msgstr ""
-"Выводит или задает параметр конфигурации. Если [value] не указано, выведет "
-"значение [name]. Если не указаны ни [name], ни [value], выведет текущую "
-"конфигурацию."
+"Выводит или задает значение параметра конфигурации. Если значение [value] не "
+"указано - выведет текущее значение параметра [name]. Если не указаны ни имя "
+"[name], ни значение [value] - выведет всю текущую конфигурацию."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-config.js:17
 msgid "Also displays unset and hidden config variables."
-msgstr "Также показывает неустановленные или скрытые переменные конфигурации."
+msgstr "Также выводит не установленные и скрытые параметры конфигурации."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-config.js:18
 msgid "Writes all settings to STDOUT as JSON including secure variables."
 msgstr ""
+"Выводит в стандартный поток вывода все настройки в формате JSON (включая "
+"конфиденциальные переменные)."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-config.js:19
 msgid "Reads in JSON formatted settings from STDIN."
-msgstr ""
+msgstr "Считывает конфигурацию в формате JSON из потока стандартного ввода."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-config.js:20
 msgid "Reads in settings from <file>. <file> must contain valid JSON."
 msgstr ""
+"Загружает настройки из файла <file>. <file> должен содержать данные в "
+"формате JSON."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-config.js:77
 #, javascript-format
@@ -184,8 +188,8 @@ msgid ""
 "Duplicates the notes matching <note> to [notebook]. If no notebook is "
 "specified the note is duplicated in the current notebook."
 msgstr ""
-"Дублирует заметки, содержащие <note>, в [notebook]. Если блокнот не указан, "
-"заметки продублируются в текущем."
+"Дублирует заметки соответствующие выражению <note> в блокнот [notebook]. "
+"Если блокнот не указан - заметки дублируются в текущем блокноте."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-done.js:14
 msgid "Marks a to-do as done."
@@ -194,15 +198,15 @@ msgstr "Отмечает задачу как выполненную."
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-done.js:21
 #, javascript-format
 msgid "Note is not a to-do: \"%s\""
-msgstr "Заметка не является задачей: «%s»"
+msgstr "Заметка не является задачей: \"%s\""
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:18
 msgid ""
 "Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, "
 "`status`, `decrypt-file` and `target-status`."
 msgstr ""
-"Управляет конфигурацией E2EE. Команды: `enable`, `disable`, `decrypt`, "
-"`status`,'decrypt-file' и `target-status`."
+"Управляет конфигурацией E2EE. Доступные команды: `enable`, `disable`, "
+"`decrypt`, `status`, `decrypt-file` и `target-status`."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:37
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:48
@@ -223,15 +227,15 @@ msgstr "Подтвердите пароль:"
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:59
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/encryption-config.js:143
 msgid "Passwords do not match!"
-msgstr "Пароли не соответствуют!"
+msgstr "Пароли не совпадают!"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:76
 msgid ""
 "Starting decryption... Please wait as it may take several minutes depending "
 "on how much there is to decrypt."
 msgstr ""
-"Запуск расшифровки... Пожалуйста, подождите. Время расшифровки зависит от "
-"объема расшифровываемых данных."
+"Запуск расшифровки... Пожалуйста, подождите. Расшифровка может занять "
+"несколько минут в зависимости от объема данных."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-e2ee.js:93
 msgid "Completed decryption."
@@ -264,8 +268,8 @@ msgstr "Редактировать заметку."
 msgid ""
 "No text editor is defined. Please set it using `config editor <editor-path>`"
 msgstr ""
-"Текстовый редактор не определен. Задайте его, используя `config editor "
-"<editor-path>`"
+"Текстовый редактор не задан. Задайте его командой `config editor <editor-"
+"path>`"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-edit.js:40
 msgid "No active notebook."
@@ -274,7 +278,7 @@ msgstr "Нет активного блокнота."
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-edit.js:46
 #, javascript-format
 msgid "Note does not exist: \"%s\". Create it?"
-msgstr "Заметка не существует: \"%s\". Создать?"
+msgstr "Не существует заметки: \"%s\". Создать?"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-exit.js:11
 msgid "Exits the application."
@@ -285,7 +289,7 @@ msgid ""
 "Exports Joplin data to the given path. By default, it will export the "
 "complete database including notebooks, notes, tags and resources."
 msgstr ""
-"Экспортирует данные Joplin по заданному пути. По умолчанию экспортируется "
+"Экспортирует данные Joplin в указанный каталог. По умолчанию экспортируется "
 "полная база данных, включая блокноты, заметки, метки и ресурсы."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-export.js:23
@@ -303,28 +307,28 @@ msgstr "Экспортирует только заданный блокнот."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-geoloc.js:13
 msgid "Displays a geolocation URL for the note."
-msgstr "Отображает URL геолокации для заметки."
+msgstr "Отображает URL-адрес географического местоположения для заметки."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:13
 msgid "Displays usage information."
-msgstr "Отображает информацию об использовании."
+msgstr "Отображает справочную информацию."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:36
 #, javascript-format
 msgid "For information on how to customise the shortcuts please visit %s"
-msgstr "Информацию по настройке ярлыков можно получить, посетив %s"
+msgstr "Информацию по настройке сочетаний клавиш можно получить на странице %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:44
 msgid "Shortcuts are not available in CLI mode."
-msgstr "Ярлыки недоступны в режиме командной строки."
+msgstr "Сочетания клавиш недоступны в режиме командной строки."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:71
 msgid ""
 "Type `help [command]` for more information about a command; or type `help "
 "all` for the complete usage information."
 msgstr ""
-"Введите `help [команда]` для получения информации о команде или `help all` "
-"для получения полной информации по использованию."
+"Введите `help [command]` для получения справочной информации о команде "
+"[command] или `help all` для получения полной справочной информации."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:73
 msgid "The possible commands are:"
@@ -343,27 +347,27 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:79
 msgid "To move from one pane to another, press Tab or Shift+Tab."
-msgstr "Чтобы переключаться между панелями, нажимайте Tab или Shift+Tab."
+msgstr "Для переключения между панелями используйте Tab или Shift+Tab."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:80
 msgid ""
 "Use the arrows and page up/down to scroll the lists and text areas "
 "(including this console)."
 msgstr ""
-"Используйте стрелки и клавиши page up/page down для прокрутки списков и "
-"текстовых областей (включая эту консоль)."
+"Используйте стрелки и клавиши page up/down для прокрутки списков и текстовых "
+"областей (включая эту консоль)."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:81
 msgid "To maximise/minimise the console, press \"tc\"."
-msgstr "Чтобы развернуть/свернуть консоль, нажимайте \"tc\"."
+msgstr "Чтобы развернуть/свернуть консоль используйте комбинацию \"tc\"."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:82
 msgid "To enter command line mode, press \":\""
-msgstr "Чтобы войти в режим командной строки, нажмите \":\""
+msgstr "Для входа в режим командной строки нажмите \":\""
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:83
 msgid "To exit command line mode, press ESCAPE"
-msgstr "Чтобы выйти из режима командной строки, нажмите ESCAPE"
+msgstr "Для выхода из режима командной строки нажмите ESCAPE"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-help.js:84
 msgid ""
@@ -436,8 +440,8 @@ msgid ""
 "Displays the notes in the current notebook. Use `ls /` to display the list "
 "of notebooks."
 msgstr ""
-"Выводит заметки текущего блокнота. Используйте `ls /` для вывода списка "
-"блокнотов."
+"Выводит заметки текущего блокнота. Для вывода списка блокнотов используйте "
+"`ls /`."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:26
 msgid "Displays only the first top <num> notes."
@@ -446,7 +450,7 @@ msgstr "Выводит только первые <num> заметок."
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:26
 msgid "Sorts the item by <field> (eg. title, updated_time, created_time)."
 msgstr ""
-"Сортирует элементы по <field> (напр. title, updated_time, created_time)."
+"Сортирует элементы по полю <field> (напр. title, updated_time, created_time)."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:26
 msgid "Reverses the sorting order."
@@ -458,13 +462,13 @@ msgid ""
 "for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the "
 "to-dos, while `-ttd` would display notes and to-dos."
 msgstr ""
-"Отображает только элементы указанного типа(ов). Может быть `n` для заметок, "
-"`t` для задач или `nt` для заметок и задач (напр. `-tt` выведет только "
-"задачи, в то время как `-ttd` выведет заметки и задачи)."
+"Отображает только элементы заданного типа(ов). Поддерживаемые типы: `n` для "
+"заметок, `t` для задач или `nt` для заметок и задач (напр. `-tt` выведет "
+"только задачи, в то время как `-ttd` выведет и заметки и задачи)."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:26
 msgid "Either \"text\" or \"json\""
-msgstr "Также \"text\" или \"json\""
+msgstr "Или \"text\" или \"json\""
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:26
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-tag.js:18
@@ -472,7 +476,7 @@ msgid ""
 "Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, "
 "TODO_CHECKED (for to-dos), TITLE"
 msgstr ""
-"Использовать формат длинного списка. Форматом является ID, NOTE_COUNT (для "
+"Использовать расширенный формат списка. Поля формата: ID, NOTE_COUNT (для "
 "блокнотов), DATE, TODO_CHECKED (для задач), TITLE"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ls.js:56
@@ -498,11 +502,12 @@ msgstr "Создает новую задачу."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-mv.js:14
 msgid "Moves the notes matching <note> to [notebook]."
-msgstr "Перемещает заметки, содержащие <note> в [notebook]."
+msgstr ""
+"Перемещает заметки соответствующие выражению <note> в блокнот [notebook]."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-ren.js:14
 msgid "Renames the given <item> (note or notebook) to <name>."
-msgstr "Переименовывает заданный <item> (заметку или блокнот) в <name>."
+msgstr "Переименовывает элемент <item> (заметку или блокнот) в <name>."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-rmbook.js:13
 msgid "Deletes the given notebook."
@@ -518,12 +523,12 @@ msgid ""
 "Delete notebook? All notes and sub-notebooks within this notebook will also "
 "be deleted."
 msgstr ""
-"Удалить блокнот? Все заметки и вложенные блокноты в этом блокноте также "
-"будут удалены."
+"Удалить блокнот? Все содержимое блокнота, включая заметки и вложенные "
+"блокноты, будет удалено."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-rmnote.js:13
 msgid "Deletes the notes matching <note-pattern>."
-msgstr "Удаляет заметки, соответствующие <note-pattern>."
+msgstr "Удаляет заметки, соответствующие выражению <note-pattern>."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-rmnote.js:17
 msgid "Deletes the notes without asking for confirmation."
@@ -532,7 +537,7 @@ msgstr "Удаляет заметки без запроса подтвержде
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-rmnote.js:27
 #, javascript-format
 msgid "%d notes match this pattern. Delete them?"
-msgstr "%d заметок соответствуют этому шаблону. Удалить их?"
+msgstr "%d заметок соответствуют указанному выражению. Удалить их?"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-rmnote.js:27
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:347
@@ -541,7 +546,7 @@ msgstr "Удалить заметку?"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-search.js:13
 msgid "Searches for the given <pattern> in all the notes."
-msgstr "Запросы для заданного <pattern> во всех заметках."
+msgstr "Осуществляет поиск по шаблону <pattern> во всех заметках."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-server.js:14
 #, javascript-format
@@ -550,17 +555,17 @@ msgid ""
 "set the api.port config variable. Commands are (%s)."
 msgstr ""
 "Запустить, остановить или проверить сервер API. Порт сервера настраивается с "
-"помощью переменной api.port. Доступные команды: (%s)."
+"помощью параметра конфигурации api.port. Доступные команды: (%s)."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-server.js:37
 #, javascript-format
 msgid "Server is already running on port %d"
-msgstr "Сервер уже запущен на порту %d"
+msgstr "Сервер уже запущен. Порт: %d"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-server.js:43
 #, javascript-format
 msgid "Server is running on port %d"
-msgstr "Сервер запущен на порту %d"
+msgstr "Сервер запущен. Порт: %d"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-server.js:43
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-server.js:46
@@ -575,8 +580,8 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"Устанавливает для свойства <name> заданной <note> заданному [value]. "
-"Возможные свойства:\n"
+"Устанавливает значение [value] для свойства <name> заметки <note>. Доступные "
+"свойства:\n"
 "\n"
 "%s"
 
@@ -592,7 +597,7 @@ msgstr "Синхронизирует с удаленным хранилищем.
 msgid "Sync to provided target (defaults to sync.target config value)"
 msgstr ""
 "Синхронизация с заданной целью (по умолчанию используется значение "
-"конфигурации sync.target"
+"конфигурации sync.target)"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:77
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:91
@@ -615,7 +620,7 @@ msgstr ""
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/dropbox-login.js:54
 msgid "Step 1: Open this URL in your browser to authorise the application:"
 msgstr ""
-"Шаг 1: Откройте этот URL в вашем браузере, чтобы авторизовать приложение:"
+"Шаг 1: Для авторизации приложения откройте следующую ссылку в вашем браузере:"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:89
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/DropboxLoginScreen.min.js:57
@@ -627,7 +632,8 @@ msgstr "Шаг 2: Введите код, предоставленный Dropbox:
 #, javascript-format
 msgid "Not authentified with %s. Please provide any missing credentials."
 msgstr ""
-"Не аутентифицировано с %s. Пожалуйста, предоставьте все недостающие данные."
+"Не удалось аутентифицироваться с %s. Пожалуйста, предоставьте недостающие "
+"данные."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:124
 msgid "Synchronisation is already in progress."
@@ -640,8 +646,8 @@ msgid ""
 "taking place, you may delete the lock file at \"%s\" and resume the "
 "operation."
 msgstr ""
-"Файл блокировки уже установлен. Если вам известно, что синхронизация не "
-"производится, вы можете удалить файл блокировки в \"%s\" и возобновить "
+"Файл блокировки уже существует. Если вы уверены, что синхронизация не "
+"выполняется - вы можете вручную удалить файл блокировки \"%s\" и возобновить "
 "операцию."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:175
@@ -651,7 +657,7 @@ msgstr "Цель синхронизации: %s (%s)"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:177
 msgid "Cannot initialize synchroniser."
-msgstr "Не удалось инициировать синхронизацию."
+msgstr "Не удалось инициализировать модуль синхронизации."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-sync.js:179
 msgid "Starting synchronisation..."
@@ -666,17 +672,17 @@ msgid "Cancelling... Please wait."
 msgstr "Отмена... Пожалуйста, подождите."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-tag.js:14
-#, fuzzy
 msgid ""
 "<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to "
 "assign or remove [tag] from [note], to list notes associated with [tag], or "
 "to list tags associated with [note]. The command `tag list` can be used to "
 "list all the tags (use -l for long option)."
 msgstr ""
-"<tag-command> может быть \"add\", \"remove\" или \"list\", чтобы назначить "
-"или убрать [tag] с [note], или чтобы вывести список заметок, ассоциированых "
-"с [tag]. Команда `tag list` может быть использована для вывода списка всех "
-"меток."
+"<tag-command> может принимать значения \"add\", \"remove\", \"list\" или "
+"\"notetags\", позволяющие, соответственно: добавить или убрать метку [tag] с "
+"заметки [note]; вывести список заметок, ассоциированных с меткой [tag]; "
+"вывести список меток, ассоциированных с заметкой [note]. Команда `tag list` "
+"выводит список всех меток."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-tag.js:90
 #, javascript-format
@@ -690,10 +696,10 @@ msgid ""
 "target is a regular note it will be converted to a to-do). Use \"clear\" to "
 "convert the to-do back to a regular note."
 msgstr ""
-"<todo-command> может быть \"toggle\" или \"clear\". \"toggle\" используется "
-"для переключения статуса заданной задачи на завершенную или незавершенную "
-"(если применить к обычной заметке, она будет преобразована в задачу). \"clear"
-"\" используется для преобразования задачи обратно в обычную заметку."
+"<todo-command> может принимать значения \"toggle\" или \"clear\". \"toggle\" "
+"переключает статус выбранной задачи (с завершенной на незавершенную и "
+"наоборот). При применении к обычной заметке - заметка преобразуется в "
+"задачу. \"clear\" преобразует выбранную задачу в обычную заметку."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-undone.js:12
 msgid "Marks a to-do as non-completed."
@@ -704,8 +710,8 @@ msgid ""
 "Switches to [notebook] - all further operations will happen within this "
 "notebook."
 msgstr ""
-"Переключает на [блокнот] — все дальнейшие операции будут происходить в этом "
-"блокноте."
+"Совершает переход в блокнот [notebook]. Все дальнейшие операции будут "
+"совершены в этом блокноте."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/command-version.js:11
 msgid "Displays version information"
@@ -741,7 +747,7 @@ msgstr "Возможные ключи/значения:"
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/main.js:77
 msgid "Type `joplin help` for usage information."
-msgstr "Введите `joplin help` для получения информации об использовании."
+msgstr "Введите `joplin help` для получения справочной информации."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/main.js:79
 msgid "Fatal error:"
@@ -763,10 +769,9 @@ msgstr ""
 "Добро пожаловать в Joplin!\n"
 "\n"
 "Введите `:help shortcuts` для просмотра списка клавиатурных сочетаний или "
-"просто `:help` для просмотра информации об использовании.\n"
+"просто `:help` для просмотра справочной информации.\n"
 "\n"
-"Например, для создания блокнота нужно ввести `mb`, для создания заметки — "
-"`mn`."
+"Например, для создания блокнота введите `mb`, для создания заметки - `mn`."
 
 #: /Users/tessus/data/work/joplin/Tools/../CliClient/app/gui/NoteWidget.js:48
 msgid ""
@@ -775,10 +780,10 @@ msgid ""
 "supplied the password, the encrypted items are being decrypted in the "
 "background and will be available soon."
 msgstr ""
-"Один или несколько элементов зашифрованы, и для их расшифровки может "
-"потребоваться пароль. Для этого введите `e2ee decrypt`. Если пароль уже был "
-"вами предоставлен, зашифрованные элементы расшифруются в фоновом режиме и "
-"вскоре станут доступны."
+"Один или несколько элементов зашифрованы. Для расшифровки может "
+"потребоваться мастер-пароль. Для начала расшифровки введите `e2ee decrypt`. "
+"Если мастер-пароль уже был введен - зашифрованные элементы уже "
+"расшифровываются в фоновом режиме и вскоре будут доступны."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:645
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:728
@@ -916,12 +921,12 @@ msgstr "Переключить боковую панель"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:927
 msgid "Layout button sequence"
-msgstr ""
+msgstr "Порядок переключения вида"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:931
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/MainScreen.min.js:470
 msgid "Toggle note list"
-msgstr "Список заметок"
+msgstr "Переключить список заметок"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:940
 msgid "Toggle editor layout"
@@ -1000,16 +1005,16 @@ msgstr "Отмена"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/checkForUpdates.js:137
 msgid "Current version is up-to-date."
-msgstr "Текущая версия актуальна."
+msgstr "Установлена последняя версия."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/checkForUpdates.js:146
 #, javascript-format
 msgid "%s (pre-release)"
-msgstr "%s (предварительный релиз)"
+msgstr "%s (предварительный выпуск)"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/checkForUpdates.js:150
 msgid "An update is available, do you want to download it now?"
-msgstr "Доступно обновление, вы хотите загрузить его сейчас?"
+msgstr "Доступно обновление, хотите загрузить его сейчас?"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/checkForUpdates.js:150
 #, javascript-format
@@ -1031,7 +1036,7 @@ msgstr "Нет"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/checkForUpdates.js:151
 msgid "Full Release Notes"
-msgstr "Полное примечание к выпуску"
+msgstr "Описание установленной версии"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:39
 msgid "Token has been copied to the clipboard!"
@@ -1044,7 +1049,7 @@ msgstr "Служба веб-клиппера включена и настрое�
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:76
 #, javascript-format
 msgid "Status: Started on port %d"
-msgstr "Статус: запущен. Порт %d"
+msgstr "Статус: запущен. Порт: %d"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:82
 #, javascript-format
@@ -1073,11 +1078,11 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:127
 msgid "In order to use the web clipper, you need to do the following:"
-msgstr "Для использования веб-клиппера вам нужно сделать следующее:"
+msgstr "Для использования веб-клиппера сделайте следующее:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:135
 msgid "Step 1: Enable the clipper service"
-msgstr "Шаг 1: включите службу веб-клиппера"
+msgstr "Шаг 1: Включите службу веб-клиппера"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:140
 msgid ""
@@ -1091,7 +1096,7 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:154
 msgid "Step 2: Install the extension"
-msgstr "Шаг 2: установите расширение"
+msgstr "Шаг 2: Установите расширение"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ClipperConfigScreen.min.js:159
 msgid "Download and install the relevant extension for your browser:"
@@ -1114,8 +1119,8 @@ msgid ""
 "This authorisation token is only needed to allow third-party applications to "
 "access Joplin."
 msgstr ""
-"Этот токен авторизации необходим только для разрешения сторонним приложениям "
-"получать доступ к Joplin."
+"Данный токен используется только для авторизации доступа сторонних "
+"приложений к Joplin."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:82
 msgid "This will open a new screen. Save your current changes?"
@@ -1132,50 +1137,45 @@ msgid "Check synchronisation configuration"
 msgstr "Проверить настройки синхронизации"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:174
-#, fuzzy
 msgid "Unknown"
-msgstr "Неизвестный флаг: %s"
+msgstr "Неизвестно"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:178
-#, fuzzy
 msgid "Checking..."
-msgstr "Отмена..."
+msgstr "Проверка..."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:182
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Resource.js:289
-#, fuzzy
 msgid "Error"
-msgstr "Только ошибки"
+msgstr "Ошибка"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:193
 msgid ""
 "The Joplin Nextcloud App is either not installed or misconfigured. Please "
 "see the full error message below:"
 msgstr ""
+"Приложение Joplin Nextcloud не установлено или не настроено. Полный текст "
+"ошибки:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:206
-#, fuzzy
 msgid "Show Log"
-msgstr "Показать все"
+msgstr "Показать журнал"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:219
 msgid "Joplin Nextcloud App status:"
-msgstr ""
+msgstr "Статус приложения Joplin Nextcloud:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:233
-#, fuzzy
 msgid "Check Status"
-msgstr "Синхронизировать статус"
+msgstr "Проверить статус"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:240
-#, fuzzy
 msgid "Help"
-msgstr "&Помощь"
+msgstr "Помощь"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:259
-#, fuzzy
 msgid "Show Advanced Settings"
-msgstr "Расширенные настройки"
+msgstr "Показать расширенные настройки"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ConfigScreen.min.js:516
 msgid "Browse..."
@@ -1214,8 +1214,8 @@ msgid ""
 "continue?"
 msgstr ""
 "Отключение шифрования означает, что *все* ваши заметки и вложения будут "
-"пересинхронизированы и отправлены в расшифрованном виде к цели "
-"синхронизации. Вы хотите продолжить?"
+"расшифрованы и отправлены в незашифрованом виде к цели синхронизации. Вы "
+"хотите продолжить?"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/EncryptionConfigScreen.min.js:143
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/encryption-config.js:153
@@ -1226,10 +1226,10 @@ msgid ""
 "the data! To enable encryption, please enter your password below."
 msgstr ""
 "Включение шифрования означает, что *все* ваши заметки и вложения будут "
-"пересинхронизированы и отправлены в зашифрованном виде к цели синхронизации. "
-"Не теряйте пароль, так как в целях безопасности *только* с его помощью можно "
-"будет расшифровать данные! Чтобы включить шифрование, введите ваш пароль "
-"ниже."
+"зашифрованы и отправлены в зашифрованном виде к цели синхронизации. Не "
+"теряйте пароль, так как в целях безопасности расшифровка данных будет "
+"возможна *только* с его помощью! Чтобы включить шифрование, введите ваш "
+"пароль ниже."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/EncryptionConfigScreen.min.js:172
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/encryption-config.js:259
@@ -1283,7 +1283,7 @@ msgid ""
 "as \"active\"). Any of the keys might be used for decryption, depending on "
 "how the notes or notebooks were originally encrypted."
 msgstr ""
-"Внимание: Для шифрования может быть использован только один мастер-ключ "
+"Внимание: для шифрования может быть использован только один мастер-ключ "
 "(отмеченный как \"active\"). Для расшифровки может использоваться любой из "
 "ключей, в зависимости от того, как изначально были зашифрованы заметки или "
 "блокноты."
@@ -1311,7 +1311,7 @@ msgid ""
 "enable it please check the documentation:"
 msgstr ""
 "Для получения дополнительной информации о сквозном шифровании (E2EE) и "
-"советах о том, как его включить, пожалуйста, обратитесь к документации:"
+"советов о том, как его включить, пожалуйста, обратитесь к документации:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/EncryptionConfigScreen.min.js:327
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/encryption-config.js:280
@@ -1325,19 +1325,19 @@ msgstr "Шифрование:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ExtensionBadge.min.js:10
 msgid "Firefox Extension"
-msgstr ""
+msgstr "Расширение Firefox"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ExtensionBadge.min.js:17
 msgid "Chrome Web Store"
-msgstr ""
+msgstr "Интернет-магазин Chrome"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ExtensionBadge.min.js:44
 msgid "Get it now:"
-msgstr ""
+msgstr "Загрузить сейчас:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/Header.min.js:210
 msgid "Usage"
-msgstr "Использование: %s"
+msgstr "Использование"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ImportScreen.min.js:62
 #, javascript-format
@@ -1395,7 +1395,7 @@ msgstr "Новый блокнот"
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/MainScreen.min.js:505
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1046
 msgid "Layout"
-msgstr "Разметка"
+msgstr "Вид редактора"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/MainScreen.min.js:514
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteSearchBar.min.js:123
@@ -1408,7 +1408,7 @@ msgstr "Некоторые элементы не могут быть синхр�
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/MainScreen.min.js:563
 msgid "View them now"
-msgstr "Просмотреть их сейчас"
+msgstr "Просмотреть сейчас"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/MainScreen.min.js:570
 msgid "One or more master keys need a password."
@@ -1420,12 +1420,12 @@ msgstr "Установить пароль"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteList.min.js:418
 msgid "No notes in here. Create one by clicking on \"New note\"."
-msgstr "Здесь нет заметок. Создайте новую, нажав на \"Новая заметка\"."
+msgstr "Заметки отсутствуют. Создайте новую, нажав на \"Новая заметка\"."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteList.min.js:418
 msgid ""
 "There is currently no notebook. Create one by clicking on \"New notebook\"."
-msgstr "Сейчас здесь нет блокнотов. Создайте новый, нажав \"Новый блокнот\"."
+msgstr "Блокноты отсутствуют. Создайте новый, нажав на \"Новый блокнот\"."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NotePropertiesDialog.min.js:29
 msgid "Location"
@@ -1460,7 +1460,7 @@ msgstr "Заметка “%s” была успешно восстановлен
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteRevisionViewer.min.js:100
 msgid "This note has no history"
-msgstr "Эта заметка не имеет предыдущей версии"
+msgstr "Эта заметка не имеет предыдущих версий"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteRevisionViewer.min.js:139
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:853
@@ -1504,12 +1504,11 @@ msgstr "Скопировать ссылку"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:821
 msgid "There was an error downloading this attachment:"
-msgstr ""
+msgstr "Произошла ошибка при загрузке вложения:"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:823
-#, fuzzy
 msgid "This attachment is not downloaded or not decrypted yet"
-msgstr "Это вложение еще не загружено или еще не расшифровано."
+msgstr "Это вложение еще не загружено или еще не расшифровано"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1046
 #, javascript-format
@@ -1517,22 +1516,22 @@ msgid ""
 "This note has no content. Click on \"%s\" to toggle the editor and edit the "
 "note."
 msgstr ""
-"Эта заметка не имеет содержания. Нажмите на \"%s\", чтобы переключиться в "
-"редактор и отредактировать ее."
+"Эта пустая заметка. Нажмите на \"%s\", чтобы переключиться в редактор и "
+"отредактировать ее."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1455
 msgid "strong text"
-msgstr "выделенный текст"
+msgstr "полужирный текст"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1459
 msgid "emphasized text"
-msgstr "подчеркнутый текст"
+msgstr "выделенный текст"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1493
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1497
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1504
 msgid "List item"
-msgstr "Список"
+msgstr "Элемент списка"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1516
 msgid "Insert Hyperlink"
@@ -1568,7 +1567,7 @@ msgstr "Маркированный список"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1653
 msgid "Checkbox"
-msgstr "Пометка"
+msgstr "Флажок"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1661
 msgid "Heading"
@@ -1580,7 +1579,7 @@ msgstr "Горизотальный разделитель"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1691
 msgid "Click to stop external editing"
-msgstr "Нажмите, чтобы остановить внешнее редактирование"
+msgstr "Нажмите, чтобы выйти из внешнего редактора"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/NoteText.min.js:1692
 msgid "Watching..."
@@ -1620,47 +1619,44 @@ msgid "Synchronisation Status"
 msgstr "Статус синхронизации"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:163
-#, fuzzy
 msgid "Synchronising..."
-msgstr "Синхронизация"
+msgstr "Синхронизация..."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:165
-#, fuzzy
 msgid "Generating link..."
 msgid_plural "Generating links..."
-msgstr[0] "Создание новой %s..."
-msgstr[1] "Создание новой %s..."
-msgstr[2] "Создание новой %s..."
+msgstr[0] "Создание ссылки..."
+msgstr[1] "Создание ссылок..."
+msgstr[2] "Создание ссылок..."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:167
-#, fuzzy
 msgid "Link has been copied to clipboard!"
 msgid_plural "Links have been copied to clipboard!"
-msgstr[0] "Токен скопирован в буфер обмена!"
-msgstr[1] "Токен скопирован в буфер обмена!"
-msgstr[2] "Токен скопирован в буфер обмена!"
+msgstr[0] "Ссылка скопирована в буфер обмена!"
+msgstr[1] "Ссылки скопированы в буфер обмена!"
+msgstr[2] "Ссылки скопированы в буфер обмена!"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:170
 msgid ""
 "Note: When a note is shared, it will no longer be encrypted on the server."
 msgstr ""
+"Примечание: если вы поделились заметкой - она будет храниться на сервере в "
+"незашифрованном виде."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:175
-#, fuzzy
 msgid "Share Notes"
-msgstr "Восстановленные заметки"
+msgstr "Поделиться заметками"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:177
-#, fuzzy
 msgid "Copy Shareable Link"
 msgid_plural "Copy Shareable Links"
-msgstr[0] "Поделиться"
-msgstr[1] "Поделиться"
-msgstr[2] "Поделиться"
+msgstr[0] "Скопировать общедоступную ссылку"
+msgstr[1] "Скопировать общедоступные ссылки"
+msgstr[2] "Скопировать общедоступные ссылки"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/ShareNoteDialog.js:180
 msgid "Close"
-msgstr ""
+msgstr "Закрыть"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/SideBar.min.js:280
 msgid "Remove"
@@ -1676,7 +1672,7 @@ msgid ""
 msgstr ""
 "Удалить блокнот “%s”?\n"
 "\n"
-"Все заметки и вложенные блокноты в этом блокноте также будут удалены."
+"Все заметки и вложенные блокноты также будут удалены."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/SideBar.min.js:284
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:188
@@ -1715,18 +1711,18 @@ msgstr "Блокноты"
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/side-menu-content.js:322
 #, javascript-format
 msgid "Decrypting items: %d/%d"
-msgstr "Расшифровано элементов: %d/%d"
+msgstr "Расшифровка элементов: %d/%d"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/SideBar.min.js:778
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/side-menu-content.js:327
 #, javascript-format
 msgid "Fetching resources: %d/%d"
-msgstr "Получение ресурсов: %d/%d"
+msgstr "Загрузка ресурсов: %d/%d"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/StatusScreen.min.js:33
 msgid "Please select where the sync status should be exported to"
 msgstr ""
-"Пожалуйста, выберите, куда должен быть экспортирован статус синхронизации"
+"Пожалуйста, выберите куда должен быть экспортирован статус синхронизации"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/StatusScreen.min.js:87
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/status.js:106
@@ -1740,7 +1736,7 @@ msgstr "Добавить или удалить метки"
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:41
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screen-header.js:316
 msgid "Duplicate"
-msgstr "Дубликат"
+msgstr "Создать дубликат"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:46
 #, javascript-format
@@ -1748,9 +1744,8 @@ msgid "%s - Copy"
 msgstr "%s - Копия"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:66
-#, fuzzy
 msgid "Stop external editing"
-msgstr "Нажмите, чтобы остановить внешнее редактирование"
+msgstr "Выйти из внешнего редактора"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:78
 msgid "Switch between note and to-do type"
@@ -1758,11 +1753,11 @@ msgstr "Переключить между заметкой и задачей"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:101
 msgid "Switch to note type"
-msgstr "Переключить тип на заметку"
+msgstr "Конвертировать в заметку"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:110
 msgid "Switch to to-do type"
-msgstr "Переключить тип на задачу"
+msgstr "Конвертировать в задачу"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:120
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:709
@@ -1770,9 +1765,8 @@ msgid "Copy Markdown link"
 msgstr "Копировать ссылку Markdown"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:135
-#, fuzzy
 msgid "Share note..."
-msgstr "Восстановленные заметки"
+msgstr "Поделиться заметкой..."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/gui/utils/NoteListUtils.js:169
 msgid "PDF File"
@@ -1798,7 +1792,7 @@ msgid ""
 "Type a note title to jump to it. Or type # followed by a tag name, or @ "
 "followed by a notebook name."
 msgstr ""
-"Введите название заметки, чтобы перейти к ней, либо введите #имя_тега или "
+"Введите название заметки чтобы перейти к ней, либо введите #имя_метки или "
 "@имя_блокнота."
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/plugins/GotoAnything.min.js:377
@@ -1825,6 +1819,9 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Не удалось установить соединение с сервисом Joplin Nextcloud. Пожалуйста "
+"проверьте настройки синхронизации. Полный текст ошибки:\n"
+"%s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/SyncTargetDropbox.js:25
 msgid "Dropbox"
@@ -1853,7 +1850,7 @@ msgstr "WebDAV"
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/logger.js:176
 #, javascript-format
 msgid "Unknown log level: %s"
-msgstr "Неизвестный уровень лога: %s"
+msgstr "Неизвестный уровень детализации журнала: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/logger.js:185
 #, javascript-format
@@ -1863,7 +1860,7 @@ msgstr "Неизвестный уровень ID: %s"
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/onedrive-api-node-utils.js:85
 msgid ""
 "The application has been authorised - you may now close this browser tab."
-msgstr "Приложение авторизовано — можно закрыть вкладку браузера."
+msgstr "Приложение авторизовано - можно закрыть вкладку браузера."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/onedrive-api-node-utils.js:87
 msgid "The application has been successfully authorised."
@@ -1878,10 +1875,10 @@ msgid ""
 "will be shared with any third party."
 msgstr ""
 "Откройте следующую ссылку в вашем браузере для аутентификации приложения. "
-"Приложением будет создан каталог \"Apps/Joplin\". Чтение и запись файлов "
-"будет осуществляться только в нем. У приложения не будет доступа к каким-"
-"либо файлам за пределами этого каталога и другим личным данным. Никакая "
-"информация не будет передана третьим лицам."
+"Приложением будет создан отдельный каталог \"Apps/Joplin\", в котором будет "
+"происходить работа с файлами. У приложения не будет доступа ни к каким-либо "
+"файлам за пределами этого каталога ни к каким-либо другим личным данным. "
+"Никакая информация не будет передана третьим лицам."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/onedrive-api.js:270
 msgid ""
@@ -1889,7 +1886,7 @@ msgid ""
 "synchronisation again may fix the problem."
 msgstr ""
 "Невозможно обновить токен: отсутствуют данные аутентификации. Повторный "
-"запуск синхронизации может решить проблему."
+"запуск синхронизации может решить эту проблему."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/path-utils.js:65
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/path-utils.js:101
@@ -1917,7 +1914,7 @@ msgstr ""
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/shim-init-node.js:126
 #, javascript-format
 msgid "Cannot access %s"
-msgstr "Не удалось получить доступ %s"
+msgstr "Не удалось получить доступ к %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/synchronizer.js:94
 #, javascript-format
@@ -1932,12 +1929,12 @@ msgstr "Обновлено локальных элементов: %d."
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/synchronizer.js:96
 #, javascript-format
 msgid "Created remote items: %d."
-msgstr "Создано удаленных элементов: %d."
+msgstr "Создано элементов в хранилище: %d."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/synchronizer.js:97
 #, javascript-format
 msgid "Updated remote items: %d."
-msgstr "Обновлено удаленных элементов: %d."
+msgstr "Обновлено элементов в хранилище: %d."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/synchronizer.js:98
 #, javascript-format
@@ -2000,7 +1997,7 @@ msgstr "Конфликты"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Folder.js:345
 msgid "Cannot move notebook to this location"
-msgstr "Не удается переместить блокнот в это расположение"
+msgstr "Не удается переместить блокнот в указанное местоположение"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Folder.js:393
 #, javascript-format
@@ -2014,7 +2011,7 @@ msgstr "дата создания"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Note.js:104
 msgid "This note does not have geolocation information."
-msgstr "Эта заметка не содержит информации о геолокации."
+msgstr "Эта заметка не содержит информации о географическом местоположении."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Note.js:431
 #, javascript-format
@@ -2028,16 +2025,15 @@ msgstr "Не удалось переместить заметку в блокн�
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Resource.js:286
 msgid "Not downloaded"
-msgstr ""
+msgstr "Не загружено"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Resource.js:287
-#, fuzzy
 msgid "Downloading"
-msgstr "Загрузка ресурсов..."
+msgstr "Загрузка"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Resource.js:288
 msgid "Downloaded"
-msgstr ""
+msgstr "Загружено"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:27
 #, javascript-format
@@ -2046,26 +2042,26 @@ msgid ""
 "to it before syncing, otherwise all files will be removed! See the FAQ for "
 "more details: %s"
 msgstr ""
-"Внимание: если вы измените это местоположение, обязательно скопируйте все "
-"содержимое перед синхронизацией, в противном случае все файлы будут удалены! "
-"Смотрите FAQ для получения подробной информации: %s"
+"Внимание: если вы измените это местоположение, обязательно скопируйте в "
+"новое местоположение все свои данные перед синхронизацией, в противном "
+"случае все файлы будут удалены! Смотрите FAQ для получения подробной "
+"информации: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:45
 msgid "Keyboard Mode"
-msgstr ""
+msgstr "Режим работы клавиатуры"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:48
-#, fuzzy
 msgid "Default"
 msgstr "По умолчанию: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:49
 msgid "Emacs"
-msgstr ""
+msgstr "Emacs"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:50
 msgid "Vim"
-msgstr ""
+msgstr "Vim"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:60
 msgid "Synchronisation target"
@@ -2109,7 +2105,7 @@ msgstr "Пароль WebDAV"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:175
 msgid "Attachment download behaviour"
-msgstr "Правило загрузок вложений"
+msgstr "Режим загрузки вложений"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:176
 msgid ""
@@ -2117,9 +2113,9 @@ msgid ""
 "In \"Auto\", they are downloaded when you open the note. In \"Always\", all "
 "the attachments are downloaded whether you open the note or not."
 msgstr ""
-"В режиме “Ручной” вложения скачиваются, если на них кликнуть. В режиме "
-"“Автоматически”, вложения скачиваются при открытии заметки. В режиме "
-"“Всегда” все заметки скачиваются всегда."
+"В режиме “Ручной” вложения загружаются толко если на них кликнуть. В режиме "
+"“Автоматически” вложения загружаются при открытии заметки. В режиме “Всегда” "
+"вложения загружаются не зависимо от того была заметка открыта или нет."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:179
 msgid "Always"
@@ -2197,19 +2193,19 @@ msgstr "Просмотрщик"
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:263
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:264
 msgid "Split View"
-msgstr "Разделение"
+msgstr "Раздельный вид"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:261
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s / %s / %s"
-msgstr "%s = %s (%s)"
+msgstr "%s / %s / %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:262
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:263
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:264
 #, javascript-format
 msgid "%s / %s"
-msgstr ""
+msgstr "%s / %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:267
 msgid "Uncompleted to-dos on top"
@@ -2217,7 +2213,7 @@ msgstr "Незавершенные задачи сверху"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:268
 msgid "Show completed to-dos"
-msgstr "Показать незавершенные задачи"
+msgstr "Показать завершенные задачи"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:276
 msgid "Sort notes by"
@@ -2225,7 +2221,7 @@ msgstr "Сортировать заметки по"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:293
 msgid "Auto-pair braces, parenthesis, quotations, etc."
-msgstr ""
+msgstr "Автоматическое закрытие скобок, кавычек и т. д."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:295
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:313
@@ -2238,7 +2234,7 @@ msgstr "Сортировать блокноты по"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:314
 msgid "Save geo-location with notes"
-msgstr "Сохранять информацию о геолокации в заметках"
+msgstr "Сохранять информацию о географическом местоположении в заметках"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:322
 msgid "When creating a new to-do:"
@@ -2264,7 +2260,7 @@ msgstr "Включить мягкие отступы"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:352
 msgid "Enable typographer support"
-msgstr "Включить поддержку typographer "
+msgstr "Включить поддержку typographer"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:353
 msgid "Enable math expressions"
@@ -2280,7 +2276,7 @@ msgstr "Включить постраничные сноски"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:356
 msgid "Enable table of contents extension"
-msgstr "Включить расширение содержания"
+msgstr "Включить расширение поддержки оглавления"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:357
 msgid "Enable ~sub~ syntax"
@@ -2300,7 +2296,7 @@ msgstr "Включить синтаксис аббревиатур"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:361
 msgid "Enable markdown emoji"
-msgstr "Включить markdown emoji"
+msgstr "Включить эмодзи markdown"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:362
 msgid "Enable ++insert++ syntax"
@@ -2312,7 +2308,7 @@ msgstr "Включить расширение таблиц multimarkdown"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:364
 msgid "Enable Fountain syntax support"
-msgstr "Включить поддержку Fountain"
+msgstr "Включить поддержку синтаксиса Fountain"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:376
 msgid "Show tray icon"
@@ -2320,7 +2316,7 @@ msgstr "Показывать иконку в трее"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:378
 msgid "Note: Does not work in all desktop environments."
-msgstr "Примечание: работает не во всех средах рабочего стола."
+msgstr "Примечание: работает не во всех окружениях рабочего стола."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:378
 msgid ""
@@ -2329,8 +2325,8 @@ msgid ""
 "reducing the number of conflicts."
 msgstr ""
 "Это позволит Joplin работать в фоновом режиме. Рекомендуется включить этот "
-"параметр, чтобы ваши заметки синхронизировались постоянно, таким образом, "
-"уменьшая количество конфликтов."
+"параметр, чтобы ваши заметки синхронизировались постоянно, что уменьшит "
+"количество возможных конфликтов."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:382
 msgid "Start application minimised in the tray icon"
@@ -2357,12 +2353,13 @@ msgid ""
 "This must be *monospace* font or it will not work properly. If the font is "
 "incorrect or empty, it will default to a generic monospace font."
 msgstr ""
-"Это должен быть моноширинный шрифт или он не будет работать корректно. Если "
-"название некорректно или пустое, будет использован шрифт по умолчанию."
+"Для корректной работы должно быть указано название *моноширинного* шрифта. "
+"Если название шрифта не указано или указано некорректно - будет использован "
+"шрифт по умолчанию."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:463
 msgid "Custom stylesheet for Joplin-wide app styles"
-msgstr ""
+msgstr "Пользовательская таблица стилей для приложения"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:467
 msgid "Automatically update the application"
@@ -2370,7 +2367,7 @@ msgstr "Автоматически обновлять приложение"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:468
 msgid "Get pre-releases when checking for updates"
-msgstr "Получать предварительные релизы при проверке обновлений"
+msgstr "Получать предварительные выпуски при проверке обновлений"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:468
 #, javascript-format
@@ -2381,7 +2378,7 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:476
 msgid "Synchronisation interval"
-msgstr "Интервал синхронизации"
+msgstr "Период синхронизации"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:480
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:481
@@ -2410,49 +2407,49 @@ msgid ""
 "The editor command (may include arguments) that will be used to open a note. "
 "If none is provided it will try to auto-detect the default editor."
 msgstr ""
-"Редактор, в котором будут открываться заметки (может включать аргументы). "
-"Если не задан, будет произведена попытка автоматического определения "
-"редактора по умолчанию."
+"Команда запуска внешнего текстового редактора (может включать аргументы "
+"командной строки). Если команда не задана - будет произведена попытка "
+"автоматического определения редактора по умолчанию."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:495
 msgid "Page size for PDF export"
-msgstr ""
+msgstr "Размер страницы при экспорте в PDF"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:497
 msgid "A4"
-msgstr ""
+msgstr "A4"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:498
 msgid "Letter"
-msgstr ""
+msgstr "Letter"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:499
 msgid "A3"
-msgstr ""
+msgstr "A3"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:500
 msgid "A5"
-msgstr ""
+msgstr "A5"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:501
 msgid "Tabloid"
-msgstr ""
+msgstr "Tabloid"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:502
 msgid "Legal"
-msgstr ""
+msgstr "Legal"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:505
 msgid "Page orientation for PDF export"
-msgstr ""
+msgstr "Ориентация страницы при экспорте в PDF"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:507
 msgid "Portrait"
-msgstr ""
+msgstr "Вертикально"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:508
 msgid "Landscape"
-msgstr ""
+msgstr "Горизонтально"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:523
 msgid "Custom TLS certificates"
@@ -2465,11 +2462,11 @@ msgid ""
 "pem. Note that if you make changes to the TLS settings, you must save your "
 "changes before clicking on \"Check synchronisation configuration\"."
 msgstr ""
-"Разделенный запятыми список путей к каталогам для загрузки сертификатов из "
-"отдельных файлов сертификатов или путей к ним. Например: /my/cert_dir, /"
-"other/custom. Обратите внимание, что если вы вносите изменения в настройки "
-"TLS, вы должны сохранить их перед нажатием на \"Проверить настройки "
-"синхронизации\"."
+"Разделенный запятыми список путей к файлам сертификатов (поддерживаются как "
+"каталоги так и абсолютные пути к отдельным файлам). Например: /my/cert_dir, /"
+"other/custom.pem. Обратите внимание, что если вы вносите изменения в "
+"настройки TLS, вы должны сохранить внесенные изменения перед нажатием на "
+"\"Проверить настройки синхронизации\"."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:536
 msgid "Ignore TLS certificate errors"
@@ -2481,15 +2478,15 @@ msgid ""
 "result of a misconfiguration or bug)"
 msgstr ""
 "Защита от сбоев: Не очищать локальные данные, когда цель синхронизации "
-"пустая (обычно случается из-за ошибки настроек или в приложении)"
+"пустая (обычно случается из-за ошибки приложения или настроек)"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:542
 msgid ""
 "Specify the port that should be used by the API server. If not set, a "
 "default will be used."
 msgstr ""
-"Укажите порт для работы сервера API. Если не указано, будет использовано "
-"значение по умолчанию."
+"Укажите порт для использования сервером API. Если порт не указан - будет "
+"использовано значение по умолчанию."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:550
 msgid "Enable note history"
@@ -2542,7 +2539,6 @@ msgid "Encryption"
 msgstr "Шифрование"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/models/Setting.js:969
-#, fuzzy
 msgid "Web Clipper"
 msgstr "Настройки веб-клиппера"
 
@@ -2579,14 +2575,12 @@ msgid "Json Export Directory"
 msgstr "Каталог экспорта Joplin"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/InteropService.js:89
-#, fuzzy
 msgid "HTML File"
-msgstr "Файл"
+msgstr "HTML файл"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/InteropService.js:94
-#, fuzzy
 msgid "HTML Directory"
-msgstr "Каталог"
+msgstr "HTML каталог"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/InteropService.js:130
 msgid "File"
@@ -2612,8 +2606,8 @@ msgid ""
 "This item is currently encrypted: %s \"%s\". Please wait for all items to be "
 "decrypted and try again."
 msgstr ""
-"Этот элемент сейчас зашифрован: %s \"%s\". Пожалуйста, дождитесь расшифровки "
-"всех элементов и попробуйте снова."
+"Этот элемент зашифрован: %s \"%s\". Пожалуйста, дождитесь расшифровки всех "
+"элементов и попробуйте снова."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/InteropService_Exporter_Jex.js:29
 msgid "There is no data to export."
@@ -2638,19 +2632,19 @@ msgid ""
 "target. In order to find these items, either search for the title or the ID "
 "(which is displayed in brackets above)."
 msgstr ""
-"Эти элементы останутся на устройстве, но не будут загружены в целевой объект "
+"Данные элементы останутся на устройстве, но не будут выгружены в цель "
 "синхронизации. Чтобы найти эти элементы, воспользуйтесь поиском по названию "
-"или ID (который указывается в скобках выше)."
+"или ID (указан в квадратных скобках выше)."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:130
 #, javascript-format
 msgid "%s (%s) could not be uploaded: %s"
-msgstr "Не удается загрузить файл %s (%s): %s"
+msgstr "Не удается выгрузить файл %s (%s): %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:132
 #, javascript-format
 msgid "Item \"%s\" could not be downloaded: %s"
-msgstr "Не удается скачать файл “%s”: %s"
+msgstr "Не удается загрузить файл “%s”: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:142
 msgid "Items that cannot be decrypted"
@@ -2662,34 +2656,32 @@ msgid ""
 "are corrupted or too large. These items will remain on the device but Joplin "
 "will no longer attempt to decrypt them."
 msgstr ""
-"Joplin не удалось расшифровать эти файлы несколько раз. Возможно они "
-"повреждены или слишком большие. Файлы останутся на устройстве без дальнейших "
-"попыток расшифровать их."
+"Joplin не удалось расшифровать данные элементы после нескольких попыток. "
+"Возможно они повреждены или слишком большие. Данные элементы останутся на "
+"устройстве без дальнейших попыток расшифровать их."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:164
-#, fuzzy
 msgid "Attachments"
-msgstr "Прикрепить файл"
+msgstr "Вложения"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:172
 msgid "Downloaded and decrypted"
-msgstr ""
+msgstr "Загружено и расшифровано"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:172
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:173
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:176
-#, fuzzy, javascript-format
+#, javascript-format
 msgid "%s: %d"
-msgstr "%s: %s"
+msgstr "%s: %d"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:173
 msgid "Downloaded and encrypted"
-msgstr ""
+msgstr "Загружено и зашифровано"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:186
-#, fuzzy
 msgid "Attachments that could not be downloaded"
-msgstr "Не удается скачать файл “%s”: %s"
+msgstr "Не удается загрузить следующие вложения"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:191
 #, javascript-format
@@ -2698,7 +2690,7 @@ msgstr "%s (%s): %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:203
 msgid "Sync status (synced items / total items)"
-msgstr "Статус синхронизации (синхронизировано / всего)"
+msgstr "Статус синхронизации элементов (синхронизировано / всего)"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:207
 #, javascript-format
@@ -2722,7 +2714,7 @@ msgstr "К удалению: %d"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:217
 msgid "Folders"
-msgstr "Папки"
+msgstr "Каталоги"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/services/report.js:225
 #, javascript-format
@@ -2748,7 +2740,7 @@ msgstr "Необходимо ваше разрешение на использо
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/note-list.js:116
 msgid "You currently have no notebooks."
-msgstr "Сейчас у вас нет блокнотов."
+msgstr "Блокноты отсутствуют."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/note-list.js:120
 msgid "Create a notebook"
@@ -2756,7 +2748,7 @@ msgstr "Создать новый блокнот"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/note-list.js:124
 msgid "There are currently no notes. Create one by clicking on the (+) button."
-msgstr "Сейчас здесь нет заметок. Создайте новую, нажав кнопку (+)."
+msgstr "Заметки отсутствуют. Создайте новую, нажав кнопку (+)."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screen-header.js:179
 msgid "Delete these notes?"
@@ -2776,9 +2768,10 @@ msgid "Press to set the decryption password."
 msgstr "Нажмите, чтобы установить пароль для расшифровки."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screen-header.js:404
-#, fuzzy
 msgid "Some items cannot be synchronised. Press for more info."
-msgstr "Некоторые элементы не могут быть синхронизированы."
+msgstr ""
+"Некоторые элементы не могут быть синхронизированы. Нажмите для получения "
+"дополнительной информации."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/select-date-time-dialog.js:65
 msgid "Clear alarm"
@@ -2799,11 +2792,11 @@ msgstr "Подтвердить"
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/side-menu-content.js:124
 #, javascript-format
 msgid "Notebook: %s"
-msgstr "Блокноты: %s"
+msgstr "Блокнот: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/side-menu-content.js:130
 msgid "Encrypted notebooks cannot be renamed"
-msgstr "Невозможно переименовать зашифрованные блокноты"
+msgstr "Зашифрованные блокноты не могут быть переименованы"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/side-menu-content.js:309
 msgid "New Notebook"
@@ -2825,7 +2818,7 @@ msgstr "Проверка... Пожалуйста, подождите."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/shared/config-shared.js:48
 msgid "Success! Synchronisation configuration appears to be correct."
-msgstr "Успешно! Конфигурация синхронизации является корректной."
+msgstr "Успешно! Синхронизация настроена правильно."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/shared/config-shared.js:50
 msgid ""
@@ -2837,7 +2830,7 @@ msgstr ""
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/shared/dropbox-login-shared.js:39
 msgid "The application has been authorised!"
-msgstr "Приложение было авторизовано!"
+msgstr "Приложение успешно авторизовано!"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/shared/dropbox-login-shared.js:43
 #, javascript-format
@@ -2852,12 +2845,12 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"Попробуйте снова."
+"Попробуйте еще раз."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/shared/encryption-config-shared.js:71
 #, javascript-format
 msgid "Decrypted items: %s / %s"
-msgstr "Расшифровано элементов: %s / %s"
+msgstr "Расшифрованные элементы: %s / %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/NoteTagsDialog.js:161
 msgid "New tags:"
@@ -2877,8 +2870,8 @@ msgid ""
 "In order to use file system synchronisation your permission to write to "
 "external storage is required."
 msgstr ""
-"Для использование синхронизации файловой системы, необходимо дать разрешение "
-"на запись."
+"Для использование синхронизации файловой системы необходимо дать разрешение "
+"на запись во внешнее хранилище."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:151
 msgid "Information"
@@ -2895,7 +2888,7 @@ msgstr "Инструменты"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:432
 msgid "Sync Status"
-msgstr "Синхронизировать статус"
+msgstr "Статус синхронизации"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:433
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/log.js:108
@@ -2923,26 +2916,25 @@ msgid ""
 "Use this to rebuild the search index if there is a problem with search. It "
 "may take a long time depending on the number of notes."
 msgstr ""
-"Используйте это, чтобы перестроить индекс поиска, если возникли проблемы с "
-"поиском. Это может занять много времени в зависимости от количества заметок."
+"Используйте эту опцию для перестроения индекса поиска, если с поиском "
+"возникли проблемы. Процесс перестроения индекса может занять много времени в "
+"зависимости от количества заметок."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:438
-#, fuzzy
 msgid "Exporting profile..."
-msgstr "Импорт заметок..."
+msgstr "Экспортирование профиля..."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:438
-#, fuzzy
 msgid "Export profile"
-msgstr "Файл экспорта Joplin"
+msgstr "Экспорт профиля"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:438
 msgid "For debugging purpose only: export your profile to an external SD card."
-msgstr ""
+msgstr "Только для отладки: экспорт вашего профиля на внешнюю SD карту."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:453
 msgid "More information"
-msgstr "Больше информации"
+msgstr "Дополнительная информация"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:463
 msgid ""
@@ -2950,8 +2942,8 @@ msgid ""
 "them in your phone settings, in Apps > Joplin > Permissions"
 msgstr ""
 "Для корректной работы приложению необходимы следующие разрешения. "
-"Пожалуйста, включите их в настройках телефона, в Приложения > Joplin> "
-"Разрешения"
+"Пожалуйста, включите их в настройках телефона в разделе Приложения > Joplin "
+"> Разрешения"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:466
 msgid ""
@@ -2968,7 +2960,8 @@ msgstr "- Камера: позволяет сделать снимок и при
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:472
 msgid "- Location: to allow attaching geo-location information to a note."
 msgstr ""
-"- Местоположение: позволяет прикрепить геолокационную информацию к заметке."
+"- Местоположение: позволяет прикрепить информацию о географическом "
+"местоположении к заметке."
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/config.js:501
 msgid "Joplin website"
@@ -3018,7 +3011,7 @@ msgstr "Подтверждение пароля не может быть пус�
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/encryption-config.js:178
 msgid "Enable"
-msgstr "Включено"
+msgstr "Включить"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/folder.js:87
 #, javascript-format
@@ -3072,13 +3065,13 @@ msgstr "Это вложение еще не загружено или еще н�
 #, javascript-format
 msgid "The Joplin mobile app does not currently support this type of link: %s"
 msgstr ""
-"Мобильное приложение Joplin в настоящее время не поддерживает этот тип "
+"Мобильное приложение Joplin в настоящее время не поддерживает данный тип "
 "ссылки: %s"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:157
 #, javascript-format
 msgid "Links with protocol \"%s\" are not supported"
-msgstr "Связь с протоколом “%s” не поддерживается"
+msgstr "Ссылки с протоколом “%s” не поддерживаются"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:483
 #, javascript-format
@@ -3136,7 +3129,7 @@ msgstr "Свойства"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:861
 msgid "Add body"
-msgstr "Добавить тело"
+msgstr "Добавить текст заметки"
 
 #: /Users/tessus/data/work/joplin/Tools/../ReactNativeClient/lib/components/screens/note.js:896
 msgid "Add title"


### PR DESCRIPTION
## Changelog
* fact errors corrected
* all non-ASCII symbols converted to ACSII to be correctly displayed even in console app (e.g. quotation marks, em dash, etc.)
* unified translation across the whole file:
  * `geolocation` -> `географическое местоположение`
  * `URL` ->`URL-адрес`
  * `match` -> `соответствовать выражению`
  * `folder` -> `каталог`
  * `upload` -> `выгрузка`
  * `download` -> `загрузка`
  * `информация об использовании` -> `справочная информация`
  * `shortcut` -> `сочетание клавиш`
  * `item` -> `элемент`
* linguistic calques translated
  * `release` -> `релиз` (calque) -> `выпуск`
  * `log` -> `лог` (calque) -> `журнал`
  * `tag` -> `тэг` (calque) -> `метка`

## Controversial points
* `tray` - should it be translated to `лоток` or not?
* should non-translatable strings be included in this file? E.g. non-ANSI paper sizes like "Letter" or "Tabloid"; keyboard modes like "vim" and "emacs"?
* is there better option to translate `synchronization target` than `цель синхронизации`? It sounds _clumsily_, but I can't invent better option. :(
