### PR TITLE
Mobile: Add note title length limit (60)  

### DIFF
--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -38,6 +38,7 @@ const CameraView = require('lib/components/CameraView');
 const SearchEngine = require('lib/services/SearchEngine');
 const urlUtils = require('lib/urlUtils');
 
+import Toast from 'react-native-simple-toast';
 import FileViewer from 'react-native-file-viewer';
 
 class NoteScreenComponent extends BaseScreenComponent {
@@ -53,6 +54,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 			folder: null,
 			lastSavedNote: null,
 			isLoading: true,
+			notetitleLength: 60,
 			titleTextInputHeight: 20,
 			alarmDialogShown: false,
 			heightBumpView: 0,
@@ -311,6 +313,11 @@ class NoteScreenComponent extends BaseScreenComponent {
 	}
 
 	title_changeText(text) {
+		// check if text length is greater than the allowed limit
+		if (text.length > this.state.notetitleLength) {
+			Toast.show('Maximum title length reached', Toast.LONG);
+			return;
+		}
 		shared.noteComponent_change(this, 'title', text);
 		this.setState({ newAndNoTitleChangeNoteId: null });
 		this.scheduleSave();

--- a/ReactNativeClient/package.json
+++ b/ReactNativeClient/package.json
@@ -90,7 +90,8 @@
     "uuid": "^3.0.1",
     "valid-url": "^1.0.9",
     "word-wrap": "^1.2.3",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.19",
+    "react-native-simple-toast": "1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
Fixes issue #2771
This PR adds a limit to the note title in android and iOS application. 

This now prevents the title text from overflowing into multiple lines( not more than 2 lines)

If the limit is exceeded, a toast message is shown.

**Fix:**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/15264074/76725599-f58a3c80-670b-11ea-86d7-9a3341f17a27.gif)



<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
