### PR TITLE
Update macOS troubleshooting for IOS build 

### DIFF
--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -21,13 +21,6 @@ If you get a node-gyp related error, you might need to manually install it: `npm
 
 If you get the error `libtool: unrecognized option '-static'`, follow the instructions [in this post](https://stackoverflow.com/a/38552393/561309) to use the correct libtool version.
 
-If you there is an error `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` run following commands:
-
-    cd ios
-    pod deintegrate
-    pod install
-
-
 ## Other issues
 
 > The application window doesn't open or is white

--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -21,6 +21,13 @@ If you get a node-gyp related error, you might need to manually install it: `npm
 
 If you get the error `libtool: unrecognized option '-static'`, follow the instructions [in this post](https://stackoverflow.com/a/38552393/561309) to use the correct libtool version.
 
+If you there is an error `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` run following commands:
+
+    cd ios
+    pod deintegrate
+    pod install
+
+
 ## Other issues
 
 > The application window doesn't open or is white

--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -21,15 +21,15 @@ If you get a node-gyp related error, you might need to manually install it: `npm
 
 If you get the error `libtool: unrecognized option '-static'`, follow the instructions [in this post](https://stackoverflow.com/a/38552393/561309) to use the correct libtool version.
 
-#Mobile application
+# Mobile application
 
-##IOS
-If you there is an error `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` run following commands:
+## iOS
+
+If you there is an error `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` run the following commands:
 
     cd ios
     pod deintegrate
     pod install
-
 
 ## Other issues
 

--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -21,6 +21,16 @@ If you get a node-gyp related error, you might need to manually install it: `npm
 
 If you get the error `libtool: unrecognized option '-static'`, follow the instructions [in this post](https://stackoverflow.com/a/38552393/561309) to use the correct libtool version.
 
+#Mobile application
+
+##IOS
+If you there is an error `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` run following commands:
+
+    cd ios
+    pod deintegrate
+    pod install
+
+
 ## Other issues
 
 > The application window doesn't open or is white


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Building React native app on macOS caused error : `/joplin/ReactNativeClient/ios/Pods/Target Support Files/Pods-Joplin/Pods-Joplin.debug.xcconfig: unable to open file (in target "Joplin" in project "Joplin") (in target 'Joplin' from project 'Joplin')` for me so I decided to update the troubleshooting section with the fix if someone else would be stuck.