### PR TITLE
[Desktop] Add option to preview note body in note list

### DIFF
--- a/CliClient/tests/test-utils.js
+++ b/CliClient/tests/test-utils.js
@@ -138,6 +138,7 @@ async function switchClient(id) {
 
 	currentClient_ = id;
 	BaseModel.setDb(databases_[id]);
+	KvStore.instance().setDb(databases_[id]);
 
 	BaseItem.encryptionService_ = encryptionServices_[id];
 	Resource.encryptionService_ = encryptionServices_[id];
@@ -191,6 +192,7 @@ async function setupDatabase(id = null) {
 
 	if (databases_[id]) {
 		BaseModel.setDb(databases_[id]);
+		KvStore.instance().setDb(databases_[id]);
 		await clearDatabase(id);
 		await Setting.load();
 		if (!Setting.value('clientId')) Setting.setValue('clientId', uuid.create());

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -51,6 +51,7 @@ const appDefaultState = Object.assign({}, defaultState, {
 	watchedNoteFiles: [],
 	lastEditorScrollPercents: {},
 	devToolsVisible: false,
+	noteListStyle: '',
 });
 
 class Application extends BaseApplication {
@@ -230,6 +231,11 @@ class Application extends BaseApplication {
 			case 'NOTE_DEVTOOLS_SET':
 				newState = Object.assign({}, state);
 				newState.devToolsVisible = action.value;
+				break;
+
+			case 'NOTE_LIST_STYLE_SET':
+				newState = Object.assign({}, state);
+				newState.noteListStyle = action.value;
 				break;
 
 			}
@@ -980,6 +986,41 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
+					label: _('Note list display style'),
+					screens: ['Main'],
+					submenu: [{
+						id: 'view:title',
+						label: _('Title'),
+						screens: ['Main'],
+						type: 'checkbox',
+						checked: Setting.value('noteListStyle') == 'title',
+						click: () => {
+							this.dispatch({
+								type: 'NOTE_LIST_STYLE_SET',
+								value: 'title',
+							});
+							Menu.getApplicationMenu().getMenuItemById('view:snippet').checked = false;
+							Setting.setValue('noteListStyle', 'title');
+							console.log(Setting.value('noteListStyle'));
+						},
+					}, {
+						id: 'view:snippet',
+						label: _('Snippet'),
+						screens: ['Main'],
+						type: 'checkbox',
+						checked: Setting.value('noteListStyle') == 'snippet',
+						click: () => {
+							this.dispatch({
+								type: 'NOTE_LIST_STYLE_SET',
+								value: 'snippet',
+							});
+							Menu.getApplicationMenu().getMenuItemById('view:title').checked = false;
+							Setting.setValue('noteListStyle', 'snippet');
+							console.log(Setting.value('noteListStyle'));
+						},
+					},
+					],
+				}, {
 					type: 'separator',
 					screens: ['Main'],
 				}, {
@@ -1327,6 +1368,11 @@ class Application extends BaseApplication {
 		this.dispatch({
 			type: 'MASTERKEY_UPDATE_ALL',
 			items: masterKeys,
+		});
+
+		this.dispatch({
+			type: 'NOTE_LIST_STYLE_SET',
+			value: Setting.value('noteListStyle'),
 		});
 
 		this.store().dispatch({

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -32,7 +32,7 @@ class NoteListComponent extends React.Component {
 		if (this.props.listStyle === 'title') {
 			itemHeight = 32;
 		} else if (this.props.listStyle === 'snippet') {
-			itemHeight = 84;
+			itemHeight = 70;
 		}
 
 		// Note: max-width is used to specifically prevent horizontal scrolling on Linux when the scrollbar is present in the note list.
@@ -191,7 +191,8 @@ class NoteListComponent extends React.Component {
 		if (item.is_todo && !!item.todo_completed) listItemTitleStyle = Object.assign(listItemTitleStyle, this.style().listItemTitleCompleted);
 
 		const displayTitle = Note.displayTitle(item);
-		const displayBody = item.body;
+		const displayBody = Note.displayPreview(item);
+		// const displayBody = item.body;
 		let titleComp = null;
 
 		if (highlightedWords.length) {
@@ -221,7 +222,7 @@ class NoteListComponent extends React.Component {
 
 			titleComp = <span dangerouslySetInnerHTML={{ __html: titleElement.outerHTML }}></span>;
 		} else {
-			if (this.props.listStyle === 'title') {
+			if (this.props.listStyle === 'title' || !displayBody) {
 				titleComp = <span>{displayTitle}</span>;
 			} else if (this.props.listStyle === 'snippet') {
 				const myHeadingStyle = {
@@ -235,8 +236,7 @@ class NoteListComponent extends React.Component {
 					textAlign: 'justify',
 					whiteSpace: 'normal',
 					overflow: 'hidden',
-					margin: 0,
-					padding: '1em 0',
+					margin: '0.5em 0',
 					paddingRight: '1em',
 				};
 				titleComp = (

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -191,8 +191,7 @@ class NoteListComponent extends React.Component {
 		if (item.is_todo && !!item.todo_completed) listItemTitleStyle = Object.assign(listItemTitleStyle, this.style().listItemTitleCompleted);
 
 		const displayTitle = Note.displayTitle(item);
-		const displayBody = Note.displayPreview(item);
-		// const displayBody = item.body;
+		const displayBody = Note.defaultTitleFromBody(Note.displayPreview(item));
 		let titleComp = null;
 
 		if (highlightedWords.length) {

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -28,7 +28,12 @@ class NoteListComponent extends React.Component {
 	style() {
 		const theme = themeStyle(this.props.theme);
 
-		const itemHeight = 34;
+		let itemHeight = 0;
+		if (this.props.listStyle === 'title') {
+			itemHeight = 32;
+		} else if (this.props.listStyle === 'snippet') {
+			itemHeight = 84;
+		}
 
 		// Note: max-width is used to specifically prevent horizontal scrolling on Linux when the scrollbar is present in the note list.
 		// Pull request: https://github.com/laurent22/joplin/pull/2062
@@ -186,6 +191,7 @@ class NoteListComponent extends React.Component {
 		if (item.is_todo && !!item.todo_completed) listItemTitleStyle = Object.assign(listItemTitleStyle, this.style().listItemTitleCompleted);
 
 		const displayTitle = Note.displayTitle(item);
+		const displayBody = item.body;
 		let titleComp = null;
 
 		if (highlightedWords.length) {
@@ -212,9 +218,34 @@ class NoteListComponent extends React.Component {
 			// with `textContent` so it cannot contain any XSS attacks. We use this feature because
 			// mark.js can only deal with DOM elements.
 			// https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+
 			titleComp = <span dangerouslySetInnerHTML={{ __html: titleElement.outerHTML }}></span>;
 		} else {
-			titleComp = <span>{displayTitle}</span>;
+			if (this.props.listStyle === 'title') {
+				titleComp = <span>{displayTitle}</span>;
+			} else if (this.props.listStyle === 'snippet') {
+				const myHeadingStyle = {
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					margin: 0,
+					flex: 1,
+				};
+				const myParagraphStyle = {
+					flex: 2,
+					textAlign: 'justify',
+					whiteSpace: 'normal',
+					overflow: 'hidden',
+					margin: 0,
+					padding: '1em 0',
+					paddingRight: '1em',
+				};
+				titleComp = (
+					<div style={{ width: '100%', height: '80%', display: 'flex', flexDirection: 'column' }}>
+						<h4 style={myHeadingStyle}>{displayTitle}</h4>
+						<p style={myParagraphStyle}>{displayBody}</p>
+					</div>
+				);
+			}
 		}
 
 		const watchedIconStyle = {
@@ -470,6 +501,7 @@ const mapStateToProps = state => {
 		watchedNoteFiles: state.watchedNoteFiles,
 		windowCommand: state.windowCommand,
 		provisionalNoteIds: state.provisionalNoteIds,
+		listStyle: state.noteListStyle,
 	};
 };
 

--- a/ElectronClient/gui/NoteList.jsx
+++ b/ElectronClient/gui/NoteList.jsx
@@ -116,6 +116,16 @@ class NoteListComponent extends React.Component {
 					id: item.id,
 				});
 			} else {
+				if (this.props.selectedNoteIds.length == 1) {
+					const noteId = this.props.selectedNoteIds[0];
+					this.props.dispatch({
+						type: 'NOTE_UPDATE_ONE',
+						note: {
+							id: noteId,
+							preview: await Note.getUpdatedPreview(noteId),
+						},
+					});
+				}
 				this.props.dispatch({
 					type: 'NOTE_SELECT',
 					id: item.id,
@@ -191,7 +201,7 @@ class NoteListComponent extends React.Component {
 		if (item.is_todo && !!item.todo_completed) listItemTitleStyle = Object.assign(listItemTitleStyle, this.style().listItemTitleCompleted);
 
 		const displayTitle = Note.displayTitle(item);
-		const displayBody = Note.defaultTitleFromBody(Note.displayPreview(item));
+		const displayBody = Note.displayPreview(item);
 		let titleComp = null;
 
 		if (highlightedWords.length) {

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -2132,7 +2132,7 @@ class NoteTextComponent extends React.Component {
 				};
 				this.webviewRef_.current.wrappedInstance.send('setHtml', html, options);
 				this.lastSetHtml_ = html;
-				if (this.state.note) {
+				if (this.state.note && KvStore.instance().db()) {
 					KvStore.instance().setValue(this.state.note.id, Note.previewFromHtml(html));
 				}
 			}

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -41,6 +41,7 @@ const NoteTextViewer = require('./NoteTextViewer.min');
 const NoteRevisionViewer = require('./NoteRevisionViewer.min');
 const TemplateUtils = require('lib/TemplateUtils');
 const markupLanguageUtils = require('lib/markupLanguageUtils');
+const KvStore = require('lib/services/KvStore');
 
 require('brace/mode/markdown');
 // https://ace.c9.io/build/kitchen-sink.html
@@ -2131,6 +2132,9 @@ class NoteTextComponent extends React.Component {
 				};
 				this.webviewRef_.current.wrappedInstance.send('setHtml', html, options);
 				this.lastSetHtml_ = html;
+				if (this.state.note) {
+					KvStore.instance().setValue(this.state.note.id, Note.previewFromHtml(html));
+				}
 			}
 
 			let keywords = [];

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -2132,7 +2132,7 @@ class NoteTextComponent extends React.Component {
 				};
 				this.webviewRef_.current.wrappedInstance.send('setHtml', html, options);
 				this.lastSetHtml_ = html;
-				if (this.state.note && KvStore.instance().db()) {
+				if (this.state.note && KvStore.instance().db_) {
 					KvStore.instance().setValue(this.state.note.id, Note.previewFromHtml(html));
 				}
 			}

--- a/ReactNativeClient/lib/BaseModel.js
+++ b/ReactNativeClient/lib/BaseModel.js
@@ -230,6 +230,7 @@ class BaseModel {
 	static async search(options = null) {
 		if (!options) options = {};
 		if (!options.fields) options.fields = '*';
+		if (!options.unescapedFields) options.unescapedFields = '';
 
 		const conditions = options.conditions ? options.conditions.slice(0) : [];
 		const params = options.conditionsParams ? options.conditionsParams.slice(0) : [];
@@ -242,7 +243,7 @@ class BaseModel {
 
 		if ('limit' in options && options.limit <= 0) return [];
 
-		let sql = `SELECT ${this.db().escapeFields(options.fields)} FROM \`${this.tableName()}\``;
+		let sql = `SELECT ${this.db().escapeFields(options.fields) + options.unescapedFields} FROM \`${this.tableName()}\``;
 		if (conditions.length) sql += ` WHERE ${conditions.join(' AND ')}`;
 
 		const query = this.applySqlOptions(options, sql, params);

--- a/ReactNativeClient/lib/BaseModel.js
+++ b/ReactNativeClient/lib/BaseModel.js
@@ -230,7 +230,6 @@ class BaseModel {
 	static async search(options = null) {
 		if (!options) options = {};
 		if (!options.fields) options.fields = '*';
-		if (!options.unescapedFields) options.unescapedFields = '';
 
 		const conditions = options.conditions ? options.conditions.slice(0) : [];
 		const params = options.conditionsParams ? options.conditionsParams.slice(0) : [];
@@ -243,7 +242,7 @@ class BaseModel {
 
 		if ('limit' in options && options.limit <= 0) return [];
 
-		let sql = `SELECT ${this.db().escapeFields(options.fields) + options.unescapedFields} FROM \`${this.tableName()}\``;
+		let sql = `SELECT ${this.db().escapeFields(options.fields)} FROM \`${this.tableName()}\``;
 		if (conditions.length) sql += ` WHERE ${conditions.join(' AND ')}`;
 
 		const query = this.applySqlOptions(options, sql, params);

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -710,7 +710,7 @@ class BaseItem extends BaseModel {
 	static displayPreview(item) {
 		if (!item || !item.preview) return '';
 		if (item.encryption_applied) return `🔑 ${_('Encrypted')}`;
-		return item.preview.length == 80 ? (`${item.preview} ...`) : item.preview;
+		return item.preview;
 	}
 
 	static async markAllNonEncryptedForSync() {

--- a/ReactNativeClient/lib/models/BaseItem.js
+++ b/ReactNativeClient/lib/models/BaseItem.js
@@ -707,6 +707,12 @@ class BaseItem extends BaseModel {
 		return item.title ? item.title : _('Untitled');
 	}
 
+	static displayPreview(item) {
+		if (!item || !item.preview) return '';
+		if (item.encryption_applied) return `🔑 ${_('Encrypted')}`;
+		return item.preview.length == 80 ? (`${item.preview} ...`) : item.preview;
+	}
+
 	static async markAllNonEncryptedForSync() {
 		const classNames = this.encryptableItemClassNames();
 

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -267,20 +267,11 @@ class Note extends BaseItem {
 		return ['id', 'title', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
 	}
 
-	static unescapedPreviewFields() {
-		return ['substr(body,1,120) as preview'];
-	}
-
 	static previewFieldsSql(fields = null) {
 		if (fields === null) fields = this.previewFields();
 		return this.db()
 			.escapeFields(fields)
 			.join(',');
-	}
-
-	static unescapedPreviewFieldsSql(fields = null) {
-		if (fields === null) fields = this.unescapedPreviewFields();
-		return `,${fields.join(',')}`;
 	}
 
 	static async loadFolderNoteByField(folderId, field, value) {
@@ -305,7 +296,6 @@ class Note extends BaseItem {
 		if (!options.conditions) options.conditions = [];
 		if (!options.conditionsParams) options.conditionsParams = [];
 		if (!options.fields) options.fields = this.previewFields();
-		if (!options.unescapedFields) options.unescapedFields = this.unescapedPreviewFieldsSql();
 		if (!options.uncompletedTodosOnTop) options.uncompletedTodosOnTop = false;
 		if (!('showCompletedTodos' in options)) options.showCompletedTodos = true;
 

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -587,12 +587,14 @@ class Note extends BaseItem {
 
 		const preview = await KvStore.instance().value(originalNote.id);
 		const savedNote = await this.save(newNote);
-		KvStore.instance().setValue(savedNote.id, preview);
-		savedNote.preview = preview;
-		this.dispatch({
-			type: 'NOTE_UPDATE_ONE',
-			note: savedNote,
-		});
+		if (preview) {
+			KvStore.instance().setValue(savedNote.id, preview);
+			savedNote.preview = preview;
+			this.dispatch({
+				type: 'NOTE_UPDATE_ONE',
+				note: savedNote,
+			});
+		}
 
 		return savedNote;
 	}

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -289,7 +289,8 @@ class Note extends BaseItem {
 	}
 
 	static async getUpdatedPreview(noteId) {
-		return await KvStore.instance().value(noteId);
+		const preview = KvStore.instance().db() ? await KvStore.instance().value(noteId) : '';
+		return preview;
 	}
 
 	static previewFromHtml(html) {
@@ -371,7 +372,7 @@ class Note extends BaseItem {
 			const items = uncompletedTodos.concat(theRest);
 
 			for (const item of items) {
-				item.preview = await KvStore.instance().value(item.id);
+				item.preview = KvStore.instance().db() ? await KvStore.instance().value(item.id) : '';
 			}
 
 			return items;
@@ -388,7 +389,7 @@ class Note extends BaseItem {
 		const items = await this.search(options);
 
 		for (const item of items) {
-			item.preview = await KvStore.instance().value(item.id);
+			item.preview = KvStore.instance().db() ? await KvStore.instance().value(item.id) : '';
 		}
 		return items;
 	}

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -289,7 +289,7 @@ class Note extends BaseItem {
 	}
 
 	static async getUpdatedPreview(noteId) {
-		const preview = KvStore.instance().db() ? await KvStore.instance().value(noteId) : '';
+		const preview = KvStore.instance().db_ ? await KvStore.instance().value(noteId) : '';
 		return preview;
 	}
 
@@ -372,7 +372,7 @@ class Note extends BaseItem {
 			const items = uncompletedTodos.concat(theRest);
 
 			for (const item of items) {
-				item.preview = KvStore.instance().db() ? await KvStore.instance().value(item.id) : '';
+				item.preview = KvStore.instance().db_ ? await KvStore.instance().value(item.id) : '';
 			}
 
 			return items;
@@ -389,7 +389,7 @@ class Note extends BaseItem {
 		const items = await this.search(options);
 
 		for (const item of items) {
-			item.preview = KvStore.instance().db() ? await KvStore.instance().value(item.id) : '';
+			item.preview = KvStore.instance().db_ ? await KvStore.instance().value(item.id) : '';
 		}
 		return items;
 	}

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -663,6 +663,8 @@ class Note extends BaseItem {
 					type: 'NOTE_DELETE',
 					id: id,
 				});
+
+				KvStore.instance().deleteValue(id);
 			}
 		}
 	}

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -263,8 +263,8 @@ class Note extends BaseItem {
 	}
 
 	static previewFields() {
-		// return ['id', 'title', 'body', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
-		return ['id', 'title', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
+		return ['id', 'title', 'body', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
+		// return ['id', 'title', 'is_todo', 'todo_completed', 'parent_id', 'updated_time', 'user_updated_time', 'user_created_time', 'encryption_applied'];
 	}
 
 	static previewFieldsSql(fields = null) {

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -295,7 +295,7 @@ class Note extends BaseItem {
 	static previewFromHtml(html) {
 		if (!html) return;
 		const tempElement = document.createElement('div');
-		tempElement.innerHtml = html;
+		tempElement.innerHTML = html;
 		const paragraphs = tempElement.getElementsByTagName('p');
 		let preview = '';
 		for (let i = 0; i < paragraphs.length && preview.length < 100; i++) {

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -585,7 +585,16 @@ class Note extends BaseItem {
 			newNote.title = title;
 		}
 
-		return this.save(newNote);
+		const preview = await KvStore.instance().value(originalNote.id);
+		const savedNote = await this.save(newNote);
+		KvStore.instance().setValue(savedNote.id, preview);
+		savedNote.preview = preview;
+		this.dispatch({
+			type: 'NOTE_UPDATE_ONE',
+			note: savedNote,
+		});
+
+		return savedNote;
 	}
 
 	static async noteIsOlderThan(noteId, date) {

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -368,8 +368,13 @@ class Note extends BaseItem {
 			tempOptions.conditions = cond;
 			if ('limit' in tempOptions) tempOptions.limit -= uncompletedTodos.length;
 			const theRest = await this.search(tempOptions);
+			const items = uncompletedTodos.concat(theRest);
 
-			return uncompletedTodos.concat(theRest);
+			for (const item of items) {
+				item.preview = await KvStore.instance().value(item.id);
+			}
+
+			return items;
 		}
 
 		if (hasNotes && hasTodos) {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -623,6 +623,13 @@ class Setting extends BaseModel {
 				maximum: 300,
 				step: 10,
 			},
+
+			noteListStyle: {
+				value: 'title',
+				type: Setting.TYPE_STRING,
+				public: false,
+				appTypes: ['desktop'],
+			},
 		};
 
 		return this.metadata_;


### PR DESCRIPTION
Fixes #1494 (and as per the forum discussion [here](https://discourse.joplinapp.org/t/include-some-of-note-body-in-note-list/3874))
Adds a snippet from note body, generated by taking the first 100 characters from paragraph tags in the rendered HTML and caching that. Also adds an option in the "View" menu to toggle this option. 
Things to work on:
- [x] Copy preview from cache when note is duplicated (instead of regenerating it)
- [ ] Extract text from other types of tags (?)
- [ ] Add updated date to snippet (?)

Screenshot:
![snippetPR](https://user-images.githubusercontent.com/49116134/77393419-01889500-6dc3-11ea-903f-3dc0dc4f98f8.png)
