### PR TITLE
Desktop: add global shortcut to show/hide Joplin

### DIFF
--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -1,4 +1,4 @@
-const { BrowserWindow, Tray, screen } = require('electron');
+const { BrowserWindow, Tray, screen, globalShortcut } = require('electron');
 const { shim } = require('lib/shim');
 const url = require('url');
 const path = require('path');
@@ -243,6 +243,15 @@ class ElectronAppWrapper {
 		return false;
 	}
 
+	toggleWindowVisilibity() {
+		if (this.win_.isVisible()) {
+			this.win_.hide();
+		} else {
+			this.win_.setVisibleOnAllWorkspaces(true);
+			this.win_.show();
+		}
+	}
+
 	async start() {
 		// Since we are doing other async things before creating the window, we might miss
 		// the "ready" event. So we use the function below to make sure that the app is ready.
@@ -253,8 +262,17 @@ class ElectronAppWrapper {
 
 		this.createWindow();
 
+		const registerGlobalShortcut = globalShortcut.register('CommandOrControl+Alt+J', () => {
+			this.toggleWindowVisilibity();
+		});
+
+		if (!registerGlobalShortcut) {
+			console.warn('Could not register global shortcut');
+		}
+
 		this.electronApp_.on('before-quit', () => {
 			this.willQuitApp_ = true;
+			globalShortcut.unregisterAll();
 		});
 
 		this.electronApp_.on('window-all-closed', () => {

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ Notes are sorted by "relevance". Currently it means the notes that contain the r
 
 In the desktop application, press Ctrl+G or Cmd+G and type the title of a note to jump directly to it. You can also type `#` followed by a tag or `@` followed by a notebook title.
 
+# Global shortcut
+
+In the desktop application, press `Cmd+Opt+J` (macOS) or `Ctrl+Alt+J` (Linux, Windows) to show or hide Joplin in the current workspace.
+
 # Privacy
 
 Joplin values your privacy and security by giving you complete control over your information and digital footprint.


### PR DESCRIPTION
Previously it was possible to open Joplin by clicking on the tray icon.
This functionality is no longer available due to changes in Electron.

The following key combination will show or hide Joplin in the current workspace:

- macOS: `Cmd+Opt+J`
- Linux, Windows: `Ctrl+Alt+J`
