### PR TITLE
Desktop: Do not show "could not print" warning dialog after cancelling print.

### DIFF
--- a/ElectronClient/app/InteropServiceHelper.js
+++ b/ElectronClient/app/InteropServiceHelper.js
@@ -61,12 +61,12 @@ class InteropServiceHelper {
 							cleanup();
 						}
 					} else {
-						win.webContents.print(options, (success) => {
+						win.webContents.print(options, (success, reason) => {
 							// TODO: This is correct but broken in Electron 4. Need to upgrade to 5+
 							// It calls the callback right away with "false" even if the document hasn't be print yet.
 
 							cleanup();
-							if (!success) reject(new Error('Could not print'));
+							if (!success && reason !== 'cancelled') reject(new Error('Could not print', reason));
 							resolve();
 						});
 					}

--- a/ElectronClient/app/InteropServiceHelper.js
+++ b/ElectronClient/app/InteropServiceHelper.js
@@ -66,7 +66,7 @@ class InteropServiceHelper {
 							// It calls the callback right away with "false" even if the document hasn't be print yet.
 
 							cleanup();
-							if (!success && reason !== 'cancelled') reject(new Error('Could not print', reason));
+							if (!success && reason !== 'cancelled') reject(new Error('Could not print: '.concat(reason)));
 							resolve();
 						});
 					}

--- a/ElectronClient/app/InteropServiceHelper.js
+++ b/ElectronClient/app/InteropServiceHelper.js
@@ -66,7 +66,7 @@ class InteropServiceHelper {
 							// It calls the callback right away with "false" even if the document hasn't be print yet.
 
 							cleanup();
-							if (!success && reason !== 'cancelled') reject(new Error('Could not print: '.concat(reason)));
+							if (!success && reason !== 'cancelled') reject(new Error(`Could not print: ${reason}`));
 							resolve();
 						});
 					}

--- a/ElectronClient/app/bridge.js
+++ b/ElectronClient/app/bridge.js
@@ -89,6 +89,7 @@ class Bridge {
 		return this.showMessageBox_(this.window(), {
 			type: 'error',
 			message: message,
+			buttons: [_('OK')],
 		});
 	}
 


### PR DESCRIPTION
Fixes #2407

### Do not error when print cancelled

When a print is cancelled, Joplin shows an error box: "Could not print".

This PR ensures the error box is only shown in case of print **error**, and not when the print is **cancelled**.

### Always show the OK button on error dialogs

The issue also found the "OK" button is missing from error dialogs on Linux.  This PR  ensures the button is shown on all platforms.