### PR TITLE
Desktop: Fixes #3131: Long URL in Note Info Dialog

### DIFF
--- a/ElectronClient/gui/NotePropertiesDialog.jsx
+++ b/ElectronClient/gui/NotePropertiesDialog.jsx
@@ -295,8 +295,9 @@ class NotePropertiesDialog extends React.Component {
 					const ll = this.latLongFromLocation(value);
 					url = Note.geoLocationUrlFromLatLong(ll.latitude, ll.longitude);
 				}
+				const urlStyle = Object.assign({}, theme.urlStyle, { maxWidth: '180px', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' });
 				controlComp = (
-					<a href="#" onClick={() => bridge().openExternal(url)} style={theme.urlStyle}>
+					<a href="#" onClick={() => bridge().openExternal(url)} style={urlStyle}>
 						{displayedValue}
 					</a>
 				);


### PR DESCRIPTION
Fixes #3131 

## Before

![before](https://user-images.githubusercontent.com/44024553/80343561-bf4fe900-8883-11ea-8c21-0df467db020f.gif)

## After

<img width="1241" alt="Screenshot 2020-04-27 at 4 37 42 PM" src="https://user-images.githubusercontent.com/44024553/80365582-74df6400-88a5-11ea-9608-6fdfc3edb471.png">

