### PR TITLE
Desktop: fix getLineSpan logic and list token regex logic

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
@@ -47,16 +47,16 @@ export default function useListIdent(CodeMirror: any) {
 		return currentToken;
 	}
 
-	// Gets the first non-whitespace token locationof a list
-	function getListSpan(listTokens: any) {
+	// Gets the character coordinates of the start and end of a list token
+	function getListSpan(listTokens: any, line: string) {
 		let start = listTokens[0].start;
-		const end = listTokens[listTokens.length - 1].end;
+		const token = extractListToken(line);
 
 		if (listTokens.length > 1 && listTokens[0].string.match(/\s/)) {
 			start = listTokens[1].start;
 		}
 
-		return { start: start, end: end };
+		return { start: start, end: start + token.length };
 	}
 
 	CodeMirror.commands.smartListIndent = function(cm: any) {
@@ -74,7 +74,7 @@ export default function useListIdent(CodeMirror: any) {
 			} else {
 				if (olLineNumber(line)) {
 					const tokens = cm.getLineTokens(anchor.line);
-					const { start, end } = getListSpan(tokens);
+					const { start, end } = getListSpan(tokens, line);
 					// Resets numbered list to 1.
 					cm.replaceRange('1. ',  { line: anchor.line, ch: start }, { line: anchor.line, ch: end });
 				}
@@ -99,9 +99,9 @@ export default function useListIdent(CodeMirror: any) {
 			} else {
 				const newToken = newListToken(cm, anchor.line);
 				const tokens = cm.getLineTokens(anchor.line);
-				const { start, end } = getListSpan(tokens);
+				const { start, end } = getListSpan(tokens, line);
 
-				cm.replaceRange(newToken,  { line: anchor.line, ch: start }, { line: anchor.line, ch: end });
+				cm.replaceRange(newToken, { line: anchor.line, ch: start }, { line: anchor.line, ch: end });
 
 				cm.indentLine(anchor.line, 'subtract');
 			}

--- a/ReactNativeClient/lib/markdownUtils.js
+++ b/ReactNativeClient/lib/markdownUtils.js
@@ -5,7 +5,7 @@ const { setupLinkify } = require('lib/joplin-renderer');
 const removeMarkdown = require('remove-markdown');
 
 // Taken from codemirror/addon/edit/continuelist.js
-const listRegex = /^(\s*)([*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
+const listRegex = /^(\s*)([*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]\s))(\s*)/;
 const emptyListRegex = /^(\s*)([*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
 
 const markdownUtils = {


### PR DESCRIPTION
- previously getLineSpan was included line text as a token (dumb oversight)
- the regex was updated to include a space after a OL element (was missing for some reason)

This is a codemirror specific bug, it was an oversight in the logic I implemented.
![d2a5303a4d8b62c5a568e76fe3e0fde4fcd03fed](https://user-images.githubusercontent.com/2179547/84559167-b8771b80-acf5-11ea-973e-0b84bf9592d2.gif)
gif demonstrating the bug courtesy of @tessus 

