### PR TITLE
Desktop: Fix button label wrapping

### DIFF
--- a/ElectronClient/gui/Header.jsx
+++ b/ElectronClient/gui/Header.jsx
@@ -100,7 +100,7 @@ class HeaderComponent extends React.Component {
 	}
 
 	determineButtonLabelState() {
-		const mediaQuery = window.matchMedia(`(max-width: ${550 * this.props.zoomFactor}px)`);
+		const mediaQuery = window.matchMedia(`(max-width: ${780 * this.props.zoomFactor}px)`);
 		const showButtonLabels = !mediaQuery.matches;
 
 		if (this.state.showButtonLabels !== showButtonLabels) {
@@ -266,6 +266,7 @@ class HeaderComponent extends React.Component {
 			fontSize: theme.fontSize,
 			boxSizing: 'border-box',
 			cursor: 'default',
+			whiteSpace: 'nowrap',
 		};
 
 		if (showBackButton) {


### PR DESCRIPTION
Fixes #2700 

Refer following screen recording for demonstration:
![Peek 2020-03-10 01-32](https://user-images.githubusercontent.com/26695184/76252773-672b3c00-626f-11ea-9dfe-f3cd0d00dc5d.gif)

It looks like search box is too wide but it also needs space for `Usage` link so that's why it is.