### PR TITLE
Mobile: Adding Oled dark theme

### DIFF
--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -124,6 +124,37 @@ function themeStyle(theme) {
 
 	let output = Object.assign({}, globalStyle);
 	if (theme == Setting.THEME_LIGHT) return addExtraStyles(output);
+    else if (theme == Setting.THEME_OLED_DARK){
+        output.backgroundColor = '#000000';
+	    output.color = '#dddddd';
+	    output.colorFaded = '#777777';
+	    output.dividerColor = '#555555';
+	    output.strongDividerColor = '#888888';
+	    output.selectedColor = '#333333';
+	    output.textSelectionColor = '#00AEFF';
+	    output.headerBackgroundColor = '#2D3136';
+
+	    output.raisedBackgroundColor = '#0F2051';
+	    output.raisedColor = '#788BC3';
+	    output.raisedHighlightedColor = '#ffffff';
+
+	    output.htmlColor = 'rgb(220,220,220)';
+	    output.htmlBackgroundColor = 'rgb(29,32,36)';
+	    output.htmlLinkColor = 'rgb(166,166,255)';
+
+	    output.htmlDividerColor = '#3D444E';
+	    output.htmlLinkColor = 'rgb(166,166,255)';
+	    output.htmlCodeColor = '#ffffff';
+	    output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
+	    output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
+
+	    output.codeThemeCss = 'hljs-atom-one-dark-reasonable.css';
+
+	    output.colorUrl = '#7B81FF';
+
+	    themeCache_[theme] = output;
+	    return addExtraStyles(themeCache_[theme]);
+    }
 
 	output.backgroundColor = '#1D2024';
 	output.color = '#dddddd';

--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -124,37 +124,37 @@ function themeStyle(theme) {
 
 	let output = Object.assign({}, globalStyle);
 	if (theme == Setting.THEME_LIGHT) return addExtraStyles(output);
-    else if (theme == Setting.THEME_OLED_DARK){
-        output.backgroundColor = '#000000';
-	    output.color = '#dddddd';
-	    output.colorFaded = '#777777';
-	    output.dividerColor = '#555555';
-	    output.strongDividerColor = '#888888';
-	    output.selectedColor = '#333333';
-	    output.textSelectionColor = '#00AEFF';
-	    output.headerBackgroundColor = '#2D3136';
+	else if (theme == Setting.THEME_OLED_DARK) {
+		output.backgroundColor = '#000000';
+		output.color = '#dddddd';
+		output.colorFaded = '#777777';
+		output.dividerColor = '#555555';
+		output.strongDividerColor = '#888888';
+		output.selectedColor = '#333333';
+		output.textSelectionColor = '#00AEFF';
+		output.headerBackgroundColor = '#2D3136';
 
-	    output.raisedBackgroundColor = '#0F2051';
-	    output.raisedColor = '#788BC3';
-	    output.raisedHighlightedColor = '#ffffff';
+		output.raisedBackgroundColor = '#0F2051';
+		output.raisedColor = '#788BC3';
+		output.raisedHighlightedColor = '#ffffff';
 
-	    output.htmlColor = 'rgb(220,220,220)';
-	    output.htmlBackgroundColor = 'rgb(29,32,36)';
-	    output.htmlLinkColor = 'rgb(166,166,255)';
+		output.htmlColor = 'rgb(220,220,220)';
+		output.htmlBackgroundColor = 'rgb(29,32,36)';
+		output.htmlLinkColor = 'rgb(166,166,255)';
 
-	    output.htmlDividerColor = '#3D444E';
-	    output.htmlLinkColor = 'rgb(166,166,255)';
-	    output.htmlCodeColor = '#ffffff';
-	    output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
-	    output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
+		output.htmlDividerColor = '#3D444E';
+		output.htmlLinkColor = 'rgb(166,166,255)';
+		output.htmlCodeColor = '#ffffff';
+		output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
+		output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
 
-	    output.codeThemeCss = 'hljs-atom-one-dark-reasonable.css';
+		output.codeThemeCss = 'hljs-atom-one-dark-reasonable.css';
 
-	    output.colorUrl = '#7B81FF';
+		output.colorUrl = '#7B81FF';
 
-	    themeCache_[theme] = output;
-	    return addExtraStyles(themeCache_[theme]);
-    }
+		themeCache_[theme] = output;
+		return addExtraStyles(themeCache_[theme]);
+	}
 
 	output.backgroundColor = '#1D2024';
 	output.color = '#dddddd';

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -241,6 +241,7 @@ class Setting extends BaseModel {
 					let output = {};
 					output[Setting.THEME_LIGHT] = _('Light');
 					output[Setting.THEME_DARK] = _('Dark');
+					output[Setting.THEME_OLED_DARK] = _('OLED dark');
 					if (platform !== 'mobile') {
 						output[Setting.THEME_DRACULA] = _('Dracula');
 						output[Setting.THEME_SOLARIZED_LIGHT] = _('Solarised Light');
@@ -999,6 +1000,7 @@ Setting.TYPE_BUTTON = 6;
 
 Setting.THEME_LIGHT = 1;
 Setting.THEME_DARK = 2;
+Setting.THEME_OLED_DARK = 22;
 Setting.THEME_SOLARIZED_LIGHT = 3;
 Setting.THEME_SOLARIZED_DARK = 4;
 Setting.THEME_DRACULA = 5;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -240,14 +240,13 @@ class Setting extends BaseModel {
 				options: () => {
 					let output = {};
 					output[Setting.THEME_LIGHT] = _('Light');
-					output[Setting.THEME_DARK] = _('Dark');					
+					output[Setting.THEME_DARK] = _('Dark');
 					if (platform !== 'mobile') {
 						output[Setting.THEME_DRACULA] = _('Dracula');
 						output[Setting.THEME_SOLARIZED_LIGHT] = _('Solarised Light');
 						output[Setting.THEME_SOLARIZED_DARK] = _('Solarised Dark');
 						output[Setting.THEME_NORD] = _('Nord');
-					}
-					else {
+					} else {
 						output[Setting.THEME_OLED_DARK] = _('OLED dark');
 					}
 					return output;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -247,7 +247,7 @@ class Setting extends BaseModel {
 						output[Setting.THEME_SOLARIZED_DARK] = _('Solarised Dark');
 						output[Setting.THEME_NORD] = _('Nord');
 					} else {
-						output[Setting.THEME_OLED_DARK] = _('OLED dark');
+						output[Setting.THEME_OLED_DARK] = _('OLED rk');
 					}
 					return output;
 				},

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -240,13 +240,15 @@ class Setting extends BaseModel {
 				options: () => {
 					let output = {};
 					output[Setting.THEME_LIGHT] = _('Light');
-					output[Setting.THEME_DARK] = _('Dark');
-					output[Setting.THEME_OLED_DARK] = _('OLED dark');
+					output[Setting.THEME_DARK] = _('Dark');					
 					if (platform !== 'mobile') {
 						output[Setting.THEME_DRACULA] = _('Dracula');
 						output[Setting.THEME_SOLARIZED_LIGHT] = _('Solarised Light');
 						output[Setting.THEME_SOLARIZED_DARK] = _('Solarised Dark');
 						output[Setting.THEME_NORD] = _('Nord');
+					}
+					else {
+						output[Setting.THEME_OLED_DARK] = _('OLED dark');
 					}
 					return output;
 				},

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -247,7 +247,7 @@ class Setting extends BaseModel {
 						output[Setting.THEME_SOLARIZED_DARK] = _('Solarised Dark');
 						output[Setting.THEME_NORD] = _('Nord');
 					} else {
-						output[Setting.THEME_OLED_DARK] = _('OLED rk');
+						output[Setting.THEME_OLED_DARK] = _('OLED Dark');
 					}
 					return output;
 				},


### PR DESCRIPTION
A new theme with just the darker background '#000000': 
Practical for oled screens (pixel powered off), so less power consumption and easier for late night  reading
Requested in the forum:
https://discourse.joplinapp.org/t/black-oled-theme-for-mobile-version/2618