### PR TITLE
All: Fix filters when language is in Korean

### DIFF
--- a/ReactNativeClient/lib/services/searchengine/SearchEngine.js
+++ b/ReactNativeClient/lib/services/searchengine/SearchEngine.js
@@ -577,6 +577,22 @@ class SearchEngine {
 			keys.push(col);
 		}
 
+		//
+		// The object "allTerms" is used for query construction purposes (this contains all the filter terms)
+		// Since this is used for the FTS match query, we need to normalize text, title and body terms.
+		// Note, we're not normalizing terms like tag because these are matched using SQL LIKE operator and so we must preserve their diacritics.
+		//
+		// The object "terms" only include text, title, body terms and is used for highlighting.
+		// By not normalizing the text, title, body in "terms", highlighting still works correctly for words with diacritics.
+		//
+
+		allTerms = allTerms.map(x => {
+			if (x.name === 'text' || x.name === 'title' || x.name === 'body') {
+				return Object.assign(x, { value: this.normalizeText_(x.value) });
+			}
+			return x;
+		});
+
 		return {
 			termCount: termCount,
 			keys: keys,
@@ -661,12 +677,11 @@ class SearchEngine {
 			fuzzy: Setting.value('db.fuzzySearchEnabled') === 1,
 		}, options);
 
-		searchString = this.normalizeText_(searchString);
-
 		const searchType = this.determineSearchType_(searchString, options);
 
 		if (searchType === SearchEngine.SEARCH_TYPE_BASIC) {
 			// Non-alphabetical languages aren't support by SQLite FTS (except with extensions which are not available in all platforms)
+			searchString = this.normalizeText_(searchString);
 			const rows = await this.basicSearch(searchString);
 			const parsedQuery = await this.parseQuery(searchString);
 			this.processResults_(rows, parsedQuery, true);

--- a/ReactNativeClient/lib/services/searchengine/SearchEngine.js
+++ b/ReactNativeClient/lib/services/searchengine/SearchEngine.js
@@ -635,7 +635,15 @@ class SearchEngine {
 		// If preferredSearchType is "fts" we auto-detect anyway
 		// because it's not always supported.
 
-		const st = scriptType(query);
+		let allTerms = [];
+		try {
+			allTerms = filterParser(query);
+		} catch (error) {
+			console.warn(error);
+		}
+
+		const textQuery = allTerms.filter(x => x.name === 'text' || x.name == 'title' || x.name == 'body').map(x => x.value).join(' ');
+		const st = scriptType(textQuery);
 
 		if (!Setting.value('db.ftsEnabled') || ['ja', 'zh', 'ko', 'th'].indexOf(st) >= 0) {
 			return SearchEngine.SEARCH_TYPE_BASIC;


### PR DESCRIPTION
We shouldn't use basic search when the filters like "tag" have a value in languages like Korean.

Otherwise, queries like these won't work.
tag:여보세요

Bug reported here: https://discourse.joplinapp.org/t/search-tag-in-asian-laguage-doesnt-work-properly/11285
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
