### PR TITLE
Desktop: Add support for an "All To-dos" view

### DIFF
--- a/CliClient/tests/feature_ShowAllTodos.js
+++ b/CliClient/tests/feature_ShowAllTodos.js
@@ -1,0 +1,156 @@
+/* eslint-disable no-unused-vars */
+require('app-module-path').addPath(__dirname);
+const { setupDatabaseAndSynchronizer, switchClient, asyncTest, id, ids, sortedIds, at, createNTestFolders, createNTestTodos, createNTestTags, TestApp } = require('test-utils.js');
+const Setting = require('lib/models/Setting.js');
+const Folder = require('lib/models/Folder.js');
+const Note = require('lib/models/Note.js');
+const Tag = require('lib/models/Tag.js');
+const { time } = require('lib/time-utils.js');
+const { ALL_TODOS_FILTER_ID } = require('lib/reserved-ids.js');
+
+let testApp = null;
+
+describe('feature_ShowAllTodos', function() {
+
+	beforeEach(async (done) => {
+		testApp = new TestApp();
+		await testApp.start(['--no-welcome']);
+		done();
+	});
+
+	afterEach(async (done) => {
+		if (testApp !== null) await testApp.destroy();
+		testApp = null;
+		done();
+	});
+
+	it('should show all todos', asyncTest(async () => {
+
+		const folders = await createNTestFolders(3);
+		Folder.moveToFolder(id(folders[2]), id(folders[1])); // subfolder
+		await testApp.wait();
+		const todos0 = await createNTestTodos(3, folders[0]);
+		const todos1 = await createNTestTodos(3, folders[1]);
+		const todos2 = await createNTestTodos(3, folders[2]);
+		await testApp.wait();
+
+		// TEST ACTION: View all-todos
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_TODOS_FILTER_ID });
+		await testApp.wait();
+
+		// check: all the notes are shown
+		const state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(state.selectedSmartFilterId).toEqual(ALL_TODOS_FILTER_ID);
+		expect(sortedIds(state.notes)).toEqual(sortedIds(todos0.concat(todos1).concat(todos2)));
+	}));
+
+	it('should show retain note selection when going from a folder to all-todos', asyncTest(async () => {
+		// setup
+		const folders = await createNTestFolders(2);
+		const todos0 = await createNTestTodos(3, folders[0]);
+		const todos1 = await createNTestTodos(3, folders[1]);
+		await testApp.wait();
+
+		testApp.dispatch({ type: 'FOLDER_SELECT', id: id(folders[1]) });
+		await testApp.wait();
+		testApp.dispatch({ type: 'NOTE_SELECT',	id: id(todos1[1]) });
+		await testApp.wait();
+
+		// check the state is set up as expected
+		let state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('Folder');
+		expect(state.selectedFolderId).toEqual(id(folders[1]));
+		expect(sortedIds(state.notes)).toEqual(sortedIds(todos1));
+		expect(state.selectedNoteIds).toEqual(ids([todos1[1]]));
+
+		// TEST ACTION: View all-todos
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_TODOS_FILTER_ID });
+		await testApp.wait();
+
+		// check: all the notes are shown
+		state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(state.selectedSmartFilterId).toEqual(ALL_TODOS_FILTER_ID);
+		expect(sortedIds(state.notes)).toEqual(sortedIds(todos0.concat(todos1)));
+		expect(state.selectedNoteIds).toEqual(ids([todos1[1]]));
+	}));
+
+	it('should support todo duplication', asyncTest(async () => {
+		// setup
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const folder2 = await Folder.save({ title: 'folder2' });
+		const todo1 = await Note.save({ title: 'todo1', parent_id: folder1.id, is_todo: true });
+		const todo2 = await Note.save({ title: 'todo2', parent_id: folder2.id, is_todo: true });
+		testApp.dispatch({ type: 'FOLDER_SELECT', id: folder1.id }); // active folder
+		await time.msleep(100);
+		testApp.dispatch({ type: 'NOTE_SELECT',	id: todo1.id });
+		await time.msleep(100);
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_TODOS_FILTER_ID });
+		await time.msleep(100);
+
+		// check the state is set up as expected
+		let state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(sortedIds(state.notes)).toEqual(sortedIds([todo1, todo2]));
+
+		// TEST ACTION: duplicate a note from the active folder
+		const newTodo1 = await Note.duplicate(todo1.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(3);
+		expect(sortedIds(state.notes)).toEqual(sortedIds([todo1, todo2, newTodo1]));
+
+		// TEST ACTION: duplicate a note from a non-active folder
+		const newTodo2 = await Note.duplicate(todo1.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(4);
+		expect(sortedIds(state.notes)).toEqual(sortedIds([todo1, todo2, newTodo1, newTodo2]));
+	}));
+
+	it('should support changing the todo parent', asyncTest(async () => {
+		// setup
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const folder2 = await Folder.save({ title: 'folder2' });
+		const todo1 = await Note.save({ title: 'todo1', parent_id: folder1.id, is_todo: true });
+		const todo2 = await Note.save({ title: 'todo1', parent_id: folder2.id, is_todo: true });
+		testApp.dispatch({ type: 'FOLDER_SELECT', id: folder1.id }); // active folder
+		await time.msleep(100);
+		testApp.dispatch({ type: 'NOTE_SELECT',	id: todo1.id });
+		await time.msleep(100);
+		testApp.dispatch({ type: 'SMART_FILTER_SELECT', id: ALL_TODOS_FILTER_ID });
+		await time.msleep(100);
+
+		// check the state is set up as expected
+		let state = testApp.store().getState();
+		expect(state.notesParentType).toEqual('SmartFilter');
+		expect(sortedIds(state.notes)).toEqual(sortedIds([todo1, todo2]));
+		expect(todo1.parent_id).toEqual(folder1.id);
+
+		// TEST ACTION: change the notes parent
+		await Note.moveToFolder(todo1.id, folder2.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(2);
+		let n1 = await Note.load(todo1.id);
+		expect(n1.parent_id).toEqual(folder2.id);
+
+		// TEST ACTION: change the notes parent
+		await Note.moveToFolder(todo1.id, folder1.id);
+		await time.msleep(100);
+
+		// check the note is duplicated and the view updated
+		state = testApp.store().getState();
+		expect(state.notes.length).toEqual(2);
+		n1 = await Note.load(todo1.id);
+		expect(n1.parent_id).toEqual(folder1.id);
+	}));
+
+});

