### PR TITLE
Desktop: Empty note body should have 0 line count

### DIFF
--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -33,7 +33,7 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 			setCharacters(counter.all);
 			setCharactersNoSpace(counter.characters);
 		});
-		setLines(props.text.split('\n').length);
+		props.text === '' ? setLines(0) : setLines(props.text.split('\n').length);
 	}, [props.text]);
 
 	const textProperties: TextPropertiesMap = {


### PR DESCRIPTION
Per @laurent22 comment [here](https://github.com/laurent22/joplin/pull/2444#issuecomment-593090403), if note body is empty the line count should display 0. The rest of the cases should remain unchanged.

![image](https://user-images.githubusercontent.com/3140223/75628531-9ff85080-5b9f-11ea-81d4-a23523cf4ccb.png)

![image](https://user-images.githubusercontent.com/3140223/75628562-e3eb5580-5b9f-11ea-8a47-d9158558d5b6.png)

![image](https://user-images.githubusercontent.com/3140223/75628532-abe41280-5b9f-11ea-85a0-2aa136b2ff9e.png)
