### PR TITLE
Desktop: Fixed checkbox opacity for noteBody lists

### DIFF
--- a/ReactNativeClient/lib/joplin-renderer/noteStyle.js
+++ b/ReactNativeClient/lib/joplin-renderer/noteStyle.js
@@ -273,7 +273,7 @@ module.exports = function(theme) {
 		}
 
 		.md-checkbox input[type=checkbox]:checked {
-			opacity: 0.7;
+			opacity: 1;
 		}
 
 		.md-checkbox .checkbox-label-checked {


### PR DESCRIPTION
## FIXES #3015 

### Before and After
![image](https://user-images.githubusercontent.com/35633575/79008427-0008ec00-7b7b-11ea-824e-402c489f4fe1.png)
![image](https://user-images.githubusercontent.com/35633575/79008537-3cd4e300-7b7b-11ea-8a82-8d5507a52372.png)


