### PR TITLE
Ubuntu 18.04 needs sudo permission to install desktop file properly

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -94,7 +94,7 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
 
     # Create icon for Gnome
     echo 'Create Desktop icon.'
-    if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.* ]]
+    if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*ubuntu.*|.*x-cinnamon.*|.*deepin.* ]]
     then
        : "${TMPDIR:=/tmp}"
        # This command extracts to squashfs-root by default and can't be changed...
@@ -109,6 +109,11 @@ if [[ ! -e ~/.joplin/VERSION ]] || [[ $(< ~/.joplin/VERSION) != "$RELEASE_VERSIO
        mkdir -p ~/.local/share/applications
        echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/$USER/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#$APPIMAGE_VERSION" >> ~/.local/share/applications/appimagekit-joplin.desktop
        # Update application icons
+        if [[ $DESKTOP =~ .*unity.*|.*ubuntu.* ]]
+        then
+          echo "${COLOR_GREEN}Please give permission to create desktop file for Ubuntu:${COLOR_GREEN}"
+          [[ `command -v desktop-file-install` ]] && sudo desktop-file-install ~/.local/share/applications/appimagekit-joplin.desktop
+        fi
        [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications
        print "${COLOR_GREEN}OK${COLOR_RESET}"
     else


### PR DESCRIPTION
Proper Ubuntu check condition and password request prompt.

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
There was a problem when Joplin installer script didn't install desktop file in Ubuntu 18.04.
So app was installed correctly, but it wasn't enough to create desktop file inside `~/.local/share/applications/` Ubuntu needs to install it with `desktop-file-install` command, which needs "sudo" permission.

So I added extra check, and prompt with sudo to ask user to give permission to use it.