### PR TITLE
Desktop: Adjust the codemirror code block colors for the dark theme

### DIFF
--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -434,7 +434,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				color: #878787 !important;
 			}
 
-			.cm-s-solarized.cm-s-light span.cm-comment {
+			.cm-s-solarized.cm-s-dark span.cm-comment {
 				color: #8ba1a7 !important;
 			}
 		`));

--- a/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/ElectronClient/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -416,6 +416,27 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				background-color: inherit !important;
 				border-bottom: 1px dotted #dc322f;
 			}
+
+			/* The default dark theme colors don't have enough contrast with the background */
+			.cm-s-nord span.cm-comment {
+				color: #9aa4b6 !important;
+			}
+
+			.cm-s-dracula span.cm-comment {
+				color: #a1abc9 !important;
+			}
+
+			.cm-s-monokai span.cm-comment {
+				color: #908b74 !important;
+			}
+
+			.cm-s-material-darker span.cm-comment {
+				color: #878787 !important;
+			}
+
+			.cm-s-solarized.cm-s-light span.cm-comment {
+				color: #8ba1a7 !important;
+			}
 		`));
 
 		return () => {


### PR DESCRIPTION
Fixes #3793 

![image](https://user-images.githubusercontent.com/2179547/93844387-37b3ae00-fc5a-11ea-95e9-f2a26c286f23.png)

I chose these colors by taking the defaults and adjusting the lightness until the contrast was high enough
![image](https://user-images.githubusercontent.com/2179547/93844433-5ade5d80-fc5a-11ea-8c59-d1b15ec1f91e.png)
