### PR TITLE
Desktop: Added options to set default templates

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -601,11 +601,6 @@ class Application extends BaseApplication {
 				const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
 				Setting.setValue('availableTemplates', templates);
 
-				setTimeout(() => {
-					if (!templates.filter(i => i.value == Setting.value('defaultNote')).length) Setting.setValue('defaultNote', '0');
-					if (!templates.filter(i => i.value == Setting.value('defaultTodo')).length) Setting.setValue('defaultTodo', '0');
-				}, 2000);
-
 				this.store().dispatch({
 					type: 'TEMPLATE_UPDATE_ALL',
 					templates: templates,
@@ -1354,11 +1349,6 @@ class Application extends BaseApplication {
 
 		const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
 		Setting.setValue('availableTemplates', templates);
-
-		setTimeout(() => {
-			if (!templates.filter(i => i.value == Setting.value('defaultNote')).length) Setting.setValue('defaultNote', '0');
-			if (!templates.filter(i => i.value == Setting.value('defaultTodo')).length) Setting.setValue('defaultTodo', '0');
-		}, 2000);
 
 		this.store().dispatch({
 			type: 'TEMPLATE_UPDATE_ALL',

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -599,7 +599,13 @@ class Application extends BaseApplication {
 			label: _('Refresh templates'),
 			click: async () => {
 				const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
-				if (shim.isElectron()) Setting.setValue('availableTemplates', templates);
+				Setting.setValue('availableTemplates', templates);
+
+				setTimeout(() => {
+					if (!templates.filter(i => i.value == Setting.value('defaultNote')).length) Setting.setValue('defaultNote', '0');
+					if (!templates.filter(i => i.value == Setting.value('defaultTodo')).length) Setting.setValue('defaultTodo', '0');
+				}, 2000);
+
 				this.store().dispatch({
 					type: 'TEMPLATE_UPDATE_ALL',
 					templates: templates,
@@ -1347,7 +1353,12 @@ class Application extends BaseApplication {
 		});
 
 		const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
-		if (shim.isElectron()) Setting.setValue('availableTemplates', templates);
+		Setting.setValue('availableTemplates', templates);
+
+		setTimeout(() => {
+			if (!templates.filter(i => i.value == Setting.value('defaultNote')).length) Setting.setValue('defaultNote', '0');
+			if (!templates.filter(i => i.value == Setting.value('defaultTodo')).length) Setting.setValue('defaultTodo', '0');
+		}, 2000);
 
 		this.store().dispatch({
 			type: 'TEMPLATE_UPDATE_ALL',

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -599,8 +599,6 @@ class Application extends BaseApplication {
 			label: _('Refresh templates'),
 			click: async () => {
 				const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
-				Setting.setValue('availableTemplates', templates);
-
 				this.store().dispatch({
 					type: 'TEMPLATE_UPDATE_ALL',
 					templates: templates,
@@ -1348,7 +1346,6 @@ class Application extends BaseApplication {
 		});
 
 		const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
-		Setting.setValue('availableTemplates', templates);
 
 		this.store().dispatch({
 			type: 'TEMPLATE_UPDATE_ALL',

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -599,7 +599,7 @@ class Application extends BaseApplication {
 			label: _('Refresh templates'),
 			click: async () => {
 				const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
-
+				if (shim.isElectron()) Setting.setValue('availableTemplates', templates);
 				this.store().dispatch({
 					type: 'TEMPLATE_UPDATE_ALL',
 					templates: templates,
@@ -1347,6 +1347,7 @@ class Application extends BaseApplication {
 		});
 
 		const templates = await TemplateUtils.loadTemplates(Setting.value('templateDir'));
+		if (shim.isElectron()) Setting.setValue('availableTemplates', templates);
 
 		this.store().dispatch({
 			type: 'TEMPLATE_UPDATE_ALL',

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -100,14 +100,10 @@ class MainScreenComponent extends React.Component {
 			const folderId = Setting.value('activeFolderId');
 			if (!folderId) return;
 			if (!template) {
-				const templateType = isTodo ? 'defaultTodo' : 'defaultNote';
-				const settingsLabel = Setting.value(templateType);
-				if (settingsLabel != 0) {
-					const matchLabel = this.props.templates.find(i => i.label == settingsLabel);
-					if (!matchLabel) {
-						Setting.setValue(templateType, '0');
-					} else {
-						template = matchLabel.value;
+				const templateFileName = Setting.value(isTodo ? 'editor.defaultTodoTemplate' : 'editor.defaultNoteTemplate');
+				if (templateFileName) {
+					if (typeof(this.props.templates.find(i => i.label == templateFileName)) != 'undefined') {
+						template = this.props.templates.find(i => i.label == templateFileName).value;
 					}
 				}
 			}

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -100,10 +100,16 @@ class MainScreenComponent extends React.Component {
 			const folderId = Setting.value('activeFolderId');
 			if (!folderId) return;
 			if (!template) {
-				const templateDef = isTodo ? Setting.value('defaultTodo') : Setting.value('defaultNote');
-				if (templateDef != 0) template = templateDef;
+				const templateType = isTodo ? 'defaultTodo' : 'defaultNote';
+				const defaultTemplate = Setting.value(templateType);
+				if (defaultTemplate != 0) {
+					if (!this.props.templates.find(i => i.value == defaultTemplate)) {
+						Setting.setValue(templateType, '0');
+					} else {
+						template = defaultTemplate;
+					}
+				}
 			}
-
 			const body = template ? TemplateUtils.render(template) : '';
 
 			const newNote = await Note.save({

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -101,7 +101,7 @@ class MainScreenComponent extends React.Component {
 			if (!folderId) return;
 			if (!template) {
 				const templateDef = isTodo ? Setting.value('defaultTodo') : Setting.value('defaultNote');
-				if (templateDef != 0) template = Setting.value('availableTemplates')[templateDef - 1].value;
+				if ((templateDef != 0) && (templateDef <= Setting.value('availableTemplates').length)) template = Setting.value('availableTemplates')[templateDef - 1].value;
 			}
 
 			const body = template ? TemplateUtils.render(template) : '';

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -101,12 +101,13 @@ class MainScreenComponent extends React.Component {
 			if (!folderId) return;
 			if (!template) {
 				const templateType = isTodo ? 'defaultTodo' : 'defaultNote';
-				const defaultTemplate = Setting.value(templateType);
-				if (defaultTemplate != 0) {
-					if (!this.props.templates.find(i => i.value == defaultTemplate)) {
+				const settingsLabel = Setting.value(templateType);
+				if (settingsLabel != 0) {
+					const matchLabel = this.props.templates.find(i => i.label == settingsLabel);
+					if (!matchLabel) {
 						Setting.setValue(templateType, '0');
 					} else {
-						template = defaultTemplate;
+						template = matchLabel.value;
 					}
 				}
 			}

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -101,7 +101,7 @@ class MainScreenComponent extends React.Component {
 			if (!folderId) return;
 			if (!template) {
 				const templateDef = isTodo ? Setting.value('defaultTodo') : Setting.value('defaultNote');
-				if ((templateDef != 0) && (templateDef <= Setting.value('availableTemplates').length)) template = Setting.value('availableTemplates')[templateDef - 1].value;
+				if (templateDef != 0) template = templateDef;
 			}
 
 			const body = template ? TemplateUtils.render(template) : '';

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -99,6 +99,10 @@ class MainScreenComponent extends React.Component {
 		const createNewNote = async (template, isTodo) => {
 			const folderId = Setting.value('activeFolderId');
 			if (!folderId) return;
+			if (!template) {
+				const templateDef = isTodo ? Setting.value('defaultTodo') : Setting.value('defaultNote');
+				if (templateDef != 0) template = Setting.value('availableTemplates')[templateDef - 1].value;
+			}
 
 			const body = template ? TemplateUtils.render(template) : '';
 

--- a/ReactNativeClient/lib/TemplateUtils.js
+++ b/ReactNativeClient/lib/TemplateUtils.js
@@ -3,7 +3,7 @@ const { time } = require('lib/time-utils.js');
 const Mustache = require('mustache');
 
 const TemplateUtils = {};
-
+TemplateUtils.availableTemplates_ = [];
 
 // Mustache escapes strings (including /) with the html code by default
 // This isn't useful for markdown so it's disabled
@@ -62,7 +62,12 @@ TemplateUtils.loadTemplates = async function(filePath) {
 		});
 	}
 
+	TemplateUtils.availableTemplates_ = templates;
 	return templates;
+};
+
+TemplateUtils.availableTemplates = function() {
+	return TemplateUtils.availableTemplates_;
 };
 
 module.exports = TemplateUtils;

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -359,7 +359,7 @@ class Setting extends BaseModel {
 					const templates = Setting.value('availableTemplates');
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
-						options[i + 1] = templates[i].label;
+						options[templates[i].value] = templates[i].label;
 					}
 					return options;
 				},
@@ -376,7 +376,7 @@ class Setting extends BaseModel {
 					const templates = Setting.value('availableTemplates');
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
-						options[i + 1] = templates[i].label;
+						options[templates[i].value] = templates[i].label;
 					}
 					return options;
 				},

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -346,6 +346,41 @@ class Setting extends BaseModel {
 					};
 				},
 			},
+			availableTemplates: { value: [], type: Setting.TYPE_ARRAY, public: false, appTypes: ['desktop'] },
+			defaultNote: {
+				value: '0',
+				type: Setting.TYPE_STRING,
+				section: 'note',
+				isEnum: true,
+				public: true,
+				appTypes: ['desktop'],
+				label: () => _('Choose default template for new note:'),
+				options: () => {
+					const templates = Setting.value('availableTemplates');
+					const options = { 0: 'None' };
+					for (let i = 0; i < templates.length; i++) {
+						options[i + 1] = templates[i].label;
+					}
+					return options;
+				},
+			},
+			defaultTodo: {
+				value: '0',
+				type: Setting.TYPE_STRING,
+				section: 'note',
+				isEnum: true,
+				public: true,
+				appTypes: ['desktop'],
+				label: () => _('Choose default template for new todo:'),
+				options: () => {
+					const templates = Setting.value('availableTemplates');
+					const options = { 0: 'None' };
+					for (let i = 0; i < templates.length; i++) {
+						options[i + 1] = templates[i].label;
+					}
+					return options;
+				},
+			},
 
 			// Deprecated - use markdown.plugin.*
 			'markdown.softbreaks': { value: false, type: Setting.TYPE_BOOL, public: false, appTypes: ['mobile', 'desktop'] },

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -359,7 +359,7 @@ class Setting extends BaseModel {
 					const templates = Setting.value('availableTemplates');
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
-						options[templates[i].value] = templates[i].label;
+						options[templates[i].label] = templates[i].label;
 					}
 					return options;
 				},
@@ -376,7 +376,7 @@ class Setting extends BaseModel {
 					const templates = Setting.value('availableTemplates');
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
-						options[templates[i].value] = templates[i].label;
+						options[templates[i].label] = templates[i].label;
 					}
 					return options;
 				},

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -347,39 +347,25 @@ class Setting extends BaseModel {
 					};
 				},
 			},
-			defaultNote: {
-				value: '0',
+			'editor.defaultNoteTemplate': {
+				value: '',
 				type: Setting.TYPE_STRING,
 				section: 'note',
 				isEnum: true,
 				public: true,
 				appTypes: ['desktop'],
-				label: () => _('Choose default template for new note:'),
-				options: () => {
-					const templates = TemplateUtils.availableTemplates();
-					const options = { 0: 'None' };
-					for (let i = 0; i < templates.length; i++) {
-						options[templates[i].label] = templates[i].label;
-					}
-					return options;
-				},
+				label: () => _('New note default template:'),
+				options: () => Setting.defaultTemplateOptions(),
 			},
-			defaultTodo: {
-				value: '0',
+			'editor.defaultTodoTemplate': {
+				value: '',
 				type: Setting.TYPE_STRING,
 				section: 'note',
 				isEnum: true,
 				public: true,
 				appTypes: ['desktop'],
-				label: () => _('Choose default template for new todo:'),
-				options: () => {
-					const templates = TemplateUtils.availableTemplates();
-					const options = { 0: 'None' };
-					for (let i = 0; i < templates.length; i++) {
-						options[templates[i].label] = templates[i].label;
-					}
-					return options;
-				},
+				label: () => _('New to-do default template:'),
+				options: () => Setting.defaultTemplateOptions(),
 			},
 
 			// Deprecated - use markdown.plugin.*
@@ -1052,6 +1038,15 @@ class Setting extends BaseModel {
 		// Not translated for now because only used on Welcome notes (which are not translated)
 		if (name === 'cli') return 'CLI';
 		return name[0].toUpperCase() + name.substr(1).toLowerCase();
+	}
+
+	static defaultTemplateOptions() {
+		const templates = TemplateUtils.availableTemplates();
+		const options = { '': 'None' };
+		for (let i = 0; i < templates.length; i++) {
+			options[templates[i].label] = templates[i].label;
+		}
+		return options;
 	}
 }
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -8,6 +8,7 @@ const { toTitleCase } = require('lib/string-utils.js');
 const { rtrimSlashes } = require('lib/path-utils.js');
 const { _, supportedLocalesToLanguages, defaultLocale } = require('lib/locale.js');
 const { shim } = require('lib/shim');
+const TemplateUtils = require('lib/TemplateUtils');
 
 class Setting extends BaseModel {
 	static tableName() {
@@ -346,7 +347,6 @@ class Setting extends BaseModel {
 					};
 				},
 			},
-			availableTemplates: { value: [], type: Setting.TYPE_ARRAY, public: false, appTypes: ['desktop'] },
 			defaultNote: {
 				value: '0',
 				type: Setting.TYPE_STRING,
@@ -356,7 +356,7 @@ class Setting extends BaseModel {
 				appTypes: ['desktop'],
 				label: () => _('Choose default template for new note:'),
 				options: () => {
-					const templates = Setting.value('availableTemplates');
+					const templates = TemplateUtils.availableTemplates();
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
 						options[templates[i].label] = templates[i].label;
@@ -373,7 +373,7 @@ class Setting extends BaseModel {
 				appTypes: ['desktop'],
 				label: () => _('Choose default template for new todo:'),
 				options: () => {
-					const templates = Setting.value('availableTemplates');
+					const templates = TemplateUtils.availableTemplates();
 					const options = { 0: 'None' };
 					for (let i = 0; i < templates.length; i++) {
 						options[templates[i].label] = templates[i].label;


### PR DESCRIPTION
@CalebJohn Here it is.

- Added two new dropdowns under Settings -> Note. One for setting default note template, and one for default todo template. Options for both are read from templateDir and default option is None. Chosen templates appear as expected on ctrl+N and ctrl+T
- “File -> Templates -> New note from template” of course overrides this, so that item is still intact even if a default template is chosen. Inserting templates also works like before.
- The Setting.value(‘availableTemplates’) is only updated when shim.isElectron = True, and otherwise defaults to an empty array.

Known issues: 
- Default templates are read from Setting.value('availableTemplates')[optionnumber].value when creating new note/todo. If the current default template, or a template with lower index number than the current one gets deleted/moved from template folder and templates are refreshed, the wrong template will be read on New note. Maybe not a huge problem, but i think it would be cleaner if it defaulted back to "None" at least when current is deleted. Haven't found a good way to solve this yet. 

```
ζ npm run test -- --filter=Setting                                                              [897d9cc2] 

> joplin@1.0.161 test /home/jo/Workspace/js/johodh-joplin/CliClient
> gulp buildTests -L && jasmine --config=tests/support/jasmine.json "--filter=Setting"

Testing with sync target: memory
Randomized with seed 64661
Started
.


Ran 1 of 265 specs
1 spec, 0 failures
Finished in 0.162 seconds
Randomized with seed 64661 (jasmine --random=true --seed=64661)
```
