### PR TITLE
discard and save error after editing a note

### DIFF
--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -96,8 +96,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		};
 
 		this.backHandler = async () => {
-			const r = await saveDialog();
-			if (r) return r;
 
 			const isProvisionalNote = this.props.provisionalNoteIds.includes(this.props.noteId);
 

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -97,6 +97,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 		this.backHandler = async () => {
 
+			await this.saveNoteButton_press();
 			const isProvisionalNote = this.props.provisionalNoteIds.includes(this.props.noteId);
 
 			if (isProvisionalNote) {


### PR DESCRIPTION
This PR closes #2738. The notes get save automatically, with no need for dialog.
@laurent22  can you look at this PR. I commented on the lines which were showing the dialog box. Do you want me to delete those lines and the functions to show the dialog box?