### PR TITLE
Update the faq for VSCode and Sublime

### DIFF
--- a/readme/faq.md
+++ b/readme/faq.md
@@ -21,21 +21,21 @@ Some example configurations are: (comments after #)
 Linux/Mac:
 
 ```bash
-subl -n       # Opens Sublime (subl) in a new window (-n)
-code -n       # Opens Visual Studio Code (code) in a new window (-n)
+subl -n -w      # Opens Sublime (subl) in a new window (-n) and waits for close (-w)
+code -n --wait  # Opens Visual Studio Code (code) in a new window (-n) and waits for close (--wait)
 gedit --new-window    # Opens gedit (Gnome Text Editor) in a new window
-xterm -e vim  # Opens a new terminal and opens vim. Can be replaced with an
-              # alternative terminal (gnome-terminal, terminator, etc.) 
-              # or terminal text-editor (emacs, nano, etc.)
+xterm -e vim    # Opens a new terminal and opens vim. Can be replaced with an
+                # alternative terminal (gnome-terminal, terminator, etc.) 
+                # or terminal text-editor (emacs, nano, etc.)
 open -a <application> # Mac only: opens a GUI application
 ```
 
 Windows:
 
 ```bash
-subl.exe -n   # Opens Sublime (subl) in a new window (-n)
-code.exe -n   # Opens Visual Studio Code in a new window (-n)
-notepad.exe   # Opens Notepad in a new window
+subl.exe -n -w      # Opens Sublime (subl) in a new window (-n) and waits for close (-w)
+code.exe -n --wait  # Opens Visual Studio Code in a new window (-n) and waits for close (--wait)
+notepad.exe         # Opens Notepad in a new window
 notepad++.exe --openSession   # Opens Notepad ++ in new window
 ```
 


### PR DESCRIPTION
This updates the sublime text and VSCode commands to add options which
make them wait before closing. This is borrowed from how you set a
different editor for git commit messages, described by github here:
https://help.github.com/en/github/using-git/associating-text-editors-with-git

Fixes #2425

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
