### PR TITLE
Mobile: Fixes #3098: Table rendering issue in dark themes

### DIFF
--- a/ReactNativeClient/lib/components/global-style.js
+++ b/ReactNativeClient/lib/components/global-style.js
@@ -150,6 +150,7 @@ function themeStyle(theme) {
 		output.htmlDividerColor = '#3D444E';
 		output.htmlLinkColor = 'rgb(166,166,255)';
 		output.htmlCodeColor = '#ffffff';
+		output.htmlTableBackgroundColor = 'rgb(0, 0, 0)';
 		output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
 		output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
 
@@ -184,6 +185,7 @@ function themeStyle(theme) {
 	output.htmlDividerColor = '#3D444E';
 	output.htmlLinkColor = 'rgb(166,166,255)';
 	output.htmlCodeColor = '#ffffff';
+	output.htmlTableBackgroundColor = 'rgb(40, 41, 42)';
 	output.htmlCodeBackgroundColor = 'rgb(47, 48, 49)';
 	output.htmlCodeBorderColor = 'rgb(70, 70, 70)';
 


### PR DESCRIPTION
Fixes #3098 

## Before
<img src="https://user-images.githubusercontent.com/44024553/79754412-237b2600-8335-11ea-9be8-8afbe9a630f5.png" height="500" /> <img src="https://user-images.githubusercontent.com/44024553/79754406-20803580-8335-11ea-8cd0-140965176ed3.png" height="500" />

## After

<img src="https://user-images.githubusercontent.com/44024553/79754420-26761680-8335-11ea-9531-5d2d808f508e.png" height="500" /> <img src="https://user-images.githubusercontent.com/44024553/79754423-270ead00-8335-11ea-872b-d7aebb19a0a9.png" height="500" />
