### PR TITLE
Desktop : Added bottom space to the AceEditor

### DIFF
--- a/ElectronClient/gui/NoteText.jsx
+++ b/ElectronClient/gui/NoteText.jsx
@@ -2233,7 +2233,8 @@ class NoteTextComponent extends React.Component {
 				// Enable/Disable the autoclosing braces
 				setOptions={{
 					behavioursEnabled: Setting.value('editor.autoMatchingBraces'),
-					useSoftTabs: false }}
+					useSoftTabs: false,
+					scrollPastEnd: '0.1' }}
 				// Disable warning: "Automatically scrolling cursor into view after
 				// selection change this will be disabled in the next version set
 				// editor.$blockScrolling = Infinity to disable this message"


### PR DESCRIPTION
## Fixes #3147 

### BEFORE
![image](https://user-images.githubusercontent.com/35633575/80694593-56ba7380-8af2-11ea-8875-9fbb797c37dd.png)

### AFTER (Look at the bottom of editor)
![image](https://user-images.githubusercontent.com/35633575/80695265-435bd800-8af3-11ea-8368-686873e7d0bb.png)

