### PR TITLE
Android: adds "recent notes" widget

### DIFF
--- a/ReactNativeClient/android/app/src/main/AndroidManifest.xml
+++ b/ReactNativeClient/android/app/src/main/AndroidManifest.xml
@@ -114,6 +114,16 @@
 				<data android:mimeType="*/*" />
 			</intent-filter>
 		</activity>
+			<receiver android:name=".widgets.recents.RecentsWidgetProvider">
+				<intent-filter>
+					<action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+				</intent-filter>
+				<meta-data android:name="android.appwidget.provider"
+					android:resource="@xml/recents_widget_provider_info" />
+			</receiver>
+			<service android:name=".widgets.recents.RecentsWidgetService"
+				android:permission="android.permission.BIND_REMOTEVIEWS"
+				android:exported="false" />
 	</application>
 
 </manifest>

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -18,6 +18,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
+import net.cozic.joplin.widgets.WidgetDataPackage;
+
 public class MainApplication extends Application implements ReactApplication {
 
 	private final ReactNativeHost mReactNativeHost =
@@ -32,6 +34,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           packages.add(new SharePackage());
+          packages.add(new WidgetDataPackage());
           return packages;
         }
 

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/WidgetData.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/WidgetData.java
@@ -1,0 +1,80 @@
+package net.cozic.joplin.widgets;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public abstract class WidgetData {
+    private static final String NAME = "widget_data";
+    private SharedPreferences sharedPreferences;
+
+    protected Context context;
+
+    protected abstract String getKey();
+
+    protected WidgetData(Context context) {
+        this.context = context;
+        sharedPreferences = context.getSharedPreferences(NAME, Context.MODE_PRIVATE);
+    }
+
+    protected JSONObject readJSON() {
+        try {
+            return new JSONObject(readString());
+        } catch (JSONException e) {
+            return new JSONObject();
+        }
+    }
+
+    protected void writeJSON(JSONObject value) {
+        writeString(value.toString());
+    }
+
+    protected String readString() {
+        return sharedPreferences.getString(getKey(), "{}");
+    }
+
+    protected void writeString(String value) {
+        sharedPreferences.edit().putString(getKey(), value).apply();
+    }
+
+    public ReactModule createReactModule(String name) {
+        return new ReactModule((ReactApplicationContext) context, name, this);
+    }
+
+    private final static class ReactModule extends ReactContextBaseJavaModule {
+        private String name;
+        private WidgetData widgetData;
+
+        private ReactModule(@NonNull ReactApplicationContext reactContext, String name, WidgetData widgetData) {
+            super(reactContext);
+            this.name = name;
+            this.widgetData = widgetData;
+        }
+
+        @NonNull
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @ReactMethod
+        public void write(String value) {
+            widgetData.writeString(value);
+        }
+
+        @ReactMethod
+        public void read(Promise promise) {
+            promise.resolve(widgetData.readString());
+        }
+
+    }
+}

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/WidgetDataPackage.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/WidgetDataPackage.java
@@ -1,0 +1,29 @@
+package net.cozic.joplin.widgets;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import net.cozic.joplin.widgets.recents.RecentsWidgetData;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WidgetDataPackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(
+                new RecentsWidgetData(reactContext).createReactModule("RecentsWidget")
+        );
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetData.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetData.java
@@ -1,0 +1,78 @@
+package net.cozic.joplin.widgets.recents;
+
+import android.content.Context;
+import android.content.Intent;
+
+import net.cozic.joplin.widgets.WidgetData;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RecentsWidgetData extends WidgetData {
+    public RecentsWidgetData(Context context) {
+        super(context);
+    }
+
+    private void broadcastUpdate() {
+        Intent intent = new Intent(context, RecentsWidgetProvider.class);
+        intent.setAction(RecentsWidgetProvider.UPDATE_ACTION);
+        context.sendBroadcast(intent);
+    }
+
+    public List<NoteItem> readRecents() {
+        JSONObject data = readJSON();
+        try {
+            JSONArray notes = data.getJSONArray("notes");
+            List<NoteItem> result = new ArrayList<>(notes.length());
+            for (int i = 0; i < notes.length(); i++) {
+                result.add(NoteItem.fromJSONObject(notes.getJSONObject(i)));
+            }
+            return result;
+        } catch (JSONException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected void writeString(String value) {
+        super.writeString(value);
+        broadcastUpdate();
+    }
+
+    @Override
+    protected String getKey() {
+        return "RecentsWidget";
+    }
+
+    public static final class NoteItem {
+        private String id;
+        private String title;
+
+        public static NoteItem fromJSONObject(JSONObject obj) throws JSONException {
+            return new NoteItem(obj.getString("id"), obj.getString("title"));
+        }
+
+        public NoteItem(String id, String title) {
+            this.id = id;
+            this.title = title;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        @Override
+        public int hashCode() {
+            return getId().hashCode();
+        }
+    }
+}

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetProvider.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetProvider.java
@@ -1,0 +1,79 @@
+package net.cozic.joplin.widgets.recents;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.widget.RemoteViews;
+
+import net.cozic.joplin.R;
+
+public class RecentsWidgetProvider extends AppWidgetProvider {
+    public static final String CLICK_ACTION = "RECENTS_WIDGET_CLICK_ACTION";
+    public static final String UPDATE_ACTION = "RECENTS_WIDGET_UPDATE_ACTION";
+
+    public static final String NOTE_ID = "RECENTS_WIDGET_NOTE_ID";
+
+    private static final int listViewId = R.id.list_view;
+
+    private void handleClick(Context context, String noteId) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("joplin://notes/" + noteId));
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+    private void handleUpdate(Context context) {
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+        int[] ids = appWidgetManager.getAppWidgetIds(new ComponentName(context, getClass()));
+        appWidgetManager.notifyAppWidgetViewDataChanged(ids, listViewId);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        super.onReceive(context, intent);
+        String action = intent.getAction();
+        if (action == null) {
+            return;
+        }
+        switch (action) {
+            case CLICK_ACTION:
+                String noteId = intent.getStringExtra(NOTE_ID);
+                if (noteId != null) {
+                    handleClick(context, noteId);
+                }
+                break;
+            case UPDATE_ACTION:
+                handleUpdate(context);
+                break;
+        }
+    }
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        for (int appWidgetId : appWidgetIds) {
+            RemoteViews rv = new RemoteViews(context.getPackageName(), R.layout.recents_widget);
+            rv.setRemoteAdapter(listViewId, widgetIntent(context, appWidgetId));
+            rv.setEmptyView(listViewId, R.id.empty_view);
+            rv.setPendingIntentTemplate(listViewId, pendingIntentTemplate(context, appWidgetId));
+            appWidgetManager.updateAppWidget(appWidgetId, rv);
+        }
+        super.onUpdate(context, appWidgetManager, appWidgetIds);
+    }
+
+    private Intent widgetIntent(Context context, int appWidgetId) {
+        Intent intent = new Intent(context, RecentsWidgetService.class);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        intent.setData(Uri.parse(intent.toUri(Intent.URI_INTENT_SCHEME)));
+        return intent;
+    }
+
+    private PendingIntent pendingIntentTemplate(Context context, int appWidgetId) {
+        Intent intent = new Intent(context, RecentsWidgetProvider.class);
+        intent.setAction(RecentsWidgetProvider.CLICK_ACTION);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+}

--- a/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetService.java
+++ b/ReactNativeClient/android/app/src/main/java/net/cozic/joplin/widgets/recents/RecentsWidgetService.java
@@ -1,0 +1,85 @@
+package net.cozic.joplin.widgets.recents;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.RemoteViews;
+import android.widget.RemoteViewsService;
+
+import net.cozic.joplin.R;
+
+import java.util.List;
+
+public class RecentsWidgetService extends RemoteViewsService {
+    @Override
+    public RemoteViewsFactory onGetViewFactory(Intent intent) {
+        return new RecentsWidgetDataViewsFactory(getApplicationContext(), intent);
+    }
+
+    private static class RecentsWidgetDataViewsFactory implements RemoteViewsService.RemoteViewsFactory {
+        private List<RecentsWidgetData.NoteItem> notes;
+        private Context context;
+        private RecentsWidgetData recentsWidgetData;
+
+        public RecentsWidgetDataViewsFactory(Context context, Intent intent) {
+            this.context = context;
+            recentsWidgetData = new RecentsWidgetData(context);
+        }
+
+        @Override
+        public void onCreate() {
+            notes = recentsWidgetData.readRecents();
+        }
+
+        @Override
+        public void onDataSetChanged() {
+            notes = recentsWidgetData.readRecents();
+        }
+
+        @Override
+        public RemoteViews getViewAt(int position) {
+            RemoteViews rv = new RemoteViews(context.getPackageName(), R.layout.recents_widget_item);
+            rv.setTextViewText(R.id.recents_widget_item, notes.get(position).getTitle());
+            rv.setOnClickFillInIntent(R.id.recents_widget_item, fillInIntent(notes.get(position).getId()));
+            return rv;
+        }
+
+        private Intent fillInIntent(String noteId) {
+            Bundle extras = new Bundle();
+            extras.putString(RecentsWidgetProvider.NOTE_ID, noteId);
+            Intent intent = new Intent();
+            intent.putExtras(extras);
+            return intent;
+        }
+
+        @Override
+        public void onDestroy() {
+            notes.clear();
+        }
+
+        @Override
+        public int getCount() {
+            return notes.size();
+        }
+
+        @Override
+        public RemoteViews getLoadingView() {
+            return null;
+        }
+
+        @Override
+        public int getViewTypeCount() {
+            return 1;
+        }
+
+        @Override
+        public boolean hasStableIds() {
+            return true;
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return notes.get(position).hashCode();
+        }
+    }
+}

--- a/ReactNativeClient/android/app/src/main/res/layout/recents_widget.xml
+++ b/ReactNativeClient/android/app/src/main/res/layout/recents_widget.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground">
+
+    <ListView
+        android:id="@+id/list_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:loopViews="true" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_recent_notes_found"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="@dimen/recents_title_text_size"
+        android:textStyle="bold" />
+</FrameLayout>

--- a/ReactNativeClient/android/app/src/main/res/layout/recents_widget_item.xml
+++ b/ReactNativeClient/android/app/src/main/res/layout/recents_widget_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recents_widget_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textColor="?android:attr/textColorPrimary"
+    android:padding="@dimen/recents_title_padding"
+    android:textSize="@dimen/recents_title_text_size"
+    android:textStyle="bold" />

--- a/ReactNativeClient/android/app/src/main/res/values/dimens.xml
+++ b/ReactNativeClient/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="recents_title_text_size">16sp</dimen>
+    <dimen name="recents_title_padding">8dp</dimen>
+</resources>

--- a/ReactNativeClient/android/app/src/main/res/values/strings.xml
+++ b/ReactNativeClient/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Joplin</string>
     <string name="default_notification_channel_id">net.cozic.joplin.notification</string>
+    <string name="no_recent_notes_found">No recent notes found</string>
 </resources>

--- a/ReactNativeClient/android/app/src/main/res/xml/recents_widget_provider_info.xml
+++ b/ReactNativeClient/android/app/src/main/res/xml/recents_widget_provider_info.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+        android:minWidth="40dp"
+        android:minHeight="40dp"
+        android:initialLayout="@layout/recents_widget"
+        android:resizeMode="horizontal|vertical"
+        android:widgetCategory="home_screen" />

--- a/ReactNativeClient/lib/RecentsWidget.ts
+++ b/ReactNativeClient/lib/RecentsWidget.ts
@@ -1,0 +1,22 @@
+const { NativeModules, Platform } = require('react-native');
+
+export interface NoteItem {
+  id: string,
+	title: string,
+}
+
+interface WidgetData {
+  notes?: NoteItem[];
+}
+
+const RecentsWidget = (Platform.OS === 'android' && NativeModules.RecentsWidget) ?
+	{
+		read: async (): Promise<WidgetData> => JSON.parse(await NativeModules.RecentsWidget.read()),
+		write: async (data: WidgetData) => NativeModules.RecentsWidget.write(JSON.stringify(data)),
+	} :
+	{
+		read: async (): Promise<WidgetData> => ({}),
+		write: async (data: WidgetData) => {},
+	};
+
+export default RecentsWidget;

--- a/ReactNativeClient/lib/RecentsWidget.ts
+++ b/ReactNativeClient/lib/RecentsWidget.ts
@@ -9,14 +9,12 @@ interface WidgetData {
   notes?: NoteItem[];
 }
 
-const RecentsWidget = (Platform.OS === 'android' && NativeModules.RecentsWidget) ?
+export const RecentsWidget = (Platform.OS === 'android' && NativeModules.RecentsWidget) ?
 	{
 		read: async (): Promise<WidgetData> => JSON.parse(await NativeModules.RecentsWidget.read()),
 		write: async (data: WidgetData) => NativeModules.RecentsWidget.write(JSON.stringify(data)),
 	} :
 	{
 		read: async (): Promise<WidgetData> => ({}),
-		write: async (data: WidgetData) => {},
+		write: async (_: WidgetData) => {},
 	};
-
-export default RecentsWidget;

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -42,6 +42,7 @@ const ShareExtension = require('lib/ShareExtension.js').default;
 const CameraView = require('lib/components/CameraView');
 const SearchEngine = require('lib/services/SearchEngine');
 const urlUtils = require('lib/urlUtils');
+const { addNoteToRecentsWidget } = require('lib/widgetHandler.ts');
 
 class NoteScreenComponent extends BaseScreenComponent {
 	static navigationOptions() {
@@ -372,6 +373,10 @@ class NoteScreenComponent extends BaseScreenComponent {
 			const resourceIds = await Note.linkedResourceIds(this.state.note.body);
 			await ResourceFetcher.instance().markForDownload(resourceIds);
 		}
+
+		if (this.state.note) {
+			addNoteToRecentsWidget(this.state.note);
+		}
 	}
 
 	onMarkForDownload(event) {
@@ -393,6 +398,8 @@ class NoteScreenComponent extends BaseScreenComponent {
 	}
 
 	componentWillUnmount() {
+		addNoteToRecentsWidget(this.state.note);
+
 		BackButtonService.removeHandler(this.backHandler);
 		NavService.removeHandler(this.navHandler);
 

--- a/ReactNativeClient/lib/components/screens/note.js
+++ b/ReactNativeClient/lib/components/screens/note.js
@@ -369,13 +369,14 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.undoRedoService_ = new UndoRedoService();
 		this.undoRedoService_.on('stackChange', this.undoRedoService_stackChange);
 
-		if (this.state.note && this.state.note.body && Setting.value('sync.resourceDownloadMode') === 'auto') {
+		if (this.state.note) {
+			if (this.state.note.title) {
+				addNoteToRecentsWidget(this.state.note);
+			}
+			if (this.state.note.body && Setting.value('sync.resourceDownloadMode') === 'auto') {
 			const resourceIds = await Note.linkedResourceIds(this.state.note.body);
 			await ResourceFetcher.instance().markForDownload(resourceIds);
-		}
-
-		if (this.state.note) {
-			addNoteToRecentsWidget(this.state.note);
+			}
 		}
 	}
 

--- a/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
+++ b/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
@@ -5,6 +5,7 @@ const Note = require('lib/models/Note');
 const { reg } = require('lib/registry.js');
 const ResourceFetcher = require('lib/services/ResourceFetcher');
 const DecryptionWorker = require('lib/services/DecryptionWorker');
+const { removeNoteFromRecentsWidget } = require('lib/widgetHandler.ts');
 
 const reduxSharedMiddleware = async function(store, next, action) {
 	const newState = store.getState();
@@ -79,6 +80,10 @@ const reduxSharedMiddleware = async function(store, next, action) {
 
 	if (mustAutoAddResources) {
 		ResourceFetcher.instance().autoAddResources();
+	}
+
+	if (action.type === 'NOTE_DELETE') {
+		removeNoteFromRecentsWidget(action.id);
 	}
 
 	if (refreshTags) {

--- a/ReactNativeClient/lib/widgetHandler.ts
+++ b/ReactNativeClient/lib/widgetHandler.ts
@@ -1,8 +1,8 @@
-import RecentsWidget, { NoteItem } from './RecentsWidget';
+import { RecentsWidget, NoteItem } from './RecentsWidget';
 
 const MAX_COUNT = 10;
 
-export async function addNoteToRecentsWidget(note) {
+export async function addNoteToRecentsWidget(note: NoteItem) {
   let recents: NoteItem[] = (await RecentsWidget.read()).notes || [];
   recents = recents.filter(recent => recent.id !== note.id).slice(0, MAX_COUNT);
   recents.unshift({
@@ -14,7 +14,7 @@ export async function addNoteToRecentsWidget(note) {
   });
 }
 
-export async function removeNoteFromRecentsWidget(noteId) {
+export async function removeNoteFromRecentsWidget(noteId: string) {
   let recents: NoteItem[] = (await RecentsWidget.read()).notes || [];
   recents = recents.filter(recent => recent.id !== noteId);
   return RecentsWidget.write({

--- a/ReactNativeClient/lib/widgetHandler.ts
+++ b/ReactNativeClient/lib/widgetHandler.ts
@@ -1,0 +1,23 @@
+import RecentsWidget, { NoteItem } from './RecentsWidget';
+
+const MAX_COUNT = 10;
+
+export async function addNoteToRecentsWidget(note) {
+  let recents: NoteItem[] = (await RecentsWidget.read()).notes || [];
+  recents = recents.filter(recent => recent.id !== note.id).slice(0, MAX_COUNT);
+  recents.unshift({
+    id: note.id,
+    title: note.title
+  });
+  return RecentsWidget.write({
+    notes: recents
+  });
+}
+
+export async function removeNoteFromRecentsWidget(noteId) {
+  let recents: NoteItem[] = (await RecentsWidget.read()).notes || [];
+  recents = recents.filter(recent => recent.id !== noteId);
+  return RecentsWidget.write({
+    notes: recents
+  });
+}


### PR DESCRIPTION
[Link to proposal](https://discourse.joplinapp.org/t/proposal-to-add-android-app-widget/9095)

This PR adds a simple widget that displays up to 10 most recently opened notes:

![image](https://user-images.githubusercontent.com/250887/86543435-5dac9a80-bf16-11ea-83f5-59139afe1d0c.png)

In addition, it adds a reusable framework for sharing data using [`SharedPreferences`](https://developer.android.com/training/data-storage/shared-preferences) that should help us add more widgets in the future, if needed.

This PR requires deep links to be implemented: when a note in the widget is clicked, it expects an app to respond to `joplin://notes/<id>` style links.

Open to suggestions on how whether the current widget logic should be made more or less generic and what (if anything) should be configurable in the app UI or settings.