### PR TITLE
Mobile: fixed overlapping text in dropbox sync page

### DIFF
--- a/ReactNativeClient/lib/components/screens/dropbox-login.js
+++ b/ReactNativeClient/lib/components/screens/dropbox-login.js
@@ -33,6 +33,7 @@ class DropboxLoginScreenComponent extends BaseScreenComponent {
 		const styles = {
 			container: {
 				padding: theme.margin,
+				backgroundColor: theme.backgroundColor,
 			},
 			stepText: Object.assign({}, theme.normalText, { marginBottom: theme.margin }),
 			urlText: Object.assign({}, theme.urlText, { marginBottom: theme.margin }),


### PR DESCRIPTION
closes #2843 

I fixed the issue of text overlapping and added the case of the dropbox sync page in note list component. 
@PackElend  please label me.