### PR TITLE
Desktop: Remove cancelled keys in favour of explicit keymaps

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -50,17 +50,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 	const { resetScroll, editor_scroll, setEditorPercentScroll, setViewerPercentScroll } = useScrollHandler(editorRef, webviewRef, props.onScroll);
 
-	const cancelledKeys: {mac: string[], default: string[]} = { mac: [], default: [] };
-	// Remove Joplin reserved key bindings from the editor
-	const letters = ['F', 'T', 'P', 'Q', 'L', ',', 'G', 'K'];
-	for (let i = 0; i < letters.length; i++) {
-		const l = letters[i];
-		cancelledKeys.default.push(`Ctrl-${l}`);
-		cancelledKeys.mac.push(`Cmd-${l}`);
-	}
-	cancelledKeys.default.push('Alt-E');
-	cancelledKeys.mac.push('Alt-E');
-
 	const codeMirror_change = useCallback((newBody: string) => {
 		props_onChangeRef.current({ changeId: null, content: newBody });
 	}, []);
@@ -381,7 +370,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 					readOnly={props.visiblePanes.indexOf('editor') < 0}
 					autoMatchBraces={Setting.value('editor.autoMatchingBraces')}
 					keyMap={props.keyboardMode}
-					cancelledKeys={cancelledKeys}
 					onChange={codeMirror_change}
 					onScroll={editor_scroll}
 					onEditorContextMenu={onEditorContextMenu}

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -28,11 +28,6 @@ import 'codemirror/mode/clike/clike';
 import 'codemirror/mode/diff/diff';
 import 'codemirror/mode/sql/sql';
 
