### PR TITLE
Mobile: fixed the issue of export path text not visible in dark theme

### DIFF
--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -217,6 +217,9 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				color: theme.color,
 				flex: 1,
 			},
+			textInput: {
+				color: theme.color,
+			},
 		};
 
 		styles.settingContainerNoBottomBorder = Object.assign({}, styles.settingContainer, {
@@ -450,7 +453,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				const profileExportPrompt = (
 					<View style={this.styles().settingContainer}>
 						<Text style={this.styles().settingText}>Path:</Text>
-						<TextInput style={{ paddingRight: 20 }} onChange={(event) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard"></TextInput>
+						<TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard"></TextInput>
 						<Button title="OK" onPress={this.exportProfileButtonPress2_}></Button>
 					</View>
 				);


### PR DESCRIPTION
In mobile: 
Export profile path text field's text is not visible in the dark theme, because it was set to black color.
Before:
![Annotation 2020-03-26 085649](https://user-images.githubusercontent.com/27751740/77607768-5b16ce00-6f41-11ea-813f-dad2520ef728.png)

After:
![Annotation 2020-03-26 090909](https://user-images.githubusercontent.com/27751740/77607808-78e43300-6f41-11ea-8d17-d1e530d29311.png)

@PackElend  please label my PR.
