### PR TITLE
Desktop: Ignore no-sandbox start flag at joplin startup

### DIFF
--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -176,6 +176,14 @@ class BaseApplication {
 				continue;
 			}
 
+			if (arg === '--no-sandbox') {
+				// Electron-specific flag for running the app without chrome-sandbox
+				// Allows users to use it as a workaround for the electron+AppImage issue
+				// https://github.com/laurent22/joplin/issues/2246
+				argv.splice(0, 1);
+				continue;
+			}
+
 			if (arg.length && arg[0] == '-') {
 				throw new JoplinError(_('Unknown flag: %s', arg), 'flagError');
 			} else {


### PR DESCRIPTION
The change allows `--no-sandbox` flag at Joplin desktop app startup. This enables the users to optionally run the app without the electron sandbox as a workaround for the electron + AppImage package issue discussed in https://github.com/laurent22/joplin/issues/2246.