### PR TITLE
Desktop: allow scrolling past end in Ace editor

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/AceEditor/AceEditor.tsx
@@ -601,6 +601,7 @@ function AceEditor(props: NoteBodyEditorProps, ref: any) {
 						{
 							behavioursEnabled: Setting.value('editor.autoMatchingBraces'),
 							useSoftTabs: false,
+							scrollPastEnd: '0.1',
 						}
 					}
 					// Disable warning: "Automatically scrolling cursor into view after


### PR DESCRIPTION
follow-up to #3156
fixes #3147

/ref https://discourse.joplinapp.org/t/scrolling-past-end/5043
