### PR TITLE
Desktop: Follows #3148: Add button to scaffold markdown tables

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -895,6 +895,16 @@ class Application extends BaseApplication {
 						});
 					},
 				}, {
+					id: 'edit:insertMarkdownTable',
+					label: _('Insert Table'),
+					screens: ['Main'],
+					click: () => {
+						this.dispatch({
+							type: 'WINDOW_COMMAND',
+							name: 'textMarkdownTable',
+						});
+					},
+				}, {
 					type: 'separator',
 					screens: ['Main'],
 				}, {

--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -8,6 +8,7 @@ const { stateUtils } = require('lib/reducer.js');
 const { PromptDialog } = require('./PromptDialog.min.js');
 const NoteContentPropertiesDialog = require('./NoteContentPropertiesDialog.js').default;
 const NotePropertiesDialog = require('./NotePropertiesDialog.min.js');
+const { MarkdownTable } = require('./MarkdownTableDialog.min.js');
 const ShareNoteDialog = require('./ShareNoteDialog.js').default;
 const InteropServiceHelper = require('../InteropServiceHelper.js');
 const Setting = require('lib/models/Setting.js');
@@ -39,6 +40,7 @@ class MainScreenComponent extends React.Component {
 				message: '',
 			},
 			notePropertiesDialogOptions: {},
+			markdownTableDialogOptions: {},
 			noteContentPropertiesDialogOptions: {},
 			shareNoteDialogOptions: {},
 		};
