### PR TITLE
Allow context menu to display options for both copy text and copy URL

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -626,6 +626,7 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 								let itemType:ContextMenuItemType = ContextMenuItemType.None;
 								let resourceId = '';
 								let textToCopy = '';
+								const urlToCopy = '';
 
 								if (element.nodeName === 'IMG') {
 									itemType = ContextMenuItemType.Image;
@@ -638,7 +639,7 @@ const TinyMCE = (props:NoteBodyEditorProps, ref:any) => {
 									textToCopy = editor.selection.getContent({ format: 'text' });
 								}
 
-								contextMenuActionOptions.current = { itemType, resourceId, textToCopy };
+								contextMenuActionOptions.current = { itemType, resourceId, textToCopy, urlToCopy };
 
 
 								return item.isActive(itemType) ? itemNameNS : '';

--- a/ElectronClient/gui/NoteEditor/utils/contextMenu.ts
+++ b/ElectronClient/gui/NoteEditor/utils/contextMenu.ts
@@ -15,12 +15,14 @@ export enum ContextMenuItemType {
 	Resource = 'resource',
 	Text = 'text',
 	Link = 'link',
+	LinkAndText = 'linkAndText',
 }
 
 export interface ContextMenuOptions {
 	itemType: ContextMenuItemType,
 	resourceId: string,
 	textToCopy: string,
+	urlToCopy: string,
 }
 
 interface ContextMenuItem {
@@ -86,14 +88,14 @@ export function menuItems():ContextMenuItems {
 			onAction: async (options:ContextMenuOptions) => {
 				clipboard.writeText(options.textToCopy);
 			},
-			isActive: (itemType:ContextMenuItemType) => itemType === ContextMenuItemType.Text,
+			isActive: (itemType:ContextMenuItemType) => itemType === ContextMenuItemType.Text || itemType === ContextMenuItemType.LinkAndText,
 		},
 		copyLinkUrl: {
 			label: _('Copy Link Address'),
 			onAction: async (options:ContextMenuOptions) => {
-				clipboard.writeText(options.textToCopy);
+				clipboard.writeText(options.urlToCopy);
 			},
-			isActive: (itemType:ContextMenuItemType) => itemType === ContextMenuItemType.Link,
+			isActive: (itemType:ContextMenuItemType) => itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.LinkAndText,
 		},
 	};
 }

--- a/ElectronClient/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/ElectronClient/gui/NoteEditor/utils/useMessageHandler.ts
@@ -41,6 +41,7 @@ export default function useMessageHandler(scrollWhenReady:any, setScrollWhenRead
 				itemType: arg0 && arg0.type,
 				resourceId: arg0.resourceId,
 				textToCopy: arg0.textToCopy,
+				urlToCopy: arg0.urlToCopy,
 			});
 
 			menu.popup(bridge().window());

--- a/ElectronClient/gui/note-viewer/index.html
+++ b/ElectronClient/gui/note-viewer/index.html
@@ -383,15 +383,21 @@
 			} else {
 				const selectedText = window.getSelection().toString();
 
-				if (selectedText) {
+				if (selectedText && !event.target.getAttribute('href')) {
 					ipcProxySendToHost('contextMenu', {
 						type: 'text',
 						textToCopy: selectedText,
 					});
-				} else if (event.target.getAttribute('href')) {
+				} else if (selectedText && event.target.getAttribute('href')) {
+					ipcProxySendToHost('contextMenu', {
+						type: 'linkAndText',
+						textToCopy: selectedText,
+						urlToCopy: event.target.getAttribute('href'),
+					});
+				} else if (!selectedText && event.target.getAttribute('href')) {
 					ipcProxySendToHost('contextMenu', {
 						type: 'link',
-						textToCopy: event.target.getAttribute('href'),
+						urlToCopy: event.target.getAttribute('href'),
 					});
 				}
 			}


### PR DESCRIPTION
Fixes #3404, _kind of_. It also adds a minor feature, which may not be desirable. 

I'm not sure when this changed, but when a user on MacOS secondary clicks a link, it also selects the link text. It seemed like the least risky way to fix this was to add an extra option to the context menu. The new logic is, if text which is not part of a link is selected when the user secondary clicks, the context menu shows "Copy". If the user secondary clicks on a link without any selected text (presumably this is still possible on Windows and Linux, although I have not tested), the context menu will show "Copy Link Address". If the user secondary clicks on a link _and_ has selected text, there will be two context menu options - "Copy" and "Copy Link Address". This will always be the case on MacOS, as far as I can tell.

I don't see any tests around any of this, but I'm happy to update them if that was an oversight on my part. I also don't have easy access to a Windows or Linux machine, so I've only tested on MacOS 10.15.5 Catalina, but this appears to work just fine there.

This is my first time attempting to contribute, apologies if I missed anything!

<img width="600" alt="context_menu03" src="https://user-images.githubusercontent.com/3893765/86979831-7ea40400-c13f-11ea-91b9-ee92e65dd292.png">
<img width="600" alt="context_menu01" src="https://user-images.githubusercontent.com/3893765/86979814-78ae2300-c13f-11ea-839e-8ce1b745ebb6.png">
<img width="600" alt="context_menu02" src="https://user-images.githubusercontent.com/3893765/86979821-7ba91380-c13f-11ea-8ed3-dd1acecc9265.png">