### PR TITLE
Desktop: Remove auto-indent for in note html/xml

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
@@ -126,7 +126,15 @@ export default function useListIdent(CodeMirror: any) {
 					cm.replaceRange('', { line: anchor.line, ch: 0 }, anchor);
 				}
 			} else {
-				cm.execCommand('newlineAndIndentContinueMarkdownList');
+				// Disable automatic indent for html/xml outside of codeblocks
+				const state = cm.getTokenAt(anchor).state;
+				const mode = cm.getModeAt(anchor);
+				// html/xml inside of a codeblock is fair game for auto-indent
+				if (mode.name !== 'xml' || state.overlay.codeBlock) {
+					cm.execCommand('newlineAndIndentContinueMarkdownList');
+				} else {
+					cm.replaceSelection('\n');
+				}
 			}
 		}
 	};


### PR DESCRIPTION
This just checks the current mode while pressing enter and disables the auto-indent for html outside of code blocks. The unfortunate consequence of this is that an indent inserted by the user will not be followed, although I'm not sure if that's really a big issue. 

[Reference from the forum]