### PR TITLE
Android: Fixed Export Profile Error

### DIFF
--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -118,7 +118,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 					const files = await shim.fsDriver().readDirStats(Setting.value('resourceDir'));
 
 					for (const file of files) {
-						if (file.path == "pluginAssets") continue;
+						if (file.path == 'pluginAssets') continue;
 						const source = `${Setting.value('resourceDir')}/${file.path}`;
 						const dest = `${this.state.profileExportPath}/resources/${file.path}`;
 						reg.logger().info(`Copying profile: ${source} => ${dest}`);

--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -98,32 +98,29 @@ class ConfigScreenComponent extends BaseScreenComponent {
 			this.setState({ profileExportStatus: 'exporting' });
 
 			const dbPath = '/data/data/net.cozic.joplin/databases';
-
+			const exportPath = this.state.profileExportPath;
+			const resourcePath = `${exportPath}/resources`;
 			try {
-				await shim.fsDriver().mkdir(this.state.profileExportPath);
-				await shim.fsDriver().mkdir(`${this.state.profileExportPath}/resources`);
 
 				{
-					const files = await shim.fsDriver().readDirStats(dbPath);
+					const copyFiles = async (source, dest) => {
+						await shim.fsDriver().mkdir(dest);
 
-					for (const file of files) {
-						const source = `${dbPath}/${file.path}`;
-						const dest = `${this.state.profileExportPath}/${file.path}`;
-						reg.logger().info(`Copying profile: ${source} => ${dest}`);
-						await shim.fsDriver().copy(source, dest);
-					}
-				}
+						const files = await shim.fsDriver().readDirStats(source);
 
-				{
-					const files = await shim.fsDriver().readDirStats(Setting.value('resourceDir'));
-
-					for (const file of files) {
-						if (file.path == 'pluginAssets') continue;
-						const source = `${Setting.value('resourceDir')}/${file.path}`;
-						const dest = `${this.state.profileExportPath}/resources/${file.path}`;
-						reg.logger().info(`Copying profile: ${source} => ${dest}`);
-						await shim.fsDriver().copy(source, dest);
-					}
+						for (const file of files) {
+							const source_ = `${source}/${file.path}`;
+							const dest_ = `${dest}/${file.path}`;
+							if (!file.isDirectory()) {
+								reg.logger().info(`Copying profile: ${source_} => ${dest_}`);
+								await shim.fsDriver().copy(source_, dest_);
+							} else {
+								await copyFiles(source_, dest_);
+							}
+						}
+					};
+					await copyFiles(dbPath, exportPath);
+					await copyFiles(Setting.value('resourceDir'), resourcePath);
 				}
 
 				alert('Profile has been exported!');

--- a/ReactNativeClient/lib/components/screens/config.js
+++ b/ReactNativeClient/lib/components/screens/config.js
@@ -118,6 +118,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 					const files = await shim.fsDriver().readDirStats(Setting.value('resourceDir'));
 
 					for (const file of files) {
+						if (file.path == "pluginAssets") continue;
 						const source = `${Setting.value('resourceDir')}/${file.path}`;
 						const dest = `${this.state.profileExportPath}/resources/${file.path}`;
 						reg.logger().info(`Copying profile: ${source} => ${dest}`);


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Fixed issue: https://github.com/laurent22/joplin/issues/3010

**EISDIR** stands for "Error, Is Directory". This means that NPM is trying to do something to a _file_ but it is a _directory_. In our case app is trying to copy the files from PluginAssets directory but it didn't find any files in that directory so `fsDriver().copy()` is trying to copy the blank directory which causes this error. Now I fixed it by skipping PluginAssets directory while exporting.


@PackElend can you please label me, thank you!