### PR TITLE
Desktop: Correct numbering of list items when indenting/outdenting

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/useListIdent.ts
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/useListIdent.ts
@@ -1,15 +1,60 @@
 import { useEffect } from 'react';
 import { selectionRange } from './index';
+const markdownUtils = require('lib/markdownUtils');
 
-interface HookDependencies {
-	editor: any,
+// The line that contains only `- ` is
+// recognized as a heading in Ace.
+function hyphenEmptyListItem(tokens: any[]) {
+	return (
+		tokens.length === 2 &&
+		tokens[0].type === 'markup.heading.2' &&
+		tokens[0].value === '-' &&
+		tokens[1].type === 'text.xml' &&
+		tokens[1].value === ' '
+	);
 }
 
-export default function useListIdent(dependencies:HookDependencies) {
+// Returns tokens of the line if it starts with a 'markup.list' token.
+function listTokens(editor: any, row: number) {
+	const tokens = editor.session.getTokens(row);
+	if (
+		!(tokens.length > 0 && tokens[0].type === 'markup.list') &&
+		!hyphenEmptyListItem(tokens)
+	) {
+		return [];
+	}
+	return tokens;
+}
+
+function countIndent(line: string): number {
+	return line.match(/\t| {4}/g)?.length || 0;
+}
+
+// Finds the list item with indent level `prevIndent`.
+function findPrevListNum(editor: any, row: number, indent: number) {
+	while (row > 0) {
+		row--;
+		const line = editor.session.getLine(row);
+
+		if (countIndent(line) === indent) {
+			const num = markdownUtils.olLineNumber(line.trimLeft());
+			if (num) {
+				return num;
+			}
+		}
+	}
+	return 0;
+}
+
+interface HookDependencies {
+	editor: any;
+}
+
+export default function useListIdent(dependencies: HookDependencies) {
 	const { editor } = dependencies;
 
 	useEffect(() => {
-		if (!editor) return;
+		if (!editor) return () => {};
 
 		// Markdown list indentation. (https://github.com/laurent22/joplin/pull/2713)
 		// If the current line starts with `markup.list` token,
@@ -20,13 +65,19 @@ export default function useListIdent(dependencies:HookDependencies) {
 			const range = selectionRange(editor);
 			if (range.isEmpty()) {
 				const row = range.start.row;
-				const tokens = this.session.getTokens(row);
+				const tokens = listTokens(this, row);
 
-				if (tokens.length > 0 && tokens[0].type == 'markup.list') {
+				if (tokens.length > 0) {
 					if (tokens[0].value.search(/\d+\./) != -1) {
-						// Resets numbered list to 1.
-						this.session.replace({ start: { row, column: 0 }, end: { row, column: tokens[0].value.length } },
-							tokens[0].value.replace(/\d+\./, '1.'));
+						const line = this.session.getLine(row);
+						const n = findPrevListNum(this, row, countIndent(line) + 1) + 1;
+						this.session.replace(
+							{
+								start: { row, column: 0 },
+								end: { row, column: tokens[0].value.length },
+							},
+							tokens[0].value.replace(/\d+\./, `${n}.`)
+						);
 					}
 
 					this.session.indentRows(row, row, '\t');
@@ -35,6 +86,45 @@ export default function useListIdent(dependencies:HookDependencies) {
 			}
 
 			if (originalEditorIndent) originalEditorIndent.call(this);
+		};
+
+		// Correct the number of numbered list item when outdenting.
+		editor.commands.addCommand({
+			name: 'markdownOutdent',
+			bindKey: { win: 'Shift+Tab', mac: 'Shift+Tab' },
+			multiSelectAction: 'forEachLine',
+			exec: function(editor: any) {
+				const range = selectionRange(editor);
+
+				if (range.isEmpty()) {
+					const row = range.start.row;
+
+					const tokens = editor.session.getTokens(row);
+					if (tokens.length && tokens[0].type === 'markup.list') {
+						const matches = tokens[0].value.match(/^(\t+)\d+\./);
+						if (matches && matches.length) {
+							const indent = countIndent(matches[1]);
+							const n = findPrevListNum(editor, row, indent - 1) + 1;
+							console.log(n);
+							editor.session.replace(
+								{
+									start: { row, column: 0 },
+									end: { row, column: tokens[0].value.length },
+								},
+								tokens[0].value.replace(/\d+\./, `${n}.`)
+							);
+						}
+					}
+				}
+
+				editor.blockOutdent();
+			},
+			readonly: false,
+		});
+
+		return () => {
+			editor.indent = originalEditorIndent;
+			editor.commands.removeCommand('markdownOutdent');
 		};
 	}, [editor]);
 }


### PR DESCRIPTION
Fixes the issue pointed out by @tessus: https://github.com/laurent22/joplin/pull/2713#issuecomment-599397409

When (Shift+)Tab key is pressed, the editor will try finding out the numbered list item with the current indent level + 1 (or - 1 if Shift+Tab) and sets the current line's number accordingly.