### PR TITLE
Desktop: Enhance notelist focus behaviour

### DIFF
--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -349,6 +349,7 @@ class NoteListComponent extends React.Component {
 			});
 
 			this.itemListRef.current.makeItemIndexVisible(noteIndex);
+
 			this.focusNoteId_(newSelectedNote.id);
 
 			event.preventDefault();
@@ -357,7 +358,6 @@ class NoteListComponent extends React.Component {
 		if (noteIds.length && (keyCode === 46 || (keyCode === 8 && event.metaKey))) {
 			// DELETE / CMD+Backspace
 			event.preventDefault();
-
 			await NoteListUtils.confirmDeleteNotes(noteIds);
 		}
 

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -357,6 +357,7 @@ class NoteListComponent extends React.Component {
 		if (noteIds.length && (keyCode === 46 || (keyCode === 8 && event.metaKey))) {
 			// DELETE / CMD+Backspace
 			event.preventDefault();
+
 			await NoteListUtils.confirmDeleteNotes(noteIds);
 		}
 

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -284,10 +284,15 @@ class NoteListComponent extends React.Component {
 
 		if (prevProps.selectedNoteIds !== this.props.selectedNoteIds && this.props.selectedNoteIds.length === 1) {
 			const id = this.props.selectedNoteIds[0];
+			const doRefocus = this.props.notes.length < prevProps.notes.length;
 			for (let i = 0; i < this.props.notes.length; i++) {
 				if (this.props.notes[i].id === id) {
 					this.itemListRef.current.makeItemIndexVisible(i);
-					this.focusNoteId_(this.props.notes[i].id);
+
+					if (doRefocus) {
+						const ref = this.itemAnchorRef(this.props.selectedNoteIds[0]);
+						if (ref) ref.focus();
+					}
 					break;
 				}
 			}
@@ -320,10 +325,8 @@ class NoteListComponent extends React.Component {
 			// Down
 			noteIndex += 1;
 		}
-
 		if (noteIndex < 0) noteIndex = 0;
 		if (noteIndex > this.props.notes.length - 1) noteIndex = this.props.notes.length - 1;
-
 		return noteIndex;
 	}
 
@@ -345,13 +348,16 @@ class NoteListComponent extends React.Component {
 				id: newSelectedNote.id,
 			});
 
+			this.itemListRef.current.makeItemIndexVisible(noteIndex);
+			this.focusNoteId_(newSelectedNote.id);
+
 			event.preventDefault();
 		}
 
 		if (noteIds.length && (keyCode === 46 || (keyCode === 8 && event.metaKey))) {
 			// DELETE / CMD+Backspace
 			event.preventDefault();
-			await NoteListUtils.confirmDeleteNotes(noteIds);
+			await NoteListUtils.confirmDeleteNotes(noteIds, this.props);
 		}
 
 		if (noteIds.length && keyCode === 32) {

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -285,12 +285,12 @@ class NoteListComponent extends React.Component {
 		if (prevProps.selectedNoteIds !== this.props.selectedNoteIds && this.props.selectedNoteIds.length === 1) {
 			const id = this.props.selectedNoteIds[0];
 			const doRefocus = this.props.notes.length < prevProps.notes.length;
+
 			for (let i = 0; i < this.props.notes.length; i++) {
 				if (this.props.notes[i].id === id) {
 					this.itemListRef.current.makeItemIndexVisible(i);
-
 					if (doRefocus) {
-						const ref = this.itemAnchorRef(this.props.selectedNoteIds[0]);
+						const ref = this.itemAnchorRef(id);
 						if (ref) ref.focus();
 					}
 					break;

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -331,7 +331,7 @@ class NoteListComponent extends React.Component {
 		const keyCode = event.keyCode;
 		const noteIds = this.props.selectedNoteIds;
 
-		if (noteIds.length === 1 && (keyCode === 40 || keyCode === 38 || keyCode === 33 || keyCode === 34 || keyCode === 35 || keyCode == 36)) {
+		if (noteIds.length > 0 && (keyCode === 40 || keyCode === 38 || keyCode === 33 || keyCode === 34 || keyCode === 35 || keyCode == 36)) {
 			// DOWN / UP / PAGEDOWN / PAGEUP / END / HOME
 			const noteId = noteIds[0];
 			let noteIndex = BaseModel.modelIndexById(this.props.notes, noteId);

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -287,6 +287,7 @@ class NoteListComponent extends React.Component {
 			for (let i = 0; i < this.props.notes.length; i++) {
 				if (this.props.notes[i].id === id) {
 					this.itemListRef.current.makeItemIndexVisible(i);
+					this.focusNoteId_(this.props.notes[i].id);
 					break;
 				}
 			}
@@ -343,10 +344,6 @@ class NoteListComponent extends React.Component {
 				type: 'NOTE_SELECT',
 				id: newSelectedNote.id,
 			});
-
-			this.itemListRef.current.makeItemIndexVisible(noteIndex);
-
-			this.focusNoteId_(newSelectedNote.id);
 
 			event.preventDefault();
 		}

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -357,7 +357,7 @@ class NoteListComponent extends React.Component {
 		if (noteIds.length && (keyCode === 46 || (keyCode === 8 && event.metaKey))) {
 			// DELETE / CMD+Backspace
 			event.preventDefault();
-			await NoteListUtils.confirmDeleteNotes(noteIds, this.props);
+			await NoteListUtils.confirmDeleteNotes(noteIds);
 		}
 
 		if (noteIds.length && keyCode === 32) {


### PR DESCRIPTION
This PR contains two enhancements to focus behaviour in the note list:

## Focus following delete
1. Delete a note from the note list (eg using `Delete` key or context-menu)
2. Use `Up` or `Down` key to select the next note

Expected: the next note is selected, the user can continue navigating with the keys
Actual: nothing, the note list does not respond to the navigation keys anymore

## Focus when navigating "away" from multiple-note selection.

1. Select multiple notes in the note list (eg Ctrl-A, or using mouse)
2. Use `Up` or `Down` key to select the next note

Expected: the next note is selected, and the previous notes are deselected
Actual: nothing, the note list does not respond to navigation keys anymore

This fix also fixes another issue discussed in [forum](https://discourse.joplinapp.org/t/please-help-test-the-new-desktop-pre-release) as a side effect.