### PR TITLE
All: Show repeatable error requests on sidebar

### DIFF
--- a/ReactNativeClient/lib/synchronizer.js
+++ b/ReactNativeClient/lib/synchronizer.js
@@ -841,14 +841,12 @@ class Synchronizer {
 					if (!shim.isTestingEnv()) this.progressReport_.errors.push(error.message);
 					this.logLastRequests();
 				}
-			} else if (error.code === 'unknownItemType') {
-				this.progressReport_.errors.push(_('Unknown item type downloaded - please upgrade Joplin to the latest version'));
-				this.logger().error(error);
 			} else {
 				this.logger().error(error);
 
-				// Don't save to the report errors that are due to things like temporary network errors or timeout.
-				if (!shim.fetchRequestCanBeRetried(error)) {
+				if (error.code === 'unknownItemType') {
+					this.progressReport_.errors.push(_('Unknown item type downloaded - please upgrade Joplin to the latest version'));
+				} else {
 					this.progressReport_.errors.push(error);
 					this.logLastRequests();
 				}


### PR DESCRIPTION
This is actually a kind request for removing an existing feature. A couple of weeks ago I switched from OneDrive to Nextcloud. I was pleased to see the message "Completed" after my first sync to Nextcloud on the sidebar. However to be on the safe side I checked in the Nextcloud web app the size of the Joplin directory and I was surprised that the size was much smaller than it has been on OneDrive. So I also checked the log file and found out that some large files haven't been uploaded. For me this is not so problematic as I can just save the files in Nextcloud directly. But I found it really problematic that I haven't been notified in the GUI. I expect from a synchronization tool that either all files are synchron between all my devices or to receive a clearly visible error message in the GUI. I was sure that this is a Bug which I wanted to fix. But after investigating the source code I found out that this is actually a feature as Joplin consciously don't show errors in the sidebar for requests that can be repeated.  

I understand that it is not good to show errors in the GUI which usually disappear when repeating the request but the method `tryAndRepeat`  in the `file-api.js` file should already make sure that a sync doesn't fail due to temporary errors. It is not only me who find this behavior misleading as it has been criticized multiple times at github and the forum (e. g. At issue #3424 or [in this thread](https://discourse.joplinapp.org/t/android-sync-not-working-changes-not-updating-on-desktop-no-error-message/9304)). 

I love Joplin and I will keep using it even you reject this pull request. Personally I just prefer to try my best to solve a problem instead of ignoring it. I am sure you had your reasons to hide repeatable errors on the sidebar but I don't see the reason therefore.  I asked for a reason therefore also on [the forum](https://discourse.joplinapp.org/t/why-are-some-sync-error-messages-not-shown-in-the-gui/10750) a couple of weeks ago but unfortunately without an answer. This is not a reproach as I can understand that you have a lot to do but I just wanted to make clear that I made this PR not on a whim but as last attempt to solve a problem. 
