### PR TITLE
Desktop: Added i3wm as a Desktop option, fixing an install issue

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -162,7 +162,7 @@ DESKTOP=${DESKTOP,,}  # convert to lower case
 
 #-----------------------------------------------------
 echo 'Create Desktop icon...'
-if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.* ]]
+if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.* ]]
 then
     : "${TMPDIR:=$TEMP_DIR}"
     # This command extracts to squashfs-root by default and can't be changed...


### PR DESCRIPTION
Changed a single line of code to allow installation of the Desktop app when using [i3wm](https://i3wm.org/). 

Essentially the issue was that, without this fix, the Joplin desktop app would not be installed to ~/.local/share/applications. This would not allow the user to launch it using things like [Rofi](https://github.com/davatorium/rofi).

I've tested this on i3wm on Arch and it works great. 