### PR TITLE
remove first 3 lines from version output when copying it to clipboard

### DIFF
--- a/ElectronClient/gui/MenuBar.tsx
+++ b/ElectronClient/gui/MenuBar.tsx
@@ -373,7 +373,7 @@ function useMenu(props:Props) {
 			});
 
 			if (copyToClipboard === 0) {
-				clipboard.writeText(v.message);
+				clipboard.writeText(v.message.split('\n').splice(3).join('\n'));
 			}
 		}
 


### PR DESCRIPTION
We don't need the first 3 lines in the output.

```
Joplin for Desktop

Copyright © 2016-2020 Laurent Cozic
Joplin 1.3.3 (dev, darwin)

Client ID: e354a932e6e143c782264aad4112b674
Sync Version: 2
Profile Version: 34
Keychain Supported: Yes

Revision: 7e78d7716 (dev)
```

vs

```
Joplin 1.3.3 (dev, darwin)

Client ID: e354a932e6e143c782264aad4112b674
Sync Version: 2
Profile Version: 34
Keychain Supported: Yes

Revision: 7e78d7716 (fix/about-copy-output)
```
