### PR TITLE
Desktop, Mobile: fix link color for dark theme

### DIFF
--- a/ReactNativeClient/lib/themes/dark.js
+++ b/ReactNativeClient/lib/themes/dark.js
@@ -11,7 +11,7 @@ const darkStyle = {
 	colorBright: '#ffffff', // For important text
 	dividerColor: '#555555',
 	selectedColor: '#333333',
-	urlColor: '#4E87EE',
+	urlColor: 'rgb(166,166,255)',
 
 	backgroundColor2: '#181A1D',
 	color2: '#ffffff',


### PR DESCRIPTION
# before re-factoring

<img width="174" alt="image" src="https://user-images.githubusercontent.com/223439/85212287-5d5dae00-b31f-11ea-8316-53924d4e54a6.png">

# after re-factoring

<img width="170" alt="image" src="https://user-images.githubusercontent.com/223439/85212309-854d1180-b31f-11ea-9d86-591cf9b319fa.png">

This PR changes it back to the previous color.