### PR TITLE
Desktop: Make “update is available” dialog box easier to use

### DIFF
--- a/ElectronClient/checkForUpdates.js
+++ b/ElectronClient/checkForUpdates.js
@@ -149,8 +149,10 @@ function checkForUpdates(inBackground, window, logFilePath, options) {
 
 			const result = await dialog.showMessageBox(parentWindow_, {
 				type: 'info',
-				message: `${_('An update is available, do you want to download it now?')}\n\n${_('Your version: %s', packageInfo.version)}\n${_('New version: %s', newVersionString)}${releaseNotes}`,
-				buttons: [_('Yes'), _('No')].concat(truncateReleaseNotes ? [_('Full Release Notes')] : []),
+				message: `${_('An update is available. Download it now?')}`,
+				detail: `${_('Your version: %s', packageInfo.version)}\n${_('New version: %s', newVersionString)}${releaseNotes}`,
+				buttons: [_('Download'), _('Cancel')].concat(truncateReleaseNotes ? [_('Open Full Release Notes')] : []),
+				cancelId: 1,
 			});
 
 			const buttonIndex = result.response;

--- a/ElectronClient/checkForUpdates.js
+++ b/ElectronClient/checkForUpdates.js
@@ -149,9 +149,9 @@ function checkForUpdates(inBackground, window, logFilePath, options) {
 
 			const result = await dialog.showMessageBox(parentWindow_, {
 				type: 'info',
-				message: `${_('An update is available. Download it now?')}`,
+				message: `${_('An update is available, do you want to download it now?')}`,
 				detail: `${_('Your version: %s', packageInfo.version)}\n${_('New version: %s', newVersionString)}${releaseNotes}`,
-				buttons: [_('Download'), _('Cancel')].concat(truncateReleaseNotes ? [_('Open Full Release Notes')] : []),
+				buttons: [_('Download'), _('Cancel')].concat(truncateReleaseNotes ? [_('Full Release Notes')] : []),
 				cancelId: 1,
 			});
 


### PR DESCRIPTION
Electron docs for `dialog.showMessageBox`: https://www.electronjs.org/docs/api/dialog#dialogshowmessageboxbrowserwindow-options

- In the message, fix a comma splice (grammar error) and remove some unnecessary words.

- Split the message into `message` and `detail` parts.

- Use specific verbs for the button labels. This follows the UI guidelines of major operating systems, including macOS and Windows. (`cancelId` was added while testing out different button labels that Electron might not automatically recognize as a cancel button. I think the `cancelId` is worth keeping to ensure the Esc key still works if the label is changed in the future.)

## Screenshots

Old update dialog box as seen in v1.0.241:

<img width="1264" alt="old dialog in v1 0 241" src="https://user-images.githubusercontent.com/79168/95345444-b9c1ea80-0888-11eb-98c7-4bb3d09a2852.png">

New update dialog box with this change, with long release notes:

<img width="1264" alt="new dialog with long, truncated release notes" src="https://user-images.githubusercontent.com/79168/95345559-d9f1a980-0888-11eb-96fe-2ab46206acc0.png">

New update dialog box with short release notes:

<img width="1264" alt="new dialog with short release notes" src="https://user-images.githubusercontent.com/79168/95345570-de1dc700-0888-11eb-9365-5cce0c1387d2.png">

New update dialog box with no release notes:

<img width="1264" alt="new dialog with no release notes" src="https://user-images.githubusercontent.com/79168/95345581-e1b14e00-0888-11eb-8fa9-22827b5be362.png">
