### PR TITLE
API: Fix tags update on updating a note

### DIFF
--- a/CliClient/app/command-apidoc.js
+++ b/CliClient/app/command-apidoc.js
@@ -179,11 +179,11 @@ class Command extends BaseCommand {
 					type: Database.enumId('fieldType', 'text'),
 					description: 'If an image is provided, you can also specify an optional rectangle that will be used to crop the image. In format `{ x: x, y: y, width: width, height: height }`',
 				});
-				// tableFields.push({
-				// 	name: 'tags',
-				// 	type: Database.enumId('fieldType', 'text'),
-				// 	description: 'Comma-separated list of tags. eg. `tag1,tag2`.',
-				// });
+				tableFields.push({
+					name: 'tags',
+					type: Database.enumId('fieldType', 'text'),
+					description: 'Comma-separated list of tags. eg. `tag1,tag2`.',
+				});
 			}
 
 			lines.push(`# ${toTitleCase(tableName)}`);

--- a/CliClient/tests/services_rest_Api.js
+++ b/CliClient/tests/services_rest_Api.js
@@ -326,4 +326,28 @@ describe('services_rest_Api', function() {
 		expect(response3.length).toBe(2);
 	}));
 
+	it('should update tags when updating notes', asyncTest(async () => {
+		const tag1 = await Tag.save({ title: 'mon étiquette 1' });
+		const tag2 = await Tag.save({ title: 'mon étiquette 2' });
+		const tag3 = await Tag.save({ title: 'mon étiquette 3' });
+		const note = await Note.save({
+			title: 'ma note un',
+			tags: `${tag1.title},${tag2.title}`,
+		});
+
+		const response1 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			tags: `${tag1.title},${tag3.title}`,
+		}));
+		expect(response1.tags === `${tag1.title},${tag3.title}`).toBe(true);
+
+		const response2 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			tags: `${tag1.title}`,
+		}));
+		expect(response2.tags === `${tag1.title}`).toBe(true);
+
+		const response3 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			tags: `${tag1.title},${tag2.title},${tag3.title}`,
+		}));
+		expect(response3.tags === `${tag1.title},${tag2.title},${tag3.title}`).toBe(true);
+	}));
 });

--- a/CliClient/tests/services_rest_Api.js
+++ b/CliClient/tests/services_rest_Api.js
@@ -331,7 +331,6 @@ describe('services_rest_Api', function() {
 		const tag1 = await Tag.save({ title: 'mon étiquette 1' });
 		const tag2 = await Tag.save({ title: 'mon étiquette 2' });
 		const tag3 = await Tag.save({ title: 'mon étiquette 3' });
-		const newTagTitle = 'mon étiquette 4';
 
 		const note = await Note.save({
 			title: 'ma note un',
@@ -339,38 +338,73 @@ describe('services_rest_Api', function() {
 		Tag.addNote(tag1.id, note.id);
 		Tag.addNote(tag2.id, note.id);
 
-		const response1 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+		const response = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
 			tags: `${tag1.title},${tag3.title}`,
 		}));
-		const tagIds1 = await NoteTag.tagIdsByNoteId(note.id);
-		expect(response1.tags === `${tag1.title},${tag3.title}`).toBe(true);
-		expect(tagIds1.length === 2).toBe(true);
-		expect(tagIds1.includes(tag1.id)).toBe(true);
-		expect(tagIds1.includes(tag3.id)).toBe(true);
+		const tagIds = await NoteTag.tagIdsByNoteId(note.id);
+		expect(response.tags === `${tag1.title},${tag3.title}`).toBe(true);
+		expect(tagIds.length === 2).toBe(true);
+		expect(tagIds.includes(tag1.id)).toBe(true);
+		expect(tagIds.includes(tag3.id)).toBe(true);
+	}));
 
-		const response2 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
-			tags: `${tag2.title},${newTagTitle}`,
+	it('should create and update tags when updating notes', asyncTest(async () => {
+		const tag1 = await Tag.save({ title: 'mon étiquette 1' });
+		const tag2 = await Tag.save({ title: 'mon étiquette 2' });
+		const newTagTitle = 'mon étiquette 3';
+
+		const note = await Note.save({
+			title: 'ma note un',
+		});
+		Tag.addNote(tag1.id, note.id);
+		Tag.addNote(tag2.id, note.id);
+
+		const response = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			tags: `${tag1.title},${newTagTitle}`,
 		}));
 		const newTag = await Tag.loadByTitle(newTagTitle);
-		const tagIds2 = await NoteTag.tagIdsByNoteId(note.id);
-		expect(response2.tags === `${tag2.title},${newTag.title}`).toBe(true);
-		expect(tagIds2.length === 2).toBe(true);
-		expect(tagIds2.includes(tag2.id)).toBe(true);
-		expect(tagIds2.includes(newTag.id)).toBe(true);
+		const tagIds = await NoteTag.tagIdsByNoteId(note.id);
+		expect(response.tags === `${tag1.title},${newTag.title}`).toBe(true);
+		expect(tagIds.length === 2).toBe(true);
+		expect(tagIds.includes(tag1.id)).toBe(true);
+		expect(tagIds.includes(newTag.id)).toBe(true);
+	}));
 
