### PR TITLE
Fix export of pluginAssets when exporting to html/pdf

### DIFF
--- a/ReactNativeClient/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/ReactNativeClient/lib/services/interop/InteropService_Exporter_Html.ts
@@ -103,7 +103,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 			// The source path is a bit hard-coded but shouldn't change.
 			for (let i = 0; i < result.pluginAssets.length; i++) {
 				const asset = result.pluginAssets[i];
-				const filePath = `${dirname(dirname(__dirname))}/gui/note-viewer/pluginAssets/${asset.name}`;
+				const filePath = `${dirname(dirname(dirname(__dirname)))}/gui/note-viewer/pluginAssets/${asset.name}`;
 				const destPath = `${dirname(noteFilePath)}/pluginAssets/${asset.name}`;
 				await shim.fsDriver().mkdir(dirname(destPath));
 				await shim.fsDriver().copy(filePath, destPath);


### PR DESCRIPTION
I was receiving the following error when exporting a pdf on v1.3.2
```
main-html.js:49 Error: Error: ENOENT: no such file or directory, lstat '/home/caleb/programming/github/joplin/ElectronClient/lib/gui/note-viewer/pluginAssets/katex/katex.css'. Path: /home/caleb/programming/github/joplin/ElectronClient/lib/gui/note-viewer/pluginAssets/katex/katex.css
    at FsDriverNode.fsErrorToJsError_ (/home/caleb/programming/github/joplin/ElectronClient/lib/fs-driver-node.js:9)
    at FsDriverNode.copy (/home/caleb/programming/github/joplin/ElectronClient/lib/fs-driver-node.js:168)
```
It was simply because the line I edited was only navigating up 2 directories, when it needs to navigate up 3. Adding another call to `dirname` gets the correct file path and exports normally.