### PR TITLE
Desktop: Treat spaces as spaces in markdown editor.

### DIFF
--- a/ElectronClient/app/gui/NoteText.jsx
+++ b/ElectronClient/app/gui/NoteText.jsx
@@ -2146,7 +2146,9 @@ class NoteTextComponent extends React.Component {
 				onFocus={this.aceEditor_focus}
 				readOnly={visiblePanes.indexOf('editor') < 0}
 				// Enable/Disable the autoclosing braces
-				setOptions={{ behavioursEnabled: Setting.value('editor.autoMatchingBraces') }}
+				setOptions={{
+					behavioursEnabled: Setting.value('editor.autoMatchingBraces'),
+					useSoftTabs: false }}
 				// Disable warning: "Automatically scrolling cursor into view after
 				// selection change this will be disabled in the next version set
 				// editor.$blockScrolling = Infinity to disable this message"


### PR DESCRIPTION
Fixes #2240 

User entered spaces are being navigated and deleted in fours (as if they were tabs).  For example, after entering 4 spaces, the user is not able to backspace just one.

This fix ensures that the editor allows the user to interact with the text in whatever form it was entered -- tabs are treated like tabs, and spaces are treated like spaces.
