### PR TITLE
Desktop: Attempt to fix Outlook drag and drop #2

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -142,6 +142,8 @@ function Editor(props: EditorProps, ref: any) {
 			const coords = cm.coordsChar({ left: event.x, top: event.y });
 			cm.setCursor(coords);
 		}
+
+		event.dataTransfer.dropEffect = 'copy';
 	}, []);
 
 	useEffect(() => {

--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -10,7 +10,6 @@ export default function useDropHandler(dependencies: HookDependencies) {
 
 	return useCallback(async (event: any) => {
 		const dt = event.dataTransfer;
-		dt.dropEffect = 'copy';
 		const createFileURL = event.altKey;
 
 		if (dt.types.indexOf('text/x-jop-note-ids') >= 0) {


### PR DESCRIPTION
Follow up to #4031 
Based on [user feedback](https://discourse.joplinapp.org/t/drag-and-drop-behaviour/10546/31?u=calebjohn) the previous pull didn't work.
I went in and had a closer look at the [forum post](https://answers.microsoft.com/en-us/msoffice/forum/msoffice_outlook-mso_windows8-mso_2016/drag-and-drop-works-however-deletes-email-can-we/865f60c3-7980-4465-8a19-4d60b0ae5aba?page=1) I based the fix off of. And I took a closer look at the [documentation for dropEffect](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect) specifically where it says

> Within event handlers for dragenter and dragover events, dropEffect should be modified if a different action is desired than the action that the user is requesting.

So it seems that the previous pull request did nothing.
This new pull request properly sets the `dropEffect` in the `dragover` event. This causes the cursor to change on my system (but otherwise I see no change), which is promising because the copy operation always worked on the TinyMCE editor and the cursor now matches TinyMCE.

Again, I can't be certain that this will fix the problem that forum users are having, but I am certain that it won't hurt other users.