### PR TITLE
Android: Try to fix external storage access on Android 10

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,12 @@
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:allowBackup="false"
 		android:networkSecurityConfig="@xml/network_security_config"
+		<!--
+			Android 10 introduced new "scoped storage" mechanism.
+			Apps targeting Android 10 (sdk 29) can no longer freely access arbitrary paths on the shared storage.
+			For now this flag allows to opt out of this restriction.
+			See https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
+		-->
 		android:requestLegacyExternalStorage="true"
 		android:theme="@style/AppTheme">
 

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:allowBackup="false"
 		android:networkSecurityConfig="@xml/network_security_config"
+		android:requestLegacyExternalStorage="true"
 		android:theme="@style/AppTheme">
 
 		<!-- RN-NOTIFICATION -->

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,11 @@
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
+	<!--
+		Android 10 introduced new "scoped storage" mechanism.
+		Apps targeting Android 10 (sdk 29) can no longer freely access arbitrary paths on the shared storage.
+		The attribute "requestLegacyExternalStorage" below allows to opt out of this restriction.
+	-->
 	<application
 		android:name=".MainApplication"
 		android:label="@string/app_name"
@@ -25,12 +30,6 @@
 		android:roundIcon="@mipmap/ic_launcher_round"
 		android:allowBackup="false"
 		android:networkSecurityConfig="@xml/network_security_config"
-		<!--
-			Android 10 introduced new "scoped storage" mechanism.
-			Apps targeting Android 10 (sdk 29) can no longer freely access arbitrary paths on the shared storage.
-			For now this flag allows to opt out of this restriction.
-			See https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
-		-->
 		android:requestLegacyExternalStorage="true"
 		android:theme="@style/AppTheme">
 


### PR DESCRIPTION
Maybe fixes #4122

There was a change in storage access permissions in Android 10. This PR should restore the old behaviour according to this document: https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
I do not have any devices running Android 10 so can't test if this really helps. Does not seem to break anything though.