### PR TITLE
All: Resolves #3691: Added support for a custom S3 URL

### DIFF
--- a/CliClient/tests/services_rest_Api.ts
+++ b/CliClient/tests/services_rest_Api.ts
@@ -146,7 +146,7 @@ describe('services_rest_Api', function() {
 		}));
 
 		const noteId = response.id;
-		
+
 		{
 			const note = await Note.load(noteId);
 			expect(note.latitude).toBe('48.73207100');
@@ -154,7 +154,7 @@ describe('services_rest_Api', function() {
 			expect(note.altitude).toBe('21.0000');
 		}
 
-		await api.route('PUT', 'notes/' + noteId, null, JSON.stringify({
+		await api.route('PUT', `notes/${noteId}`, null, JSON.stringify({
 			latitude: '49',
 			longitude: '-3',
 			altitude: '22',

--- a/ReactNativeClient/lib/SyncTargetAmazonS3.js
+++ b/ReactNativeClient/lib/SyncTargetAmazonS3.js
@@ -4,7 +4,7 @@ const Setting = require('lib/models/Setting').default;
 const { FileApi } = require('lib/file-api.js');
 const Synchronizer = require('lib/Synchronizer').default;
 const { FileApiDriverAmazonS3 } = require('lib/file-api-driver-amazon-s3.js');
-const AWS = require("aws-sdk");
+const AWS = require('aws-sdk');
 
 class SyncTargetAmazonS3 extends BaseSyncTarget {
 	static id() {

--- a/ReactNativeClient/lib/SyncTargetAmazonS3.js
+++ b/ReactNativeClient/lib/SyncTargetAmazonS3.js
@@ -4,7 +4,7 @@ const Setting = require('lib/models/Setting').default;
 const { FileApi } = require('lib/file-api.js');
 const Synchronizer = require('lib/Synchronizer').default;
 const { FileApiDriverAmazonS3 } = require('lib/file-api-driver-amazon-s3.js');
-const S3 = require('aws-sdk/clients/s3');
+const AWS = require("aws-sdk");
 
 class SyncTargetAmazonS3 extends BaseSyncTarget {
 	static id() {
@@ -41,13 +41,15 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			accessKeyId: Setting.value('sync.8.username'),
 			secretAccessKey: Setting.value('sync.8.password'),
 			s3UseArnRegion: true, // override the request region with the region inferred from requested resource's ARN
+			s3ForcePathStyle: true,
+			endpoint: new AWS.Endpoint(Setting.value('sync.8.url')),
 		};
 	}
 
 	api() {
 		if (this.api_) return this.api_;
 
-		this.api_ = new S3(this.s3AuthParameters());
+		this.api_ = new AWS.S3(this.s3AuthParameters());
 		return this.api_;
 	}
 
@@ -56,9 +58,11 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			accessKeyId: options.username(),
 			secretAccessKey: options.password(),
 			s3UseArnRegion: true,
+			s3ForcePathStyle: true,
+			endpoint: new AWS.Endpoint(options.url()),
 		};
 
-		const api = new S3(apiOptions);
+		const api = new AWS.S3(apiOptions);
 		const driver = new FileApiDriverAmazonS3(api, SyncTargetAmazonS3.s3BucketName());
 		const fileApi = new FileApi('', driver);
 		fileApi.setSyncTargetId(syncTargetId);

--- a/ReactNativeClient/lib/SyncTargetAmazonS3.js
+++ b/ReactNativeClient/lib/SyncTargetAmazonS3.js
@@ -4,7 +4,7 @@ const Setting = require('lib/models/Setting').default;
 const { FileApi } = require('lib/file-api.js');
 const Synchronizer = require('lib/Synchronizer').default;
 const { FileApiDriverAmazonS3 } = require('lib/file-api-driver-amazon-s3.js');
-const AWS = require('aws-sdk');
+const S3 = require('aws-sdk/clients/s3');
 
 class SyncTargetAmazonS3 extends BaseSyncTarget {
 	static id() {
@@ -42,14 +42,14 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			secretAccessKey: Setting.value('sync.8.password'),
 			s3UseArnRegion: true, // override the request region with the region inferred from requested resource's ARN
 			s3ForcePathStyle: true,
-			endpoint: new AWS.Endpoint(Setting.value('sync.8.url')),
+			endpoint: Setting.value('sync.8.url'),
 		};
 	}
 
 	api() {
 		if (this.api_) return this.api_;
 
-		this.api_ = new AWS.S3(this.s3AuthParameters());
+		this.api_ = new S3(this.s3AuthParameters());
 		return this.api_;
 	}
 
@@ -59,10 +59,10 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			secretAccessKey: options.password(),
 			s3UseArnRegion: true,
 			s3ForcePathStyle: true,
-			endpoint: new AWS.Endpoint(options.url()),
+			endpoint: options.url(),
 		};
 
-		const api = new AWS.S3(apiOptions);
+		const api = new S3(apiOptions);
 		const driver = new FileApiDriverAmazonS3(api, SyncTargetAmazonS3.s3BucketName());
 		const fileApi = new FileApi('', driver);
 		fileApi.setSyncTargetId(syncTargetId);

--- a/ReactNativeClient/lib/models/Setting.ts
+++ b/ReactNativeClient/lib/models/Setting.ts
@@ -274,6 +274,17 @@ class Setting extends BaseModel {
 				label: () => _('AWS S3 bucket'),
 				description: () => emptyDirWarning,
 			},
+			'sync.8.url': {
+				value: 'https://s3.amazonaws.com/',
+				type: SettingItemType.String,
+				section: 'sync',
+				show: (settings:any) => {
+					return settings['sync.target'] == SyncTargetRegistry.nameToId('amazon_s3');
+				},
+				public: true,
+				label: () => _('AWS S3 URL'),
+				secure: false,
+			},
 			'sync.8.username': {
 				value: '',
 				type: SettingItemType.String,


### PR DESCRIPTION
Hi all,

I have added support a custom S3 URL so you can use your own S3 provider instead of AWS. (https://github.com/laurent22/joplin/issues/3691)

I have added a URL option in the S3 Synchronization Settings page which defaults to `https://s3.amazonaws.com/` and added support in `SyncTargetAmazonS3.ts` for custom endpoints.

I have used this with AWS S3 and MinIO.