-		const response3 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+	it('should not update tags if tags is not mentioned when updating', asyncTest(async () => {
+		const tag1 = await Tag.save({ title: 'mon étiquette 1' });
+		const tag2 = await Tag.save({ title: 'mon étiquette 2' });
+
+		const note = await Note.save({
+			title: 'ma note un',
+		});
+		Tag.addNote(tag1.id, note.id);
+		Tag.addNote(tag2.id, note.id);
+
+		const response = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
 			title: 'Some other title',
 		}));
-		const tagIds3 = await NoteTag.tagIdsByNoteId(note.id);
-		expect(tagIds3.length === 2).toBe(true);
-		expect(tagIds3.includes(tag2.id)).toBe(true);
-		expect(tagIds3.includes(newTag.id)).toBe(true);
+		const tagIds = await NoteTag.tagIdsByNoteId(note.id);
+		expect(response.tags === undefined).toBe(true);
+		expect(tagIds.length === 2).toBe(true);
+		expect(tagIds.includes(tag1.id)).toBe(true);
+		expect(tagIds.includes(tag2.id)).toBe(true);
+	}));
 
-		const response4 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+	it('should remove tags from note if tags is set to empty string when updating', asyncTest(async () => {
+		const tag1 = await Tag.save({ title: 'mon étiquette 1' });
+		const tag2 = await Tag.save({ title: 'mon étiquette 2' });
+
+		const note = await Note.save({
+			title: 'ma note un',
+		});
+		Tag.addNote(tag1.id, note.id);
+		Tag.addNote(tag2.id, note.id);
+
+		const response = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
 			tags: '',
 		}));
-		const tagIds4 = await NoteTag.tagIdsByNoteId(note.id);
-		expect(response4.tags === '').toBe(true);
-		expect(tagIds4.length === 0).toBe(true);
+		const tagIds = await NoteTag.tagIdsByNoteId(note.id);
+		expect(response.tags === '').toBe(true);
+		expect(tagIds.length === 0).toBe(true);
 	}));
 });

--- a/CliClient/tests/services_rest_Api.js
+++ b/CliClient/tests/services_rest_Api.js
@@ -344,6 +344,7 @@ describe('services_rest_Api', function() {
 		}));
 		const tagIds1 = await NoteTag.tagIdsByNoteId(note.id);
 		expect(response1.tags === `${tag1.title},${tag3.title}`).toBe(true);
+		expect(tagIds1.length === 2).toBe(true);
 		expect(tagIds1.includes(tag1.id)).toBe(true);
 		expect(tagIds1.includes(tag3.id)).toBe(true);
 
@@ -353,7 +354,23 @@ describe('services_rest_Api', function() {
 		const newTag = await Tag.loadByTitle(newTagTitle);
 		const tagIds2 = await NoteTag.tagIdsByNoteId(note.id);
 		expect(response2.tags === `${tag2.title},${newTag.title}`).toBe(true);
+		expect(tagIds2.length === 2).toBe(true);
 		expect(tagIds2.includes(tag2.id)).toBe(true);
 		expect(tagIds2.includes(newTag.id)).toBe(true);
+
+		const response3 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			title: 'Some other title',
+		}));
+		const tagIds3 = await NoteTag.tagIdsByNoteId(note.id);
+		expect(tagIds3.length === 2).toBe(true);
+		expect(tagIds3.includes(tag2.id)).toBe(true);
+		expect(tagIds3.includes(newTag.id)).toBe(true);
+
+		const response4 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
+			tags: '',
+		}));
+		const tagIds4 = await NoteTag.tagIdsByNoteId(note.id);
+		expect(response4.tags === '').toBe(true);
+		expect(tagIds4.length === 0).toBe(true);
 	}));
 });

--- a/CliClient/tests/services_rest_Api.js
+++ b/CliClient/tests/services_rest_Api.js
@@ -344,8 +344,8 @@ describe('services_rest_Api', function() {
 		}));
 		const tagIds1 = await NoteTag.tagIdsByNoteId(note.id);
 		expect(response1.tags === `${tag1.title},${tag3.title}`).toBe(true);
