### PR TITLE
DESKTOP: Fixes the bug where selected text was not being converted into bold text. 

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1435,9 +1435,17 @@ class NoteTextComponent extends React.Component {
 			let selectedStrings = byLine ? selectedLines.split(/\r?\n/) : [selectedLines];
 
 			newBody = this.state.note.body.substr(0, selection.start);
+
 			for (let i = 0; i < selectedStrings.length; i++) {
-				newBody += string1 + selectedStrings[i] + string2;
-			}
+				if (byLine == false) {
+					let start = selectedStrings[i].search(/[^\s]/);
+					let end = selectedStrings[i].search(/[^\s](?=[\s]*$)/);
+					newBody += selectedStrings[i].substr(0, start) + string1 + selectedStrings[i].substr(start, end - start + 1) + string2 + selectedStrings[i].substr(end + 1);
+					if (this.state.note.body.substr(selection.end) === '') newBody = newBody.trim();
+				} else { newBody += string1 + selectedStrings[i] + string2; }
+
+			}			
+			
 			newBody += this.state.note.body.substr(selection.end);
 
 			const r = this.selectionRange_;

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1444,8 +1444,8 @@ class NoteTextComponent extends React.Component {
 					if (this.state.note.body.substr(selection.end) === '') newBody = newBody.trim();
 				} else { newBody += string1 + selectedStrings[i] + string2; }
 
-			}			
-			
+			}
+
 			newBody += this.state.note.body.substr(selection.end);
 
 			const r = this.selectionRange_;


### PR DESCRIPTION
fixes  #2573 

This PR fixes the bug where the selected text was not being converted into bold/italic text if followed or preceded by  a white space

@laurent22  @PackElend  @tessus 

# IMPROVEMENTS

## BEFORE
![PR BUG](https://user-images.githubusercontent.com/54576074/75273998-f411d680-5827-11ea-80c6-a14587ed94e1.gif)

## AFTER

![PR BUG-SOLVE](https://user-images.githubusercontent.com/54576074/75274062-28859280-5828-11ea-9a33-a97292b65ebb.gif)



### EXPLAINING THE CHANGES (For the code reviewers)

-  `/[^\s]/` - to find the first occurrence(index position) of any character that is not a white space (line breaks, tabs, spaces, hard spaces) and store it in start

- ` /[^\s](?=[\s]*$)/`  Matches any character (that is not white space) and then asserts ((?=) is positive lookahead) that no other character up to the end of the string. 

- using substring to add the [spaces+markdown rule+selected text+markdown rule+ space]

-  the trim functionality was inspired when I was looking through Github editor, so if no text is followed after our selected text in the document we trim the end our newBody variable

