### PR TITLE
Windows/MacOS fix sync fetching for AWS S3

### DIFF
--- a/CliClient/tests/file_api_driver.js
+++ b/CliClient/tests/file_api_driver.js
@@ -42,6 +42,7 @@ describe('fileApi', function() {
 			const items = response.items;
 			expect(items.length).toBe(3);
 			expect(items[0].path).toBe('1');
+			expect(items[0].updated_time).toMatch(/^\d+$/); // make sure it's using epoch timestamp
 		}));
 
 		it('should default to only files on root directory', asyncTest(async () => {

--- a/ReactNativeClient/lib/file-api-driver-amazon-s3.js
+++ b/ReactNativeClient/lib/file-api-driver-amazon-s3.js
@@ -145,10 +145,11 @@ class FileApiDriverAmazonS3 {
 
 	metadataToStat_(md, path) {
 		const relativePath = basename(path);
+		const lastModifiedDate = md['LastModified'] ? new Date(md['LastModified']) : new Date();
 
 		const output = {
 			path: relativePath,
-			updated_time: md['LastModified'] ? new Date(md['LastModified']) : new Date(),
+			updated_time: lastModifiedDate.getTime(),
 			isDeleted: !!md['DeleteMarker'],
 			isDir: false,
 		};


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/3591. 
Use timestamp instead of `Date` for updated_time, which caused the basic delta to always think there's a change.


