### PR TITLE
[All / Desktop] Add pinned notes feature

### DIFF
--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -214,7 +214,8 @@ class NoteListComponent extends React.Component {
 			// https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
 			titleComp = <span dangerouslySetInnerHTML={{ __html: titleElement.outerHTML }}></span>;
 		} else {
-			titleComp = <span>{displayTitle}</span>;
+			const pinStyle = item.pinned ? { fontWeight: 'bold' } : {};
+			titleComp = <span style={pinStyle}>{displayTitle}</span>;
 		}
 
 		const watchedIconStyle = {
@@ -448,7 +449,7 @@ class NoteListComponent extends React.Component {
 					backgroundColor: theme.backgroundColor,
 					fontFamily: theme.fontFamily,
 				},
-				style
+				style,
 			);
 			emptyDivStyle.width = emptyDivStyle.width - padding * 2;
 			emptyDivStyle.height = emptyDivStyle.height - padding * 2;

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -214,7 +214,7 @@ class NoteListComponent extends React.Component {
 			// https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
 			titleComp = <span dangerouslySetInnerHTML={{ __html: titleElement.outerHTML }}></span>;
 		} else {
-			const pinStyle = item.pinned ? { fontWeight: 'bold' } : {};
+			const pinStyle = item.isPinned ? { fontWeight: 'bold' } : {};
 			titleComp = <span style={pinStyle}>{displayTitle}</span>;
 		}
 

--- a/ElectronClient/gui/utils/NoteListUtils.js
+++ b/ElectronClient/gui/utils/NoteListUtils.js
@@ -32,7 +32,7 @@ class NoteListUtils {
 							noteIds: noteIds,
 						});
 					},
-				})
+				}),
 			);
 
 			menu.append(
@@ -46,7 +46,7 @@ class NoteListUtils {
 							});
 						}
 					},
-				})
+				}),
 			);
 
 			if (props.watchedNoteFiles.indexOf(noteIds[0]) < 0) {
@@ -57,7 +57,7 @@ class NoteListUtils {
 						click: async () => {
 							this.startExternalEditing(noteIds[0]);
 						},
-					})
+					}),
 				);
 			} else {
 				menu.append(
@@ -67,7 +67,7 @@ class NoteListUtils {
 						click: async () => {
 							this.stopExternalEditing(noteIds[0]);
 						},
-					})
+					}),
 				);
 			}
 
@@ -82,7 +82,7 @@ class NoteListUtils {
 								eventManager.emit('noteTypeToggle', { noteId: note.id });
 							}
 						},
-					})
+					}),
 				);
 			} else {
 				const switchNoteType = async (noteIds, type) => {
@@ -101,7 +101,7 @@ class NoteListUtils {
 						click: async () => {
 							await switchNoteType(noteIds, 'note');
 						},
-					})
+					}),
 				);
 
 				menu.append(
@@ -110,7 +110,7 @@ class NoteListUtils {
 						click: async () => {
 							await switchNoteType(noteIds, 'todo');
 						},
-					})
+					}),
 				);
 			}
 
@@ -126,8 +126,21 @@ class NoteListUtils {
 						}
 						clipboard.writeText(links.join(' '));
 					},
-				})
+				}),
 			);
+
+			if (noteIds.length <= 1) {
+				menu.append(
+					new MenuItem({
+						label: _('Pin Item'),
+						click: async () => {
+							const newNote = await Note.load(noteIds[0]);
+							newNote.pinned = !newNote.pinned;
+							await Note.save(newNote);
+						},
+					}),
+				);
+			}
 
 			menu.append(
 				new MenuItem({
@@ -140,7 +153,7 @@ class NoteListUtils {
 							noteIds: noteIds.slice(),
 						});
 					},
-				})
+				}),
 			);
 
 			const exportMenu = new Menu();
@@ -158,7 +171,7 @@ class NoteListUtils {
 						click: async () => {
 							await InteropServiceHelper.export(props.dispatch.bind(this), module, { sourceNoteIds: noteIds });
 						},
-					})
+					}),
 				);
 			}
 
@@ -172,7 +185,7 @@ class NoteListUtils {
 							noteIds: noteIds,
 						});
 					},
-				})
+				}),
 			);
 
 			const exportMenuItem = new MenuItem({ label: _('Export'), submenu: exportMenu });
@@ -186,7 +199,7 @@ class NoteListUtils {
 				click: async () => {
 					await this.confirmDeleteNotes(noteIds);
 				},
-			})
+			}),
 		);
 
 		return menu;

