### PR TITLE
Desktop: add button to About box to copy Joplin's information to the clipboard

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -664,14 +664,9 @@ class Application extends BaseApplication {
 			}
 			const text = message.join('\n');
 
-			const copyLabel = _('Copy');
-			// The following hack helps to position the OK button approximately in the middle
-			// of the dialog box (if the copyLabel is not longer than 14 characters)
-			const spacer = ' '.repeat(Math.max(0, Math.trunc((14 - copyLabel.length) / 2)));
-
 			const copyToClipboard = bridge().showConfirmMessageBox(text, {
 				icon: `${bridge().electronApp().buildDir()}/icons/128x128.png`,
-				buttons: [spacer + copyLabel + spacer, _('OK')],
+				buttons: [_('Copy'), _('OK')],
 				defaultId: 1,
 			});
 			if (copyToClipboard) {

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -664,12 +664,13 @@ class Application extends BaseApplication {
 			}
 			const text = message.join('\n');
 
-			const copyToClipboard = bridge().showConfirmMessageBox(text, {
+			const copyToClipboard = bridge().showMessageBox(text, {
 				icon: `${bridge().electronApp().buildDir()}/icons/128x128.png`,
 				buttons: [_('Copy'), _('OK')],
+				cancelId: 1,
 				defaultId: 1,
 			});
-			if (copyToClipboard) {
+			if (copyToClipboard === 0) {
 				clipboard.writeText(text);
 			}
 		}

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -671,7 +671,7 @@ class Application extends BaseApplication {
 				defaultId: 1,
 			});
 			if (copyToClipboard === 0) {
-				clipboard.writeText(text);
+				clipboard.writeText(message.splice(3).join('\n'));
 			}
 		}
 

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -23,7 +23,7 @@ const ResourceService = require('lib/services/ResourceService');
 const ClipperServer = require('lib/ClipperServer');
 const ExternalEditWatcher = require('lib/services/ExternalEditWatcher');
 const { bridge } = require('electron').remote.require('./bridge');
-const { shell, webFrame } = require('electron');
+const { shell, webFrame, clipboard } = require('electron');
 const Menu = bridge().Menu;
 const PluginManager = require('lib/services/PluginManager');
 const RevisionService = require('lib/services/RevisionService');
@@ -662,9 +662,21 @@ class Application extends BaseApplication {
 				message.push(`\n${gitInfo}`);
 				console.info(gitInfo);
 			}
-			bridge().showInfoMessageBox(message.join('\n'), {
+			const text = message.join('\n');
+
+			const copyLabel = _('Copy');
+			// The following hack helps to position the OK button approximately in the middle
+			// of the dialog box (if the copyLabel is not longer than 14 characters)
+			const spacer = ' '.repeat(Math.max(0, Math.trunc((14 - copyLabel.length) / 2)));
+
+			const copyToClipboard = bridge().showConfirmMessageBox(text, {
 				icon: `${bridge().electronApp().buildDir()}/icons/128x128.png`,
+				buttons: [spacer + copyLabel + spacer, _('OK')],
+				defaultId: 1,
 			});
+			if (copyToClipboard) {
+				clipboard.writeText(text);
+			}
 		}
 
 		const rootMenuFile = {

--- a/ElectronClient/bridge.js
+++ b/ElectronClient/bridge.js
@@ -106,6 +106,19 @@ class Bridge {
 		return result === 0;
 	}
 
+	/* returns the index of the clicked button */
+	showMessageBox(message, options = null) {
+		if (options === null) options = {};
+
+		const result = this.showMessageBox_(this.window(), Object.assign({}, {
+			type: 'question',
+			message: message,
+			buttons: [_('OK'), _('Cancel')],
+		}, options));
+
+		return result;
+	}
+
 	showInfoMessageBox(message, options = {}) {
 		const result = this.showMessageBox_(this.window(), Object.assign({}, {
 			type: 'info',


### PR DESCRIPTION
On certain OS it is not possible to copy the text in the About window.
This change allows to copy that info to the Clipboard.

Due to some shortfalls in Electron, it is not possible to set `defaultId` and `cancelId` to 0.
(Actually one can set them to 0, but the result is not what one would expect.)
Thus I had to move the default `OK` button to the left.

I also added a hack to position the `OK` button approximately in the middle of the dialog box (if the copyLabel is not longer than 14 characters).

![image](https://user-images.githubusercontent.com/223439/76265821-f9195180-623b-11ea-8f17-2cc2fb1ec5c0.png)
