### PR TITLE
Desktop: (Linux) fixed regex in install script that parses tag_name

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -102,7 +102,7 @@ fi
 
 #-----------------------------------------------------
 print "Checking latest version..."
-RELEASE_VERSION=$(wget -qO - "https://api.github.com/repos/laurent22/joplin/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
+RELEASE_VERSION=$(wget -qO - "https://api.github.com/repos/laurent22/joplin/releases/latest" | grep -Po '"tag_name":\s*"v\K.*?(?=")')
 
 # Check if it's in the latest version
 if [[ -e ~/.joplin/VERSION ]] && [[ $(< ~/.joplin/VERSION) == "${RELEASE_VERSION}" ]]; then


### PR DESCRIPTION
The script `Joplin_install_and_update.sh` downloads [JSON data](https://api.github.com/repos/laurent22/joplin/releases/latest) to check the latest version tag. In version v1.0.195, the relevant part of the JSON stream is `"tag_name":"v1.0.195"`. The regular expression used in `Joplin_install_and_update.sh` to parse the tag value is `"tag_name": "v\K.*?(?=")`, i. e. a blank after the colon is expected.

On my Debian system, the failing regex match stops the script, so neither part of the following if statement is entered and the script stops with output `Checking latest version...`

I made the regular expression more flexible so it accepts whitespaces between the JSON tag name and its value.

To avoid confusion: When clicking above link to the JSON data in the browser, there are whitespaces. But of course the script uses

`wget -qO - "https://api.github.com/repos/laurent22/joplin/releases/latest"`

to download the JSON data. There are no linefeeds or whitespaces.