### PR TITLE
Android: fixes http-url image render

### DIFF
--- a/ReactNativeClient/android/app/src/main/res/xml/network_security_config.xml
+++ b/ReactNativeClient/android/app/src/main/res/xml/network_security_config.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
-            <certificates src="system"/>
+            <certificates src="system" />
             <certificates src="user"/>
         </trust-anchors>
     </base-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">10.0.1.1</domain>
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">10.0.3.2</domain>
-    </domain-config>
 </network-security-config>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->


 **"Android" Joplin app**
This change allows the image with http-url to be rendered
Reference of issue #2496 

below block of code from network_security_config.xml file was  causing the problem 
![Link to Screenshot from 2020-02-23 18-57-37](https://user-images.githubusercontent.com/12906090/75113337-20d0bd00-5673-11ea-8e7f-fb65c54ab149.png)

