### PR TITLE
Fix: Tag note count cache performance update

### DIFF
--- a/CliClient/app/app.js
+++ b/CliClient/app/app.js
@@ -432,7 +432,9 @@ class Application extends BaseApplication {
 
 			await FoldersScreenUtils.refreshFolders();
 
-			const tags = await Tag.allWithNotes();
+			let tags = await Tag.all();
+			await Tag.updateCachedNoteCountForIds(tags.map((t) => t.id));
+			tags = tags.filter((t) => Tag.getCachedNoteCount(t.id) > 0);
 
 			ResourceService.runInBackground();
 

--- a/CliClient/tests/models_Tag.js
+++ b/CliClient/tests/models_Tag.js
@@ -28,6 +28,7 @@ describe('models_Tag', function() {
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 
 		await Tag.setNoteTagsByTitles(note1.id, ['un', 'deux']);
+		await Tag.updateCachedNoteCountForIds([(await Tag.loadByTitle('un')).id, (await Tag.loadByTitle('deux')).id]);
 
 		const noteTags = await Tag.tagsByNoteId(note1.id);
 		expect(noteTags.length).toBe(2);
@@ -49,11 +50,14 @@ describe('models_Tag', function() {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
+		const tagId = (await Tag.loadByTitle('un')).id;
+		await Tag.updateCachedNoteCountForIds([tagId]);
 
 		let tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(1);
 
 		await Note.delete(note1.id);
+		await Tag.updateCachedNoteCountForIds([tagId]);
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
@@ -65,18 +69,22 @@ describe('models_Tag', function() {
 		const note2 = await Note.save({ title: 'ma 2nd note', parent_id: folder1.id });
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
 		await Tag.setNoteTagsByTitles(note2.id, ['un']);
+		const tagId = (await Tag.loadByTitle('un')).id;
+		await Tag.updateCachedNoteCountForIds([tagId]);
 
 		let tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(1);
 		expect(Tag.getCachedNoteCount(tags[0].id)).toBe(2);
 
 		await Note.delete(note1.id);
+		await Tag.updateCachedNoteCountForIds([tagId]);
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(1);
 		expect(Tag.getCachedNoteCount(tags[0].id)).toBe(1);
 
 		await Note.delete(note2.id);
+		await Tag.updateCachedNoteCountForIds([tagId]);
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
@@ -185,6 +193,7 @@ describe('models_Tag', function() {
 
 		const note0 = await Note.save({ title: 'my note 0', parent_id: folder1.id });
 		await Tag.addNote(tag0.id, note0.id);
+		await Tag.updateCachedNoteCountForIds([parent_tag.id]);
 
 		parent_tag = await Tag.loadWithCount(parent_tag.id);
 		expect(Tag.getCachedNoteCount(parent_tag.id)).toBe(1);

--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -1163,7 +1163,9 @@ class Application extends BaseApplication {
 
 		await FoldersScreenUtils.refreshFolders();
 
-		const tags = await Tag.allWithNotes();
+		let tags = await Tag.all();
+		await Tag.updateCachedNoteCountForIds(tags.map((t) => t.id));
+		tags = tags.filter((t) => Tag.getCachedNoteCount(t.id) > 0);
 
 		this.dispatch({
 			type: 'TAG_UPDATE_ALL',

--- a/ElectronClient/gui/MainScreen/commands/setTags.ts
+++ b/ElectronClient/gui/MainScreen/commands/setTags.ts
@@ -18,16 +18,16 @@ export const runtime = (comp:any):CommandRuntime => {
 					return { value: a.id, label: Tag.getCachedFullTitle(a.id) };
 				})
 				.sort((a:any, b:any) => {
-					// sensitivity accent will treat accented characters as differemt
+					// sensitivity accent will treat accented characters as different
 					// but treats caps as equal
 					return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
 				});
-			const allTags = await Tag.allWithNotes();
+			const allTags = await Tag.all();
 			const tagSuggestions = allTags.map((a:any) => {
 				return { value: a.id, label: Tag.getCachedFullTitle(a.id) };
 			})
 				.sort((a:any, b:any) => {
-				// sensitivity accent will treat accented characters as differemt
+				// sensitivity accent will treat accented characters as different
 				// but treats caps as equal
 					return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
 				});

--- a/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
+++ b/ReactNativeClient/lib/components/shared/reduxSharedMiddleware.js
@@ -81,6 +81,12 @@ const reduxSharedMiddleware = async function(store, next, action) {
 		});
 	}
 
+	if (action.type === 'TAGS_NOTE_COUNT_UPDATE') {
+		await Tag.updateCachedNoteCountForIdsAndAncestors(action.tagIds, { deleteAbandoned: true });
+
+		refreshTags = true;
+	}
+
 	if (mustAutoAddResources) {
 		ResourceFetcher.instance().autoAddResources();
 	}

--- a/ReactNativeClient/lib/models/Note.js
+++ b/ReactNativeClient/lib/models/Note.js
@@ -4,6 +4,7 @@ const BaseItem = require('lib/models/BaseItem.js');
 const ItemChange = require('lib/models/ItemChange.js');
 const Resource = require('lib/models/Resource.js');
 const Setting = require('lib/models/Setting.js');
+const NoteTag = require('lib/models/NoteTag.js');
 const { shim } = require('lib/shim.js');
 const { pregQuote } = require('lib/string-utils.js');
 const { time } = require('lib/time-utils.js');
@@ -639,7 +640,24 @@ class Note extends BaseItem {
 					id: id,
 				});
 			}
+
+			const noteTags = await NoteTag.byNoteIds(notes.map((n) => n.id));
+			this.dispatch({
+				type: 'TAGS_NOTE_COUNT_UPDATE',
+				tagIds: noteTags.map((nt) => nt.tag_id),
+			});
 		}
+	}
+
+	static async delete(id, options = null) {
+		const output = await super.delete(id, options);
+
+		this.dispatch({
+			type: 'TAGS_NOTE_COUNT_UPDATE',
+			tagIds: await NoteTag.tagIdsByNoteId(id),
+		});
+
+		return output;
 	}
 
 	static dueNotes() {

--- a/ReactNativeClient/lib/models/NoteTag.js
+++ b/ReactNativeClient/lib/models/NoteTag.js
@@ -23,6 +23,29 @@ class NoteTag extends BaseItem {
 		}
 		return output;
 	}
+
+	static async delete(id, options = null) {
+		const noteTag = NoteTag.byId(id);
+		const output = await super.delete(id, options);
+
+		this.dispatch({
+			type: 'TAGS_NOTE_COUNT_UPDATE',
+			tagIds: [noteTag.tag_id],
+		});
+
+		return output;
+	}
+
+	static async save(o, options = null) {
+		const noteTag = await super.save(o, options);
+
+		this.dispatch({
+			type: 'TAGS_NOTE_COUNT_UPDATE',
+			tagIds: [noteTag.tag_id],
+		});
+
+		return noteTag;
+	}
 }
 
 module.exports = NoteTag;

--- a/ReactNativeClient/root.js
+++ b/ReactNativeClient/root.js
@@ -512,7 +512,9 @@ async function initialize(dispatch) {
 
 		await FoldersScreenUtils.refreshFolders();
 
-		const tags = await Tag.allWithNotes();
+		let tags = await Tag.all();
+		await Tag.updateCachedNoteCountForIds(tags.map((t) => t.id));
+		tags = tags.filter((t) => Tag.getCachedNoteCount(t.id) > 0);
 
 		dispatch({
 			type: 'TAG_UPDATE_ALL',


### PR DESCRIPTION
A follow up to #2572. This should fix the performance issues indicated by the users in the current pre-release. 

Now the tag note count cache is initiated once at the application start up and then only relevant tags are updated when changes occur. The changes that trigger cache updates are:

1. `Tag.save()` if the tag's parent was changed, then count cache must be updated to the new and old parents.
2. `Tag.rename()` or `Tag.moveTag()` if the parent changes - update count cache for old/new parents
3. `Tag.delete()` update count to the parents
4. `NoteTag.save()` and `NoteTag.delete()`
5. `Note.delete()` - looks up all associated tags from NoteTag and updates cache for those tags (and their parents).
6. Is there anything I've missed?

The note count cache updates from Note and NoteTag classes are called from a new `TAGS_NOTE_COUNT_UPDATE` event in the shared middleware. This was because I couldn't call methods of `Tag` class in `NoteTag` due to cyclic imports. This is not ideal since I don't think the middleware is run in the test suite and hence I had to add a couple of extra "update cache" (`await Tag.updateCachedNoteCountForIds([tagId])`) statements to the tests. So thoughts on this would be appreciated.

I've also added a statement that initialises the cache on application startup, so startup might take a little while longer. But once its loaded, then it should be kept in the correct state by only changing the relevant tag counts.

Finally, I think there is one more improvement that could be made. Getting the tag hierarchy (descendants or ancestors) is the most expensive part of the cache updates. Hence it would be useful to cache the tag hierarchy such that you could quickly lookup all of its descendants or ancestors. This could greatly increase the performance of the updates. But I think this could be left for a followup work. I think this change alone should be able to resolve most of the performance issues. 