### PR TITLE
CLI: Implemented configurable layout for terminal

### DIFF
--- a/CliClient/app/app-gui.js
+++ b/CliClient/app/app-gui.js
@@ -5,6 +5,7 @@ const Tag = require('lib/models/Tag.js');
 const BaseModel = require('lib/BaseModel.js');
 const Note = require('lib/models/Note.js');
 const Resource = require('lib/models/Resource.js');
+const Setting = require('lib/models/Setting.js');
 const { reducer, defaultState } = require('lib/reducer.js');
 const { splitCommandString } = require('lib/string-utils.js');
 const { reg } = require('lib/registry.js');
@@ -243,9 +244,9 @@ class AppGui {
 
 		const hLayout = new HLayoutWidget();
 		hLayout.name = 'hLayout';
-		hLayout.addChild(folderList, { type: 'stretch', factor: 1 });
-		hLayout.addChild(noteList, { type: 'stretch', factor: 1 });
-		hLayout.addChild(noteLayout, { type: 'stretch', factor: 2 });
+		hLayout.addChild(folderList, { type: 'stretch', factor: Setting.value('layout.folderList.factor') });
+		hLayout.addChild(noteList, { type: 'stretch', factor: Setting.value('layout.noteList.factor') });
+		hLayout.addChild(noteLayout, { type: 'stretch', factor: Setting.value('layout.note.factor') });
 
 		const vLayout = new VLayoutWidget();
 		vLayout.name = 'vLayout';

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -623,6 +623,46 @@ class Setting extends BaseModel {
 				maximum: 300,
 				step: 10,
 			},
+
+			'layout.folderList.factor': {
+				value: 1,
+				type: Setting.TYPE_INT,
+				section: 'appearance',
+				public: true,
+				appTypes: ['cli'],
+				label: () => _('Notebook list growth factor'),
+				description: () =>
+					_('The factor property sets how the item will grow or shrink ' +
+				'to fit the available space in its container with respect to the other items. ' +
+				'Thus an item with a factor of 2 will take twice as much space as an item with a factor of 1.' +
+				'Restart app to see changes.'),
+			},
+			'layout.noteList.factor': {
+				value: 1,
+				type: Setting.TYPE_INT,
+				section: 'appearance',
+				public: true,
+				appTypes: ['cli'],
+				label: () => _('Note list growth factor'),
+				description: () =>
+					_('The factor property sets how the item will grow or shrink ' +
+				'to fit the available space in its container with respect to the other items. ' +
+				'Thus an item with a factor of 2 will take twice as much space as an item with a factor of 1.' +
+				'Restart app to see changes.'),
+			},
+			'layout.note.factor': {
+				value: 2,
+				type: Setting.TYPE_INT,
+				section: 'appearance',
+				public: true,
+				appTypes: ['cli'],
+				label: () => _('Note area growth factor'),
+				description: () =>
+					_('The factor property sets how the item will grow or shrink ' +
+				'to fit the available space in its container with respect to the other items. ' +
+				'Thus an item with a factor of 2 will take twice as much space as an item with a factor of 1.' +
+				'Restart app to see changes.'),
+			},
 		};
 
 		return this.metadata_;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Implements: #2110 

This PR makes it possible to configure pane sizes of note list, notebook list, and note areas in the terminal app. I made use of the discussions of this closed PR: #2613 (it deserves some credit, I guess). 

This implementation of configurable layouts requires the users to restart the CLI app to see the changes. I have indicated this in the properties' descriptions. 

Please review and tell me if the PR needs anything more. :)

@PackElend label me, please!