### PR TITLE
Desktop: Attempt to fix outlook delete on drop

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -10,6 +10,7 @@ export default function useDropHandler(dependencies:HookDependencies) {
 
 	return useCallback(async (event:any) => {
 		const dt = event.dataTransfer;
+		dt.dropEffect = 'copy';
 		const createFileURL = event.altKey;
 
 		if (dt.types.indexOf('text/x-jop-note-ids') >= 0) {


### PR DESCRIPTION
[This microsoft forum](https://answers.microsoft.com/en-us/msoffice/forum/msoffice_outlook-mso_windows8-mso_2016/drag-and-drop-works-however-deletes-email-can-we/865f60c3-7980-4465-8a19-4d60b0ae5aba) exchange says that the behaviour of drag and drop can be changed adjusting the dropEffect value.

It seems that before dropEffect was "none" and this might have been messing with outlook. 

I don't have outlook so I wasn't able to actually test this, but I did test dragging and dropping from the filesystem and it doesn't seem to affect it (I think most programs were interpreting `none` as `copy` anyway).