### PR TITLE
Import <strike>,<s> tags (strikethrough) from Evernote

### DIFF
--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -556,7 +556,7 @@ function enexXmlToMdArray(stream, resources) {
 			} else if (isStrongTag(n)) {
 				section.lines.push('**');
 			} else if (isStrikeTag(n)) {
-				section.lines.push('~~');
+				section.lines.push('<s>');
 			} else if (isInlineCodeTag(n)) {
 				section.lines.push('`');
 			} else if (n == 'q') {
@@ -739,7 +739,7 @@ function enexXmlToMdArray(stream, resources) {
 			} else if (isStrongTag(n)) {
 				section.lines.push('**');
 			} else if (isStrikeTag(n)) {
-				section.lines.push('~~');
+				section.lines.push('</s>');
 			} else if (isInlineCodeTag(n)) {
 				section.lines.push('`');
 			} else if (isEmTag(n)) {

--- a/ReactNativeClient/lib/import-enex-md-gen.js
+++ b/ReactNativeClient/lib/import-enex-md-gen.js
@@ -556,7 +556,7 @@ function enexXmlToMdArray(stream, resources) {
 			} else if (isStrongTag(n)) {
 				section.lines.push('**');
 			} else if (isStrikeTag(n)) {
-				section.lines.push('(');
+				section.lines.push('~~');
 			} else if (isInlineCodeTag(n)) {
 				section.lines.push('`');
 			} else if (n == 'q') {
@@ -739,7 +739,7 @@ function enexXmlToMdArray(stream, resources) {
 			} else if (isStrongTag(n)) {
 				section.lines.push('**');
 			} else if (isStrikeTag(n)) {
-				section.lines.push(')');
+				section.lines.push('~~');
 			} else if (isInlineCodeTag(n)) {
 				section.lines.push('`');
 			} else if (isEmTag(n)) {


### PR DESCRIPTION
- Desktop:  Added strikethrough markdown codes

I am assuming the `~~` Markdown tags for strikethrough are a relatively recent addition because the import from Evernote replaces them with `(` and `)` as  start and end markers.

This PR is a naive change to simply replace the `(` and `)` with `~~` and `~~`.

It does the trick for importing to Markdown, but still has the same limitations for some edge cases, for example it will be ignored if there is trailing space before the closing `~~`. This also happens for other tags such as bold/italic, so there needs to be a more general fix for importing format tags.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
