### PR TITLE
Desktop: Change Toolbar Layout

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1675,20 +1675,6 @@ class NoteTextComponent extends React.Component {
 
 	createToolbarItems(note, editorIsVisible) {
 		const toolbarItems = [];
-		if (note && this.state.folder && ['Search', 'Tag', 'SmartFilter'].includes(this.props.notesParentType)) {
-			toolbarItems.push({
-				title: _('In: %s', substrWithEllipsis(this.state.folder.title, 0, 16)),
-				iconName: 'fa-book',
-				onClick: () => {
-					this.props.dispatch({
-						type: 'FOLDER_AND_NOTE_SELECT',
-						folderId: this.state.folder.id,
-						noteId: note.id,
-					});
-					Folder.expandTree(this.props.folders, this.state.folder.parent_id);
-				},
-			});
-		}
 
 		toolbarItems.push({
 			tooltip: _('Back'),
@@ -1723,6 +1709,29 @@ class NoteTextComponent extends React.Component {
 				});
 			},
 		});
+
+		toolbarItems.push({
+			type: 'separator',
+		});
+
+		if (note && this.state.folder && ['Search', 'Tag', 'SmartFilter'].includes(this.props.notesParentType)) {
+			toolbarItems.push({
+				title: _('In: %s', substrWithEllipsis(this.state.folder.title, 0, 16)),
+				iconName: 'fa-book',
+				onClick: () => {
+					this.props.dispatch({
+						type: 'FOLDER_AND_NOTE_SELECT',
+						folderId: this.state.folder.id,
+						noteId: note.id,
+					});
+					Folder.expandTree(this.props.folders, this.state.folder.parent_id);
+				},
+			});
+
+			toolbarItems.push({
+				type: 'separator',
+			});
+		}
 
 		if (note.markup_language === MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN && editorIsVisible) {
 			toolbarItems.push({
@@ -1767,10 +1776,6 @@ class NoteTextComponent extends React.Component {
 				onClick: () => {
 					return this.commandAttachFile();
 				},
-			});
-
-			toolbarItems.push({
-				type: 'separator',
 			});
 
 			toolbarItems.push({
@@ -1821,9 +1826,11 @@ class NoteTextComponent extends React.Component {
 				},
 			});
 
-			toolbarItems.push({
-				type: 'separator',
-			});
+			for (let i = 0; i < 3; i++) {
+				toolbarItems.push({
+					type: 'separator',
+				});
+			}
 		}
 
 		if (note && this.props.watchedNoteFiles.indexOf(note.id) >= 0) {
@@ -1870,8 +1877,24 @@ class NoteTextComponent extends React.Component {
 		}
 
 		toolbarItems.push({
+			tooltip: _('Content Properties'),
+			iconName: 'fa-sticky-note',
+			onClick: () => {
+				this.props.dispatch({
+					type: 'WINDOW_COMMAND',
+					name: 'commandContentProperties',
+					text: this.state.note.body,
+				});
+			},
+		});
+
+		toolbarItems.push({
 			tooltip: _('Note properties'),
 			iconName: 'fa-info-circle',
+			style: {
+				marginLeft: 'auto',
+				marginRight: '5px',
+			},
 			onClick: () => {
 				const n = this.state.note;
 				if (!n || !n.id) return;
@@ -1883,18 +1906,6 @@ class NoteTextComponent extends React.Component {
 					onRevisionLinkClick: () => {
 						this.setState({ showRevisions: true });
 					},
-				});
-			},
-		});
-
-		toolbarItems.push({
-			tooltip: _('Content Properties'),
-			iconName: 'fa-sticky-note',
-			onClick: () => {
-				this.props.dispatch({
-					type: 'WINDOW_COMMAND',
-					name: 'commandContentProperties',
-					text: this.state.note.body,
 				});
 			},
 		});

--- a/ElectronClient/gui/ToolbarButton.jsx
+++ b/ElectronClient/gui/ToolbarButton.jsx
@@ -5,7 +5,7 @@ class ToolbarButton extends React.Component {
 	render() {
 		const theme = themeStyle(this.props.theme);
 
-		const style = Object.assign({}, theme.toolbarStyle);
+		const style = Object.assign({}, theme.toolbarStyle, this.props.style);
 
 		const title = this.props.title ? this.props.title : '';
 		const tooltip = this.props.tooltip ? this.props.tooltip : title;


### PR DESCRIPTION
Resolves #1944 

- [x] Rearrange the toolbar items to improve visual hierarchy.
- [x] Move the note properties icon to right under date/time to improve visibility.

## Before
<img width="820" alt="Screenshot 2020-04-06 at 3 05 01 PM" src="https://user-images.githubusercontent.com/44024553/78544825-5d6a0980-7818-11ea-9968-8140ccca9333.png">

## After

<img width="854" alt="Screenshot 2020-04-14 at 12 46 42 PM" src="https://user-images.githubusercontent.com/44024553/79196803-582b4100-7e4e-11ea-8501-4c335b03e411.png">

Modified the ToolBarButton component so that it accepts custom styles.
