### PR TITLE
Desktop: Use joplin list handling in emacs mode

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -152,6 +152,10 @@ function Editor(props: EditorProps, ref: any) {
 			'Insert': 'toggleOverwrite',
 			'Esc': 'singleSelection',
 		};
+		// Add some of the Joplin smart list handling to emacs mode
+		CodeMirror.keyMap.emacs['Tab'] = 'smartListIndent';
+		CodeMirror.keyMap.emacs['Enter'] = 'insertListElement';
+		CodeMirror.keyMap.emacs['Shift-Tab'] = 'smartListUnindent';
 
 		if (shim.isMac()) {
 			CodeMirror.keyMap.default = {


### PR DESCRIPTION
fixes #3749 #3750

Based on what @meznak discovered, I've manually added the Joplin list handling to emacs mode. Previously emacs mode overwrote the the Tab and Enter keys to do it's own default behaviour (which was the basic behaviour), but I think the expected behaviour will be for the editing to be consistent across all modes. I don't think we need to overwrite emacs mode further than what I did here because we didn't really edit any of the other default keys.