### PR TITLE
Pull Electron to 8.3.2 - Fix systray icon visibility

### DIFF
--- a/ElectronClient/package.json
+++ b/ElectronClient/package.json
@@ -99,7 +99,7 @@
     "app-builder-bin": "^1.9.11",
     "babel-cli": "^6.26.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "^8.2.5",
+    "electron": "^8.3.2",
     "electron-builder": "22.3.2",
     "electron-rebuild": "^1.10.1",
     "glob": "^7.1.6",


### PR DESCRIPTION
Electron Client
Resolves  #3323, #3320 

Icon fix is backported to Electron since 8.3.2, see log here: https://github.com/electron/electron/releases/tag/v8.3.2
- Restored old implementation of Linux Tray icons to fix a collection of issues where the tray icon wouldn't appear, would be the wrong size or would randomly disappear. #23927

Joplin electron client pulls 8.2.5 as dependency. I've managed to build several recent stable releases against Electron 8.3.2. Indeed, icon is shown correctly in system tray without need of starting snixembed. Consider to pull up electron version to ^8.3.2 on occasion.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
