### PR TITLE
Desktop: Focus the editor whenever the user toggles the visible panes

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -544,6 +544,18 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	useEffect(() => {
 		if (!editorRef.current) return;
 
+		// Anytime the user toggles the visible panes AND the editor is visible as a result
+		// we should focus the editor
+		// The intuition is that a panel toggle (with editor in view) is the equivalent of
+		// an editor interaction so users should expect the editor to be focused
+		if (props.visiblePanes.indexOf('editor') >= 0) {
+			editorRef.current.focus();
+		}
+	}, [props.visiblePanes]);
+
+	useEffect(() => {
+		if (!editorRef.current) return;
+
 		// Need to let codemirror know that it's container's size has changed so that it can
 		// re-compute anything it needs to. This ensures the cursor (and anything that is
 		// based on window size will be correct


### PR DESCRIPTION
I only implemented this for codemirror but the change can easily be backported to Ace.

fixes #3631

I ended up implementing this as an effect in the editor because I couldn't see a clean solution that would be possible inside of the command system. 
One thing that I wasn't sure about when implementing this is if my solution here is guaranteed to only trigger when the user presses Ctrl-L, I did some testing and it seemed okay. @laurent22  I can add a guard with `usePrevious` if you think that this will sometimes unnecessarily focus the editor.