### PR TITLE
Desktop: Resolves #3529: Fix AppImage Icon

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -41,7 +41,7 @@ showHelp() {
     print "\t" "--changelog" "\t" "Show the changelog after installation"
     print "\t" "--force" "\t" "Always download the latest version"
     print "\t" "--silent" "\t" "Don't print any output"
-    print "\t" "--prerelease" "\t" "Check for new Versions including Pre-Releases"
+    print "\t" "--prerelease" "\t" "Check for new Versions including Pre-Releases" 
 
     if [[ ! -z $1 ]]; then
         print "\n" "${COLOR_RED}ERROR: " "$*" "${COLOR_RESET}" "\n"

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -41,7 +41,7 @@ showHelp() {
     print "\t" "--changelog" "\t" "Show the changelog after installation"
     print "\t" "--force" "\t" "Always download the latest version"
     print "\t" "--silent" "\t" "Don't print any output"
-    print "\t" "--prerelease" "\t" "Check for new Versions including Pre-Releases" 
+    print "\t" "--prerelease" "\t" "Check for new Versions including Pre-Releases"
 
     if [[ ! -z $1 ]]; then
         print "\n" "${COLOR_RED}ERROR: " "$*" "${COLOR_RESET}" "\n"
@@ -176,7 +176,7 @@ then
     mkdir -p ~/.local/share/applications
     echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#${APPIMAGE_VERSION}" >> ~/.local/share/applications/appimagekit-joplin.desktop
     # Update application icons
-    [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications
+    [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications && update-desktop-database ~/.local/share/icons
     print "${COLOR_GREEN}OK${COLOR_RESET}"
 else
     print "${COLOR_RED}NOT DONE, unknown desktop '${DESKTOP}'${COLOR_RESET}"


### PR DESCRIPTION
Appends  `&& update-desktop-database ~/.local/share/icons` in addition to `~/.local/share/applications`.  
Checked on Budgie 20.04 LTS.

@Tiger862000 Does this work for you on Pop!_OS?