### PR TITLE
Desktop: Change codemirror to user import syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -69,6 +69,7 @@ ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/index.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/types.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/useListIdent.js
+ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/codemirror.d.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/styles/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ ElectronClient/gui/NoteEditor/NoteBody/AceEditor/Toolbar.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/index.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/types.js
 ElectronClient/gui/NoteEditor/NoteBody/AceEditor/utils/useListIdent.js
+ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/codemirror.d.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.js
 ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/styles/index.js

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { useEffect, useImperativeHandle, useState, useRef, useCallback, forwardRef } from 'react';
+
+import * as CodeMirror from 'codemirror';
+
 import 'codemirror/addon/comment/comment';
 import 'codemirror/addon/dialog/dialog';
 import 'codemirror/addon/edit/closebrackets';
@@ -24,8 +27,6 @@ import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/diff/diff';
 import 'codemirror/mode/sql/sql';
-
-const CodeMirror = require('codemirror');
 
 export interface CancelledKeys {
 	mac: string[],

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/codemirror.d.ts
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/codemirror.d.ts
@@ -1,0 +1,4 @@
+// Declare codemirror module so that we can import it using the import syntax.
+// This also means it will implicitly have the any type, which is necessary because
+// of the flexible manner that codemirror is made https://discuss.codemirror.net/t/basic-codemirror-configuration-in-typescript-project/2047/2
+declare module 'codemirror';


### PR DESCRIPTION
I was originally planning on adding more type information to the codemirror interactions using [this third party package](https://www.npmjs.com/package/@types/codemirror) but unfortunately codemirror [isn't made to work well with strict typing](https://discuss.codemirror.net/t/basic-codemirror-configuration-in-typescript-project/2047/2) and it seems that we would need to make the code fairly convoluted to get it working.

Based on the recommendations of the codemirror maintainer I decided to leave the typing alone and just fix this one issue.

Ultimately I think Joplin should switch to codemirror 6 (several years from now) and typing support should be better then.