### PR TITLE
Desktop: Fix #2365 by ensuring the main window is hidden when Joplin starts

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -124,6 +124,12 @@ class ElectronAppWrapper {
 		// automatically (the listeners will be removed when the window is closed)
 		// and restore the maximized or full screen state
 		windowState.manage(this.win_);
+		// Ensure the window is hidden, as windowStateKeeper may make the window
+		// visible with isMaximized set to true in window-state-${this.env_}.json.
+		// Fix: https://github.com/laurent22/joplin/issues/2365
+		if (!windowOptions.show) {
+			this.win_.hide();
+		}
 	}
 
 	async waitForElectronAppReady() {

--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -124,9 +124,10 @@ class ElectronAppWrapper {
 		// automatically (the listeners will be removed when the window is closed)
 		// and restore the maximized or full screen state
 		windowState.manage(this.win_);
-		// Ensure the window is hidden, as windowStateKeeper may make the window
+		
+		// HACK: Ensure the window is hidden, as `windowState.manage` may make the window
 		// visible with isMaximized set to true in window-state-${this.env_}.json.
-		// Fix: https://github.com/laurent22/joplin/issues/2365
+		// https://github.com/laurent22/joplin/issues/2365
 		if (!windowOptions.show) {
 			this.win_.hide();
 		}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

The bug is described in details in https://github.com/laurent22/joplin/issues/2365. 

Currently, starting in tray is implemented by creating a hidden main window, and making it visible only if starting in tray is disabled. However, just after the creation of the window, a listener from the package `electron-window-state` is registered on the window. This listener makes the window visible again when restoring from a **maximized** window state as a side-effect. This can be replicated by setting the `isMaximized` property to `true` in `window-state-{dev,prod}.json` located in `~/.config/Joplin/`(Linux) or `%APPDATA%\Joplin\`(Windows).

This PR hides the window again after registering the listener, preventing the window from being shown.