### PR TITLE
Desktop: Toggle Editor rather than setting split mode on search

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -398,8 +398,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			// to the viewer if they only want to scroll through matches
 			if (!props.visiblePanes.includes('editor') && props.searchMarkers !== previousSearchMarkers) {
 				props.dispatch({
-					type: 'NOTE_VISIBLE_PANES_SET',
-					panes: ['editor', 'viewer'],
+					type: 'NOTE_VISIBLE_PANES_TOGGLE',
 				});
 			}
 			// SEARCHHACK

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -392,15 +392,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 	useEffect(() => {
 		if (props.searchMarkers !== previousSearchMarkers || renderedBody !== previousRenderedBody) {
-			// Force both viewers to be visible during search
-			// This view should only change when the search terms change, this means the user
-			// is always presented with the currently highlighted text, but can revert
-			// to the viewer if they only want to scroll through matches
-			if (!props.visiblePanes.includes('editor') && props.searchMarkers !== previousSearchMarkers) {
-				props.dispatch({
-					type: 'NOTE_VISIBLE_PANES_TOGGLE',
-				});
-			}
 			// SEARCHHACK
 			// TODO: remove this options hack when aceeditor is removed
 			// Currently the webviewRef will send out an ipcMessage to set the results count
@@ -420,9 +411,17 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			webviewRef.current.wrappedInstance.send('setMarkers', props.searchMarkers.keywords, options);
 			//  SEARCHHACK
 			if (editorRef.current) {
-
 				const matches = editorRef.current.setMarkers(props.searchMarkers.keywords, props.searchMarkers.options);
-				props.setLocalSearchResultCount(matches);
+
+				// SEARCHHACK
+				// TODO: when aceeditor is removed then this check will be performed in the NoteSearchbar
+				// End the if statement can be removed in favor of simply returning matches
+				if (props.visiblePanes.includes('editor')) {
+					props.setLocalSearchResultCount(matches);
+				} else {
+					props.setLocalSearchResultCount(-1);
+				}
+				// end SEARCHHACK
 			}
 		}
 	}, [props.searchMarkers, props.setLocalSearchResultCount, renderedBody]);

--- a/ElectronClient/gui/NoteSearchBar.jsx
+++ b/ElectronClient/gui/NoteSearchBar.jsx
@@ -159,7 +159,7 @@ class NoteSearchBarComponent extends React.Component {
 
 		const viewerWarning = (
 			<div style={textStyle}>
-				{_('Jumping between matches is not available in the viewer, please toggle the editor')}
+				{'Jumping between matches is not available in the viewer, please toggle the editor'}
 			</div>
 		);
 

--- a/ElectronClient/gui/NoteSearchBar.jsx
+++ b/ElectronClient/gui/NoteSearchBar.jsx
@@ -148,6 +148,21 @@ class NoteSearchBarComponent extends React.Component {
 			</div>
 		) : null;
 
+		// Currently searching in the viewer does not support jumping between matches
+		// So we explicitly disable those commands when only the viewer is open (this is
+		// currently signaled by results count being set to -1, but once Ace editor is removed
+		// we can observe the visible panes directly).
+		// SEARCHHACK
+		// TODO: remove the props.resultCount check here and replace it by checking visible panes directly
+		const allowScrolling = this.props.resultCount !== -1;
+		// end SEARCHHACK
+
+		const viewerWarning = (
+			<div style={textStyle}>
+				{_('Jumping between matches is not available in the viewer, please toggle the editor')}
+			</div>
+		);
+
 		return (
 			<div style={this.props.style}>
 				<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
@@ -161,9 +176,10 @@ class NoteSearchBarComponent extends React.Component {
 						type="text"
 						style={{ width: 200, marginRight: 5, backgroundColor: this.backgroundColor, color: theme.color }}
 					/>
-					{nextButton}
-					{previousButton}
-					{matchesFoundString}
+					{allowScrolling ? nextButton : null}
+					{allowScrolling ? previousButton : null}
+					{allowScrolling ? matchesFoundString : null}
+					{!allowScrolling ? viewerWarning : null}
 				</div>
 			</div>
 		);


### PR DESCRIPTION
[reference](https://discourse.joplinapp.org/t/1-0-227-regressions/10156/5)

Before I was manually setting split view which was particularly annoying for users who had disabled the split view. This is how I should have implemented it originally.
Before merging this I'd like to get some community feedback about the current behaviour. 