### PR TITLE
Linux: Remove the appimage version from installer script

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -164,18 +164,12 @@ DESKTOP=${DESKTOP,,}  # convert to lower case
 echo 'Create Desktop icon...'
 if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.* ]]
 then
-    : "${TMPDIR:=$TEMP_DIR}"
-    # This command extracts to squashfs-root by default and can't be changed...
-    # So we run it in the tmp directory and clean up after ourselves
-    (cd $TMPDIR && ~/.joplin/Joplin.AppImage --appimage-extract joplin.desktop &> /dev/null)
-    APPIMAGE_VERSION=$(grep "^X-AppImage-Version=" $TMPDIR/squashfs-root/joplin.desktop | head -n 1 | cut -d "=" -f 2)
-    rm -rf $TMPDIR/squashfs-root
     # Only delete the desktop file if it will be replaced
     rm -f ~/.local/share/applications/appimagekit-joplin.desktop
 
     # On some systems this directory doesn't exist by default
     mkdir -p ~/.local/share/applications
-    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;\n#${APPIMAGE_VERSION}" >> ~/.local/share/applications/appimagekit-joplin.desktop
+    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;" >> ~/.local/share/applications/appimagekit-joplin.desktop
     # Update application icons
     [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications && update-desktop-database ~/.local/share/icons
     print "${COLOR_GREEN}OK${COLOR_RESET}"


### PR DESCRIPTION
It's been awhile since the appimage format changed and this bit of code stopped working. That same change made this version matching unnecessary so there's no reason to keep it in. There won't be any change from the user perspective (aside from the error that would appear while running the update script will be gone).

We actually don't need to call the desktop file `appimagekit-joplin.desktop` any more either, but I don't think it's worth changing.