### PR TITLE
Desktop: Disable Toggle Editor Layout Shortcut and Button in Empty Notebook

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -960,6 +960,7 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
+					id: 'toggleLayout',
 					label: _('Toggle editor layout'),
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+L',
@@ -1180,8 +1181,8 @@ class Application extends BaseApplication {
 			if (!menuItem) continue;
 			menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
 		}
-		
-		const toggleLayout = Menu.getApplicationMenu().getMenuItemById('view:toggle');
+
+		const toggleLayout = Menu.getApplicationMenu().getMenuItemById('view:toggleLayout');
 		toggleLayout.enabled = note !== null ? true : false;
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 		menuItem.checked = state.devToolsVisible;

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1180,7 +1180,9 @@ class Application extends BaseApplication {
 			if (!menuItem) continue;
 			menuItem.enabled = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
 		}
-
+		
+		const toggleLayout = Menu.getApplicationMenu().getMenuItemById('view:toggle');
+		toggleLayout.enabled = note !== null ? true : false;
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 		menuItem.checked = state.devToolsVisible;
 	}

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -960,7 +960,7 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
-					id: 'toggleLayout',
+					id: 'view:toggleLayout',
 					label: _('Toggle editor layout'),
 					screens: ['Main'],
 					accelerator: 'CommandOrControl+L',
@@ -1183,7 +1183,7 @@ class Application extends BaseApplication {
 		}
 
 		const toggleLayout = Menu.getApplicationMenu().getMenuItemById('view:toggleLayout');
-		toggleLayout.enabled = note !== null ? true : false;
+		toggleLayout.enabled = !!note;
 		const menuItem = Menu.getApplicationMenu().getMenuItemById('help:toggleDevTools');
 		menuItem.checked = state.devToolsVisible;
 	}


### PR DESCRIPTION
fixes #2608 

 This PR causes the toggle editor layout shortcut and button (ctrl+l/cmd+l) to be disabled in an empty notebook (notebook without notes) just like the toggle editor layout icon. I still don't know if its done by design, but it doesn't seem right, so figured out i just solve it

**BEFORE**
![joplin-toggle-error](https://user-images.githubusercontent.com/35904727/75633385-99e88b00-5c04-11ea-9fed-83c8eac53b6f.gif)

**AFTER**
![joplin-toggle-fix](https://user-images.githubusercontent.com/35904727/75633439-11b6b580-5c05-11ea-9ce1-047d9ec48e64.gif)

