### PR TITLE
Mobile: fixed text input when title of note is too large and closes #2873

### DIFF
--- a/ReactNativeClient/lib/components/note-item.js
+++ b/ReactNativeClient/lib/components/note-item.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const Component = React.Component;
 const { connect } = require('react-redux');
-const { Text, TouchableOpacity, View, StyleSheet } = require('react-native');
+const { Text, TouchableOpacity, View, StyleSheet, Dimensions } = require('react-native');
 const { Checkbox } = require('lib/components/checkbox.js');
 const Note = require('lib/models/Note.js');
 const { time } = require('lib/time-utils.js');
@@ -105,6 +105,17 @@ class NoteItemComponent extends Component {
 
 	render() {
 		const note = this.props.note ? this.props.note : {};
+
+		// this is to show only limited characters of title on note-list according to screen size
+		// the number 2 which is used to divide the height is here by testing screen sizes in different
+		// screen sizes emulator
+
+		const height = Dimensions.get('window').height;
+		const allowedLength = Math.round(height / 2);
+		if (note.title && note.title.length > allowedLength) {
+			note.title = `${note.title.substr(0,allowedLength)}...`;
+		}
+
 		const isTodo = !!Number(note.is_todo);
 
 		const theme = themeStyle(this.props.theme);

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const { ScrollView, Platform, Clipboard, Keyboard, View, TextInput, StyleSheet, Linking, Image, Share } = require('react-native');
+const { ScrollView, Platform, Clipboard, Keyboard, View, TextInput, StyleSheet, Linking, Image, Share, Dimensions } = require('react-native');
 const { connect } = require('react-redux');
 const { uuid } = require('lib/uuid.js');
 const { MarkdownEditor } = require('../../../MarkdownEditor/index.js');
@@ -758,7 +758,13 @@ class NoteScreenComponent extends BaseScreenComponent {
 	titleTextInput_contentSizeChange(event) {
 		if (!this.enableMultilineTitle_) return;
 
-		const height = event.nativeEvent.contentSize.height;
+		let height = event.nativeEvent.contentSize.height;
+
+		// this is to limit the size of text input, so that it can't cover full screen
+		const heightOfDevice = Dimensions.get('window').height;
+		const allowedLength = Math.round(heightOfDevice / 6);
+		height = height > allowedLength ? allowedLength : height;
+
 		this.setState({ titleTextInputHeight: height });
 	}
 


### PR DESCRIPTION
closes #2873 
I fixed the max height to 100 so that it doesn't cover the full screen. And in the note-list screen, if the title is more than 100 characters, only the first 100 characters are shown and then '......' will be added.

users can still scroll to see their hidden titles.

@PackElend  please label me.
![Screenshot_1584984659](https://user-images.githubusercontent.com/27751740/77345479-ae7af780-6d5a-11ea-9766-4edc84b47229.png)
![Screenshot_1584984656](https://user-images.githubusercontent.com/27751740/77345481-b044bb00-6d5a-11ea-9c22-35bf2bfa9150.png)
