### PR TITLE
Added hierarchical/nested tags

### DIFF
--- a/CliClient/app/autocompletion.js
+++ b/CliClient/app/autocompletion.js
@@ -95,8 +95,8 @@ async function handleAutocompletionPromise(line) {
 		}
 
 		if (argName == 'tag') {
-			const tags = await Tag.search({ titlePattern: `${next}*` });
-			l.push(...tags.map(n => n.title));
+			const tags = await Tag.search({ fullTitleRegex: `${next}.*` });
+			l.push(...tags.map(n => n.full_title));
 		}
 
 		if (argName == 'file') {

--- a/CliClient/app/autocompletion.js
+++ b/CliClient/app/autocompletion.js
@@ -96,7 +96,7 @@ async function handleAutocompletionPromise(line) {
 
 		if (argName == 'tag') {
 			const tags = await Tag.search({ fullTitleRegex: `${next}.*` });
-			l.push(...tags.map(n => n.full_title));
+			l.push(...tags.map(tag => Tag.getCachedFullTitle(tag.id)));
 		}
 
 		if (argName == 'file') {

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -34,7 +34,7 @@ class Command extends BaseCommand {
 
 		if (command == 'add') {
 			if (!notes.length) throw new Error(_('Cannot find "%s".', args.note));
-			if (!tag) tag = await Tag.saveNested({ title: args.tag }, { userSideValidation: true });
+			if (!tag) tag = await Tag.saveNested({ full_title: args.tag }, { userSideValidation: true });
 			for (let i = 0; i < notes.length; i++) {
 				await Tag.addNote(tag.id, notes[i].id);
 			}
@@ -72,7 +72,7 @@ class Command extends BaseCommand {
 			} else {
 				const tags = await Tag.all();
 				tags.map(tag => {
-					this.stdout(tag.title);
+					this.stdout(tag.full_title);
 				});
 			}
 		} else if (command == 'notetags') {

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -34,7 +34,7 @@ class Command extends BaseCommand {
 
 		if (command == 'add') {
 			if (!notes.length) throw new Error(_('Cannot find "%s".', args.note));
-			if (!tag) tag = await Tag.saveNested({ full_title: args.tag }, { userSideValidation: true });
+			if (!tag) tag = await Tag.saveNested({}, args.tag, { userSideValidation: true });
 			for (let i = 0; i < notes.length; i++) {
 				await Tag.addNote(tag.id, notes[i].id);
 			}

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -72,7 +72,7 @@ class Command extends BaseCommand {
 			} else {
 				const tags = await Tag.all();
 				tags.map(tag => {
-					this.stdout(tag.full_title);
+					this.stdout(Tag.getCachedFullTitle(tag.id));
 				});
 			}
 		} else if (command == 'notetags') {

--- a/CliClient/app/command-tag.js
+++ b/CliClient/app/command-tag.js
@@ -34,7 +34,7 @@ class Command extends BaseCommand {
 
 		if (command == 'add') {
 			if (!notes.length) throw new Error(_('Cannot find "%s".', args.note));
-			if (!tag) tag = await Tag.save({ title: args.tag }, { userSideValidation: true });
+			if (!tag) tag = await Tag.saveNested({ title: args.tag }, { userSideValidation: true });
 			for (let i = 0; i < notes.length; i++) {
 				await Tag.addNote(tag.id, notes[i].id);
 			}

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -253,10 +253,10 @@ describe('models_Tag', function() {
 		await Tag.setNoteTagsByIds(note0.id, [tag1.id, subtag2.id]);
 		await Tag.renameNested(tag1_parent, 'tag2');
 
-		expect((await Tag.loadWithCount(tag1_parent.id)).full_title).toBe('tag2');
-		expect((await Tag.loadWithCount(tag1.id)).full_title).toBe('tag2/subtag1/subsubtag');
-		expect((await Tag.loadWithCount(subtag1.id)).full_title).toBe('tag2/subtag1');
-		expect((await Tag.loadWithCount(subtag2.id)).full_title).toBe('tag2/subtag2');
+		expect(Tag.getCachedFullTitle((await Tag.loadWithCount(tag1_parent.id)).id)).toBe('tag2');
+		expect(Tag.getCachedFullTitle((await Tag.loadWithCount(tag1.id)).id)).toBe('tag2/subtag1/subsubtag');
+		expect(Tag.getCachedFullTitle((await Tag.loadWithCount(subtag1.id)).id)).toBe('tag2/subtag1');
+		expect(Tag.getCachedFullTitle((await Tag.loadWithCount(subtag2.id)).id)).toBe('tag2/subtag2');
 	}));
 
 	it('renaming parent prefix should branch-out to two hierarchies', asyncTest(async () => {
@@ -297,7 +297,7 @@ describe('models_Tag', function() {
 
 		await Tag.moveTag(subsubtag1.id, tag2.id);
 
-		expect((await Tag.loadWithCount(subsubtag1.id)).full_title).toBe('tag2/subsubtag1');
+		expect(Tag.getCachedFullTitle((await Tag.loadWithCount(subsubtag1.id)).id)).toBe('tag2/subsubtag1');
 	}));
 
 	it('moving tag to itself or its descendant throws error', asyncTest(async () => {
@@ -336,11 +336,11 @@ describe('models_Tag', function() {
 
 		await Tag.setNoteTagsByIds(note1.id, [abc.id, adef.id]);
 
-		expect((await Tag.searchAllWithNotes({ fullTitleRegex: '.*c.*' })).length).toBe(1);
-		expect((await Tag.searchAllWithNotes({ fullTitleRegex: '.*b.*' })).length).toBe(2);
-		expect((await Tag.searchAllWithNotes({ fullTitleRegex: '.*b/c.*' })).length).toBe(1);
-		expect((await Tag.searchAllWithNotes({ fullTitleRegex: '.*a.*' })).length).toBe(6);
-		expect((await Tag.searchAllWithNotes({ fullTitleRegex: '.*a/d.*' })).length).toBe(3);
+		expect((await Tag.search({ fullTitleRegex: '.*c.*' })).length).toBe(1);
+		expect((await Tag.search({ fullTitleRegex: '.*b.*' })).length).toBe(2);
+		expect((await Tag.search({ fullTitleRegex: '.*b/c.*' })).length).toBe(1);
+		expect((await Tag.search({ fullTitleRegex: '.*a.*' })).length).toBe(6);
+		expect((await Tag.search({ fullTitleRegex: '.*a/d.*' })).length).toBe(3);
 	}));
 
 	it('creating tags with the same name at the same level should throw exception', asyncTest(async () => {

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -151,7 +151,7 @@ describe('models_Tag', function() {
 	}));
 
 	it('should create parent tags', asyncTest(async () => {
-		const tag = await Tag.save({ title: 'tag1/subtag1/subtag2' });
+		const tag = await Tag.saveNested({ title: 'tag1/subtag1/subtag2' });
 		expect(tag).not.toEqual(null);
 
 		let parent_tag = await Tag.loadByTitle('tag1/subtag1');
@@ -163,7 +163,7 @@ describe('models_Tag', function() {
 
 	it('should should find notes tagged with descendant tag', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag' });
 		const tag1 = await Tag.loadByTitle('tag1/subtag1');
 
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
@@ -180,7 +180,7 @@ describe('models_Tag', function() {
 
 	it('should untag descendant tags', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag' });
 		const parent_tag = await Tag.loadByTitle('tag1');
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 
@@ -195,7 +195,7 @@ describe('models_Tag', function() {
 
 	it('should count note_tags of descendant tags', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag' });
 		const parent_tag = await Tag.loadByTitle('tag1');
 
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
@@ -206,7 +206,7 @@ describe('models_Tag', function() {
 	}));
 
 	it('should delete descendant tags', asyncTest(async () => {
-		let tag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		let tag1 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag' });
 		let tag1_subtag1 = await Tag.loadByTitle('tag1/subtag1');
 		expect(tag1).toBeDefined();
 		expect(tag1_subtag1).toBeDefined();
@@ -223,8 +223,8 @@ describe('models_Tag', function() {
 	}));
 
 	it('renaming should change prefix in descendant tags', asyncTest(async () => {
-		const tag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
-		const subtag2 = await Tag.save({ title: 'tag1/subtag2' });
+		const tag1 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag' });
+		const subtag2 = await Tag.saveNested({ title: 'tag1/subtag2' });
 		const subtag1 = await Tag.loadByTitle('tag1/subtag1');
 		const tag1_parent = await Tag.loadByTitle('tag1');
 
@@ -240,8 +240,8 @@ describe('models_Tag', function() {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
 		const note2 = await Note.save({ title: 'my note 2', parent_id: folder1.id });
-		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		const subsubtag2 = await Tag.save({ title: 'tag1/subtag1/subsubtag2' });
+		const subsubtag1 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag1' });
+		const subsubtag2 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag2' });
 		await Tag.addNote(subsubtag1.id, note1.id);
 		await Tag.addNote(subsubtag2.id, note2.id);
 
@@ -254,8 +254,11 @@ describe('models_Tag', function() {
 	}));
 
 	it('renaming parent prefix to existing tag should remove unused old tag', asyncTest(async () => {
-		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		const subsubtag2 = await Tag.save({ title: 'tag1/subtag2/subsubtag2' });
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
+		const subsubtag1 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag1' });
+		const subsubtag2 = await Tag.saveNested({ title: 'tag1/subtag2/subsubtag2' });
+		await Tag.addNote(subsubtag2.id, note1.id);
 
 		await Tag.rename(subsubtag1, 'tag1/subtag2/subsubtag1');
 
@@ -263,8 +266,11 @@ describe('models_Tag', function() {
 	}));
 
 	it('moving tag should change prefix name', asyncTest(async () => {
-		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		const tag2 = await Tag.save({ title: 'tag2' });
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
+		const subsubtag1 = await Tag.saveNested({ title: 'tag1/subtag1/subsubtag1' });
+		const tag2 = await Tag.saveNested({ title: 'tag2' });
+		await Tag.addNote(tag2.id, note1.id);
 
 		await Tag.moveTag(subsubtag1.id, tag2.id);
 

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -151,7 +151,7 @@ describe('models_Tag', function() {
 	}));
 
 	it('should create parent tags', asyncTest(async () => {
-		const tag = await Tag.saveNested({ full_title: 'tag1/subtag1/subtag2' });
+		const tag = await Tag.saveNested({}, 'tag1/subtag1/subtag2');
 		expect(tag).not.toEqual(null);
 
 		let parent_tag = await Tag.loadByTitle('tag1/subtag1');
@@ -163,7 +163,7 @@ describe('models_Tag', function() {
 
 	it('should should find notes tagged with descendant tag', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
 		const tag1 = await Tag.loadByTitle('tag1/subtag1');
 
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
@@ -180,7 +180,7 @@ describe('models_Tag', function() {
 
 	it('should untag descendant tags', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
 		const parent_tag = await Tag.loadByTitle('tag1');
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 
@@ -195,7 +195,7 @@ describe('models_Tag', function() {
 
 	it('should count note_tags of descendant tags', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const tag0 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
+		const tag0 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
 		const parent_tag = await Tag.loadByTitle('tag1');
 
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
@@ -206,7 +206,7 @@ describe('models_Tag', function() {
 	}));
 
 	it('should delete descendant tags', asyncTest(async () => {
-		let tag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
+		let tag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
 		let tag1_subtag1 = await Tag.loadByTitle('tag1/subtag1');
 		expect(tag1).toBeDefined();
 		expect(tag1_subtag1).toBeDefined();
@@ -225,7 +225,7 @@ describe('models_Tag', function() {
 	it('should delete noteless parent tags', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
-		const subsubtag = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
+		const subsubtag = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
 		await Tag.addNote(subsubtag.id, note0.id);
 		let tag1_subtag1 = await Tag.loadByTitle('tag1/subtag1');
 
@@ -245,8 +245,8 @@ describe('models_Tag', function() {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 
-		const tag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag' });
-		const subtag2 = await Tag.saveNested({ full_title: 'tag1/subtag2' });
+		const tag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag');
+		const subtag2 = await Tag.saveNested({}, 'tag1/subtag2');
 		const subtag1 = await Tag.loadByTitle('tag1/subtag1');
 		const tag1_parent = await Tag.loadByTitle('tag1');
 
@@ -263,8 +263,8 @@ describe('models_Tag', function() {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
 		const note2 = await Note.save({ title: 'my note 2', parent_id: folder1.id });
-		const subsubtag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag1' });
-		const subsubtag2 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag2' });
+		const subsubtag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag1');
+		const subsubtag2 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag2');
 		await Tag.addNote(subsubtag1.id, note1.id);
 		await Tag.addNote(subsubtag2.id, note2.id);
 
@@ -279,8 +279,8 @@ describe('models_Tag', function() {
 	it('renaming parent prefix to existing tag should remove unused old tag', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		const subsubtag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag1' });
-		const subsubtag2 = await Tag.saveNested({ full_title: 'tag1/subtag2/subsubtag2' });
+		const subsubtag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag1');
+		const subsubtag2 = await Tag.saveNested({}, 'tag1/subtag2/subsubtag2');
 		await Tag.addNote(subsubtag2.id, note1.id);
 
 		await Tag.renameNested(subsubtag1, 'tag1/subtag2/subsubtag1');
@@ -291,8 +291,8 @@ describe('models_Tag', function() {
 	it('moving tag should change prefix name', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		const subsubtag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag1' });
-		const tag2 = await Tag.saveNested({ full_title: 'tag2' });
+		const subsubtag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag1');
+		const tag2 = await Tag.saveNested({}, 'tag2');
 		await Tag.setNoteTagsByIds(note1.id, [tag2.id, subsubtag1.id]);
 
 		await Tag.moveTag(subsubtag1.id, tag2.id);
@@ -303,7 +303,7 @@ describe('models_Tag', function() {
 	it('moving tag to itself or its descendant throws error', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		const subsubtag1 = await Tag.saveNested({ full_title: 'tag1/subtag1/subsubtag1' });
+		const subsubtag1 = await Tag.saveNested({}, 'tag1/subtag1/subsubtag1');
 		await Tag.addNote(subsubtag1.id, note1.id);
 
 		const tag1 = await Tag.loadByTitle('tag1');
@@ -317,7 +317,7 @@ describe('models_Tag', function() {
 	it('renaming tag as a child of itself creates new parent', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		const subtag1 = await Tag.saveNested({ full_title: 'tag1/subtag1' });
+		const subtag1 = await Tag.saveNested({}, 'tag1/subtag1');
 		await Tag.addNote(subtag1.id, note1.id);
 
 		const a = await Tag.renameNested(subtag1, 'tag1/subtag1/a/subtag1');
@@ -331,8 +331,8 @@ describe('models_Tag', function() {
 	it('should search by full title regex', asyncTest(async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		const abc = await Tag.saveNested({ full_title: 'a/b/c' });
-		const adef = await Tag.saveNested({ full_title: 'a/d/e/f' });
+		const abc = await Tag.saveNested({}, 'a/b/c');
+		const adef = await Tag.saveNested({}, 'a/d/e/f');
 
 		await Tag.setNoteTagsByIds(note1.id, [abc.id, adef.id]);
 
@@ -345,16 +345,16 @@ describe('models_Tag', function() {
 
 	it('creating tags with the same name at the same level should throw exception', asyncTest(async () => {
 		// Should not complain when creating at different levels
-		await Tag.saveNested({ full_title: 'a/b/c' });
-		await Tag.saveNested({ full_title: 'a/d/e/c' });
-		await Tag.saveNested({ full_title: 'c' });
+		await Tag.saveNested({}, 'a/b/c');
+		await Tag.saveNested({}, 'a/d/e/c');
+		await Tag.saveNested({}, 'c');
 
 		// Should complain when creating at the same level
-		let hasThrown = await checkThrowAsync(async () => await Tag.saveNested({ full_title: 'a/d' }, { userSideValidation: true }));
+		let hasThrown = await checkThrowAsync(async () => await Tag.saveNested({}, 'a/d', { userSideValidation: true }));
 		expect(hasThrown).toBe(true);
-		hasThrown = await checkThrowAsync(async () => await Tag.saveNested({ full_title: 'a' }, { userSideValidation: true }));
+		hasThrown = await checkThrowAsync(async () => await Tag.saveNested({}, 'a', { userSideValidation: true }));
 		expect(hasThrown).toBe(true);
-		hasThrown = await checkThrowAsync(async () => await Tag.saveNested({ full_title: 'a/b/c' }, { userSideValidation: true }));
+		hasThrown = await checkThrowAsync(async () => await Tag.saveNested({}, 'a/b/c', { userSideValidation: true }));
 		expect(hasThrown).toBe(true);
 	}));
 });

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -151,7 +151,7 @@ describe('models_Tag', function() {
 	}));
 
 	it('should create parent tags', asyncTest(async () => {
-		let tag = await Tag.save({ title: 'tag1/subtag1/subtag2' });
+		const tag = await Tag.save({ title: 'tag1/subtag1/subtag2' });
 		expect(tag).not.toEqual(null);
 
 		let parent_tag = await Tag.loadByTitle('tag1/subtag1');
@@ -162,27 +162,27 @@ describe('models_Tag', function() {
 	}));
 
 	it('should should find notes tagged with descendant tag', asyncTest(async () => {
-		let folder1 = await Folder.save({ title: 'folder1' });
-		let tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
-		let tag1 = await Tag.loadByTitle('tag1/subtag1');
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const tag1 = await Tag.loadByTitle('tag1/subtag1');
 
-		let note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
-		let note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
+		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
+		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
 
 		await Tag.addNote(tag0.id, note0.id);
 		await Tag.addNote(tag1.id, note1.id);
 
-		let parent_tag = await Tag.loadByTitle('tag1');
-		let noteIds = await Tag.noteIds(parent_tag.id);
+		const parent_tag = await Tag.loadByTitle('tag1');
+		const noteIds = await Tag.noteIds(parent_tag.id);
 		expect(noteIds.includes(note0.id)).toBe(true);
 		expect(noteIds.includes(note1.id)).toBe(true);
 	}));
 
 	it('should untag descendant tags', asyncTest(async () => {
-		let folder1 = await Folder.save({ title: 'folder1' });
-		let tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
-		let parent_tag = await Tag.loadByTitle('tag1');
-		let note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const parent_tag = await Tag.loadByTitle('tag1');
+		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 
 		await Tag.addNote(tag0.id, note0.id);
 		let tagIds = await NoteTag.tagIdsByNoteId(note0.id);
@@ -194,14 +194,14 @@ describe('models_Tag', function() {
 	}));
 
 	it('should count note_tags of descendant tags', asyncTest(async () => {
-		let folder1 = await Folder.save({ title: 'folder1' });
-		let tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
-		let parent_tag = await Tag.loadByTitle('tag1');
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const tag0 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const parent_tag = await Tag.loadByTitle('tag1');
 
-		let note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
+		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 		await Tag.addNote(tag0.id, note0.id);
 
-		let parent_tag_with_count = await Tag.loadWithCount(parent_tag.id);
+		const parent_tag_with_count = await Tag.loadWithCount(parent_tag.id);
 		expect(parent_tag_with_count.note_count).toBe(1);
 	}));
 
@@ -223,10 +223,10 @@ describe('models_Tag', function() {
 	}));
 
 	it('renaming should change prefix in descendant tags', asyncTest(async () => {
-		let tag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
-		let subtag2 = await Tag.save({ title: 'tag1/subtag2' });
-		let subtag1 = await Tag.loadByTitle('tag1/subtag1');
-		let tag1_parent = await Tag.loadByTitle('tag1');
+		const tag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag' });
+		const subtag2 = await Tag.save({ title: 'tag1/subtag2' });
+		const subtag1 = await Tag.loadByTitle('tag1/subtag1');
+		const tag1_parent = await Tag.loadByTitle('tag1');
 
 		await Tag.rename(tag1_parent, 'tag2');
 
@@ -237,25 +237,25 @@ describe('models_Tag', function() {
 	}));
 
 	it('renaming parent prefix should branch-out to two hierarchies', asyncTest(async () => {
-		let folder1 = await Folder.save({ title: 'folder1' });
-		let note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
-		let note2 = await Note.save({ title: 'my note 2', parent_id: folder1.id });
-		let subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		let subsubtag2 = await Tag.save({ title: 'tag1/subtag1/subsubtag2' });
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'my note 1', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'my note 2', parent_id: folder1.id });
+		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
+		const subsubtag2 = await Tag.save({ title: 'tag1/subtag1/subsubtag2' });
 		await Tag.addNote(subsubtag1.id, note1.id);
 		await Tag.addNote(subsubtag2.id, note2.id);
 
 		await Tag.rename(subsubtag1, 'tag1/subtag2/subsubtag1');
 
-		let subtag1 = await Tag.loadByTitle('tag1/subtag1');
-		let subtag2 = await Tag.loadByTitle('tag1/subtag2');
+		const subtag1 = await Tag.loadByTitle('tag1/subtag1');
+		const subtag2 = await Tag.loadByTitle('tag1/subtag2');
 		expect(subtag1).toBeDefined();
 		expect(subtag2).toBeDefined();
 	}));
 
 	it('renaming parent prefix to existing tag should remove unused old tag', asyncTest(async () => {
-		let subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		let subsubtag2 = await Tag.save({ title: 'tag1/subtag2/subsubtag2' });
+		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
+		const subsubtag2 = await Tag.save({ title: 'tag1/subtag2/subsubtag2' });
 
 		await Tag.rename(subsubtag1, 'tag1/subtag2/subsubtag1');
 
@@ -263,8 +263,8 @@ describe('models_Tag', function() {
 	}));
 
 	it('moving tag should change prefix name', asyncTest(async () => {
-		let subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
-		let tag2 = await Tag.save({ title: 'tag2' });
+		const subsubtag1 = await Tag.save({ title: 'tag1/subtag1/subsubtag1' });
+		const tag2 = await Tag.save({ title: 'tag2' });
 
 		await Tag.moveTag(subsubtag1.id, tag2.id);
 

--- a/CliClient/tests/synchronizer.js
+++ b/CliClient/tests/synchronizer.js
@@ -581,7 +581,7 @@ describe('synchronizer', function() {
 	it('should sync tag deletion', asyncTest(async () => {
 		const f1 = await Folder.save({ title: 'folder' });
 		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
-		const tag = await Tag.saveNested({ full_title: 'a/b/c' });
+		const tag = await Tag.saveNested({}, 'a/b/c');
 		await Tag.addNote(tag.id, n1.id);
 		await synchronizer().start();
 
@@ -611,8 +611,8 @@ describe('synchronizer', function() {
 	it('should sync child tag deletion', asyncTest(async () => {
 		const f1 = await Folder.save({ title: 'folder' });
 		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
-		const tag1 = await Tag.saveNested({ full_title: 'a/b/c/d' });
-		const tag2 = await Tag.saveNested({ full_title: 'a/b/d' });
+		const tag1 = await Tag.saveNested({}, 'a/b/c/d');
+		const tag2 = await Tag.saveNested({}, 'a/b/d');
 		await Tag.addNote(tag1.id, n1.id);
 		await Tag.addNote(tag2.id, n1.id);
 		let taga = await Tag.loadByTitle('a');

--- a/CliClient/tests/synchronizer.js
+++ b/CliClient/tests/synchronizer.js
@@ -581,7 +581,7 @@ describe('synchronizer', function() {
 	it('should sync tag deletion', asyncTest(async () => {
 		const f1 = await Folder.save({ title: 'folder' });
 		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
-		const tag = await Tag.saveNested({ title: 'a/b/c' });
+		const tag = await Tag.saveNested({ full_title: 'a/b/c' });
 		await Tag.addNote(tag.id, n1.id);
 		await synchronizer().start();
 
@@ -611,8 +611,8 @@ describe('synchronizer', function() {
 	it('should sync child tag deletion', asyncTest(async () => {
 		const f1 = await Folder.save({ title: 'folder' });
 		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
-		const tag1 = await Tag.saveNested({ title: 'a/b/c/d' });
-		const tag2 = await Tag.saveNested({ title: 'a/b/d' });
+		const tag1 = await Tag.saveNested({ full_title: 'a/b/c/d' });
+		const tag2 = await Tag.saveNested({ full_title: 'a/b/d' });
 		await Tag.addNote(tag1.id, n1.id);
 		await Tag.addNote(tag2.id, n1.id);
 		let taga = await Tag.loadByTitle('a');

--- a/CliClient/tests/synchronizer.js
+++ b/CliClient/tests/synchronizer.js
@@ -578,6 +578,89 @@ describe('synchronizer', function() {
 		await shoudSyncTagTest(true);
 	}));
 
+	it('should sync tag deletion', asyncTest(async () => {
+		const f1 = await Folder.save({ title: 'folder' });
+		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
+		const tag = await Tag.saveNested({ title: 'a/b/c' });
+		await Tag.addNote(tag.id, n1.id);
+		await synchronizer().start();
+
+		await switchClient(2);
+		await synchronizer().start();
+		let taga = await Tag.loadByTitle('a');
+		let tagb = await Tag.loadByTitle('a/b');
+		let tagc = await Tag.loadByTitle('a/b/c');
+		expect(taga).toBeDefined();
+		expect(tagb).toBeDefined();
+		expect(tagc).toBeDefined();
+
+		// Should remove both parent and children tags in this case
+		await Tag.delete(tagb.id);
+		await synchronizer().start();
+
+		await switchClient(1);
+		await synchronizer().start();
+		taga = await Tag.loadByTitle('a');
+		tagb = await Tag.loadByTitle('a/b');
+		tagc = await Tag.loadByTitle('a/b/c');
+		expect(taga).not.toBeDefined();
+		expect(tagb).not.toBeDefined();
+		expect(tagc).not.toBeDefined();
+	}));
+
+	it('should sync child tag deletion', asyncTest(async () => {
+		const f1 = await Folder.save({ title: 'folder' });
+		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id });
+		const tag1 = await Tag.saveNested({ title: 'a/b/c/d' });
+		const tag2 = await Tag.saveNested({ title: 'a/b/d' });
+		await Tag.addNote(tag1.id, n1.id);
+		await Tag.addNote(tag2.id, n1.id);
+		let taga = await Tag.loadByTitle('a');
+		let tagb = await Tag.loadByTitle('a/b');
+		let tagc = await Tag.loadByTitle('a/b/c');
+		let tagabcd = await Tag.loadByTitle('a/b/c/d');
+		let tagabd = await Tag.loadByTitle('a/b/d');
+		await synchronizer().start();
+
+		await switchClient(2);
+		await synchronizer().start();
+		const taga2 = await Tag.loadByTitle('a');
+		const tagb2 = await Tag.loadByTitle('a/b');
+		const tagc2 = await Tag.loadByTitle('a/b/c');
+		const tagabcd2 = await Tag.loadByTitle('a/b/c/d');
+		const tagabd2 = await Tag.loadByTitle('a/b/d');
+		expect(taga2).toBeDefined();
+		expect(tagb2).toBeDefined();
+		expect(tagc2).toBeDefined();
+		expect(tagabcd2).toBeDefined();
+		expect(tagabd2).toBeDefined();
+		expect(taga2.id).toBe(taga.id);
+		expect(tagb2.id).toBe(tagb.id);
+		expect(tagc2.id).toBe(tagc.id);
+		expect(tagabcd2.id).toBe(tagabcd.id);
+		expect(tagabd2.id).toBe(tagabd.id);
+
+		// Should remove children tags in this case
+		await Tag.delete(tagc.id);
+		await synchronizer().start();
+
+		await switchClient(1);
+		await synchronizer().start();
+		taga = await Tag.loadByTitle('a');
+		tagb = await Tag.loadByTitle('a/b');
+		tagc = await Tag.loadByTitle('a/b/c');
+		tagabcd = await Tag.loadByTitle('a/b/c/d');
+		tagabd = await Tag.loadByTitle('a/b/d');
+		expect(taga).toBeDefined();
+		expect(tagb).toBeDefined();
+		expect(tagc).not.toBeDefined();
+		expect(tagabcd).not.toBeDefined();
+		expect(tagabd).toBeDefined();
+		expect(taga.id).toBe(taga2.id);
+		expect(tagb.id).toBe(tagb2.id);
+		expect(tagabd.id).toBe(tagabd2.id);
+	}));
+
 	it('should not sync notes with conflicts', asyncTest(async () => {
 		const f1 = await Folder.save({ title: 'folder' });
 		const n1 = await Note.save({ title: 'mynote', parent_id: f1.id, is_conflict: 1 });

--- a/Clipper/popup/src/App.js
+++ b/Clipper/popup/src/App.js
@@ -368,7 +368,7 @@ class AppComponent extends Component {
 		const tagDataListOptions = [];
 		for (let i = 0; i < this.props.tags.length; i++) {
 			const tag = this.props.tags[i];
-			tagDataListOptions.push(<option key={tag.id}>{tag.title}</option>);
+			tagDataListOptions.push(<option key={tag.id}>{tag.full_title}</option>);
 		}
 
 		let simplifiedPageButtonLabel = 'Clip simplified page';

--- a/Clipper/popup/src/bridge.js
+++ b/Clipper/popup/src/bridge.js
@@ -150,7 +150,7 @@ class Bridge {
 					const folders = await this.folderTree();
 					this.dispatch({ type: 'FOLDERS_SET', folders: folders });
 
-					const tags = await this.clipperApiExec('GET', 'tags');
+					const tags = await this.clipperApiExec('GET', 'tags', { fields: 'full_title' });
 					this.dispatch({ type: 'TAGS_SET', tags: tags });
 
 					bridge().restoreState();

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1186,6 +1186,11 @@ class Application extends BaseApplication {
 			ids: Setting.value('collapsedFolderIds'),
 		});
 
+		this.store().dispatch({
+			type: 'TAG_SET_COLLAPSED_ALL',
+			ids: Setting.value('collapsedTagIds'),
+		});
+
 		// Loads custom Markdown preview styles
 		const cssString = await CssUtils.loadCustomCss(`${Setting.value('profileDir')}/userstyle.css`);
 		this.store().dispatch({

--- a/ElectronClient/gui/MainScreen/commands/renameTag.ts
+++ b/ElectronClient/gui/MainScreen/commands/renameTag.ts
@@ -16,12 +16,11 @@ export const runtime = (comp:any):CommandRuntime => {
 				comp.setState({
 					promptOptions: {
 						label: _('Rename tag:'),
-						value: tag.title,
+						value: Tag.getCachedFullTitle(tag.id),
 						onClose: async (answer:string) => {
 							if (answer !== null) {
 								try {
-									tag.title = answer;
-									await Tag.save(tag, { fields: ['title'], userSideValidation: true });
+									await Tag.renameNested(tag, answer);
 								} catch (error) {
 									bridge().showErrorMessageBox(error.message);
 								}

--- a/ElectronClient/gui/SideBar/SideBar.jsx
+++ b/ElectronClient/gui/SideBar/SideBar.jsx
@@ -424,7 +424,7 @@ class SideBarComponent extends React.Component {
 			collapsedIds = this.props.collapsedTagIds;
 			jsxItemIdAttribute.tagid = item.id;
 			anchorRef = this.anchorItemRef('tag', item.id);
-			noteCount = Setting.value('showNoteCounts') ? this.noteCountElement(item.note_count) : '';
+			noteCount = Setting.value('showNoteCounts') ? this.noteCountElement(Tag.getCachedNoteCount(item.id)) : '';
 			onDragStart = this.onTagDragStart_;
 			onDragOver = this.onTagDragOver_;
 			onDrop = this.onTagDrop_;

--- a/ElectronClient/gui/SideBar/SideBar.jsx
+++ b/ElectronClient/gui/SideBar/SideBar.jsx
@@ -99,8 +99,12 @@ class SideBarComponent extends React.Component {
 				event.preventDefault();
 
 				const tagIds = JSON.parse(dt.getData('text/x-jop-tag-ids'));
-				for (let i = 0; i < tagIds.length; i++) {
-					await Tag.moveTag(tagIds[i], tagId);
+				try {
+					for (let i = 0; i < tagIds.length; i++) {
+						await Tag.moveTag(tagIds[i], tagId);
+					}
+				} catch (error) {
+					bridge().showErrorMessageBox(error.message);
 				}
 			}
 		};
@@ -446,11 +450,11 @@ class SideBarComponent extends React.Component {
 	tagItem(tag, selected, hasChildren, depth) {
 		let style = Object.assign({}, this.style().listItem);
 
-		let containerStyle = Object.assign({}, this.style(depth).listItemContainer);
+		const containerStyle = Object.assign({}, this.style(depth).listItemContainer);
 		if (selected) style = Object.assign(style, this.style().listItemSelected);
 
-		let expandLinkStyle = Object.assign({}, this.style().listItemExpandIcon);
-		let expandIconStyle = {
+		const expandLinkStyle = Object.assign({}, this.style().listItemExpandIcon);
+		const expandIconStyle = {
 			visibility: hasChildren ? 'visible' : 'hidden',
 			paddingLeft: 8 + depth * 10,
 		};

--- a/ElectronClient/gui/SideBar/SideBar.jsx
+++ b/ElectronClient/gui/SideBar/SideBar.jsx
@@ -273,7 +273,7 @@ class SideBarComponent extends React.Component {
 			buttonLabel = _('Delete');
 		} else if (itemType === BaseModel.TYPE_TAG) {
 			const tag = await Tag.load(itemId);
-			deleteMessage = _('Remove tag "%s" and its descendant tags from all notes?', substrStartWithEllipsis(tag.full_title, -32, 32));
+			deleteMessage = _('Remove tag "%s" and its descendant tags from all notes?', substrStartWithEllipsis(Tag.getCachedFullTitle(tag.id), -32, 32));
 		} else if (itemType === BaseModel.TYPE_SEARCH) {
 			deleteMessage = _('Remove this search from the sidebar?');
 		}

--- a/ElectronClient/gui/SideBar/SideBar.jsx
+++ b/ElectronClient/gui/SideBar/SideBar.jsx
@@ -14,7 +14,7 @@ const { bridge } = require('electron').remote.require('./bridge');
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
 const InteropServiceHelper = require('../../InteropServiceHelper.js');
-const { substrWithEllipsis } = require('lib/string-utils');
+const { substrWithEllipsis, substrStartWithEllipsis } = require('lib/string-utils');
 const { ALL_NOTES_FILTER_ID } = require('lib/reserved-ids');
 
 const commands = [
@@ -273,7 +273,7 @@ class SideBarComponent extends React.Component {
 			buttonLabel = _('Delete');
 		} else if (itemType === BaseModel.TYPE_TAG) {
 			const tag = await Tag.load(itemId);
-			deleteMessage = _('Remove tag "%s" and its descendant tags from all notes?', substrWithEllipsis(tag.title, 0, 32));
+			deleteMessage = _('Remove tag "%s" and its descendant tags from all notes?', substrStartWithEllipsis(tag.full_title, -32, 32));
 		} else if (itemType === BaseModel.TYPE_SEARCH) {
 			deleteMessage = _('Remove this search from the sidebar?');
 		}

--- a/ElectronClient/gui/TagList.jsx
+++ b/ElectronClient/gui/TagList.jsx
@@ -21,12 +21,12 @@ class TagListComponent extends React.Component {
 		if (tags && tags.length > 0) {
 			// Sort by id for now, but probably needs to be changed in the future.
 			tags.sort((a, b) => {
-				return a.title < b.title ? -1 : +1;
+				return a.full_title < b.full_title ? -1 : +1;
 			});
 
 			for (let i = 0; i < tags.length; i++) {
 				const props = {
-					title: tags[i].title,
+					title: tags[i].full_title,
 					key: tags[i].id,
 				};
 				tagItems.push(<TagItem {...props} />);

--- a/ElectronClient/gui/TagList.jsx
+++ b/ElectronClient/gui/TagList.jsx
@@ -2,6 +2,7 @@ const React = require('react');
 const { connect } = require('react-redux');
 const { themeStyle } = require('lib/theme');
 const TagItem = require('./TagItem.min.js');
+const Tag = require('lib/models/Tag.js');
 
 class TagListComponent extends React.Component {
 	render() {
@@ -21,12 +22,12 @@ class TagListComponent extends React.Component {
 		if (tags && tags.length > 0) {
 			// Sort by id for now, but probably needs to be changed in the future.
 			tags.sort((a, b) => {
-				return a.full_title < b.full_title ? -1 : +1;
+				return Tag.getCachedFullTitle(a.id) < Tag.getCachedFullTitle(b.id) ? -1 : +1;
 			});
 
 			for (let i = 0; i < tags.length; i++) {
 				const props = {
-					title: tags[i].full_title,
+					title: Tag.getCachedFullTitle(tags[i].id),
 					key: tags[i].id,
 				};
 				tagItems.push(<TagItem {...props} />);

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -194,9 +194,7 @@ class Dialog extends React.PureComponent {
 				listType = BaseModel.TYPE_TAG;
 				searchQuery = this.state.query.split(' ')[0].substr(1).trim();
 				results = await Tag.search({ fullTitleRegex: `.*${searchQuery}.*` });
-				for (let i = 0; i < results.length; i++) {
-					results[i].title = Tag.getCachedFullTitle(results[i].id);
-				}
+				results = results.map(tag => Object.assign({}, tag, { title: Tag.getCachedFullTitle(tag.id) }));
 			} else if (this.state.query.indexOf('@') === 0) { // FOLDERS
 				listType = BaseModel.TYPE_FOLDER;
 				searchQuery = `*${this.state.query.split(' ')[0].substr(1).trim()}*`;

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -295,6 +295,18 @@ class Dialog extends React.PureComponent {
 			}
 		}
 
+		if (this.state.listType === BaseModel.TYPE_TAG) {
+			const tagPath = await Tag.tagPath(this.props.tags, item.parent_id);
+
+			for (const tag of tagPath) {
+				this.props.dispatch({
+					type: 'TAG_SET_COLLAPSED',
+					id: tag.id,
+					collapsed: false,
+				});
+			}
+		}
+
 		if (this.state.listType === BaseModel.TYPE_NOTE) {
 			this.props.dispatch({
 				type: 'FOLDER_AND_NOTE_SELECT',

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -193,9 +193,9 @@ class Dialog extends React.PureComponent {
 			if (this.state.query.indexOf('#') === 0) { // TAGS
 				listType = BaseModel.TYPE_TAG;
 				searchQuery = this.state.query.split(' ')[0].substr(1).trim();
-				results = await Tag.searchAllWithNotes({ fullTitleRegex: `.*${searchQuery}.*` });
+				results = await Tag.search({ fullTitleRegex: `.*${searchQuery}.*` });
 				for (let i = 0; i < results.length; i++) {
-					results[i].title = results[i].full_title;
+					results[i].title = Tag.getCachedFullTitle(results[i].id);
 				}
 			} else if (this.state.query.indexOf('@') === 0) { // FOLDERS
 				listType = BaseModel.TYPE_FOLDER;

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -192,8 +192,11 @@ class Dialog extends React.PureComponent {
 
 			if (this.state.query.indexOf('#') === 0) { // TAGS
 				listType = BaseModel.TYPE_TAG;
-				searchQuery = `*${this.state.query.split(' ')[0].substr(1).trim()}*`;
-				results = await Tag.searchAllWithNotes({ titlePattern: searchQuery });
+				searchQuery = this.state.query.split(' ')[0].substr(1).trim();
+				results = await Tag.searchAllWithNotes({ fullTitleRegex: `.*${searchQuery}.*` });
+				for (let i = 0; i < results.length; i++) {
+					results[i].title = results[i].full_title;
+				}
 			} else if (this.state.query.indexOf('@') === 0) { // FOLDERS
 				listType = BaseModel.TYPE_FOLDER;
 				searchQuery = `*${this.state.query.split(' ')[0].substr(1).trim()}*`;
@@ -451,6 +454,7 @@ class Dialog extends React.PureComponent {
 const mapStateToProps = (state) => {
 	return {
 		folders: state.folders,
+		tags: state.tags,
 		theme: state.settings.theme,
 	};
 };

--- a/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
+++ b/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
@@ -103,13 +103,13 @@ class NoteTagsDialogComponent extends React.Component {
 		const tagListData = this.props.tags.map(tag => {
 			return {
 				id: tag.id,
-				title: tag.title,
+				title: tag.full_title,
 				selected: tagIds.indexOf(tag.id) >= 0,
 			};
 		});
 
 		tagListData.sort((a, b) => {
-			return naturalCompare.caseInsensitive(a.title, b.title);
+			return naturalCompare.caseInsensitive(a.full_title, b.full_title);
 		});
 
 		this.setState({ tagListData: tagListData });

--- a/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
+++ b/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
@@ -103,13 +103,13 @@ class NoteTagsDialogComponent extends React.Component {
 		const tagListData = this.props.tags.map(tag => {
 			return {
 				id: tag.id,
-				title: tag.full_title,
+				title: Tag.getCachedFullTitle(tag.id),
 				selected: tagIds.indexOf(tag.id) >= 0,
 			};
 		});
 
 		tagListData.sort((a, b) => {
-			return naturalCompare.caseInsensitive(a.full_title, b.full_title);
+			return naturalCompare.caseInsensitive(Tag.getCachedFullTitle(a.id), Tag.getCachedFullTitle(b.id));
 		});
 
 		this.setState({ tagListData: tagListData });

--- a/ReactNativeClient/lib/components/screens/notes.js
+++ b/ReactNativeClient/lib/components/screens/notes.js
@@ -184,7 +184,7 @@ class NotesScreenComponent extends BaseScreenComponent {
 			output = Folder.byId(props.folders, props.selectedFolderId);
 		} else if (props.notesParentType == 'Tag') {
 			output = Tag.byId(props.tags, props.selectedTagId);
-			output.title = output.full_title;
+			output.title = Tag.getCachedFullTitle(output.id);
 		} else if (props.notesParentType == 'SmartFilter') {
 			output = { id: this.props.selectedSmartFilterId, title: _('All notes') };
 		} else {

--- a/ReactNativeClient/lib/components/screens/notes.js
+++ b/ReactNativeClient/lib/components/screens/notes.js
@@ -183,8 +183,8 @@ class NotesScreenComponent extends BaseScreenComponent {
 		if (props.notesParentType == 'Folder') {
 			output = Folder.byId(props.folders, props.selectedFolderId);
 		} else if (props.notesParentType == 'Tag') {
-			output = Tag.byId(props.tags, props.selectedTagId);
-			output.title = Tag.getCachedFullTitle(output.id);
+			const tag = Tag.byId(props.tags, props.selectedTagId);
+			output = Object.assign({}, tag, { title: Tag.getCachedFullTitle(tag.id) });
 		} else if (props.notesParentType == 'SmartFilter') {
 			output = { id: this.props.selectedSmartFilterId, title: _('All notes') };
 		} else {

--- a/ReactNativeClient/lib/components/screens/notes.js
+++ b/ReactNativeClient/lib/components/screens/notes.js
@@ -184,6 +184,7 @@ class NotesScreenComponent extends BaseScreenComponent {
 			output = Folder.byId(props.folders, props.selectedFolderId);
 		} else if (props.notesParentType == 'Tag') {
 			output = Tag.byId(props.tags, props.selectedTagId);
+			output.title = output.full_title;
 		} else if (props.notesParentType == 'SmartFilter') {
 			output = { id: this.props.selectedSmartFilterId, title: _('All notes') };
 		} else {

--- a/ReactNativeClient/lib/components/screens/tags.js
+++ b/ReactNativeClient/lib/components/screens/tags.js
@@ -70,7 +70,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 				}}
 			>
 				<View style={this.styles().listItem}>
-					<Text style={this.styles().listItemText}>{tag.full_title}</Text>
+					<Text style={this.styles().listItemText}>{Tag.getCachedFullTitle(tag.id)}</Text>
 				</View>
 			</TouchableOpacity>
 		);
@@ -83,7 +83,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 	async componentDidMount() {
 		const tags = await Tag.allWithNotes();
 		tags.sort((a, b) => {
-			return a.full_title.toLowerCase() < b.full_title.toLowerCase() ? -1 : +1;
+			return Tag.getCachedFullTitle(a.id).toLowerCase() < Tag.getCachedFullTitle(b.id).toLowerCase() ? -1 : +1;
 		});
 		this.setState({ tags: tags });
 	}

--- a/ReactNativeClient/lib/components/screens/tags.js
+++ b/ReactNativeClient/lib/components/screens/tags.js
@@ -70,7 +70,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 				}}
 			>
 				<View style={this.styles().listItem}>
-					<Text style={this.styles().listItemText}>{tag.title}</Text>
+					<Text style={this.styles().listItemText}>{tag.full_title}</Text>
 				</View>
 			</TouchableOpacity>
 		);
@@ -83,7 +83,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 	async componentDidMount() {
 		const tags = await Tag.allWithNotes();
 		tags.sort((a, b) => {
-			return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : +1;
+			return a.full_title.toLowerCase() < b.full_title.toLowerCase() ? -1 : +1;
 		});
 		this.setState({ tags: tags });
 	}

--- a/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
+++ b/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
@@ -15,6 +15,10 @@ const reduxSharedMiddleware = async function(store, next, action) {
 		Setting.setValue('collapsedFolderIds', newState.collapsedFolderIds);
 	}
 
+	if (action.type == 'TAG_SET_COLLAPSED' || action.type == 'TAG_TOGGLE') {
+		Setting.setValue('collapsedTagIds', newState.collapsedTagIds);
+	}
+
 	if (action.type === 'SETTING_UPDATE_ONE' && !!action.key.match(/^sync\.\d+\.path$/)) {
 		reg.resetSyncTarget();
 	}

--- a/ReactNativeClient/lib/components/shared/side-menu-shared.js
+++ b/ReactNativeClient/lib/components/shared/side-menu-shared.js
@@ -1,39 +1,55 @@
-const Folder = require('lib/models/Folder');
+const BaseItem = require('lib/models/BaseItem');
 const BaseModel = require('lib/BaseModel');
 
 const shared = {};
 
-function folderHasChildren_(folders, folderId) {
-	for (let i = 0; i < folders.length; i++) {
-		const folder = folders[i];
-		if (folder.parent_id === folderId) return true;
+function itemHasChildren_(items, itemId) {
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (item.parent_id === itemId) return true;
 	}
 	return false;
 }
 
-function folderIsVisible(folders, folderId, collapsedFolderIds) {
-	if (!collapsedFolderIds || !collapsedFolderIds.length) return true;
+function itemIsVisible(items, itemId, collapsedItemIds) {
+	if (!collapsedItemIds || !collapsedItemIds.length) return true;
 
 	while (true) {
-		const folder = BaseModel.byId(folders, folderId);
-		if (!folder) throw new Error(`No folder with id ${folder.id}`);
-		if (!folder.parent_id) return true;
-		if (collapsedFolderIds.indexOf(folder.parent_id) >= 0) return false;
-		folderId = folder.parent_id;
+		const item = BaseModel.byId(items, itemId);
+		if (!item) throw new Error(`No item with id ${itemId}`);
+		if (!item.parent_id) return true;
+		if (collapsedItemIds.indexOf(item.parent_id) >= 0) return false;
+		itemId = item.parent_id;
 	}
 }
 
-function renderFoldersRecursive_(props, renderItem, items, parentId, depth, order) {
-	const folders = props.folders;
-	for (let i = 0; i < folders.length; i++) {
-		const folder = folders[i];
-		if (!Folder.idsEqual(folder.parent_id, parentId)) continue;
-		if (!folderIsVisible(props.folders, folder.id, props.collapsedFolderIds)) continue;
-		const hasChildren = folderHasChildren_(folders, folder.id);
-		order.push(folder.id);
-		items.push(renderItem(folder, props.selectedFolderId == folder.id && props.notesParentType == 'Folder', hasChildren, depth));
+function renderItemsRecursive_(props, renderItem, items, parentId, depth, order, itemType) {
+	let itemsKey = '';
+	let notesParentType = '';
+	let collapsedItemsKey = '';
+	let selectedItemKey = '';
+	if (itemType === BaseModel.TYPE_FOLDER) {
+		itemsKey = 'folders';
+		notesParentType = 'Folder';
+		collapsedItemsKey = 'collapsedFolderIds';
+		selectedItemKey = 'selectedFolderId';
+	} else if (itemType === BaseModel.TYPE_TAG) {
+		itemsKey = 'tags';
+		notesParentType = 'Tag';
+		collapsedItemsKey = 'collapsedTagIds';
+		selectedItemKey = 'selectedTagId';
+	}
+
+	const propItems = props[itemsKey];
+	for (let i = 0; i < propItems.length; i++) {
+		const item = propItems[i];
+		if (!BaseItem.getClassByItemType(itemType).idsEqual(item.parent_id, parentId)) continue;
+		if (!itemIsVisible(props[itemsKey], item.id, props[collapsedItemsKey])) continue;
+		const hasChildren = itemHasChildren_(propItems, item.id);
+		order.push(item.id);
+		items.push(renderItem(item, props[selectedItemKey] == item.id && props.notesParentType == notesParentType, hasChildren, depth));
 		if (hasChildren) {
-			const result = renderFoldersRecursive_(props, renderItem, items, folder.id, depth + 1, order);
+			const result = renderItemsRecursive_(props, renderItem, items, item.id, depth + 1, order, itemType);
 			items = result.items;
 			order = result.order;
 		}
@@ -45,25 +61,11 @@ function renderFoldersRecursive_(props, renderItem, items, parentId, depth, orde
 }
 
 shared.renderFolders = function(props, renderItem) {
-	return renderFoldersRecursive_(props, renderItem, [], '', 0, []);
+	return renderItemsRecursive_(props, renderItem, [], '', 0, [], BaseModel.TYPE_FOLDER);
 };
 
 shared.renderTags = function(props, renderItem) {
-	const tags = props.tags.slice();
-	tags.sort((a, b) => {
-		return a.title < b.title ? -1 : +1;
-	});
-	const tagItems = [];
-	const order = [];
-	for (let i = 0; i < tags.length; i++) {
-		const tag = tags[i];
-		order.push(tag.id);
-		tagItems.push(renderItem(tag, props.selectedTagId == tag.id && props.notesParentType == 'Tag'));
-	}
-	return {
-		items: tagItems,
-		order: order,
-	};
+	return renderItemsRecursive_(props, renderItem, [], '', 0, [], BaseModel.TYPE_TAG);
 };
 
 // shared.renderSearches = function(props, renderItem) {

--- a/ReactNativeClient/lib/components/side-menu-content.js
+++ b/ReactNativeClient/lib/components/side-menu-content.js
@@ -402,6 +402,7 @@ const SideMenuContent = connect(state => {
 		// Don't do the opacity animation as it means re-rendering the list multiple times
 		// opacity: state.sideMenuOpenPercent,
 		collapsedFolderIds: state.collapsedFolderIds,
+		collapsedTagIds: state.collapsedTagIds,
 		decryptionWorker: state.decryptionWorker,
 		resourceFetcher: state.resourceFetcher,
 	};

--- a/ReactNativeClient/lib/import-enex.js
+++ b/ReactNativeClient/lib/import-enex.js
@@ -185,7 +185,7 @@ async function saveNoteTags(note) {
 		const tagTitle = note.tags[i];
 
 		let tag = await Tag.loadByTitle(tagTitle);
-		if (!tag) tag = await Tag.save({ title: tagTitle });
+		if (!tag) tag = await Tag.saveNested({ full_title: tagTitle });
 
 		await Tag.addNote(tag.id, note.id);
 

--- a/ReactNativeClient/lib/import-enex.js
+++ b/ReactNativeClient/lib/import-enex.js
@@ -185,7 +185,7 @@ async function saveNoteTags(note) {
 		const tagTitle = note.tags[i];
 
 		let tag = await Tag.loadByTitle(tagTitle);
-		if (!tag) tag = await Tag.saveNested({ full_title: tagTitle });
+		if (!tag) tag = await Tag.saveNested({}, tagTitle);
 
 		await Tag.addNote(tag.id, note.id);
 

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -739,7 +739,7 @@ class JoplinDatabase extends Database {
 				queries.push('ALTER TABLE tags ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""');
 				// Drop the tag note count view, instead compute note count on the fly
 				queries.push('DROP VIEW tags_with_note_count');
-				queries.push(this.addMigrationFile(30));
+				queries.push(this.addMigrationFile(31));
 			}
 
 			queries.push({ sql: 'UPDATE version SET version = ?', params: [targetVersion] });

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -326,7 +326,7 @@ class JoplinDatabase extends Database {
 		// must be set in the synchronizer too.
 
 		// Note: v16 and v17 don't do anything. They were used to debug an issue.
-		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30];
+		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
 
 		let currentVersionIndex = existingDatabaseVersions.indexOf(fromVersion);
 
@@ -733,6 +733,24 @@ class JoplinDatabase extends Database {
 						is_shared: 'INT NOT NULL DEFAULT 0',
 					})
 				);
+			}
+
+			if (targetVersion == 31) {
+				queries.push('ALTER TABLE tags ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""');
+				// Modify the tags_with_note_count view table for hierarchical tags
+				queries.push('DROP VIEW tags_with_note_count');
+				queries.push(`CREATE VIEW tags_with_note_count AS
+									WITH RECURSIVE
+									parent_of(id, parent_id, title, created_time, updated_time, child_id) AS 
+									(SELECT id, parent_id, title, created_time, updated_time, id FROM tags
+										UNION ALL
+										SELECT parent_of.id, parent_of.parent_id, parent_of.title, parent_of.created_time, parent_of.updated_time, tags2.id FROM parent_of JOIN tags AS tags2 ON parent_of.child_id=tags2.parent_id)
+									SELECT parent_of.id, parent_of.parent_id, parent_of.title, parent_of.created_time, parent_of.updated_time, COUNT(DISTINCT notes.id) as note_count FROM
+											parent_of
+											LEFT JOIN note_tags nt on nt.tag_id = parent_of.child_id 
+											LEFT JOIN notes on notes.id = nt.note_id 
+											WHERE notes.id IS NOT NULL
+										GROUP BY parent_of.id`);
 			}
 
 			queries.push({ sql: 'UPDATE version SET version = ?', params: [targetVersion] });

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -739,6 +739,7 @@ class JoplinDatabase extends Database {
 				queries.push('ALTER TABLE tags ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""');
 				// Drop the tag note count view, instead compute note count on the fly
 				queries.push('DROP VIEW tags_with_note_count');
+				queries.push(this.addMigrationFile(30));
 			}
 
 			queries.push({ sql: 'UPDATE version SET version = ?', params: [targetVersion] });

--- a/ReactNativeClient/lib/migrations/30.js
+++ b/ReactNativeClient/lib/migrations/30.js
@@ -1,0 +1,33 @@
+const Tag = require('lib/models/Tag');
+
+const script = {};
+
+script.exec = async function() {
+	const tags = await Tag.all();
+
+	// In case tags with `/` exist, we want to transform them into nested tags
+	for (let i = 0; i < tags.length; i++) {
+		const tag = tags[i];
+		// Remove any starting sequence of '/'
+		tag.title = tag.title.replace(/^\/*/, '');
+		// Remove any ending sequence of '/'
+		tag.title = tag.title.replace(/\/*$/, '');
+		// Trim any sequence of '/'+ to a single '/'
+		tag.title = tag.title.replace(/\/\/+/g, '/');
+
+		const tag_title = tag.title;
+		let other = await Tag.loadByTitle(tag_title);
+		let count = 1;
+		// In case above trimming creates duplicate tags
+		// then add a counter to the dupes
+		while ((other && other.id != tag.id) && count < 1000) {
+			tag.title = `${tag_title}-${count}`;
+			other = await Tag.loadByTitle(tag.title);
+			count++;
+		}
+
+		await Tag.saveNested(tag);
+	}
+};
+
+module.exports = script;

--- a/ReactNativeClient/lib/migrations/31.js
+++ b/ReactNativeClient/lib/migrations/31.js
@@ -26,8 +26,7 @@ script.exec = async function() {
 			count++;
 		}
 
-		tag.full_title = tag.title;
-		await Tag.saveNested(tag);
+		await Tag.saveNested(tag, tag.title);
 	}
 };
 

--- a/ReactNativeClient/lib/migrations/31.js
+++ b/ReactNativeClient/lib/migrations/31.js
@@ -26,6 +26,7 @@ script.exec = async function() {
 			count++;
 		}
 
+		tag.full_title = tag.title;
 		await Tag.saveNested(tag);
 	}
 };

--- a/ReactNativeClient/lib/migrations/31.js
+++ b/ReactNativeClient/lib/migrations/31.js
@@ -7,7 +7,7 @@ script.exec = async function() {
 
 	// In case tags with `/` exist, we want to transform them into nested tags
 	for (let i = 0; i < tags.length; i++) {
-		const tag = tags[i];
+		const tag = Object.assign({}, tags[i]);
 		// Remove any starting sequence of '/'
 		tag.title = tag.title.replace(/^\/*/, '');
 		// Remove any ending sequence of '/'

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -4,6 +4,7 @@ const Note = require('lib/models/Note.js');
 const { Database } = require('lib/database.js');
 const { _ } = require('lib/locale.js');
 const BaseItem = require('lib/models/BaseItem.js');
+const { nestedPath } = require('lib/nested-utils.js');
 const { substrWithEllipsis } = require('lib/string-utils.js');
 
 class Folder extends BaseItem {
@@ -263,22 +264,7 @@ class Folder extends BaseItem {
 	}
 
 	static folderPath(folders, folderId) {
-		const idToFolders = {};
-		for (let i = 0; i < folders.length; i++) {
-			idToFolders[folders[i].id] = folders[i];
-		}
-
-		const path = [];
-		while (folderId) {
-			const folder = idToFolders[folderId];
-			if (!folder) break; // Shouldn't happen
-			path.push(folder);
-			folderId = folder.parent_id;
-		}
-
-		path.reverse();
-
-		return path;
+		return nestedPath(folders, folderId);
 	}
 
 	static folderPathString(folders, folderId, maxTotalLength = 80) {

--- a/ReactNativeClient/lib/models/Migration.js
+++ b/ReactNativeClient/lib/models/Migration.js
@@ -3,6 +3,7 @@ const BaseModel = require('lib/BaseModel.js');
 const migrationScripts = {
 	20: require('lib/migrations/20.js'),
 	27: require('lib/migrations/27.js'),
+	30: require('lib/migrations/30.js'),
 };
 
 class Migration extends BaseModel {

--- a/ReactNativeClient/lib/models/Migration.js
+++ b/ReactNativeClient/lib/models/Migration.js
@@ -3,7 +3,7 @@ const BaseModel = require('lib/BaseModel.js');
 const migrationScripts = {
 	20: require('lib/migrations/20.js'),
 	27: require('lib/migrations/27.js'),
-	30: require('lib/migrations/30.js'),
+	31: require('lib/migrations/31.js'),
 };
 
 class Migration extends BaseModel {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -456,6 +456,7 @@ class Setting extends BaseModel {
 			startMinimized: { value: false, type: Setting.TYPE_BOOL, section: 'application', public: true, appTypes: ['desktop'], label: () => _('Start application minimised in the tray icon') },
 
 			collapsedFolderIds: { value: [], type: Setting.TYPE_ARRAY, public: false },
+			collapsedTagIds: { value: [], type: Setting.TYPE_ARRAY, public: false },
 
 			'keychain.supported': { value: -1, type: Setting.TYPE_INT, public: false },
 			'db.ftsEnabled': { value: -1, type: Setting.TYPE_INT, public: false },

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -353,14 +353,12 @@ class Tag extends BaseItem {
 		}
 		if (!parentTagId) parentTagId = '';
 
-		let tag = await Tag.load(tagId);
+		const tag = await Tag.load(tagId);
 		if (!tag) return;
 
 		const oldParentTagId = tag.parent_id;
-
 		// Save new parent id
-		tag.parent_id = parentTagId;
-		tag = await Tag.save(tag, { userSideValidation: true });
+		const newTag = await Tag.save({ id: tag.id, parent_id: parentTagId }, { userSideValidation: true });
 
 		if (parentTagId !== oldParentTagId) {
 			// If the parent tag has changed, and the ancestor doesn't
@@ -371,7 +369,7 @@ class Tag extends BaseItem {
 			}
 		}
 
-		return tag;
+		return newTag;
 	}
 
 	static async renameNested(tag, newTitle) {
@@ -401,13 +399,14 @@ class Tag extends BaseItem {
 			throw new Error(_('Tag name cannot contain `//`.'));
 		}
 
+		const newTag = Object.assign({}, tag);
 		let parentId = '';
 		// Check if the tag is nested using `/` as separator
 		const separator = '/';
 		const i = fullTitle.lastIndexOf(separator);
 		if (i !== -1) {
 			const parentTitle = fullTitle.slice(0,i);
-			tag.title = fullTitle.slice(i + 1);
+			newTag.title = fullTitle.slice(i + 1);
 
 			// Try to get the parent tag
 			const parentTag = await Tag.loadByTitle(parentTitle);
@@ -428,12 +427,12 @@ class Tag extends BaseItem {
 			}
 		} else {
 			// Tag is not nested so set the title to full title
-			tag.title = fullTitle;
+			newTag.title = fullTitle;
 		}
 
 		// Set parent_id
-		tag.parent_id = parentId;
-		return await Tag.save(tag, options);
+		newTag.parent_id = parentId;
+		return await Tag.save(newTag, options);
 	}
 
 	static async save(o, options = null) {

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -54,6 +54,9 @@ class Tag extends BaseItem {
 		let childrenIds = await Tag.childrenTagIds(parentId);
 		for (let i = 0; i < childrenIds.length; i++) {
 			const childId = childrenIds[i];
+			// Fail-safe in case of a loop in the tag hierarchy.
+			if (descendantIds.includes(childId)) continue;
+
 			descendantIds.push(childId);
 			childrenIds = childrenIds.concat(await Tag.childrenTagIds(childId));
 		}

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -303,7 +303,7 @@ class Tag extends BaseItem {
 	static async moveTag(tagId, parentTagId) {
 		if (tagId === parentTagId
 				|| (await Tag.descendantTagIds(tagId)).includes(parentTagId)) {
-			throw new Error(_('Cannot move tag to this location'));
+			throw new Error(_('Cannot move tag to this location.'));
 		}
 
 		const tag = await Tag.load(tagId);
@@ -322,6 +322,12 @@ class Tag extends BaseItem {
 		if (!options) options = {};
 		// The following option is used to prevent loops in the tag hierarchy
 		if (!('mainTagId' in options) && tag.id) options.mainTagId = tag.id;
+
+		if (tag.title.startsWith('/') || tag.title.endsWith('/')) {
+			throw new Error(_('Tag name cannot start or end with a `/`.'));
+		} else if (tag.title.includes('//')) {
+			throw new Error(_('Tag name cannot contain `//`.'));
+		}
 
 		let parentId = '';
 		// Check if the tag is nested using `/` as separator

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -52,11 +52,11 @@ class Tag extends BaseItem {
 		if (!options) options = {};
 		if (!('deleteChildren' in options)) options.deleteChildren = true;
 
-		let tag = await Tag.load(tagId);
+		const tag = await Tag.load(tagId);
 		if (!tag) return; // noop
 
 		if (options.deleteChildren) {
-			let childrenTagIds = await Tag.childrenTagIds(tagId);
+			const childrenTagIds = await Tag.childrenTagIds(tagId);
 			for (let i = 0; i < childrenTagIds.length; i++) {
 				await Tag.untagAll(childrenTagIds[i]);
 			}
@@ -75,11 +75,11 @@ class Tag extends BaseItem {
 		if (!options) options = {};
 		if (!('deleteChildren' in options)) options.deleteChildren = true;
 
-		let tag = await Tag.load(id);
+		const tag = await Tag.load(id);
 		if (!tag) return; // noop
 
 		if (options.deleteChildren) {
-			let childrenTagIds = await Tag.childrenTagIds(id);
+			const childrenTagIds = await Tag.childrenTagIds(id);
 			for (let i = 0; i < childrenTagIds.length; i++) {
 				await Tag.delete(childrenTagIds[i]);
 			}
@@ -230,19 +230,19 @@ class Tag extends BaseItem {
 	}
 
 	static displayTitle(item) {
-		let title = super.displayTitle(item);
+		const title = super.displayTitle(item);
 		const separator = '/';
 		const i = title.lastIndexOf(separator);
-		if (i !== -1) return title.slice(i+separator.length);
+		if (i !== -1) return title.slice(i + separator.length);
 		return title;
 	}
 
 	static async changeDescendantPrefix(parentItem, parentPrefix) {
 		const childrenTagIds = await Tag.childrenTagIds(parentItem.id);
 		for (let i = 0; i < childrenTagIds.length; i++) {
-			let childItem = await Tag.load(childrenTagIds[i]);
+			const childItem = await Tag.load(childrenTagIds[i]);
 			// The new title of the child is new prefix + display name
-			let childName = `${parentPrefix}/${await Tag.displayTitle(childItem)}`;
+			const childName = `${parentPrefix}/${await Tag.displayTitle(childItem)}`;
 			childItem.title = childName;
 			// Change the child title
 			await Tag.save(childItem, { selectNoteTag: false, createParents: false });
@@ -274,11 +274,11 @@ class Tag extends BaseItem {
 	}
 
 	static async moveTag(tagId, parentTagId) {
-		let tag = await Tag.load(tagId);
+		const tag = await Tag.load(tagId);
 		if (!tag) return;
 		let tagTitle = await Tag.displayTitle(tag);
 
-		let parentTag = await Tag.load(parentTagId);
+		const parentTag = await Tag.load(parentTagId);
 		if (parentTag) {
 			tagTitle = `${parentTag.title}/${tagTitle}`;
 		}
@@ -308,17 +308,17 @@ class Tag extends BaseItem {
 				parentTitle = o.title.slice(0,i);
 
 				// Try to get the parent tag
-				let parentTag = await Tag.loadByTitle(parentTitle);
+				const parentTag = await Tag.loadByTitle(parentTitle);
 				if (parentTag) parentId = parentTag.id;
 			}
 
 			if (options && options.createParents && parentTitle && !parentId) {
 				// Create the parent tag if it doesn't exist
-				let parent = {
+				const parent = {
 					title: parentTitle,
 				};
 				// Do not select the parent note_tags
-				let parentOpts = {};
+				const parentOpts = {};
 				parentOpts.selectNoteTag = false;
 				const parentTag = await Tag.save(parent, parentOpts);
 				parentId = parentTag.id;

--- a/ReactNativeClient/lib/nested-utils.js
+++ b/ReactNativeClient/lib/nested-utils.js
@@ -1,0 +1,22 @@
+/* eslint no-useless-escape: 0*/
+
+function nestedPath(items, itemId) {
+	const idToItem = {};
+	for (let i = 0; i < items.length; i++) {
+		idToItem[items[i].id] = items[i];
+	}
+
+	const path = [];
+	while (itemId) {
+		const item = idToItem[itemId];
+		if (!item) break; // Shouldn't happen
+		path.push(item);
+		itemId = item.parent_id;
+	}
+
+	path.reverse();
+
+	return path;
+}
+
+module.exports = { nestedPath };

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -38,6 +38,7 @@ const defaultState = {
 	customCss: '',
 	templates: [],
 	collapsedFolderIds: [],
+	collapsedTagIds: [],
 	clipperServer: {
 		startState: 'idle',
 		port: null,
@@ -172,20 +173,24 @@ function stateHasEncryptedItems(state) {
 	return false;
 }
 
-function folderSetCollapsed(state, action) {
-	const collapsedFolderIds = state.collapsedFolderIds.slice();
-	const idx = collapsedFolderIds.indexOf(action.id);
+function itemSetCollapsed(state, action) {
+	let collapsedItemsKey = null;
+	if (action.type.indexOf('TAG_') !== -1) collapsedItemsKey = 'collapsedTagIds';
+	else if (action.type.indexOf('FOLDER_') !== -1) collapsedItemsKey = 'collapsedFolderIds';
+
+	const collapsedItemIds = state[collapsedItemsKey].slice();
+	const idx = collapsedItemIds.indexOf(action.id);
 
 	if (action.collapsed) {
 		if (idx >= 0) return state;
-		collapsedFolderIds.push(action.id);
+		collapsedItemIds.push(action.id);
 	} else {
 		if (idx < 0) return state;
-		collapsedFolderIds.splice(idx, 1);
+		collapsedItemIds.splice(idx, 1);
 	}
 
 	const newState = Object.assign({}, state);
-	newState.collapsedFolderIds = collapsedFolderIds;
+	newState[collapsedItemsKey] = collapsedItemIds;
 	return newState;
 }
 
@@ -754,20 +759,37 @@ const reducer = (state = defaultState, action) => {
 			break;
 
 		case 'FOLDER_SET_COLLAPSED':
-			newState = folderSetCollapsed(state, action);
+			newState = itemSetCollapsed(state, action);
 			break;
 
 		case 'FOLDER_TOGGLE':
 			if (state.collapsedFolderIds.indexOf(action.id) >= 0) {
-				newState = folderSetCollapsed(state, Object.assign({ collapsed: false }, action));
+				newState = itemSetCollapsed(state, Object.assign({ collapsed: false }, action));
 			} else {
-				newState = folderSetCollapsed(state, Object.assign({ collapsed: true }, action));
+				newState = itemSetCollapsed(state, Object.assign({ collapsed: true }, action));
 			}
 			break;
 
 		case 'FOLDER_SET_COLLAPSED_ALL':
 			newState = Object.assign({}, state);
 			newState.collapsedFolderIds = action.ids.slice();
+			break;
+
+		case 'TAG_SET_COLLAPSED':
+			newState = itemSetCollapsed(state, action);
+			break;
+
+		case 'TAG_TOGGLE':
+			if (state.collapsedTagIds.indexOf(action.id) >= 0) {
+				newState = itemSetCollapsed(state, Object.assign({ collapsed: false }, action));
+			} else {
+				newState = itemSetCollapsed(state, Object.assign({ collapsed: true }, action));
+			}
+			break;
+
+		case 'TAG_SET_COLLAPSED_ALL':
+			newState = Object.assign({}, state);
+			newState.collapsedTagIds = action.ids.slice();
 			break;
 
 		case 'TAG_UPDATE_ALL':

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -312,17 +312,14 @@ class Api {
 		const hasFullTitleField = checkAndRemoveFullTitleField(request);
 
 		if (hasFullTitleField && request.method === 'GET' && !id) {
-			const tags = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
-
-			for (let i = 0; i < tags.length; i++) {
-				tags[i].full_title = Tag.getCachedFullTitle(tags[i].id);
-			}
+			let tags = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
+			tags = tags.map(tag => Object.assign({}, tag, { full_title: Tag.getCachedFullTitle(tag.id) }));
 			return tags;
 		}
 
 		if (hasFullTitleField && request.method === 'GET' && id) {
-			const tag = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
-			tag.full_title = Tag.getCachedFullTitle(tag.id);
+			let tag = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
+			tag = Object.assign({}, tag, { full_title: Tag.getCachedFullTitle(tag.id) });
 			return tag;
 		}
 

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -284,6 +284,70 @@ class Api {
 			}
 		}
 
+		const checkAndRemoveFullTitleField = function(request) {
+			const fields = this.fields_(request);
+			let hasFullTitleField = false;
+			for (let i = 0; i < fields.length; i++) {
+				if (fields[i] === 'full_title') {
+					hasFullTitleField = true;
+					// Remove field from field list
+					fields.splice(i, 1);
+					break;
+				}
+			}
+
+			// Remove the full_title field from the query
+			if (hasFullTitleField) {
+				if (fields.length > 0) {
+					request.query.fields = fields.join(',');
+				} else if (request.query && request.query.fields) {
+					delete request.query.fields;
+				}
+			}
+
+			return hasFullTitleField;
+		}.bind(this);
+
+		// Handle full_title for GET requests
+		const hasFullTitleField = checkAndRemoveFullTitleField(request);
+
+		if (hasFullTitleField && request.method === 'GET' && !id) {
+			const tags = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
+
+			for (let i = 0; i < tags.length; i++) {
+				tags[i].full_title = Tag.getCachedFullTitle(tags[i].id);
+			}
+			return tags;
+		}
+
+		if (hasFullTitleField && request.method === 'GET' && id) {
+			const tag = await this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
+			tag.full_title = Tag.getCachedFullTitle(tag.id);
+			return tag;
+		}
+
+		// Handle full_title for POST and PUT requests
+		if (request.method === 'PUT' || request.method === 'POST') {
+			const props = this.readonlyProperties(request.method);
+			if (props.includes('full_title')) {
+				if (request.method === 'PUT' && id) {
+					const model = await Tag.load(id);
+					if (!model) throw new ErrorNotFound();
+					let newModel = Object.assign({}, model, request.bodyJson(props));
+					newModel = await Tag.renameNested(newModel, newModel['full_title']);
+					return newModel;
+				}
+
+				if (request.method === 'POST') {
+					const idIdx = props.indexOf('id');
+					if (idIdx >= 0) props.splice(idIdx, 1);
+					const model = request.bodyJson(props);
+					const result = await Tag.saveNested(model, model['full_title'], this.defaultSaveOptions_(model, 'POST'));
+					return result;
+				}
+			}
+		}
+
 		return this.defaultAction_(BaseModel.TYPE_TAG, request, id, link);
 	}
 

--- a/ReactNativeClient/lib/string-utils.js
+++ b/ReactNativeClient/lib/string-utils.js
@@ -264,6 +264,11 @@ function substrWithEllipsis(s, start, length) {
 	return `${s.substr(start, length - 3)}...`;
 }
 
+function substrStartWithEllipsis(s, start, length) {
+	if (s.length <= length) return s;
+	return `...${s.substr(start + 3, length)}`;
+}
+
 function nextWhitespaceIndex(s, begin) {
 	// returns index of the next whitespace character
 	const i = s.slice(begin).search(/\s/);
@@ -285,4 +290,4 @@ function scriptType(s) {
 	return 'en';
 }
 
-module.exports = Object.assign({ removeDiacritics, substrWithEllipsis, nextWhitespaceIndex, escapeFilename, wrap, splitCommandString, padLeft, toTitleCase, urlDecode, escapeHtml, surroundKeywords, scriptType, commandArgumentsToString }, stringUtilsCommon);
+module.exports = Object.assign({ removeDiacritics, substrWithEllipsis, substrStartWithEllipsis, nextWhitespaceIndex, escapeFilename, wrap, splitCommandString, padLeft, toTitleCase, urlDecode, escapeHtml, surroundKeywords, scriptType, commandArgumentsToString }, stringUtilsCommon);

--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -1,6 +1,7 @@
 const BaseItem = require('lib/models/BaseItem.js');
 const Folder = require('lib/models/Folder.js');
 const Note = require('lib/models/Note.js');
+const Tag = require('lib/models/Tag.js');
 const Resource = require('lib/models/Resource.js');
 const ItemChange = require('lib/models/ItemChange.js');
 const Setting = require('lib/models/Setting.js');
@@ -776,7 +777,15 @@ class Synchronizer {
 							}
 
 							const ItemClass = BaseItem.itemClass(local.type_);
-							await ItemClass.delete(local.id, { trackDeleted: false, changeSource: ItemChange.SOURCE_SYNC });
+							if (ItemClass === Tag) {
+								await Tag.delete(local.id, {
+									trackDeleted: false,
+									changeSource: ItemChange.SOURCE_SYNC,
+									deleteChildren: false,
+									deleteNotelessParents: false });
+							} else {
+								await ItemClass.delete(local.id, { trackDeleted: false, changeSource: ItemChange.SOURCE_SYNC });
+							}
 						}
 					}
 

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -536,6 +536,11 @@ async function initialize(dispatch) {
 			ids: Setting.value('collapsedFolderIds'),
 		});
 
+		dispatch({
+			type: 'TAG_SET_COLLAPSED_ALL',
+			ids: Setting.value('collapsedTagIds'),
+		});
+
 		if (!folder) {
 			dispatch(DEFAULT_ROUTE);
 		} else {


### PR DESCRIPTION
Potentially resolves 
* https://github.com/laurent22/joplin/issues/375
* https://discourse.joplinapp.org/t/nested-tags-nested-notebook-structure-from-evernote/1562.

## Details

The implementation uses `/` symbol as a nesting separator. I.e. `tag/subtag` is a nested tag, where `tag` is the parent tag and `subtag` is its child. Creating a tag named `tag/subtag/subsubtag` creates three tags, one for each level. The tags are associated using `parent_id` field.

In the app, viewing notes with a tag will also show all notes that are associated with any of the tag's descendant tags (same for the note count). Deleting a tag will also delete all its descendant tags.

In the desktop app the tags are shown nested just like the notebooks:
![Screenshot from 2020-02-24 16-23-08](https://user-images.githubusercontent.com/5730052/75165085-1f120280-5722-11ea-92d4-01b97c9f3fff.png)
And in the editor they are shown using the `/` separator:
![Screenshot from 2020-02-24 16-25-22](https://user-images.githubusercontent.com/5730052/75165216-55e81880-5722-11ea-8c2b-a54b91d96857.png)

The tag hierarchy can be changed by drag-and-drop. I.e. you can drag a tag and drop it into the default scope or place it under another tag.

## Examples
1. Creating a new tag `a/b` creates a tag `a/b` and `a` (if it does not already exist). It then attaches `a/b` to the current note. 
In the tag explorer, the note will show up whenever `a` or `a/b` is selected. 
Also, the note will add to the count of notes for `a` and `a/b`. 
2. Dragging a tag `a/b` onto the `Tags` section will rename the tag to `b`, essentially moving it from hierarchy under `a` to the default scope.
3. Dragging a tag `a/b/c` onto `a` will create `a/c`. The note count for `a/b` is automatically updated.
4. If `b` already exists, and you try to drag `a/b` onto the default scope, then the error popup will be shown `The tag "%s" already exists. Please choose a different name.`.
5. The same dragging behaviour exists when renaming tags. Additionally, if you rename `a/b` to `c/b` and `c` does not already exist, then the parent tag `c` will be created.
6. Deleting a tag `a`, when it has descendants `a/b` and `a/c` will delete all tags `a`, `a/b`, and `a/c` - the deletion confirmation popup reminds that with `Remove tag "%s" and its descendant tags from all notes?'`.