### PR TITLE
Mobile: check for provisional note instead of empty note id

### DIFF
--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -846,8 +846,9 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 	async folderPickerOptions_valueChanged(itemValue) {
 		const note = this.state.note;
+		const isProvisionalNote = this.props.provisionalNoteIds.includes(note.id);
 
-		if (!note.id) {
+		if (isProvisionalNote) {
 			await this.saveNoteButton_press(itemValue);
 		} else {
 			await Note.moveToFolder(note.id, itemValue);


### PR DESCRIPTION
Fixes #3343 