### PR TITLE
Desktop: fixes long lines warpped

### DIFF
--- a/ReactNativeClient/lib/joplin-renderer/noteStyle.js
+++ b/ReactNativeClient/lib/joplin-renderer/noteStyle.js
@@ -14,6 +14,7 @@ module.exports = function(style, options) {
 		body {
 			font-size: ${style.htmlFontSize};
 			color: ${style.htmlColor};
+			word-wrap: break-word;
 			line-height: ${style.htmlLineHeight};
 			background-color: ${style.htmlBackgroundColor};
 			font-family: ${fontFamily};


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
**"Desktop" for the Windows/macOS/Linux app (Electron app)**
- This change allows warping long lines in the view area of note editor.
- Reference of the issue #2170
