### PR TITLE
fix escaping of title when generating a markdown link

### DIFF
--- a/CliClient/tests/markdownUtils.js
+++ b/CliClient/tests/markdownUtils.js
@@ -49,4 +49,19 @@ describe('markdownUtils', function() {
 		}
 	}));
 
+	it('escape a markdown link (title)', asyncTest(async () => {
+
+		const testCases = [
+			['Helmut K. C. Tessarek', 'Helmut K. C. Tessarek'],
+			['Helmut (K. C.) Tessarek', 'Helmut (K. C.) Tessarek'],
+			['Helmut [K. C.] Tessarek', 'Helmut \\[K. C.\\] Tessarek'],
+		];
+
+		for (let i = 0; i < testCases.length; i++) {
+			const md = testCases[i][0];
+			const expected = testCases[i][1];
+			expect(markdownUtils.escapeTitleText(md)).toBe(expected);
+		}
+	}));
+
 });

--- a/ReactNativeClient/lib/markdownUtils.js
+++ b/ReactNativeClient/lib/markdownUtils.js
@@ -9,6 +9,11 @@ const markdownUtils = {
 		return text.replace(/(\[|\]|\(|\))/g, '_');
 	},
 
+	// Titles for markdown links only need escaping for [ and ]
+	escapeTitleText(text) {
+		return text.replace(/(\[|\])/g, '\\$1');
+	},
+
 	escapeLinkUrl(url) {
 		url = url.replace(/\(/g, '%28');
 		url = url.replace(/\)/g, '%29');

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -761,7 +761,7 @@ class BaseItem extends BaseModel {
 
 		const output = [];
 		output.push('[');
-		output.push(markdownUtils.escapeLinkText(item.title));
+		output.push(markdownUtils.escapeTitleText(item.title));
 		output.push(']');
 		output.push(`(:/${item.id})`);
 		return output.join('');


### PR DESCRIPTION
Previously a title with brackets was escaped incorrectly. The brackets were replaced by underscores.

The following title `title [square] (round)` looked like this:

```
[title _square_ _round_](:/c54794f53e5e4b1aa558699e255d5f95)
```

Now it looks like this:

```
[title \[square\] (round)](:/c54794f53e5e4b1aa558699e255d5f95)
```

<img width="687" alt="image" src="https://user-images.githubusercontent.com/223439/73993697-fb2c7f80-4920-11ea-8038-7e9f37e0db05.png">


fixes #2085 
