### PR TITLE
DESKTOP: improving toggle functionality

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -1448,7 +1448,7 @@ class NoteTextComponent extends React.Component {
 		return this.selectionRange_ ? this.rangeToTextOffsets(this.selectionRange_, this.state.note.body) : null;
 	}
 
-	wrapSelectionWithStrings(string1, string2 = '', defaultText = '', replacementText = null, byLine = false,toggle) {
+	wrapSelectionWithStrings(string1, string2 = '', defaultText = '', replacementText = null, byLine = false, toggle) {
 		if (!this.rawEditor() || !this.state.note) return;
 
 		const selection = this.textOffsetSelection();
@@ -1510,9 +1510,8 @@ class NoteTextComponent extends React.Component {
 				};
 			}
 
-			// we dont need to this for toggle copy-paste
+			// we dont need to do this for toggle
 			if (replacementText !== null && toggle.rule == null) {
-			// if (replacementText !== null ) {
 				const diff = replacementText.length - (selection.end - selection.start);
 				newRange.end.column += diff;
 			}
@@ -1575,13 +1574,14 @@ class NoteTextComponent extends React.Component {
 		mdRule[1] = (mdRule[1]) ? mdRule[1] : mdRule[0];
 		// if there is not alternate markdown rule then set mdRule[1]=mdRule[0]
 		const escapedMdRule = mdRule[0].replace(/\\/g,'');
-		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
 		const mdRuleOffset = escapedMdRule.length;
+		let string = this.state.note.body.substr(selection.start, selection.end - selection.start);
+
 		const toggle = {
-			flag: false, rule: escapedMdRule };
+			flag: false,
+			rule: escapedMdRule };
 
 		if (!string.trim().startsWith(escapedMdRule)) {
-			// remove if
 			toggle.flag = true;
 			if (selection.start - mdRuleOffset) {
 				selection.start = selection.start - mdRuleOffset;


### PR DESCRIPTION
fixes #2842 
Changing the toggle functionality so the markdown rule is removed on toggling the button (like in WYSIWYG mode), plus that's how it works on GitHub
![TOGGLE-desired](https://user-images.githubusercontent.com/54576074/79577126-dc492700-80e1-11ea-884a-8389082ff9d6.gif)


<details><summary> Changes</summary>
CHANGES 
BEFORE:-


![toggle-before](https://user-images.githubusercontent.com/54576074/79578759-482c8f00-80e4-11ea-848e-d77ca11a63fc.gif)


AFTER:-

![toggle-after](https://user-images.githubusercontent.com/54576074/79579361-1b2cac00-80e5-11ea-9002-3fad73d20ebc.gif)
</details>
@PackElend can you please label me, thank you
