### PR TITLE
added auto save feature for notebooks (enhancement)

### DIFF
--- a/ReactNativeClient/lib/components/screens/folder.js
+++ b/ReactNativeClient/lib/components/screens/folder.js
@@ -74,13 +74,24 @@ class FolderScreenComponent extends BaseScreenComponent {
 		});
 	}
 
-	title_changeText(text) {
-		this.folderComponent_change('title', text);
+	scheduleSave() {
+		if (this.scheduleSaveIID_) {
+			clearTimeout(this.scheduleSaveIID_);
+			this.scheduleSaveIID_ = null;
+		}
+
+		this.scheduleSaveIID_ = setTimeout(async () => {
+			await this.saveFolderButton_press_without_closing();
+		}, 1000);
 	}
 
-	async saveFolderButton_press() {
-		let folder = Object.assign({}, this.state.folder);
+	title_changeText(text) {
+		this.folderComponent_change('title', text);
+		this.scheduleSave();
+	}
 
+	async saveFolderButton_press_without_closing() {
+		let folder = Object.assign({}, this.state.folder);
 		try {
 			folder = await Folder.save(folder, { userSideValidation: true });
 		} catch (error) {
@@ -92,11 +103,15 @@ class FolderScreenComponent extends BaseScreenComponent {
 			lastSavedFolder: Object.assign({}, folder),
 			folder: folder,
 		});
+	}
+
+	async saveFolderButton_press() {
+		this.saveFolderButton_press_without_closing();
 
 		this.props.dispatch({
 			type: 'NAV_GO',
 			routeName: 'Notes',
-			folderId: folder.id,
+			folderId: this.state.folder.id,
 		});
 	}
 


### PR DESCRIPTION
In mobile, Joplin notes have a feature of autosave. But notebooks don't have such a feature. Many users get used to just typing and going back in notes, so sometimes its irregular for a user to type and save for notebooks. So the autosave feature should be there for notebooks also. I added the autosave feature for notebooks.
Test :
1.  I tested manually that whenever types something and stays, the notebook gets saved automatically.
2. When user types and goes back instantly, the notebook is still successfully saved.
3. When the user types something and deletes it, then the notebook is saved as Untitled notebook.
4. When the user clicks on the back button, they go back to the last notebook.
5. When users click on the save button ( they don't need to, the text is saved automatically ), they go to the latest notebook.

@PackElend please label this PR for GSoC. 
Please have a look at this PR. If there is anything I need to change let me know. I will fix that as soon as possible.



![5e6bd4afa6894306123681](https://user-images.githubusercontent.com/27751740/76650676-1d04cc00-6589-11ea-93ea-80d73f5126e9.gif)
