### PR TITLE
Update Katex to v0.12.0

### DIFF
--- a/CliClient/package-lock.json
+++ b/CliClient/package-lock.json
@@ -3922,9 +3922,9 @@
       "dev": true
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
       },

--- a/CliClient/package.json
+++ b/CliClient/package.json
@@ -60,7 +60,7 @@
     "joplin-turndown-plugin-gfm": "^1.0.12",
     "json-stringify-safe": "^5.0.1",
     "jssha": "^2.3.0",
-    "katex": "^0.11.1",
+    "katex": "^0.12.0",
     "keytar": "^5.4.0",
     "levenshtein": "^1.0.5",
     "markdown-it": "^10.0.0",

--- a/ElectronClient/package-lock.json
+++ b/ElectronClient/package-lock.json
@@ -7145,9 +7145,9 @@
       "dev": true
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
       },

--- a/ElectronClient/package.json
+++ b/ElectronClient/package.json
@@ -130,7 +130,7 @@
     "joplin-turndown-plugin-gfm": "^1.0.12",
     "json-stringify-safe": "^5.0.1",
     "jssha": "^2.3.1",
-    "katex": "^0.11.1",
+    "katex": "^0.12.0",
     "keytar": "^5.4.0",
     "levenshtein": "^1.0.5",
     "lodash": "^4.17.15",

--- a/ReactNativeClient/lib/joplin-renderer/package.json
+++ b/ReactNativeClient/lib/joplin-renderer/package.json
@@ -21,7 +21,7 @@
     "highlight.js": "10.1.1",
     "html-entities": "^1.2.1",
     "json-stringify-safe": "^5.0.1",
-    "katex": "^0.11.1",
+    "katex": "^0.12.0",
     "markdown-it": "^10.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-anchor": "^5.2.5",

--- a/ReactNativeClient/package-lock.json
+++ b/ReactNativeClient/package-lock.json
@@ -6365,18 +6365,11 @@
       "dev": true
     },
     "katex": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
         "commander": "^2.19.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
       }
     },
     "kind-of": {

--- a/ReactNativeClient/package.json
+++ b/ReactNativeClient/package.json
@@ -32,7 +32,7 @@
     "htmlparser2": "^4.1.0",
     "jsc-android": "241213.1.0",
     "json-stringify-safe": "^5.0.1",
-    "katex": "^0.11.1",
+    "katex": "^0.12.0",
     "markdown-it": "^10.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-anchor": "^5.2.5",


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

I want to use bra-ket notation to write some notes about quantum stuff. Joplin's current Katex dependency is 0.11.1, which does not support this notation. Katex 0.12.0 (the current stable release) does support this notation, so I propose to update Joplin's dependency to the new version.
