### PR TITLE
Desktop: fix deprecation of getName() in Electron

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -187,7 +187,7 @@ class ElectronAppWrapper {
 	createTray(contextMenu) {
 		try {
 			this.tray_ = new Tray(`${this.buildDir()}/icons/${this.trayIconFilename_()}`);
-			this.tray_.setToolTip(this.electronApp_.getName());
+			this.tray_.setToolTip(this.electronApp_.name);
 			this.tray_.setContextMenu(contextMenu);
 
 			this.tray_.on('click', () => {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1150,7 +1150,7 @@ class Application extends BaseApplication {
 			app.destroyTray();
 		} else {
 			const contextMenu = Menu.buildFromTemplate([
-				{ label: _('Open %s', app.electronApp().getName()), click: () => { app.window().show(); } },
+				{ label: _('Open %s', app.electronApp().name), click: () => { app.window().show(); } },
 				{ type: 'separator' },
 				{ label: _('Exit'), click: () => { app.quit(); } },
 			]);


### PR DESCRIPTION
This change fixes the following deprecation:

```
(electron) 'getName function' is deprecated and will be removed. Please use 'name property' instead.
```