### PR TITLE
show master instead of HEAD as branch

### DIFF
--- a/ElectronClient/app/compile-package-info.js
+++ b/ElectronClient/app/compile-package-info.js
@@ -23,6 +23,8 @@ try {
 	// Use stdio: 'pipe' so that execSync doesn't print error directly to stdout
 	branch = execSync('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }).toString().trim();
 	hash   = execSync('git log --pretty="%h" -1', { stdio: 'pipe' }).toString().trim();
+	// The builds in CI are done from a 'detached HEAD' state
+	if (branch === 'HEAD') branch = 'master';
 } catch (err) {
 	// Don't display error object as it's a "fatal" error, but
 	// not for us, since is it not critical information


### PR DESCRIPTION
Builds in CI are done from a 'detached HEAD' state. Thus `git rev-parse --abbrev-ref HEAD` always returns HEAD, which is not master.
Releases are always created from the master branch, thus HEAD -> master.
