### PR TITLE
Fix sponsors table layout in the GitHub README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The Web Clipper is a browser extension that allows you to save web pages and scr
 * * *
 
 |     |     |     |
-| :---: | :---: | :---: | :---: |
+| :---: | :---: | :---: |
 | <img width="50" src="https://avatars0.githubusercontent.com/u/6979755?s=96&v=4"/></br>[Devon Zuegel](https://github.com/devonzuegel) | <img width="50" src="https://avatars2.githubusercontent.com/u/24908652?s=96&v=4"/></br>[小西　孝宗](https://github.com/konishi-t) | <img width="50" src="https://avatars2.githubusercontent.com/u/215668?s=96&v=4"/></br>[Alexander van der Berg](https://github.com/avanderberg)
 | <img width="50" src="https://avatars0.githubusercontent.com/u/1168659?s=96&v=4"/></br>[Nicholas Head](https://github.com/nicholashead)
 


### PR DESCRIPTION
This PR fixes the sponsors table layout in the GitHub README.md

The table is currently displayed correctly only on https://joplinapp.org/
