### PR TITLE
Desktop: Fix typo when passing generic editor commands to the editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -223,7 +223,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 					if (commands[cmd.name]) {
 						commandOutput = commands[cmd.name](cmd.value);
 					} else if (editorRef.current.supportsCommand(cmd)) {
-						commandOutput = editorRef.current.execCommandFromJoplinCommand(cmd);
+						commandOutput = editorRef.current.execCommandFromJoplin(cmd);
 					} else {
 						reg.logger().warn('CodeMirror: unsupported Joplin command: ', cmd);
 					}


### PR DESCRIPTION
[ref](https://discourse.joplinapp.org/t/pre-release-v1-5-is-available-with-support-for-media-players-updated-20-12-20/12885/7?u=calebjohn)

I'm not sure when I introduced this typo, but I should have double checked that the menu commands work before the final merge. Sorry about that.