### PR TITLE
Mobile: added filter for notes  option

### DIFF
--- a/ReactNativeClient/lib/components/note-list.js
+++ b/ReactNativeClient/lib/components/note-list.js
@@ -75,6 +75,28 @@ class NoteListComponent extends Component {
 		return output;
 	}
 
+	filteredNotes() {
+		const type = this.props.filterType;
+		const items = this.props.items;
+		const notes = items.filter(note => note.is_todo == 0);
+		const todo = items.filter(item => item.is_todo);
+		const pendingTodo = todo.filter(todo => todo.todo_completed == 0);
+		const completedTodo = todo.filter(todo => todo.todo_completed != 0);
+		console.debug(items);
+		switch (type) {
+		case 'All':
+			return items;
+		case 'Completed Todo':
+			return completedTodo;
+		case 'Incomplete Todos':
+			return pendingTodo;
+		case 'Notes':
+			return notes;
+		default:
+			return items;
+		}
+	}
+
 	UNSAFE_componentWillReceiveProps(newProps) {
 		// Make sure scroll position is reset when switching from one folder to another or to a tag list.
 		if (this.rootRef_ && newProps.notesSource != this.props.notesSource) {
@@ -88,7 +110,7 @@ class NoteListComponent extends Component {
 		if (this.props.items.length) {
 			return <FlatList
 				ref={ref => (this.rootRef_ = ref)}
-				data={this.props.items}
+				data={this.filteredNotes()}
 				renderItem={({ item }) => <NoteItem note={item} />}
 				keyExtractor={item => item.id}
 			/>;
@@ -116,6 +138,7 @@ const NoteList = connect(state => {
 		notesSource: state.notesSource,
 		theme: state.settings.theme,
 		noteSelectionEnabled: state.noteSelectionEnabled,
+		filterType: state.filterType,
 	};
 })(NoteListComponent);
 

--- a/ReactNativeClient/lib/components/screen-header.js
+++ b/ReactNativeClient/lib/components/screen-header.js
@@ -258,6 +258,16 @@ class ScreenHeaderComponent extends React.PureComponent {
 			);
 		}
 
+		function filterButton(styles, onPress) {
+			return (
+				<TouchableOpacity onPress={onPress}>
+					<View style={styles.iconButton}>
+						<Icon name="md-square-outline" style={styles.topIcon} />
+					</View>
+				</TouchableOpacity>
+			);
+		}
+
 		function searchButton(styles, onPress) {
 			return (
 				<TouchableOpacity onPress={onPress}>
@@ -420,6 +430,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 
 		const showSideMenuButton = !!this.props.showSideMenuButton && !this.props.noteSelectionEnabled;
 		const showSelectAllButton = this.props.noteSelectionEnabled;
+		const showFilterButton = !this.props.noteSelectionEnabled && this.props.showBackButton == false;
 		const showSearchButton = !!this.props.showSearchButton && !this.props.noteSelectionEnabled;
 		const showContextMenuButton = this.props.showContextMenuButton !== false;
 		const showBackButton = !!this.props.noteSelectionEnabled || this.props.showBackButton !== false;
@@ -431,6 +442,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 		const sideMenuComp = !showSideMenuButton ? null : sideMenuButton(this.styles(), () => this.sideMenuButton_press());
 		const backButtonComp = !showBackButton ? null : backButton(this.styles(), () => this.backButton_press(), backButtonDisabled);
 		const selectAllButtonComp = !showSelectAllButton ? null : selectAllButton(this.styles(), () => this.selectAllButton_press());
+		const filterButtonComp = !showFilterButton ? null : filterButton(this.styles(), () => this.props.filterButton_press());
 		const searchButtonComp = !showSearchButton ? null : searchButton(this.styles(), () => this.searchButton_press());
 		const deleteButtonComp = this.props.noteSelectionEnabled ? deleteButton(this.styles(), () => this.deleteButton_press()) : null;
 		const duplicateButtonComp = this.props.noteSelectionEnabled ? duplicateButton(this.styles(), () => this.duplicateButton_press()) : null;
@@ -469,6 +481,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 					)}
 					{titleComp}
 					{selectAllButtonComp}
+					{filterButtonComp}
 					{searchButtonComp}
 					{deleteButtonComp}
 					{duplicateButtonComp}

--- a/ReactNativeClient/lib/components/screens/notes.js
+++ b/ReactNativeClient/lib/components/screens/notes.js
@@ -68,6 +68,26 @@ class NotesScreenComponent extends BaseScreenComponent {
 
 			Setting.setValue(r.name, r.value);
 		};
+
+		this.filterButton_press = async () => {
+			const buttons = [];
+			const sortNoteOptions = ['All','Completed Todo','Incomplete Todos','Notes'];
+			let value = this.props.filterType;
+			for (const field of sortNoteOptions) {
+				buttons.push({
+					text: field == value ? `⬤ ${field}` : field,
+					id: { name: 'notes.filter.field', value: field },
+				});
+			}
+
+			const r = await dialogs.pop(this, 'Choose Filter', buttons);
+			if (!r) return;
+			value = r.value;
+			this.props.dispatch({
+				type: 'CHANGE_FILTER_TYPE',
+				filterType: value,
+			});
+		};
 	}
 
 	styles() {
@@ -222,7 +242,7 @@ class NotesScreenComponent extends BaseScreenComponent {
 
 		return (
 			<View style={rootStyle}>
-				<ScreenHeader title={title} showBackButton={false} parentComponent={thisComp} sortButton_press={this.sortButton_press} folderPickerOptions={this.folderPickerOptions()} showSearchButton={true} showSideMenuButton={true} />
+				<ScreenHeader title={title} showBackButton={false} parentComponent={thisComp} filterButton_press={this.filterButton_press} sortButton_press={this.sortButton_press} folderPickerOptions={this.folderPickerOptions()} showSearchButton={true} showSideMenuButton={true} />
 				<NoteList style={this.styles().noteList} />
 				{actionButtonComp}
 				<DialogBox
@@ -251,6 +271,7 @@ const NotesScreen = connect(state => {
 		theme: state.settings.theme,
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		notesOrder: stateUtils.notesOrder(state.settings),
+		filterType: state.filterType,
 	};
 })(NotesScreenComponent);
 

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -55,6 +55,7 @@ const defaultState = {
 	plugins: {},
 	provisionalNoteIds: [],
 	editorNoteStatuses: {},
+	filterType: 'All',
 };
 
 const stateUtils = {};
@@ -500,6 +501,13 @@ const reducer = (state = defaultState, action) => {
 				const newSettings = Object.assign({}, state.settings);
 				newSettings[action.key] = action.value;
 				newState.settings = newSettings;
+			}
+			break;
+
+		case 'CHANGE_FILTER_TYPE':
+			{
+				newState = Object.assign({}, state);
+				newState.filterType = action.filterType;
 			}
 			break;
 


### PR DESCRIPTION
I added a filter option on the mobile platform. Now, users can filter their notes and can only see their todos, completed todos, incomplete todos, and notes.  If admins allow this, I will add more filter options such as notes from the last 1 day, last 1 week, between two dates, etc.
@PackElend  please label this PR.

![Screenshot_1584533996](https://user-images.githubusercontent.com/27751740/76960471-8b5add00-6941-11ea-873e-22e95cbc5d45.png)
