### PR TITLE
CLI: Removed confusing and incorrect export format "html"

### DIFF
--- a/packages/app-cli/app/command-export.js
+++ b/packages/app-cli/app/command-export.js
@@ -25,11 +25,12 @@ class Command extends BaseCommand {
 
 	async action(args) {
 		const exportOptions = {};
+		const validFormats = ['jex', 'raw', 'json', 'md'];
 		exportOptions.path = args.path;
 
 		exportOptions.format = args.options.format ? args.options.format : 'jex';
 
-		if (exportOptions.format === 'html') throw new Error('HTML export is not supported. Please use the desktop application.');
+		if (!validFormats.includes(exportOptions.format)) throw new Error(_('%s export format is not supported in the cli app.', exportOptions.format));
 
 		if (args.options.note) {
 			const notes = await app().loadItems(BaseModel.TYPE_NOTE, args.options.note, { parent: app().currentFolder() });

--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -485,8 +485,7 @@ The following commands are available in [command-line mode](#command-line-mode):
 
 	    --format <format>      Destination format: jex (Joplin Export File), raw 
 	                           (Joplin Export Directory), json (Json Export 
-	                           Directory), md (Markdown), html (HTML File), html 
-	                           (HTML Directory)
+	                           Directory), md (Markdown)
 	    --note <note>          Exports only the given note.
 	    --notebook <notebook>  Exports only the given notebook.
 


### PR DESCRIPTION
There is no objective reason to keep "html" in the docs if it's not supported.

It would be awesome to have a html directory or file automatically regenerated every time I change my joplin files. I was writing a script for this in the assumptions that html-export would be possible only to get the disappointing message "HTML export is not supported. Please use the desktop application.".

Why have it in the docs for the cli app? We might as well add jpeg, wav and psd and then add more notifications that these export methods are not supported. ;-)

Also, *when* (or if) html export is supported, the docs should clarify single file vs directory export. Currently it seems that both have the same flag (i.e. html). Confusing.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
