### PR TITLE
Desktop: Changed Focus to viewer in viewer-only mode

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -322,6 +322,14 @@ class Application extends BaseApplication {
 		});
 	}
 
+	checkLayout(layout) {
+		if (layout === 'viewer') {
+			this.focusElement_('noteTextViewer');
+		} else {
+			this.focusElement_('noteBody');
+		}
+	}
+
 	async updateMenu(screen) {
 		if (this.lastMenuScreen_ === screen) return;
 
@@ -382,9 +390,11 @@ class Application extends BaseApplication {
 
 		focusItems.push({
 			label: _('Note body'),
-			click: () => { this.focusElement_('noteBody'); },
+			click: () => { this.checkLayout(this.store().getState().noteVisiblePanes[0]); },
 			accelerator: 'CommandOrControl+Shift+B',
 		});
+
+
 
 		let toolsItems = [];
 		const importItems = [];

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1180,6 +1180,13 @@ class NoteTextComponent extends React.Component {
 			};
 		}
 
+		if (command.name === 'focusElement' && command.target === 'noteTextViewer') {
+			fn = () => {
+				if (!this.webviewRef_) return;
+				this.webviewRef_.current.wrappedInstance.webviewRef_.current.focus();
+			};
+		}
+
 		if (!fn) return;
 
 		this.props.dispatch({


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Closes #2810 

This is my first time making a pull request here, so if I can somehow rewrite the code better, please let me know and I will make changes accordingly.

I am detecting the current layout and sending in two different ```focusElement``` calls, the desired output has been achieved. 