### PR TITLE
More info for "unknown profile version" error message

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1,7 +1,6 @@
 require('app-module-path').addPath(__dirname);
 
 const { BaseApplication } = require('lib/BaseApplication');
-const BaseModel = require('lib/BaseModel');
 const { FoldersScreenUtils } = require('lib/folders-screen-utils.js');
 const Setting = require('lib/models/Setting.js');
 const { shim } = require('lib/shim.js');
@@ -630,7 +629,7 @@ class Application extends BaseApplication {
 				'',
 				_('Client ID: %s', Setting.value('clientId')),
 				_('Sync Version: %s', Setting.value('syncVersion')),
-				_('Profile Version: %s', BaseModel.db().version()),
+				_('Profile Version: %s', reg.db().version()),
 			];
 			if (gitInfo) {
 				message.push(`\n${gitInfo}`);

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1,6 +1,7 @@
 require('app-module-path').addPath(__dirname);
 
 const { BaseApplication } = require('lib/BaseApplication');
+const BaseModel = require('lib/BaseModel');
 const { FoldersScreenUtils } = require('lib/folders-screen-utils.js');
 const Setting = require('lib/models/Setting.js');
 const { shim } = require('lib/shim.js');
@@ -629,6 +630,7 @@ class Application extends BaseApplication {
 				'',
 				_('Client ID: %s', Setting.value('clientId')),
 				_('Sync Version: %s', Setting.value('syncVersion')),
+				_('Profile Version: %s', BaseModel.db().version()),
 			];
 			if (gitInfo) {
 				message.push(`\n${gitInfo}`);

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -315,7 +315,11 @@ class JoplinDatabase extends Database {
 		// currentVersionIndex < 0 if for the case where an old version of Joplin used with a newer
 		// version of the database, so that migration is not run in this case.
 		if (currentVersionIndex < 0) {
-			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\nJoplin version: ${shim.appVersion()}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
+			throw new Error(
+				'Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n'
+				+ `Joplin version: ${shim.appVersion()}\n`
+				+ `Profile version: ${fromVersion}\n`
+				+ `Expected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 		}
 
 		if (currentVersionIndex == existingDatabaseVersions.length - 1) return fromVersion;

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -314,6 +314,7 @@ class JoplinDatabase extends Database {
 		// currentVersionIndex < 0 if for the case where an old version of Joplin used with a newer
 		// version of the database, so that migration is not run in this case.
 		if (currentVersionIndex < 0) {
+			this.logger().error(`Cannot convert database from version ${fromVersion} to ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 			const p = require('../package.json');
 			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n${p.name} version: ${p.version}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 		}

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -315,7 +315,6 @@ class JoplinDatabase extends Database {
 		// currentVersionIndex < 0 if for the case where an old version of Joplin used with a newer
 		// version of the database, so that migration is not run in this case.
 		if (currentVersionIndex < 0) {
-			this.logger().error(`Cannot convert database from version ${fromVersion} to ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\nJoplin version: ${shim.appVersion()}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 		}
 

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -313,7 +313,10 @@ class JoplinDatabase extends Database {
 
 		// currentVersionIndex < 0 if for the case where an old version of Joplin used with a newer
 		// version of the database, so that migration is not run in this case.
-		if (currentVersionIndex < 0) throw new Error('Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.');
+		if (currentVersionIndex < 0) {
+			const p = require('../package.json');
+			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n${p.name} version: ${p.version}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
+		}
 
 		if (currentVersionIndex == existingDatabaseVersions.length - 1) return fromVersion;
 

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -2,6 +2,7 @@ const { promiseChain } = require('lib/promise-utils.js');
 const { Database } = require('lib/database.js');
 const { sprintf } = require('sprintf-js');
 const Resource = require('lib/models/Resource');
+const { shim } = require('lib/shim.js');
 
 const structureSql = `
 CREATE TABLE folders (
@@ -315,8 +316,7 @@ class JoplinDatabase extends Database {
 		// version of the database, so that migration is not run in this case.
 		if (currentVersionIndex < 0) {
 			this.logger().error(`Cannot convert database from version ${fromVersion} to ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
-			const p = require('../package.json');
-			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n${p.name} version: ${p.version}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
+			throw new Error(`Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\nJoplin version: ${shim.appVersion()}\nProfile version: ${fromVersion}\nExpected version: ${existingDatabaseVersions[existingDatabaseVersions.length-1]}`);
 		}
 
 		if (currentVersionIndex == existingDatabaseVersions.length - 1) return fromVersion;


### PR DESCRIPTION
Resolves #2280

# Changes
Adds version information to profile error message
Add profile error message to log

Error message:
![version-error](https://user-images.githubusercontent.com/1732810/72670420-3a3d8280-3a91-11ea-8cec-80b9589fdc88.png)

About box:
![about](https://user-images.githubusercontent.com/1732810/72670422-3c9fdc80-3a91-11ea-8032-2d42e8349f6e.png)

Log messages
> 2020-01-19 03:31:18: "Database was open successfully"
2020-01-19 03:31:18: "Checking for database schema update..."
2020-01-19 03:31:18: "Current database version", "28"
2020-01-19 03:31:18: "Cannot convert database from version 28 to 27"

# Tests
Tested manually on
-  Electron (error msg, log msg, about box)
-  CliClient (error msg, log msg)
-  Mobile (error msg, but did not check log msg because not sure where to find it)

# Comments
For further details see previous abandoned pull request #2313