### PR TITLE
Desktop: Add support to open profile dir from options screen

### DIFF
--- a/ElectronClient/gui/ConfigScreen/ConfigScreen.tsx
+++ b/ElectronClient/gui/ConfigScreen/ConfigScreen.tsx
@@ -10,6 +10,7 @@ const pathUtils = require('lib/path-utils.js');
 const SyncTargetRegistry = require('lib/SyncTargetRegistry');
 const shared = require('lib/components/shared/config-shared.js');
 const bridge = require('electron').remote.require('./bridge').default;
+const { shell } = require('electron');
 const { EncryptionConfigScreen } = require('../EncryptionConfigScreen.min');
 const { ClipperConfigScreen } = require('../ClipperConfigScreen.min');
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
@@ -126,11 +127,28 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		if (!description) return null;
 
 		const theme = themeStyle(this.props.themeId);
-		return (
-			<div style={Object.assign({}, theme.textStyle, { marginBottom: 15 })}>
-				{description}
-			</div>
-		);
+
+		if (section.name === 'general') {
+			return (
+				<div style={Object.assign({}, theme.textStyle, { marginBottom: 15 })}>
+					<a
+						onClick={() => {
+							shell.openItem(Setting.value('profileDir'));
+						}}
+						href="#"
+						style={theme.urlStyle}
+					>
+						{description}
+					</a>
+				</div>
+			);
+		} else {
+			return (
+				<div style={Object.assign({}, theme.textStyle, { marginBottom: 15 })}>
+					{description}
+				</div>
+			);
+		}
 	}
 
 	sectionToComponent(key:string, section:any, settings:any, selected:boolean) {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
As discussed in https://discourse.joplinapp.org/t/feature-request-add-open-profile-directory-help-menu-item/11773/