### PR TITLE
Desktop: Add `add or remove tags` for multiple notes.

### DIFF
--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -97,7 +97,7 @@ describe('models_Tag', function() {
 		expect(tagWithCount.note_count).toBe(2);
 	}));
 
-	it('should add tags by title', asyncTest(async () => {
+	it('should get common tags for set of notes', asyncTest(async () => {
 		let folder1 = await Folder.save({ title: 'folder1' });
 		let taga = await Tag.save({ title: 'mytaga'});
 		let tagb = await Tag.save({ title: 'mytagb'});
@@ -118,7 +118,16 @@ describe('models_Tag', function() {
 		await Tag.addNote(tagb.id, note3.id);
 		await Tag.addNote(tagc.id, note3.id);
 
-		let commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
+		let commonTags = await Tag.commonTagsByNoteIds(null);
+		expect(commonTags.length).toBe(0);
+
+		commonTags = await Tag.commonTagsByNoteIds(undefined);
+		expect(commonTags.length).toBe(0);
+
+		commonTags = await Tag.commonTagsByNoteIds([]);
+		expect(commonTags.length).toBe(0);
+
+		commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
 		let commonTagIds = commonTags.map(t => t.id);
 		expect(commonTagIds.length).toBe(0);
 

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -97,4 +97,44 @@ describe('models_Tag', function() {
 		expect(tagWithCount.note_count).toBe(2);
 	}));
 
+	it('should add tags by title', asyncTest(async () => {
+		let folder1 = await Folder.save({ title: 'folder1' });
+		let taga = await Tag.save({ title: 'mytaga'});
+		let tagb = await Tag.save({ title: 'mytagb'});
+		let tagc = await Tag.save({ title: 'mytagc'});
+		let tagd = await Tag.save({ title: 'mytagd'});
+
+		let note0 = await Note.save({ title: 'ma note 0', parent_id: folder1.id });
+		let note1 = await Note.save({ title: 'ma note 1', parent_id: folder1.id });
+		let note2 = await Note.save({ title: 'ma note 2', parent_id: folder1.id });
+		let note3 = await Note.save({ title: 'ma note 3', parent_id: folder1.id });
+
+		await Tag.addNote(taga.id, note1.id);
+
+		await Tag.addNote(taga.id, note2.id);
+		await Tag.addNote(tagb.id, note2.id);
+
+		await Tag.addNote(taga.id, note3.id);
+		await Tag.addNote(tagb.id, note3.id);
+		await Tag.addNote(tagc.id, note3.id);
+
+		let commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
+		expect(commonTags.length).toBe(0);
+
+		commonTags = await Tag.commonTagsByNoteIds([note1.id, note2.id, note3.id]);
+		expect(commonTags.length).toBe(1);
+		expect(commonTags[0].id).toBe(taga.id);
+
+		commonTags = await Tag.commonTagsByNoteIds([note2.id, note3.id]);
+		expect(commonTags.length).toBe(2);
+		expect(commonTags[0].id).toBe(taga.id);
+		expect(commonTags[1].id).toBe(tagb.id);
+
+		commonTags = await Tag.commonTagsByNoteIds([note3.id]);
+		expect(commonTags.length).toBe(3);
+		expect(commonTags[0].id).toBe(taga.id);
+		expect(commonTags[1].id).toBe(tagb.id);
+		expect(commonTags[2].id).toBe(tagc.id);
+	}));
+
 });

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -119,22 +119,26 @@ describe('models_Tag', function() {
 		await Tag.addNote(tagc.id, note3.id);
 
 		let commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
-		expect(commonTags.length).toBe(0);
+		let commonTagIds = commonTags.map(t => t.id);
+		expect(commonTagIds.length).toBe(0);
 
 		commonTags = await Tag.commonTagsByNoteIds([note1.id, note2.id, note3.id]);
-		expect(commonTags.length).toBe(1);
-		expect(commonTags[0].id).toBe(taga.id);
+		commonTagIds = commonTags.map(t => t.id);
+		expect(commonTagIds.length).toBe(1);
+		expect(commonTagIds.includes(taga.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note2.id, note3.id]);
-		expect(commonTags.length).toBe(2);
-		expect(commonTags[0].id).toBe(taga.id);
-		expect(commonTags[1].id).toBe(tagb.id);
+		commonTagIds = commonTags.map(t => t.id);
+		expect(commonTagIds.length).toBe(2);
+		expect(commonTagIds.includes(taga.id)).toBe(true);
+		expect(commonTagIds.includes(tagb.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note3.id]);
+		commonTagIds = commonTags.map(t => t.id);
 		expect(commonTags.length).toBe(3);
-		expect(commonTags[0].id).toBe(taga.id);
-		expect(commonTags[1].id).toBe(tagb.id);
-		expect(commonTags[2].id).toBe(tagc.id);
+		expect(commonTagIds.includes(taga.id)).toBe(true);
+		expect(commonTagIds.includes(tagb.id)).toBe(true);
+		expect(commonTagIds.includes(tagc.id)).toBe(true);
 	}));
 
 });

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -873,12 +873,10 @@ class Application extends BaseApplication {
 					accelerator: 'CommandOrControl+Alt+T',
 					click: () => {
 						const selectedNoteIds = this.store().getState().selectedNoteIds;
-						if (selectedNoteIds.length !== 1) return;
-
 						this.dispatch({
 							type: 'WINDOW_COMMAND',
 							name: 'setTags',
-							noteId: selectedNoteIds[0],
+							noteIds: selectedNoteIds,
 						});
 					},
 				}, {

--- a/ElectronClient/app/app.js
+++ b/ElectronClient/app/app.js
@@ -1129,7 +1129,7 @@ class Application extends BaseApplication {
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
 
-		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'setTags', 'showLocalSearch']) {
+		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
 			menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -175,7 +175,7 @@ class MainScreenComponent extends React.Component {
 								const addTags = endTagTitles.filter(value => !startTagsTitles.includes(value));
 								const delTags = startTagsTitles.filter(value => !endTagTitles.includes(value));
 
-								// update the tags for each selected note
+								// apply the tag additions and deletions to each selected note
 								for (let i = 0; i < command.noteIds.length; i++) {
 									const tags = await Tag.tagsByNoteId(command.noteIds[i]);
 									let tagTitles = tags.map(a => { return a.title; });

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -142,8 +142,8 @@ class MainScreenComponent extends React.Component {
 				},
 			});
 		} else if (command.name === 'setTags') {
-			const tags = await Tag.tagsByNoteId(command.noteId);
-			const noteTags = tags
+			const tags = await Tag.commonTagsByNoteIds(command.noteIds);
+			const startTags = tags
 				.map(a => {
 					return { value: a.id, label: a.title };
 				})
@@ -161,14 +161,29 @@ class MainScreenComponent extends React.Component {
 				promptOptions: {
 					label: _('Add or remove tags:'),
 					inputType: 'tags',
-					value: noteTags,
+					value: startTags,
 					autocomplete: tagSuggestions,
 					onClose: async answer => {
 						if (answer !== null) {
-							const tagTitles = answer.map(a => {
+							const endTagTitles = answer.map(a => {
 								return a.label.trim();
 							});
-							await Tag.setNoteTagsByTitles(command.noteId, tagTitles);
+							if (command.noteIds.length === 1) {
+								await Tag.setNoteTagsByTitles(command.noteIds[0], endTagTitles);
+							} else {
+								const startTagsTitles = startTags.map(a => { return a.label.trim(); });
+								const addTags = endTagTitles.filter(value => !startTagsTitles.includes(value));
+								const delTags = startTagsTitles.filter(value => !endTagTitles.includes(value));
+
+								// update the tags for each selected note
+								for (let i = 0; i < command.noteIds.length; i++) {
+									const tags = await Tag.tagsByNoteId(command.noteIds[i]);
+									let tagTitles = tags.map(a => { return a.title; });
+									tagTitles = tagTitles.concat(addTags);
+									tagTitles = tagTitles.filter(value => !delTags.includes(value));
+									await Tag.setNoteTagsByTitles(command.noteIds[i], tagTitles);
+								}
+							}
 						}
 						this.setState({ promptOptions: null });
 					},

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -171,9 +171,9 @@ class MainScreenComponent extends React.Component {
 							if (command.noteIds.length === 1) {
 								await Tag.setNoteTagsByTitles(command.noteIds[0], endTagTitles);
 							} else {
-								const startTagsTitles = startTags.map(a => { return a.label.trim(); });
-								const addTags = endTagTitles.filter(value => !startTagsTitles.includes(value));
-								const delTags = startTagsTitles.filter(value => !endTagTitles.includes(value));
+								const startTagTitles = startTags.map(a => { return a.label.trim(); });
+								const addTags = endTagTitles.filter(value => !startTagTitles.includes(value));
+								const delTags = startTagTitles.filter(value => !endTagTitles.includes(value));
 
 								// apply the tag additions and deletions to each selected note
 								for (let i = 0; i < command.noteIds.length; i++) {

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1334,7 +1334,7 @@ class NoteTextComponent extends React.Component {
 		this.props.dispatch({
 			type: 'WINDOW_COMMAND',
 			name: 'setTags',
-			noteId: this.state.note.id,
+			noteIds: [this.state.note.id],
 		});
 	}
 

--- a/ElectronClient/app/gui/utils/NoteListUtils.js
+++ b/ElectronClient/app/gui/utils/NoteListUtils.js
@@ -25,12 +25,11 @@ class NoteListUtils {
 			menu.append(
 				new MenuItem({
 					label: _('Add or remove tags'),
-					enabled: noteIds.length === 1,
 					click: async () => {
 						props.dispatch({
 							type: 'WINDOW_COMMAND',
 							name: 'setTags',
-							noteId: noteIds[0],
+							noteIds: noteIds,
 						});
 					},
 				})

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -112,6 +112,15 @@ class Tag extends BaseItem {
 		return this.modelSelectAll(`SELECT * FROM tags WHERE id IN ("${tagIds.join('","')}")`);
 	}
 
+	static async commonTagsByNoteIds(noteIds) {
+		let commonTagIds = await NoteTag.tagIdsByNoteId(noteIds[0]);
+		for (let i = 1; i < noteIds.length; i++) {
+			const tagIds = await NoteTag.tagIdsByNoteId(noteIds[i]);
+			commonTagIds = commonTagIds.filter(value => tagIds.includes(value));
+		}
+		return this.modelSelectAll(`SELECT * FROM tags WHERE id IN ("${commonTagIds.join('","')}")`);
+	}
+
 	static async loadByTitle(title) {
 		return this.loadByField('title', title, { caseInsensitive: true });
 	}

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -113,13 +113,16 @@ class Tag extends BaseItem {
 	}
 
 	static async commonTagsByNoteIds(noteIds) {
-		if (!noteIds || noteIds.length == 0) {
+		if (!noteIds || noteIds.length === 0) {
 			return [];
 		}
 		let commonTagIds = await NoteTag.tagIdsByNoteId(noteIds[0]);
 		for (let i = 1; i < noteIds.length; i++) {
 			const tagIds = await NoteTag.tagIdsByNoteId(noteIds[i]);
 			commonTagIds = commonTagIds.filter(value => tagIds.includes(value));
+			if (commonTagIds.length === 0) {
+				break;
+			}
 		}
 		return this.modelSelectAll(`SELECT * FROM tags WHERE id IN ("${commonTagIds.join('","')}")`);
 	}

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -113,6 +113,9 @@ class Tag extends BaseItem {
 	}
 
 	static async commonTagsByNoteIds(noteIds) {
+		if (!noteIds || noteIds.length == 0) {
+			return [];
+		}
 		let commonTagIds = await NoteTag.tagIdsByNoteId(noteIds[0]);
 		for (let i = 1; i < noteIds.length; i++) {
 			const tagIds = await NoteTag.tagIdsByNoteId(noteIds[i]);


### PR DESCRIPTION
Resolves #359 

# Spec
When multiple notes are selected and add or remove tags is actioned
- the list of common tags is presented in the dialog
- the additions and deletions are applied to each selected note

When one note is selected and add or remove tags is actioned:
- behaviour is unchanged from current

# Tests
- [x] Add unit tests for new Tag method

Manual tests
- [x] Check tag added to multiple notes
- [x] Check tag added to multiple notes when some notes already have the tag
- [x] Check tag removed from multiple notes
- [x] Check simultaneous tag add and remove from multiple notes
- [x] Check tag add and remove on large number (100) selected notes
- [x] Check launch from note pane multi-note context menu
- [x] Check launch from right-click context menu
- [x] Check launch from main-menu (Edit -> Tags)
- [x] Check single note tag add/remove still works

# Comments

Enhancement suggestion: When multiple notes are selected, the `add or remove tags` dialog only shows tags that are common to all selected notes. Tags that are on only some notes are not shown.  An enhancement might be to show these tags in the dialog too, perhaps in faded or broken boxes, and interactive. 

