### PR TITLE
Desktop: set min width/height window size

### DIFF
--- a/ElectronClient/app/ElectronAppWrapper.js
+++ b/ElectronClient/app/ElectronAppWrapper.js
@@ -59,6 +59,8 @@ class ElectronAppWrapper {
 			y: windowState.y,
 			width: windowState.width,
 			height: windowState.height,
+			minWidth: 480,
+			minHeight: 320,
 			backgroundColor: '#fff', // required to enable sub pixel rendering, can't be in css
 			webPreferences: {
 				nodeIntegration: true,


### PR DESCRIPTION
Solves the user occasionally scale the window to a minimum line (and can't find the Joplin window) issue, discussed in

https://discourse.joplinapp.org/t/installing-joplin-1-0-174-on-macos-catalina-results-in-no-visible-window/4425

PR https://github.com/laurent22/joplin/pull/2514 can also fix that but I suggest to set with a barely workable size `minWidth: 480, minHeight: 320` (like general mobile screen size) 

![Imgur](https://i.imgur.com/nyXCD0V.png)