### PR TITLE
DESKTOP:Improved readability of searched word in NoteSearchBar

### DIFF
--- a/ElectronClient/gui/NoteSearchBar.jsx
+++ b/ElectronClient/gui/NoteSearchBar.jsx
@@ -146,7 +146,7 @@ class NoteSearchBarComponent extends React.Component {
 			<div style={textStyle}>
 				{`${this.props.selectedIndex + 1} / ${this.props.resultCount}`}
 			</div>
-		) : null;
+		) : (query.length === 0 ? null : 'No matches found');
 
 		return (
 			<div style={this.props.style}>

--- a/ElectronClient/gui/NoteSearchBar.jsx
+++ b/ElectronClient/gui/NoteSearchBar.jsx
@@ -146,7 +146,7 @@ class NoteSearchBarComponent extends React.Component {
 			<div style={textStyle}>
 				{`${this.props.selectedIndex + 1} / ${this.props.resultCount}`}
 			</div>
-		) : (query.length === 0 ? null : 'No matches found');
+		) : (query.length === 0 ? null : 'Phrase not found');
 
 		return (
 			<div style={this.props.style}>


### PR DESCRIPTION

Earlier while searching for a phrase in Note searchbar if no matched phrases were found then only background colour of search bar was changing without giving the information  <b>: Phrase not found</b>

### Before:
![jop3](https://user-images.githubusercontent.com/42652941/75657033-54bb6c00-5c8b-11ea-8899-437e79e5fc3f.png)

### After:
![jop4](https://user-images.githubusercontent.com/42652941/75657501-5f2a3580-5c8c-11ea-89e8-547327007a3c.png)


