### PR TITLE
Desktop: Add toggling functionality for bold, italics and code in Editor Toolbar

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1511,24 +1511,29 @@ class NoteTextComponent extends React.Component {
 		this.scheduleSave();
 	}
 
-	commandTextBold() {
+	toggleWrapSelection(strings1, strings2, defaultText) {
 		const selection = this.textOffsetSelection();
 		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
-		if (string.startsWith('**') && string.endsWith('**')) {
-			this.wrapSelectionWithStrings('', '', '', string.substr(2, selection.end - selection.start - 4));
-		} else {
-			this.wrapSelectionWithStrings('**', '**', _('strong text'));
+		let replaced = false;
+		for (var i = 0; i < strings1.length; i++) {
+			if (string.startsWith(strings1[i]) && string.endsWith(strings1[i])) {
+				this.wrapSelectionWithStrings('', '', '', string.substr(strings1[i].length, selection.end - selection.start - (2 * strings1[i].length)));
+				replaced = true;
+				break;
+			}
 		}
+		if (!replaced) {
+			this.wrapSelectionWithStrings(strings1[0], strings2[0], defaultText);
+		}
+
+	}
+
+	commandTextBold() {
+		this.toggleWrapSelection(['**'], ['**'], _('strong text'));
 	}
 
 	commandTextItalic() {
-		const selection = this.textOffsetSelection();
-		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
-		if ((string.startsWith('*') && string.endsWith('*')) || (string.startsWith('_') && string.endsWith('_'))) {
-			this.wrapSelectionWithStrings('', '', '', string.substr(1, selection.end - selection.start - 2));
-		} else {
-			this.wrapSelectionWithStrings('*', '*', _('emphasized text'));
-		}
+		this.toggleWrapSelection(['*', '_'], ['*', '_'], _('emphasized text'));
 	}
 
 	commandDateTime() {
@@ -1550,11 +1555,7 @@ class NoteTextComponent extends React.Component {
 				this.wrapSelectionWithStrings(`\`\`\`${match[0]}`, `${match[0]}\`\`\``);
 			}
 		} else {
-			if (string.startsWith('`') && string.endsWith('`')) {
-				this.wrapSelectionWithStrings('', '', '', string.substr(1, selection.end - selection.start - 2));
-			} else {
-				this.wrapSelectionWithStrings('`', '`');
-			}
+			this.toggleWrapSelection(['`'], ['`'], '');
 		}
 	}
 

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1512,11 +1512,23 @@ class NoteTextComponent extends React.Component {
 	}
 
 	commandTextBold() {
-		this.wrapSelectionWithStrings('**', '**', _('strong text'));
+		const selection = this.textOffsetSelection();
+		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
+		if (string.startsWith('**') && string.endsWith('**')) {
+			this.wrapSelectionWithStrings('', '', '', string.substr(2, selection.end - selection.start - 4));
+		} else {
+			this.wrapSelectionWithStrings('**', '**', _('strong text'));
+		}
 	}
 
 	commandTextItalic() {
-		this.wrapSelectionWithStrings('*', '*', _('emphasized text'));
+		const selection = this.textOffsetSelection();
+		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
+		if ((string.startsWith('*') && string.endsWith('*')) || (string.startsWith('_') && string.endsWith('_'))) {
+			this.wrapSelectionWithStrings('', '', '', string.substr(1, selection.end - selection.start - 2));
+		} else {
+			this.wrapSelectionWithStrings('*', '*', _('emphasized text'));
+		}
 	}
 
 	commandDateTime() {
@@ -1532,9 +1544,17 @@ class NoteTextComponent extends React.Component {
 
 		if (match && match.length > 0) {
 			// Follow the same newline style
-			this.wrapSelectionWithStrings(`\`\`\`${match[0]}`, `${match[0]}\`\`\``);
+			if (string.startsWith('```') && string.endsWith('```')) {
+				this.wrapSelectionWithStrings('', '', '', string.substr(4, selection.end - selection.start - 8));
+			} else {
+				this.wrapSelectionWithStrings(`\`\`\`${match[0]}`, `${match[0]}\`\`\``);
+			}
 		} else {
-			this.wrapSelectionWithStrings('`', '`');
+			if (string.startsWith('`') && string.endsWith('`')) {
+				this.wrapSelectionWithStrings('', '', '', string.substr(1, selection.end - selection.start - 2));
+			} else {
+				this.wrapSelectionWithStrings('`', '`');
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes issue #2560 

This PR adds a toggling function for bold, italics and code elements in the Editor Toolbar.

As mentioned in the issue:

> You have a text `bla`, select it and click `Bold`. Then you get `**bla**`, you select `**bla**`, click `Bold` and get `bla`.

#### Improvements

Added italics toggling for wrapping using underscores

![Italics](https://s5.gifyu.com/images/newc44a4fecaacb012c.gif)

### Before

![Before](https://s5.gifyu.com/images/before03b449b38f685406.gif)

### After

![After](https://s5.gifyu.com/images/after22afa2f80361976be.gif)