### PR TITLE
DESKTOP: Adding copy to clipboard button for code block

### DIFF
--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
@@ -248,7 +248,7 @@ class MdToHtml {
 				} catch (error) {
 					outputCodeHtml = markdownIt.utils.escapeHtml(trimmedStr);
 				}
-				// ! chaging the below order markup could effect to copy to clipboard plugin
+				// ! changing the below markup order could effect the copy to clipboard plugin
 				return {
 					wrapCode: false,
 					html: `<div class="joplin-editable">${sourceBlockHtml}<pre class="hljs"><code>${outputCodeHtml}</code></pre></div>`,

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
@@ -17,6 +17,7 @@ const rules = {
 	code_inline: require('./MdToHtml/rules/code_inline'),
 	fountain: require('./MdToHtml/rules/fountain'),
 	mermaid: require('./MdToHtml/rules/mermaid').default,
+	copy_to_clipboard: require('./MdToHtml/rules/copy_to_clipboard'),
 };
 
 const setupLinkify = require('./MdToHtml/setupLinkify');
@@ -247,7 +248,7 @@ class MdToHtml {
 				} catch (error) {
 					outputCodeHtml = markdownIt.utils.escapeHtml(trimmedStr);
 				}
-
+				// ! chaging the below order markup could effect to copy to clipboard plugin
 				return {
 					wrapCode: false,
 					html: `<div class="joplin-editable">${sourceBlockHtml}<pre class="hljs"><code>${outputCodeHtml}</code></pre></div>`,

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/copy_to_clipboard.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/copy_to_clipboard.js
@@ -5,25 +5,23 @@ const copyButtonCss = () => {
 			inline: true,
 			mime: 'text/css',
 			text: `
-                .hljs {
-                    position: relative;
-                }
-
-                .copyButton {
+				.hljs {
+					position: relative;
+				}
+				.copyButton {
 					outline: none;
-                    position: absolute;
-                    right: 5px;
-                    top: 5px;
-                    opacity: 0.3;
-                    color: inherit;
-                    background: inherit;
-                    border: 0;
-                    cursor: pointer;
-                }
-                
-                .copyButton:hover {
-                    opacity: 1;
-                }
+					position: absolute;
+					right: 5px;
+					top: 5px;
+					opacity: 0.3;
+					color: inherit;
+					background: inherit;
+					border: 0;
+					cursor: pointer;
+				}
+				.copyButton:hover {
+					opacity: 1;
+				}
                 `,
 		},
 	];
@@ -31,6 +29,7 @@ const copyButtonCss = () => {
 
 const buttonCode_ = (text)=>  {
 	return (`
+			console.log(event);
 			const textArea = document.createElement('textarea');
 			textArea.value = \`${text}\`;
 			textArea.style.position = 'absolute';
@@ -38,7 +37,6 @@ const buttonCode_ = (text)=>  {
 			textArea.style.left = 0;
 			textArea.style.background = 'transparent';
 
-			
 			document.body.appendChild(textArea);
 			textArea.focus();
 			textArea.select();
@@ -49,16 +47,14 @@ const buttonCode_ = (text)=>  {
 			console.log(err);
 			}
 			document.body.removeChild(textArea);
-
-			document.querySelector('.copyButton').innerHTML='Copied!';
+			console.log(event.target.innerText);
+			event.target.innerHTML='Copied!';
 			setTimeout( function() {
-			document.querySelector('.copyButton').innerHTML='copy';}
-			, 1500);
-							`
+			event.target.innerHTML='copy';}
+			, 800);
+			`
 	);
 };
-
-
 
 const buttonText = 'copy';
 
@@ -101,9 +97,9 @@ function installRule(markdownIt, mdOptions, ruleOptions, context) {
 			'</button>',
 		];
 		// negative lookahead find the last occurance of the closring </pre> tag
-		const regex = /(<\/pre>)(?!.*(<\/pre>))/gm ;
+		const pos = renderedToken.lastIndexOf(lastTag);
 		button = button.join('');
-		const newRenderedToken = renderedToken.replace(regex, `${button}${lastTag}`);
+		const newRenderedToken = `${renderedToken.substring(0,pos)}${button}${renderedToken.substring(pos,renderedToken.length)}`;
 		return newRenderedToken;
 
 	};

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/copy_to_clipboard.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/copy_to_clipboard.js
@@ -1,0 +1,119 @@
+
+const copyButtonCss = () => {
+	return [
+		{
+			inline: true,
+			mime: 'text/css',
+			text: `
+                .hljs {
+                    position: relative;
+                }
+
+                .copyButton {
+					outline: none;
+                    position: absolute;
+                    right: 5px;
+                    top: 5px;
+                    opacity: 0.3;
+                    color: inherit;
+                    background: inherit;
+                    border: 0;
+                    cursor: pointer;
+                }
+                
+                .copyButton:hover {
+                    opacity: 1;
+                }
+                `,
+		},
+	];
+};
+
+const buttonCode_ = (text)=>  {
+	return (`
+			const textArea = document.createElement('textarea');
+			textArea.value = \`${text}\`;
+			textArea.style.position = 'absolute';
+			textArea.style.top = 0;
+			textArea.style.left = 0;
+			textArea.style.background = 'transparent';
+
+			
+			document.body.appendChild(textArea);
+			textArea.focus();
+			textArea.select();
+			
+			try {
+			const successful = document.execCommand('copy');
+			} catch (err) {
+			console.log(err);
+			}
+			document.body.removeChild(textArea);
+
+			document.querySelector('.copyButton').innerHTML='Copied!';
+			setTimeout( function() {
+			document.querySelector('.copyButton').innerHTML='copy';}
+			, 1500);
+							`
+	);
+};
+
+
+
+const buttonText = 'copy';
+
+function addContextAssets(context) {
+	if ('copy_to_clipboard' in context.pluginAssets) return;
+
+	context.pluginAssets['copy_to_clipboard'] = copyButtonCss();
+}
+
+function installRule(markdownIt, mdOptions, ruleOptions, context) {
+	const defaultRender = markdownIt.renderer.rules.fence;
+	const lastTag = '</pre>';
+
+	markdownIt.renderer.rules.fence = (tokens, idx, options, env, self) => {
+
+		// give the rendered value og the toke!
+		const renderedToken = defaultRender(tokens, idx, options, env, self);
+
+		const token = tokens[idx];
+		let text = token.content;
+
+		// extracting text from token gives the text inside the fence block
+		// with and extra new line so we removing redundant last new line
+		// which was added by default while extracting text from token
+
+		if (text) {
+			text = text.replace(/\n$/,'');
+		}
+		let buttonCode = buttonCode_(text);
+		buttonCode = markdownIt.utils.escapeHtml(buttonCode);
+		// escaping HTML characters
+
+		if (!('copy_to_clipboard' in context.pluginAssets)) {
+			addContextAssets(context);
+		}
+		let button = [
+			'<button ',
+			'class="copyButton" ',
+			`onclick="${buttonCode}">${buttonText}`,
+			'</button>',
+		];
+		// negative lookahead find the last occurance of the closring </pre> tag
+		const regex = /(<\/pre>)(?!.*(<\/pre>))/gm ;
+		button = button.join('');
+		const newRenderedToken = renderedToken.replace(regex, `${button}${lastTag}`);
+		return newRenderedToken;
+
+	};
+}
+
+module.exports = {
+	install: function(context, ruleOptions) {
+		return function(md, mdOptions) {
+			installRule(md, mdOptions, ruleOptions, context);
+		};
+	},
+	style: copyButtonCss,
+};

--- a/ReactNativeClient/lib/joplin-renderer/noteStyle.js
+++ b/ReactNativeClient/lib/joplin-renderer/noteStyle.js
@@ -114,6 +114,9 @@ module.exports = function(theme) {
 			margin-top: 0.2em;
 			margin-bottom: 0;
 		}
+		.hljs{
+			position: relative;
+		}
 		.resource-icon {
 			display: inline-block;
 			position: relative;


### PR DESCRIPTION
fixes: #2383 

# Changes

![copy-to-clipboard](https://user-images.githubusercontent.com/54576074/79045616-b4614b80-7c29-11ea-960d-ea828c0aad35.gif)

Added copy to clipboard functionality for fences-code block

Note: I only tested this on the desktop app I did not test to for mobile.

TODOS:
- correcting the unit test case
- ~~improving the regex used to replace the pre tag (it is not accurate for cases having multiple lines right now )~~
- 🐞 : the button moves to the left when there is an option to scroll horizontally

I will make the changes and update this as soon as possible