### PR TITLE
Fixes InvalidAuthenticationToken for OneDrive

### DIFF
--- a/ReactNativeClient/lib/onedrive-api.js
+++ b/ReactNativeClient/lib/onedrive-api.js
@@ -327,22 +327,15 @@ class OneDriveApi {
 	}
 
 	async execAccountPropertiesRequest() {
-		const response = await shim.fetch('https://graph.microsoft.com/v1.0/me/drive', {
-			method: 'GET',
-			headers: {
-				'Authorization': this.token(),
-			},
-		});
 
-		if (!response.ok) {
-			const text = await response.text();
-			throw new Error(`Could not retrieve account details (drive ID, Account type): ${response.status}: ${response.statusText}: ${text}`);
-		} else {
+		try {
+			const response = await this.exec('GET','https://graph.microsoft.com/v1.0/me/drive');
 			const data = await response.json();
 			const accountProperties = { accountType: data.driveType, driveId: data.id };
 			return accountProperties;
+		} catch (error) {
+			throw new Error(`Could not retrieve account details (drive ID, Account type. Error code: ${error.code}, Error message: ${error.message}`);
 		}
-
 	}
 
 	async execJson(method, path, query, data) {


### PR DESCRIPTION
Bug reported in the [forum](InvalidAuthenticationToken). The Bug has been introduced in the [pr for onedrive for business](https://github.com/laurent22/joplin/pull/3433). The Bug happened because of missing error handling when requesting the account properties. Sorry for that :-(. It should work now. 

The Bug can be reproduced by the following: 
1. Set the value for sync.3.context in the "settings" table in the sqlite database to ""
2. Change the access token in the JSON text for sync.3.auth in the "settings" table so that the token is invalid (just change one character) 
3. start joplin and sync to onedrive 
