### PR TITLE
Desktop: fix #3153: make GotoAnyting work with East Asian charactors

### DIFF
--- a/ReactNativeClient/lib/services/SearchEngine.js
+++ b/ReactNativeClient/lib/services/SearchEngine.js
@@ -236,7 +236,7 @@ class SearchEngine {
 	}
 
 	processBasicSearchResults_(rows, parsedQuery) {
-		const valueRegexs = parsedQuery.keys.includes('_') ? parsedQuery.terms['_'].map(term => term.valueRegex) : [];
+		const valueRegexs = parsedQuery.keys.includes('_') ? parsedQuery.terms['_'].map(term => term.valueRegex || term.value) : [];
 		const isTitleSearch = parsedQuery.keys.includes('title');
 		const isOnlyTitle = parsedQuery.keys.length === 1 && isTitleSearch;
 

--- a/ReactNativeClient/lib/services/SearchEngine.js
+++ b/ReactNativeClient/lib/services/SearchEngine.js
@@ -7,6 +7,7 @@ const ItemChangeUtils = require('lib/services/ItemChangeUtils');
 const { pregQuote, scriptType } = require('lib/string-utils.js');
 const removeDiacritics = require('diacritics').remove;
 const { sprintf } = require('sprintf-js');
+const { map, pickBy, identity, isEmpty } = require('lodash');
 
 class SearchEngine {
 	constructor() {
@@ -235,13 +236,36 @@ class SearchEngine {
 		return occurenceCount / spread;
 	}
 
-	processResults_(rows, parsedQuery) {
+	processBasicSearchResults_(rows, parsedQuery) {
+		const valueRegexs = parsedQuery.keys.includes('_') ? map(parsedQuery.terms['_'], 'valueRegex') : [];
+		const isTitleSearch = parsedQuery.keys.includes('title');
+		const isOnlyTitle = parsedQuery.keys.length === 1 && isTitleSearch;
+
 		for (let i = 0; i < rows.length; i++) {
 			const row = rows[i];
-			const offsets = row.offsets.split(' ').map(o => Number(o));
-			row.weight = this.calculateWeight_(offsets, parsedQuery.termCount);
-			row.fields = this.fieldNamesFromOffsets_(offsets);
+			const testTitle = regex => new RegExp(regex, 'ig').test(row.title);
+			const matchedFields = {
+				title: isTitleSearch || valueRegexs.some(testTitle),
+				body: !isOnlyTitle,
+			};
+
+			row.fields = Object.keys(pickBy(matchedFields, identity));
+			row.weight = 0;
 		}
+	}
+
+	processResults_(rows, parsedQuery, isBasicSearchResults = false) {
+		if (isBasicSearchResults) {
+			this.processBasicSearchResults_(rows, parsedQuery);
+		} else {
+			for (let i = 0; i < rows.length; i++) {
+				const row = rows[i];
+				const offsets = row.offsets.split(' ').map(o => Number(o));
+				row.weight = this.calculateWeight_(offsets, parsedQuery.termCount);
+				row.fields = this.fieldNamesFromOffsets_(offsets);
+			}
+		}
+
 
 		rows.sort((a, b) => {
 			if (a.fields.includes('title') && !b.fields.includes('title')) return -1;
@@ -383,6 +407,8 @@ class SearchEngine {
 		const searchOptions = {};
 
 		for (const key of parsedQuery.keys) {
+			if (isEmpty(parsedQuery.terms[key])) continue;
+
 			const term = parsedQuery.terms[key][0].value;
 			if (key === '_') searchOptions.anywherePattern = `*${term}*`;
 			if (key === 'title') searchOptions.titlePattern = `*${term}*`;
@@ -415,10 +441,13 @@ class SearchEngine {
 		query = this.normalizeText_(query);
 
 		const searchType = this.determineSearchType_(query, options.searchType);
+		const parsedQuery = this.parseQuery(query);
 
 		if (searchType === SearchEngine.SEARCH_TYPE_BASIC) {
 			// Non-alphabetical languages aren't support by SQLite FTS (except with extensions which are not available in all platforms)
-			return this.basicSearch(query);
+			const rows = await this.basicSearch(query);
+			this.processResults_(rows, parsedQuery, true);
+			return rows;
 		} else { // SEARCH_TYPE_FTS
 			// FTS will ignore all special characters, like "-" in the index. So if
 			// we search for "this-phrase" it won't find it because it will only
@@ -426,7 +455,6 @@ class SearchEngine {
 			// when searching.
 			// https://github.com/laurent22/joplin/issues/1075#issuecomment-459258856
 			query = query.replace(/-/g, ' ');
-			const parsedQuery = this.parseQuery(query);
 			const sql = `
 				SELECT
 					notes_fts.id,

--- a/ReactNativeClient/lib/services/SearchEngine.js
+++ b/ReactNativeClient/lib/services/SearchEngine.js
@@ -7,7 +7,6 @@ const ItemChangeUtils = require('lib/services/ItemChangeUtils');
 const { pregQuote, scriptType } = require('lib/string-utils.js');
 const removeDiacritics = require('diacritics').remove;
 const { sprintf } = require('sprintf-js');
-const { map, pickBy, identity, isEmpty } = require('lodash');
 
 class SearchEngine {
 	constructor() {
@@ -237,7 +236,7 @@ class SearchEngine {
 	}
 
 	processBasicSearchResults_(rows, parsedQuery) {
-		const valueRegexs = parsedQuery.keys.includes('_') ? map(parsedQuery.terms['_'], 'valueRegex') : [];
+		const valueRegexs = parsedQuery.keys.includes('_') ? parsedQuery.terms['_'].map(term => term.valueRegex) : [];
 		const isTitleSearch = parsedQuery.keys.includes('title');
 		const isOnlyTitle = parsedQuery.keys.length === 1 && isTitleSearch;
 
@@ -249,7 +248,7 @@ class SearchEngine {
 				body: !isOnlyTitle,
 			};
 
-			row.fields = Object.keys(pickBy(matchedFields, identity));
+			row.fields = Object.keys(matchedFields).filter(key => matchedFields[key]);
 			row.weight = 0;
 		}
 	}
@@ -407,7 +406,7 @@ class SearchEngine {
 		const searchOptions = {};
 
 		for (const key of parsedQuery.keys) {
-			if (isEmpty(parsedQuery.terms[key])) continue;
+			if (parsedQuery.terms[key].length === 0) continue;
 
 			const term = parsedQuery.terms[key][0].value;
 			if (key === '_') searchOptions.anywherePattern = `*${term}*`;


### PR DESCRIPTION
fix #3153.  Code review discussion before seen in #3154.

While typing East Asian charactors, the `SearchEngine` return a basic search result, which doesn't contain `fields`, and this break the code of highlighing process. Fix this bug add a `processBasicSearchResults_`  function to make the basic search result object consistent.
