### PR TITLE
Desktop: Expand Tree on Search Result

### DIFF
--- a/CliClient/tests/models_Folder.js
+++ b/CliClient/tests/models_Folder.js
@@ -177,4 +177,19 @@ describe('models_Folder', function() {
 		expect(foldersById[f4.id].note_count).toBe(0);
 	}));
 
+	it('should recursively find folder path', asyncTest(async () => {
+
+		let f1 = await Folder.save({ title: 'folder1' });
+		let f2 = await Folder.save({ title: 'folder2', parent_id: f1.id });
+		let f3 = await Folder.save({ title: 'folder3', parent_id: f2.id });
+
+		const folders = await Folder.all();
+		const folderPath = await Folder.folderPath(folders, f3.id);
+
+		expect(folderPath.length).toBe(3);
+		expect(folderPath[0].id).toBe(f1.id);
+		expect(folderPath[1].id).toBe(f2.id);
+		expect(folderPath[2].id).toBe(f3.id);
+	}));
+
 });

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1624,6 +1624,7 @@ class NoteTextComponent extends React.Component {
 						folderId: this.state.folder.id,
 						noteId: note.id,
 					});
+					Folder.expandTree(this.props.folders, this.state.folder.parent_id);
 				},
 			});
 		}

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -218,6 +218,17 @@ class Folder extends BaseItem {
 		return output;
 	}
 
+	static async expandTree(folders, parentId) {
+		const folderPath = await this.folderPath(folders, parentId);
+		for (const folder of folderPath) {
+			this.dispatch({
+				type: 'FOLDER_SET_COLLAPSED',
+				id: folder.id,
+				collapsed: false,
+			});
+		}
+	}
+
 	static async allAsTree(folders = null, options = null) {
 		const all = folders ? folders : await this.all(options);
 


### PR DESCRIPTION
Fixes #2616 

Earlier, if the result of a search is a note inside a sub-notebook whose tree has been collapsed, the tree wouldn't expand when the In: Folder button was clicked. 

### Before

![Before.gif](https://s5.gifyu.com/images/beforec9b97afed29bbb4d.gif)

### After

![After.gif](https://s5.gifyu.com/images/after071c958b6075f07d.gif)