### PR TITLE
Desktop: Manually refresh codemirror whenever the parent div size changes

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -370,15 +370,24 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	const editorReadOnly = props.visiblePanes.indexOf('editor') < 0;
 
 	function renderEditor() {
+		// The editor needs to be kept up to date on the actual space that it's filling
+		// Ogherwise we can get some rendering errors when the editor size is changed
+		// (this can happen when switching layout of when toggling sidebars for example)
+		const editorStyle = Object.assign({ width: 0, height: 0 }, styles.editor);
+		if (rootRef.current && props.visiblePanes.includes('editor')) {
+			const rootSize = rootRef.current.getBoundingClientRect();
+			editorStyle.width = !props.visiblePanes.includes('viewer') ? rootSize.width : Math.floor(rootSize.width / 2);
+			editorStyle.height = rootSize.height;
+		}
+
 		return (
 			<div style={cellEditorStyle}>
 				<Editor
 					value={props.content}
 					ref={editorRef}
-					parentSize={rootRef.current ? rootRef.current.getBoundingClientRect() : null}
 					mode={props.contentMarkupLanguage === Note.MARKUP_LANGUAGE_HTML ? 'xml' : 'gfm'}
 					theme={styles.editor.codeMirrorTheme}
-					style={styles.editor}
+					style={editorStyle}
 					readOnly={props.visiblePanes.indexOf('editor') < 0}
 					autoMatchBraces={Setting.value('editor.autoMatchingBraces')}
 					keyMap={props.keyboardMode}

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -375,6 +375,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				<Editor
 					value={props.content}
 					ref={editorRef}
+					parentSize={rootRef.current ? rootRef.current.getBoundingClientRect() : null}
 					mode={props.contentMarkupLanguage === Note.MARKUP_LANGUAGE_HTML ? 'xml' : 'gfm'}
 					theme={styles.editor.codeMirrorTheme}
 					style={styles.editor}

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -35,6 +35,7 @@ export interface CancelledKeys {
 
 export interface EditorProps {
 	value: string,
+	parentSize: any,
 	mode: string,
 	style: any,
 	theme: any,
@@ -183,6 +184,18 @@ function Editor(props: EditorProps, ref: any) {
 			editor.setOption('keyMap', props.keyMap ? props.keyMap : 'default');
 		}
 	}, [props.value, props.theme, props.mode, props.readOnly, props.autoMatchBraces, props.keyMap]);
+
+	useEffect(() => {
+		if (editor) {
+			// Need to let codemirror know that it's container's size has changed so that it can
+			// re-compute anything it needs to. This ensures the cursor (and anything that is
+			// based on window size will be correct
+			// Manually calling refresh here will cause a double refresh in some instances (when the
+			// windows size is changed for example) but this is a fairly quick operation so it's worth
+			// it.
+			editor.refresh();
+		}
+	}, [props.parentSize]);
 
 	return <div style={props.style} ref={editorParent} />;
 }

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -35,7 +35,6 @@ export interface CancelledKeys {
 
 export interface EditorProps {
 	value: string,
-	parentSize: any,
 	mode: string,
 	style: any,
 	theme: any,
@@ -195,7 +194,7 @@ function Editor(props: EditorProps, ref: any) {
 			// it.
 			editor.refresh();
 		}
-	}, [props.parentSize]);
+	}, [props.style.width, props.style.height]);
 
 	return <div style={props.style} ref={editorParent} />;
 }

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/index.ts
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/utils/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 
 export function cursorPositionToTextOffset(cursorPos: any, body: string) {
 	if (!body) return 0;
@@ -81,4 +81,23 @@ export function useScrollHandler(editorRef: any, webviewRef: any, onScroll: Func
 	}, []);
 
 	return { resetScroll, setEditorPercentScroll, setViewerPercentScroll, editor_scroll };
+}
+
+
+export function useRootSize(dependencies:any) {
+	const { rootRef } = dependencies;
+
+	const [rootSize, setRootSize] = useState({ width: 0, height: 0 });
+
+	useEffect(() => {
+		if (!rootRef.current) return;
+
+		const { width, height } = rootRef.current.getBoundingClientRect();
+
+		if (rootSize.width !== width || rootSize.height !== height) {
+			setRootSize({ width: width, height: height });
+		}
+	});
+
+	return rootSize;
 }


### PR DESCRIPTION
[reference](https://discourse.joplinapp.org/t/codemirror-issues/9392)

This fixes issue number 2 highlighted by t0dd.
The method I found to reliably reproduce this issue is:

1. Move Joplin to one side of the screen (so it's width is only half the display width)
2. Collapse the note list and the sidebar
3. Click into the codemirror editor, the cursor won't be aligned with text

After manually calling refresh (as I do in this code) or performing an action such as a window resize or entering text, the cursor will go to the correct location.

I was only able to reliably reproduce this with one note, I think because it's particularly long, but I'm not sure exactly. 