### PR TITLE
Desktop: Clear highlight after search

### DIFF
--- a/ReactNativeClient/lib/reducer.js
+++ b/ReactNativeClient/lib/reducer.js
@@ -619,6 +619,8 @@ const reducer = (state = defaultState, action) => {
 
 		case 'FOLDER_SELECT':
 			newState = changeSelectedFolder(newState, action, { clearSelectedNoteIds: true });
+			// Highlights should be cleared when moving away from search results
+			newState = Object.assign({}, newState, { highlightedWords: [] });
 			break;
 
 		case 'FOLDER_AND_NOTE_SELECT':


### PR DESCRIPTION
Highlight persists even after search.

A quick fix would be to reset it when moving to another notebook. (i.e., moving away from search results)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
