### PR TITLE
Desktop: Modified electronRebuild.js to run electron-builds for specific windows archs

### DIFF
--- a/ElectronClient/app/electronRebuild.js
+++ b/ElectronClient/app/electronRebuild.js
@@ -29,8 +29,7 @@ async function main() {
 	if (isWindows()) exePath += '.cmd';
 
 	if (isWindows()) {
-		console.info(await execCommand([`"${exePath}"`, '--arch ia32'].join(' ')));
-		console.info(await execCommand([`"${exePath}"`, '--arch x64'].join(' ')));
+		process.arch === 'ia32' ? console.info(await execCommand([`"${exePath}"`, '--arch ia32'].join(' '))) :  console.info(await execCommand([`"${exePath}"`, '--arch x64'].join(' ')));
 	} else {
 		console.info(await execCommand([`"${exePath}"`].join(' ')));
 	}


### PR DESCRIPTION
The present code makes the electron build command to run for both **ia32 arch** and **x64 arch,** this doesn't seem right, this is what caused my electron-build to fail when i initially wanted to build the Electron application on my Windows (x64) OS, because my Windows OS is a **x64 arch**, it failed because the code executed the first build optionm which is for **ia32 arch.**

i believe proper way this code should be written is to check for the arch of the windows os, by using `process.arch` and then deciding which electron-build option should be executed instead of just running the two options that has caused frustration for me.

Taking my advice, i modified the joplin-test\joplin\ElectronClient\app\electronRebuild.js to the new changes in my commit.

this worked perfectly for me, Joplin Desktop dependecies successfully got installed via `npm install` and the `postinstall script - "postinstall": "node compile.js && node compile-package-info.js && node electronRebuild.js"` also executed successfully and after following the rest of the building instructions my Electron App built successfully after (12hrs of hacking and frustration).

To prevent other windows users from facing this problem, i hereby propose this change. 

