### PR TITLE
Mobile: Add an option to see encrytion password

### DIFF
--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -53,7 +53,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 			const mk = masterKeys[i];
 
 			this.setState(prevState =>({
-				passwordShow: [{ id: mk.id, [mk.id]: true }, ...prevState.passwordShow],
+				passwordHide: [{ id: mk.id, [mk.id]: true }, ...prevState.passwordHide],
 			}));
 		}
 	}
@@ -67,7 +67,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 	}
 
 	handlePasswordShow(id) {
-		const prevState = this.state.passwordShow;
+		const prevState = this.state.passwordHide;
 		const prevValue = prevState.find(obj => obj.id === id)[id];
 		const newState = prevState.map(obj => {
 			if (obj.id == id) {
@@ -79,7 +79,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				return obj;
 			}
 		});
-		this.setState({ passwordShow: newState });
+		this.setState({ passwordHide: newState });
 	}
 
 	styles() {
@@ -225,15 +225,15 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 		const decryptedItemsInfo = this.props.encryptionEnabled ? <Text style={this.styles().normalText}>{shared.decryptedStatText(this)}</Text> : null;
 
 		const mkComps = [];
-		const passwordShow = this.state.passwordShow;
+		const passwordHide = this.state.passwordHide;
 
 		const nonExistingMasterKeyIds = this.props.notLoadedMasterKeys.slice();
 
 		for (let i = 0; i < masterKeys.length; i++) {
 			const mk = masterKeys[i];
 
-			const showPasswordObj = passwordShow.find(obj => obj.id == mk.id);
-			const secureTextEntry = showPasswordObj ? showPasswordObj[mk.id] : true;
+			const hidePasswordObj = passwordHide.find(obj => obj.id == mk.id);
+			const secureTextEntry = hidePasswordObj ? hidePasswordObj[mk.id] : true;
 
 			mkComps.push(this.renderMasterKey(i + 1, mk,secureTextEntry));
 

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -10,7 +10,10 @@ const { themeStyle } = require('lib/components/global-style.js');
 const { time } = require('lib/time-utils.js');
 const shared = require('lib/components/shared/encryption-config-shared.js');
 const { dialogs } = require('lib/dialogs.js');
+const Icon = require('react-native-vector-icons/Ionicons').default;
 const DialogBox = require('react-native-dialogbox').default;
+
+Icon.loadFont();
 
 class EncryptionConfigScreenComponent extends BaseScreenComponent {
 	static navigationOptions() {
@@ -131,8 +134,13 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 					<Text style={{ flex: 0, fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{_('Password:')}</Text>
 					<TextInput selectionColor={theme.textSelectionColor} secureTextEntry={secureTextEntry} value={password} onChangeText={text => onPasswordChange(text)} style={inputStyle}></TextInput>
 					<Text style={{ fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{passwordOk}</Text>
-					<Button title={'👁️'} onPress={()=>this.handlePasswordShow(mk.id)}  ></Button>
-					<Text>  </Text>
+					<Icon
+						name="md-eye"
+						color='black'
+						raised
+						style={{ fontSize: 30, marginRight: 10 }}
+						onPress={()=>this.handlePasswordShow(mk.id)}
+					></Icon>
 					<Button title={_('Save')} onPress={() => onSaveClick()}></Button>
 				</View>
 			</View>

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -46,16 +46,6 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 	componentDidMount() {
 		this.isMounted_ = true;
 		shared.componentDidMount(this);
-
-		const masterKeys = this.props.masterKeys;
-
-		for (let i = 0; i < masterKeys.length; i++) {
-			const mk = masterKeys[i];
-
-			this.setState(prevState =>({
-				passwordHide: [{ id: mk.id, [mk.id]: true }, ...prevState.passwordHide],
-			}));
-		}
 	}
 
 	componentDidUpdate(prevProps) {
@@ -67,19 +57,12 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 	}
 
 	handlePasswordShow(id) {
-		const prevState = this.state.passwordHide;
-		const prevValue = prevState.find(obj => obj.id === id)[id];
-		const newState = prevState.map(obj => {
-			if (obj.id == id) {
-				return {
-					id: obj.id,
-					[id]: !prevValue,
-				};
-			} else {
-				return obj;
-			}
-		});
-		this.setState({ passwordHide: newState });
+		const showedID = this.state.passwordShowID;
+		if (id == showedID) {
+			this.setState({ passwordShowID: null });
+		} else {
+			this.setState({ passwordShowID: id });
+		}
 	}
 
 	styles() {
@@ -225,15 +208,13 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 		const decryptedItemsInfo = this.props.encryptionEnabled ? <Text style={this.styles().normalText}>{shared.decryptedStatText(this)}</Text> : null;
 
 		const mkComps = [];
-		const passwordHide = this.state.passwordHide;
 
 		const nonExistingMasterKeyIds = this.props.notLoadedMasterKeys.slice();
 
 		for (let i = 0; i < masterKeys.length; i++) {
 			const mk = masterKeys[i];
 
-			const hidePasswordObj = passwordHide.find(obj => obj.id == mk.id);
-			const secureTextEntry = hidePasswordObj ? hidePasswordObj[mk.id] : true;
+			const secureTextEntry = mk.id == this.state.passwordShowID ? false : true;
 
 			mkComps.push(this.renderMasterKey(i + 1, mk,secureTextEntry));
 

--- a/ReactNativeClient/lib/components/shared/encryption-config-shared.js
+++ b/ReactNativeClient/lib/components/shared/encryption-config-shared.js
@@ -14,6 +14,7 @@ shared.constructor = function(comp) {
 			encrypted: null,
 			total: null,
 		},
+		passwordShow: [],
 	};
 	comp.isMounted_ = false;
 

--- a/ReactNativeClient/lib/components/shared/encryption-config-shared.js
+++ b/ReactNativeClient/lib/components/shared/encryption-config-shared.js
@@ -14,7 +14,7 @@ shared.constructor = function(comp) {
 			encrypted: null,
 			total: null,
 		},
-		passwordHide: [],
+		passwordShowID: null,
 	};
 	comp.isMounted_ = false;
 

--- a/ReactNativeClient/lib/components/shared/encryption-config-shared.js
+++ b/ReactNativeClient/lib/components/shared/encryption-config-shared.js
@@ -14,7 +14,7 @@ shared.constructor = function(comp) {
 			encrypted: null,
 			total: null,
 		},
-		passwordShow: [],
+		passwordHide: [],
 	};
 	comp.isMounted_ = false;
 


### PR DESCRIPTION
In mobile,
I added an option to see the password for master keys, it was not here before. If anyone opens the encryption page the first time, all their passwords will be hidden, but they can choose to see it and edit it. It will be useful if a user adds a master key and forgets, now they can see their mastery and add it to other devices whenever needed. They don't need to make a new master key. And should I add this feature to the prompts where users are entering their master key first time ( enter and confirm password )? 
@PackElend  please label me. 

Inspiration was taken from the desktop version:
https://github.com/laurent22/joplin/pull/2789#issuecomment-600344003

![Screenshot_1584705512](https://user-images.githubusercontent.com/27751740/77161750-6cd71c00-6ad0-11ea-8d89-8d1be9176992.png)

