### PR TITLE
Desktop: add + to access 'Zoom In', allows to use the numpad

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1021,6 +1021,11 @@ class Application extends BaseApplication {
 					},
 					accelerator: 'CommandOrControl+0',
 				}, {
+					// There are 2 shortcuts for the action 'zoom in', mainly to increase the user experience.
+					// Most applications handle this the same way. These applications indicate Ctrl +, but actually mean Ctrl =.
+					// Actually they allow both: + and =. On the English keyboard layout - and = are used without the shift key.
+					// So to use Ctrl + would mean to use the shift key, but this is not the case in any of the apps that show Ctrl +.
+					// Additionally it allows the use of the plus key on the numpad.
 					label: _('Zoom In'),
 					click: () => {
 						Setting.incValue('windowContentZoomFactor', 10);

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1025,6 +1025,13 @@ class Application extends BaseApplication {
 					click: () => {
 						Setting.incValue('windowContentZoomFactor', 10);
 					},
+					accelerator: 'CommandOrControl+Plus',
+				}, {
+					label: _('Zoom In'),
+					visible: false,
+					click: () => {
+						Setting.incValue('windowContentZoomFactor', 10);
+					},
 					accelerator: 'CommandOrControl+=',
 				}, {
 					label: _('Zoom Out'),

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1023,7 +1023,7 @@ class Application extends BaseApplication {
 				}, {
 					// There are 2 shortcuts for the action 'zoom in', mainly to increase the user experience.
 					// Most applications handle this the same way. These applications indicate Ctrl +, but actually mean Ctrl =.
-					// Actually they allow both: + and =. On the English keyboard layout - and = are used without the shift key.
+					// In fact they allow both: + and =. On the English keyboard layout - and = are used without the shift key.
 					// So to use Ctrl + would mean to use the shift key, but this is not the case in any of the apps that show Ctrl +.
 					// Additionally it allows the use of the plus key on the numpad.
 					label: _('Zoom In'),


### PR DESCRIPTION
This change aligns Joplin's behavior with all other apps that have shortcuts for `Zoom In`.
It therefore improves the user experience.

/ref

- https://discourse.joplinapp.org/t/please-help-test-the-new-desktop-pre-release/6445/2?u=tessus
- https://github.com/laurent22/joplin/pull/2165#issuecomment-593106648
