### PR TITLE
Fixed theme list issue in settings

### DIFF
--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -242,7 +242,7 @@ class Setting extends BaseModel {
 					let output = {};
 					output[Setting.THEME_LIGHT] = _('Light');
 					output[Setting.THEME_DARK] = _('Dark');
-					if (platform !== 'mobile') {
+					if (platform !== mobilePlatform) {
 						output[Setting.THEME_DRACULA] = _('Dracula');
 						output[Setting.THEME_SOLARIZED_LIGHT] = _('Solarised Light');
 						output[Setting.THEME_SOLARIZED_DARK] = _('Solarised Dark');


### PR DESCRIPTION
This fixes an issue in themes list on desktop and mobile, the problem is due to a wrong platform identification 

The test condition on plateform is no more valid with the last modification in : ReactNativeClient/lib/shim.js :
-	if (shim.isReactNative()) return 'mobile';
+	if (shim.isReactNative()) return shim.mobilePlatform();

I tested it on desktop and Android and it work fine with this modification