### PR TITLE
Desktop: Support "select all" in the note list

### DIFF
--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -362,6 +362,15 @@ class NoteListComponent extends React.Component {
 				});
 			}
 		}
+
+		if (event.keyCode === 65 && event.ctrlKey) {
+			// Ctrl+A key
+			event.preventDefault();
+
+			this.props.dispatch({
+				type: 'NOTE_SELECT_ALL',
+			});
+		}
 	}
 
 	focusNoteId_(noteId) {

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -363,7 +363,7 @@ class NoteListComponent extends React.Component {
 			}
 		}
 
-		if (event.keyCode === 65 && event.ctrlKey) {
+		if (event.keyCode === 65 && (event.ctrlKey || event.metaKey)) {
 			// Ctrl+A key
 			event.preventDefault();
 

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -679,7 +679,7 @@ class SideBarComponent extends React.Component {
 			});
 		}
 
-		if (keyCode === 65 && event.ctrlKey) {
+		if (keyCode === 65 && (event.ctrlKey || event.metaKey)) {
 			// Ctrl+A key
 			event.preventDefault();
 		}

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -678,6 +678,11 @@ class SideBarComponent extends React.Component {
 				id: selectedItem.id,
 			});
 		}
+
+		if (keyCode === 65 && event.ctrlKey) {
+			// Ctrl+A key
+			event.preventDefault();
+		}
 	}
 
 	onHeaderClick_(key, event) {

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -394,6 +394,11 @@ const reducer = (state = defaultState, action) => {
 			}
 			break;
 
+		case 'NOTE_SELECT_ALL':
+			newState = Object.assign({}, state);
+			newState.selectedNoteIds = newState.notes.map(n => n.id);
+			break;
+
 		case 'FOLDER_SELECT':
 			newState = changeSelectedFolder(state, action, { clearSelectedNoteIds: true });
 			break;


### PR DESCRIPTION
Please consider this PR for enhancing the "select all" function in Joplin.

As mentioned in [forum](https://discourse.joplinapp.org/t/desktop-select-all-in-the-note-list/5491)

# Spec
- When focus is in the note list, "select all" selects all notes.
- When in the folder list, "select all" does nothing.
- When in the tag list, "select all" does nothing.
- The key combination "select all" is "Ctrl-A" or "Cmd-A"

![select-all-new](https://user-images.githubusercontent.com/1732810/73326693-3f77aa00-42a7-11ea-9698-d5ceef40112a.png)

For reference, the current behaviour is this:
![select-all-current](https://user-images.githubusercontent.com/1732810/73326699-4acad580-42a7-11ea-9eac-e3302e631420.png)

# Tests
- [x] Add unit test for new "NOTE_SELECT_ALL" handler in reducer

### Manual tests:
Check 'select all' works:
- [x] in note list  (selects all notes in note list)
- [x] in tag list  (does nothing)
- [x] in folder list  (does nothing)
- [x] in note text  (still works and is unaffected)

# Discussion
If the note list is short, and "select all" is actioned below the last note, the application menus are selected. I would like to stop this too, but don't know where to catch it.  So leaving it as is for now.
