### PR TITLE
Change to the documentation: Edits build instructions to avoid confusion

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -33,7 +33,9 @@ Before building any of the applications, you need to build the tools and pre-com
 npm install && cd Tools && npm install
 ```
 
-## Building the Electron application on Linux and macOS
+# Building the Electron application
+
+## Linux and macOS
 
 ```
 npm run copyLib
@@ -53,7 +55,9 @@ That will create the executable file in the `dist` directory.
 
 From `/ElectronClient` you can also run `run.sh` to run the app for testing.
 
-## Building Electron application on Windows
+## Windows
+
+Run the following commands on Windows Command prompt running as Administrator:
 
 ```
 xcopy /C /I /H /R /Y /S ReactNativeClient\lib ElectronClient\app\lib

--- a/BUILD.md
+++ b/BUILD.md
@@ -33,7 +33,7 @@ Before building any of the applications, you need to build the tools and pre-com
 npm install && cd Tools && npm install
 ```
 
-# Building the Electron application
+## Building the Electron application on Linux and macOS
 
 ```
 npm run copyLib


### PR DESCRIPTION
When i was trying to build the Electron Project, i was a bit confused about which commands to follow for building in the projects on my OS (Windows).

there was two headers,   **Building the Electron application** and   **Building the Electron application for windows**.

the former can lead a beginner to confusion because it seems to be "a generalized statement", unlike the latter that was more specific. 

In order to improve the developers experience, i had to change the former heading to **Building the Electron application for Linux and macOS** to help them understand easily.


