### PR TITLE
All: Fix format of geolocation data

### DIFF
--- a/CliClient/tests/models_BaseItem.js
+++ b/CliClient/tests/models_BaseItem.js
@@ -59,7 +59,7 @@ describe('models_BaseItem', function() {
 
 	it('should correctly unserialize note timestamps', asyncTest(async () => {
 		const folder = await Folder.save({ title: 'folder' });
-		let note = await Note.save({ title: 'note', parent_id: folder.id });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
 
 		const serialized = await Note.serialize(note);
 		const unserialized = await Note.unserialize(serialized);
@@ -68,7 +68,7 @@ describe('models_BaseItem', function() {
 		expect(unserialized.updated_time).toEqual(note.updated_time);
 		expect(unserialized.user_created_time).toEqual(note.user_created_time);
 		expect(unserialized.user_updated_time).toEqual(note.user_updated_time);
-    }));
+	}));
 
 	it('should serialize geolocation fields', asyncTest(async () => {
 		const folder = await Folder.save({ title: 'folder' });
@@ -91,5 +91,17 @@ describe('models_BaseItem', function() {
 		expect(unserialized.latitude).toEqual(note.latitude);
 		expect(unserialized.longitude).toEqual(note.longitude);
 		expect(unserialized.altitude).toEqual(note.altitude);
+	}));
+
+	it('should serialize and unserialize notes', asyncTest(async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		const note = await Note.save({ title: 'note', parent_id: folder.id });
+		await Note.updateGeolocation(note.id);
+
+		const noteBefore = await Note.load(note.id);
+		const serialized = await Note.serialize(noteBefore);
+		const noteAfter = await Note.unserialize(serialized);
+
+		expect(noteAfter).toEqual(noteBefore);
 	}));
 });

--- a/CliClient/tests/models_BaseItem.js
+++ b/CliClient/tests/models_BaseItem.js
@@ -58,15 +58,38 @@ describe('models_BaseItem', function() {
 	}));
 
 	it('should correctly unserialize note timestamps', asyncTest(async () => {
-		let folder = await Folder.save({ title: 'folder' });
+		const folder = await Folder.save({ title: 'folder' });
 		let note = await Note.save({ title: 'note', parent_id: folder.id });
 
-		let serialized = await Note.serialize(note);
-		let unserialized = await Note.unserialize(serialized);
+		const serialized = await Note.serialize(note);
+		const unserialized = await Note.unserialize(serialized);
 
 		expect(unserialized.created_time).toEqual(note.created_time);
 		expect(unserialized.updated_time).toEqual(note.updated_time);
 		expect(unserialized.user_created_time).toEqual(note.user_created_time);
 		expect(unserialized.user_updated_time).toEqual(note.user_updated_time);
+    }));
+
+	it('should serialize geolocation fields', asyncTest(async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		let note = await Note.save({ title: 'note', parent_id: folder.id });
+		note = await Note.load(note.id);
+
+		let serialized = await Note.serialize(note);
+		let unserialized = await Note.unserialize(serialized);
+
+		expect(unserialized.latitude).toEqual('0.00000000');
+		expect(unserialized.longitude).toEqual('0.00000000');
+		expect(unserialized.altitude).toEqual('0.0000');
+
+		await Note.updateGeolocation(note.id);
+		note = await Note.load(note.id);
+
+		serialized = await Note.serialize(note);
+		unserialized = await Note.unserialize(serialized);
+
+		expect(unserialized.latitude).toEqual(note.latitude);
+		expect(unserialized.longitude).toEqual(note.longitude);
+		expect(unserialized.altitude).toEqual(note.altitude);
 	}));
 });

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -255,14 +255,17 @@ class BaseItem extends BaseModel {
 		const ItemClass = this.itemClass(type);
 
 		if (['title_diff', 'body_diff'].indexOf(propName) >= 0) {
-			if (!propValue) return '';
-			propValue = JSON.parse(propValue);
-		} else {
+ 			if (!propValue) return '';
+ 			propValue = JSON.parse(propValue);
+		} else if (['longitude', 'latitude', 'altitude'].indexOf(propName) >= 0) {
+			const places = (propName === 'altitude') ? 4 : 8;
+			propValue = Number(propValue).toFixed(places);
+ 		} else {
 			if (['created_time', 'updated_time', 'user_created_time', 'user_updated_time'].indexOf(propName) >= 0) {
 				propValue = (!propValue) ? '0' : moment(propValue, 'YYYY-MM-DDTHH:mm:ss.SSSZ').format('x');
 			}
 			propValue = Database.formatValue(ItemClass.fieldType(propName), propValue);
-		}
+ 		}
 
 		return propValue;
 	}

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -255,17 +255,17 @@ class BaseItem extends BaseModel {
 		const ItemClass = this.itemClass(type);
 
 		if (['title_diff', 'body_diff'].indexOf(propName) >= 0) {
- 			if (!propValue) return '';
- 			propValue = JSON.parse(propValue);
+			if (!propValue) return '';
+			propValue = JSON.parse(propValue);
 		} else if (['longitude', 'latitude', 'altitude'].indexOf(propName) >= 0) {
 			const places = (propName === 'altitude') ? 4 : 8;
 			propValue = Number(propValue).toFixed(places);
- 		} else {
+		} else {
 			if (['created_time', 'updated_time', 'user_created_time', 'user_updated_time'].indexOf(propName) >= 0) {
 				propValue = (!propValue) ? '0' : moment(propValue, 'YYYY-MM-DDTHH:mm:ss.SSSZ').format('x');
 			}
 			propValue = Database.formatValue(ItemClass.fieldType(propName), propValue);
- 		}
+		}
 
 		return propValue;
 	}


### PR DESCRIPTION
Geolocation data changes format through serialization between number and string.  It means that the clients on either end of a sync hold the same data but in different formats.  It is expected that it would be identical on both clients.

The database specifies the format of geo data as NUMBER. However the app seems to use it as formatted string.

One solution is to modify the database so the format is specified as STRING. However this would require a database migration upon upgrade, I'm not sure how simple that would be for a base data type.

Alternatively, though not ideal, here we propose to make an exception for geo data in the BaseItem serialization methods so that the database specification is ignored, and the format is maintained as string throughout serialization / unserialization.