--- a/CliClient/tests/test-utils.js
+++ b/CliClient/tests/test-utils.js
@@ -513,6 +513,24 @@ async function createNTestTags(n) {
 	return tags;
 }
 
+
+async function createNTestTodos(n, folder, tagIds = null, title = 'todo') {
+	const todos = [];
+	for (let i = 0; i < n; i++) {
+		const title_ = n > 1 ? `${title}${i}` : title;
+		const todo = await Note.save({ title: title_, parent_id: folder.id, is_conflict: 0, is_todo: true });
+		todos.push(todo);
+		await time.msleep(10);
+	}
+	if (tagIds) {
+		for (let i = 0; i < todos.length; i++) {
+			await Tag.setNoteTagsByIds(todos[i].id, tagIds);
+			await time.msleep(10);
+		}
+	}
+	return todos;
+}
+
 function tempFilePath(ext) {
 	return `${Setting.value('tempDir')}/${md5(Date.now() + Math.random())}.${ext}`;
 }
@@ -585,4 +603,4 @@ class TestApp extends BaseApplication {
 	}
 }
 
-module.exports = { kvStore, resourceService, resourceFetcher, tempFilePath, allSyncTargetItemsEncrypted, setupDatabase, revisionService, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync, checkThrow, encryptionService, loadEncryptionMasterKey, fileContentEqual, decryptionWorker, asyncTest, currentClientId, id, ids, sortedIds, at, createNTestNotes, createNTestFolders, createNTestTags, TestApp };
+module.exports = { kvStore, resourceService, resourceFetcher, tempFilePath, allSyncTargetItemsEncrypted, setupDatabase, revisionService, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync, checkThrow, encryptionService, loadEncryptionMasterKey, fileContentEqual, decryptionWorker, asyncTest, currentClientId, id, ids, sortedIds, at, createNTestNotes, createNTestFolders, createNTestTags, createNTestTodos, TestApp };

