### PR TITLE
Desktop: Fix to update the note list if the selected tag is deleted.

### DIFF
--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -445,11 +445,10 @@ class BaseApplication {
 		if (action.type == 'NOTE_TAG_REMOVE') {
 			if (newState.notesParentType === 'Tag' && newState.selectedTagId === action.item.id) {
 				if (newState.notes.length === newState.selectedNoteIds.length) {
-					newState.notesParentType = 'Folder';
 					this.refreshCurrentFolder();
-				} else {
-					refreshNotes = true;
+					refreshNotesUseSelectedNoteId = true;
 				}
+				refreshNotes = true;
 			}
 		}
 

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -442,6 +442,12 @@ class BaseApplication {
 			refreshNotes = true;
 		}
 
+		if (action.type == 'NOTE_TAG_REMOVE') {
+			if (newState.notesParentType === 'Tag' && newState.selectedTagId === action.item.id) {
+				refreshNotes = true;
+			}
+		}
+
 		if (refreshNotes) {
 			await this.refreshNotes(newState, refreshNotesUseSelectedNoteId, refreshNotesHash);
 		}

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -444,7 +444,12 @@ class BaseApplication {
 
 		if (action.type == 'NOTE_TAG_REMOVE') {
 			if (newState.notesParentType === 'Tag' && newState.selectedTagId === action.item.id) {
-				refreshNotes = true;
+				if (newState.notes.length === newState.selectedNoteIds.length) {
+					newState.notesParentType = 'Folder';
+					this.refreshCurrentFolder();
+				} else {
+					refreshNotes = true;
+				}
 			}
 		}
 

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -445,7 +445,7 @@ class BaseApplication {
 		if (action.type == 'NOTE_TAG_REMOVE') {
 			if (newState.notesParentType === 'Tag' && newState.selectedTagId === action.item.id) {
 				if (newState.notes.length === newState.selectedNoteIds.length) {
-					this.refreshCurrentFolder();
+					await this.refreshCurrentFolder();
 					refreshNotesUseSelectedNoteId = true;
 				}
 				refreshNotes = true;


### PR DESCRIPTION
This is a small PR to fix a small GUI issue that is described below.

I haven't created an issue in github, but will describe it here.  (please let me know if this is not OK for small issues like this)

# Description
After removing a tag from a note, the note list does not always reflect the selection in sidebar.

# Steps to Reproduce Issue
1. Start with default profile
2. Add a tag `aaa` to two notes
3. Select tag `aaa` in side bar
4. Select a note and remove tag `aaa` from it

## Expected result: 
The tag `aaa` is still selected in the side bar
The untagged note is removed from the note list (as it is no longer has tag `aaa`)
The note list shows the remaining notes that have the tag

## Observed result:
The tag `aaa` is still selected in the side bar
The note list is unchanged (and shows the note that no longer has the tag `aaa`)

# Discussion
The observed result is a problem, because the sidebar and note list are no longer in agreement.

# Tests
- [x] Remove tag from note while the tag is selected
- [x] Remove tag from note while tag is selected and the note is the last with the tag
- [x] Remove tag from note while another tag is selected
- [x] Remove tag from note while notebook is selected

