### PR TITLE
Desktop: Fix broken fileURL with special characters in path or filename in Windows

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -876,8 +876,11 @@ class NoteTextComponent extends React.Component {
 			}
 		} else if (urlUtils.urlProtocol(msg)) {
 			if (msg.indexOf('file://') === 0) {
-				// When using the file:// protocol, openExternal doesn't work (does nothing) with URL-encoded paths
-				require('electron').shell.openExternal(urlDecode(msg));
+				if (shim.platformName()  === 'win32') {
+					require('electron').shell.openItem(urlDecode(msg).replace(/file:\/{2,3}/, '')); // file://C:/... and file:///C:/... both valid fileURLs for windows
+				} else {
+					require('electron').shell.openItem(urlDecode(msg).replace(/file:\/{2}/, ''));
+				}
 			} else {
 				require('electron').shell.openExternal(msg);
 			}


### PR DESCRIPTION
Since some time fileURL-links with a path containing special characters (like german Umlauts) don't work anymore in Windows (still works well in Linux and MacOS though). The code I commited a while ago seems to be untouched [REF](https://github.com/laurent22/joplin/commit/f7fcabbf417f21001e27f0829d57bead4db3b485), I do not have the slightest idea why this is happening.

The first version failing to support these kind of links is v1.0.177 released on 30 Dec 2019. I scanned the commits but found nothing that could be related to this issue. Maybe this is related to the Upgrade to Electron 7 (from 4), as the files are opened with `shell.openExternal`

A work around is to use `shell.openItem`instead. As we are aiming to open a local file `shell.openItem` seems to be more appropriate too.

https://www.electronjs.org/docs/api/shell

Tested on Windows and Linux.