### PR TITLE
Desktop: Exposes source URL in note editor

### DIFF
--- a/ElectronClient/gui/MainScreen.jsx
+++ b/ElectronClient/gui/MainScreen.jsx
@@ -360,6 +360,7 @@ class MainScreenComponent extends React.Component {
 					noteId: command.noteId,
 					visible: true,
 					onRevisionLinkClick: command.onRevisionLinkClick,
+					onChange: command.onChange,
 				},
 			});
 		} else if (command.name === 'commandContentProperties') {
@@ -873,7 +874,7 @@ class MainScreenComponent extends React.Component {
 				<div style={modalLayerStyle}>{this.state.modalLayer.message}</div>
 
 				{noteContentPropertiesDialogOptions.visible && <NoteContentPropertiesDialog theme={this.props.theme} onClose={this.noteContentPropertiesDialog_close} text={noteContentPropertiesDialogOptions.text} lines={noteContentPropertiesDialogOptions.lines}/>}
-				{notePropertiesDialogOptions.visible && <NotePropertiesDialog theme={this.props.theme} noteId={notePropertiesDialogOptions.noteId} onClose={this.notePropertiesDialog_close} onRevisionLinkClick={notePropertiesDialogOptions.onRevisionLinkClick} />}
+				{notePropertiesDialogOptions.visible && <NotePropertiesDialog theme={this.props.theme} noteId={notePropertiesDialogOptions.noteId} onClose={this.notePropertiesDialog_close} onRevisionLinkClick={notePropertiesDialogOptions.onRevisionLinkClick} onChange={notePropertiesDialogOptions.onChange} />}
 				{shareNoteDialogOptions.visible && <ShareNoteDialog theme={this.props.theme} noteIds={shareNoteDialogOptions.noteIds} onClose={this.shareNoteDialog_close} />}
 
 				<PromptDialog autocomplete={promptOptions && 'autocomplete' in promptOptions ? promptOptions.autocomplete : null} defaultValue={promptOptions && promptOptions.value ? promptOptions.value : ''} theme={this.props.theme} style={styles.prompt} onClose={this.promptOnClose_} label={promptOptions ? promptOptions.label : ''} description={promptOptions ? promptOptions.description : null} visible={!!this.state.promptOptions} buttons={promptOptions && 'buttons' in promptOptions ? promptOptions.buttons : null} inputType={promptOptions && 'inputType' in promptOptions ? promptOptions.inputType : null} />

--- a/ElectronClient/gui/NoteEditor/NoteEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteEditor.tsx
@@ -189,11 +189,8 @@ function NoteEditor(props: NoteEditorProps) {
 
 		handleProvisionalFlag();
 
-		const change = field === 'body' ? {
-			body: value,
-		} : {
-			title: value,
-		};
+		const change: { [key: string]: any } = {};
+		change[field] = value;
 
 		const newNote = {
 			...formNote,
@@ -316,6 +313,20 @@ function NoteEditor(props: NoteEditorProps) {
 	const noteToolbar_buttonClick = useCallback((event: any) => {
 		const cases: any = {
 
+			'noteProperties': async () => {
+				props.dispatch({
+					type: 'WINDOW_COMMAND',
+					name: 'commandNoteProperties',
+					noteId: formNote.id,
+					onRevisionLinkClick: () => {
+						noteToolbar_buttonClick({ name: 'showRevisions' });
+					},
+					onChange: (key: string, value: any) => {
+						onFieldChange(key, value);
+					},
+				});
+			},
+
 			'startExternalEditing': async () => {
 				props.dispatch({
 					type: 'WINDOW_COMMAND',
@@ -410,6 +421,22 @@ function NoteEditor(props: NoteEditorProps) {
 					value={formNote.title}
 				/>
 				{titleBarDate}
+			</div>
+		);
+	}
+
+	function renderUrlBar() {
+		if (!formNote.source_url) return false;
+
+		return (
+			<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+				<a
+					href="#"
+					onClick={() => bridge().openExternal(formNote.source_url)}
+					style={styles.urlStyle}
+				>
+					{formNote.source_url}
+				</a>
 			</div>
 		);
 	}
@@ -525,6 +552,7 @@ function NoteEditor(props: NoteEditorProps) {
 		<div style={styles.root} onDrop={onDrop}>
 			<div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
 				{renderTitleBar()}
+				{renderUrlBar()}
 				<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
 					{renderNoteToolbar()}{renderTagBar()}
 				</div>

--- a/ElectronClient/gui/NoteEditor/styles/index.ts
+++ b/ElectronClient/gui/NoteEditor/styles/index.ts
@@ -31,6 +31,14 @@ export default function styles(props: NoteEditorProps) {
 				border: '1px solid',
 				borderColor: theme.dividerColor,
 			},
+			urlStyle: {
+				...theme.urlStyle,
+				whiteSpace: 'nowrap',
+				overflow: 'hidden',
+				textOverflow: 'ellipsis',
+				margin: 8,
+				marginBottom: 3,
+			},
 			warningBanner: {
 				background: theme.warningBackgroundColor,
 				fontFamily: theme.fontFamily,

--- a/ElectronClient/gui/NoteEditor/utils/types.ts
+++ b/ElectronClient/gui/NoteEditor/utils/types.ts
@@ -61,6 +61,7 @@ export interface FormNote {
 	markup_language: number,
 	user_updated_time: number,
 	encryption_applied: number,
+	source_url: string,
 
 	hasChanged: boolean,
 
@@ -111,6 +112,7 @@ export function defaultFormNote():FormNote {
 		hasChanged: false,
 		user_updated_time: 0,
 		encryption_applied: 0,
+		source_url: '',
 	};
 }
 

--- a/ElectronClient/gui/NoteEditor/utils/useFormNote.ts
+++ b/ElectronClient/gui/NoteEditor/utils/useFormNote.ts
@@ -73,6 +73,7 @@ export default function useFormNote(dependencies:HookDependencies) {
 			hasChanged: false,
 			user_updated_time: n.user_updated_time,
 			encryption_applied: n.encryption_applied,
+			source_url: n.source_url,
 		};
 
 		// Note that for performance reason,the call to setResourceInfos should

--- a/ElectronClient/gui/NotePropertiesDialog.jsx
+++ b/ElectronClient/gui/NotePropertiesDialog.jsx
@@ -198,6 +198,10 @@ class NotePropertiesDialog extends React.Component {
 				newFormNote[this.state.editedKey] = this.state.editedValue;
 			}
 
+			if (this.props.onChange) {
+				this.props.onChange(this.state.editedKey, newFormNote[this.state.editedKey]);
+			}
+
 			this.setState(
 				{
 					formNote: newFormNote,

--- a/ElectronClient/gui/NoteToolbar/NoteToolbar.tsx
+++ b/ElectronClient/gui/NoteToolbar/NoteToolbar.tsx
@@ -37,8 +37,8 @@ function styles_(props:NoteToolbarProps) {
 }
 
 function useToolbarItems(props:NoteToolbarProps) {
-	const { note, folders, watchedNoteFiles, notesParentType, dispatch
-		, onButtonClick, backwardHistoryNotes, forwardHistoryNotes } = props;
+	const { note, folders, watchedNoteFiles, notesParentType, onButtonClick
+		, backwardHistoryNotes, forwardHistoryNotes } = props;
 
 	const toolbarItems = [];
 
@@ -86,14 +86,7 @@ function useToolbarItems(props:NoteToolbarProps) {
 		tooltip: _('Note properties'),
 		iconName: 'fa-info-circle',
 		onClick: () => {
-			dispatch({
-				type: 'WINDOW_COMMAND',
-				name: 'commandNoteProperties',
-				noteId: note.id,
-				onRevisionLinkClick: () => {
-					onButtonClick({ name: 'showRevisions' });
-				},
-			});
+			onButtonClick({ name: 'noteProperties' });
 		},
 	});
 


### PR DESCRIPTION
This makes the source URL field (usually set by Web Clipper) exposed in the note editor (so you wouldn't have to click on properties to determine if a note has a URL):

![image](https://user-images.githubusercontent.com/250887/83649669-5b6dbe00-a5af-11ea-8219-4348d0898491.png)

Relevant discussion:

- [Indicator for URL field](https://discourse.joplinapp.org/t/indicator-for-url-field/1272)
- [Feature request: URL button](https://discourse.joplinapp.org/t/feature-request-url-button/4825)
- [Web clipper source URL - why hidden in note properties?](https://discourse.joplinapp.org/t/web-clipper-source-url-why-hidden-in-note-properties/8845)
