### PR TITLE
Fix hang when selecting tag when multiple notes are selected (also for search)

### DIFF
--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -676,6 +676,7 @@ const reducer = (state = defaultState, action) => {
 			} else {
 				newState.notesParentType = 'Search';
 			}
+			newState.selectedNoteIds = [];
 			break;
 
 		case 'APP_STATE_SET':

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -548,6 +548,7 @@ const reducer = (state = defaultState, action) => {
 			} else {
 				newState.notesParentType = 'Tag';
 			}
+			newState.selectedNoteIds = [];
 			break;
 
 		case 'TAG_UPDATE_ONE':


### PR DESCRIPTION
Fixes #2371 

During investigation, also found the same type of bug affects search results, so fixed that too.

The search version of the bug is:
1. Start with default profile
2. Search for `Joplin`
3. Select multiple notes in the note list
4. Modify the search eg add a character to make it `Joplinx`

Expected result: Note list shows new results
Observed result: Entire Joplin window renders white

Tested fix manually on desktop
Did not reproduce bug or test fix on CLI or mobile.

