### PR TITLE
Desktop: Fix incorrect location format

### DIFF
--- a/ElectronClient/app/gui/NotePropertiesDialog.jsx
+++ b/ElectronClient/app/gui/NotePropertiesDialog.jsx
@@ -292,7 +292,7 @@ class NotePropertiesDialog extends React.Component {
 			if (key === 'location') {
 				try {
 					const dms = formatcoords(value);
-					displayedValue = dms.format('DDMMss', { decimalPlaces: 0 });
+					displayedValue = dms.format('DD MM ss X', { latLonSeparator: ', ', decimalPlaces: 2 });
 				} catch (error) {
 					displayedValue = '';
 				}


### PR DESCRIPTION
Fixes #2470

Coordinates are now shown as `27° 43′ 31.79″ N 18° 1′ 27.48″ W`
I've used 2 decimal points. Let me know if it requires any adjustment.

