### PR TITLE
Removed overlapping on dropbox sync screen.

### DIFF
--- a/ReactNativeClient/lib/components/screens/dropbox-login.js
+++ b/ReactNativeClient/lib/components/screens/dropbox-login.js
@@ -45,8 +45,13 @@ class DropboxLoginScreenComponent extends BaseScreenComponent {
 
 	render() {
 		const theme = themeStyle(this.props.theme);
+		const rootStyle = {
+			flex: 1,
+			backgroundColor: theme.backgroundColor,
+		};
 
 		return (
+			<View style={rootStyle}>
 			<View style={this.styles().screen}>
 				<ScreenHeader title={_('Login with Dropbox')} />
 


### PR DESCRIPTION
whenever we create a new notebook and save it and go to synchronize dropbox it was overlapping
check this video(BUG):-https://drive.google.com/file/d/1oYvXIt2LHHjQqqGH0MNCJwRWkFZiT0AX/view?usp=sharing

After solving bug:-https://drive.google.com/file/d/1gGbTH9fii6un0wpdrlXSppgHgXpnOlt8/view?usp=sharing

I changed this using view style as a  root style which is correct way and easy to understand in code as same thing is in tag screen code.
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
