### PR TITLE
Desktop: New search-result orderings

### DIFF
--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -350,6 +350,7 @@ class Application extends BaseApplication {
 
 		const sortNoteItems = sortNoteFolderItems('notes');
 		const sortFolderItems = sortNoteFolderItems('folders');
+		const sortSearchItems = sortNoteFolderItems('search');
 
 		const focusItems = [];
 
@@ -957,6 +958,10 @@ class Application extends BaseApplication {
 					label: Setting.settingMetadata('folders.sortOrder.field').label(),
 					screens: ['Main'],
 					submenu: sortFolderItems,
+				}, {
+					label: Setting.settingMetadata('search.sortOrder.field').label(),
+					screens: ['Main'],
+					submenu: sortSearchItems,
 				}, {
 					label: Setting.settingMetadata('showNoteCounts').label(),
 					type: 'checkbox',

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -241,7 +241,10 @@ class BaseApplication {
 				notes = await Tag.notes(parentId, options);
 			} else if (parentType === BaseModel.TYPE_SEARCH) {
 				const search = BaseModel.byId(state.searches, parentId);
-				notes = await SearchEngineUtils.notesForQuery(search.query_pattern);
+				let seOptions = {
+					order: stateUtils.searchOrder(state.settings),
+				};
+				notes = await SearchEngineUtils.notesForQuery(search.query_pattern, null, seOptions);
 			}
 		}
 
@@ -431,6 +434,10 @@ class BaseApplication {
 		}
 
 		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key.indexOf('notes.sortOrder') === 0) || action.type == 'SETTING_UPDATE_ALL')) {
+			refreshNotes = true;
+		}
+
+		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key.indexOf('search.sortOrder') === 0) || action.type == 'SETTING_UPDATE_ALL')) {
 			refreshNotes = true;
 		}
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -323,7 +323,7 @@ class Setting extends BaseModel {
 				label: () => _('Sort search results by'),
 				options: () => {
 					const SearchEngine = require('lib/services/SearchEngine');
-					const searchSortFields = ['best_match', 'user_updated_time', 'title'];
+					const searchSortFields = ['best_match', 'title', 'user_updated_time'];
 					const options = {};
 					for (let i = 0; i < searchSortFields.length; i++) {
 						options[searchSortFields[i]] = toTitleCase(SearchEngine.fieldToLabel(searchSortFields[i]));

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -312,6 +312,27 @@ class Setting extends BaseModel {
 			},
 			'folders.sortOrder.reverse': { value: false, type: Setting.TYPE_BOOL, public: true, label: () => _('Reverse sort order'), appTypes: ['cli'] },
 			trackLocation: { value: true, type: Setting.TYPE_BOOL, section: 'note', public: true, label: () => _('Save geo-location with notes') },
+
+			'search.sortOrder.field': {
+				value: 'best_match',
+				type: Setting.TYPE_STRING,
+				section: 'note',
+				isEnum: true,
+				public: true,
+				appTypes: ['cli'],
+				label: () => _('Sort search results by'),
+				options: () => {
+					const SearchEngine = require('lib/services/SearchEngine');
+					const searchSortFields = ['best_match', 'user_updated_time', 'title'];
+					const options = {};
+					for (let i = 0; i < searchSortFields.length; i++) {
+						options[searchSortFields[i]] = toTitleCase(SearchEngine.fieldToLabel(searchSortFields[i]));
+					}
+					return options;
+				},
+			},
+			'search.sortOrder.reverse': { value: false, type: Setting.TYPE_BOOL, section: 'note', public: true, label: () => _('Reverse sort order'), appTypes: ['cli'] },
+
 			newTodoFocus: {
 				value: 'title',
 				type: Setting.TYPE_STRING,

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -85,6 +85,15 @@ stateUtils.foldersOrder = function(stateSettings) {
 	]);
 };
 
+stateUtils.searchOrder = function(stateSettings) {
+	return cacheEnabledOutput('searchOrder', [
+		{
+			by: stateSettings['search.sortOrder.field'],
+			dir: stateSettings['search.sortOrder.reverse'] ? 'DESC' : 'ASC',
+		},
+	]);
+};
+
 stateUtils.parentItem = function(state) {
 	const t = state.notesParentType;
 	let id = null;

--- a/ReactNativeClient/lib/services/SearchEngine.js
+++ b/ReactNativeClient/lib/services/SearchEngine.js
@@ -257,8 +257,8 @@ class SearchEngine {
 
 	orderByTitle_(rows) {
 		rows.sort((a, b) => {
-			if (a.title < b.title) return +1;
-			if (a.title > b.title) return -1;
+			if (a.title > b.title) return +1;
+			if (a.title < b.title) return -1;
 			if (a.is_todo && a.todo_completed) return +1;
 			if (b.is_todo && b.todo_completed) return -1;
 			if (a.user_updated_time < b.user_updated_time) return +1;
@@ -287,7 +287,7 @@ class SearchEngine {
 		} else {
 			this.logger().warn(`Unimplemented search order: ${order}`);
 		}
-		if (order.dir === 'ASC') {
+		if (order.dir === 'DESC') {
 			rows = rows.reverse();
 		}
 	}
@@ -442,8 +442,8 @@ class SearchEngine {
 			const sql = 'SELECT notes_fts.id, notes_fts.title AS normalized_title, offsets(notes_fts) AS offsets, notes.title, notes.user_updated_time, notes.is_todo, notes.todo_completed, notes.parent_id FROM notes_fts LEFT JOIN notes ON notes_fts.id = notes.id WHERE notes_fts MATCH ?';
 			try {
 				const rows = await this.db().selectAll(sql, [query]);
-				let order = { by: 'best_match', dir: 'DESC' };
-				if (options.order && options.order.length > 0) {
+				let order = { by: 'best_match', dir: 'ASC' };
+				if (options && options.order && options.order.length > 0) {
 					order.by = options.order[0].by;
 					order.dir = options.order[0].dir;
 				}

--- a/ReactNativeClient/lib/services/SearchEngineUtils.js
+++ b/ReactNativeClient/lib/services/SearchEngineUtils.js
@@ -2,10 +2,10 @@ const SearchEngine = require('lib/services/SearchEngine');
 const Note = require('lib/models/Note');
 
 class SearchEngineUtils {
-	static async notesForQuery(query, options = null) {
+	static async notesForQuery(query, options = null, seOptions = null) {
 		if (!options) options = {};
 
-		const results = await SearchEngine.instance().search(query);
+		const results = await SearchEngine.instance().search(query, seOptions);
 		const noteIds = results.map(n => n.id);
 
 		// We need at least the note ID to be able to sort them below so if not


### PR DESCRIPTION
Resolves #2071 
Resolves #1388

# Changes
- Add menu item to allow user to select search-results order as
  - best match (current method),
  - updated time or
  - title
- Add menu item to allow user to reverse the search-results order
- Add setting to store the selections
- Modify search engine to support new ordering methods
- Add unit tests

![search-order-menu](https://user-images.githubusercontent.com/1732810/73131448-3ac0b500-405f-11ea-8eb7-1b5e682fac60.png)

# Testing
- all unit tests pass (old and new) 
- manual testing of desktop app
  - check search results ordered by best match with/without reverse
  - check search results ordered by title with/without reverse
  - check search results ordered by updated time with/without reverse
  - check results list is updated when new selection is made
  - check new settings are saved and restored
  - check order notes behaviour is unaffected

# Comments
There is modified code in ReactNative however the changes are only visible in the desktop app. There is no change in behaviour for mobile and command-line apps.