### PR TITLE
Mobile: Fixes #2798: Switch keyboard appearance with theme

### DIFF
--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -19,6 +19,7 @@ const globalStyle = {
 	disabledOpacity: 0.2,
 	colorUrl: '#7B81FF',
 	textSelectionColor: '#0096FF',
+	appearance: 'light',
 
 	raisedBackgroundColor: '#0080EF',
 	raisedColor: '#003363',
@@ -95,6 +96,8 @@ function addExtraStyles(style) {
 		backgroundColor: style.headerBackgroundColor,
 	};
 
+	style.keyboardAppearance = style.appearance;
+
 	return style;
 }
 
@@ -133,6 +136,7 @@ function themeStyle(theme) {
 		output.strongDividerColor = '#888888';
 		output.selectedColor = '#333333';
 		output.textSelectionColor = '#00AEFF';
+		output.appearance = 'dark';
 		output.headerBackgroundColor = '#2D3136';
 
 		output.raisedBackgroundColor = '#0F2051';
@@ -166,6 +170,7 @@ function themeStyle(theme) {
 	output.strongDividerColor = '#888888';
 	output.selectedColor = '#333333';
 	output.textSelectionColor = '#00AEFF';
+	output.appearance = 'dark';
 	output.headerBackgroundColor = '#2D3136';
 
 	output.raisedBackgroundColor = '#0F2051';

--- a/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
+++ b/ReactNativeClient/lib/components/screens/NoteTagsDialog.js
@@ -163,6 +163,7 @@ class NoteTagsDialogComponent extends React.Component {
 					<Text style={this.styles().newTagBoxLabel}>{_('New tags:')}</Text>
 					<TextInput
 						selectionColor={theme.textSelectionColor}
+						keyboardAppearance={theme.keyboardAppearance}
 						value={this.state.newTags}
 						onChangeText={value => {
 							this.setState({ newTags: value });

--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -422,7 +422,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 					<Text key="label" style={this.styles().settingText}>
 						{md.label()}
 					</Text>
-					<TextInput autoCorrect={false} autoCompleteType="off" selectionColor={theme.textSelectionColor} autoCapitalize="none" key="control" style={this.styles().settingControl} value={value} onChangeText={value => updateSettingValue(key, value)} secureTextEntry={!!md.secure} />
+					<TextInput autoCorrect={false} autoCompleteType="off" selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} autoCapitalize="none" key="control" style={this.styles().settingControl} value={value} onChangeText={value => updateSettingValue(key, value)} secureTextEntry={!!md.secure} />
 				</View>
 			);
 		} else {
@@ -434,6 +434,8 @@ class ConfigScreenComponent extends BaseScreenComponent {
 
 	render() {
 		const settings = this.state.settings;
+
+		const theme = themeStyle(this.props.theme);
 
 		const settingComps = shared.settingsToComponents2(this, 'mobile', settings);
 
@@ -453,7 +455,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				const profileExportPrompt = (
 					<View style={this.styles().settingContainer}>
 						<Text style={this.styles().settingText}>Path:</Text>
-						<TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard"></TextInput>
+						<TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance}></TextInput>
 						<Button title="OK" onPress={this.exportProfileButtonPress2_}></Button>
 					</View>
 				);

--- a/ReactNativeClient/lib/components/screens/dropbox-login.js
+++ b/ReactNativeClient/lib/components/screens/dropbox-login.js
@@ -59,7 +59,7 @@ class DropboxLoginScreenComponent extends BaseScreenComponent {
 						</TouchableOpacity>
 					</View>
 					<Text style={this.styles().stepText}>{_('Step 2: Enter the code provided by Dropbox:')}</Text>
-					<TextInput placeholder={_('Enter code here')} placeholderTextColor={theme.colorFaded} selectionColor={theme.textSelectionColor} value={this.state.authCode} onChangeText={this.shared_.authCodeInput_change} style={theme.lineInput} />
+					<TextInput placeholder={_('Enter code here')} placeholderTextColor={theme.colorFaded} selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} value={this.state.authCode} onChangeText={this.shared_.authCodeInput_change} style={theme.lineInput} />
 					<View style={{ height: 10 }}></View>
 					<Button disabled={this.state.checkingAuthToken} title={_('Submit')} onPress={this.shared_.submit_click}></Button>
 

--- a/ReactNativeClient/lib/components/screens/encryption-config.js
+++ b/ReactNativeClient/lib/components/screens/encryption-config.js
@@ -120,7 +120,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				<Text style={this.styles().normalText}>{_('Created: %s', time.formatMsToLocal(mk.created_time))}</Text>
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 					<Text style={{ flex: 0, fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{_('Password:')}</Text>
-					<TextInput selectionColor={theme.textSelectionColor} secureTextEntry={true} value={password} onChangeText={text => onPasswordChange(text)} style={inputStyle}></TextInput>
+					<TextInput selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} secureTextEntry={true} value={password} onChangeText={text => onPasswordChange(text)} style={inputStyle}></TextInput>
 					<Text style={{ fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{passwordOk}</Text>
 					<Button title={_('Save')} onPress={() => onSaveClick()}></Button>
 				</View>
@@ -151,6 +151,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				<Text style={this.styles().normalText}>{_('Password:')}</Text>
 				<TextInput
 					selectionColor={theme.textSelectionColor}
+					keyboardAppearance={theme.keyboardAppearance}
 					style={this.styles().normalTextInput}
 					secureTextEntry={true}
 					value={this.state.passwordPromptAnswer}
@@ -162,6 +163,7 @@ class EncryptionConfigScreenComponent extends BaseScreenComponent {
 				<Text style={this.styles().normalText}>{_('Confirm password:')}</Text>
 				<TextInput
 					selectionColor={theme.textSelectionColor}
+					keyboardAppearance={theme.keyboardAppearance}
 					style={this.styles().normalTextInput}
 					secureTextEntry={true}
 					value={this.state.passwordPromptConfirmAnswer}

--- a/ReactNativeClient/lib/components/screens/folder.js
+++ b/ReactNativeClient/lib/components/screens/folder.js
@@ -107,7 +107,7 @@ class FolderScreenComponent extends BaseScreenComponent {
 		return (
 			<View style={this.rootStyle(this.props.theme).root}>
 				<ScreenHeader title={_('Edit notebook')} showSaveButton={true} saveButtonDisabled={saveButtonDisabled} onSaveButtonPress={() => this.saveFolderButton_press()} showSideMenuButton={false} showSearchButton={false} />
-				<TextInput placeholder={_('Enter notebook title')} underlineColorAndroid={theme.strongDividerColor} selectionColor={theme.textSelectionColor} style={this.styles().textInput} autoFocus={true} value={this.state.folder.title} onChangeText={text => this.title_changeText(text)} />
+				<TextInput placeholder={_('Enter notebook title')} underlineColorAndroid={theme.strongDividerColor} selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} style={this.styles().textInput} autoFocus={true} value={this.state.folder.title} onChangeText={text => this.title_changeText(text)} />
 				<dialogs.DialogBox
 					ref={dialogbox => {
 						this.dialogbox = dialogbox;

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -937,6 +937,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					saveText={text => this.body_changeText(text)}
 					blurOnSubmit={false}
 					selectionColor={theme.textSelectionColor}
+					keyboardAppearance={theme.keyboardAppearance}
 					placeholder={_('Add body')}
 					placeholderTextColor={theme.colorFaded}
 					noteBodyViewer={{
@@ -969,7 +970,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 				/>
 				: (
 					<ScrollView persistentScrollbar>
-						<TextInput autoCapitalize="sentences" style={this.styles().bodyTextInput} ref="noteBodyTextField" multiline={true} value={note.body} onChangeText={text => this.body_changeText(text)} blurOnSubmit={false} selectionColor={theme.textSelectionColor} placeholder={_('Add body')} placeholderTextColor={theme.colorFaded} />
+						<TextInput autoCapitalize="sentences" style={this.styles().bodyTextInput} ref="noteBodyTextField" multiline={true} value={note.body} onChangeText={text => this.body_changeText(text)} blurOnSubmit={false} selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} placeholder={_('Add body')} placeholderTextColor={theme.colorFaded} />
 					</ScrollView>
 				);
 		}
@@ -1006,7 +1007,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 		const titleComp = (
 			<View style={titleContainerStyle}>
 				{isTodo && <Checkbox style={this.styles().checkbox} checked={!!Number(note.todo_completed)} onChange={this.todoCheckbox_change} />}
-				<TextInput onContentSizeChange={this.titleTextInput_contentSizeChange} multiline={this.enableMultilineTitle_} ref="titleTextField" underlineColorAndroid="#ffffff00" autoCapitalize="sentences" style={this.styles().titleTextInput} value={note.title} onChangeText={this.title_changeText} selectionColor={theme.textSelectionColor} placeholder={_('Add title')} placeholderTextColor={theme.colorFaded} />
+				<TextInput onContentSizeChange={this.titleTextInput_contentSizeChange} multiline={this.enableMultilineTitle_} ref="titleTextField" underlineColorAndroid="#ffffff00" autoCapitalize="sentences" style={this.styles().titleTextInput} value={note.title} onChangeText={this.title_changeText} selectionColor={theme.textSelectionColor} keyboardAppearance={theme.keyboardAppearance} placeholder={_('Add title')} placeholderTextColor={theme.colorFaded} />
 			</View>
 		);
 

--- a/ReactNativeClient/lib/components/screens/search.js
+++ b/ReactNativeClient/lib/components/screens/search.js
@@ -181,6 +181,7 @@ class SearchScreenComponent extends BaseScreenComponent {
 							onChangeText={text => this.searchTextInput_changeText(text)}
 							value={this.state.query}
 							selectionColor={theme.textSelectionColor}
+							keyboardAppearance={theme.keyboardAppearance}
 						/>
 						<TouchableHighlight onPress={() => this.clearButton_press()}>
 							<Icon name="md-close-circle" style={this.styles().clearIcon} />


### PR DESCRIPTION
Fixes #2798 

Keyboard Appearance switches based on the Theme.
The appearance is configured in global-styles.js.

## Before

<img src="https://user-images.githubusercontent.com/44024553/79307772-0f8a8b00-7f15-11ea-8560-9df0536bf300.PNG" height="500px">

## After

<img src="https://user-images.githubusercontent.com/44024553/79307782-12857b80-7f15-11ea-9be1-e5ee227ad9ca.PNG" height="500px">
