### PR TITLE
Desktop: Renaming a Tag adds it to Note regardless if such a Tag exists

### DIFF
--- a/CliClient/tests/reducer.js
+++ b/CliClient/tests/reducer.js
@@ -345,4 +345,16 @@ describe('Reducer', function() {
 		expect(state.selectedNoteIds).toEqual(expected.selectedIds);
 	}));
 
+	it('should rename tag', asyncTest(async () => {
+		let tags = await createNTestTags(3);
+		let state = initTestState(null, null, null, null, tags, [2]);
+
+		tags[2].title = 'algorithms';
+
+		let expected = createExpectedState(tags, [0,1,2], [2]);
+
+		// test action
+		state = reducer(state, { type: 'TAG_UPDATE_ONE', item: tags[2] });
+		expect(state.tags[2]).toEqual(expected.items[2]);
+	}));
 });

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -238,7 +238,7 @@ class MainScreenComponent extends React.Component {
 							if (answer !== null) {
 								try {
 									tag.title = answer;
-									await Tag.save(tag, { fields: ['title'], userSideValidation: true });
+									await Tag.save(tag, { fields: ['title'], userSideValidation: true, rename: true });
 								} catch (error) {
 									bridge().showErrorMessageBox(error.message);
 								}

--- a/ReactNativeClient/lib/models/Tag.js
+++ b/ReactNativeClient/lib/models/Tag.js
@@ -188,6 +188,7 @@ class Tag extends BaseItem {
 			this.dispatch({
 				type: 'TAG_UPDATE_ONE',
 				item: tag,
+				rename: (options && options.rename) || false,
 			});
 			return tag;
 		});

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -227,7 +227,7 @@ function updateOneItem(state, action, keyName = '') {
 		}
 	}
 
-	if (!found) newItems.push(item);
+	if (!action.rename && !found) newItems.push(item);
 
 	let newState = Object.assign({}, state);
 
@@ -577,8 +577,10 @@ const reducer = (state = defaultState, action) => {
 			break;
 
 		case 'TAG_UPDATE_ONE':
-			newState = updateOneItem(state, action);
-			newState = updateOneItem(newState, action, 'selectedNoteTags');
+			{
+				newState = updateOneItem(state, action);
+				newState = updateOneItem(newState, action, 'selectedNoteTags');
+			}
 			break;
 
 		case 'NOTE_TAG_REMOVE':


### PR DESCRIPTION
Closes #2618 
Bug: Renaming a tag that is not associated with the currently selected note should not add the tag item to the top bar in the editor. #2618 


![PR#2618](https://user-images.githubusercontent.com/18138383/76161156-74a0d300-6156-11ea-8339-23d6dc0c2cfa.gif)
