### PR TITLE
Mobile: Add the functionality of adding notebook on clicking action button

### DIFF
--- a/ReactNativeClient/lib/components/action-button.js
+++ b/ReactNativeClient/lib/components/action-button.js
@@ -93,7 +93,7 @@ class ActionButtonComponent extends React.Component {
 		}
 
 		if (!buttonComps.length && !this.props.mainButton) {
-			return <ReactNativeActionButton style={{ display: 'none' }} />;
+			return null;
 		}
 
 		const mainButton = this.props.mainButton ? this.props.mainButton : {};


### PR DESCRIPTION
On Mobile,
When there are no notebooks, the home screen still shows an action button that is disabled, but instead, it should be enabled and on clicking that should add a notebook.  I enabled that button and on clicking that button it will prompt to enter notebook name, that should be the appropriate behavior of that button.
@PackElend  can you please label my PR.

Before
![Screenshot_1584402197](https://user-images.githubusercontent.com/27751740/76808575-31a5c600-680e-11ea-806d-e1ae090c612b.png)

After
![Screenshot_1584401958](https://user-images.githubusercontent.com/27751740/76808580-35394d00-680e-11ea-9af7-5771fef92faf.png)
