### PR TITLE
Desktop: Prevent lines from shifting in Markdown Editor when Scrollbar appears

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -409,9 +409,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				padding-bottom: 400px !important;
 			}
 
-			// Add a fixed right padding to account for the appearance (and disappearance) 
-			// of the sidebar
 			.CodeMirror-sizer {
+				/* Add a fixed right padding to account for the appearance (and disappearance) */
+				/* of the sidebar */
 				padding-right: 10px !important;
 			}
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -409,6 +409,12 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				padding-bottom: 400px !important;
 			}
 
+			// Add a fixed right padding to account for the appearance (and disappearance) 
+			// of the sidebar
+			.CodeMirror-sizer {
+				padding-right: 10px !important;
+			}
+
 			.cm-header-1 {
 				font-size: 1.5em;
 			}


### PR DESCRIPTION
This is done by adding a constant padding to the right hand side of the codemirror editor.

Before long lines could get pushed around when the scroll bar appeared.
Compare
![image](https://user-images.githubusercontent.com/2179547/99605849-c8420c80-29c5-11eb-8cf4-c0aeaca3d2d5.png)
->
![image](https://user-images.githubusercontent.com/2179547/99605897-ddb73680-29c5-11eb-812d-771bbad3e4d5.png)

And the new behavior
![image](https://user-images.githubusercontent.com/2179547/99606045-2e2e9400-29c6-11eb-8581-0de778b333fc.png)
->
![image](https://user-images.githubusercontent.com/2179547/99605897-ddb73680-29c5-11eb-812d-771bbad3e4d5.png)
