### PR TITLE
All: Translation: Fix typo in ko.po

### DIFF
--- a/CliClient/locales/ko.po
+++ b/CliClient/locales/ko.po
@@ -1189,7 +1189,7 @@ msgstr "코드"
 #: ElectronClient/gui/NoteEditor/commands/editorCommandDeclarations.js:55
 #: ElectronClient/gui/NoteText.min.js:1738
 msgid "Numbered List"
-msgstr "번호 매기 목록"
+msgstr "번호 매기기 목록"
 
 #: ElectronClient/gui/NoteEditor/commands/editorCommandDeclarations.js:60
 #: ElectronClient/gui/NoteText.min.js:1746


### PR DESCRIPTION
This PR fixes a trivial typo in Korean translation(ko.po)

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/master/CONTRIBUTING.md

-->
