### PR TITLE
[mobile] webview: Enable debugging on browser.

### DIFF
--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -2,6 +2,8 @@ package net.cozic.joplin;
 
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
+import android.webkit.WebView;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
@@ -50,6 +52,13 @@ public class MainApplication extends Application implements ReactApplication {
 	@Override
 	public void onCreate() {
 		super.onCreate();
+
+		// Enable debugging with the WebView we use to display notes
+		// Changes are made as recommended by folks at `react-native-webview`
+		// https://github.com/react-native-community/react-native-webview/blob/master/docs/Debugging.md
+		if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+			WebView.setWebContentsDebuggingEnabled(true);
+		}
 
 		// To try to fix the error "Row too big to fit into CursorWindow"
 		// https://github.com/andpor/react-native-sqlite-storage/issues/364#issuecomment-526423153


### PR DESCRIPTION
Enables debugging for the android plugin which
`react-native-webview` uses. This method is mentioned in their guide
for the same.
https://github.com/react-native-community/react-native-webview/blob/master/docs/Debugging.md

Unfortunately the call requires API version >= 19 (After Kitkat),
which is fine because our testing may occur at a higher API level.

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
