### PR TITLE
Return empty default for exports with no note ids (jex for example)

### DIFF
--- a/ElectronClient/InteropServiceHelper.js
+++ b/ElectronClient/InteropServiceHelper.js
@@ -96,6 +96,11 @@ class InteropServiceHelper {
 	}
 
 	static async defaultFilename(noteIds, fileExtension) {
+		// Use of == here is because noteIds is potentiall undefined
+		if (noteIds == null) {
+			return '';
+		}
+
 		const note = await Note.load(noteIds[0]);
 		// In a rare case the passed not will be null, use the id for filename
 		if (note === null) {

--- a/ElectronClient/InteropServiceHelper.js
+++ b/ElectronClient/InteropServiceHelper.js
@@ -96,8 +96,7 @@ class InteropServiceHelper {
 	}
 
 	static async defaultFilename(noteIds, fileExtension) {
-		// Use of == here is because noteIds is potentiall undefined
-		if (noteIds == null) {
+		if (!noteIds) {
 			return '';
 		}
 


### PR DESCRIPTION
The previous behavior was to have an empty name. I've kept it like that (to get the PR up quicker) but eventually I'd like to find a way to also have a friendly filename for jex exports.