### PR TITLE
Desktop: Resolves #3206: Added option to display subnotebook notes in parent notebook

### DIFF
--- a/ElectronClient/app.js
+++ b/ElectronClient/app.js
@@ -783,6 +783,14 @@ class Application extends BaseApplication {
 						screens: ['Main'],
 						submenu: sortFolderItems,
 					}, {
+						label: Setting.settingMetadata('showChildNotes').label(),
+						type: 'checkbox',
+						checked: Setting.value('showChildNotes'),
+						screens: ['Main'],
+						click: () => {
+							Setting.setValue('showChildNotes', !Setting.value('showChildNotes'));
+						},
+					}, {
 						label: Setting.settingMetadata('showNoteCounts').label(),
 						type: 'checkbox',
 						checked: Setting.value('showNoteCounts'),

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -277,7 +277,13 @@ class BaseApplication {
 
 		if (parentId) {
 			if (parentType === Folder.modelType()) {
-				notes = await Note.previews(parentId, options);
+				let folderIds = [parentId];
+				// TODO: put in state.settings
+				const showChildNotes = true;
+				if (showChildNotes) {
+					folderIds = folderIds.concat(await Folder.childrenIds(parentId));
+				}
+				notes = await Note.previews(folderIds, options);
 			} else if (parentType === Tag.modelType()) {
 				notes = await Tag.notes(parentId, options);
 			} else if (parentType === BaseModel.TYPE_SEARCH) {

--- a/ReactNativeClient/lib/BaseApplication.js
+++ b/ReactNativeClient/lib/BaseApplication.js
@@ -278,9 +278,7 @@ class BaseApplication {
 		if (parentId) {
 			if (parentType === Folder.modelType()) {
 				let folderIds = [parentId];
-				// TODO: put in state.settings
-				const showChildNotes = true;
-				if (showChildNotes) {
+				if (Setting.value('showChildNotes')) {
 					folderIds = folderIds.concat(await Folder.childrenIds(parentId));
 				}
 				notes = await Note.previews(folderIds, options);
@@ -471,15 +469,19 @@ class BaseApplication {
 			refreshNotes = true;
 		}
 
-		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key == 'uncompletedTodosOnTop') || action.type == 'SETTING_UPDATE_ALL')) {
+		if (this.hasGui() && action.type == 'SETTING_UPDATE_ALL') {
 			refreshNotes = true;
 		}
 
-		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key == 'showCompletedTodos') || action.type == 'SETTING_UPDATE_ALL')) {
+		const settingsToRefresh = ['showCompletedTodos', 'showChildNotes', 'uncompletedTodosOnTop'];
+		if (
+			this.hasGui()
+			&& ((action.type == 'SETTING_UPDATE_ONE' && settingsToRefresh.includes(action.key)))
+		) {
 			refreshNotes = true;
 		}
 
-		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key.indexOf('notes.sortOrder') === 0) || action.type == 'SETTING_UPDATE_ALL')) {
+		if (this.hasGui() && ((action.type == 'SETTING_UPDATE_ONE' && action.key.indexOf('notes.sortOrder') === 0))) {
 			refreshNotes = true;
 		}
 

--- a/ReactNativeClient/lib/models/Setting.js
+++ b/ReactNativeClient/lib/models/Setting.js
@@ -349,6 +349,13 @@ class Setting extends BaseModel {
 				options: () => themeOptions(),
 			},
 
+			showChildNotes: {
+				value: false,
+				type: Setting.TYPE_BOOL,
+				public: false,
+				appTypes: ['desktop'],
+				label: () => _('Display notes from subnotebooks'),
+			},
 			showNoteCounts: { value: true, type: Setting.TYPE_BOOL, public: false, advanced: true, appTypes: ['desktop'], label: () => _('Show note counts') },
 
 			layoutButtonSequence: {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->

# Displaying Notes from Subnotebooks

This PR adds a toggleable setting that allows the notes to cascade. When it is on, notes from all the subnotebooks will appear in the note list for a display notebook.

In the code, the setting is called `showChildNotes`.

The functionality is implemented by fetching all the subnotebook ids for the current folder (`Folder.childrenIds(parentId)`) and finding the notes of those children. Originally, I implemented the collation of notes solely in `BaseApplication`, but considering that the notes needed to be sorted anew, I thought it would be cleaner to allow `Note.previews` to accept an array of `parentIds`.

For consistent user experience with current functionality, it defaults to `false`.

# Screenshots

When off:
![Screen Shot 2020-08-28 at 7 43 20 PM](https://user-images.githubusercontent.com/14897503/91626741-bcb2ec80-e966-11ea-8a3a-af522db3c6e2.png)

The setting in the View menu of the Desktop app:
![Screen Shot 2020-08-28 at 7 42 29 PM](https://user-images.githubusercontent.com/14897503/91626723-9ee58780-e966-11ea-9f20-72600831adf1.png)

When on:
![Screen Shot 2020-08-28 at 7 43 55 PM](https://user-images.githubusercontent.com/14897503/91626754-d0f6e980-e966-11ea-8214-d4ed605d131a.png)



A relevant (albeit very stale) forum discussion [here](https://discourse.joplinapp.org/t/see-to-dos-of-subnotebooks-in-parent-notebook/306/3).
Issue #3206 