### PR TITLE
Desktop: Fix Go To Anything closing when clicking inside the modal

### DIFF
--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -115,12 +115,14 @@ class Dialog extends React.PureComponent {
 		}
 	}
 
-	modalLayer_onClick() {
-		this.props.dispatch({
-			pluginName: PLUGIN_NAME,
-			type: 'PLUGIN_DIALOG_SET',
-			open: false,
-		});
+	modalLayer_onClick(event) {
+		if (event.currentTarget == event.target) {
+			this.props.dispatch({
+				pluginName: PLUGIN_NAME,
+				type: 'PLUGIN_DIALOG_SET',
+				open: false,
+			});
+		}
 	}
 
 	helpButton_onClick() {
@@ -398,8 +400,8 @@ class Dialog extends React.PureComponent {
 				<div style={style.dialogBox}>
 					{helpComp}
 					<div style={style.inputHelpWrapper}>
-						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown}/>
-						<HelpButton onClick={this.helpButton_onClick}/>
+						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown} />
+						<HelpButton onClick={this.helpButton_onClick} />
 					</div>
 					{this.renderList()}
 				</div>

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -401,7 +401,7 @@ class Dialog extends React.PureComponent {
 					{helpComp}
 					<div style={style.inputHelpWrapper}>
 						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown} />
-						<HelpButton onClick={this.helpButton_onClick} />
+						<HelpButton onClick={this.helpButton_onClick}/>
 					</div>
 					{this.renderList()}
 				</div>

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -400,7 +400,7 @@ class Dialog extends React.PureComponent {
 				<div style={style.dialogBox}>
 					{helpComp}
 					<div style={style.inputHelpWrapper}>
-						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown} />
+						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown}/>
 						<HelpButton onClick={this.helpButton_onClick}/>
 					</div>
 					{this.renderList()}


### PR DESCRIPTION
Fixes #3028

Issue was caused by the Go To Anything modal inheriting onClick behaviour from its parent: Dialog modal layer. 

This PR adds a condition to check if the element which dispatched the onClick event is the same element which the onClick event handler was originally attached to. Therefore only clicking on the dialog modal layer will close the modal. Other events are discarded.