### PR TITLE
Desktop: Fixed auto scroll issue in editor

### DIFF
--- a/ElectronClient/gui/note-viewer/index.html
+++ b/ElectronClient/gui/note-viewer/index.html
@@ -316,17 +316,22 @@
 			// the scroll position has already been updated. Also we add a 200ms interval
 			// because otherwise it's most likely a glitch where we called ipc.setPercentScroll
 			// but the scroll event listener has not been called.
-			if (lastScrollEventTime && Date.now() - lastScrollEventTime < 200) {
-				lastScrollEventTime = 0;
-				return;
-			}
-
-			lastScrollEventTime = 0;
-
-			const percent = currentPercentScroll();
-			setPercentScroll(percent);
 			
-			ipcProxySendToHost('percentScroll', percent);
+			// The editor position should change parallelly when the user scrolls on the viewer. 
+			// The position change in the viewer might be caused by two events. First, the user 
+			// scrolls in the viewer side. Second, when the user scrolls in the editor side, the 
+			// viewer position changes simultaneously. Third, content changes in the viewer. We 
+			// use lastScrollEventTime to detect second event, and lastTextLength to detect third
+			// event
+
+			if ((lastScrollEventTime && Date.now() - lastScrollEventTime > 200) && 
+			    (contentElement.innerText.length == lastTextLength)){
+				const percent = currentPercentScroll();
+				ipcProxySendToHost('percentScroll', percent);
+			}
+			else{
+				lastTextLength = contentElement.innerText.length;
+			}
 		}));
 
 		document.addEventListener('contextmenu', webviewLib.logEnabledEventHandler(event => {

--- a/ElectronClient/gui/note-viewer/index.html
+++ b/ElectronClient/gui/note-viewer/index.html
@@ -319,7 +319,7 @@
 			// but the scroll event listener has not been called.
 			
 			// The editor position should change parallelly when the user scrolls on the viewer. 
-			// The position change in the viewer might be caused by two events. First, the user 
+			// The position change in the viewer might be caused by three events. First, the user 
 			// scrolls in the viewer side. Second, when the user scrolls in the editor side, the 
 			// viewer position changes simultaneously. Third, content changes in the viewer. We 
 			// use lastScrollEventTime to detect second event, and lastTextLength to detect third

--- a/ElectronClient/gui/note-viewer/index.html
+++ b/ElectronClient/gui/note-viewer/index.html
@@ -310,6 +310,7 @@
 			return m ? contentElement.scrollTop / m : 0;
 		}
 
+		let lastTextLength=0;
 		contentElement.addEventListener('scroll', webviewLib.logEnabledEventHandler(e => {
 			// If the last scroll event was done by the user, lastScrollEventTime is set and
 			// we can use that to skip the event handling. We skip it because in that case

--- a/ElectronClient/gui/note-viewer/index.html
+++ b/ElectronClient/gui/note-viewer/index.html
@@ -318,7 +318,7 @@
 			// because otherwise it's most likely a glitch where we called ipc.setPercentScroll
 			// but the scroll event listener has not been called.
 			
-			// The editor position should change parallelly when the user scrolls on the viewer. 
+			// The editor position will change when the user scrolls on the viewer. 
 			// The position change in the viewer might be caused by three events. First, the user 
 			// scrolls in the viewer side. Second, when the user scrolls in the editor side, the 
 			// viewer position changes simultaneously. Third, content changes in the viewer. We 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
The scroll event in the viewer might be triggered by some text input in the editor. Then scroll event will adjust editor's position, which causes auto scroll issue. I fixed this issue by a workaround. The editor position will not be changed by scroll event in the viewer until there is no content changes in the viewer. That is, the user is scrolling the viewer.
Fixed #1546
Fixed #2702 probably
Because this is just a workaround, I will look into position synchronization in the viewer side later.
