### PR TITLE
Translation: Fix an sprintf format error in ja_JP.po

### DIFF
--- a/CliClient/locales/ja_JP.po
+++ b/CliClient/locales/ja_JP.po
@@ -1015,7 +1015,7 @@ msgstr "フォーカス"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:1000
 msgid "Actual Size"
-msgstr "100%表示"
+msgstr "100%%表示"
 
 #: /Users/tessus/data/work/joplin/Tools/../ElectronClient/app/app.js:1006
 msgid "Zoom In"


### PR DESCRIPTION
Fix an invalid sprintf format string I accidentally added in #2537

![ErrorInTranslationOfActualSize](https://user-images.githubusercontent.com/29672555/74997997-e1e80f00-549a-11ea-95ba-d4732757edf0.png)

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
