### PR TITLE
Desktop: Go To Anything by body

### DIFF
--- a/CliClient/tests/ArrayUtils.js
+++ b/CliClient/tests/ArrayUtils.js
@@ -49,4 +49,41 @@ describe('ArrayUtils', function() {
 		expect(ArrayUtils.contentEquals(['b'], ['a', 'b'])).toBe(false);
 	}));
 
+	it('should merge overlapping intervals', asyncTest(async () => {
+		const testCases = [
+			[
+				[],
+				[],
+			],
+			[
+				[[0, 50]],
+				[[0, 50]],
+			],
+			[
+				[[0, 20], [20, 30]],
+				[[0, 30]],
+			],
+			[
+				[[0, 10], [10, 50], [15, 30], [20, 80], [80, 95]],
+				[[0, 95]],
+			],
+			[
+				[[0, 5], [0, 10], [25, 35], [30, 60], [50, 60], [85, 100]],
+				[[0, 10], [25, 60], [85, 100]],
+			],
+			[
+				[[0, 5], [10, 40], [35, 50], [35, 75], [50, 60], [80, 85], [80, 90]],
+				[[0, 5], [10, 75], [80, 90]],
+			],
+		];
+
+		testCases.forEach((t, i) => {
+			const intervals = t[0];
+			const expected = t[1];
+
+			const actual = ArrayUtils.mergeOverlappingIntervals(intervals);
+			expect(actual).toEqual(expected, `Test case ${i}`);
+		});
+	}));
+
 });

--- a/CliClient/tests/ArrayUtils.js
+++ b/CliClient/tests/ArrayUtils.js
@@ -81,7 +81,7 @@ describe('ArrayUtils', function() {
 			const intervals = t[0];
 			const expected = t[1];
 
-			const actual = ArrayUtils.mergeOverlappingIntervals(intervals);
+			const actual = ArrayUtils.mergeOverlappingIntervals(intervals, intervals.length);
 			expect(actual).toEqual(expected, `Test case ${i}`);
 		});
 	}));

--- a/CliClient/tests/StringUtils.js
+++ b/CliClient/tests/StringUtils.js
@@ -41,4 +41,23 @@ describe('StringUtils', function() {
 		}
 	}));
 
+	it('should find the next whitespace character', asyncTest(async () => {
+		const testCases = [
+			['', [[0, 0]]],
+			['Joplin', [[0, 6], [3, 6], [6, 6]]],
+			['Joplin is a free, open source\n note taking and *to-do* application', [[0, 6], [12, 17], [23, 29], [48, 54]]],
+		];
+
+		testCases.forEach((t, i) => {
+			const str = t[0];
+			t[1].forEach((pair, j) => {
+				const begin = pair[0];
+				const expected = pair[1];
+
+				const actual = StringUtils.nextWhitespaceIndex(str, begin);
+				expect(actual).toBe(expected, `Test string ${i} - case ${j}`);
+			});
+		});
+	}));
+
 });

--- a/ReactNativeClient/lib/ArrayUtils.js
+++ b/ReactNativeClient/lib/ArrayUtils.js
@@ -58,4 +58,26 @@ ArrayUtils.contentEquals = function(array1, array2) {
 	return true;
 };
 
+// Merges multiple overlapping intervals into a single interval
+// e.g. [0, 25], [20, 50], [75, 100] --> [0, 50], [75, 100]
+ArrayUtils.mergeOverlappingIntervals = function(intervals, limit = intervals.length) {
+	intervals.sort((a, b) => a[0] - b[0]);
+
+	const stack = [];
+	if (intervals.length) {
+		stack.push(intervals[0]);
+		for (let i = 1; i < intervals.length && stack.length < limit; i++) {
+			const top = stack[stack.length - 1];
+			if (top[1] < intervals[i][0]) {
+				stack.push(intervals[i]);
+			} else if (top[1] < intervals[i][1]) {
+				top[1] = intervals[i][1];
+				stack.pop();
+				stack.push(top);
+			}
+		}
+	}
+	return stack;
+};
+
 module.exports = ArrayUtils;

--- a/ReactNativeClient/lib/ArrayUtils.js
+++ b/ReactNativeClient/lib/ArrayUtils.js
@@ -60,7 +60,7 @@ ArrayUtils.contentEquals = function(array1, array2) {
 
 // Merges multiple overlapping intervals into a single interval
 // e.g. [0, 25], [20, 50], [75, 100] --> [0, 50], [75, 100]
-ArrayUtils.mergeOverlappingIntervals = function(intervals, limit = intervals.length) {
+ArrayUtils.mergeOverlappingIntervals = function(intervals, limit) {
 	intervals.sort((a, b) => a[0] - b[0]);
 
 	const stack = [];

--- a/ReactNativeClient/lib/string-utils.js
+++ b/ReactNativeClient/lib/string-utils.js
@@ -264,6 +264,12 @@ function substrWithEllipsis(s, start, length) {
 	return `${s.substr(start, length - 3)}...`;
 }
 
+function nextWhitespaceIndex(s, begin) {
+	// returns index of the next whitespace character
+	const i = s.slice(begin).search(/\s/);
+	return i < 0 ? s.length : begin + i;
+}
+
 const REGEX_JAPANESE = /[\u3000-\u303f]|[\u3040-\u309f]|[\u30a0-\u30ff]|[\uff00-\uff9f]|[\u4e00-\u9faf]|[\u3400-\u4dbf]/;
 const REGEX_CHINESE = /[\u4e00-\u9fff]|[\u3400-\u4dbf]|[\u{20000}-\u{2a6df}]|[\u{2a700}-\u{2b73f}]|[\u{2b740}-\u{2b81f}]|[\u{2b820}-\u{2ceaf}]|[\uf900-\ufaff]|[\u3300-\u33ff]|[\ufe30-\ufe4f]|[\uf900-\ufaff]|[\u{2f800}-\u{2fa1f}]/u;
 const REGEX_KOREAN = /[\uac00-\ud7af]|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff]/;
@@ -279,4 +285,4 @@ function scriptType(s) {
 	return 'en';
 }
 
-module.exports = Object.assign({ removeDiacritics, substrWithEllipsis, escapeFilename, wrap, splitCommandString, padLeft, toTitleCase, urlDecode, escapeHtml, surroundKeywords, scriptType, commandArgumentsToString }, stringUtilsCommon);
+module.exports = Object.assign({ removeDiacritics, substrWithEllipsis, nextWhitespaceIndex, escapeFilename, wrap, splitCommandString, padLeft, toTitleCase, urlDecode, escapeHtml, surroundKeywords, scriptType, commandArgumentsToString }, stringUtilsCommon);


### PR DESCRIPTION
Closes #2683 

Using `/` prefix followed by a search query now shows list of notes which matches the query in their bodies. I had to add a new state variable `highlightKeywords` to prevent body search keywords getting highlighted in the titles.

![1](https://user-images.githubusercontent.com/26695184/76160453-6bad0300-6150-11ea-8d7b-d62020d66ba0.gif)

I've also edited the help text. Hope that's not an issue for translation?


