### PR TITLE
Desktop: Added Support for automatic dark/light theme switching

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -51,6 +51,8 @@ const appDefaultState = Object.assign({}, defaultState, {
 	watchedNoteFiles: [],
 	lastEditorScrollPercents: {},
 	devToolsVisible: false,
+	isdarkMode: false,
+
 });
 
 class Application extends BaseApplication {
@@ -118,6 +120,13 @@ class Application extends BaseApplication {
 					const command = Object.assign({}, action);
 					delete command.type;
 					newState.windowCommand = command.name ? command : null;
+				}
+				break;
+
+			case 'THEME_TOGGLE':
+				{
+					newState = Object.assign({}, state);
+					newState.isdarkMode = !state.isdarkMode;
 				}
 				break;
 
@@ -305,6 +314,24 @@ class Application extends BaseApplication {
 			this.updateMenuItemStates(newState);
 		}
 
+		if (['THEME_TOGGLE'].indexOf(action.type) >= 0) {
+			// check for Auto Detect option
+			if (Setting.value('themeAutoDetect')) {
+				// setting preferred theme
+				if (newState.isdarkMode) {
+					Setting.setValue('theme', Setting.value('preferredDarkTheme'));
+				} else {
+					Setting.setValue('theme', Setting.value('preferredLightTheme'));
+				}
+			} else {
+				// setting default Ligth & Dark theme
+				if (newState.isdarkMode) {
+					Setting.setValue('theme', Setting.THEME_DARK);
+				} else {
+					Setting.setValue('theme', Setting.THEME_LIGHT);
+				}
+			}
+		}
 		return result;
 	}
 

--- a/ElectronClient/bridge.js
+++ b/ElectronClient/bridge.js
@@ -1,6 +1,6 @@
 const { _, setLocale } = require('lib/locale.js');
 const { dirname } = require('lib/path-utils.js');
