### PR TITLE
Desktop: Sort tags alphabetically in side-menu

### DIFF
--- a/ReactNativeClient/lib/components/shared/side-menu-shared.js
+++ b/ReactNativeClient/lib/components/shared/side-menu-shared.js
@@ -1,5 +1,6 @@
 const BaseItem = require('lib/models/BaseItem');
 const BaseModel = require('lib/BaseModel');
+const Tag = require('lib/models/Tag');
 
 const shared = {};
 
@@ -65,6 +66,13 @@ shared.renderFolders = function(props, renderItem) {
 };
 
 shared.renderTags = function(props, renderItem) {
+	props = Object.assign({}, props);
+	const tags = props.tags.slice();
+	// Sort tags alphabetically
+	tags.sort((a, b) => {
+		return Tag.getCachedFullTitle(a.id) < Tag.getCachedFullTitle(b.id) ? -1 : 1;
+	});
+	props.tags = tags;
 	return renderItemsRecursive_(props, renderItem, [], '', 0, [], BaseModel.TYPE_TAG);
 };
 


### PR DESCRIPTION
This PR brings back alphabetical sorting of the tags in the desktop app side-menu as it was removed during refactoring in #2572.