-export interface CancelledKeys {
-	mac: string[],
-	default: string[],
-}
-
 export interface EditorProps {
 	value: string,
 	mode: string,
@@ -41,7 +36,6 @@ export interface EditorProps {
 	readOnly: boolean,
 	autoMatchBraces: boolean,
 	keyMap: string,
-	cancelledKeys: CancelledKeys,
 	onChange: any,
 	onScroll: any,
 	onEditorContextMenu: any,
@@ -59,18 +53,73 @@ function Editor(props: EditorProps, ref: any) {
 	useCursorUtils(CodeMirror);
 	useLineSorting(CodeMirror);
 
-	useEffect(() => {
-		if (props.cancelledKeys) {
-			for (let i = 0; i < props.cancelledKeys.mac.length; i++) {
-				const k = props.cancelledKeys.mac[i];
-				CodeMirror.keyMap.macDefault[k] = null;
-			}
-			for (let i = 0; i < props.cancelledKeys.default.length; i++) {
-				const k = props.cancelledKeys.default[i];
-				CodeMirror.keyMap.default[k] = null;
-			}
-		}
-	}, [props.cancelledKeys]);
+	CodeMirror.keyMap.basic = {
+		'Left': 'goCharLeft',
+		'Right': 'goCharRight',
+		'Up': 'goLineUp',
+		'Down': 'goLineDown',
+		'End': 'goLineEnd',
+		'Home': 'goLineStartSmart',
+		'PageUp': 'goPageUp',
+		'PageDown': 'goPageDown',
+		'Delete': 'delCharAfter',
+		'Backspace': 'delCharBefore',
+		'Shift-Backspace': 'delCharBefore',
+		'Tab': 'smartListIndent',
+		'Shift-Tab': 'smartListUnindent',
+		'Enter': 'insertListElement',
+		'Insert': 'toggleOverwrite',
+		'Esc': 'singleSelection',
+	};
+	CodeMirror.keyMap.default = {
+		'Ctrl-A': 'selectAll',
+		'Ctrl-D': 'deleteLine',
+		'Ctrl-Z': 'undo',
+		'Shift-Ctrl-Z': 'redo',
+		'Ctrl-Y': 'redo',
+		'Ctrl-Home': 'goDocStart',
+		'Ctrl-End': 'goDocEnd',
+		'Ctrl-Up': 'goLineUp',
+		'Ctrl-Down': 'goLineDown',
+		'Ctrl-Left': 'goGroupLeft',
+		'Ctrl-Right': 'goGroupRight',
+		'Alt-Left': 'goLineStart',
+		'Alt-Right': 'goLineEnd',
+		'Ctrl-Backspace': 'delGroupBefore',
+		'Ctrl-Delete': 'delGroupAfter',
+		'Ctrl-[': 'indentLess',
+		'Ctrl-]': 'indentMore',
+		'Ctrl-/': 'toggleComment',
+		'Ctrl-Alt-S': 'sortSelectedLines',
+		'Alt-Up': 'swapLineUp',
+		'Alt-Down': 'swapLineDown',
+		'fallthrough': 'basic',
+	};
+	CodeMirror.keyMap.pcDefault = CodeMirror.keyMap.default;
+	CodeMirror.keyMap.macDefault = {
+		'Cmd-A': 'selectAll',
+		'Cmd-D': 'deleteLine',
+		'Cmd-Z': 'undo',
+		'Shift-Cmd-Z': 'redo',
+		'Cmd-Y': 'redo',
+		'Cmd-Home': 'goDocStart',
+		'Cmd-Up': 'goDocStart',
+		'Cmd-End': 'goDocEnd',
+		'Cmd-Down': 'goDocEnd',
+		'Alt-Left': 'goGroupLeft',
+		'Alt-Right': 'goGroupRight',
+		'Cmd-Left': 'goLineLeft',
+		'Cmd-Right': 'goLineRight',
+		'Alt-Backspace': 'delGroupBefore',
+		'Alt-Delete': 'delGroupAfter',
+		'Cmd-[': 'indentLess',
+		'Cmd-]': 'indentMore',
+		'Cmd-/': 'toggleComment',
+		'Cmd-Opt-S': 'sortSelectedLines',
+		'Opt-Up': 'swapLineUp',
+		'Opt-Down': 'swapLineDown',
+		'fallthrough': 'basic',
+	};
 
 	useImperativeHandle(ref, () => {
 		return editor;
@@ -133,17 +182,6 @@ function Editor(props: EditorProps, ref: any) {
 			spellcheck: true,
 			allowDropFileTypes: [''], // disable codemirror drop handling
 			keyMap: props.keyMap ? props.keyMap : 'default',
-			extraKeys: { 'Enter': 'insertListElement',
-				'Ctrl-/': 'toggleComment',
-				'Ctrl-Alt-S': 'sortSelectedLines',
-				'Alt-Up': 'swapLineUp',
-				'Alt-Down': 'swapLineDown',
-				'Cmd-/': 'toggleComment',
-				'Cmd-Opt-S': 'sortSelectedLines',
-				'Opt-Up': 'swapLineUp',
-				'Opt-Down': 'swapLineDown',
-				'Tab': 'smartListIndent',
-				'Shift-Tab': 'smartListUnindent' },
 		};
 		const cm = CodeMirror(editorParent.current, cmOptions);
 		setEditor(cm);


### PR DESCRIPTION
To do this I took the default keymap and removed any keys that didn't seem useful. I'm not claiming that this is the perfect list of supported functions, so I'm open to any input @laurent22 @tessus 



Below is the keymap as it exists before this change

### basic
Left: "goCharLeft"
Right: "goCharRight"
Up: "goLineUp"
Down: "goLineDown"
End: "goLineEnd"
Home: "goLineStartSmart"
PageUp: "goPageUp"
PageDown: "goPageDown"
Delete: "delCharAfter"
Backspace: "delCharBefore"
Shift-Backspace: "delCharBefore"
Tab: "defaultTab"
Shift-Tab: "indentAuto"
Enter: "newlineAndIndent"
Insert: "toggleOverwrite"
Esc: "singleSelection"

### default
Ctrl-A: "selectAll"
Ctrl-D: "deleteLine"
Ctrl-Z: "undo"
Shift-Ctrl-Z: "redo"
Ctrl-Y: "redo"
Ctrl-Home: "goDocStart"
Ctrl-End: "goDocEnd"
Ctrl-Up: "goLineUp"
Ctrl-Down: "goLineDown"
Ctrl-Left: "goGroupLeft"
Ctrl-Right: "goGroupRight"
Alt-Left: "goLineStart"
Alt-Right: "goLineEnd"
Ctrl-Backspace: "delGroupBefore"
Ctrl-Delete: "delGroupAfter"
Ctrl-S: "save"
Shift-Ctrl-G: "findPrev"
Shift-Ctrl-F: "replace"
Shift-Ctrl-R: "replaceAll"
Ctrl-[: "indentLess"
Ctrl-]: "indentMore"
Ctrl-U: "undoSelection"
Shift-Ctrl-U: "redoSelection"
Alt-U: "redoSelection"
fallthrough: "basic"

### macDefault
Cmd-A: "selectAll"
Cmd-D: "deleteLine"
Cmd-Z: "undo"
Shift-Cmd-Z: "redo"
Cmd-Y: "redo"
Cmd-Home: "goDocStart"
Cmd-Up: "goDocStart"
Cmd-End: "goDocEnd"
Cmd-Down: "goDocEnd"
Alt-Left: "goGroupLeft"
Alt-Right: "goGroupRight"
Cmd-Left: "goLineLeft"
Cmd-Right: "goLineRight"
Alt-Backspace: "delGroupBefore"
Ctrl-Alt-Backspace: "delGroupAfter"
Alt-Delete: "delGroupAfter"
Cmd-S: "save"
Shift-Cmd-G: "findPrev"
Cmd-Alt-F: "replace"
Shift-Cmd-Alt-F: "replaceAll"
Cmd-[: "indentLess"
Cmd-]: "indentMore"
Cmd-Backspace: "delWrappedLineLeft"
Cmd-Delete: "delWrappedLineRight"
Cmd-U: "undoSelection"
Shift-Cmd-U: "redoSelection"
Ctrl-Up: "goDocStart"
Ctrl-Down: "goDocEnd"