### PR TITLE
supporting [[Wiki Links]] syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -71,6 +71,7 @@ ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/checkbox.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/fence.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/mermaid.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/sanitize_html.js
+ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/wiki_links.js
 ReactNativeClient/lib/JoplinServerApi.js
 ReactNativeClient/PluginAssetsLoader.js
 ReactNativeClient/setUpQuickActions.js

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/checkbox.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/fence.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/mermaid.js
 ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/sanitize_html.js
+ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/wiki_links.js
 ReactNativeClient/lib/JoplinServerApi.js
 ReactNativeClient/PluginAssetsLoader.js
 ReactNativeClient/setUpQuickActions.js

--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -841,6 +841,30 @@ class NoteTextComponent extends React.Component {
 			}
 
 			menu.popup(bridge().window());
+		} else if (msg.indexOf('joplin://by_title?' === 0)) {
+			const url = new URL(msg);
+			const title = decodeURIComponent(url.search.substr(1));
+			const notes = await Note.search({
+				conditions: ['title=?'],
+				conditionsParams: [title],
+			});
+
+			if (notes && notes.length) {
+				// TODO: if length > 1 offer user a choice
+				const note = notes[0];
+				this.props.dispatch({
+					type: 'FOLDER_AND_NOTE_SELECT',
+					folderId: note.parent_id,
+					noteId: note.id,
+					hash: url.hash,
+					historyAction: 'goto',
+				});
+			} else {
+				// TODO: offer user to create a new note
+				bridge().showErrorMessageBox(`${_('Note not found: ')}${title}`);
+			}
+
+			return;
 		} else if (msg.indexOf('joplin://') === 0) {
 			const resourceUrlInfo = urlUtils.parseResourceUrl(msg);
 			const itemId = resourceUrlInfo.itemId;

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml.js
@@ -17,6 +17,7 @@ const rules = {
 	code_inline: require('./MdToHtml/rules/code_inline'),
 	fountain: require('./MdToHtml/rules/fountain'),
 	mermaid: require('./MdToHtml/rules/mermaid').default,
+	wiki_links: require('./MdToHtml/rules/wiki_links').default,
 };
 
 const setupLinkify = require('./MdToHtml/setupLinkify');

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/wiki_links.ts
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/wiki_links.ts
@@ -1,0 +1,36 @@
+// Replaces [[Wiki Links]] by links to nodes.
+
+// [[Page/Path|Optional Title]]
+const regex = /\[\[([\w\s/]+)(\|([\w\s/]+))?\]\]/;
+
+function installRule(markdownIt: any) {
+	// parser
+	markdownIt.inline.ruler.push('wiki_links', (state: any, silent: boolean) => {
+		const match = regex.exec(state.src.slice(state.pos));
+		if (!match) return false;
+
+		state.pos += match[0].length;
+		if (!silent) {
+			const token = state.push('wiki_links', '', 0);
+			token.meta = { match: match };
+		}
+		return true;
+	});
+
+	// renderer
+	markdownIt.renderer.rules.wiki_links = (tokens: any[], idx: number) => {
+		const token = tokens[idx];
+		const match = token.meta.match;
+		const isSplit = !!match[3];
+		const label = isSplit ? match[3] : match[1];
+		const note = match[1];
+		const url = `joplin://by_title?${encodeURIComponent(note)}`;
+		return `<a href="${url}">${label}</a>`;
+	};
+}
+
+export default function() {
+	return (markdownIt: any) => {
+		installRule(markdownIt);
+	};
+}

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -387,6 +387,7 @@ class Setting extends BaseModel {
 			'markdown.plugin.emoji': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => `${_('Enable markdown emoji')}${wysiwygNo}` },
 			'markdown.plugin.insert': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => `${_('Enable ++insert++ syntax')}${wysiwygNo}` },
 			'markdown.plugin.multitable': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => `${_('Enable multimarkdown table extension')}${wysiwygNo}` },
+			'markdown.plugin.wiki_links': { value: false, type: Setting.TYPE_BOOL, section: 'plugins', public: true, appTypes: ['mobile', 'desktop'], label: () => `${_('Enable [[wiki links]] syntax')}${wysiwygNo}` },
 
 			// Tray icon (called AppIndicator) doesn't work in Ubuntu
 			// http://www.webupd8.org/2017/04/fix-appindicator-not-working-for.html

--- a/joplin.sublime-project
+++ b/joplin.sublime-project
@@ -48,6 +48,7 @@
 				"ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/mermaid.js",
 				"ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/fence.js",
 				"ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/checkbox.js"
+				"ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/wiki_links.js",
 			],
 			"folder_exclude_patterns":
 			[


### PR DESCRIPTION
The change adds support for [[Wiki Links|With Label]] syntax.
The syntax is implemented by a trivial markdown-it plug-in to minimize project dependencies.

The biggest open question is URL specification. I chose `joplin://by_title?<note_tile>`. Let me know if there's anything else you prefer.

I plan to add following follow-up improvements:
- offer user to create a note
- offer user to choose a note among multiple
- Support Notebook/Note syntax