### PR TITLE
Mobile: Added functionality of adding due dates for todos and sorting on their basis

### DIFF
--- a/ReactNativeClient/lib/components/select-date-time-dialog.js
+++ b/ReactNativeClient/lib/components/select-date-time-dialog.js
@@ -64,16 +64,32 @@ class SelectDateTimeDialog extends React.PureComponent {
 	render() {
 		const clearAlarmText = _('Clear alarm'); // For unknown reasons, this particular string doesn't get translated if it's directly in the text property below
 
-		const popupActions = [
+		// these are the popup actions which will be used for alarm time popup
+
+		const popupActionsForAlarm = [
 			<DialogButton text={_('Save alarm')} align="center" onPress={() => this.onAccept()} key="saveButton" />,
 			<DialogButton text={clearAlarmText} align="center" onPress={() => this.onClear()} key="clearButton" />,
 			<DialogButton text={_('Cancel')} align="center" onPress={() => this.onReject()} key="cancelButton" />,
 		];
 
+		// these are the popup actions which will be used for due date (expire date of todos) popup
+
+		const popupActionsForDueDate = [
+			<DialogButton text={_('Set Due Date')} align="center" onPress={() => this.onAccept()} key="saveButton" />,
+			<DialogButton text={_('Clear Due Date')} align="center" onPress={() => this.onClear()} key="clearButton" />,
+			<DialogButton text={_('Cancel')} align="center" onPress={() => this.onReject()} key="cancelButton" />,
+		];
+
+		const type = this.props.type;
+
+		const popupActions = type === 'alarm' ? popupActionsForAlarm : popupActionsForDueDate;
+
+		const title = type === 'alarm' ? _('Set alarm') : _('Set due date');
+
 		return (
 			<PopupDialog
 				ref={(dialog) => { this.dialog_ = dialog; }}
-				dialogTitle={<DialogTitle title={_('Set alarm')} />}
+				dialogTitle={<DialogTitle title={title} />}
 				actions={popupActions}
 				dismissOnTouchOutside={false}
 				width={0.9}

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -4,6 +4,9 @@ const { sprintf } = require('sprintf-js');
 const Resource = require('lib/models/Resource');
 const { shim } = require('lib/shim.js');
 
+// todo_due is due time of alarms in notes and due_date is for their
+// expire. It is used to sort them on the basis of their expire date
+
 const structureSql = `
 CREATE TABLE folders (
 	id TEXT PRIMARY KEY,
@@ -34,7 +37,8 @@ CREATE TABLE notes (
 	source TEXT NOT NULL DEFAULT "",
 	source_application TEXT NOT NULL DEFAULT "",
 	application_data TEXT NOT NULL DEFAULT "",
-	\`order\` INT NOT NULL DEFAULT 0
+	\`order\` INT NOT NULL DEFAULT 0,
+	due_date INT DEFAULT 0
 );
 
 CREATE INDEX notes_title ON notes (title);

--- a/ReactNativeClient/lib/joplin-database.js
+++ b/ReactNativeClient/lib/joplin-database.js
@@ -37,8 +37,7 @@ CREATE TABLE notes (
 	source TEXT NOT NULL DEFAULT "",
 	source_application TEXT NOT NULL DEFAULT "",
 	application_data TEXT NOT NULL DEFAULT "",
-	\`order\` INT NOT NULL DEFAULT 0,
-	due_date INT DEFAULT 0
+	\`order\` INT NOT NULL DEFAULT 0
 );
 
 CREATE INDEX notes_title ON notes (title);
@@ -312,7 +311,7 @@ class JoplinDatabase extends Database {
 		// must be set in the synchronizer too.
 
 		// Note: v16 and v17 don't do anything. They were used to debug an issue.
-		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28];
+		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,29];
 
 		let currentVersionIndex = existingDatabaseVersions.indexOf(fromVersion);
 
@@ -678,6 +677,10 @@ class JoplinDatabase extends Database {
 
 			if (targetVersion == 28) {
 				queries.push('CREATE INDEX resources_size ON resources(size)');
+			}
+
+			if (targetVersion == 29) {
+				queries.push('ALTER TABLE notes ADD COLUMN `due_date` INT DEFAULT 0');
 			}
 
 			queries.push({ sql: 'UPDATE version SET version = ?', params: [targetVersion] });

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -322,7 +322,7 @@ class Note extends BaseItem {
 		// is used to sort already loaded notes.
 
 		if (!options) options = {};
-		if (!('order' in options)) options.order = [{ by: 'user_updated_time', dir: 'DESC' }, { by: 'user_created_time', dir: 'DESC' }, { by: 'title', dir: 'DESC' }, { by: 'id', dir: 'DESC' }, { by: 'due_date', dir: 'DESC' }];
+		if (!('order' in options)) options.order = [{ by: 'user_updated_time', dir: 'DESC' }, { by: 'user_created_time', dir: 'DESC' }, { by: 'title', dir: 'DESC' }, { by: 'id', dir: 'DESC' }];
 		if (!options.conditions) options.conditions = [];
 		if (!options.conditionsParams) options.conditionsParams = [];
 		if (!options.fields) options.fields = this.previewFields();

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -258,7 +258,11 @@ class Note extends BaseItem {
 				if (!a.todo_completed && b.todo_completed) return -1;
 
 				// in all incomplete todos, the one with due dates set by user have to be on top
-				if (dueDateSet(a) && dueDateSet(b)) return new Date(a.due_date) - new Date(b.due_date);
+				if (res.dir == 'ASC') {
+					if (dueDateSet(a) && dueDateSet(b)) return new Date(a.due_date) - new Date(b.due_date);
+				} else {
+					if (dueDateSet(a) && dueDateSet(b)) return new Date(b.due_date) - new Date(a.due_date);
+				}
 
 				// if one note has due date set and one hasn't, then the one with due date will be on top
 				if (dueDateSet(a) && !dueDateSet(b)) return -1;

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -365,7 +365,7 @@ class Note extends BaseItem {
 
 		// these will be cases to sort on basis of due_date:
 		// 1 incomplete todos with less due date will be on top
-		// 2 incomplete todos with more due date afterwards
+		// 2 incomplete todos with more due date afterwards and then incomplete todos with no due dates.
 		// 3 completes todos with less due date
 		// 4 complete todos with more due date
 		// 5 complete todos with no due dates

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -280,7 +280,7 @@ class Setting extends BaseModel {
 				label: () => _('Sort notes by'),
 				options: () => {
 					const Note = require('lib/models/Note');
-					const noteSortFields = ['user_updated_time', 'user_created_time', 'title'];
+					const noteSortFields = ['user_updated_time', 'user_created_time', 'title','due_date'];
 					const options = {};
 					for (let i = 0; i < noteSortFields.length; i++) {
 						options[noteSortFields[i]] = toTitleCase(Note.fieldToLabel(noteSortFields[i]));

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -571,6 +571,7 @@ const reducer = (state = defaultState, action) => {
 				newNotes = Note.sortNotes(newNotes, stateUtils.notesOrder(state.settings), newState.settings.uncompletedTodosOnTop);
 				newState = Object.assign({}, state);
 				newState.notes = newNotes;
+
 				if (noteFolderHasChanged) {
 					let newIndex = movedNotePreviousIndex;
 					if (newIndex >= newNotes.length) newIndex = newNotes.length - 1;

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -571,7 +571,6 @@ const reducer = (state = defaultState, action) => {
 				newNotes = Note.sortNotes(newNotes, stateUtils.notesOrder(state.settings), newState.settings.uncompletedTodosOnTop);
 				newState = Object.assign({}, state);
 				newState.notes = newNotes;
-
 				if (noteFolderHasChanged) {
 					let newIndex = movedNotePreviousIndex;
 					if (newIndex >= newNotes.length) newIndex = newNotes.length - 1;

--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -706,6 +706,7 @@ class Synchronizer {
 							// Let's leave these two lines for 6 months, by which time all the clients should have been synced.
 							if (!content.user_updated_time) content.user_updated_time = content.updated_time;
 							if (!content.user_created_time) content.user_created_time = content.created_time;
+							if (!content.due_date) content.due_date = 0;
 
 							const options = {
 								autoTimestamp: false,


### PR DESCRIPTION
I have added an option to add due dates for todos, which is like their expire date and time. And using that I am giving users the option to sort them.

The sorting mechanism I used for notes is:
1. incomplete todos with a less due date will be on top
2. incomplete todos with more due date afterward and then incomplete todos with no due dates.
3. completes todos with a less due date
4. complete todos with the more due date
5. complete todos with no due dates
6. notes ( sorted on their updated time, created time, id )

For this, I have added a new column in the notes table, **due_date**, which can be used further to add this feature in desktop also.

**For more info about this feature and the users who want this:**
[Discourse Link of Feature Request with GSoC-2020 label](https://discourse.joplinapp.org/t/feature-request-todo-expiration-dates-for-sorting)

**Link for release apk of Joplin with this feature**
https://drive.google.com/file/d/10q_Z04aeHSFbaCCdu-i5L34P2MOO94aJ/view

Here is the working of this feature:

![sort_due_date_last](https://user-images.githubusercontent.com/27751740/77865251-0928bd80-724b-11ea-91ff-b0f726644837.gif)
