### PR TITLE
Mobile: Fixes #2853: Fix white corners on switching themes in iOS

### DIFF
--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -752,7 +752,7 @@ class AppComponent extends React.Component {
 				}}
 			>
 				<StatusBar barStyle="dark-content" />
-				<MenuContext style={{ flex: 1 }}>
+				<MenuContext style={{ flex: 1, backgroundColor: theme.backgroundColor  }}>
 					<SafeAreaView style={{ flex: 1 }}>
 						<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 							<AppNav screens={appNavInit} />


### PR DESCRIPTION
Fixes #2853 
Also #2781 

## Before

<img src="https://user-images.githubusercontent.com/44024553/79241842-356e4c00-7e91-11ea-92de-74fd55617f52.png" height="500" />

## After

<img src="https://user-images.githubusercontent.com/44024553/79241440-af520580-7e90-11ea-9388-4af55fe1a31e.png" height="500"/>
