### PR TITLE
Desktop: Editor Spellcheck Integration

### DIFF
--- a/ElectronClient/ElectronAppWrapper.js
+++ b/ElectronClient/ElectronAppWrapper.js
@@ -67,6 +67,7 @@ class ElectronAppWrapper {
 			backgroundColor: '#fff', // required to enable sub pixel rendering, can't be in css
 			webPreferences: {
 				nodeIntegration: true,
+				spellcheck: true,
 			},
 			webviewTag: true,
 			// We start with a hidden window, which is then made visible depending on the showTrayIcon setting

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -240,8 +240,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	}, []);
 
 	const onEditorContextMenu = useCallback(() => {
-
-		bridge().window().webContents.on('context-menu', (_event: any, params: any) => {
+		bridge().window().webContents.once('context-menu', (_event: any, params: any) => {
 			const menu = new Menu();
 
 			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
@@ -264,7 +263,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 				menu.append(
 					new MenuItem({
-						label: _(`Add "${params.misspelledWord}" to dictionary`),
+						label: _('Add "%s" to dictionary', params.misspelledWord),
 						click: async () => bridge().window().webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord),
 					})
 				);

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -124,13 +124,13 @@ function Editor(props: EditorProps, ref: any) {
 			mode: props.mode,
 			readOnly: props.readOnly,
 			autoCloseBrackets: props.autoMatchBraces,
-			inputStyle: 'contenteditable', // contenteditable loses cursor position on focus change, use textarea instead
+			inputStyle: 'contenteditable',
 			lineWrapping: true,
 			lineNumbers: false,
 			scrollPastEnd: true,
 			indentWithTabs: true,
 			indentUnit: 4,
-			spellcheck: Setting.value('spellcheck'),
+			spellcheck: Setting.value('spellcheck.enabled'),
 			allowDropFileTypes: [''], // disable codemirror drop handling
 			keyMap: props.keyMap ? props.keyMap : 'default',
 			extraKeys: { 'Enter': 'insertListElement',

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useEffect, useImperativeHandle, useState, useRef, useCallback, forwardRef } from 'react';
 
-const CodeMirror = require('codemirror');
 import 'codemirror/addon/comment/comment';
 import 'codemirror/addon/dialog/dialog';
 import 'codemirror/addon/edit/closebrackets';
@@ -25,6 +24,9 @@ import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/diff/diff';
 import 'codemirror/mode/sql/sql';
+
+const CodeMirror = require('codemirror');
+const Setting = require('lib/models/Setting');
 
 export interface CancelledKeys {
 	mac: string[],
@@ -122,13 +124,13 @@ function Editor(props: EditorProps, ref: any) {
 			mode: props.mode,
 			readOnly: props.readOnly,
 			autoCloseBrackets: props.autoMatchBraces,
-			inputStyle: 'textarea', // contenteditable loses cursor position on focus change, use textarea instead
+			inputStyle: 'contenteditable', // contenteditable loses cursor position on focus change, use textarea instead
 			lineWrapping: true,
 			lineNumbers: false,
 			scrollPastEnd: true,
 			indentWithTabs: true,
 			indentUnit: 4,
-			spellcheck: true,
+			spellcheck: Setting.value('spellcheck'),
 			allowDropFileTypes: [''], // disable codemirror drop handling
 			keyMap: props.keyMap ? props.keyMap : 'default',
 			extraKeys: { 'Enter': 'insertListElement',

--- a/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -13,6 +13,7 @@ const Resource = require('lib/models/Resource');
 const { themeStyle, buildStyle } = require('../../../../theme.js');
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
+const Setting = require('lib/models/Setting');
 
 function markupRenderOptions(override:any = null) {
 	return {
@@ -491,7 +492,8 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 				resize: false,
 				icons: 'Joplin',
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
-				plugins: 'noneditable link joplinLists hr searchreplace codesample table',
+				plugins: 'noneditable link joplinLists hr searchreplace codesample table spellchecker',
+				browser_spellcheck: Setting.value('spellcheck'),
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
 				valid_elements: '*[*]', // We already filter in sanitize_html
 				menubar: false,
@@ -500,8 +502,9 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 				target_list: false,
 				table_resize_bars: false,
 				language: ['en_US', 'en_GB'].includes(language) ? undefined : language,
-				toolbar: 'bold italic | link joplinInlineCode joplinCodeBlock joplinAttach | numlist bullist joplinChecklist | h1 h2 h3 hr blockquote table joplinInsertDateTime',
+				toolbar: 'bold italic | link joplinInlineCode joplinCodeBlock joplinAttach | numlist bullist joplinChecklist | h1 h2 h3 hr blockquote table joplinInsertDateTime', // TODO: Look into spellchecker toolbar plugin
 				localization_function: _,
+				// TODO: spellchecker_callback function for context menu
 				contextmenu: contextMenuItemNames.join(' '),
 				setup: (editor:any) => {
 

--- a/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -493,7 +493,7 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 				icons: 'Joplin',
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
 				plugins: 'noneditable link joplinLists hr searchreplace codesample table spellchecker',
-				browser_spellcheck: Setting.value('spellcheck'),
+				browser_spellcheck: Setting.value('spellcheck.enabled'),
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
 				valid_elements: '*[*]', // We already filter in sanitize_html
 				menubar: false,
@@ -504,7 +504,6 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 				language: ['en_US', 'en_GB'].includes(language) ? undefined : language,
 				toolbar: 'bold italic | link joplinInlineCode joplinCodeBlock joplinAttach | numlist bullist joplinChecklist | h1 h2 h3 hr blockquote table joplinInsertDateTime', // TODO: Look into spellchecker toolbar plugin
 				localization_function: _,
-				// TODO: spellchecker_callback function for context menu
 				contextmenu: contextMenuItemNames.join(' '),
 				setup: (editor:any) => {
 

--- a/ReactNativeClient/lib/BaseModel.js
+++ b/ReactNativeClient/lib/BaseModel.js
@@ -5,11 +5,11 @@ const Mutex = require('async-mutex').Mutex;
 
 class BaseModel {
 	static modelType() {
-		throw new Error('Must be overriden');
+		throw new Error('Must be overridden');
 	}
 
 	static tableName() {
-		throw new Error('Must be overriden');
+		throw new Error('Must be overridden');
 	}
 
 	static setDb(db) {

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -43,7 +43,7 @@ class Setting extends BaseModel {
 		const emptyDirWarning = _('Attention: If you change this location, make sure you copy all your content to it before syncing, otherwise all files will be removed! See the FAQ for more details: %s', 'https://joplinapp.org/faq/');
 
 		// A "public" setting means that it will show up in the various config screens (or config command for the CLI tool), however
-		// if if private a setting might still be handled and modified by the app. For instance, the settings related to sorting notes are not
+		// if private a setting might still be handled and modified by the app. For instance, the settings related to sorting notes are not
 		// public for the mobile and desktop apps because they are handled separately in menus.
 
 		const themeOptions = () => {
@@ -252,7 +252,13 @@ class Setting extends BaseModel {
 					return options;
 				},
 			},
-
+			spellcheck: {
+				value: true,
+				type: Setting.TYPE_BOOL,
+				public: true,
+				appTypes: ['desktop'],
+				label: () => _('Enable Spellcheck (BETA: Only works with CodeMirror)'),
+			},
 			theme: {
 				value: Setting.THEME_LIGHT,
 				type: Setting.TYPE_INT,

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -252,12 +252,12 @@ class Setting extends BaseModel {
 					return options;
 				},
 			},
-			spellcheck: {
+			'spellcheck.enabled': {
 				value: true,
 				type: Setting.TYPE_BOOL,
 				public: true,
 				appTypes: ['desktop'],
-				label: () => _('Enable Spellcheck (BETA: Only works with CodeMirror)'),
+				label: () => _('Enable spellcheck'),
 			},
 			theme: {
 				value: Setting.THEME_LIGHT,


### PR DESCRIPTION
The long-awaited Joplin spellcheck integration. These are my changes:

**CodeMirror**
Highlights misspelled words, can correct words through the context-menu or add words to the built-in dictionary.

**TinyMCE**
Highlights misspelled words and that's it so far. I think I will leave the context-menu outside the scope of this PR as I've found it hard to understand how TinyMCE handles context-menus. Just having underlined misspellings still seems like a worthy addition as of right now and could be added to in the future.

**AceEditor**
Also outside the scope of this PR as there is no built-in spellcheck setting so it would have to be done manually.

Toggling spellcheck in the preferences toggles within the editors but spellcheck is permanently turned on in the title field as of right now. to turn it off there you'd have to toggle it within the ElectronWrapper window settings after launch which I haven't been able to figure out, but if anyone had any ideas I'd be happy to make the change to toggle it globally.

I haven't tested this with any other languages yet (because I don't know any) but Electron should be able to auto-detect the language being used and adjust accordingly.
