### PR TITLE
Desktop: Markdown list indentation

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1018,7 +1018,9 @@ class NoteTextComponent extends React.Component {
 				return this.$getIndent(line);
 			};
 
-			// Markdown list indentation.
+			// Markdown list indentation. (https://github.com/laurent22/joplin/pull/2713)
+			// If the current line starts with `markup.list` token,
+			// hitting `Tab` key indents the line instead of inserting tab at cursor.
 			const indentOrig = this.editor_.editor.indent;
 			this.editor_.editor.indent = function() {
 				const range = this.getSelectionRange();
@@ -1029,6 +1031,7 @@ class NoteTextComponent extends React.Component {
 					if (tokens.length > 0 && tokens[0].type == 'markup.list') {
 						let num_list = tokens[0].value.search(/\d+\./);
 						if (num_list != -1) {
+							// Resets numbered list to 1.
 							this.session.replace({ start: { row, column: 0 }, end: { row, column: tokens[0].value.length } },
 								tokens[0].value.replace(/\d+\./, '1.'));
 						}

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1017,6 +1017,29 @@ class NoteTextComponent extends React.Component {
 
 				return this.$getIndent(line);
 			};
+
+			// Markdown list indentation.
+			const indentOrig = this.editor_.editor.indent;
+			this.editor_.editor.indent = function() {
+				const range = this.getSelectionRange();
+				if (range.isEmpty()) {
+					const row = range.start.row;
+					const tokens = this.session.getTokens(row);
+
+					if (tokens.length > 0 && tokens[0].type == 'markup.list') {
+						let num_list = tokens[0].value.search(/\d+\./);
+						if (num_list != -1) {
+							this.session.replace({ start: { row, column: 0 }, end: { row, column: tokens[0].value.length } },
+								tokens[0].value.replace(/\d+\./, '1.'));
+						}
+
+						this.session.indentRows(row, row, '\t');
+						return;
+					}
+				}
+
+				indentOrig.call(this);
+			};
 		}
 	}
 

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -956,6 +956,7 @@ class NoteTextComponent extends React.Component {
 			document.querySelector('#note-editor').removeEventListener('paste', this.onEditorPaste_, true);
 			document.querySelector('#note-editor').removeEventListener('keydown', this.onEditorKeyDown_);
 			document.querySelector('#note-editor').removeEventListener('contextmenu', this.onEditorContextMenu_);
+			this.editor_.editor.indent = this.indentOrig;
 		}
 
 		this.editor_ = element;
@@ -1021,7 +1022,8 @@ class NoteTextComponent extends React.Component {
 			// Markdown list indentation. (https://github.com/laurent22/joplin/pull/2713)
 			// If the current line starts with `markup.list` token,
 			// hitting `Tab` key indents the line instead of inserting tab at cursor.
-			const indentOrig = this.editor_.editor.indent;
+			this.indentOrig = this.editor_.editor.indent;
+			const indentOrig = this.indentOrig;
 			this.editor_.editor.indent = function() {
 				const range = this.getSelectionRange();
 				if (range.isEmpty()) {
@@ -1029,8 +1031,7 @@ class NoteTextComponent extends React.Component {
 					const tokens = this.session.getTokens(row);
 
 					if (tokens.length > 0 && tokens[0].type == 'markup.list') {
-						let num_list = tokens[0].value.search(/\d+\./);
-						if (num_list != -1) {
+						if (tokens[0].value.search(/\d+\./) != -1) {
 							// Resets numbered list to 1.
 							this.session.replace({ start: { row, column: 0 }, end: { row, column: tokens[0].value.length } },
 								tokens[0].value.replace(/\d+\./, '1.'));


### PR DESCRIPTION
Overrides Ace's `Editor.indent` function to insert indentation at start of line when editing Markdown list. Also resets numbered lists to `1.`.

Fixes #498. This PR does not implement "when caret is at start of line" part though. I'm accustomed to Dropbox Paper's behavior that pressing Tab indents a list item wherever caret is, and I thought that's more intuitive.

![Peek 2020-03-10 16-40](https://user-images.githubusercontent.com/7091080/76290052-d34c8500-62ed-11ea-8e69-3da7de743612.gif)