### PR TITLE
NotebookPropertiesDialog Component To Spec For Review

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -53,3 +53,4 @@ ReactNativeClient/lib/joplin-renderer/vendor/fountain.min.js
 ElectronClient/app/gui/ShareNoteDialog.js
 ReactNativeClient/lib/JoplinServerApi.js
 ReactNativeClient/PluginAssetsLoader.js
+ElectronClient/app/gui/NotebookPropertiesDialog.js

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ Tools/commit_hook.txt
 
 # Ignore files generated from TypeScript files
 ElectronClient/app/gui/ShareNoteDialog.js
+ElectronClient/app/gui/NotebookPropertiesDialog.js
 ReactNativeClient/lib/JoplinServerApi.js
 ReactNativeClient/PluginAssetsLoader.js

--- a/ElectronClient/app/gui/MainScreen.jsx
+++ b/ElectronClient/app/gui/MainScreen.jsx
@@ -256,7 +256,7 @@ class MainScreenComponent extends React.Component {
 					onRevisionLinkClick: command.onRevisionLinkClick,
 				},
 			});
-		} else if (command.name === 'openNotebookProperties') {
+		} else if (command.name === 'openNotebookProperties') {  //
 			this.setState({
 				notebookPropertiesDialogOptions: {
 					folderId: command.folderId,

--- a/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
+++ b/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState, useEffect } from 'react';
 
 const { _ } = require('lib/locale.js');
-const { themeStyle } = require('../theme.js');
+const { themeStyle, buildStyle } = require('../theme.js');
 const DialogButtonRow = require('./DialogButtonRow.min');
 
 const Folder = require('lib/models/Folder.js');
@@ -13,17 +13,58 @@ interface FolderPropertiesDialogProps {
 	onClose: Function,
 }
 
+function styles_(props:FolderPropertiesDialogProps) {
+	return buildStyle('FolderPropertiesDialog', props.theme, (theme: any) => {
+		return {
+			folderLabel: {
+				...theme.textStyle,
+				flex: 1,
+				display: 'flex',
+				fontWeight: 'bold',
+				color: theme.color,
+			},
+			folderSaveButton: {
+				background: 'none',
+				border: 'none',
+			},
+			folderSaveButtonIcon: {
+				color: theme.color,
+				fontSize: '1.4em',
+			},
+			titleForm: {
+				display: 'inline-block',
+				color: theme.color,
+				backgroundColor: theme.backgroundColor,
+				border: '1px solid',
+				borderColor: theme.dividerColor,
+				marginLeft: '3em',
+				width: '6em',
+			},
+			iconForm: {
+				display: 'inline-block',
+				color: theme.color,
+				backgroundColor: theme.backgroundColor,
+				border: '1px solid',
+				borderColor: theme.dividerColor,
+				marginLeft: '3.6em',
+				width: '6em',
+			},
+		};
+	});
+}
+
 export default function FolderPropertiesDialog(props: FolderPropertiesDialogProps) {
 	console.info('Render NotebookPropertiesDialog');
 
 	const [formFolder, setFormFolder] = useState<any>({});
 
 	const theme = themeStyle(props.theme);
+	const styles = styles_(props);
 
 	useEffect(() => {
 		async function fetchFolder() {
 			if (!props.folderId) {
-				setFormFolder({folder: null});
+				throw new Error('FolderID is not set. This Notebook is not valid!!!');
 			} else {
 				setFormFolder(await Folder.load(props.folderId));
 			}
@@ -44,17 +85,50 @@ export default function FolderPropertiesDialog(props: FolderPropertiesDialogProp
 	const rootStyle = Object.assign({}, theme.dialogBox);
 	rootStyle.width = '50%';
 
+	let titleComp = (
+		<label
+			style={styles.folderLabel}>
+			{_('Name: ')}
+			<input
+				defaultValue={formFolder.title}
+				onChange={event => formFolder.title = event.target.value}
+				style={styles.titleForm} />
+			<button
+				onClick={saveFolder}
+				style={styles.folderSaveButton}>
+				<i
+					style={styles.folderSaveButtonIcon}
+					className={'fa fa-save'}>
+				</i>
+			</button>
+		</label>
+	);
+
+	let iconComp = (
+		<label
+			style={styles.folderLabel}>
+			{_('Icon: ')}
+			<input
+				defaultValue={formFolder.icon}
+				onChange={event => formFolder.icon = event.target.value}
+				style={styles.iconForm} />
+			<button
+				onClick={saveFolder}
+				style={styles.folderSaveButton}>
+				<i
+					style={styles.folderSaveButtonIcon}
+					className={'fa fa-save'}>
+				</i>
+			</button>
+		</label>
+	);
+
 	return (
 		<div style={theme.dialogModalLayer}>
 			<div style={rootStyle}>
 				<div style={theme.dialogTitle}>{_('Notebook Properties')}</div>
-				<label style={theme.textStyle}>{_('Name: ')}</label>
-				<input defaultValue={formFolder.title} onChange={event => formFolder.title = event.target.value} />
-				<button onClick={saveFolder}>{_('Save')}</button>
-				<br />
-				<label style={theme.textStyle}>{_('Icon: ')}</label>
-				<input defaultValue={formFolder.icon} onChange={event => formFolder.icon = event.target.value} />
-				<button onClick={saveFolder}>{_('Save')}</button>
+				{titleComp}
+				{iconComp}
 				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
 			</div>
 		</div>

--- a/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
+++ b/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
@@ -7,75 +7,55 @@ const DialogButtonRow = require('./DialogButtonRow.min');
 
 const Folder = require('lib/models/Folder.js');
 
-interface NotebookPropertiesDialogProps {
+interface FolderPropertiesDialogProps {
 	theme: number,
 	folderId: string,
 	onClose: Function,
 }
 
-export default function NotebookPropertiesDialog(props: NotebookPropertiesDialogProps) {
+export default function FolderPropertiesDialog(props: FolderPropertiesDialogProps) {
 	console.info('Render NotebookPropertiesDialog');
 
-	const [notebook, setNotebook] = useState<any>({});
-	const [icon, setIcon] = useState<string>('fa fa-book'); //
-	const [loaded, setLoaded] = useState<boolean>(false);
+	const [formFolder, setFormFolder] = useState<any>({});
 
 	const theme = themeStyle(props.theme);
 
 	useEffect(() => {
-		async function fetchNotebook() {
+		async function fetchFolder() {
 			if (!props.folderId) {
-				setNotebook({notebook: null});
+				setFormFolder({folder: null});
 			} else {
-				const n = await Folder.load(props.folderId);
-				const nb = formNotebook(n);
-				setNotebook(nb);
+				setFormFolder(await Folder.load(props.folderId));
 			}
 		}
 
-		fetchNotebook();
+		fetchFolder();
 	}, [props.folderId]);
 
-	const formNotebook = (targetNotebook:any) => {
-		if (!loaded) {
-			const nb = Object.assign({}, targetNotebook, {
-				icon: targetNotebook.icon,
-			});
-			setIcon(nb.icon);
-			setLoaded(true);
-			return nb;
-		}
-	};
 
 	const buttonRow_click = () => {
 		props.onClose();
 	};
 
-	// having issues wrapping my head around saving folder information to the database
-	const saveNotebook = async () => {
-		console.info('Saving Notebook Now');
-		if (!notebook) {
-			console.error('Notebook saving failed in the NotebookPropertiesDialog');
-		} else {
-			const nb = await Folder.save(notebook, {userSideValidation: true});
-			setNotebook(nb);
-		}
-		props.onClose();
+	const saveFolder = async () => {
+		await Folder.save({id: formFolder.id, title: formFolder.title, icon: formFolder.icon}, {userValidation: true});
 	};
 
 	const rootStyle = Object.assign({}, theme.dialogBox);
 	rootStyle.width = '50%';
 
-	console.info('Icon: %s', icon);
-
 	return (
 		<div style={theme.dialogModalLayer}>
 			<div style={rootStyle}>
 				<div style={theme.dialogTitle}>{_('Notebook Properties')}</div>
+				<label style={theme.textStyle}>{_('Name: ')}</label>
+				<input defaultValue={formFolder.title} onChange={event => formFolder.title = event.target.value} />
+				<button onClick={saveFolder}>{_('Save')}</button>
+				<br />
 				<label style={theme.textStyle}>{_('Icon: ')}</label>
-				<input defaultValue={notebook.icon} onChange={event => setIcon(event.target.value)} />
-				<button onClick={saveNotebook}>{_('Save')}</button>
-				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Cancel')}/>
+				<input defaultValue={formFolder.icon} onChange={event => formFolder.icon = event.target.value} />
+				<button onClick={saveFolder}>{_('Save')}</button>
+				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
 			</div>
 		</div>
 	);

--- a/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
+++ b/ElectronClient/app/gui/NotebookPropertiesDialog.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { useState, useEffect } from 'react';
+
+const { _ } = require('lib/locale.js');
+const { themeStyle } = require('../theme.js');
+const DialogButtonRow = require('./DialogButtonRow.min');
+
+const Folder = require('lib/models/Folder.js');
+
+interface NotebookPropertiesDialogProps {
+	theme: number,
+	folderId: string,
+	onClose: Function,
+}
+
+export default function NotebookPropertiesDialog(props: NotebookPropertiesDialogProps) {
+	console.info('Render NotebookPropertiesDialog');
+
+	const [notebook, setNotebook] = useState<any>({});
+	const [icon, setIcon] = useState<string>('fa fa-book'); //
+	const [loaded, setLoaded] = useState<boolean>(false);
+
+	const theme = themeStyle(props.theme);
+
+	useEffect(() => {
+		async function fetchNotebook() {
+			if (!props.folderId) {
+				setNotebook({notebook: null});
+			} else {
+				const n = await Folder.load(props.folderId);
+				const nb = formNotebook(n);
+				setNotebook(nb);
+			}
+		}
+
+		fetchNotebook();
+	}, [props.folderId]);
+
+	const formNotebook = (targetNotebook:any) => {
+		if (!loaded) {
+			const nb = Object.assign({}, targetNotebook, {
+				icon: targetNotebook.icon,
+			});
+			setIcon(nb.icon);
+			setLoaded(true);
+			return nb;
+		}
+	};
+
+	const buttonRow_click = () => {
+		props.onClose();
+	};
+
+	// having issues wrapping my head around saving folder information to the database
+	const saveNotebook = async () => {
+		console.info('Saving Notebook Now');
+		if (!notebook) {
+			console.error('Notebook saving failed in the NotebookPropertiesDialog');
+		} else {
+			const nb = await Folder.save(notebook, {userSideValidation: true});
+			setNotebook(nb);
+		}
+		props.onClose();
+	};
+
+	const rootStyle = Object.assign({}, theme.dialogBox);
+	rootStyle.width = '50%';
+
+	console.info('Icon: %s', icon);
+
+	return (
+		<div style={theme.dialogModalLayer}>
+			<div style={rootStyle}>
+				<div style={theme.dialogTitle}>{_('Notebook Properties')}</div>
+				<label style={theme.textStyle}>{_('Icon: ')}</label>
+				<input defaultValue={notebook.icon} onChange={event => setIcon(event.target.value)} />
+				<button onClick={saveNotebook}>{_('Save')}</button>
+				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Cancel')}/>
+			</div>
+		</div>
+	);
+}

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -461,7 +461,8 @@ class SideBarComponent extends React.Component {
 
 		let folderIconStyle = {
 			visibility: 'visible',
-			paddingLeft: 5 + depth * 10,
+			paddingLeft: 5,
+			paddingRight: 5,
 		};
 
 		let expandLinkStyle = Object.assign({}, this.style().listItemExpandIcon);
@@ -470,7 +471,7 @@ class SideBarComponent extends React.Component {
 			paddingLeft: 8 + depth * 10,
 		};
 
-		const folderIconName = folder.icon != '' ? folder.icon : 'fa-book';
+		const folderIconName = folder.icon !== '' ? folder.icon : 'fa-book';
 		const folderIcon = <i style={folderIconStyle} className={`fa ${folderIconName}`}></i>;
 		const iconName = this.props.collapsedFolderIds.indexOf(folder.id) >= 0 ? 'fa-plus-square' : 'fa-minus-square';
 		const expandIcon = <i style={expandIconStyle} className={`fa ${iconName}`}></i>;

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -338,7 +338,7 @@ class SideBarComponent extends React.Component {
 		if (itemType === BaseModel.TYPE_FOLDER && !item.encryption_applied) {
 			menu.append(
 				new MenuItem({
-					label: _('Properties'),
+					label: _('Properties'), //
 					click: async () => {
 						this.props.dispatch({
 							type: 'WINDOW_COMMAND',
@@ -459,12 +459,19 @@ class SideBarComponent extends React.Component {
 		let containerStyle = Object.assign({}, this.style(depth).listItemContainer);
 		if (selected) containerStyle = Object.assign(containerStyle, this.style().listItemSelected);
 
+		let folderIconStyle = {
+			visibility: 'visible',
+			paddingLeft: 5 + depth * 10,
+		};
+
 		let expandLinkStyle = Object.assign({}, this.style().listItemExpandIcon);
 		let expandIconStyle = {
 			visibility: hasChildren ? 'visible' : 'hidden',
 			paddingLeft: 8 + depth * 10,
 		};
 
+		const folderIconName = folder.icon != '' ? folder.icon : 'fa-book';
+		const folderIcon = <i style={folderIconStyle} className={`fa ${folderIconName}`}></i>;
 		const iconName = this.props.collapsedFolderIds.indexOf(folder.id) >= 0 ? 'fa-plus-square' : 'fa-minus-square';
 		const expandIcon = <i style={expandIconStyle} className={`fa ${iconName}`}></i>;
 		const expandLink = hasChildren ? (
@@ -495,7 +502,7 @@ class SideBarComponent extends React.Component {
 					}}
 					onDoubleClick={this.onFolderToggleClick_}
 				>
-					{itemTitle} {noteCount}
+					{folderIcon} {itemTitle} {noteCount}
 				</a>
 			</div>
 		);

--- a/ElectronClient/app/gui/SideBar.jsx
+++ b/ElectronClient/app/gui/SideBar.jsx
@@ -338,12 +338,12 @@ class SideBarComponent extends React.Component {
 		if (itemType === BaseModel.TYPE_FOLDER && !item.encryption_applied) {
 			menu.append(
 				new MenuItem({
-					label: _('Rename'),
+					label: _('Properties'),
 					click: async () => {
 						this.props.dispatch({
 							type: 'WINDOW_COMMAND',
-							name: 'renameFolder',
-							id: itemId,
+							name: 'openNotebookProperties',
+							folderId: itemId,
 						});
 					},
 				})

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -8,6 +8,7 @@ const structureSql = `
 CREATE TABLE folders (
 	id TEXT PRIMARY KEY,
 	title TEXT NOT NULL DEFAULT "",
+	icon TEXT NOT NULL DEFAULT "",
 	created_time INT NOT NULL,
 	updated_time INT NOT NULL
 );

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -19,13 +19,14 @@ class Folder extends BaseItem {
 		return {
 			id: null,
 			title: '',
-			icon: '', //
+			icon: 'fa-book',
 		};
 	}
 
 	static fieldToLabel(field) {
 		const fieldsToLabels = {
 			title: _('title'),
+			icon: _('icon'),
 			last_note_user_updated_time: _('updated date'),
 		};
 

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -19,6 +19,7 @@ class Folder extends BaseItem {
 		return {
 			id: null,
 			title: '',
+			icon: '',
 		};
 	}
 

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -19,7 +19,7 @@ class Folder extends BaseItem {
 		return {
 			id: null,
 			title: '',
-			icon: '',
+			icon: '', //
 		};
 	}
 

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -19,7 +19,7 @@ class Folder extends BaseItem {
 		return {
 			id: null,
 			title: '',
-			icon: 'fa-book',
+			icon: '',
 		};
 	}
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

I spent the last two days taking your feedback and working on learning how React Hooks work, and also reevaluating my code, because, let's be frank, my previous submission didn't work a quarter as good as this so far. That's because I went off spec and tried to take the easy way out and pretty much copy by hand a different component to see how the code flows. This time I took my time, went through the spec and built the NotebookPropertiesDialog component in chunks.

## Tasks Completed

- Add a new icon property to the Folder object - it will be a string that will take any of the Fork Awesome icon names.
- Make sure Fork Awesome is loaded in the app (it should already be) so that its icons can be displayed
- When right-clicking a notebook, change "Rename" to "Properties"
- Change the Rename dialog to a more generic Notebook Properties dialog
- Add the option to set the icon there. Initially it can be a simple text input where the user inputs the name of the icon directly. We can link to the Fork Awesome page to give the list of possible icons.

## Tasks mostly completed with bugs

- When the user click Save, save the icon to the database
- In the sidebar, display the icon next to the notebook name.

The final two commits were my attempts at getting these two parts to function properly, but I am a bit at a loss for why neither one are working properly and welcome feedback.