### PR TITLE
Desktop: Disable ok button at empty input

### DIFF
--- a/ElectronClient/gui/PromptDialog.jsx
+++ b/ElectronClient/gui/PromptDialog.jsx
@@ -232,7 +232,7 @@ class PromptDialog extends React.Component {
 		const buttonComps = [];
 		if (buttonTypes.indexOf('ok') >= 0) {
 			buttonComps.push(
-				<button key="ok" style={styles.button} onClick={() => onClose(true, 'ok')}>
+				<button key="ok" disabled={!this.state.answer} style={styles.button} onClick={() => onClose(true, 'ok')}>
 					{_('OK')}
 				</button>
 			);


### PR DESCRIPTION

fixes #2799 and more such issue. 

## Explaination
This pull request changes the state of `ok` button to disabled in the `PromptDialog.jsx` whenever the input value in the dialog box is null or empty and i have tested this feature in various cases (New Notebook, Inserting a template) in which it disables the 'ok' button and the screenshots, GIF are shown below.

## Screenshots and GIFs
### Before 
- New Notebook 
![image](https://user-images.githubusercontent.com/35633575/77556619-c2e7fd00-6ede-11ea-8e08-aeb361e9b75b.png)

- Insert Template
![image](https://user-images.githubusercontent.com/35633575/77556686-d4c9a000-6ede-11ea-9be5-ef0f948612fb.png)

***

### After
- New Notebook
![image](https://user-images.githubusercontent.com/35633575/77556866-08a4c580-6edf-11ea-939c-13c9d916144f.png)
 **after adding title**
![image](https://user-images.githubusercontent.com/35633575/77556937-1f4b1c80-6edf-11ea-8bfc-5ad1045c701d.png)

- Insert Template
![image](https://user-images.githubusercontent.com/35633575/77556984-2ffb9280-6edf-11ea-9b3d-8c0a2a0d8cc3.png)

