### PR TITLE
Desktop: Load codemirror css in index.html

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -309,11 +309,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		async function loadScripts() {
 			const scriptsToLoad:{src: string, id:string, loaded: boolean}[] = [
 				{
-					src: 'node_modules/codemirror/lib/codemirror.css',
-					id: 'codemirrorBaseStyle',
-					loaded: false,
-				},
-				{
 					src: 'node_modules/codemirror/addon/dialog/dialog.css',
 					id: 'codemirrorDialogStyle',
 					loaded: false,

--- a/ElectronClient/index.html
+++ b/ElectronClient/index.html
@@ -12,6 +12,7 @@
 		<link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/all.min.css">
 		<link rel="stylesheet" href="node_modules/react-datetime/css/react-datetime.css">
 		<link rel="stylesheet" href="node_modules/smalltalk/css/smalltalk.css">
+		<link rel="stylesheet" href="node_modules/codemirror/lib/codemirror.css">
 
 		<style>
 			.smalltalk {


### PR DESCRIPTION
[reference](https://discourse.joplinapp.org/t/bug-cursor-jumps-in-codemirror/10713)

I couldn't pinpoint the exact cause of failure on this one, but it seems like codemirror doesn't like it when the css is lazy loaded. I think there is probably some form of race condition happening while it is initializing. 

I figured the simplest solution would be to load the 8.5KB codemirror.css file in index.html. If that is too slow we could probably change this to add only the exact css needed in index.html and lazy load the rest of the file, but I don't think that's really worth the complexity.