### PR TITLE
Desktop: Fixes #3720: Fix icons path in AppImage build

### DIFF
--- a/ElectronClient/package.json
+++ b/ElectronClient/package.json
@@ -78,7 +78,7 @@
       ]
     },
     "linux": {
-      "icon": "../Assets/LinuxIcons/256x256.png",
+      "icon": "../Assets/LinuxIcons",
       "category": "Office",
       "desktop": {
         "Icon": "joplin"


### PR DESCRIPTION
This Pull Request fixes an issue with missing Joplin icon in AppImage build (fixes #3720). It turned out that omitting the file name in "icon" parameter in `package.json` file, leads to generating correct directory structure with the use of all icons resolutions available (and not only the faulty `0x0` directory).

![image](https://user-images.githubusercontent.com/15014287/92413171-24c7b680-f14f-11ea-82ac-a0183fdc4bae.png)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
