### PR TITLE
Desktop: Fixes #3569: Show full folder name in mouse-over pop-up text

### DIFF
--- a/ElectronClient/gui/NoteToolbar/NoteToolbar.tsx
+++ b/ElectronClient/gui/NoteToolbar/NoteToolbar.tsx
@@ -59,6 +59,7 @@ function NoteToolbar(props:NoteToolbarProps) {
 		if (folderId && ['Search', 'Tag', 'SmartFilter'].includes(props.notesParentType)) {
 			output.push({
 				title: _('In: %s', substrWithEllipsis(folderTitle, 0, 16)),
+				tooltip: folderTitle,
 				iconName: 'fa-book',
 				onClick: () => {
 					props.dispatch({


### PR DESCRIPTION
fixes #3569

Defining the `tooltip` property here, it is then propagated to the ToolbarButton component that will use it to define the html title of the tag while keeping the truncated version as content.

```js
const tooltip = this.props.tooltip ? this.props.tooltip : title;
```

https://github.com/laurent22/joplin/blob/dev/ElectronClient/gui/ToolbarButton.jsx#L11

![joplin-hover](https://user-images.githubusercontent.com/7129815/89232455-c8b9c180-d5e7-11ea-83b1-a38e723cb556.png)

