### PR TITLE
Add support for Rule of Hooks plugin (#2579)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
 		// Checks rules of Hooks
 		"react-hooks/rules-of-hooks": "error",
 		// Checks effect dependencies
-    	"react-hooks/exhaustive-deps": "error",
+		"react-hooks/exhaustive-deps": "error",
 
 		// -------------------------------
 		// Formatting

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
 		// Checks rules of Hooks
 		"react-hooks/rules-of-hooks": "error",
 		// Checks effect dependencies
-    	"react-hooks/exhaustive-deps": "warn",
+    	"react-hooks/exhaustive-deps": "error",
 
 		// -------------------------------
 		// Formatting

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,11 @@ module.exports = {
 		// possible race conditions in contexts where we know it cannot happen.
 		"require-atomic-updates": 0,
 
+		// Checks rules of Hooks
+		"react-hooks/rules-of-hooks": "error",
+		// Checks effect dependencies
+    	"react-hooks/exhaustive-deps": "warn",
+
 		// -------------------------------
 		// Formatting
 		// -------------------------------
@@ -90,5 +95,6 @@ module.exports = {
 	"plugins": [
 		"react",
 		"@typescript-eslint",
+		"react-hooks"
 	],
 };

--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -34,7 +34,7 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 			setCharactersNoSpace(counter.characters);
 		});
 		setLines(props.text.split('\n').length);
-	}, []);
+	}, [props.text]);
 
 	const textProperties: TextPropertiesMap = {
 		lines: lines,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,6 +1695,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.4.0.tgz",
+      "integrity": "sha512-bH5DOCP6WpuOqNaux2BlaDCrSgv8s5BitP90bTgtZ1ZsRn2bdIfeMDY5F2RnJVnyKDy6KRQRDbipPLZ1y77QtQ==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@typescript-eslint/parser": "^2.10.0",
     "eslint": "^6.1.0",
     "eslint-plugin-react": "^7.18.0",
+    "eslint-plugin-react-hooks": "^2.4.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
     "gulp": "^4.0.2",


### PR DESCRIPTION
This PR Adds support for #2579 Rule of Hooks plugins by:
- Installing `eslint-plugin-react-hooks`
- adding the rules to `.eslintrc.js`
- fixes errors
**How to test**
run `npm run linter ./` in the root directory
**Expected result**
- No errors