### PR TITLE
Desktop: Added "Open containing directory" right-click context item for resources

### DIFF
--- a/ElectronClient/bridge.js
+++ b/ElectronClient/bridge.js
@@ -140,6 +140,10 @@ class Bridge {
 		return require('electron').MenuItem;
 	}
 
+	showItemInFolder(fullPath) {
+		require('electron').shell.showItemInFolder(fullPath);
+	}
+
 	openExternal(url) {
 		return require('electron').shell.openExternal(url);
 	}

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -791,7 +791,7 @@ class NoteTextComponent extends React.Component {
 
 				menu.append(
 					new MenuItem({
-						label: _('Open containing directory'),
+						label: _('Reveal file in folder'),
 						click: async () => {
 							bridge().showItemInFolder(resourcePath);
 						},

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -791,6 +791,15 @@ class NoteTextComponent extends React.Component {
 
 				menu.append(
 					new MenuItem({
+						label: _('Open containing directory'),
+						click: async () => {
+							bridge().showItemInFolder(resourcePath);
+						},
+					})
+				);
+
+				menu.append(
+					new MenuItem({
 						label: _('Save as...'),
 						click: async () => {
 							const filePath = bridge().showSaveDialog({


### PR DESCRIPTION
Added a "Open containing directory" context menu item to the right-click context menu for resource links and images in notes.

![context-menu](https://user-images.githubusercontent.com/5730052/77363425-9dc28580-6d4a-11ea-921b-b69a989e4bad.png)

This should open the resources directory using the system's file manager and select the file if it's supported for the platform/desktop manager.

This PR is with regards to https://discourse.joplinapp.org/t/desktop-native-open-with-dialog-for-opening-resources-from-a-note/7186. Feel free to reject or make suggestions if it would be better implemented in another way, I chose the easy option :)