### PR TITLE
Desktop: Actually apply theme for ace editor

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
@@ -590,7 +590,7 @@ function AceEditor(props: NoteBodyEditorProps, ref: any) {
 				<AceEditorReact
 					value={props.content}
 					mode={props.contentMarkupLanguage === Note.MARKUP_LANGUAGE_HTML ? 'text' : 'markdown'}
-					theme={styles.editor.editorTheme}
+					theme={styles.editor.aceEditorTheme}
 					style={styles.editor}
 					width={`${width}px`}
 					fontSize={styles.editor.fontSize}


### PR DESCRIPTION
fixes #3337 

This fixes a regression I accidentally introduced with the code mirror change. As you can see it's a silly typo. I promise that I didn't subtly break the aceeditor in an effort to get people to switch over to the beta codemirror editor...