-const { BrowserWindow } = require('electron');
+const { BrowserWindow, nativeTheme } = require('electron');
 
 class Bridge {
 
@@ -9,6 +9,7 @@ class Bridge {
 		this.autoUpdateLogger_ = null;
 		this.lastSelectedPath_ = null;
 	}
+
 
 	electronApp() {
 		return this.electronWrapper_;
@@ -161,6 +162,11 @@ class Bridge {
 		return require('electron').screen;
 	}
 
+	// Detect system theme
+	systemTheme() {
+		return nativeTheme.shouldUseDarkColors; // return true for system dark theme
+	}
+
 }
 
 let bridge_ = null;
@@ -175,5 +181,6 @@ function bridge() {
 	if (!bridge_) throw new Error('Bridge not initialized');
 	return bridge_;
 }
+
 
 module.exports = { bridge, initBridge };

--- a/ElectronClient/gui/ConfigScreen.jsx
+++ b/ElectronClient/gui/ConfigScreen.jsx
@@ -19,6 +19,10 @@ class ConfigScreenComponent extends React.Component {
 
 		this.state.selectedSectionName = 'general';
 		this.state.screenName = '';
+		this.state.activeTheme = Setting.value('theme');
+		this.state.activePreferredDarkTheme = Setting.THEME_DARK;
+		this.state.activePreferredLightTheme = Setting.THEME_LIGHT;
+
 
 		this.checkSyncConfig_ = async () => {
 			await shared.checkSyncConfig(this, this.state.settings);
@@ -66,8 +70,8 @@ class ConfigScreenComponent extends React.Component {
 	}
 
 	screenFromName(screenName) {
-		if (screenName === 'encryption') return <EncryptionConfigScreen theme={this.props.theme}/>;
-		if (screenName === 'server') return <ClipperConfigScreen theme={this.props.theme}/>;
+		if (screenName === 'encryption') return <EncryptionConfigScreen theme={this.props.theme} />;
+		if (screenName === 'server') return <ClipperConfigScreen theme={this.props.theme} />;
 
 		throw new Error(`Invalid screen name: ${screenName}`);
 	}
@@ -270,8 +274,39 @@ class ConfigScreenComponent extends React.Component {
 			borderRadius: 4,
 		});
 
+		const toggleAutoDetect = (value) => {
+			this.setState({
+				activeTheme: Setting.value('theme'),
+				activePreferredDarkTheme: Setting.value('preferredDarkTheme'),
+				activePreferredLightTheme: Setting.value('preferredLightTheme'),
+			});
+
+			if (value == true) {
+
+				if (Setting.value('isDarkMode')) {
+					Setting.setValue('preferredDarkTheme', this.state.activePreferredDarkTheme); // setting theme for theme button
+					Setting.setValue('theme', this.state.activePreferredDarkTheme); // setting current theme to detected theme
+				} else {
+					Setting.setValue('preferredLightTheme', this.state.activePreferredLightTheme); // setting theme for theme button
+					Setting.setValue('theme', this.state.activePreferredLightTheme); // setting current theme to detected theme
+				}
+
+			} else {
+				Setting.setValue('theme', this.state.activeTheme);
+			}
+
+			// Setting Visiblity
+			const md = Setting.metadata_;
+			md.theme.public = !value;
+			md.preferredDarkTheme.public = value;
+			md.preferredLightTheme.public = value;
+		};
+
 		const updateSettingValue = (key, value) => {
 			// console.info(key + ' = ' + value);
+			if (key == 'themeAutoDetect') {
+				toggleAutoDetect(value);
+			}
 			return shared.updateSettingValue(this, key, value);
 		};
 
@@ -599,7 +634,7 @@ class ConfigScreenComponent extends React.Component {
 						<i style={theme.buttonIconStyle} className={'fa fa-chevron-left'}></i>
 						{hasChanges && !screenComp ? _('Cancel') : _('Back')}
 					</button>
-					{ !screenComp && (
+					{!screenComp && (
 						<div>
 							<button disabled={!hasChanges} onClick={() => { this.onSaveClick(); }} style={buttonStyleApprove}>{_('OK')}</button>
 							<button disabled={!hasChanges} onClick={() => { this.onApplyClick(); }} style={buttonStyleApprove}>{_('Apply')}</button>

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -75,6 +75,12 @@ class MainScreenComponent extends React.Component {
 		}
 	}
 
+	toggleTheme() {
+		this.props.dispatch({
+			type: 'THEME_TOGGLE',
+		});
+	}
+
 	toggleVisiblePanes() {
 		this.props.dispatch({
 			type: 'NOTE_VISIBLE_PANES_TOGGLE',
@@ -308,6 +314,8 @@ class MainScreenComponent extends React.Component {
 			this.toggleSidebar();
 		} else if (command.name === 'toggleNoteList') {
 			this.toggleNoteList();
+		} else if (command.name === 'toggleTheme') {
+			this.toggleTheme();
 		} else if (command.name === 'showModalMessage') {
 			this.setState({
 				modalLayer: {
@@ -626,6 +634,14 @@ class MainScreenComponent extends React.Component {
 			enabled: !!notes.length,
 			onClick: () => {
 				this.doCommand({ name: 'toggleVisiblePanes' });
+			},
+		});
+
+		headerItems.push({
+			title: _('Theme'),
+			iconName: 'fa-tint',
+			onClick: () => {
+				this.doCommand({ name: 'toggleTheme' });
 			},
 		});
 

--- a/ElectronClient/main-html.js
+++ b/ElectronClient/main-html.js
@@ -76,6 +76,7 @@ BaseItem.loadClass('Revision', Revision);
 
 Setting.setConstant('appId', 'net.cozic.joplin-desktop');
 Setting.setConstant('appType', 'desktop');
+Setting.setConstant('isDarkMode', bridge().systemTheme());
 
 shimInit();
 


### PR DESCRIPTION
Added a Auto Detect Checkbox enabling it will hide existing Theme drop down and change current theme to detected system theme (Dark or Light) and Preferred Light Theme & Preferred Dark Theme drop downs under Tools > Options > Appearance and will be visible based on Auto Detect option.

- Added Theme Toggle Button on home screen which toggle between Dark Theme & Light Theme also supports selected preferred themes from Tools > Options > Appearance, if Auto Detect Option is enabled.

- For detailed explanation I have made explanatory video [Joplin Theme Feature ](https://drive.google.com/file/d/1dJyaigWjWcIBvu0diap-Ss6t1D3Rpdwo/view?usp=sharing)
Please check it and suggest me if any changes needed.

Missing:

- Theme Toggle button remains same on toggling. I tried changing icon and label but didn't work! it remains same on toggling. Maybe it's not huge problem, but would be cool if it changes.

- We must need to restart Joplin to detect changes in system theme because system theme is detected by Electron and it detects the system theme on start. I tried but couldn't make it real time

Will try again to work on this bugs later.

 @PackElend label me please
I hope my commit satisfies all fixes needed for this issue.