### PR TITLE
Mobile: Fixed notebook text overflow

### DIFF
--- a/ReactNativeClient/lib/components/screen-header.js
+++ b/ReactNativeClient/lib/components/screen-header.js
@@ -409,7 +409,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 				);
 			} else {
 				const title = 'title' in this.props && this.props.title !== null ? this.props.title : '';
-				return <Text numberOfLines={1} style={this.styles().titleText}>{title}</Text>;
+				return <Text ellipsizeMode={'tail'} numberOfLines={1} style={this.styles().titleText}>{title}</Text>;
 			}
 		};
 

--- a/ReactNativeClient/lib/components/screen-header.js
+++ b/ReactNativeClient/lib/components/screen-header.js
@@ -409,7 +409,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 				);
 			} else {
 				const title = 'title' in this.props && this.props.title !== null ? this.props.title : '';
-				return <Text style={this.styles().titleText}>{title}</Text>;
+				return <Text numberOfLines={1} style={this.styles().titleText}>{title}</Text>;
 			}
 		};
 


### PR DESCRIPTION
closes #2875 
I fixed the issue and now only the limited characters of the title are shown, which is the ideal case.
@PackElend  please label my PR.
![Screenshot_1584993002](https://user-images.githubusercontent.com/27751740/77357896-ec821680-6d6e-11ea-9d32-c19424f00aab.png)
