### PR TITLE
Tray: Exit -> Quit

### DIFF
--- a/ElectronClient/app.ts
+++ b/ElectronClient/app.ts
@@ -425,7 +425,7 @@ class Application extends BaseApplication {
 			const contextMenu = Menu.buildFromTemplate([
 				{ label: _('Open %s', app.electronApp().name), click: () => { app.window().show(); } },
 				{ type: 'separator' },
-				{ label: _('Exit'), click: () => { app.quit(); } },
+				{ label: _('Quit'), click: () => { app.quit(); } },
 			]);
 			app.createTray(contextMenu);
 		}


### PR DESCRIPTION
Make the tray menu consistent with the app. The app uses Quit, so should the tray.

<img width="126" alt="image" src="https://user-images.githubusercontent.com/223439/96357895-482b3d00-10cf-11eb-9ab0-77c3abfa3a6e.png">
