### PR TITLE
Desktop: fix window dimensions and position when the application start

### DIFF
--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -43,9 +43,12 @@ class ElectronAppWrapper {
 
 		const windowStateKeeper = require('electron-window-state');
 
+		const currentWorkArea = screen.getPrimaryDisplay().workArea;
+		const [defaultWidth, defaultHeight] = [0.8*currentWorkArea.width, 0.8*currentWorkArea.width];
+
 		const stateOptions = {
-			defaultWidth: 800,
-			defaultHeight: 600,
+			defaultWidth: defaultWidth,
+			defaultHeight: defaultHeight,
 			file: `window-state-${this.env_}.json`,
 		};
 

--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -43,12 +43,10 @@ class ElectronAppWrapper {
 
 		const windowStateKeeper = require('electron-window-state');
 
-		const currentWorkArea = screen.getPrimaryDisplay().workArea;
-		const [defaultWidth, defaultHeight] = [0.8*currentWorkArea.width, 0.8*currentWorkArea.height];
 
 		const stateOptions = {
-			defaultWidth: defaultWidth,
-			defaultHeight: defaultHeight,
+			defaultWidth: Math.round(0.8*screen.getPrimaryDisplay().workArea.width),
+			defaultHeight: Math.round(0.8*screen.getPrimaryDisplay().workArea.height),
 			file: `window-state-${this.env_}.json`,
 		};
 

--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -59,6 +59,8 @@ class ElectronAppWrapper {
 			y: windowState.y,
 			width: windowState.width,
 			height: windowState.height,
+			minWidth: 100,
+			minHeight: 100,
 			backgroundColor: '#fff', // required to enable sub pixel rendering, can't be in css
 			webPreferences: {
 				nodeIntegration: true,

--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -44,7 +44,7 @@ class ElectronAppWrapper {
 		const windowStateKeeper = require('electron-window-state');
 
 		const currentWorkArea = screen.getPrimaryDisplay().workArea;
-		const [defaultWidth, defaultHeight] = [0.8*currentWorkArea.width, 0.8*currentWorkArea.width];
+		const [defaultWidth, defaultHeight] = [0.8*currentWorkArea.width, 0.8*currentWorkArea.height];
 
 		const stateOptions = {
 			defaultWidth: defaultWidth,

--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -1,4 +1,4 @@
-const { BrowserWindow, Tray } = require('electron');
+const { BrowserWindow, Tray, screen } = require('electron');
 const { shim } = require('lib/shim');
 const url = require('url');
 const path = require('path');
@@ -84,6 +84,12 @@ class ElectronAppWrapper {
 		});
 
 		this.win_ = new BrowserWindow(windowOptions);
+
+		if (!screen.getDisplayMatching(this.win_.getBounds())) {
+			const { width: windowWidth, height: windowHeight } = this.win_.getBounds();
+			const { width: primaryDisplayWidth, height: primaryDisplayHeight } = screen.getPrimaryDisplay().workArea;
+			this.win_.setPosition(primaryDisplayWidth/2 - windowWidth, primaryDisplayHeight/2 - windowHeight);
+		}
 
 		this.win_.loadURL(url.format({
 			pathname: path.join(__dirname, 'index.html'),


### PR DESCRIPTION
Addresses #2476

1. BrowserWindow set up to have a minimum width and height of 100 px. This is addressed by setting minWidth, minHeight properties of BrowserWindow.
2. Centered position on a primary display is enforced if BrowserWindow rectangle doesn't match any display.

Electron app doesn't allow scaling any lower than minHeight and minWidth, which I've checked. However, I could not enforce the application to have a position outside my only display both through setting x, y manually [here](https://github.com/laurent22/joplin/blob/4f8e7b0e2b3436025cf704c8bbc278499764a228/ElectronClient/app/ElectronAppWrapper.js#L57) or through [BrowserWindow.setPosition()](https://www.electronjs.org/docs/api/browser-window#winsetpositionx-y-animate). Hence, I could not check my solution on this one.

I initially wanted to discuss my approach (like setting arbitrary 100px for minHeight/minWidth) in the issue, but (sorry if I'm wrong) I thought that since pull request would either way be reviewed discussion could be set here.

Looking forward for comments.