### PR TITLE
Desktop: Support list creation on multi-line selections

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1425,12 +1425,12 @@ class NoteTextComponent extends React.Component {
 		let newBody = this.state.note.body;
 
 		if (selection && selection.start !== selection.end) {
-			const selLines = replacementText ? replacementText : this.state.note.body.substr(selection.start, selection.end - selection.start);
-			let selStrings = byLine ? selLines.split(/\r?\n/) : [selLines];
+			const selectedLines = replacementText ? replacementText : this.state.note.body.substr(selection.start, selection.end - selection.start);
+			let selectedStrings = byLine ? selectedLines.split(/\r?\n/) : [selectedLines];
 
 			newBody = this.state.note.body.substr(0, selection.start);
-			for (let i = 0; i < selStrings.length; i++) {
-				newBody += string1 + selStrings[i] + string2;
+			for (let i = 0; i < selectedStrings.length; i++) {
+				newBody += string1 + selectedStrings[i] + string2;
 			}
 			newBody += this.state.note.body.substr(selection.end);
 

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1413,17 +1413,6 @@ class NoteTextComponent extends React.Component {
 		return this.lineAtRow(row);
 	}
 
-	selectionRangeLines() {
-		if (!this.selectionRange_) return '';
-		const firstRow = this.selectionRange_.start.row;
-		const lastRow = this.selectionRange_.end.row;
-		let lines = [];
-		for (let i = firstRow; i < lastRow; i++) {
-			lines[i] = this.lineAtRow(i);
-		}
-		return lines;
-	}
-
 	textOffsetSelection() {
 		return this.selectionRange_ ? this.rangeToTextOffsets(this.selectionRange_, this.state.note.body) : null;
 	}
@@ -1550,9 +1539,11 @@ class NoteTextComponent extends React.Component {
 	}
 
 	addListItem(string1, string2 = '', defaultText = '', byLine=false) {
-		const currentLines = this.selectionRangeLines();
 		let newLine = '\n';
-		if (currentLines.length === 0) newLine = '';
+		const range = this.selectionRange_;
+		if (!range || (range.start.row === range.end.row && !this.selectionRangeCurrentLine())) {
+			newLine = '';
+		}
 		this.wrapSelectionWithStrings(newLine + string1, string2, defaultText, '', byLine);
 	}
 

--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -1425,16 +1425,14 @@ class NoteTextComponent extends React.Component {
 		let newBody = this.state.note.body;
 
 		if (selection && selection.start !== selection.end) {
-			const s1 = this.state.note.body.substr(0, selection.start);
-			const s2 = replacementText ? replacementText : this.state.note.body.substr(selection.start, selection.end - selection.start);
-			const s3 = this.state.note.body.substr(selection.end);
+			const selLines = replacementText ? replacementText : this.state.note.body.substr(selection.start, selection.end - selection.start);
+			let selStrings = byLine ? selLines.split(/\r?\n/) : [selLines];
 
-			newBody = s1;
-			let s2Split = byLine ? s2.split(/\r?\n/) : [s2];
-			for (let i = 0; i < s2Split.length; i++) {
-				newBody += string1 + s2Split[i] + string2;
+			newBody = this.state.note.body.substr(0, selection.start);
+			for (let i = 0; i < selStrings.length; i++) {
+				newBody += string1 + selStrings[i] + string2;
 			}
-			newBody += s3;
+			newBody += this.state.note.body.substr(selection.end);
 
 			const r = this.selectionRange_;
 


### PR DESCRIPTION
Resolves #1014 

# Tests
- [x] Check ordered lists (for single, single blank line, and multi-line selections)
- [x] Check unordered lists (single, single blank, multi-line)
- [x] Check checkbox list (single, single blank, multi-line)
- [x] Check heading  (confirm no change in behaviour)

# Discussion
The existing behaviour is to insert a blank line before the new list item (if not creating a list item on a single empty line).  Is there a reason for this (is it intended)?

If the action is undone (Ctrl-Z) the new selected area is incorrect ie it is different to that previously selected. This seems to be a pre-existing issue.
