### PR TITLE
Fix keytar library being loaded up in FreeBSD.

### DIFF
--- a/ReactNativeClient/lib/services/keychain/KeychainServiceDriver.node.ts
+++ b/ReactNativeClient/lib/services/keychain/KeychainServiceDriver.node.ts
@@ -17,7 +17,7 @@ const { shim } = require('lib/shim.js');
 
 let keytar:any;
 try {
-	keytar = shim.isLinux() || shim.isPortable() ? null : require('keytar');
+	keytar = (shim.isWindows() || shim.isMac()) && !shim.isPortable() ? require('keytar') : null;
 } catch (error) {
 	console.error('Cannot load keytar - keychain support will be disabled', error);
 	keytar = null;


### PR DESCRIPTION
Issue https://github.com/laurent22/joplin/issues/3711

This patch replaces the 'isLinux' check by a more restrictive version
which fixes the false positive in BSD systems. This was causing Joplin
not to load due to the lack of X11 in headless mode.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