--- a/ElectronClient/gui/SideBar/SideBar.jsx
+++ b/ElectronClient/gui/SideBar/SideBar.jsx
@@ -15,7 +15,7 @@ const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
 const InteropServiceHelper = require('../../InteropServiceHelper.js');
 const { substrWithEllipsis, substrStartWithEllipsis } = require('lib/string-utils');
-const { ALL_NOTES_FILTER_ID } = require('lib/reserved-ids');
+const { ALL_NOTES_FILTER_ID, ALL_TODOS_FILTER_ID } = require('lib/reserved-ids');
 
 const commands = [
 	require('./commands/focusElementSideBar'),
@@ -134,6 +134,7 @@ class SideBarComponent extends React.Component {
 
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onAllNotesClick_ = this.onAllNotesClick_.bind(this);
+		this.onAllTodosClick_ = this.onAllTodosClick_.bind(this);
 
 		this.rootRef = React.createRef();
 
@@ -648,6 +649,13 @@ class SideBarComponent extends React.Component {
 		});
 	}
 
+	onAllTodosClick_() {
+		this.props.dispatch({
+			type: 'SMART_FILTER_SELECT',
+			id: ALL_TODOS_FILTER_ID,
+		});
+	}
+
 	synchronizeButton(type) {
 		const style = Object.assign({}, this.style().button, { marginBottom: 5 });
 		const iconName = 'fa-sync-alt';
@@ -689,6 +697,13 @@ class SideBarComponent extends React.Component {
 			this.makeHeader('allNotesHeader', _('All notes'), 'fa-clone', {
 				onClick: this.onAllNotesClick_,
 				selected: this.props.notesParentType === 'SmartFilter' && this.props.selectedSmartFilterId === ALL_NOTES_FILTER_ID,
+			})
+		);
+
+		items.push(
+			this.makeHeader('allTodosHeader', _('All To-dos'), 'fa-check-square', {
+				onClick: this.onAllTodosClick_,
+				selected: this.props.notesParentType === 'SmartFilter' && this.props.selectedSmartFilterId === ALL_TODOS_FILTER_ID,
 			})
 		);
 

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -13,7 +13,7 @@ const lodash = require('lodash');
 const urlUtils = require('lib/urlUtils.js');
 const markdownUtils = require('lib/markdownUtils.js');
 const { MarkupToHtml } = require('lib/joplin-renderer');
-const { ALL_NOTES_FILTER_ID } = require('lib/reserved-ids');
+const { ALL_NOTES_FILTER_ID,ALL_TODOS_FILTER_ID } = require('lib/reserved-ids');
 
 class Note extends BaseItem {
 	static tableName() {
@@ -310,7 +310,7 @@ class Note extends BaseItem {
 			options.conditions.push('is_conflict = 1');
 		} else {
 			options.conditions.push('is_conflict = 0');
-			if (parentId && parentId !== ALL_NOTES_FILTER_ID) {
+			if (parentId && parentId !== ALL_NOTES_FILTER_ID && parentId !== ALL_TODOS_FILTER_ID) {
 				options.conditions.push('parent_id = ?');
 				options.conditionsParams.push(parentId);
 			}
@@ -337,9 +337,13 @@ class Note extends BaseItem {
 			options.conditions.push('todo_completed <= 0');
 		}
 
+		if (parentId === ALL_TODOS_FILTER_ID) {
+			options.conditions.push('is_todo = 1');
+		}
+
 		if (options.uncompletedTodosOnTop && hasTodos) {
 			let cond = options.conditions.slice();
-			cond.push('is_todo = 1');
+			if (parentId !== ALL_TODOS_FILTER_ID) cond.push('is_todo = 1');
 			cond.push('(todo_completed <= 0 OR todo_completed IS NULL)');
 			let tempOptions = Object.assign({}, options);
 			tempOptions.conditions = cond;

--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -1,7 +1,7 @@
 const Note = require('lib/models/Note.js');
 const Folder = require('lib/models/Folder.js');
 const ArrayUtils = require('lib/ArrayUtils.js');
-const { ALL_NOTES_FILTER_ID } = require('lib/reserved-ids');
+const { ALL_NOTES_FILTER_ID, ALL_TODOS_FILTER_ID } = require('lib/reserved-ids');
 const CommandService = require('lib/services/CommandService').default;
 
 const defaultState = {
@@ -671,6 +671,7 @@ const reducer = (state = defaultState, action) => {
 			{
 				const modNote = action.note;
 				const isViewingAllNotes = (state.notesParentType === 'SmartFilter' && state.selectedSmartFilterId === ALL_NOTES_FILTER_ID);
+				const isViewingAllTodos = (state.notesParentType === 'SmartFilter' && state.selectedSmartFilterId === ALL_TODOS_FILTER_ID);
 				const isViewingConflictFolder = state.notesParentType === 'Folder' && state.selectedFolderId === Folder.conflictFolderId();
 
 				const noteIsInFolder = function(note, folderId) {
@@ -687,7 +688,7 @@ const reducer = (state = defaultState, action) => {
 					const n = newNotes[i];
 					if (n.id == modNote.id) {
 						// Note is still in the same folder
-						if (isViewingAllNotes || noteIsInFolder(modNote, n.parent_id)) {
+						if (isViewingAllNotes || isViewingAllTodos ||  noteIsInFolder(modNote, n.parent_id)) {
 							// Merge the properties that have changed (in modNote) into
 							// the object we already have.
 							newNotes[i] = Object.assign({}, newNotes[i]);
@@ -710,7 +711,7 @@ const reducer = (state = defaultState, action) => {
 				// Note was not found - if the current folder is the same as the note folder,
 				// add it to it.
 				if (!found) {
-					if (isViewingAllNotes || noteIsInFolder(modNote, state.selectedFolderId)) {
+					if (isViewingAllNotes || isViewingAllTodos || noteIsInFolder(modNote, state.selectedFolderId)) {
 						newNotes.push(modNote);
 					}
 				}

--- a/ReactNativeClient/lib/reserved-ids.js
+++ b/ReactNativeClient/lib/reserved-ids.js
@@ -2,5 +2,6 @@
 module.exports = Object.freeze({
 
 	ALL_NOTES_FILTER_ID: 'c3176726992c11e9ac940492261af972',
+	ALL_TODOS_FILTER_ID: 'fca33f6ab5aa4233a4a98b202f9c4d0d',
 
 });


### PR DESCRIPTION
## Description

* `All To-Do's` is a selectable field within the side bar
* Clicking on `All To-Do's` will display all of your todo's across all of your notebooks.
* Implemented following the smart filter flow similar to GH-2472
* View respects your sort and todo preferences (i.e. hide completed, uncompleted at top, etc.)
* Contains automated tests for feature

![image](https://user-images.githubusercontent.com/531415/88124904-03047700-cb83-11ea-8bec-d3c54993a825.png)

_Note: Due to this change (sans the tests) being under 50 lines and being discussed previously on the forum, I did not create an additional thread.  I didn't see anything barring this feature addition, but If there's a broader reason that this feature/PR can't be added that I missed, feel free to let me know.  Thanks!_