### PR TITLE
CLI: Ensure test-build does not contain unrelated files.

### DIFF
--- a/CliClient/run_test.sh
+++ b/CliClient/run_test.sh
@@ -4,9 +4,9 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$ROOT_DIR/tests-build"
 FILTER="$1"
 
-rsync -a --exclude "node_modules/" "$ROOT_DIR/tests/" "$BUILD_DIR/"
-rsync -a "$ROOT_DIR/../ReactNativeClient/lib/" "$BUILD_DIR/lib/"
-rsync -a "$ROOT_DIR/../ReactNativeClient/locales/" "$BUILD_DIR/locales/"
+rsync -a --delete --exclude "lib/" --exclude "locales/" --exclude "node_modules/" "$ROOT_DIR/tests/" "$BUILD_DIR/"
+rsync -a --delete "$ROOT_DIR/../ReactNativeClient/lib/" "$BUILD_DIR/lib/"
+rsync -a --delete "$ROOT_DIR/../ReactNativeClient/locales/" "$BUILD_DIR/locales/"
 mkdir -p "$BUILD_DIR/data"
 
 function finish {


### PR DESCRIPTION
When running the unit tests, various code for testing is copied to the `test-build` directory.

This PR ensures that files in `test-build` are removed if they don't belong.

This is important if you switch between branches. For example, if you create a new test script on a branch, it will not be removed when you run tests on another branch, resulting in failed tests and confusion.