### PR TITLE
Added text hint for tag screen

### DIFF
--- a/ReactNativeClient/lib/components/screens/tags.js
+++ b/ReactNativeClient/lib/components/screens/tags.js
@@ -27,9 +27,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 
 	styles() {
 		if (this.styles_) return this.styles_;
-
 		const theme = themeStyle(this.props.theme);
-
 		this.styles_ = StyleSheet.create({
 			listItem: {
 				flexDirection: 'row',
@@ -40,6 +38,15 @@ class TagsScreenComponent extends BaseScreenComponent {
 				paddingRight: theme.marginRight,
 				paddingTop: theme.itemMarginTop,
 				paddingBottom: theme.itemMarginBottom,
+			},
+			AddTagMessage: {
+				paddingLeft: theme.marginLeft,
+				paddingRight: theme.marginRight,
+				paddingTop: theme.marginTop,
+				paddingBottom: theme.marginBottom,
+				fontSize: theme.fontSize,
+				color: theme.color,
+				textAlign: 'center',
 			},
 			listItemText: {
 				flex: 1,
@@ -89,8 +96,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 	}
 
 	render() {
-		const theme = themeStyle(this.props.theme);
-
+		const theme = themeStyle(this.props.theme); 
 		const rootStyle = {
 			flex: 1,
 			backgroundColor: theme.backgroundColor,
@@ -99,6 +105,7 @@ class TagsScreenComponent extends BaseScreenComponent {
 		return (
 			<View style={rootStyle}>
 				<ScreenHeader title={_('Tags')} parentComponent={this} showSearchButton={false} />
+				<Text style={this.styles().AddTagMessage}>{'Create a tag by going on notes and clicking on options'}</Text>
 				<FlatList style={{ flex: 1 }} data={this.state.tags} renderItem={this.tagList_renderItem} keyExtractor={this.tagList_keyExtractor} />
 			</View>
 		);


### PR DESCRIPTION
Before adding his I asked out on the community and members liked it.
There is a text hint on the notebook screen about “how to create a note” but not on tag screen so I added a hint

Text hint on Tag page:-
![tag](https://user-images.githubusercontent.com/34892772/77765356-28b1c180-7064-11ea-9b76-dc3d4d0675dd.PNG)

After adding a Tag:-
![tagadd](https://user-images.githubusercontent.com/34892772/77765399-38c9a100-7064-11ea-8811-ab0f9ae3a647.PNG)


<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
