### PR TITLE
Clarify the random ID generation

### DIFF
--- a/readme/api.md
+++ b/readme/api.md
@@ -173,7 +173,7 @@ Examples:
 
 ### Creating a note with a specific ID
 
-When a new note is created, it is automatically assigned a new unique ID so **normally you do not need to set the ID**. However, if for some reason you want to set it, you can supply it as the `id` property. It needs to be a 32 characters long hexadecimal string. **Make sure it is unique**, for example by generating it using whatever GUID function is available in your programming language.
+When a new note is created, it is automatically assigned a new unique ID so **normally you do not need to set the ID**. However, if for some reason you want to set it, you can supply it as the `id` property. It needs to be a 32 characters long hexadecimal string. **Make sure it is unique**, for example by generating it using whatever 32 bits hash function is available in your programming language.
 
       curl --data '{ "id": "00a87474082744c1a8515da6aa5792d2", "title": "My note with custom ID"}' http://127.0.0.1:41184/notes
 


### PR DESCRIPTION
I believe it would be worthwhile to remove the reference to GUID in the part related to manual ID generation. A GUID example is `3F2504E0-4F89-11D3-9A0C-0305E82C3301` which is not the expected 32 bits.

Such an id will be silently skipped when synchronizing (at least Nextcloud → desktop, see [my problem with that](https://discourse.joplinapp.org/t/problem-synchronizing-tags-created-via-the-api-bug/8565)) so it would be better to just mention 32 bits and not GUID