### PR TITLE
Desktop: Feat/highlight header button

### DIFF
--- a/ElectronClient/gui/Header.jsx
+++ b/ElectronClient/gui/Header.jsx
@@ -149,11 +149,13 @@ class HeaderComponent extends React.Component {
 		}
 
 		const isEnabled = !('enabled' in options) || options.enabled;
+		const isHighlighted = options.highlight;
 		const classes = ['button'];
 		if (!isEnabled) classes.push('disabled');
 
 		const finalStyle = Object.assign({}, style, {
 			opacity: isEnabled ? 1 : 0.4,
+			borderBottom: isHighlighted ? 'solid' : 'inherit',
 		});
 
 		const title = options.title ? options.title : '';

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -664,6 +664,7 @@ class MainScreenComponent extends React.Component {
 			onClick: () => {
 				this.doCommand({ name: 'newNote' });
 			},
+			highlight: true,
 		});
 
 		headerItems.push({


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

I have found myself creating toDo notes very often when I wanted to make normal note without even noticing. The buttons for ToDo Note and normal Note are next to eachoder and very similar. My solution is to simply put a bottom border to a normal Note button because I think that is the most used button (I may be wrong).
I realise this is very personal customatization but maybe it makse sense to make it available.

This is my very first pull request so if I am doing something wrong I am sorry.

Thanks for making this amazing app.