### PR TITLE
Desktop: Changing bold-text preview color for Aritim-dark theme

### DIFF
--- a/ElectronClient/gui/style/theme/aritimDark.js
+++ b/ElectronClient/gui/style/theme/aritimDark.js
@@ -6,7 +6,7 @@ const aritimStyle = {
 	colorError: '#9a2f2f',
 	colorWarn: '#d66500',
 	colorFaded: '#666a73', // For less important text (e.g. not selected menu in settings)
-	colorBright: '#ffffff', // For important text; (e.g. bold)
+	colorBright: '#d3dae3', // For important text; (e.g. bold)
 	dividerColor: '#141a21', // Borders, I wish I could remove them
 	selectedColor: '#2b5278', // Selected note
 	urlColor: '#356693', // Links to external sites (e.g. in settings)

--- a/ElectronClient/gui/style/theme/aritimDark.js
+++ b/ElectronClient/gui/style/theme/aritimDark.js
@@ -6,7 +6,7 @@ const aritimStyle = {
 	colorError: '#9a2f2f',
 	colorWarn: '#d66500',
 	colorFaded: '#666a73', // For less important text (e.g. not selected menu in settings)
-	colorBright: '#005b47', // For important text; (e.g. bold)
+	colorBright: '#ffffff', // For important text; (e.g. bold)
 	dividerColor: '#141a21', // Borders, I wish I could remove them
 	selectedColor: '#2b5278', // Selected note
 	urlColor: '#356693', // Links to external sites (e.g. in settings)


### PR DESCRIPTION
fixes #3011 

## Describe what happens
![image](https://user-images.githubusercontent.com/54576074/78974769-57359f00-7b30-11ea-88fc-6f95041ddc12.png)

## Describe what you expected to happen
![image](https://user-images.githubusercontent.com/54576074/78974777-5e5cad00-7b30-11ea-8320-e0df3ecd615a.png)