### PR TITLE
Desktop: Fixes #3628: Add scroll offset for dragging notes (ui_update branch)

### DIFF
--- a/ElectronClient/gui/ItemList.jsx
+++ b/ElectronClient/gui/ItemList.jsx
@@ -36,6 +36,10 @@ class ItemList extends React.Component {
 		return this.listRef.current ? this.listRef.current.offsetTop : 0;
 	}
 
+	offsetScroll() {
+		return this.scrollTop_;
+	}
+
 	UNSAFE_componentWillMount() {
 		this.updateStateItemIndexes();
 	}

--- a/ElectronClient/gui/NoteList/NoteList.tsx
+++ b/ElectronClient/gui/NoteList/NoteList.tsx
@@ -141,7 +141,7 @@ class NoteListComponent extends React.Component {
 	}
 
 	dragTargetNoteIndex_(event:any) {
-		return Math.abs(Math.round((event.clientY - this.itemListRef.current.offsetTop()) / this.itemHeight)) - 1;
+		return Math.abs(Math.round((event.clientY - this.itemListRef.current.offsetTop() + this.itemListRef.current.offsetScroll()) / this.itemHeight));
 	}
 
 	noteItem_noteDragOver(event:any) {


### PR DESCRIPTION
Fixes laurent22/joplin#3628

The note dragging was not taking into account the scroll distance.
This caused the notes to be dragged to a different location than the mouse.
This scroll offset should fix that issue.

This fix was moved to ui_update branch instead of dev branch.
[Original pull request](https://github.com/laurent22/joplin/pull/3643) on dev branch

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
