### PR TITLE
Desktop: Close `Goto Anything` modal on outside click

### DIFF
--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -48,7 +48,7 @@ class Dialog extends React.PureComponent {
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.input_onChange = this.input_onChange.bind(this);
 		this.input_onKeyDown = this.input_onKeyDown.bind(this);
-		this.modalClose = this.modalClose.bind(this);
+		this.modalLayer_onClick = this.dialogModalLayer_onClick.bind(this);
 		this.listItemRenderer = this.listItemRenderer.bind(this);
 		this.listItem_onClick = this.listItem_onClick.bind(this);
 		this.helpButton_onClick = this.helpButton_onClick.bind(this);
@@ -115,7 +115,7 @@ class Dialog extends React.PureComponent {
 		}
 	}
 
-	modalClose() {
+	modalLayer_onClick() {
 		this.props.dispatch({
 			pluginName: PLUGIN_NAME,
 			type: 'PLUGIN_DIALOG_SET',
@@ -394,7 +394,7 @@ class Dialog extends React.PureComponent {
 		const helpComp = !this.state.showHelp ? null : <div style={style.help}>{_('Type a note title to jump to it. Or type # followed by a tag name, or @ followed by a notebook name, or / followed by note content.')}</div>;
 
 		return (
-			<div onClick={this.modalClose} style={theme.dialogModalLayer}>
+			<div onClick={this.modalLayer_onClick} style={theme.dialogModalLayer}>
 				<div style={style.dialogBox}>
 					{helpComp}
 					<div style={style.inputHelpWrapper}>

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -48,6 +48,7 @@ class Dialog extends React.PureComponent {
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.input_onChange = this.input_onChange.bind(this);
 		this.input_onKeyDown = this.input_onKeyDown.bind(this);
+		this.modalClose = this.modalClose.bind(this);
 		this.listItemRenderer = this.listItemRenderer.bind(this);
 		this.listItem_onClick = this.listItem_onClick.bind(this);
 		this.helpButton_onClick = this.helpButton_onClick.bind(this);
@@ -112,6 +113,14 @@ class Dialog extends React.PureComponent {
 				open: false,
 			});
 		}
+	}
+
+	modalClose() {
+		this.props.dispatch({
+			pluginName: PLUGIN_NAME,
+			type: 'PLUGIN_DIALOG_SET',
+			open: false,
+		});
 	}
 
 	helpButton_onClick() {
@@ -385,7 +394,7 @@ class Dialog extends React.PureComponent {
 		const helpComp = !this.state.showHelp ? null : <div style={style.help}>{_('Type a note title to jump to it. Or type # followed by a tag name, or @ followed by a notebook name, or / followed by note content.')}</div>;
 
 		return (
-			<div style={theme.dialogModalLayer}>
+			<div onClick={this.modalClose} style={theme.dialogModalLayer}>
 				<div style={style.dialogBox}>
 					{helpComp}
 					<div style={style.inputHelpWrapper}>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Issue fixed [Closing of Goto Anything modal](https://discourse.joplinapp.org/t/closing-of-modal-when-clicked-outside-of-it/7480/7)
![Screen-Recording-2020-03-30-at-1 (1)](https://user-images.githubusercontent.com/35633575/77923933-b8ec4280-72c0-11ea-9cac-a5ab507b7ac3.gif)

