### PR TITLE
Desktop: Support scrolling in the note list using keys (eg page up, page down)

### DIFF
--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -293,32 +293,31 @@ class NoteListComponent extends React.Component {
 		}
 	}
 
-	newNoteIndex_(keyCode, ctrlKey, metaKey, noteIndex) {
-		let newNoteIndex = noteIndex;
+	scrollNoteIndex_(keyCode, ctrlKey, metaKey, noteIndex) {
 
 		if (keyCode === 33) {
-			newNoteIndex = newNoteIndex - (this.itemListRef.current.visibleItemCount() - 1);
+			noteIndex -= (this.itemListRef.current.visibleItemCount() - 1);
 		}
 		if (keyCode === 34) {
-			newNoteIndex = newNoteIndex + (this.itemListRef.current.visibleItemCount() - 1);
+			noteIndex += (this.itemListRef.current.visibleItemCount() - 1);
 		}
 		if ((keyCode === 35 && ctrlKey) || (keyCode === 40 && metaKey)) {
-			newNoteIndex = this.props.notes.length - 1;
+			noteIndex = this.props.notes.length - 1;
 		}
 		if ((keyCode === 36 && ctrlKey) || (keyCode === 38 && metaKey)) {
-			newNoteIndex = 0;
+			noteIndex = 0;
 		}
 		if (keyCode === 38 && !metaKey) {
-			newNoteIndex = newNoteIndex - 1;
+			noteIndex -= 1;
 		}
 		if (keyCode === 40 && !metaKey) {
-			newNoteIndex = newNoteIndex + 1;
+			noteIndex += 1;
 		}
 
-		if (newNoteIndex < 0) newNoteIndex = 0;
-		if (newNoteIndex > this.props.notes.length - 1) newNoteIndex = this.props.notes.length - 1;
+		if (noteIndex < 0) noteIndex = 0;
+		if (noteIndex > this.props.notes.length - 1) noteIndex = this.props.notes.length - 1;
 
-		return newNoteIndex;
+		return noteIndex;
 	}
 
 	async onKeyDown(event) {
@@ -330,7 +329,7 @@ class NoteListComponent extends React.Component {
 			const noteId = noteIds[0];
 			let noteIndex = BaseModel.modelIndexById(this.props.notes, noteId);
 
-			noteIndex = this.newNoteIndex_(keyCode, event.ctrlKey, event.metaKey, noteIndex);
+			noteIndex = this.scrollNoteIndex_(keyCode, event.ctrlKey, event.metaKey, noteIndex);
 
 			const newSelectedNote = this.props.notes[noteIndex];
 

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -293,26 +293,26 @@ class NoteListComponent extends React.Component {
 		}
 	}
 
-	newNoteIndex_(keyCode, noteIndex) {
+	newNoteIndex_(keyCode, ctrlKey, metaKey, noteIndex) {
 		let newNoteIndex = noteIndex;
 
-		if (keyCode === 38) {
-			newNoteIndex = newNoteIndex - 1;
-		}
-		if (keyCode === 40) {
-			newNoteIndex = newNoteIndex + 1;
-		}
 		if (keyCode === 33) {
 			newNoteIndex = newNoteIndex - (this.itemListRef.current.visibleItemCount() - 1);
 		}
 		if (keyCode === 34) {
 			newNoteIndex = newNoteIndex + (this.itemListRef.current.visibleItemCount() - 1);
 		}
-		if (keyCode === 36) {
+		if ((keyCode === 35 && ctrlKey) || (keyCode === 40 && metaKey)) {
+			newNoteIndex = this.props.notes.length - 1;
+		}
+		if ((keyCode === 36 && ctrlKey) || (keyCode === 38 && metaKey)) {
 			newNoteIndex = 0;
 		}
-		if (keyCode === 35) {
-			newNoteIndex = this.props.notes.length - 1;
+		if (keyCode === 38 && !metaKey) {
+			newNoteIndex = newNoteIndex - 1;
+		}
+		if (keyCode === 40 && !metaKey) {
+			newNoteIndex = newNoteIndex + 1;
 		}
 
 		if (newNoteIndex < 0) newNoteIndex = 0;
@@ -330,7 +330,7 @@ class NoteListComponent extends React.Component {
 			const noteId = noteIds[0];
 			let noteIndex = BaseModel.modelIndexById(this.props.notes, noteId);
 
-			noteIndex = this.newNoteIndex_(keyCode, noteIndex);
+			noteIndex = this.newNoteIndex_(keyCode, event.ctrlKey, event.metaKey, noteIndex);
 
 			const newSelectedNote = this.props.notes[noteIndex];
 

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -293,20 +293,44 @@ class NoteListComponent extends React.Component {
 		}
 	}
 
+	newNoteIndex_(keyCode, noteIndex) {
+		let newNoteIndex = noteIndex;
+
+		if (keyCode === 38) {
+			newNoteIndex = newNoteIndex - 1;
+		}
+		if (keyCode === 40) {
+			newNoteIndex = newNoteIndex + 1;
+		}
+		if (keyCode === 33) {
+			newNoteIndex = newNoteIndex - (this.itemListRef.current.visibleItemCount() - 1);
+		}
+		if (keyCode === 34) {
+			newNoteIndex = newNoteIndex + (this.itemListRef.current.visibleItemCount() - 1);
+		}
+		if (keyCode === 36) {
+			newNoteIndex = 0;
+		}
+		if (keyCode === 35) {
+			newNoteIndex = this.props.notes.length - 1;
+		}
+
+		if (newNoteIndex < 0) newNoteIndex = 0;
+		if (newNoteIndex > this.props.notes.length - 1) newNoteIndex = this.props.notes.length - 1;
+
+		return newNoteIndex;
+	}
+
 	async onKeyDown(event) {
 		const keyCode = event.keyCode;
 		const noteIds = this.props.selectedNoteIds;
 
-		if (noteIds.length === 1 && (keyCode === 40 || keyCode === 38)) {
-			// DOWN / UP
+		if (noteIds.length === 1 && (keyCode === 40 || keyCode === 38 || keyCode === 33 || keyCode === 34 || keyCode === 35 || keyCode == 36)) {
+			// DOWN / UP / PAGEDOWN / PAGEUP / END / HOME
 			const noteId = noteIds[0];
 			let noteIndex = BaseModel.modelIndexById(this.props.notes, noteId);
-			const inc = keyCode === 38 ? -1 : +1;
 
-			noteIndex += inc;
-
-			if (noteIndex < 0) noteIndex = 0;
-			if (noteIndex > this.props.notes.length - 1) noteIndex = this.props.notes.length - 1;
+			noteIndex = this.newNoteIndex_(keyCode, noteIndex);
 
 			const newSelectedNote = this.props.notes[noteIndex];
 

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -310,6 +310,7 @@ class NoteListComponent extends React.Component {
 		} else if ((keyCode === 36 && ctrlKey) || (keyCode === 38 && metaKey)) {
 			// CTRL+Home, CMD+Up
 			noteIndex = 0;
+
 		} else if (keyCode === 38 && !metaKey) {
 			// Up
 			noteIndex -= 1;

--- a/ElectronClient/app/gui/NoteList.jsx
+++ b/ElectronClient/app/gui/NoteList.jsx
@@ -296,21 +296,26 @@ class NoteListComponent extends React.Component {
 	scrollNoteIndex_(keyCode, ctrlKey, metaKey, noteIndex) {
 
 		if (keyCode === 33) {
+			// Page Up
 			noteIndex -= (this.itemListRef.current.visibleItemCount() - 1);
-		}
-		if (keyCode === 34) {
+
+		} else if (keyCode === 34) {
+			// Page Down
 			noteIndex += (this.itemListRef.current.visibleItemCount() - 1);
-		}
-		if ((keyCode === 35 && ctrlKey) || (keyCode === 40 && metaKey)) {
+
+		} else if ((keyCode === 35 && ctrlKey) || (keyCode === 40 && metaKey)) {
+			// CTRL+End, CMD+Down
 			noteIndex = this.props.notes.length - 1;
-		}
-		if ((keyCode === 36 && ctrlKey) || (keyCode === 38 && metaKey)) {
+
+		} else if ((keyCode === 36 && ctrlKey) || (keyCode === 38 && metaKey)) {
+			// CTRL+Home, CMD+Up
 			noteIndex = 0;
-		}
-		if (keyCode === 38 && !metaKey) {
+		} else if (keyCode === 38 && !metaKey) {
+			// Up
 			noteIndex -= 1;
-		}
-		if (keyCode === 40 && !metaKey) {
+
+		} else if (keyCode === 40 && !metaKey) {
+			// Down
 			noteIndex += 1;
 		}
 


### PR DESCRIPTION
Please consider this PR to implement navigation in the note list using standard keys.

# Description
Currently using navigation keys in the note list does not work after the first key. This PR implements these functions for standard keys (Mac, Windows, Linux):

**Navigation**  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;**Key**

Up one line  &nbsp; &nbsp;&nbsp;&nbsp; &nbsp; `Up`&nbsp;&nbsp;&nbsp; (already supported)
Down one line  &nbsp;&nbsp; `Down`&nbsp;&nbsp;&nbsp; (already supported)
Up one page &nbsp;&nbsp;&nbsp;&nbsp; `Page Up`
Down one page `Page Down`
Start of list  &nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `Cmd+Up`, `Ctrl+Home`
End of list   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp; `Cmd+Down`, `Ctrl+End`

# Tests
Manual testing in note list:
- [x] Line up / down
- [x] Page up / down
- [x] Start / end

# Discussion
If the user has scrolled the selected item off the screen, then none of the key actions work. This issue is pre-existing and not related to any change in this PR.