### PR TITLE
New Idea: Separate Windows For Panes

### DIFF
--- a/readme/gsod2020/ideas.md
+++ b/readme/gsod2020/ideas.md
@@ -19,3 +19,6 @@ You can start with:
 # 3. Idea - create a tool to collect ideas and suggestions based on the content of the community forum
 There are many ideas in the forum and attempts to organize and streamline them.
 Task is to find a toolset to structure them and make the knowledge buried in there available easily.
+
+# 4. Idea - Divide panel into separate windows
+Joplin has 4 panes: side bar, notes list, code and view. Change joplin in a way that these parts can be different windows. Thus it is possible to put these windows on different screens for more space and better overview.


### PR DESCRIPTION
Joplin has 4 panes: side bar, notes list, code and view. Change joplin in a way that these parts can be different windows. Thus it is possible to put these windows on different screens for more space and better overview.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
