### PR TITLE
[Desktop] Fix inconsistency in viewer mode options

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -353,7 +353,6 @@ class Application extends BaseApplication {
 					Setting.setValue(`${type}.sortOrder.reverse`, !Setting.value(`${type}.sortOrder.reverse`));
 				},
 			});
-
 			return sortItems;
 		};
 
@@ -1188,7 +1187,7 @@ class Application extends BaseApplication {
 		const selectedNoteIds = state.selectedNoteIds;
 		const note = selectedNoteIds.length === 1 ? await Note.load(selectedNoteIds[0]) : null;
 
-		for (const itemId of ['copy', 'paste', 'cut', 'selectAll', 'bold', 'italic', 'link', 'code', 'insertDateTime', 'commandStartExternalEditing', 'showLocalSearch']) {
+		for (const itemId of ['paste', 'cut', 'bold', 'italic', 'link', 'code', 'insertDateTime']) {
 			const menuItem = Menu.getApplicationMenu().getMenuItemById(`edit:${itemId}`);
 			if (!menuItem) continue;
 			const isHtmlNote = !!note && note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML;


### PR DESCRIPTION
Fixes #2780 
Re-enabled options in the edit menu which user should be able to use in the viewer-only mode. Please let me know if I need to change something, as I did not get a response to my final proposed idea.
Since it's essentially the same fix, this also includes the fix for #2762 , which is open in #2765 
