### PR TITLE
Reset created and updated times for a duplicate Note

### DIFF
--- a/CliClient/tests/models_Note.js
+++ b/CliClient/tests/models_Note.js
@@ -116,4 +116,17 @@ describe('models_Note', function() {
 		}
 	}));
 
+	it('should reset fields for a duplicate', asyncTest(async () => {
+		let folder1 = await Folder.save({ title: 'folder1'});
+		let note1 = await Note.save({ title: 'note', parent_id: folder1.id });
+
+		let duplicatedNote = await Note.duplicate(note1.id);
+
+		expect(duplicatedNote !== note1).toBe(true);
+		expect(duplicatedNote.created_time !== note1.created_time).toBe(true);
+		expect(duplicatedNote.updated_time !== note1.updated_time).toBe(true);
+		expect(duplicatedNote.user_created_time !== note1.user_created_time).toBe(true);
+		expect(duplicatedNote.user_updated_time !== note1.user_updated_time).toBe(true);
+	}));
+
 });

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -511,7 +511,11 @@ class Note extends BaseItem {
 		if (!originalNote) throw new Error(`Unknown note: ${noteId}`);
 
 		let newNote = Object.assign({}, originalNote);
-		delete newNote.id;
+		const fieldsToReset = ['id', 'created_time', 'updated_time', 'user_created_time', 'user_updated_time'];
+
+		for (let field of fieldsToReset) {
+			delete newNote[field];
+		}
 
 		for (let n in changes) {
 			if (!changes.hasOwnProperty(n)) continue;


### PR DESCRIPTION
#### Justification
I'd like to say many thanks for the great product! I really like Joplin!
I enjoy sorting by created date for Notes, but unfortunately, when I duplicate a Note, it breaks the sorting. I found out that during duplication we reset only `id`. I'm not sure if it's appropriate, but I feel it might be reasonable to reset `created_time` and `updated_time` fields as well. I couldn't find a reason we need to carry over these fields to a duplicated Note. Might be I missed something, let me know if it's not a great idea resetting these fields.

#### Changes
1. Reset id, created_time, updated_time, user_created_time, user_updated_time fields when duplicate a `Note`

#### Demo before the fix
![Kapture 2020-02-02 at 0 03 38](https://user-images.githubusercontent.com/5417051/73603414-4d038d00-4550-11ea-8d73-4544ce0d2e7b.gif)


#### Demo after the fix
![Kapture 2020-02-02 at 0 05 04](https://user-images.githubusercontent.com/5417051/73603412-4aa13300-4550-11ea-9773-4caa48534586.gif)