### PR TITLE
Desktop: Handle confirm password prompt for encryption enabling

### DIFF
--- a/ElectronClient/gui/EncryptionConfigScreen.jsx
+++ b/ElectronClient/gui/EncryptionConfigScreen.jsx
@@ -116,6 +116,16 @@ class EncryptionConfigScreenComponent extends React.Component {
 
 			if (!answer) return;
 
+			if (!isEnabled) {
+				let confirmAnswer = '';
+				let confirmPasswordMessage = 'Re-enter your password to verify it.';
+				do {
+					confirmAnswer = await dialogs.prompt(_(confirmPasswordMessage), '', '', { type: 'password' });
+					confirmPasswordMessage = 'Passwords don\'t match!\nRe-enter your password to verify it.';
+				} while (confirmAnswer != answer);
+			}
+
+
 			try {
 				if (isEnabled) {
 					await EncryptionService.instance().disableEncryption();


### PR DESCRIPTION
fixes #1656 

As said, using custom prompts only allow one user input at a time so i tried to make it a 2-step process instead of the 3-step implementation in #1936 whereas

After entering the password
![2](https://user-images.githubusercontent.com/30902406/76898596-b0e2da80-689e-11ea-8d01-bdbf0bb61342.PNG)

User is kept prompted 
![3](https://user-images.githubusercontent.com/30902406/76898669-d07a0300-689e-11ea-9499-2cdd604cb615.PNG)

Until passwords match
![4](https://user-images.githubusercontent.com/30902406/76898698-dec81f00-689e-11ea-873f-a2adcda972b4.PNG)

then the behavior follows as default.

A gif for new flow :
https://gph.is/g/Z8eVeL0