### PR TITLE
Desktop: Fix notelist navigation when multiple notes are selected.

### DIFF
--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -330,7 +330,7 @@ class NoteListComponent extends React.Component {
 		const keyCode = event.keyCode;
 		const noteIds = this.props.selectedNoteIds;
 
-		if (noteIds.length === 1 && (keyCode === 40 || keyCode === 38 || keyCode === 33 || keyCode === 34 || keyCode === 35 || keyCode == 36)) {
+		if (noteIds.length > 0 && (keyCode === 40 || keyCode === 38 || keyCode === 33 || keyCode === 34 || keyCode === 35 || keyCode == 36)) {
 			// DOWN / UP / PAGEDOWN / PAGEUP / END / HOME
 			const noteId = noteIds[0];
 			let noteIndex = BaseModel.modelIndexById(this.props.notes, noteId);


### PR DESCRIPTION
Fixes issue discussed in [forum](https://discourse.joplinapp.org/t/please-help-test-the-new-desktop-pre-release/6445/6?u=mic704b)

When multiple notes are selected, the navigation keys stop working when the selected notes are scrolled off-screen.

The fix is to change the behaviour to do the same as the single note behaviour.  It updates the note selection so the selected note is always one that is onscreen.  For example,  `Page Down` will unselect the currently selected note/s, and select another note one page below.
