### PR TITLE
Fixed menubar (Edit, Alt+E) shortcut problem while editing a note

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -968,6 +968,7 @@ class NoteTextComponent extends React.Component {
 				cancelledKeys.push(`Ctrl+${l}`);
 				cancelledKeys.push(`Command+${l}`);
 			}
+			cancelledKeys.push('Alt+E');
 
 			for (let i = 0; i < cancelledKeys.length; i++) {
 				const k = cancelledKeys[i];


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

**Disclaimer**: This is my first pull request. 

**Description**
Generally, menubar items (e.g. *File*, *Edit*, *View*) can be easily accessed by using `Alt + (the first character of menubar item name)` shortcut like e.g. `Alt + F` for *File*, `Alt + E` for *Edit* and it usually works. Except for the *Edit* menubar item. When you are not editing a note, `Alt + E` shortcut works, but when you do, 'Looks good!' message pops up like in the screenshot below.

**Screenshot**
![16 03 2020-10:39:36](https://user-images.githubusercontent.com/31123054/76731952-bd750f00-6788-11ea-890c-16335dd2614f.png)

**Cause**
In node module 'brace' there is a builtin keybinding `Alt + E` that is written in the *index.js* file.
``` 
    name: "goToNextError",
    bindKey: bindKey("Alt-E", "F4"),
    exec: function(editor) {
        config.loadModule("ace/ext/error_marker", function(module) {
            module.showErrorMarker(editor, 1);
        });
    },
    scrollIntoView: "animate",
    readOnly: true
```
That's the reason why *Alt + E* shortcut doens't work properly.

**Solution**
Since editing files inside `node_modules` is not an option, I decided to change `Alt + E` shortcut to something else. I fixed it by changing the label property from `_('&Edit')` to `_('E&dit')`. Now the default shortcut for accessing Edit menubar entry is `Alt + D`. It may not be intuitive as Alt + E, but now it works when file is being edited, unlike default `Alt + E`.

```
		const rootMenus = {
			edit: {
				id: 'edit',
				label: _('E&dit'),
```
