### PR TITLE
Desktop: Fixed KaTeX font issue in exported PDF

### DIFF
--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
@@ -16,6 +16,10 @@ katex = mhchemModule(katex);
 
 function katexStyle() {
 	return [
+		// Note: Declaring the fonts is not needed for in-app rendering because
+		// they will be loaded automatically from katex.css.
+		// However they must be specified for exporting notes to HTML and PDF,
+		// so that they can be bundled with the other assets.
 		{ name: 'katex.css' },
 		{ name: 'fonts/KaTeX_AMS-Regular.woff2' },
 		{ name: 'fonts/KaTeX_Caligraphic-Bold.woff2' },
@@ -37,8 +41,6 @@ function katexStyle() {
 		{ name: 'fonts/KaTeX_Size3-Regular.woff2' },
 		{ name: 'fonts/KaTeX_Size4-Regular.woff2' },
 		{ name: 'fonts/KaTeX_Typewriter-Regular.woff2' },
-		// Note: Katex also requires a number of fonts and they need to be specified here
-		// since they will be required while exporting to HTML or PDF.
 	];
 }
 

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
@@ -17,8 +17,28 @@ katex = mhchemModule(katex);
 function katexStyle() {
 	return [
 		{ name: 'katex.css' },
-		// Note: Katex also requires a number of fonts but they don't need to be specified here
-		// since they will be loaded as needed from the CSS.
+		{ name: 'fonts/KaTeX_AMS-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Caligraphic-Bold.woff2' },
+		{ name: 'fonts/KaTeX_Caligraphic-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Fraktur-Bold.woff2' },
+		{ name: 'fonts/KaTeX_Fraktur-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Main-Bold.woff2' },
+		{ name: 'fonts/KaTeX_Main-BoldItalic.woff2' },
+		{ name: 'fonts/KaTeX_Main-Italic.woff2' },
+		{ name: 'fonts/KaTeX_Main-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Math-BoldItalic.woff2' },
+		{ name: 'fonts/KaTeX_Math-Italic.woff2' },
+		{ name: 'fonts/KaTeX_SansSerif-Bold.woff2' },
+		{ name: 'fonts/KaTeX_SansSerif-Italic.woff2' },
+		{ name: 'fonts/KaTeX_SansSerif-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Script-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Size1-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Size2-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Size3-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Size4-Regular.woff2' },
+		{ name: 'fonts/KaTeX_Typewriter-Regular.woff2' },
+		// Note: Katex also requires a number of fonts and they need to be specified here
+		// since they will be required while exporting to HTML or PDF.
 	];
 }
 

--- a/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
+++ b/ReactNativeClient/lib/joplin-renderer/MdToHtml/rules/katex.js
@@ -16,11 +16,11 @@ katex = mhchemModule(katex);
 
 function katexStyle() {
 	return [
+		{ name: 'katex.css' },
 		// Note: Declaring the fonts is not needed for in-app rendering because
 		// they will be loaded automatically from katex.css.
 		// However they must be specified for exporting notes to HTML and PDF,
 		// so that they can be bundled with the other assets.
-		{ name: 'katex.css' },
 		{ name: 'fonts/KaTeX_AMS-Regular.woff2' },
 		{ name: 'fonts/KaTeX_Caligraphic-Bold.woff2' },
 		{ name: 'fonts/KaTeX_Caligraphic-Regular.woff2' },


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

For example: "Desktop: Added new setting to change font", or "Mobile: Fixed config screen error"

PLEASE READ THE GUIDE FIRST: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
Fixes #3078

When we export a note `InteropService()` render a note in HTML file in temp directory then using that HTML file PDF get exported, Now I figured out that HTML file requires a `katex.css` which is already exported by plugin and `katex.css` requires the fonts included in fonts directory which is not exported by plugin so we need to export the fonts directory also along with `katex.css` now I added the fonts in `katex.js` so they also will be exported. Now everything working fine!

@PackElend Can you label me please? Thank you!
