### PR TITLE
Desktop: Handle compositionend event in TinyMCE

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -787,6 +787,9 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 		editor.on('keyup', onKeyUp);
 		editor.on('keypress', onKeypress);
 		editor.on('paste', onPaste);
+		// `compositionend` means that a user has finished entering a Chinese
+		// (or other languages that require IME) character.
+		editor.on('compositionend', onChangeHandler);
 		editor.on('cut', onChangeHandler);
 		editor.on('joplinChange', onChangeHandler);
 		editor.on('Undo', onChangeHandler);
@@ -798,6 +801,7 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 				editor.off('keyup', onKeyUp);
 				editor.off('keypress', onKeypress);
 				editor.off('paste', onPaste);
+				editor.off('compositionend', onChangeHandler);
 				editor.off('cut', onChangeHandler);
 				editor.off('joplinChange', onChangeHandler);
 				editor.off('Undo', onChangeHandler);


### PR DESCRIPTION
I noticed that texts are not properly saved when using IME (input method editor) on TinyMCE. Calling `onChangeHandler` on `compositionend` event fixes the problem.

![Peek 2020-05-04 20-13](https://user-images.githubusercontent.com/7091080/80960517-fefa7000-8e43-11ea-8333-5889e531e5f6.gif)

(Steps to reproduce: 1. Input some text using IME. 2. Switch to another note. 3. Switch to the original note, and you see that the text was not saved)
