### PR TITLE
added feature of select all and closes #2721

### DIFF
--- a/ReactNativeClient/lib/components/screen-header.js
+++ b/ReactNativeClient/lib/components/screen-header.js
@@ -160,6 +160,10 @@ class ScreenHeaderComponent extends React.PureComponent {
 		}
 	}
 
+	selectAllButton_press() {
+		this.props.dispatch({ type: 'NOTE_SELECT_ALL' });
+	}
+
 	searchButton_press() {
 		NavService.go('Search');
 	}
@@ -240,6 +244,16 @@ class ScreenHeaderComponent extends React.PureComponent {
 			return (
 				<TouchableOpacity onPress={onPress} disabled={disabled} style={{ padding: 0 }}>
 					<View style={disabled ? styles.saveButtonDisabled : styles.saveButton}>{icon}</View>
+				</TouchableOpacity>
+			);
+		}
+
+		function selectAllButton(styles, onPress) {
+			return (
+				<TouchableOpacity onPress={onPress}>
+					<View style={styles.iconButton}>
+						<Icon name="md-checkmark-circle-outline" style={styles.topIcon} />
+					</View>
 				</TouchableOpacity>
 			);
 		}
@@ -405,6 +419,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 		if (this.props.hasDisabledSyncItems) warningComps.push(this.renderWarningBox('Status', _('Some items cannot be synchronised. Press for more info.')));
 
 		const showSideMenuButton = !!this.props.showSideMenuButton && !this.props.noteSelectionEnabled;
+		const showSelectAllButton = this.props.noteSelectionEnabled;
 		const showSearchButton = !!this.props.showSearchButton && !this.props.noteSelectionEnabled;
 		const showContextMenuButton = this.props.showContextMenuButton !== false;
 		const showBackButton = !!this.props.noteSelectionEnabled || this.props.showBackButton !== false;
@@ -415,6 +430,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 		const titleComp = createTitleComponent();
 		const sideMenuComp = !showSideMenuButton ? null : sideMenuButton(this.styles(), () => this.sideMenuButton_press());
 		const backButtonComp = !showBackButton ? null : backButton(this.styles(), () => this.backButton_press(), backButtonDisabled);
+		const selectAllButtonComp = !showSelectAllButton ? null : selectAllButton(this.styles(), () => this.selectAllButton_press());
 		const searchButtonComp = !showSearchButton ? null : searchButton(this.styles(), () => this.searchButton_press());
 		const deleteButtonComp = this.props.noteSelectionEnabled ? deleteButton(this.styles(), () => this.deleteButton_press()) : null;
 		const duplicateButtonComp = this.props.noteSelectionEnabled ? duplicateButton(this.styles(), () => this.duplicateButton_press()) : null;
@@ -452,6 +468,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 						this.props.showSaveButton === true
 					)}
 					{titleComp}
+					{selectAllButtonComp}
 					{searchButtonComp}
 					{deleteButtonComp}
 					{duplicateButtonComp}

--- a/ReactNativeClient/lib/components/screen-header.js
+++ b/ReactNativeClient/lib/components/screen-header.js
@@ -161,7 +161,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 	}
 
 	selectAllButton_press() {
-		this.props.dispatch({ type: 'NOTE_SELECT_ALL' });
+		this.props.dispatch({ type: 'NOTE_SELECT_ALL_TOGGLE' });
 	}
 
 	searchButton_press() {

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -393,6 +393,16 @@ const reducer = (state = defaultState, action) => {
 			newState.selectedNoteIds = newState.notes.map(n => n.id);
 			break;
 
+		case 'NOTE_SELECT_ALL_TOGGLE': {
+			newState = Object.assign({}, state);
+			const allSelected = state.notes.every(n => state.selectedNoteIds.includes(n.id));
+			if (allSelected)
+				newState.selectedNoteIds = [];
+			else
+				newState.selectedNoteIds = newState.notes.map(n => n.id);
+			break;
+		}
+
 		case 'SMART_FILTER_SELECT':
 			newState = Object.assign({}, state);
 			newState.notesParentType = 'SmartFilter';


### PR DESCRIPTION
closes #2721 

I added an option to select all notes at a time. I added a button that will appear when the user selects any note and then they can click on them to select all notes of that particular screen. This way they can easily manipulate multiple notes.

Tests:
1. I tested manually that the icon is only appearing on the screen when users choose any note and nowhere else. And also checked configuration and other pages, just to be sure.
2. I checked that when user clicks on select all button, only the notes of that page are getting selected and no other notes. I confirmed this by logging the changing values in the reducer.
3. I checked that after selecting all the notes, deleting, duplicating and all the other options are working.
4. I checked that after selecting all the options if we deselect some options, everything goes as expected.

@PackElend can you please add gsoc2020 label and have a look at this PR. 


![select_all](https://user-images.githubusercontent.com/27751740/76574505-87166600-64e2-11ea-9cb1-7526eced6465.gif)


