### PR TITLE
Desktop: remove 7zip from optional dependencies

### DIFF
--- a/ElectronClient/package.json
+++ b/ElectronClient/package.json
@@ -90,11 +90,6 @@
     "js-sha512": "^0.8.0",
     "patch-package": "^6.2.0"
   },
-  "optionalDependencies": {
-    "7zip-bin-linux": "^1.0.1",
-    "7zip-bin-mac": "^1.0.1",
-    "7zip-bin-win": "^2.1.1"
-  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
     "app-module-path": "^2.2.0",


### PR DESCRIPTION
It isn't being used anywhere(maybe but tools/release-clipper.js), and takes up ~5M in every package.