--- a/ElectronClient/gui/utils/NoteListUtils.js
+++ b/ElectronClient/gui/utils/NoteListUtils.js
@@ -132,10 +132,10 @@ class NoteListUtils {
 			if (noteIds.length <= 1) {
 				menu.append(
 					new MenuItem({
-						label: _('Pin Item'),
+						label: _('Pin/Unpin note'),
 						click: async () => {
 							const newNote = await Note.load(noteIds[0]);
-							newNote.pinned = !newNote.pinned;
+							newNote.isPinned = !newNote.isPinned;
 							await Note.save(newNote);
 						},
 					}),

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -31,6 +31,7 @@ CREATE TABLE notes (
 	is_todo INT NOT NULL DEFAULT 0,
 	todo_due INT NOT NULL DEFAULT 0,
 	todo_completed INT NOT NULL DEFAULT 0,
+	pinned INT NOT NULL DEFAULT 0,
 	source TEXT NOT NULL DEFAULT "",
 	source_application TEXT NOT NULL DEFAULT "",
 	application_data TEXT NOT NULL DEFAULT "",

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -31,7 +31,6 @@ CREATE TABLE notes (
 	is_todo INT NOT NULL DEFAULT 0,
 	todo_due INT NOT NULL DEFAULT 0,
 	todo_completed INT NOT NULL DEFAULT 0,
-	pinned INT NOT NULL DEFAULT 0,
 	source TEXT NOT NULL DEFAULT "",
 	source_application TEXT NOT NULL DEFAULT "",
 	application_data TEXT NOT NULL DEFAULT "",
@@ -309,7 +308,7 @@ class JoplinDatabase extends Database {
 		// must be set in the synchronizer too.
 
 		// Note: v16 and v17 don't do anything. They were used to debug an issue.
-		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28];
+		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29];
 
 		let currentVersionIndex = existingDatabaseVersions.indexOf(fromVersion);
 
@@ -500,7 +499,7 @@ class JoplinDatabase extends Database {
 						encryption_cipher_text: 'TEXT NOT NULL DEFAULT ""',
 						encryption_applied: 'INT NOT NULL DEFAULT 0',
 						encryption_blob_encrypted: 'INT NOT NULL DEFAULT 0',
-					})
+					}),
 				);
 			}
 
@@ -675,6 +674,10 @@ class JoplinDatabase extends Database {
 
 			if (targetVersion == 28) {
 				queries.push('CREATE INDEX resources_size ON resources(size)');
+			}
+
+			if (targetVersion == 29) {
+				queries.push('ALTER TABLE notes ADD COLUMN isPinned INT NOT NULL DEFAULT 0');
 			}
 
 			queries.push({ sql: 'UPDATE version SET version = ?', params: [targetVersion] });

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -364,7 +364,8 @@ class Note extends BaseItem {
 			options.conditions.push('is_todo = 1');
 		}
 
-		return pinnedItems.concat(this.search(options));
+		const theRest = await this.search(options);
+		return pinnedItems.concat(theRest);
 	}
 
 	static preview(noteId, options = null) {

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -210,8 +210,8 @@ class Note extends BaseItem {
 			return uncompletedTodosOnTop && note.is_todo && !note.todo_completed;
 		};
 
-		const notePinned = note => {
-			return note.pinned;
+		const isPinned = note => {
+			return note.isPinned;
 		};
 
 		const noteFieldComp = (f1, f2) => {
@@ -239,8 +239,8 @@ class Note extends BaseItem {
 		return notes.sort((a, b) => {
 			if (noteOnTop(a) && !noteOnTop(b)) return -1;
 			if (!noteOnTop(a) && noteOnTop(b)) return +1;
-			if (notePinned(a) && !notePinned(b)) return -1;
-			if (!notePinned(a) && notePinned(b)) return +1;
+			if (isPinned(a) && !isPinned(b)) return -1;
+			if (!isPinned(a) && isPinned(b)) return +1;
 
 			let r = 0;
 
@@ -262,7 +262,7 @@ class Note extends BaseItem {
 
 	static previewFields() {
 		// return ['id', 'title', 'body', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
-		return ['id', 'title', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied', 'pinned'];
+		return ['id', 'title', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied', 'isPinned'];
 	}
 
 	static previewFieldsSql(fields = null) {
@@ -324,12 +324,9 @@ class Note extends BaseItem {
 			}
 		}
 
-		const cond = options.conditions.slice();
-		cond.push('pinned = 1');
-		const tempOptions = Object.assign({}, options);
-		tempOptions.conditions = cond;
+		const tempOptions = Object.assign({}, options, { conditions: [...options.conditions, 'isPinned = 1'] });
 		const pinnedItems = await this.search(tempOptions);
-		options.conditions.push('pinned = 0');
+		options.conditions.push('isPinned = 0');
 
 		if (!options.showCompletedTodos) {
 			options.conditions.push('todo_completed <= 0');
@@ -356,7 +353,6 @@ class Note extends BaseItem {
 			if ('limit' in tempOptions) tempOptions.limit -= uncompletedTodos.length;
 			const theRest = await this.search(tempOptions);
 
-			// return uncompletedTodos.concat(theRest);
 			return uncompletedTodos.concat(pinnedItems.concat(theRest));
 		}
 

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -381,7 +381,9 @@ class Note extends BaseItem {
 		if (options.bodyPattern) {
 			const pattern = options.bodyPattern.replace(/\*/g, '%');
 			options.conditions.push('body LIKE ?');
-			options.conditionsParams.push(pattern);
+			if (options.conditionsParams.indexOf(pattern) < 0) {
+				options.conditionsParams.push(pattern);
+			}
 		}
 
 		return super.search(options);


### PR DESCRIPTION
Fixes #296 

Notes can be marked as pinned from the context menu in the note list. Once pinned, they are displayed at the top of the notebook, sorted among themselves in the same order as rest of the notes. Pinned notes have lower priority than uncompleted todos (if that option is being used) i.e, the following order is followed:
* Uncompleted pinned todos
* Uncompleted unpinned todos
* Completed pinned todos and pinned notes
* Completed unpinned todos and unpinned notes

Items can be marked as pinned in the desktop client only (through context menu), and pinned items are displayed in bold in the notelist of desktop client. However, sorting is platform-independent

![ezgif com-optimize](https://user-images.githubusercontent.com/49116134/77250629-40a5d180-6c6f-11ea-8508-fa097a106659.gif)