### PR TITLE
CLI: refactor app-gui

### DIFF
--- a/ElectronClient/app/gui/ResourceScreen.tsx
+++ b/ElectronClient/app/gui/ResourceScreen.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable enforce-react-hooks/enforce-react-hooks */
 import * as React from 'react';
 
 const { connect } = require('react-redux');


### PR DESCRIPTION
At the moment the handling of shortcuts happens in an arrow function in the start method
`term.on("key", async (name) => ... )`

which makes the start function quite long.

Now it is split up into multiple functions with about 20-30 lines each.