### PR TITLE
Desktop: Update Electron to 7.1.11

### DIFF
--- a/ElectronClient/app/package-lock.json
+++ b/ElectronClient/app/package-lock.json
@@ -225,9 +225,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+      "version": "12.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
       "dev": true
     },
     "abab": {
@@ -2739,9 +2739,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.9.tgz",
-      "integrity": "sha512-gkzDr08XxRaNZhwPLRXYNXDaPuiAeCrRPcClowlDVfCLKi+kRNhzekZpfYUBq8DdZCD29D3rCtgc9IHjD/xuHw==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.11.tgz",
+      "integrity": "sha512-YDXfnovKY+8iZ5ISQh1kRqYIRKbpOSxGXCx2WVxPFPutEQ7Q/Xzr3h4GePEY25/NXMytMfhKaAZAYjtWUm3r9Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -3619,18 +3619,18 @@
       }
     },
     "global-agent": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.7.tgz",
-      "integrity": "sha512-ooK7eqGYZku+LgnbfH/Iv0RJ74XfhrBZDlke1QSzcBt0bw1PmJcnRADPAQuFE+R45pKKDTynAr25SBasY2kvow==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
-        "core-js": "^3.4.1",
+        "core-js": "^3.6.4",
         "es6-error": "^4.1.1",
-        "matcher": "^2.0.0",
-        "roarr": "^2.14.5",
-        "semver": "^6.3.0",
+        "matcher": "^2.1.0",
+        "roarr": "^2.15.2",
+        "semver": "^7.1.2",
         "serialize-error": "^5.0.0"
       },
       "dependencies": {
@@ -3642,9 +3642,9 @@
           "optional": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+          "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
           "dev": true,
           "optional": true
         }
@@ -6132,15 +6132,15 @@
       }
     },
     "roarr": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.6.tgz",
-      "integrity": "sha512-qjbw0BEesKA+3XFBPt+KVe1PC/Z6ShfJ4wPlx2XifqH5h2Lj8/KQT5XJTsy3n1Es5kai+BwKALaECW3F70B1cg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
         "detect-node": "^2.0.4",
-        "globalthis": "^1.0.0",
+        "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
         "semver-compare": "^1.0.0",
         "sprintf-js": "^1.1.2"

--- a/ElectronClient/app/package.json
+++ b/ElectronClient/app/package.json
@@ -74,7 +74,7 @@
     "app-builder-bin": "^1.9.11",
     "babel-cli": "^6.26.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "^7.1.9",
+    "electron": "^7.1.11",
     "electron-builder": "22.3.2",
     "electron-rebuild": "^1.8.8"
   },


### PR DESCRIPTION
This is only a minor bump but several issues have been fixed since 7.1.9:

- Fixed an edge case in checkbox logic on Windows. electron/electron#21860
- Fixed an issue where window.print() only worked once on a single BrowserWindow. electron/electron#21911
- Fixed an issue where the credits set in About Panel credits were not dark mode aware on macOS. electron/electron#21924
- Fixed error thrown when importing powerMonitor on Linux before app's 'ready' event. electron/electron#21941
- Fixed fuzzy font rendering when hot-plugging displays on macOS Catalina. electron/electron#21872
- Fixed BrowserWindow.setFocusable(true) not working on Windows. electron/electron#21855
- Fixed set-cookie header not passed in net module. electron/electron#21770
- Fixed an issue where custom stream protocols would sometimes not complete responses when the data stream ended. electron/electron#21758
- Fixed crash when restoring minimized hidden window on Windows. electron/electron#21820
- Fixed issue where non-zero size pixels in CSS styles could be rounded down to zero size pixels. electron/electron#21857
- Fixed memory leak when using javascript generator functions. electron/electron#21773
- Fixed potential hang when sending synchronous IPC messages on process shutdown. electron/electron#21776
