### PR TITLE
Desktop : Adding the title option in the url promt

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -993,7 +993,7 @@ class NoteTextComponent extends React.Component {
 			document.querySelector('#note-editor').addEventListener('keydown', this.onEditorKeyDown_);
 			document.querySelector('#note-editor').addEventListener('contextmenu', this.onEditorContextMenu_);
 
-			const lineLeftSpaces = function (line) {
+			const lineLeftSpaces = function(line) {
 				let output = '';
 				for (let i = 0; i < line.length; i++) {
 					if ([' ', '\t'].indexOf(line[i]) >= 0) {
@@ -1008,7 +1008,7 @@ class NoteTextComponent extends React.Component {
 			// Disable Markdown auto-completion (eg. auto-adding a dash after a line with a dash.
 			// https://github.com/ajaxorg/ace/issues/2754
 			const that = this; // The "this" within the function below refers to something else
-			this.editor_.editor.getSession().getMode().getNextLineIndent = function (state, line) {
+			this.editor_.editor.getSession().getMode().getNextLineIndent = function(state, line) {
 				const ls = that.state.lastKeys;
 				if (ls.length >= 2 && ls[ls.length - 1] === 'Enter' && ls[ls.length - 2] === 'Enter') return this.$getIndent(line);
 
@@ -1181,8 +1181,7 @@ class NoteTextComponent extends React.Component {
 		} else {
 			this.setState({
 				showLocalSearch: true,
-				localSearch: Object.assign({}, this.localSearchDefaultState)
-			});
+				localSearch: Object.assign({}, this.localSearchDefaultState) });
 		}
 
 		this.props.dispatch({
@@ -1457,14 +1456,10 @@ class NoteTextComponent extends React.Component {
 			// Add the number of newlines to the row
 			// and add the length of the final line to the column (for strings with no newlines this is the string length)
 			const newRange = {
-				start: {
-					row: r.start.row + str1Split.length - 1,
-					column: r.start.column + str1Split[str1Split.length - 1].length
-				},
-				end: {
-					row: r.end.row + str1Split.length - 1,
-					column: r.end.column + str1Split[str1Split.length - 1].length
-				},
+				start: { row: r.start.row + str1Split.length - 1,
+					column: r.start.column + str1Split[str1Split.length - 1].length },
+				end: { row: r.end.row + str1Split.length - 1,
+					column: r.end.column + str1Split[str1Split.length - 1].length },
 			};
 
 			if (replacementText !== null) {
@@ -1555,7 +1550,7 @@ class NoteTextComponent extends React.Component {
 		this.wrapSelectionWithStrings(TemplateUtils.render(value));
 	}
 
-	addListItem(string1, string2 = '', defaultText = '', byLine = false) {
+	addListItem(string1, string2 = '', defaultText = '', byLine=false) {
 		let newLine = '\n';
 		const range = this.selectionRange_;
 		if (!range || (range.start.row === range.end.row && !this.selectionRangeCurrentLine())) {
@@ -1588,11 +1583,9 @@ class NoteTextComponent extends React.Component {
 	commandTextHorizontalRule() {
 		this.addListItem('* * *');
 	}
-	// const url = await dialogs.prompt(_('Insert Hyperlink'));
 
 	async commandTextLink() {
-		const formValues = (await dialogs.promptUrl(_('Insert Hyperlink')));
-		console.log(formValues);
+		const formValues= (await dialogs.promptUrl(_('Insert Hyperlink')));
 		try {
 			this.wrapSelectionWithStrings(`[${formValues.value.title}`, `](${formValues.value.url})`);
 		} catch (error) {
@@ -1978,7 +1971,7 @@ class NoteTextComponent extends React.Component {
 			paddingRight: 8,
 			marginRight: rootStyle.paddingLeft,
 			color: theme.textStyle.color,
-			fontSize: theme.textStyle.fontSize * 1.25 * 1.5,
+			fontSize: theme.textStyle.fontSize * 1.25 *1.5,
 			backgroundColor: theme.backgroundColor,
 			border: '1px solid',
 			borderColor: theme.dividerColor,
@@ -2001,7 +1994,7 @@ class NoteTextComponent extends React.Component {
 			bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom - tagStyle.height - tagStyle.marginBottom;
 		} else {
 			toolbarStyle.marginBottom = tagStyle.marginBottom,
-				bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom;
+			bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom;
 		}
 
 		bottomRowHeight -= searchBarHeight;
@@ -2150,7 +2143,7 @@ class NoteTextComponent extends React.Component {
 				VimApi.CodeMirror.Vim.defineEx('write', 'w', save);
 			}
 		};
-		const onLoad = () => { };
+		const onLoad = () => {};
 		const editor = (
 			<AceEditor
 				value={body}
@@ -2179,8 +2172,7 @@ class NoteTextComponent extends React.Component {
 				// Enable/Disable the autoclosing braces
 				setOptions={{
 					behavioursEnabled: Setting.value('editor.autoMatchingBraces'),
-					useSoftTabs: false
-				}}
+					useSoftTabs: false }}
 				// Disable warning: "Automatically scrolling cursor into view after
 				// selection change this will be disabled in the next version set
 				// editor.$blockScrolling = Infinity to disable this message"

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -993,7 +993,7 @@ class NoteTextComponent extends React.Component {
 			document.querySelector('#note-editor').addEventListener('keydown', this.onEditorKeyDown_);
 			document.querySelector('#note-editor').addEventListener('contextmenu', this.onEditorContextMenu_);
 
-			const lineLeftSpaces = function(line) {
+			const lineLeftSpaces = function (line) {
 				let output = '';
 				for (let i = 0; i < line.length; i++) {
 					if ([' ', '\t'].indexOf(line[i]) >= 0) {
@@ -1008,7 +1008,7 @@ class NoteTextComponent extends React.Component {
 			// Disable Markdown auto-completion (eg. auto-adding a dash after a line with a dash.
 			// https://github.com/ajaxorg/ace/issues/2754
 			const that = this; // The "this" within the function below refers to something else
-			this.editor_.editor.getSession().getMode().getNextLineIndent = function(state, line) {
+			this.editor_.editor.getSession().getMode().getNextLineIndent = function (state, line) {
 				const ls = that.state.lastKeys;
 				if (ls.length >= 2 && ls[ls.length - 1] === 'Enter' && ls[ls.length - 2] === 'Enter') return this.$getIndent(line);
 
@@ -1181,7 +1181,8 @@ class NoteTextComponent extends React.Component {
 		} else {
 			this.setState({
 				showLocalSearch: true,
-				localSearch: Object.assign({}, this.localSearchDefaultState) });
+				localSearch: Object.assign({}, this.localSearchDefaultState)
+			});
 		}
 
 		this.props.dispatch({
@@ -1456,10 +1457,14 @@ class NoteTextComponent extends React.Component {
 			// Add the number of newlines to the row
 			// and add the length of the final line to the column (for strings with no newlines this is the string length)
 			const newRange = {
-				start: { row: r.start.row + str1Split.length - 1,
-					column: r.start.column + str1Split[str1Split.length - 1].length },
-				end: { row: r.end.row + str1Split.length - 1,
-					column: r.end.column + str1Split[str1Split.length - 1].length },
+				start: {
+					row: r.start.row + str1Split.length - 1,
+					column: r.start.column + str1Split[str1Split.length - 1].length
+				},
+				end: {
+					row: r.end.row + str1Split.length - 1,
+					column: r.end.column + str1Split[str1Split.length - 1].length
+				},
 			};
 
 			if (replacementText !== null) {
@@ -1550,7 +1555,7 @@ class NoteTextComponent extends React.Component {
 		this.wrapSelectionWithStrings(TemplateUtils.render(value));
 	}
 
-	addListItem(string1, string2 = '', defaultText = '', byLine=false) {
+	addListItem(string1, string2 = '', defaultText = '', byLine = false) {
 		let newLine = '\n';
 		const range = this.selectionRange_;
 		if (!range || (range.start.row === range.end.row && !this.selectionRangeCurrentLine())) {
@@ -1583,10 +1588,18 @@ class NoteTextComponent extends React.Component {
 	commandTextHorizontalRule() {
 		this.addListItem('* * *');
 	}
+	// const url = await dialogs.prompt(_('Insert Hyperlink'));
 
 	async commandTextLink() {
-		const url = await dialogs.prompt(_('Insert Hyperlink'));
-		this.wrapSelectionWithStrings('[', `](${url})`);
+		const formValues = (await dialogs.promptUrl(_('Insert Hyperlink')));
+		console.log(formValues);
+		try {
+			this.wrapSelectionWithStrings(`[${formValues.value.title}`, `](${formValues.value.url})`);
+		} catch (error) {
+			return null;
+		}
+
+
 	}
 
 	itemContextMenu() {
@@ -1965,7 +1978,7 @@ class NoteTextComponent extends React.Component {
 			paddingRight: 8,
 			marginRight: rootStyle.paddingLeft,
 			color: theme.textStyle.color,
-			fontSize: theme.textStyle.fontSize * 1.25 *1.5,
+			fontSize: theme.textStyle.fontSize * 1.25 * 1.5,
 			backgroundColor: theme.backgroundColor,
 			border: '1px solid',
 			borderColor: theme.dividerColor,
@@ -1988,7 +2001,7 @@ class NoteTextComponent extends React.Component {
 			bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom - tagStyle.height - tagStyle.marginBottom;
 		} else {
 			toolbarStyle.marginBottom = tagStyle.marginBottom,
-			bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom;
+				bottomRowHeight = rootStyle.height - titleBarStyle.height - titleBarStyle.marginBottom - titleBarStyle.marginTop - theme.toolbarHeight - toolbarStyle.marginTop - toolbarStyle.marginBottom;
 		}
 
 		bottomRowHeight -= searchBarHeight;
@@ -2137,7 +2150,7 @@ class NoteTextComponent extends React.Component {
 				VimApi.CodeMirror.Vim.defineEx('write', 'w', save);
 			}
 		};
-		const onLoad = () => {};
+		const onLoad = () => { };
 		const editor = (
 			<AceEditor
 				value={body}
@@ -2166,7 +2179,8 @@ class NoteTextComponent extends React.Component {
 				// Enable/Disable the autoclosing braces
 				setOptions={{
 					behavioursEnabled: Setting.value('editor.autoMatchingBraces'),
-					useSoftTabs: false }}
+					useSoftTabs: false
+				}}
 				// Disable warning: "Automatically scrolling cursor into view after
 				// selection change this will be disabled in the next version set
 				// editor.$blockScrolling = Infinity to disable this message"

--- a/ElectronClient/gui/dialogs.js
+++ b/ElectronClient/gui/dialogs.js
@@ -1,4 +1,5 @@
 const smalltalk = require('smalltalk');
+const Swal = require('sweetalert2');
 
 class Dialogs {
 	async alert(message, title = '') {
@@ -13,6 +14,30 @@ class Dialogs {
 			return false;
 		}
 	}
+	async promptUrl(message) {
+		try {
+			let formValues = { title: '', url: '', dismiss: '' };
+			formValues = await Swal.fire({
+				title: `${message}`,
+				html:
+					'<input id="URL" class="swal2-input" placeholder="Enter the URl">' +
+					'<input id="Title" class="swal2-input" placeholder="Title">',
+				focusConfirm: false,
+				showCancelButton: true,
+
+				preConfirm: () => {
+					return ({
+						url: document.getElementById('URL').value,
+						title: document.getElementById('Title').value,
+					});
+				},
+			});
+
+			return (formValues);
+		} catch (error) { return null; }
+	}
+
+
 
 	async prompt(message, title = '', defaultValue = '', options = null) {
 		if (options === null) options = {};

--- a/ElectronClient/package-lock.json
+++ b/ElectronClient/package-lock.json
@@ -10560,6 +10560,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "sweetalert2": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-9.8.2.tgz",
+      "integrity": "sha512-Lr7DbVi/uNwQ9LOJXt9N5JZkJT0Tga9bCGfPbtnm9Gwfhs/Wthp8vSrtE+x9kjMSpvlkvoPO7TDFxoP0jFnDow=="
+    },
     "symbol-observable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",

--- a/ElectronClient/package.json
+++ b/ElectronClient/package.json
@@ -160,6 +160,7 @@
     "sqlite3": "^4.1.1",
     "string-padding": "^1.0.2",
     "string-to-stream": "^1.1.1",
+    "sweetalert2": "^9.8.2",
     "syswide-cas": "^5.1.0",
     "tar": "^4.4.4",
     "tcp-port-used": "^0.1.2",


### PR DESCRIPTION
fixes #1731 

The previous dependency we were using, namely Smalltalk had this bottleneck for only one one user input prompt, so I tried to use a different dependency on the suggestion of @laurent22  

Anyway tell me if this is useful and if we can also add auto extraction of tittle (by using regexp on the URL)


@PackElend @tessus @laurent22  @Perkolator any inputs

# Before

![Adding tiitle](https://user-images.githubusercontent.com/54576074/75556541-725abc80-5a64-11ea-8e0e-d22433d5ee3c.gif)


# After

![Adding tiitle-solve](https://user-images.githubusercontent.com/54576074/75556556-771f7080-5a64-11ea-86e6-215069f9a620.gif)
