### PR TITLE
Desktop: Update Electron to 7.1.12

### DIFF
--- a/ElectronClient/app/package-lock.json
+++ b/ElectronClient/app/package-lock.json
@@ -89,9 +89,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.7.2.tgz",
-      "integrity": "sha512-LSE4LZGMjGS9TloDx0yO44D2UTbaeKRk+QjlhWLiQlikV6J4spgDCjb6z4YIcqmPAwNzlNCnWF4dubytwI+ATA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.7.6.tgz",
+      "integrity": "sha512-zlNikt6ziVLNcm4lly1L4y62fJd/eYpEBjF5DiV/VAQq2vdPjH4sbUphXt9upmHz86lAhAj8g9lTnWrxJ/KBZw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -230,9 +230,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+      "version": "12.12.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.27.tgz",
+      "integrity": "sha512-odQFl/+B9idbdS0e8IxDl2ia/LP8KZLXhV3BUeI98TrZp0uoIzQPhGd+5EtzHmT0SMOIaPd7jfz6pOHLWTtl7A==",
       "dev": true
     },
     "@yarnpkg/lockfile": {
@@ -1703,9 +1703,9 @@
       }
     },
     "boolean": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.0.tgz",
-      "integrity": "sha512-OElxJ1lUSinuoUnkpOgLmxp0DC4ytEhODEL6QJU0NpxE/mI4rUSh8h1P1Wkvfi3xQEBcxXR2gBIPNYNuaFcAbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
       "dev": true,
       "optional": true
     },
@@ -3251,9 +3251,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.9.tgz",
-      "integrity": "sha512-gkzDr08XxRaNZhwPLRXYNXDaPuiAeCrRPcClowlDVfCLKi+kRNhzekZpfYUBq8DdZCD29D3rCtgc9IHjD/xuHw==",
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.12.tgz",
+      "integrity": "sha512-gOJxAlJX2UyCRRncKzKzHSZStDI6MdoDzsustTCzudoZx3vlst1kkIP0n5t3TWTNoKNY/ihRsYIpeu63ar1m/g==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -4344,18 +4344,18 @@
       }
     },
     "global-agent": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.7.tgz",
-      "integrity": "sha512-ooK7eqGYZku+LgnbfH/Iv0RJ74XfhrBZDlke1QSzcBt0bw1PmJcnRADPAQuFE+R45pKKDTynAr25SBasY2kvow==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
-        "core-js": "^3.4.1",
+        "core-js": "^3.6.4",
         "es6-error": "^4.1.1",
-        "matcher": "^2.0.0",
-        "roarr": "^2.14.5",
-        "semver": "^6.3.0",
+        "matcher": "^2.1.0",
+        "roarr": "^2.15.2",
+        "semver": "^7.1.2",
         "serialize-error": "^5.0.0"
       },
       "dependencies": {
@@ -4367,9 +4367,9 @@
           "optional": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
           "dev": true,
           "optional": true
         }
@@ -7750,15 +7750,15 @@
       }
     },
     "roarr": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.6.tgz",
-      "integrity": "sha512-qjbw0BEesKA+3XFBPt+KVe1PC/Z6ShfJ4wPlx2XifqH5h2Lj8/KQT5XJTsy3n1Es5kai+BwKALaECW3F70B1cg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
         "detect-node": "^2.0.4",
-        "globalthis": "^1.0.0",
+        "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
         "semver-compare": "^1.0.0",
         "sprintf-js": "^1.1.2"

--- a/ElectronClient/app/package.json
+++ b/ElectronClient/app/package.json
@@ -74,7 +74,7 @@
     "app-builder-bin": "^1.9.11",
     "babel-cli": "^6.26.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "^7.1.9",
+    "electron": "^7.1.12",
     "electron-builder": "22.3.2",
     "electron-rebuild": "^1.8.8",
     "patch-package": "^6.2.0"


### PR DESCRIPTION
This is only a minor bump but several issues have been fixed since 7.1.9:

- Fixed an issue where sending complex objects over IPC could in some cases cause the renderer process to be terminated. electron/electron#21922
- Fixed crash with Date.toLocaleString for invalid locale and locale of the format aa@BB. electron/electron#21969
- Fixed flash plugin not working. electron/electron#22109
- Fixed issue where renderers could crash during GC when using the contextBridge module. electron/electron#22112
- Fixed netLog.stopLogging returning undefined instead of the path to the log. electron/electron#21988
- Fixed an edge case in checkbox logic on Windows. electron/electron#21860
- Fixed an issue where window.print() only worked once on a single BrowserWindow. electron/electron#21911
- Fixed an issue where the credits set in About Panel credits were not dark mode aware on macOS. electron/electron#21924
- Fixed error thrown when importing powerMonitor on Linux before app's 'ready' event. electron/electron#21941
- Fixed fuzzy font rendering when hot-plugging displays on macOS Catalina. electron/electron#21872
- Fixed BrowserWindow.setFocusable(true) not working on Windows. electron/electron#21855
- Fixed set-cookie header not passed in net module. electron/electron#21770
- Fixed an issue where custom stream protocols would sometimes not complete responses when the data stream ended. electron/electron#21758
- Fixed crash when restoring minimized hidden window on Windows. electron/electron#21820
- Fixed issue where non-zero size pixels in CSS styles could be rounded down to zero size pixels. electron/electron#21857
- Fixed memory leak when using javascript generator functions. electron/electron#21773
- Fixed potential hang when sending synchronous IPC messages on process shutdown. electron/electron#21776
