### PR TITLE
CLI: Add an option to mkbook command to the CLI client for creating sub notebooks. Fixes #1728

### DIFF
--- a/CliClient/app/cli-integration-tests.js
+++ b/CliClient/app/cli-integration-tests.js
@@ -96,6 +96,22 @@ testUnits.testFolders = async () => {
 	assertEquals(0, folders.length);
 };
 
+testUnits.testSubFolders = async () => {
+	await execCommand(client, 'mkbook nb1');
+	await execCommand(client, 'mkbook -s nb2');
+
+	let folders = await Folder.all();
+	assertEquals(2, folders.length);
+	assertEquals('nb1', folders[0].title);
+	assertEquals('nb2', folders[1].title);
+	assertEquals(folders[0].id, folders[1].parentId);
+
+	await execCommand(client, 'rm -r -f nb1');
+
+	folders = await Folder.all();
+	assertEquals(0, folders.length);
+};
+
 testUnits.testNotes = async () => {
 	await execCommand(client, 'mkbook nb1');
 	await execCommand(client, 'mknote n1');

--- a/CliClient/app/command-mkbook.js
+++ b/CliClient/app/command-mkbook.js
@@ -12,8 +12,25 @@ class Command extends BaseCommand {
 		return _('Creates a new notebook.');
 	}
 
+	options() {
+		return [
+			['-s, --sub', _('Creates the new notebook as a sub-notebook of the currently selected notebook')],
+		];
+	}
+
 	async action(args) {
-		const folder = await Folder.save({ title: args['new-notebook'] }, { userSideValidation: true });
+		const options = args.options;
+
+		const book = {
+			title: args['new-notebook'],
+		};
+
+		if (options && options.sub) {
+			if (!app().currentFolder()) throw new Error(_('Sub-notebooks can only be created within a notebook.'));
+			book.parent_id = app().currentFolder().id;
+		}
+
+		const folder = await Folder.save(book, { userSideValidation: true });
 		app().switchCurrentFolder(folder);
 	}
 }


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
I had a need to create notebook hierarchies in the CLI and saw a simple way of doing it. 

I haven't seen this method mentioned in #1728 so I offer this PR as a potential starting point. It avoids the name conflict metioned in [this comment](https://github.com/laurent22/joplin/issues/1728#issuecomment-543017735) by using the currently selected folders ID in the same way that the mknote command does. 
