### PR TITLE
[WIP]Desktop: Add support for notebook icons

### DIFF
--- a/ElectronClient/gui/SideBar.jsx
+++ b/ElectronClient/gui/SideBar.jsx
@@ -338,7 +338,7 @@ class SideBarComponent extends React.Component {
 		if (itemType === BaseModel.TYPE_FOLDER && !item.encryption_applied) {
 			menu.append(
 				new MenuItem({
-					label: _('Rename'),
+					label: _('Properties'),
 					click: async () => {
 						this.props.dispatch({
 							type: 'WINDOW_COMMAND',


### PR DESCRIPTION
Fixes #2268 

Creating a draft. I will remove the WIP progress tag and mark it for review when it is ready.

To do:

- [ ] Add a new icon property to the Folder object - it will be a string that will take any of the Fork Awesome icon names.
- [ ] Make sure Fork Awesome is loaded in the app (it should already be) so that its icons can be displayed
- [x] When right-clicking a notebook, change "Rename" to "Properties"
- [ ] Change the Rename dialog to a more generic Notebook Properties dialog
- [ ] Add the option to set the icon there. Initially it can be a simple text input where the user inputs the name of the icon directly. We can link to the Fork Awesome page to give the list of possible icons.
- [ ] When the user click Save, save the icon to the database
- [ ] In the sidebar, display the icon next to the notebook name.