@@ -46,6 +48,7 @@ class MainScreenComponent extends React.Component {
 		this.setupAppCloseHandling();
 
 		this.notePropertiesDialog_close = this.notePropertiesDialog_close.bind(this);
+		this.markdownTableDialog_close = this.markdownTableDialog_close.bind(this);
 		this.noteContentPropertiesDialog_close = this.noteContentPropertiesDialog_close.bind(this);
 		this.shareNoteDialog_close = this.shareNoteDialog_close.bind(this);
 		this.sidebar_onDrag = this.sidebar_onDrag.bind(this);
@@ -95,6 +98,10 @@ class MainScreenComponent extends React.Component {
 
 	notePropertiesDialog_close() {
 		this.setState({ notePropertiesDialogOptions: {} });
+	}
+
+	markdownTableDialog_close() {
+		this.setState({ markdownTableDialogOptions: {} });
 	}
 
 	noteContentPropertiesDialog_close() {
@@ -356,6 +363,13 @@ class MainScreenComponent extends React.Component {
 					noteId: command.noteId,
 					visible: true,
 					onRevisionLinkClick: command.onRevisionLinkClick,
+				},
+			});
+		} else if (command.name === 'showMarkdownTable') {
+			this.setState({
+				markdownTableDialogOptions: {
+					noteId: command.noteId,
+					visible: true,
 				},
 			});
 		} else if (command.name === 'commandContentProperties') {
@@ -856,6 +870,7 @@ class MainScreenComponent extends React.Component {
 		const modalLayerStyle = Object.assign({}, styles.modalLayer, { display: this.state.modalLayer.visible ? 'block' : 'none' });
 
 		const notePropertiesDialogOptions = this.state.notePropertiesDialogOptions;
+		const markdownTableDialogOptions = this.state.markdownTableDialogOptions;
 		const noteContentPropertiesDialogOptions = this.state.noteContentPropertiesDialogOptions;
 		const shareNoteDialogOptions = this.state.shareNoteDialogOptions;
 
@@ -867,6 +882,7 @@ class MainScreenComponent extends React.Component {
 
 				{noteContentPropertiesDialogOptions.visible && <NoteContentPropertiesDialog theme={this.props.theme} onClose={this.noteContentPropertiesDialog_close} text={noteContentPropertiesDialogOptions.text} lines={noteContentPropertiesDialogOptions.lines}/>}
 				{notePropertiesDialogOptions.visible && <NotePropertiesDialog theme={this.props.theme} noteId={notePropertiesDialogOptions.noteId} onClose={this.notePropertiesDialog_close} onRevisionLinkClick={notePropertiesDialogOptions.onRevisionLinkClick} />}
+				{markdownTableDialogOptions.visible && <MarkdownTable theme={this.props.theme} noteId={markdownTableDialogOptions.noteId} onClose={this.markdownTableDialog_close} />}
 				{shareNoteDialogOptions.visible && <ShareNoteDialog theme={this.props.theme} noteIds={shareNoteDialogOptions.noteIds} onClose={this.shareNoteDialog_close} />}
 
 				<PromptDialog autocomplete={promptOptions && 'autocomplete' in promptOptions ? promptOptions.autocomplete : null} defaultValue={promptOptions && promptOptions.value ? promptOptions.value : ''} theme={this.props.theme} style={styles.prompt} onClose={this.promptOnClose_} label={promptOptions ? promptOptions.label : ''} description={promptOptions ? promptOptions.description : null} visible={!!this.state.promptOptions} buttons={promptOptions && 'buttons' in promptOptions ? promptOptions.buttons : null} inputType={promptOptions && 'inputType' in promptOptions ? promptOptions.inputType : null} />

--- a/ElectronClient/gui/MarkdownTableDialog.jsx
+++ b/ElectronClient/gui/MarkdownTableDialog.jsx
@@ -70,32 +70,31 @@ const MarkdownTable = (props) => {
 	};
 
 
-	const getMarkdownRule = () => {
-		let tableString = '',
-			i = 0,
-			j = 0;
+	const getMarkdownRule = (width, height) => {
+		let tableString = '';
+		let	i = 0;
+		let j = 0;
 
 		// Header
-		for (j = 1; j <= x; j++) {
+		for (j = 1; j <= width; j++) {
 			tableString += '|     ';
 		}
 		tableString += '|\n';
 
 		// Separator
-		for (j = 1; j <= x; j++) {
+		for (j = 1; j <= width; j++) {
 			tableString += '| --- ';
 		}
 		tableString += '|\n';
 
 		// Body
-		for (i = 1; i <= y; i++) {
-			for (j = 1; j <= x; j++) {
+		for (i = 1; i <= height; i++) {
+			for (j = 1; j <= width; j++) {
 				tableString += '|     ';
 			}
 			tableString += '|\n';
 		}
 
-		outsideResolve(tableString);
 		return tableString;
 	};
 
@@ -106,9 +105,9 @@ const MarkdownTable = (props) => {
 	};
 
 	const onClickHandler = () => {
-		getMarkdownRule();
+		const markdownTable = getMarkdownRule(x, y);
+		outsideResolve(markdownTable);
 		closeDialog();
-
 	};
 
 	const onCancelClickHandler = () => {

--- a/ElectronClient/gui/MarkdownTableDialog.jsx
+++ b/ElectronClient/gui/MarkdownTableDialog.jsx
@@ -1,0 +1,162 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+const React = require('react');
+const { useState, useRef } = require('react');
+const { themeStyle } = require('../theme.js');
+const { _ } = require('lib/locale.js');
+
+let outsideResolve;
+
+const getMarkdown = () => {
+	return new Promise(function(resolve) {
+		outsideResolve = resolve;
+	});
+};
+
+const MarkdownTable = (props) => {
+
+	const theme = themeStyle(props.theme);
+
+	const styles_ = {
+		page: {
+			minWidth: 'unset',
+		},
+		title: {
+			margin: '1.2em',
+		},
+		table: {
+			borderSpacing: 1,
+			borderCollapse: 'unset',
+			backgroundColor: theme.backgroundColor,
+			cursor: 'pointer',
+			margin: '1.2em',
+			marginBottom: '0',
+		},
+	};
+
+	const [x, setX] = useState(0);
+	const [y, setY] = useState(0);
+	const tableEl = useRef(null);
+
+	const _onMouseMove = (event) => {
+		const table = tableEl.current;
+		const height = table.clientHeight;
+		const width = table.clientWidth;
+
+		// we cannot use event.offsetX which give the relative position of the mouse with respect to
+		// the div as here we are dealing with neseted elements and not a plain div, a table has <tr> and
+		// <td> elements which confuses react, which element is the point of reference, more info:
+		// https://stackoverflow.com/questions/3234256/find-mouse-position-relative-to-element
+
+		const obj = table.getBoundingClientRect();
+		const oX = event.clientX - obj.left; // x position within the element.
+		const oY = event.clientY - obj.top; // y position within the element.
+
+		const col = Math.floor((oX / width) * 10) + 1;
+		const row = Math.floor((oY / height) * 10) + 1;
+
+		setX(col);
+		setY(row);
+		if (table) {
+			for (let j = 0; j < table.rows.length; j++) {
+				for (let i = 0; i < table.rows[j].cells.length; i++) {
+					if (j < row && i < col) {
+						table.rows[j].cells[i].style.background = '#DEF';
+					} else {
+						table.rows[j].cells[i].style.background = theme.backgroundColor;
+					}
+				}
+			}
+		}
+	};
+
+
+	const getMarkdownRule = () => {
+		let tableString = '',
+			i = 0,
+			j = 0;
+		// every table should have a heading
+
+		// Header
+		for (j = 1; j <= x; j++) {
+			tableString += '|     ';
+		}
+		tableString += '|\n';
+
+		// Separator
+		for (j = 1; j <= x; j++) {
+			tableString += '| --- ';
+		}
+		tableString += '|\n';
+
+		// Body
+		for (i = 1; i <= y; i++) {
+			for (j = 1; j <= x; j++) {
+				tableString += '|     ';
+			}
+			tableString += '|\n';
+		}
+
+		outsideResolve(tableString);
+		return tableString;
+	};
+
+	const closeDialog = () => {
+		if (props.onClose) {
+			props.onClose();
+		}
+	};
+
+	const onClickHandler = () => {
+		getMarkdownRule();
+		closeDialog();
+
+	};
+
+	const onCancelClickHandler = () => {
+		outsideResolve('');
+		closeDialog();
+	};
+
+	return (
+		<div className="smalltalk">
+			<div className="page" style={styles_.page}>
+				<div style={styles_.title}>
+					<div style={theme.dialogTitle}>{_(`Rows: ${y} Columns: ${x}`)}</div>
+				</div>
+				<table
+					className="tableEl"
+					style={styles_.table}
+					onMouseMove={_onMouseMove}
+					// onMouseOut={this._onMouseOut}
+					ref={tableEl}
+				>
+					<tbody>
+						{Array(10).fill().map(() => {
+							return (
+								<tr>
+									{Array(10).fill().map(() => {
+										return (
+											<td onClick={onClickHandler}></td>
+										);
+									})}
+								</tr>
+							);
+						})}
+					</tbody>
+				</table>
+				<div className="action-area">
+					<div className="button-strip">
+						<button style={theme.button} onClick={onCancelClickHandler}>
+							{'Cancel'}
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+module.exports = {
+	MarkdownTable,
+	getMarkdown,
+};

--- a/ElectronClient/gui/MarkdownTableDialog.jsx
+++ b/ElectronClient/gui/MarkdownTableDialog.jsx
@@ -74,7 +74,6 @@ const MarkdownTable = (props) => {
 		let tableString = '',
 			i = 0,
 			j = 0;
-		// every table should have a heading
 
 		// Header
 		for (j = 1; j <= x; j++) {
@@ -127,7 +126,6 @@ const MarkdownTable = (props) => {
 					className="tableEl"
 					style={styles_.table}
 					onMouseMove={_onMouseMove}
-					// onMouseOut={this._onMouseOut}
 					ref={tableEl}
 				>
 					<tbody>

--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
@@ -285,7 +285,7 @@ function AceEditor(props: NoteBodyEditorProps, ref: any) {
 							});
 
 							const mdTable = await getMarkdown();
-							wrapSelectionWithStrings(mdTable == '' ? '' : '/n', mdTable);
+							wrapSelectionWithStrings(mdTable == '' ? '' : '\n', mdTable);
 						},
 						textLink: async () => {
 							const url = await dialogs.prompt(_('Insert Hyperlink'));

--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
@@ -285,7 +285,7 @@ function AceEditor(props: NoteBodyEditorProps, ref: any) {
 							});
 
 							const mdTable = await getMarkdown();
-							wrapSelectionWithStrings('\n', mdTable);
+							wrapSelectionWithStrings(mdTable == '' ? '' : '/n', mdTable);
 						},
 						textLink: async () => {
 							const url = await dialogs.prompt(_('Insert Hyperlink'));

--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
@@ -11,6 +11,8 @@ import Toolbar from './Toolbar';
 import styles_ from './styles';
 import { RenderedBody, defaultRenderedBody } from './utils/types';
 
+const { getMarkdown } = require('../../../MarkdownTableDialog.min.js');
+
 const AceEditorReact = require('react-ace').default;
 const { bridge } = require('electron').remote.require('./bridge');
 const Note = require('lib/models/Note.js');
@@ -276,6 +278,15 @@ function AceEditor(props: NoteBodyEditorProps, ref: any) {
 					const commands: any = {
 						textBold: () => wrapSelectionWithStrings('**', '**', _('strong text')),
 						textItalic: () => wrapSelectionWithStrings('*', '*', _('emphasized text')),
+						textMarkdownTable: async () => {
+							props.dispatch({
+								type: 'WINDOW_COMMAND',
+								name: 'showMarkdownTable',
+							});
+
+							const mdTable = await getMarkdown();
+							wrapSelectionWithStrings('\n', mdTable);
+						},
 						textLink: async () => {
 							const url = await dialogs.prompt(_('Insert Hyperlink'));
 							if (url) wrapSelectionWithStrings('[', `](${url})`);

--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.tsx
@@ -144,7 +144,7 @@ export default function Toolbar(props:ToolbarProps) {
 			},
 		});
 		toolbarItems.push({
-			tooltip: _('Table'),
+			tooltip: _('Insert Table'),
 			iconName: 'fa-table',
 			onClick: async () => {
 				props.dispatch({

--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.tsx
@@ -143,7 +143,16 @@ export default function Toolbar(props:ToolbarProps) {
 				});
 			},
 		});
-
+		toolbarItems.push({
+			tooltip: _('Table'),
+			iconName: 'fa-table',
+			onClick: async () => {
+				props.dispatch({
+					type: 'WINDOW_COMMAND',
+					name: 'textMarkdownTable',
+				});
+			},
+		});
 		toolbarItems.push({
 			tooltip: _('Insert Date Time'),
 			iconName: 'fa-calendar-plus-o',

--- a/ElectronClient/gui/NoteEditor/utils/useWindowCommandHandler.ts
+++ b/ElectronClient/gui/NoteEditor/utils/useWindowCommandHandler.ts
@@ -42,6 +42,7 @@ export default function useWindowCommandHandler(dependencies:HookDependencies) {
 				'textCheckbox',
 				'textHeading',
 				'textHorizontalRule',
+				'textMarkdownTable',
 			];
 
 			if (directMapCommands.includes(command.name)) {


### PR DESCRIPTION
Hello,
I was quite sad when #3148 got closed as I was eagerly waiting (and following the PR) for the feature to land. I tend to use tables quite a lot.

So, hoping to not offend anybody, I gave it a try, taking much of the previous code as inspiration.

The discussion:
https://discourse.joplinapp.org/t/add-tables-to-the-toolbar/6213

The new prompt dialog use the same style of the one used to insert link (managed by the `smalltalk` package)
The final result:

|Insert table prompt| Insert link|
|---|---|
|<img width="1280" alt="Schermata 2020-05-15 alle 17 33 16" src="https://user-images.githubusercontent.com/6209647/82068384-3550ae80-96d2-11ea-948e-46cc5860bbd3.png">|<img width="1280" alt="Schermata 2020-05-15 alle 17 33 25" src="https://user-images.githubusercontent.com/6209647/82068394-384b9f00-96d2-11ea-898d-191b722618cf.png">|

It can be accessed in two ways:

|Toolbar button| Edit menu|
|---|---|
|<img width="272" alt="Schermata 2020-05-15 alle 17 34 29 3" src="https://user-images.githubusercontent.com/6209647/82068818-cd4e9800-96d2-11ea-81af-1f32d5493142.png">|<img width="247" alt="Schermata 2020-05-15 alle 17 34 29 2" src="https://user-images.githubusercontent.com/6209647/82068813-cc1d6b00-96d2-11ea-9d0e-5c3c3b72d0f1.png">|

I saw that in the previous PR and the forum discussion there is a mild interest in the ability to also edit the table. I personally have no interest in such feature (and I would certainly define it as bloat, since the text editor is just underneath, but this is only my opinion).

This PR aims to fulfill the simple need for a shortcut to fastly scaffold empty markdown tables, to be then filled afterwards.