### PR TITLE
Desktop: Fixed order of notebooks in moveToNotebook dialog

### DIFF
--- a/CliClient/tests/models_Folder.js
+++ b/CliClient/tests/models_Folder.js
@@ -199,4 +199,23 @@ describe('models_Folder', function() {
 		expect(folderPath[2].id).toBe(f3.id);
 	}));
 
+	it('should sort folders alphabetically', asyncTest(async () => {
+		const f1 = await Folder.save({ title: 'folder1' });
+		const f2 = await Folder.save({ title: 'folder2', parent_id: f1.id });
+		const f3 = await Folder.save({ title: 'folder3', parent_id: f1.id });
+		const f4 = await Folder.save({ title: 'folder4' });
+		const f5 = await Folder.save({ title: 'folder5', parent_id: f4.id });
+		const f6 = await Folder.save({ title: 'folder6' });
+
+		const folders = await Folder.allAsTree();
+		const sortedFolderTree = await Folder.sortFolderTree(folders);
+
+		expect(sortedFolderTree.length).toBe(3);
+		expect(sortedFolderTree[0].id).toBe(f1.id);
+		expect(sortedFolderTree[0].children[0].id).toBe(f2.id);
+		expect(sortedFolderTree[0].children[1].id).toBe(f3.id);
+		expect(sortedFolderTree[1].id).toBe(f4.id);
+		expect(sortedFolderTree[1].children[0].id).toBe(f5.id);
+		expect(sortedFolderTree[2].id).toBe(f6.id);
+	}));
 });

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -242,6 +242,7 @@ class MainScreenComponent extends React.Component {
 				},
 			});
 		} else if (command.name === 'moveToFolder') {
+			const folders = await Folder.sortFolderTree();
 			const startFolders = [];
 			const maxDepth = 15;
 
@@ -252,7 +253,8 @@ class MainScreenComponent extends React.Component {
 					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth);
 				}
 			};
-			addOptions(await Folder.allAsTree(), 0);
+
+			addOptions(folders, 0);
 
 			this.setState({
 				promptOptions: {
@@ -627,7 +629,7 @@ class MainScreenComponent extends React.Component {
 				color: theme.color,
 				backgroundColor: theme.backgroundColor,
 			},
-			this.props.style
+			this.props.style,
 		);
 		const promptOptions = this.state.promptOptions;
 		const folders = this.props.folders;

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -323,8 +323,8 @@ class Folder extends BaseItem {
 		return rootFolders;
 	}
 
-	static async sortFolderTree() {
-		const output = await this.allAsTree();
+	static async sortFolderTree(folders) {
+		const output = folders ? folders : await this.allAsTree();
 
 		const sortFoldersAlphabetically = (folders) => {
 			folders.sort((a, b) => {

--- a/ReactNativeClient/lib/models/Folder.js
+++ b/ReactNativeClient/lib/models/Folder.js
@@ -323,6 +323,33 @@ class Folder extends BaseItem {
 		return rootFolders;
 	}
 
+	static async sortFolderTree() {
+		const output = await this.allAsTree();
+
+		const sortFoldersAlphabetically = (folders) => {
+			folders.sort((a, b) => {
+				if (a.parentId === b.parentId) {
+					return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
+				}
+			});
+			return folders;
+		};
+
+		const sortFolders = (folders) => {
+			for (let i = 0; i < folders.length; i++) {
+				const folder = folders[i];
+				if (folder.children) {
+					folder.children = sortFoldersAlphabetically(folder.children);
+					sortFolders(folder.children);
+				}
+			}
+			return folders;
+		};
+
+		sortFolders(sortFoldersAlphabetically(output));
+		return output;
+	}
+
 	static load(id) {
 		if (id == this.conflictFolderId()) return this.conflictFolder();
 		return super.load(id);


### PR DESCRIPTION
fixes #3052 
I tried to test all kind of edge cases. 

### Before 
![Screen-Recording-2020-04-18-at-4](https://user-images.githubusercontent.com/35633575/79635925-99468c80-8191-11ea-9745-c580339d28bf.gif)

### After
![Screen-Recording-2020-04-18-at-4 (1)](https://user-images.githubusercontent.com/35633575/79635952-d448c000-8191-11ea-9eae-1af045cf40ea.gif)
