### PR TITLE
Desktop: fix #3171: add support for matching text with diacritics for GotoAnything 

### DIFF
--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -234,7 +234,9 @@ class Dialog extends React.PureComponent {
 								const body = notesById[row.id];
 
 								// Iterate over all matches in the body for each search keyword
-								for (const { valueRegex } of searchKeywords) {
+								for (let { valueRegex } of searchKeywords) {
+									valueRegex = removeDiacritics(valueRegex);
+
 									for (const match of removeDiacritics(body).matchAll(new RegExp(valueRegex, 'ig'))) {
 										// Populate 'indices' with [begin index, end index] of each note fragment
 										// Begins at the regex matching index, ends at the next whitespace after seeking 15 characters to the right

--- a/ElectronClient/plugins/GotoAnything.jsx
+++ b/ElectronClient/plugins/GotoAnything.jsx
@@ -9,7 +9,7 @@ const Folder = require('lib/models/Folder');
 const Note = require('lib/models/Note');
 const { ItemList } = require('../gui/ItemList.min');
 const HelpButton = require('../gui/HelpButton.min');
-const { surroundKeywords, nextWhitespaceIndex } = require('lib/string-utils.js');
+const { surroundKeywords, nextWhitespaceIndex, removeDiacritics } = require('lib/string-utils.js');
 const { mergeOverlappingIntervals } = require('lib/ArrayUtils.js');
 const PLUGIN_NAME = 'gotoAnything';
 
@@ -235,7 +235,7 @@ class Dialog extends React.PureComponent {
 
 								// Iterate over all matches in the body for each search keyword
 								for (const { valueRegex } of searchKeywords) {
-									for (const match of body.matchAll(new RegExp(valueRegex, 'ig'))) {
+									for (const match of removeDiacritics(body).matchAll(new RegExp(valueRegex, 'ig'))) {
 										// Populate 'indices' with [begin index, end index] of each note fragment
 										// Begins at the regex matching index, ends at the next whitespace after seeking 15 characters to the right
 										indices.push([match.index, nextWhitespaceIndex(body, match.index + match[0].length + 15)]);


### PR DESCRIPTION
fix #3171. When matching text for highlighting, use diacritics-removed keywords to match diacritics-removed body.

FYI: I find anohter way to remove diacritics:

```
function removeDiacritics(str) {
  return str
    .normalize('NFD')
    .replace(/[\u0300-\u036f]/g, '');
}
```
Should we replace the origin implementation in `string-utils.js` with this implementation?