### PR TITLE
add option to show line numbers in editor

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -2127,7 +2127,7 @@ class NoteTextComponent extends React.Component {
 				width={`${editorStyle.width}px`}
 				height={`${editorStyle.height}px`}
 				fontSize={editorStyle.fontSize}
-				showGutter={false}
+				showGutter={ Setting.value('editor.showGutter') }
 				name="note-editor"
 				wrapEnabled={true}
 				onScroll={() => {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -434,7 +434,7 @@ class Setting extends BaseModel {
 					},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
-			'editor.showGutter': { value: false, type: Setting.TYPE_BOOL, section: 'appearance', public: true, appTypes: ['desktop'], label: () => _('Show line numbers in editor (allows code folding)') },
+			'editor.showGutter': { value: false, type: Setting.TYPE_BOOL, section: 'appearance', public: true, appTypes: ['desktop'], label: () => _('Show line numbers and folding marks in editor') },
 
 			// TODO: Is there a better way to do this? The goal here is to simply have
 			// a way to display a link to the customizable stylesheets, not for it to

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -434,6 +434,7 @@ class Setting extends BaseModel {
 					},
 			'style.sidebar.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
 			'style.noteList.width': { value: 150, minimum: 80, maximum: 400, type: Setting.TYPE_INT, public: false, appTypes: ['desktop'] },
+			'editor.showGutter': { value: false, type: Setting.TYPE_BOOL, section: 'appearance', public: true, appTypes: ['desktop'], label: () => _('Show line numbers in editor (allows code folding)') },
 
 			// TODO: Is there a better way to do this? The goal here is to simply have
 			// a way to display a link to the customizable stylesheets, not for it to


### PR DESCRIPTION
This also allows code folding in the editor.

The editor options `showLineNumbers` and `showFoldWidgets` are `true` by default.
But they only show up, if the gutter is displayed, which is explicitly disabled in Joplin.
Therefore this change only toggles the gutter.

see https://discourse.joplinapp.org/t/feature-request-folding-sections-of-text/5752?u=tessus