### PR TITLE
Desktop: Fix bug with quotes

### DIFF
--- a/CliClient/tests/filterParser.js
+++ b/CliClient/tests/filterParser.js
@@ -108,6 +108,9 @@ describe('filterParser should be correct filter for keyword', () => {
 
 		searchString = 'tag:bl*sphemy';
 		expect(filterParser(searchString)).toContain(makeTerm('tag', 'bl%sphemy', false));
+
+		searchString = 'tag:"space travel"';
+		expect(filterParser(searchString)).toContain(makeTerm('tag', 'space travel', false));
 	});
 
 	it('wildcard notebooks', () => {

--- a/CliClient/tests/services_SearchFilter.js
+++ b/CliClient/tests/services_SearchFilter.js
@@ -268,7 +268,7 @@ describe('services_SearchFilter', function() {
 
 		await Tag.setNoteTagsByTitles(n1.id, ['tag1', 'tag2']);
 		await Tag.setNoteTagsByTitles(n2.id, ['tag2', 'tag3']);
-		await Tag.setNoteTagsByTitles(n3.id, ['tag3', 'tag4']);
+		await Tag.setNoteTagsByTitles(n3.id, ['tag3', 'tag4', 'space travel']);
 
 		await engine.syncTables();
 
@@ -303,6 +303,10 @@ describe('services_SearchFilter', function() {
 		rows = await engine.search('any:1 -tag:tag2 -tag:tag3');
 		expect(rows.length).toBe(2);
 		expect(ids(rows)).toContain(n1.id);
+		expect(ids(rows)).toContain(n3.id);
+
+		rows = await engine.search('tag:"space travel"');
+		expect(rows.length).toBe(1);
 		expect(ids(rows)).toContain(n3.id);
 	}));
 

--- a/ReactNativeClient/lib/services/searchengine/filterParser.ts
+++ b/ReactNativeClient/lib/services/searchengine/filterParser.ts
@@ -82,7 +82,7 @@ const parseQuery = (query: string): Term[] => {
 			}
 
 			if (name === 'tag' || name === 'notebook' || name === 'resource' || name === 'sourceurl') {
-				result.push({ name, value: value.replace(/[*]/g, '%'), negated }); // for wildcard search
+				result.push({ name, value: trimQuotes(value.replace(/[*]/g, '%')), negated }); // for wildcard search
 			} else if (name === 'title' || name === 'body') {
 				// Trim quotes since we don't support phrase query here
 				// eg. Split title:"hello world" to title:hello title:world


### PR DESCRIPTION
This doesn't work now. We need to trim the quotes.

```
tag:"space travel"
```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
