### PR TITLE
Desktop : Enable external editing in viewer mode (Fixes #2762)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ joplin-webclipper-source.zip
 Tools/commit_hook.txt
 .vscode/*
 *.map
+GTAGS
+GRTAGS
+GPATH
+cscope.out
+.starscope.db
 
 # AUTO-GENERATED - EXCLUDED TYPESCRIPT BUILD
 ElectronClient/gui/editors/PlainEditor.js

--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,6 @@ joplin-webclipper-source.zip
 Tools/commit_hook.txt
 .vscode/*
 *.map
-GTAGS
-GRTAGS
-GPATH
-cscope.out
-.starscope.db
 
 # AUTO-GENERATED - EXCLUDED TYPESCRIPT BUILD
 ElectronClient/gui/editors/PlainEditor.js

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1188,7 +1188,7 @@ class Application extends BaseApplication {
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
 
-		for (const itemId of ['paste', 'cut', 'bold', 'italic', 'link', 'code', 'insertDateTime']) {
+		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'showLocalSearch']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
 			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML;

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1188,7 +1188,7 @@ class Application extends BaseApplication {
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
 
-		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
+		for (const itemId of ['paste', 'cut', 'bold', 'italic', 'link', 'code', 'insertDateTime']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
 			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML;


### PR DESCRIPTION
Removed disable of "Edit in external editor", "Copy", "Select All" and "Search in Current Note" features in viewer mode, as these features are valid for all modes. These options have been removed from the enable validation in `app.js`.

Fixes #2762
