### PR TITLE
Mobile: fixed css error in code block in oled theme in mobiles and closes #2859

### DIFF
--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -149,7 +149,7 @@ function themeStyle(theme) {
 		output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
 		output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
 
-		output.codeThemeCss = 'hljs-atom-one-dark-reasonable.css';
+		output.codeThemeCss = 'atom-one-dark-reasonable.css';
 
 		output.colorUrl = '#7B81FF';
 


### PR DESCRIPTION
closes #2859 

@PackElend  please label me
New Images:

![Screenshot_1584989778](https://user-images.githubusercontent.com/27751740/77352959-1aaf2880-6d66-11ea-8aed-f2c6f37457d9.png)
![Screenshot_1584989774](https://user-images.githubusercontent.com/27751740/77352969-1daa1900-6d66-11ea-903c-b746c35c2400.png)