-		expect(tagIds1[0]).toBe(tag1.id);
-		expect(tagIds1[1]).toBe(tag3.id);
+		expect(tagIds1.includes(tag1.id)).toBe(true);
+		expect(tagIds1.includes(tag3.id)).toBe(true);
 
 		const response2 = await api.route('PUT', `notes/${note.id}`, null, JSON.stringify({
 			tags: `${tag2.title},${newTagTitle}`,
@@ -353,7 +353,7 @@ describe('services_rest_Api', function() {
 		const newTag = await Tag.loadByTitle(newTagTitle);
 		const tagIds2 = await NoteTag.tagIdsByNoteId(note.id);
 		expect(response2.tags === `${tag2.title},${newTag.title}`).toBe(true);
-		expect(tagIds2[0]).toBe(tag2.id);
-		expect(tagIds2[1]).toBe(newTag.id);
+		expect(tagIds2.includes(tag2.id)).toBe(true);
+		expect(tagIds2.includes(newTag.id)).toBe(true);
 	}));
 });

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -453,16 +453,15 @@ class Api {
 
 		if (request.method === 'PUT') {
 			const note = await Note.load(id);
-			const requestBody = JSON.parse(request.body);
 
 			if (!note) throw new ErrorNotFound();
 
-			let updatedNote = Object.assign({}, note, request.bodyJson(this.readonlyProperties('PUT')));
-			updatedNote = await Note.save(updatedNote, { userSideValidation: true });
+			let updatedNote = await this.defaultAction_(BaseModel.TYPE_NOTE, request, id, link);
 
-			if (requestBody.tags) {
-				const tagTitles = requestBody.tags.split(',');
-				await Tag.setNoteTagsByTitles(updatedNote.id, tagTitles);
+			const requestNote = JSON.parse(request.body);
+			if (requestNote.tags) {
+				const tagTitles = requestNote.tags.split(',');
+				await Tag.setNoteTagsByTitles(id, tagTitles);
 			}
 
 			return updatedNote;

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -459,9 +459,7 @@ class Api {
 			let updatedNote = await this.defaultAction_(BaseModel.TYPE_NOTE, request, id, link);
 
 			const requestNote = JSON.parse(request.body);
-			if (requestNote.tags === '') {
-				await Tag.setNoteTagsByTitles(id, '');
-			} else if (requestNote.tags) {
+			if (requestNote.tags || requestNote.tags === '') {
 				const tagTitles = requestNote.tags.split(',');
 				await Tag.setNoteTagsByTitles(id, tagTitles);
 			}

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -457,15 +457,15 @@ class Api {
 
 			if (!note) throw new ErrorNotFound();
 
-			let newNote = Object.assign({}, note, request.bodyJson(this.readonlyProperties('PUT')));
-			newNote = await Note.save(newNote, { userSideValidation: true });
+			let updatedNote = Object.assign({}, note, request.bodyJson(this.readonlyProperties('PUT')));
+			updatedNote = await Note.save(updatedNote, { userSideValidation: true });
 
 			if (requestBody.tags) {
 				const tagTitles = requestBody.tags.split(',');
-				await Tag.setNoteTagsByTitles(newNote.id, tagTitles);
+				await Tag.setNoteTagsByTitles(updatedNote.id, tagTitles);
 			}
 
-			return newNote;
+			return updatedNote;
 		}
 
 		return this.defaultAction_(BaseModel.TYPE_NOTE, request, id, link);

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -451,6 +451,23 @@ class Api {
 			return note;
 		}
 
+		if (request.method === 'PUT') {
+			const note = await Note.load(id);
+			const requestBody = JSON.parse(request.body);
+
+			if (!note) throw new ErrorNotFound();
+
+			let newNote = Object.assign({}, note, request.bodyJson(this.readonlyProperties('PUT')));
+			newNote = await Note.save(newNote, { userSideValidation: true });
+
+			if (requestBody.tags) {
+				const tagTitles = requestBody.tags.split(',');
+				await Tag.setNoteTagsByTitles(newNote.id, tagTitles);
+			}
+
+			return newNote;
+		}
+
 		return this.defaultAction_(BaseModel.TYPE_NOTE, request, id, link);
 	}
 

--- a/ReactNativeClient/lib/services/rest/Api.js
+++ b/ReactNativeClient/lib/services/rest/Api.js
@@ -459,7 +459,9 @@ class Api {
 			let updatedNote = await this.defaultAction_(BaseModel.TYPE_NOTE, request, id, link);
 
 			const requestNote = JSON.parse(request.body);
-			if (requestNote.tags) {
+			if (requestNote.tags === '') {
+				await Tag.setNoteTagsByTitles(id, '');
+			} else if (requestNote.tags) {
 				const tagTitles = requestNote.tags.split(',');
 				await Tag.setNoteTagsByTitles(id, tagTitles);
 			}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Fixes #941 

**Before:**
![before-2020-03-04-002019](https://user-images.githubusercontent.com/29891001/75809479-d6f08100-5dae-11ea-9d50-a2f9befbe3b5.gif)

**After:**
![after-2020-03-04-000934](https://user-images.githubusercontent.com/29891001/75808388-04d4c600-5dad-11ea-865e-66af171f76ce.gif)

The issue as mentioned in #941 was that the tags were not updated. This was due to the fact that in `PUT` request method the tags were not explicitly set unlike how the `POST` request method was handled in the `action_notes` function. 

The fix I have given makes the necessary changes. I have also written unit tests for the code. Looking forward to any comments or suggestions!