### PR TITLE
Desktop: Fix katex formula render

### DIFF
--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
@@ -243,7 +243,7 @@ module.exports = function(context) {
 		const katexInline = function(latex) {
 			options.displayMode = false;
 			try {
-				return `<span class="joplin-editable"><pre class="joplin-source" data-joplin-source-open="$" data-joplin-source-close="$">${latex}</pre>${renderToStringWithCache(latex, options)}</span>`;
+				return renderToStringWithCache(latex, options);
 			} catch (error) {
 				console.error('Katex error for:', latex, error);
 				return latex;
@@ -258,7 +258,7 @@ module.exports = function(context) {
 		const katexBlock = function(latex) {
 			options.displayMode = true;
 			try {
-				return `<div class="joplin-editable"><pre class="joplin-source" data-joplin-source-open="$$&#10;" data-joplin-source-close="&#10;$$&#10;">${latex}</pre>${renderToStringWithCache(latex, options)}</div>`;
+				return renderToStringWithCache(latex, options);
 			} catch (error) {
 				console.error('Katex error for:', latex, error);
 				return latex;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Fixed #2811 

Joplin rendered formula source code.
Detailed comparison:

- Before:

<img width="727" alt="Screenshot 2020-03-22 at 15 30 18" src="https://user-images.githubusercontent.com/28362310/77250975-4346fd80-6c54-11ea-9a66-f5b718b53075.png">

- After:

![image](https://user-images.githubusercontent.com/28362310/77250984-5954be00-6c54-11ea-85ba-4c584d1eaf15.png)
