### PR TITLE
Desktop: Speed up Webdav Sync on Linux

### DIFF
--- a/ReactNativeClient/lib/WebDavApi.js
+++ b/ReactNativeClient/lib/WebDavApi.js
@@ -21,10 +21,10 @@ class WebDavApi {
 		this.options_ = options;
 		this.lastRequests_ = [];
 		this.AgentSettings = 	{
-						keepAlive: true,
-						maxSockets: 1,
-						keepAliveMsecs: 5000,
-					};
+			keepAlive: true,
+			maxSockets: 1,
+			keepAliveMsecs: 5000,
+		};
 	}
 
 	logRequest_(request, responseText) {
@@ -366,16 +366,15 @@ class WebDavApi {
 		const fetchOptions = {};
 		fetchOptions.headers = headers;
 		fetchOptions.method = method;
+		if (options.path) fetchOptions.path = options.path;
+		if (body) fetchOptions.body = body;
 		if (shim.isLinux()) {
-			if (this.baseUrl().startsWith('https')){
+			if (this.baseUrl().startsWith('https')) {
 				fetchOptions.agent = new https.Agent(this.AgentSettings);
-			}else{
+			} else {
 				fetchOptions.agent = new http.Agent(this.AgentSettings);
 			}
 		}
-		
-		if (options.path) fetchOptions.path = options.path;
-		if (body) fetchOptions.body = body;
 
 		const url = `${this.baseUrl()}/${path}`;
 

--- a/ReactNativeClient/lib/WebDavApi.js
+++ b/ReactNativeClient/lib/WebDavApi.js
@@ -5,10 +5,7 @@ const JoplinError = require('lib/JoplinError');
 const URL = require('url-parse');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const base64 = require('base-64');
-if (shim.isLinux()) {
-	const http = require('http');
-	const https = require('https');
-}
+
 
 // Note that the d: namespace (the DAV namespace) is specific to Nextcloud. The RFC for example uses "D:" however
 // we make all the tags and attributes lowercase so we handle both the Nextcloud style and RFC. Hopefully other
@@ -21,11 +18,6 @@ class WebDavApi {
 		this.logger_ = new Logger();
 		this.options_ = options;
 		this.lastRequests_ = [];
-		this.AgentSettings = 	{
-			keepAlive: true,
-			maxSockets: 1,
-			keepAliveMsecs: 5000,
-		};
 	}
 
 	logRequest_(request, responseText) {
@@ -369,15 +361,10 @@ class WebDavApi {
 		fetchOptions.method = method;
 		if (options.path) fetchOptions.path = options.path;
 		if (body) fetchOptions.body = body;
-		if (shim.isLinux()) {
-			if (this.baseUrl().startsWith('https')) {
-				fetchOptions.agent = new https.Agent(this.AgentSettings);
-			} else {
-				fetchOptions.agent = new http.Agent(this.AgentSettings);
-			}
-		}
-
 		const url = `${this.baseUrl()}/${path}`;
+
+		if (shim.httpAgent(url)) fetchOptions.agent = shim.httpAgent(url);
+
 
 		let response = null;
 

--- a/ReactNativeClient/lib/WebDavApi.js
+++ b/ReactNativeClient/lib/WebDavApi.js
@@ -5,9 +5,10 @@ const JoplinError = require('lib/JoplinError');
 const URL = require('url-parse');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const base64 = require('base-64');
-const http = require('http');
-const https = require('https');
-
+if (shim.isLinux()) {
+	const http = require('http');
+	const https = require('https');
+}
 
 // Note that the d: namespace (the DAV namespace) is specific to Nextcloud. The RFC for example uses "D:" however
 // we make all the tags and attributes lowercase so we handle both the Nextcloud style and RFC. Hopefully other

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -365,7 +365,7 @@ function shimInit() {
 		return bridge().openExternal(url);
 	};
 
-	shim.agent = null;
+	shim.agent_ = null;
 
 	shim.httpAgent = url => {
 		if (shim.isLinux() && !shim.httpAgent) {
@@ -375,12 +375,12 @@ function shimInit() {
 				keepAliveMsecs: 5000,
 			};
 			if (url.startsWith('https')) {
-				shim.agent = new https.Agent(AgentSettings);
+				shim.agent_ = new https.Agent(AgentSettings);
 			} else {
-				shim.agent = new http.Agent(AgentSettings);
+				shim.agent_ = new http.Agent(AgentSettings);
 			}
 		}
-		return shim.agent;
+		return shim.agent_;
 	};
 
 	shim.openOrCreateFile = (filepath, defaultContents) => {

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -365,7 +365,7 @@ function shimInit() {
 		return bridge().openExternal(url);
 	};
 
-	shim.agent_ = null;
+	shim.httpAgent_ = null;
 
 	shim.httpAgent = url => {
 		if (shim.isLinux() && !shim.httpAgent) {
@@ -375,12 +375,12 @@ function shimInit() {
 				keepAliveMsecs: 5000,
 			};
 			if (url.startsWith('https')) {
-				shim.agent_ = new https.Agent(AgentSettings);
+				shim.httpAgent_ = new https.Agent(AgentSettings);
 			} else {
-				shim.agent_ = new http.Agent(AgentSettings);
+				shim.httpAgent_ = new http.Agent(AgentSettings);
 			}
 		}
-		return shim.agent_;
+		return shim.httpAgent_;
 	};
 
 	shim.openOrCreateFile = (filepath, defaultContents) => {

--- a/ReactNativeClient/lib/shim-init-node.js
+++ b/ReactNativeClient/lib/shim-init-node.js
@@ -9,6 +9,8 @@ const Note = require('lib/models/Note.js');
 const Resource = require('lib/models/Resource.js');
 const urlValidator = require('valid-url');
 const { _ } = require('lib/locale.js');
+const http = require('http');
+const https = require('https');
 
 function shimInit() {
 	shim.fsDriver = () => {
@@ -361,6 +363,24 @@ function shimInit() {
 		// Returns true if it opens the file successfully; returns false if it could
 		// not find the file.
 		return bridge().openExternal(url);
+	};
+
+	shim.agent = null;
+
+	shim.httpAgent = url => {
+		if (shim.isLinux() && !shim.httpAgent) {
+			var AgentSettings = {
+				keepAlive: true,
+				maxSockets: 1,
+				keepAliveMsecs: 5000,
+			};
+			if (url.startsWith('https')) {
+				shim.agent = new https.Agent(AgentSettings);
+			} else {
+				shim.agent = new http.Agent(AgentSettings);
+			}
+		}
+		return shim.agent;
 	};
 
 	shim.openOrCreateFile = (filepath, defaultContents) => {

--- a/ReactNativeClient/lib/shim-init-react.js
+++ b/ReactNativeClient/lib/shim-init-react.js
@@ -132,6 +132,10 @@ function shimInit() {
 		Linking.openURL(url);
 	};
 
+	shim.httpAgent = () => {
+		return null;
+	};
+
 	shim.waitForFrame = () => {
 		return new Promise(function(resolve) {
 			requestAnimationFrame(function() {

--- a/ReactNativeClient/lib/shim.js
+++ b/ReactNativeClient/lib/shim.js
@@ -190,6 +190,9 @@ shim.Buffer = null;
 shim.openUrl = () => {
 	throw new Error('Not implemented');
 };
+shim.httpAgent = () => {
+	throw new Error('Not implemented');
+};
 shim.openOrCreateFile = () => {
 	throw new Error('Not implemented');
 };


### PR DESCRIPTION
In its basics, this is a second attempt on #1931 
I shamelessly took the changes done by @e-ihrke and followed through the problems presented by @laurent22 and @tessus to finish up this older problem presented in its current form best in issue #1023 
This keepalive fix sped up my setup enormously, it is now comparable to my android app. Before, it took about 5 minutes to sync a change of a few characters in a single file with my around 250 notes. Now, its down to about 4 seconds. 
This pull will only have an impact on linux users and is using https if needed. Check the code for further details if you like. In the long run, this could be implemented for other Clients if it proves to be useful, but for now its important to bring this out to the problematic linux desktop first.
Automated testing showed no errors.