### PR TITLE
All: Fix format of note timestamps

### DIFF
--- a/CliClient/tests/models_BaseItem.js
+++ b/CliClient/tests/models_BaseItem.js
@@ -57,4 +57,16 @@ describe('models_BaseItem', function() {
 		expect(unserialized2.title).toBe(folder2.title);
 	}));
 
+	it('should correctly unserialize note timestamps', asyncTest(async () => {
+		let folder = await Folder.save({ title: 'folder' });
+		let note = await Note.save({ title: 'note', parent_id: folder.id });
+
+		let serialized = await Note.serialize(note);
+		let unserialized = await Note.unserialize(serialized);
+
+		expect(unserialized.created_time).toEqual(note.created_time);
+		expect(unserialized.updated_time).toEqual(note.updated_time);
+		expect(unserialized.user_created_time).toEqual(note.user_created_time);
+		expect(unserialized.user_updated_time).toEqual(note.user_updated_time);
+	}));
 });

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -254,13 +254,13 @@ class BaseItem extends BaseModel {
 
 		const ItemClass = this.itemClass(type);
 
-		if (['created_time', 'updated_time', 'user_created_time', 'user_updated_time'].indexOf(propName) >= 0) {
-			if (!propValue) return 0;
-			propValue = moment(propValue, 'YYYY-MM-DDTHH:mm:ss.SSSZ').format('x');
-		} else if (['title_diff', 'body_diff'].indexOf(propName) >= 0) {
+		if (['title_diff', 'body_diff'].indexOf(propName) >= 0) {
 			if (!propValue) return '';
 			propValue = JSON.parse(propValue);
 		} else {
+			if (['created_time', 'updated_time', 'user_created_time', 'user_updated_time'].indexOf(propName) >= 0) {
+				propValue = (!propValue) ? '0' : moment(propValue, 'YYYY-MM-DDTHH:mm:ss.SSSZ').format('x');
+			}
 			propValue = Database.formatValue(ItemClass.fieldType(propName), propValue);
 		}
 


### PR DESCRIPTION
During unserialization, note timestamps are returned as strings.  This is inconsistent with their format defined in the database, which says they are meant to be integers.  This PR fixes the inconsistency.
