### PR TITLE
Development: Use ensureDir instead of mkdir in utils

### DIFF
--- a/Tools/gulp/utils.js
+++ b/Tools/gulp/utils.js
@@ -126,7 +126,7 @@ utils.mkdir = async function(dir) {
 	if (utils.isWindows()) {
 		return utils.execCommand(`if not exist "${utils.toSystemSlashes(dir)}" mkdir "${utils.toSystemSlashes(dir)}"`);
 	} else {
-		return fs.ensureDir(dir);
+		return fs.mkdirp(dir);
 	}
 };
 

--- a/Tools/gulp/utils.js
+++ b/Tools/gulp/utils.js
@@ -126,7 +126,7 @@ utils.mkdir = async function(dir) {
 	if (utils.isWindows()) {
 		return utils.execCommand(`if not exist "${utils.toSystemSlashes(dir)}" mkdir "${utils.toSystemSlashes(dir)}"`);
 	} else {
-		return fs.mkdir(dir);
+		return fs.ensureDir(dir);
 	}
 };
 


### PR DESCRIPTION
The [latest commit](https://github.com/laurent22/joplin/commit/5143870d3b3132d15e6d8ecc83b284f1d36a4ce2) broke development on linux. This was because it was trying to mkdir when the directory already exists

```
[13:43:49] Finished 'compileScripts' after 18 ms
[13:43:49] Finished 'compilePackageInfo' after 18 ms
[13:43:49] 'copyPluginAssets' errored after 19 ms
[13:43:49] Error: EEXIST: file already exists, mkdir '/home/caleb/programming/github/joplin/ElectronClient/tools/../gui/note-viewer/pluginAssets'
```

This fix replaces the call to `mkdir` with [`ensureDir`](https://github.com/jprichardson/node-fs-extra/blob/HEAD/docs/ensureDir.md) Which first checks if a directory exists and creates it if it doesn't.