### PR TITLE
Desktop: preview mode fix

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1177,15 +1177,19 @@ class Application extends BaseApplication {
 
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
+
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
+			if (!menuItem) continue;
+			// noteCheck stores the boolean value for if there is a note and if the note is a HTML note
 			const noteCheck = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
 			if (noteCheck === false || viewer === 'viewer') {
 				menuItem.enabled = false;
-			} else if (noteCheck === true || viewer !== 'viewer') {
+			} else {
 				menuItem.enabled = true;
 			}
 		}
+
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 		menuItem.checked = state.devToolsVisible;
 	}

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1181,16 +1181,11 @@ class Application extends BaseApplication {
 
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
-			if (!menuItem) continue;
-			if (viewer) {
-				if (viewer === 'viewer') {
-					menuItem.enabled = false;
-				} else {
-					menuItem.enabled = true;
-				}
-			} else {
-
-				menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			const noteCheck = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			if (noteCheck === false || viewer === 'viewer') {
+				menuItem.enabled = false;
+			} else if (noteCheck === true || viewer !== 'viewer') {
+				menuItem.enabled = true;
 			}
 		}
 

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1181,13 +1181,8 @@ class Application extends BaseApplication {
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
-			// noteCheck stores the boolean value for if there is a note and if the note is a HTML note
-			const noteCheck = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
-			if (noteCheck === false || viewer === 'viewer') {
-				menuItem.enabled = false;
-			} else {
-				menuItem.enabled = true;
-			}
+			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			!isHtmlNote || viewer === 'viewer' ?  menuItem.enabled = false : menuItem.enabled = true;
 		}
 
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1181,7 +1181,7 @@ class Application extends BaseApplication {
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
-			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			const isHtmlNote = !!note && note.markup_language !== MarkupToHtml.MARKUP_LANGUAGE_HTML;
 			menuItem.enabled = isHtmlNote && viewer !== 'viewer';
 		}
 

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1182,7 +1182,7 @@ class Application extends BaseApplication {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
 			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
-			!isHtmlNote || viewer === 'viewer' ?  menuItem.enabled = false : menuItem.enabled = true;
+			menuItem.enabled = isHtmlNote && viewer !== 'viewer';
 		}
 
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -281,8 +281,8 @@ class Application extends BaseApplication {
 
 		if (['NOTE_VISIBLE_PANES_TOGGLE', 'NOTE_VISIBLE_PANES_SET'].indexOf(action.type) >= 0) {
 			Setting.setValue('noteVisiblePanes', newState.noteVisiblePanes);
-			const viewer = newState.noteVisiblePanes[0];
-			this.updateMenuItemStates(viewer);
+			const layout = newState.noteVisiblePanes[0];
+			this.updateMenuItemStates(layout);
 		}
 
 		if (['SIDEBAR_VISIBILITY_TOGGLE', 'SIDEBAR_VISIBILITY_SET'].indexOf(action.type) >= 0) {
@@ -294,8 +294,8 @@ class Application extends BaseApplication {
 		}
 
 		if (action.type.indexOf('NOTE_SELECT') === 0 || action.type.indexOf('FOLDER_SELECT') === 0) {
-			const viewer = newState.noteVisiblePanes[0];
-			this.updateMenuItemStates(viewer, newState);
+			const layout = newState.noteVisiblePanes[0];
+			this.updateMenuItemStates(layout, newState);
 		}
 
 		if (['NOTE_DEVTOOLS_TOGGLE', 'NOTE_DEVTOOLS_SET'].indexOf(action.type) >= 0) {
@@ -1169,7 +1169,7 @@ class Application extends BaseApplication {
 		this.lastMenuScreen_ = screen;
 	}
 
-	async updateMenuItemStates(viewer, state = null) {
+	async updateMenuItemStates(layout, state = null) {
 		if (!this.lastMenuScreen_) return;
 		if (!this.store() && !state) return;
 
@@ -1181,8 +1181,8 @@ class Application extends BaseApplication {
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
-			const isHtmlNote = !!note && note.markup_language !== MarkupToHtml.MARKUP_LANGUAGE_HTML;
-			menuItem.enabled = isHtmlNote && viewer !== 'viewer';
+			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML;
+			menuItem.enabled = !isHtmlNote && layout !== 'viewer' && !!note;
 		}
 
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -283,7 +283,6 @@ class Application extends BaseApplication {
 			Setting.setValue('noteVisiblePanes', newState.noteVisiblePanes);
 			const viewer = newState.noteVisiblePanes[0];
 			this.updateMenuItemStates(viewer);
-
 		}
 
 		if (['SIDEBAR_VISIBILITY_TOGGLE', 'SIDEBAR_VISIBILITY_SET'].indexOf(action.type) >= 0) {
@@ -1178,7 +1177,6 @@ class Application extends BaseApplication {
 
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
-
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			const noteCheck = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
@@ -1188,7 +1186,6 @@ class Application extends BaseApplication {
 				menuItem.enabled = true;
 			}
 		}
-
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 		menuItem.checked = state.devToolsVisible;
 	}

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -281,6 +281,9 @@ class Application extends BaseApplication {
 
 		if (['NOTE_VISIBLE_PANES_TOGGLE', 'NOTE_VISIBLE_PANES_SET'].indexOf(action.type) >= 0) {
 			Setting.setValue('noteVisiblePanes', newState.noteVisiblePanes);
+			const viewer = newState.noteVisiblePanes[0];
+			this.updateMenuItemStates(viewer);
+
 		}
 
 		if (['SIDEBAR_VISIBILITY_TOGGLE', 'SIDEBAR_VISIBILITY_SET'].indexOf(action.type) >= 0) {
@@ -292,7 +295,8 @@ class Application extends BaseApplication {
 		}
 
 		if (action.type.indexOf('NOTE_SELECT') === 0 || action.type.indexOf('FOLDER_SELECT') === 0) {
-			this.updateMenuItemStates(newState);
+			const viewer = newState.noteVisiblePanes[0];
+			this.updateMenuItemStates(viewer, newState);
 		}
 
 		if (['NOTE_DEVTOOLS_TOGGLE', 'NOTE_DEVTOOLS_SET'].indexOf(action.type) >= 0) {
@@ -1166,7 +1170,7 @@ class Application extends BaseApplication {
 		this.lastMenuScreen_ = screen;
 	}
 
-	async updateMenuItemStates(state = null) {
+	async updateMenuItemStates(viewer, state = null) {
 		if (!this.lastMenuScreen_) return;
 		if (!this.store() && !state) return;
 
@@ -1178,7 +1182,16 @@ class Application extends BaseApplication {
 		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
-			menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			if (viewer) {
+				if (viewer === 'viewer') {
+					menuItem.enabled = false;
+				} else {
+					menuItem.enabled = true;
+				}
+			} else {
+
+				menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
+			}
 		}
 
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');


### PR DESCRIPTION
**DESCRIPTION:**
This patch is a fix for the issue #2467 . Previously before this solution, the Edit menu items were not disabled on PREVIEW, this caused users to be able to use short cuts such as CTRL+B, CTRL+` on PREVIEW mode which is an unwanted behavior.

**HOW TO TEST**
Use the following test cases to confirm this solution::

- Add a note to a notebook and click the layout toggler to PREVIEW:
EXPECTED RESULT: 'copy', 'paste', 'cut', 'select all', 'bold', 'italic', 'link', 'code', 'insert Date Time', 'Start External Editing', 'show Local Search' should be **disabled**
- Add a note to a notebook and click the layout toggler to EDITOR:
EXPECTED RESULT: 'copy', 'paste', 'cut', 'select all', 'bold', 'italic', 'link', 'code', 'insert Date Time', 'Start External Editing', 'show Local Search' should be **enabled**
- Add a note to a notebook and click the layout toggler to EDITOR AND PREVIEW MODE:
EXPECTED RESULT: 'copy', 'paste', 'cut', 'select all', 'bold', 'italic', 'link', 'code', 'insert Date Time', 'Start External Editing', 'show Local Search' should be **enabled**
- Imported a HTML note  and click the layout toggler to EDITOR/PREVIEW MODE/SPLIT:
EXPECTED RESULT: 'copy', 'paste', 'cut', 'select all', 'bold', 'italic', 'link', 'code', 'insert Date Time', 'Start External Editing', 'show Local Search' should be **disabled**
- CREATE an Empty Notebook (book without notes)
EXPECTED RESULT: 'copy', 'paste', 'cut', 'select all', 'bold', 'italic', 'link', 'code', 'insert Date Time', 'Start External Editing', 'show Local Search' should be **disabled**
