### PR TITLE
update react-native-version-info to 1.0.1

### DIFF
--- a/ReactNativeClient/package-lock.json
+++ b/ReactNativeClient/package-lock.json
@@ -7590,9 +7590,9 @@
       }
     },
     "react-native-version-info": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-version-info/-/react-native-version-info-0.5.1.tgz",
-      "integrity": "sha512-DFnjbp+EsN/fADwNo4uFryM1KsRmRQOLns2njArAfFOM9faW77BX0wtRgBrtlpm3DKU97W9eI89WP8FGPBgKtA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-version-info/-/react-native-version-info-1.0.1.tgz",
+      "integrity": "sha512-8OnKRYncEBMYsmCEuj/v349KwEIldKrV7Y+yeSceBOsEJba2rH1wRLyA5gbkmfRnxzOWLGfY5hkxmpE+zv3c+Q=="
     },
     "react-native-webview": {
       "version": "5.12.0",

--- a/ReactNativeClient/package.json
+++ b/ReactNativeClient/package.json
@@ -72,7 +72,7 @@
     "react-native-side-menu": "^1.1.3",
     "react-native-sqlite-storage": "^4.1.0",
     "react-native-vector-icons": "^6.6.0",
-    "react-native-version-info": "^0.5.1",
+    "react-native-version-info": "^1.0.1",
     "react-native-webview": "^5.12.0",
     "react-redux": "5.0.7",
     "redux": "4.0.0",


### PR DESCRIPTION
This gets rid of the following warning during compile time:

```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
```