### PR TITLE
CLI: Fixed identical elements in the search history

### DIFF
--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -755,7 +755,8 @@ const reducer = (state = defaultState, action) => {
 		case 'SEARCH_ADD':
 			{
 				newState = Object.assign({}, state);
-				const searches = newState.searches.slice();
+				let searches = newState.searches.slice();
+        searches = searches.filter(s => s.title !== action.search.title);
 				searches.push(action.search);
 				newState.searches = searches;
 			}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md





-->

**Description:** When searching the same keyword again, duplicate element adds to the search history.

**Before**  
![b](https://user-images.githubusercontent.com/31123054/77551179-3b998a00-6edc-11ea-9468-bd82d882e0ac.png)  
**After**
![a](https://user-images.githubusercontent.com/31123054/77551492-9df28a80-6edc-11ea-9f87-901feba51e8c.png)
