### PR TITLE
Desktop: Fix undefined showButtonLabels

### DIFF
--- a/ElectronClient/gui/Header.jsx
+++ b/ElectronClient/gui/Header.jsx
@@ -83,14 +83,13 @@ class HeaderComponent extends React.Component {
 		}
 
 		if (this.props.zoomFactor !== prevProps.zoomFactor || this.props.size !== prevProps.size) {
-			const mediaQuery = window.matchMedia(`(max-width: ${550 * this.props.zoomFactor}px)`);
-			const showButtonLabels = !mediaQuery.matches;
+			this.determineButtonLabelState();
+		}
+	}
 
-			if (this.state.showButtonLabels !== showButtonLabels) {
-				this.setState({
-					showButtonLabels: !mediaQuery.matches,
-				});
-			}
+	componentDidMount() {
+		if (this.state.showButtonLabels == undefined) {
+			this.determineButtonLabelState();
 		}
 	}
 
@@ -98,6 +97,17 @@ class HeaderComponent extends React.Component {
 		if (this.hideSearchUsageLinkIID_) {
 			clearTimeout(this.hideSearchUsageLinkIID_);
 			this.hideSearchUsageLinkIID_ = null;
+		}
+	}
+
+	determineButtonLabelState() {
+		const mediaQuery = window.matchMedia(`(max-width: ${550 * this.props.zoomFactor}px)`);
+		const showButtonLabels = !mediaQuery.matches;
+
+		if (this.state.showButtonLabels !== showButtonLabels) {
+			this.setState({
+				showButtonLabels: !mediaQuery.matches,
+			});
 		}
 	}
 

--- a/ElectronClient/gui/Header.jsx
+++ b/ElectronClient/gui/Header.jsx
@@ -10,6 +10,7 @@ class HeaderComponent extends React.Component {
 		this.state = {
 			searchQuery: '',
 			showSearchUsageLink: false,
+			showButtonLabels: true,
 		};
 
 		this.scheduleSearchChangeEventIid_ = null;
@@ -88,9 +89,7 @@ class HeaderComponent extends React.Component {
 	}
 
 	componentDidMount() {
-		if (this.state.showButtonLabels == undefined) {
-			this.determineButtonLabelState();
-		}
+		this.determineButtonLabelState();
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
Fixes #2615 

The state variable `showButtonLabels` is assigned in the function `componentDidUpdate()` which is called initially, and whenever resizing the window, etc.. But it isn't called called before rendering the component when pressing Back button from Options, which led to the variable being undefined. I think the reason is since there are no changes to the component, there isn't any reason to call the component. (If you resize the window, it gets called and button labels come back) Hence only `render()` is called.

A solution would be using `componentDidMount()` to determine if the state variable is undefined, and then assign the value. It's only called one (after the initial rendering) so there isn't a performance issue.

An alternative way is remembering the state, which is overkill IMO.