### PR TITLE
All: Fix markdown export

### DIFF
--- a/CliClient/tests/services_InteropService.js
+++ b/CliClient/tests/services_InteropService.js
@@ -334,6 +334,35 @@ describe('services_InteropService', function() {
 		}
 	}));
 
+	it('should export selected notes in md format', asyncTest(async () => {
+		const service = new InteropService();
+		let folder1 = await Folder.save({ title: 'folder1' });
+		let note11 = await Note.save({ title: 'title note11', parent_id: folder1.id });
+		note11 = await Note.load(note11.id);
+		let note12 = await Note.save({ title: 'title note12', parent_id: folder1.id });
+		note12 = await Note.load(note12.id);
+
+		let folder2 = await Folder.save({ title: 'folder2', parent_id: folder1.id });
+		folder2 = await Folder.load(folder2.id);
+		let note21 = await Note.save({ title: 'title note21', parent_id: folder2.id });
+		note21 = await Note.load(note21.id);
+
+		let folder3 = await Folder.save({ title: 'folder3', parent_id: folder1.id });
+		folder3 = await Folder.load(folder2.id);
+
+		const outDir = exportDir();
+
+		await service.export({ path: outDir, format: 'md', sourceNoteIds: [note11.id, note21.id] });
+
+		// verify that the md files exist
+		expect(await shim.fsDriver().exists(`${outDir}/folder1`)).toBe(true);
+		expect(await shim.fsDriver().exists(`${outDir}/folder1/title note11.md`)).toBe(true);
+		expect(await shim.fsDriver().exists(`${outDir}/folder1/title note12.md`)).toBe(false);
+		expect(await shim.fsDriver().exists(`${outDir}/folder1/folder2`)).toBe(true);
+		expect(await shim.fsDriver().exists(`${outDir}/folder1/folder2/title note21.md`)).toBe(true);
+		expect(await shim.fsDriver().exists(`${outDir}/folder3`)).toBe(false);
+	}));
+
 	it('should export MD with unicode filenames', asyncTest(async () => {
 		const service = new InteropService();
 		let folder1 = await Folder.save({ title: 'folder1' });

--- a/ReactNativeClient/lib/services/InteropService_Exporter_Md.js
+++ b/ReactNativeClient/lib/services/InteropService_Exporter_Md.js
@@ -1,5 +1,5 @@
 const InteropService_Exporter_Base = require('lib/services/InteropService_Exporter_Base');
-const { basename, friendlySafeFilename } = require('lib/path-utils.js');
+const { basename, dirname, friendlySafeFilename } = require('lib/path-utils.js');
 const BaseModel = require('lib/BaseModel');
 const Folder = require('lib/models/Folder');
 const Note = require('lib/models/Note');
@@ -119,6 +119,7 @@ class InteropService_Exporter_Md extends InteropService_Exporter_Base {
 			let noteBody = await this.relaceLinkedItemIdsByRelativePaths_(item);
 			const modNote = Object.assign({}, item, { body: noteBody });
 			const noteContent = await Note.serializeForEdit(modNote);
+			await shim.fsDriver().mkdir(dirname(noteFilePath));
 			await shim.fsDriver().writeFile(noteFilePath, noteContent, 'utf-8');
 		}
 	}


### PR DESCRIPTION
Fixes #2449
Fixes #2455

- The issue occurs because the export folder for the notebook does not exist when the note md file is saved. (`fs.writeFile` does not recursively create the path) 
- The solution is to ensure the folder exists when writing the note.
- Unit tests added.
- Tested on desktop (Linux) only.
