### PR TITLE
Desktop: Keep fuzzy scores between 0 and 2

### DIFF
--- a/ReactNativeClient/lib/services/searchengine/SearchEngine.js
+++ b/ReactNativeClient/lib/services/searchengine/SearchEngine.js
@@ -460,6 +460,15 @@ class SearchEngine {
 			const fuzzyTitle = await this.fuzzifier(titleTerms.filter(x => !x.wildcard).map(x => trimQuotes(x.value)));
 			const fuzzyBody = await this.fuzzifier(bodyTerms.filter(x => !x.wildcard).map(x => trimQuotes(x.value)));
 
+			// Floor the fuzzy scores to 0, 1 and 2.
+			const floorFuzzyScore = (matches) => {
+				for (let i = 0; i < matches.length; i++) matches[i].score = i;
+			};
+
+			fuzzyText.forEach(floorFuzzyScore);
+			fuzzyTitle.forEach(floorFuzzyScore);
+			fuzzyBody.forEach(floorFuzzyScore);
+
 			const phraseTextSearch = textTerms.filter(x => x.quoted);
 			const wildCardSearch = textTerms.concat(titleTerms).concat(bodyTerms).filter(x => x.wildcard);
 


### PR DESCRIPTION
Motivated by 

https://github.com/laurent22/joplin/pull/3777#issuecomment-696491859

The fuzzy score shouldn't vary so much that it decides the sorting rather than BM25.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
