### PR TITLE
Desktop: Add approximate reading time to note statistics

### DIFF
--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -51,7 +51,9 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 	const [strippedCharacters, setStrippedCharacters] = useState<number>(0);
 	const [strippedCharactersNoSpace, setStrippedCharactersNoSpace] = useState<number>(0);
 	const [strippedReadTime, setStrippedReadTime] = useState<number>(0);
-	const wordsPerMinute = 200;
+	// This amount based on the following paper:
+	// https://www.researchgate.net/publication/332380784_How_many_words_do_we_read_per_minute_A_review_and_meta-analysis_of_reading_rate
+	const wordsPerMinute = 250;
 
 	useEffect(() => {
 		countElements(props.text, setWords, setCharacters, setCharactersNoSpace, setLines);

--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -34,7 +34,7 @@ function formatReadTime(read_time: number) {
 		return '< 1';
 	}
 
-	return Math.floor(read_time).toString();
+	return Math.ceil(read_time).toString();
 }
 
 export default function NoteContentPropertiesDialog(props:NoteContentPropertiesDialogProps) {

--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -29,6 +29,14 @@ function countElements(text:string, wordSetter:Function, characterSetter:Functio
 	text === '' ? lineSetter(0) : lineSetter(text.split('\n').length);
 }
 
+function formatReadTime(read_time: number) {
+	if (read_time < 1) {
+		return '< 1';
+	}
+
+	return Math.floor(read_time).toString();
+}
+
 export default function NoteContentPropertiesDialog(props:NoteContentPropertiesDialogProps) {
 	const theme = themeStyle(props.theme);
 	const tableBodyComps: JSX.Element[] = [];
@@ -42,6 +50,8 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 	const [strippedWords, setStrippedWords] = useState<number>(0);
 	const [strippedCharacters, setStrippedCharacters] = useState<number>(0);
 	const [strippedCharactersNoSpace, setStrippedCharactersNoSpace] = useState<number>(0);
+	const [strippedReadTime, setStrippedReadTime] = useState<number>(0);
+	const words_per_minute = 200;
 
 	useEffect(() => {
 		countElements(props.text, setWords, setCharacters, setCharactersNoSpace, setLines);
@@ -51,6 +61,11 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 		const strippedText: string = stripMarkdown(props.text);
 		countElements(strippedText, setStrippedWords, setStrippedCharacters, setStrippedCharactersNoSpace, setStrippedLines);
 	}, [props.text]);
+
+	useEffect(() => {
+		const read_time: number = strippedWords / words_per_minute;
+		setStrippedReadTime(read_time);
+	}, [strippedWords]);
 
 	const textProperties: TextPropertiesMap = {
 		lines: lines,
@@ -133,6 +148,9 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 						{tableBodyComps}
 					</tbody>
 				</table>
+				<div style={labelCompStyle}>
+					{_('Approx. reading time:')} {formatReadTime(strippedReadTime)} {_('min')}
+				</div>
 				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
 			</div>
 		</div>

--- a/ElectronClient/gui/NoteContentPropertiesDialog.tsx
+++ b/ElectronClient/gui/NoteContentPropertiesDialog.tsx
@@ -29,12 +29,12 @@ function countElements(text:string, wordSetter:Function, characterSetter:Functio
 	text === '' ? lineSetter(0) : lineSetter(text.split('\n').length);
 }
 
-function formatReadTime(read_time: number) {
-	if (read_time < 1) {
+function formatReadTime(readTimeMinutes: number) {
+	if (readTimeMinutes < 1) {
 		return '< 1';
 	}
 
-	return Math.ceil(read_time).toString();
+	return Math.ceil(readTimeMinutes).toString();
 }
 
 export default function NoteContentPropertiesDialog(props:NoteContentPropertiesDialogProps) {
@@ -51,7 +51,7 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 	const [strippedCharacters, setStrippedCharacters] = useState<number>(0);
 	const [strippedCharactersNoSpace, setStrippedCharactersNoSpace] = useState<number>(0);
 	const [strippedReadTime, setStrippedReadTime] = useState<number>(0);
-	const words_per_minute = 200;
+	const wordsPerMinute = 200;
 
 	useEffect(() => {
 		countElements(props.text, setWords, setCharacters, setCharactersNoSpace, setLines);
@@ -63,8 +63,8 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 	}, [props.text]);
 
 	useEffect(() => {
-		const read_time: number = strippedWords / words_per_minute;
-		setStrippedReadTime(read_time);
+		const readTimeMinutes: number = strippedWords / wordsPerMinute;
+		setStrippedReadTime(readTimeMinutes);
 	}, [strippedWords]);
 
 	const textProperties: TextPropertiesMap = {
@@ -149,7 +149,7 @@ export default function NoteContentPropertiesDialog(props:NoteContentPropertiesD
 					</tbody>
 				</table>
 				<div style={labelCompStyle}>
-					{_('Approx. reading time:')} {formatReadTime(strippedReadTime)} {_('min')}
+					{_('Read time: %s min', formatReadTime(strippedReadTime))}
 				</div>
 				<DialogButtonRow theme={props.theme} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
 			</div>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

I and others (according to some quick googling of feature requests) use Joplin to capture web articles to "read later" (a bit in the way Firefox's Pocket plugin is used). For that purpose, it's nice to see how long of a read a given article is.

Using the lower end of the average reading time (200 words per minute), I have added a label to the note properties dialog, because that's where we're already computing word and line counts. 

If the reading time is less than one minute, it is displayed as "< 1 min"; for anything else it is rounded up to the next integer.

In its current form it's very much a "minimum viable product"; I could certainly see making the "words per minute" number something configurable, so that a fast reader can set it to 300, or a slow reader to 150. But that can go into another pull request.

I am also very open to suggestions about style and formatting. 

