### PR TITLE
Desktop: Fix Linux install script to add support for non-default home dir

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -168,7 +168,7 @@ then
 
     # On some systems this directory doesn't exist by default
     mkdir -p ~/.local/share/applications
-    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=/home/${USER}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#${APPIMAGE_VERSION}" >> ~/.local/share/applications/appimagekit-joplin.desktop
+    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#${APPIMAGE_VERSION}" >> ~/.local/share/applications/appimagekit-joplin.desktop
     # Update application icons
     [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications
     print "${COLOR_GREEN}OK${COLOR_RESET}"


### PR DESCRIPTION
If user home directory is configured to anything other than `/home/${USER}`, `Exec` command in desktop entry points to non-existing file and desktop entry is not considered valid, thus does not appear in list of application. Standard way to get home directory is using `${HOME}` environment variable. This could also be possible root cause of https://discourse.joplinapp.org/t/joplin-not-installing-completely/5669/2

<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
