### PR TITLE
Desktop: Fixes #3917: Fixed numbered list bug in markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -75,6 +75,12 @@ export default function useCursorUtils(CodeMirror: any) {
 		// Batches the insert operations, if this wasn't done the inserts
 		// could potentially overwrite one another
 		this.operation(() => {
+
+			let num = 0;
+			if (string1.match(/^\d/)) {
+				num = Number(string1.substr(0,string1.length - 2));
+			}
+
 			for (let i = 0; i < selectedStrings.length; i++) {
 				const selected = selectedStrings[i];
 
@@ -87,7 +93,12 @@ export default function useCursorUtils(CodeMirror: any) {
 					// Only add the list token if it's not already there
 					// if it is, remove it
 					if (!line.startsWith(string1)) {
-						lines[j] = string1 + line;
+						if (num != 0) {
+							lines[j] = `${num.toString()}. ${line}`;
+							num++;
+						} else {
+							lines[j] = string1 + line;
+						}
 					} else {
 						lines[j] = line.substr(string1.length, line.length - string1.length);
 					}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,3 +1,5 @@
+import markdownUtils from '@joplin/lib/markdownUtils';
+
 // Helper functions that use the cursor
 export default function useCursorUtils(CodeMirror: any) {
 
@@ -75,14 +77,10 @@ export default function useCursorUtils(CodeMirror: any) {
 		// Batches the insert operations, if this wasn't done the inserts
 		// could potentially overwrite one another
 		this.operation(() => {
-
-			let num = 0;
-			if (string1.match(/^\d/)) {
-				num = Number(string1.substr(0,string1.length - 2));
-			}
-
 			for (let i = 0; i < selectedStrings.length; i++) {
 				const selected = selectedStrings[i];
+
+				let num = markdownUtils.olLineNumber(string1);
 
 				const lines = selected.split(/\r?\n/);
 				//  Save the newline character to restore it later
@@ -93,7 +91,7 @@ export default function useCursorUtils(CodeMirror: any) {
 					// Only add the list token if it's not already there
 					// if it is, remove it
 					if (!line.startsWith(string1)) {
-						if (num != 0) {
+						if (num) {
 							lines[j] = `${num.toString()}. ${line}`;
 							num++;
 						} else {


### PR DESCRIPTION
This PR fixed [#3917](https://github.com/laurent22/joplin/issues/3917). Increasing number will be added to the front of each line in markdown editor, if users select multiple lines and use numbered list. My solution is to detect whether the user is trying to add a numbered list by checking if string1 starts with number. If it is, add increasing number to each selected line accordingly. Please let me know if it is a good solution or I need to do something further. Thank you in advance!