### PR TITLE
Desktop: Fix `All notes` note list update bugs.

### DIFF
--- a/CliClient/tests/integration_ShowAllNotes.js
+++ b/CliClient/tests/integration_ShowAllNotes.js
@@ -90,4 +90,81 @@ describe('integration_ShowAllNotes', function() {
 		expect(sortedIds(state.notes)).toEqual(sortedIds(notes0.concat(notes1)));
 		expect(state.selectedNoteIds).toEqual(ids([notes1[1]]));
 	}));
+
+	it('should support note duplication', asyncTest(async () => {
+		// setup
+		let folder1 = await Folder.save({ title: 'folder1' });
+		let folder2 = await Folder.save({ title: 'folder2' });
+		let note1 = await Note.save({ title: 'note1', parent_id: folder1.id });
+		let note2 = await Note.save({ title: 'note2', parent_id: folder2.id });
+		testApp.dispatch({ type: 'FOLDER_SELECT', id: folder1.id }); // active folder
+		await time.msleep(100);
+		testApp.dispatch({ type: 'NOTE_SELECT',	id: note1.id });
+		await time.msleep(100);
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_NOTES_FILTER_ID });
+		await time.msleep(100);
+
+		// check the state is set up as expected
+		let state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(sortedIds(state.notes)).toEqual(sortedIds([note1, note2]));
+
+		// TEST ACTION: duplicate a note from the active folder
+		const newNote1 = await Note.duplicate(note1.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(3);
+		expect(sortedIds(state.notes)).toEqual(sortedIds([note1, note2, newNote1]));
+
+		// TEST ACTION: duplicate a note from a non-active folder
+		const newNote2 = await Note.duplicate(note2.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(4);
+		expect(sortedIds(state.notes)).toEqual(sortedIds([note1, note2, newNote1, newNote2]));
+	}));
+
+	it('should support changing the note parent', asyncTest(async () => {
+		// setup
+		let folder1 = await Folder.save({ title: 'folder1' });
+		let folder2 = await Folder.save({ title: 'folder2' });
+		let note1 = await Note.save({ title: 'note1', parent_id: folder1.id });
+		let note2 = await Note.save({ title: 'note1', parent_id: folder2.id });
+		testApp.dispatch({ type: 'FOLDER_SELECT', id: folder1.id }); // active folder
+		await time.msleep(100);
+		testApp.dispatch({ type: 'NOTE_SELECT',	id: note1.id });
+		await time.msleep(100);
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_NOTES_FILTER_ID });
+		await time.msleep(100);
+
+		// check the state is set up as expected
+		let state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(sortedIds(state.notes)).toEqual(sortedIds([note1, note2]));
+		expect(note1.parent_id).toEqual(folder1.id);
+
+		// TEST ACTION: change the notes parent
+		await Note.moveToFolder(note1.id, folder2.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(2);
+		let n1 = await Note.load(note1.id);
+		expect(n1.parent_id).toEqual(folder2.id);
+
+		// TEST ACTION: change the notes parent
+		await Note.moveToFolder(note1.id, folder1.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(2);
+		n1 = await Note.load(note1.id);
+		expect(n1.parent_id).toEqual(folder1.id);
+	}));
 });

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -1,6 +1,7 @@
 const Note = require('lib/models/Note.js');
 const Folder = require('lib/models/Folder.js');
 const ArrayUtils = require('lib/ArrayUtils.js');
+const { ALL_NOTES_FILTER_ID } = require('lib/reserved-ids');
 
 const defaultState = {
 	notes: [],
@@ -451,6 +452,7 @@ const reducer = (state = defaultState, action) => {
 		case 'NOTE_UPDATE_ONE':
 			{
 				const modNote = action.note;
+				const isViewingAllNotes = (state.notesParentType === 'SmartFilter' && state.selectedSmartFilterId === ALL_NOTES_FILTER_ID);
 
 				const noteIsInFolder = function(note, folderId) {
 					if (note.is_conflict) return folderId === Folder.conflictFolderId();
@@ -466,7 +468,7 @@ const reducer = (state = defaultState, action) => {
 					let n = newNotes[i];
 					if (n.id == modNote.id) {
 						// Note is still in the same folder
-						if (noteIsInFolder(modNote, n.parent_id)) {
+						if (isViewingAllNotes || noteIsInFolder(modNote, n.parent_id)) {
 							// Merge the properties that have changed (in modNote) into
 							// the object we already have.
 							newNotes[i] = Object.assign({}, newNotes[i]);
@@ -489,7 +491,7 @@ const reducer = (state = defaultState, action) => {
 				// Note was not found - if the current folder is the same as the note folder,
 				// add it to it.
 				if (!found) {
-					if (noteIsInFolder(modNote, state.selectedFolderId)) {
+					if (isViewingAllNotes || noteIsInFolder(modNote, state.selectedFolderId)) {
 						newNotes.push(modNote);
 					}
 				}


### PR DESCRIPTION
This PR fixes a couple of small update bugs in the All Notes list.  Tests added.

## Note list not updated when note is duplicated in `All notes`
To reproduce:
1. Create two folders (`A` and `B`) with a note `N` in folder `A`
2. Selected folder `B` in sidebar
3. Select `All notes` in sidebar
4. Duplicate note `N`

Expected: the new duplicate note appears in the `All notes` note list
Actual: nothing. The note is duplicated but does not appear.

## Note disappears from note list when dragged from `All notes` to a new parent
To reproduce:
1. Create two folders (`A` and `B`) with a note `N` in folder `A`
2. Select `All notes` in Sidebar
3. Drag note `N` to folder `B` in sidebar

Expected: the note remains visible in the `All notes` note list
Actual: the note disappears from the note list.
