### PR TITLE
Enhancement: Build tools detecting script

### DIFF
--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -12,7 +12,7 @@ const verifyBuildToolInstallation = async (tool, checkCommand, installCommand) =
 
 switch (process.platform) {
 case 'win32':
-	verifyBuildToolInstallation('Windows Build Tools', 'npm ls -g windows-build-tools', 'npm install --global windows-build-tools');
+	verifyBuildToolInstallation('Windows Build Tools', 'npm list -g windows-build-tools', 'npm install --global windows-build-tools');
 	break;
 case 'darwin':
 	verifyBuildToolInstallation('CocoaPods', 'pod --version', 'sudo gem install cocoapods');

--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -1,0 +1,44 @@
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+let OSName = '';
+if (process.platform === 'win32')   OSName = 'Windows';
+if (process.platform === 'darwin')  OSName = 'MacOS';
+if (process.platform === 'linux')   OSName = 'Linux';
+
+const verifyBuildToolInstallation = async (tool, checkCommand, installCommand = null) => {
+	try {
+		const { stdout } = await exec(checkCommand);
+		console.log(`${tool} is Installed: ${stdout}`);
+	} catch (error) {
+		installCommand ? installBuildTool(tool, installCommand) : console.warn(`WARNING: Please ensure that ${tool} is installed on your system`);
+	}
+};
+
+const installBuildTool = async (tool, command) =>  {
+	const message = `Installing ${tool}....`;
+	console.log(message);
+	try {
+		const { stdout } = await exec(command);
+		console.log(stdout);
+		console.log(`${tool} Installed Successfully`);
+	} catch (error) {
+		console.log(error);
+		console.log(`Something went wrong, Please ensure that ${tool} is installed in your system before proceeding`);
+	}
+};
+
+switch (OSName) {
+case 'Windows':
+	verifyBuildToolInstallation('Windows Build Tools', 'npm ls -g windows-build-tools', 'npm install --global windows-build-tools');
+	break;
+case 'MacOS':
+	verifyBuildToolInstallation('CocoaPods', 'pod --version', 'sudo gem install cocoapods');
+	verifyBuildToolInstallation('Rsync', 'rsync -version');
+	break;
+case 'Linux':
+	verifyBuildToolInstallation('Rsync', 'rsync -version', 'apt-get install rsync');
+	break;
+default:
+	console.log('WARNING: Please ensure that you read the documentation to know the necessary build tools that must be installed in your system to successfullly build this project');
+}

--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -1,24 +1,12 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-const verifyBuildToolInstallation = async (tool, checkCommand, installCommand = null) => {
+const verifyBuildToolInstallation = async (tool, checkCommand, installCommand) => {
 	try {
 		const { stdout } = await exec(checkCommand);
 		console.log(`${tool} is Installed: ${stdout}`);
 	} catch (error) {
-		installCommand ? installBuildTool(tool, installCommand) : console.warn(`WARNING: Please ensure that ${tool} is installed on your system`);
-	}
-};
-
-const installBuildTool = async (tool, command) => {
-	const message = `Installing ${tool}....`;
-	console.log(message);
-	try {
-		const { stdout } = await exec(command);
-		console.log(stdout);
-		console.log(`${tool} Installed Successfully`);
-	} catch (error) {
-		console.log(`Something went wrong, Please ensure that ${tool} is installed in your system before proceeding`);
+		console.warn(`WARNING: This development tool is not installed: "${tool}". Please install it using your package manager. For example: ${installCommand}`);
 	}
 };
 
@@ -28,11 +16,12 @@ case 'win32':
 	break;
 case 'darwin':
 	verifyBuildToolInstallation('CocoaPods', 'pod --version', 'sudo gem install cocoapods');
-	verifyBuildToolInstallation('Rsync', 'rsync -version');
+	verifyBuildToolInstallation('rsync', 'rsync -version','apt-get install rsync');
 	break;
 case 'linux':
-	verifyBuildToolInstallation('Rsync', 'rsync -version', 'apt-get install rsync');
+	verifyBuildToolInstallation('rsync', 'rsync -version', 'apt-get install rsync');
 	break;
 default:
 	console.log('WARNING: Please ensure that you read the documentation to know the necessary build tools that must be installed in your system to successfullly build this project');
 }
+

--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -1,11 +1,6 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 
-let OSName = '';
-if (process.platform === 'win32')   OSName = 'Windows';
-if (process.platform === 'darwin')  OSName = 'MacOS';
-if (process.platform === 'linux')   OSName = 'Linux';
-
 const verifyBuildToolInstallation = async (tool, checkCommand, installCommand = null) => {
 	try {
 		const { stdout } = await exec(checkCommand);
@@ -15,7 +10,7 @@ const verifyBuildToolInstallation = async (tool, checkCommand, installCommand = 
 	}
 };
 
-const installBuildTool = async (tool, command) =>  {
+const installBuildTool = async (tool, command) => {
 	const message = `Installing ${tool}....`;
 	console.log(message);
 	try {
@@ -23,20 +18,20 @@ const installBuildTool = async (tool, command) =>  {
 		console.log(stdout);
 		console.log(`${tool} Installed Successfully`);
 	} catch (error) {
-		console.log(error);
+		console.error(error);
 		console.log(`Something went wrong, Please ensure that ${tool} is installed in your system before proceeding`);
 	}
 };
 
-switch (OSName) {
-case 'Windows':
+switch (process.platform) {
+case 'win32':
 	verifyBuildToolInstallation('Windows Build Tools', 'npm ls -g windows-build-tools', 'npm install --global windows-build-tools');
 	break;
-case 'MacOS':
+case 'darwin':
 	verifyBuildToolInstallation('CocoaPods', 'pod --version', 'sudo gem install cocoapods');
 	verifyBuildToolInstallation('Rsync', 'rsync -version');
 	break;
-case 'Linux':
+case 'linux':
 	verifyBuildToolInstallation('Rsync', 'rsync -version', 'apt-get install rsync');
 	break;
 default:

--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -18,7 +18,6 @@ const installBuildTool = async (tool, command) => {
 		console.log(stdout);
 		console.log(`${tool} Installed Successfully`);
 	} catch (error) {
-		console.error(error);
 		console.log(`Something went wrong, Please ensure that ${tool} is installed in your system before proceeding`);
 	}
 };

--- a/build_tools_check.js
+++ b/build_tools_check.js
@@ -16,10 +16,10 @@ case 'win32':
 	break;
 case 'darwin':
 	verifyBuildToolInstallation('CocoaPods', 'pod --version', 'sudo gem install cocoapods');
-	verifyBuildToolInstallation('rsync', 'rsync -version','apt-get install rsync');
+	verifyBuildToolInstallation('rsync', 'rsync --version', 'sudo port install rsync');
 	break;
 case 'linux':
-	verifyBuildToolInstallation('rsync', 'rsync -version', 'apt-get install rsync');
+	verifyBuildToolInstallation('rsync', 'rsync --version', 'sudo apt-get install rsync');
 	break;
 default:
 	console.log('WARNING: Please ensure that you read the documentation to know the necessary build tools that must be installed in your system to successfullly build this project');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Joplin root package for linting",
   "scripts": {
+    "preinstall": "node build_tools_check.js",
     "linter": "./node_modules/.bin/eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx",
     "linter-ci": "./node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx",
     "watch": "gulp watch",


### PR DESCRIPTION
closes #2631 

This script detects the OS of the user and checks to see if the necessary build tools / dependencies needed to successfully build the app are installed. if it is not installed it simply tries to install the tool, if it cannot i install it then it sends a warning message to the console to let the user know that he has to install these tools before proceeding. I learnt quite alot writing this script and i hope it is accepted, i'm very much open to improvements and new ideas if this is not okay.