### PR TITLE
Yandex disk removed from supported WEBDAV clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ WebDAV-compatible services that are known to work with Joplin:
 - [Seafile](https://www.seafile.com/)
 - [Stack](https://www.transip.nl/stack/)
 - [WebDAV Nav](https://www.schimera.com/products/webdav-nav-server/), a macOS server.
-- [Yandex Disk](https://disk.yandex.ru/download?src=Yandex.Sidebar#pc)
 - [Zimbra](https://www.zimbra.com/)
 
 ## OneDrive synchronisation


### PR DESCRIPTION
Yandex.disk recently removed file upload support from WebDAV.

https://ru.stackoverflow.com/questions/1043523/После-загрузки-файла-на-Яндекс-Диск-по-webdav-происходят-паузы-по-60-секунд-на-к
https://qna.habr.com/q/677787

So this makes Yandex.disk unusable at the moment.

Here's a similar issue, please see recent comments: https://github.com/PhilippC/keepass2android/issues/506

I've personally tried, and cannot even access to Yandex.disk at the moment through WebDAV.

This PR simply removes yandex.disk line from the ReadMe.

Thanks,
