### PR TITLE
Android: remove hardcoded portrait screen orientation for share activity

### DIFF
--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -100,7 +100,6 @@
 			android:name=".share.ShareActivity"
 			android:configChanges="orientation"
 			android:label="@string/app_name"
-			android:screenOrientation="portrait"
 			android:excludeFromRecents="true"
 			android:theme="@style/AppTheme">
 			<intent-filter>


### PR DESCRIPTION
Raised on the forum: https://discourse.joplinapp.org/t/android-share-app-orientation/9677