### PR TITLE
Update Windows build advice in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -69,7 +69,12 @@ If you get the error `libtool: unrecognized option '-static'`, follow the instru
 
 ## On Windows
 
-If node-gyp does not work (MSBUILD: error MSB3428: Could not load the Visual C++ component "VCBuild.exe"), you might need to install `windows-build-tools` using `npm install --global windows-build-tools`.
+There are various errors that can occur from an improper build environment (such as MSBUILD: error MSB3428). It is recommended to install `windows-build-tools` with the command `npm install --global windows-build-tools` (elevation required) and then using these two commands to set the environmental variables to the proper values:
+
+```batch
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsamd64_x86.bat" 
+set "PATH=C:\Program Files\nodejs;%PATH%"
+```
 
 If `yarn dist` fails, it may need administrative rights.
 


### PR DESCRIPTION
I ran into several issues attempting to build this project (none of which were MSB3428 funnily enough). I discovered that one of the issues had to do with a VS2019 incompatibility, and another had to do with incorrect versions of node.exe taking precedence in `PATH`. One was from Adobe and another was from VS itself for some reason using a 32-bit version of node with its node.js development tools component.

I don't consider myself an expert, this is just what worked for me, feel free to make edits to this PR or just close it and use this information in one of your own commits.