### PR TITLE
Desktop: Add frequently used languages to markdown renderer

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -53,6 +53,12 @@ const topLanguages = [
 	'css',
 	'xml',
 	'markdown',
+	'yaml',
+	'shell',
+	'dockerfile',
+	'diff',
+	'erlang',
+	'sql',
 ];
 // Load Top Modes
 for (let i = 0; i < topLanguages.length; i++) {

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -28,7 +28,6 @@ const { shim } = require('lib/shim.js');
 const { reg } = require('lib/registry.js');
 
 // Based on http://pypl.github.io/PYPL.html
-// +XML (HTML) +CSS and Markdown added
 const topLanguages = [
 	'python',
 	'clike',
@@ -51,7 +50,9 @@ const topLanguages = [
 	'haskell',
 	'pascal',
 	'css',
-	'xml',
+	
+	// Additional languages, not in the PYPL list
+	'xml', // For HTML too
 	'markdown',
 	'yaml',
 	'shell',


### PR DESCRIPTION
This PR adds commonly used languages to the Markdown renderer to avoid having them with low contrast.

Example:

![image](https://user-images.githubusercontent.com/20382/93795285-89831680-fc0f-11ea-94cd-12c57b4969c3.png)
