### PR TITLE
Desktop: add {{bowm}} and {{bows}} - Beginning Of Week (Monday/Sunday)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ The currently supported template variables are:
 | `{{time}}` | Current time formatted based on the settings format | 13:00 |
 | `{{datetime}}` | Current date and time formatted based on the settings format | 01/01/19 1:00 PM |
 | `{{#custom_datetime}}` | Current date and/or time formatted based on a supplied string (using [moment.js](https://momentjs.com/) formatting) | `{{#custom_datetime}}M d{{/custom_datetime}}` |
+| `{{bowm}}` | Date of the beginning of the week (when week starts Monday) based on the settings format | |
+| `{{bows}}` | Date of the beginning of the week (when week starts Sunday) based on the settings format | |
 
 # Searching
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ The currently supported template variables are:
 | `{{time}}` | Current time formatted based on the settings format | 13:00 |
 | `{{datetime}}` | Current date and time formatted based on the settings format | 01/01/19 1:00 PM |
 | `{{#custom_datetime}}` | Current date and/or time formatted based on a supplied string (using [moment.js](https://momentjs.com/) formatting) | `{{#custom_datetime}}M d{{/custom_datetime}}` |
-| `{{bowm}}` | Date of the beginning of the week (when week starts Monday) based on the settings format | |
-| `{{bows}}` | Date of the beginning of the week (when week starts Sunday) based on the settings format | |
+| `{{bowm}}` | Date of the beginning of the week (when week starts on Monday) based on the settings format | |
+| `{{bows}}` | Date of the beginning of the week (when week starts on Sunday) based on the settings format | |
 
 # Searching
 

--- a/packages/lib/TemplateUtils.js
+++ b/packages/lib/TemplateUtils.js
@@ -11,6 +11,15 @@ Mustache.escape = text => {
 	return text;
 };
 
+function beginningOfWeek(index) {
+	// index: 0 for Sunday, 1 for Monday
+	const thisDate = new Date();
+	const day = thisDate.getDay(),
+		diff = day >= index ? day - index : 6 - day;
+
+	return new Date().setDate(thisDate.getDate() - diff);
+}
+
 TemplateUtils.render = function(input) {
 	// new template variables can be added here
 	// If there are too many, this should be moved to a new file
@@ -24,6 +33,8 @@ TemplateUtils.render = function(input) {
 				return render(time.formatMsToLocal(new Date().getTime(), text));
 			};
 		},
+		bowm: time.formatMsToLocal(beginningOfWeek(1), time.dateFormat()),
+		bows: time.formatMsToLocal(beginningOfWeek(0), time.dateFormat()),
 	};
 
 	return Mustache.render(input, view);


### PR DESCRIPTION
In certain situations it is useful to reference the beginning of the week.
Unfortunately the current system does not allow to do that, not even with a custom datetime format.

I've also added the 2 new template variables to the documentation.

| Variable | Description | Example |
| --- | --- | --- |
| `{{bowm}}` | Date of the beginning of the week (when week starts on Monday) based on the settings format | |
| `{{bows}}` | Date of the beginning of the week (when week starts on Sunday) based on the settings format | |


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
