### PR TITLE
Desktop: fix issues with shortcut editor

### DIFF
--- a/packages/app-desktop/gui/KeymapConfig/styles/index.ts
+++ b/packages/app-desktop/gui/KeymapConfig/styles/index.ts
@@ -25,6 +25,7 @@ export default function styles(themeId: number) {
 			recorderInput: {
 				...theme.inputStyle,
 				minHeight: 29,
+				width: '200px',
 			},
 			label: {
 				...theme.textStyle,

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -4,11 +4,270 @@ import { _ } from '../locale';
 
 const BaseService = require('./BaseService').default;
 
-const keysRegExp = /^([0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]']|F1*[1-9]|F10|F2[0-4]|Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen)$/;
+const keysRegExp = /^([0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]']|F1*[1-9]|F10|F2[0-4]|Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|Numlock|Scrolllock|Capslock|num([0-9]|dec|add|sub|mult|div))$/;
 const modifiersRegExp = {
 	darwin: /^(Ctrl|Option|Shift|Cmd)$/,
 	default: /^(Ctrl|Alt|AltGr|Shift|Super)$/,
 };
+
+const keycodeToElectronMap = [
+	'',                      // [0]
+	'',                      // [1]
+	'',                      // [2]
+	'',                      // [3]
+	'',                      // [4]
+	'',                      // [5]
+	'',                      // [6]
+	'',                      // [7]
+	'Backspace',             // [8]
+	'Tab',                   // [9]
+	'',                      // [10]
+	'',                      // [11]
+	'Clear',                 // [12]
+	'Enter',                 // [13]
+	'',                      // [14]
+	'',                      // [15]
+	'Shift',                 // [16]
+	'Ctrl',                  // [17]
+	'Alt',                   // [18]
+	'',                      // [19]
+	'Capslock',              // [20]
+	'',                      // [21]
+	'',                      // [22]
+	'',                      // [23]
+	'',                      // [24]
+	'',                      // [25]
+	'',                      // [26]
+	'Esc',                   // [27]
+	'',                      // [28]
+	'',                      // [29]
+	'',                      // [30]
+	'',                      // [31]
+	'Space',                 // [32]
+	'PageUp',                // [33]
+	'PageDown',              // [34]
+	'End',                   // [35]
+	'Home',                  // [36]
+	'Left',                  // [37]
+	'Up',                    // [38]
+	'Right',                 // [39]
+	'Down',                  // [40]
+	'',                      // [41]
+	'',                      // [42]
+	'',                      // [43]
+	'PrintScreen',           // [44]
+	'Insert',                // [45]
+	'Delete',                // [46]
+	'',                      // [47]
+	'0',                     // [48]
+	'1',                     // [49]
+	'2',                     // [50]
+	'3',                     // [51]
+	'4',                     // [52]
+	'5',                     // [53]
+	'6',                     // [54]
+	'7',                     // [55]
+	'8',                     // [56]
+	'9',                     // [57]
+	':',                     // [58]
+	';',                     // [59]
+	'<',                     // [60]
+	'=',                     // [61]
+	'>',                     // [62]
+	'?',                     // [63]
+	'@',                     // [64]
+	'A',                     // [65]
+	'B',                     // [66]
+	'C',                     // [67]
+	'D',                     // [68]
+	'E',                     // [69]
+	'F',                     // [70]
+	'G',                     // [71]
+	'H',                     // [72]
+	'I',                     // [73]
+	'J',                     // [74]
+	'K',                     // [75]
+	'L',                     // [76]
+	'M',                     // [77]
+	'N',                     // [78]
+	'O',                     // [79]
+	'P',                     // [80]
+	'Q',                     // [81]
+	'R',                     // [82]
+	'S',                     // [83]
+	'T',                     // [84]
+	'U',                     // [85]
+	'V',                     // [86]
+	'W',                     // [87]
+	'X',                     // [88]
+	'Y',                     // [89]
+	'Z',                     // [90]
+	'Super',                 // [91] Super: Windows Key (Windows) or Command Key (Mac)
+	'',                      // [92]
+	'ContextMenu',           // [93]
+	'',                      // [94]
+	'',                      // [95]
+	'num0',                  // [96]
+	'num1',                  // [97]
+	'num2',                  // [98]
+	'num3',                  // [99]
+	'num4',                  // [100]
+	'num5',                  // [101]
+	'num6',                  // [102]
+	'num7',                  // [103]
+	'num8',                  // [104]
+	'num9',                  // [105]
+	'nummult',               // [106] *
+	'numadd',                // [107] +
+	'',                      // [108]
+	'numsub',                // [109] -
+	'numdec',                // [110]
+	'numdiv',                // [111] ÷
+	'F1',                    // [112]
+	'F2',                    // [113]
+	'F3',                    // [114]
+	'F4',                    // [115]
+	'F5',                    // [116]
+	'F6',                    // [117]
+	'F7',                    // [118]
+	'F8',                    // [119]
+	'F9',                    // [120]
+	'F10',                   // [121]
+	'F11',                   // [122]
+	'F12',                   // [123]
+	'F13',                   // [124]
+	'F14',                   // [125]
+	'F15',                   // [126]
+	'F16',                   // [127]
+	'F17',                   // [128]
+	'F18',                   // [129]
+	'F19',                   // [130]
+	'F20',                   // [131]
+	'F21',                   // [132]
+	'F22',                   // [133]
+	'F23',                   // [134]
+	'F24',                   // [135]
+	'',                      // [136]
+	'',                      // [137]
+	'',                      // [138]
+	'',                      // [139]
+	'',                      // [140]
+	'',                      // [141]
+	'',                      // [142]
+	'',                      // [143]
+	'Numlock',               // [144]
+	'Scrolllock',            // [145]
+	'',                      // [146]
+	'',                      // [147]
+	'',                      // [148]
+	'',                      // [149]
+	'',                      // [150]
+	'',                      // [151]
+	'',                      // [152]
+	'',                      // [153]
+	'',                      // [154]
+	'',                      // [155]
+	'',                      // [156]
+	'',                      // [157]
+	'',                      // [158]
+	'',                      // [159]
+	'',                      // [160]
+	'!',                     // [161]
+	'"',                     // [162]
+	'#',                     // [163]
+	'$',                     // [164]
+	'%',                     // [165]
+	'&',                     // [166]
+	'_',                     // [167]
+	'(',                     // [168]
+	')',                     // [169]
+	'*',                     // [170]
+	'Plus',                  // [171]
+	'|',                     // [172]
+	'-',                     // [173]
+	'{',                     // [174]
+	'}',                     // [175]
+	'~',                     // [176]
+	'',                      // [177]
+	'',                      // [178]
+	'',                      // [179]
+	'',                      // [180]
+	'VolumeMute',            // [181]
+	'VolumeDown',            // [182]
+	'VolumeUp',              // [183]
+	'',                      // [184]
+	'',                      // [185]
+	';',                     // [186]
+	'=',                     // [187]
+	',',                     // [188]
+	'-',                     // [189]
+	'.',                     // [190]
+	'/',                     // [191]
+	'`',                     // [192]
+	'',                      // [193]
+	'',                      // [194]
+	'',                      // [195]
+	'',                      // [196]
+	'',                      // [197]
+	'',                      // [198]
+	'',                      // [199]
+	'',                      // [200]
+	'',                      // [201]
+	'',                      // [202]
+	'',                      // [203]
+	'',                      // [204]
+	'',                      // [205]
+	'',                      // [206]
+	'',                      // [207]
+	'',                      // [208]
+	'',                      // [209]
+	'',                      // [210]
+	'',                      // [211]
+	'',                      // [212]
+	'',                      // [213]
+	'',                      // [214]
+	'',                      // [215]
+	'',                      // [216]
+	'',                      // [217]
+	'',                      // [218]
+	'[',                     // [219]
+	'\\',                    // [220]
+	']',                     // [221]
+	'\'',                    // [222]
+	'',                      // [223]
+	'',                      // [224]
+	'AltGr',                 // [225]
+	'',                      // [226]
+	'',                      // [227]
+	'',                      // [228]
+	'',                      // [229]
+	'',                      // [230]
+	'',                      // [231]
+	'',                      // [232]
+	'',                      // [233]
+	'',                      // [234]
+	'',                      // [235]
+	'',                      // [236]
+	'',                      // [237]
+	'',                      // [238]
+	'',                      // [239]
+	'',                      // [240]
+	'',                      // [241]
+	'',                      // [242]
+	'',                      // [243]
+	'',                      // [244]
+	'',                      // [245]
+	'',                      // [246]
+	'',                      // [247]
+	'',                      // [248]
+	'',                      // [249]
+	'',                      // [250]
+	'',                      // [251]
+	'',                      // [252]
+	'',                      // [253]
+	'',                      // [254]
+	'',                       // [255]
+];
 
 const defaultKeymapItems = {
 	darwin: [
@@ -351,9 +610,13 @@ export default class KeymapService extends BaseService {
 
 	public domToElectronAccelerator(event:any) {
 		const parts = [];
-		const { key, ctrlKey, metaKey, altKey, shiftKey } = event;
+
+		// We use the "keyCode" and not "key" because the modifier keys
+		// would change the "key" value. eg "Option+U" would give "º" as a key instead of "U"
+		const { keyCode, ctrlKey, metaKey, altKey, shiftKey } = event;
 
 		// First, the modifiers
+		// We have to use the following js events, because modifiers won't stick otherwise
 		if (ctrlKey) parts.push('Ctrl');
 		switch (this.platform) {
 		case 'darwin':
@@ -367,40 +630,12 @@ export default class KeymapService extends BaseService {
 		}
 
 		// Finally, the key
-		const electronKey = KeymapService.domToElectronKey(key);
-		if (electronKey) parts.push(electronKey);
+		// String.fromCharCode expects unicode charcodes as an argument; e.keyCode returns javascript keycodes.
+		// Javascript keycodes and unicode charcodes are not the same thing!
+		const electronKey = keycodeToElectronMap[keyCode];
+		if (electronKey && keysRegExp.test(electronKey)) parts.push(electronKey);
 
 		return parts.join('+');
-	}
-
-	private static domToElectronKey(domKey: string) {
-		let electronKey;
-
-		if (/^([a-z])$/.test(domKey)) {
-			electronKey = domKey.toUpperCase();
-		} else if (/^Arrow(Up|Down|Left|Right)|Audio(VolumeUp|VolumeDown|VolumeMute)$/.test(domKey)) {
-			electronKey = domKey.slice(5);
-		} else {
-			switch (domKey) {
-			case ' ':
-				electronKey = 'Space';
-				break;
-			case '+':
-				electronKey = 'Plus';
-				break;
-			case 'MediaTrackNext':
-				electronKey = 'MediaNextTrack';
-				break;
-			case 'MediaTrackPrevious':
-				electronKey = 'MediaPreviousTrack';
-				break;
-			default:
-				electronKey = domKey;
-			}
-		}
-
-		if (keysRegExp.test(electronKey)) return electronKey;
-		else return null;
 	}
 
 	public on(eventName: string, callback: Function) {


### PR DESCRIPTION
String.fromCharCode expects unicode charcodes as an argument; e.keyCode returns javascript keycodes.
Javascript keycodes and unicode charcodes are not the same thing!

Therefore I used an array to map keycodes. This seems to be the only way to make this work properly.

I also changed the width of the shortcut recorder input field to 200px, since certain key combinations are cut off, because they don't fit in the field.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
