### PR TITLE
Joplin currently sets "Content-Type: text/plain" when sending PROPFIND requests, which stricter WebDAV implementations don't like

### DIFF
--- a/ReactNativeClient/lib/WebDavApi.js
+++ b/ReactNativeClient/lib/WebDavApi.js
@@ -243,7 +243,7 @@ class WebDavApi {
 				</d:prop>
 			</d:propfind>`;
 
-		return this.exec('PROPFIND', path, body, { Depth: depth }, options);
+		return this.exec('PROPFIND', path, body, { Depth: depth, 'Content-Type': 'application/xml' }, options);
 	}
 
 	requestToCurl_(url, options) {


### PR DESCRIPTION
Joplin currently sets "Content-Type: text/plain" when sending PROPFIND requests, which stricter WebDAV implementations don't like.

This changes it to application/xml. For background, see:

* http://www.webdav.org/specs/rfc2518.html#rfc.section.8.1.1
* http://www.webdav.org/specs/rfc2518.html#instructions.for.processing.xml.in.dav

Untested, but I believe this is the correct change.
