### PR TITLE
Desktop: Fix focus on GotoAnything and Layout Switching

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -978,6 +978,7 @@ class Application extends BaseApplication {
 							type: 'WINDOW_COMMAND',
 							name: 'toggleVisiblePanes',
 						});
+						this.focusElement_('noteBody');
 					},
 				}, {
 					type: 'separator',

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -978,7 +978,6 @@ class Application extends BaseApplication {
 							type: 'WINDOW_COMMAND',
 							name: 'toggleVisiblePanes',
 						});
-						this.focusElement_('noteBody');
 					},
 				}, {
 					type: 'separator',

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -304,6 +304,12 @@ class Dialog extends React.PureComponent {
 				noteId: item.id,
 				historyAction: 'goto',
 			});
+
+			this.props.dispatch({
+				type: 'WINDOW_COMMAND',
+				name: 'focusElement',
+				target: 'noteBody',
+			});
 		} else if (this.state.listType === BaseModel.TYPE_TAG) {
 			this.props.dispatch({
 				type: 'TAG_SELECT',


### PR DESCRIPTION
Fixes #3066 and #2960 

## Before

![before](https://user-images.githubusercontent.com/44024553/79553360-fd961d00-80b9-11ea-9704-82d0959d62fb.gif)

![vim-before](https://user-images.githubusercontent.com/44024553/79553377-038bfe00-80ba-11ea-8618-ef78ef2cab9c.gif)

## After

![after](https://user-images.githubusercontent.com/44024553/79553371-01c23a80-80ba-11ea-967c-70759430a959.gif)

![vim-after](https://user-images.githubusercontent.com/44024553/79553375-02f36780-80ba-11ea-88a2-2a96c4090974.gif)

