### PR TITLE
[FIXED] validation error on creating notebook

### DIFF
--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -149,8 +149,9 @@ class MainScreenComponent extends React.Component {
 									historyAction: 'goto',
 								});
 							}
+						} else {
+							bridge().showErrorMessageBox(_('Title must be there'));
 						}
-
 						this.setState({ promptOptions: null });
 					},
 				},

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -132,8 +132,8 @@ class MainScreenComponent extends React.Component {
 			this.setState({
 				promptOptions: {
 					label: _('Notebook title:'),
-					onClose: async answer => {
-						if (answer) {
+					onClose: async (answer, buttonType) => {
+						if (answer && buttonType === 'ok') {
 							let folder = null;
 							try {
 								folder = await Folder.save({ title: answer }, { userSideValidation: true });
@@ -149,8 +149,8 @@ class MainScreenComponent extends React.Component {
 									historyAction: 'goto',
 								});
 							}
-						} else {
-							bridge().showErrorMessageBox(_('Title must be there'));
+						} else if (!answer && buttonType === 'ok') {
+							bridge().showErrorMessageBox('please select a title first');
 						}
 						this.setState({ promptOptions: null });
 					},


### PR DESCRIPTION
- "Desktop" for the Windows/macOS/Linux app (Electron app)
Solve #2799
[FIXED] There is no validation error/prompt on creating notebooks/sub-notebooks without title. Instead the dialog simply closes.

[AFTER]
![Screenshot from 2020-03-19 03-14-03](https://user-images.githubusercontent.com/36675100/77010489-e1567180-698f-11ea-9139-2851e8cbaa2f.png)
 

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
