### PR TITLE
[Mobile] Added code to change status bar colour to match background colour on android

### DIFF
--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -24,6 +24,8 @@ const globalStyle = {
 	raisedColor: '#003363',
 	raisedHighlightedColor: '#ffffff',
 
+	barStyle: 'dark-content',
+
 	warningBackgroundColor: '#FFD08D',
 
 	// For WebView - must correspond to the properties above
@@ -139,6 +141,8 @@ function themeStyle(theme) {
 		output.raisedColor = '#788BC3';
 		output.raisedHighlightedColor = '#ffffff';
 
+		output.barStyle = 'light-content';
+
 		output.htmlColor = 'rgb(220,220,220)';
 		output.htmlBackgroundColor = 'rgb(0,0,0)';
 		output.htmlLinkColor = 'rgb(166,166,255)';
@@ -169,6 +173,8 @@ function themeStyle(theme) {
 	output.raisedBackgroundColor = '#0F2051';
 	output.raisedColor = '#788BC3';
 	output.raisedHighlightedColor = '#ffffff';
+
+	output.barStyle = 'light-content';
 
 	output.htmlColor = 'rgb(220,220,220)';
 	output.htmlBackgroundColor = 'rgb(29,32,36)';

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -751,7 +751,7 @@ class AppComponent extends React.Component {
 					});
 				}}
 			>
-				<StatusBar barStyle="dark-content" />
+				<StatusBar barStyle={theme.barStyle} backgroundColor={theme.backgroundColor} />
 				<MenuContext style={{ flex: 1 }}>
 					<SafeAreaView style={{ flex: 1 }}>
 						<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

This change makes the status bar colour the same as the background colour of the current theme. It also changes the colour of the icons to either dark or light to contrast with the background colour (see screenshots below).

This is untested on iOS. But as far as I'm aware, default behaviour on iOS should match this functionality (the background colour, not the icon colour, which is controlled by the changes I made).

More information here: https://discourse.joplinapp.org/t/android-change-status-bar-colour-to-match-theme-or-option-to-hide-it/7231/7

Before:
![BeforeStatusBarjpg](https://user-images.githubusercontent.com/9134591/77450264-efbae800-6dea-11ea-98f9-46e7db77add3.jpg)

After:
![StatusBarBackground](https://user-images.githubusercontent.com/9134591/77434770-43243a80-6dd9-11ea-9dd3-1c241664af97.png)
