### PR TITLE
Mobile: increase max resource size to 100mb

### DIFF
--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -68,7 +68,7 @@ class Synchronizer {
 
 	maxResourceSize() {
 		if (this.maxResourceSize_ !== null) return this.maxResourceSize_;
-		return this.appType_ === 'mobile' ? 10 * 1000 * 1000 : Infinity;
+		return this.appType_ === 'mobile' ? 100 * 1000 * 1000 : Infinity;
 	}
 
 	setEncryptionService(v) {


### PR DESCRIPTION
After the memory leak has been fixed it makes no sense to keep the existing 10mb max resource size limit.
I propose increasing it to 100mb, wait for a while to see if it causes any issues and if not remove it.