### PR TITLE
DESKTOP:Code was not distinguishable from text

### DIFF
--- a/ElectronClient/theme.js
+++ b/ElectronClient/theme.js
@@ -217,7 +217,7 @@ const solarizedDarkStyle = {
 	htmlLinkColor: '#268bd2',
 	htmlTableBackgroundColor: '#002b36',
 	htmlCodeBackgroundColor: '#002b36',
-	htmlCodeBorderColor: 'dimgrey',
+	htmlCodeBorderColor: '#696969',
 	htmlCodeColor: '#fdf6e3',
 
 	editorTheme: 'solarized_dark',

--- a/ElectronClient/theme.js
+++ b/ElectronClient/theme.js
@@ -217,7 +217,7 @@ const solarizedDarkStyle = {
 	htmlLinkColor: '#268bd2',
 	htmlTableBackgroundColor: '#002b36',
 	htmlCodeBackgroundColor: '#002b36',
-	htmlCodeBorderColor: '#073642',
+	htmlCodeBorderColor: 'dimgrey',
 	htmlCodeColor: '#fdf6e3',
 
 	editorTheme: 'solarized_dark',


### PR DESCRIPTION

Earlier in solarized Dark theme, code border colour was as such that code was not distinguishable prominently from normal text.

### Before
![jop1](https://user-images.githubusercontent.com/42652941/75629969-cef8db80-5c0c-11ea-9f1a-ddda07db9fe8.png)

### After
![jop2](https://user-images.githubusercontent.com/42652941/75629986-ec2daa00-5c0c-11ea-8038-186f807aaff1.png)



