### PR TITLE
All: Support natural sorting by title

### DIFF
--- a/packages/app-cli/tests/models_Note.ts
+++ b/packages/app-cli/tests/models_Note.ts
@@ -273,37 +273,46 @@ describe('models_Note', function() {
 
 	it('should perform natural sorting', (async () => {
 		const folder1 = await Folder.save({});
-		const note0 = await Note.save({ title: 'A3', parent_id: folder1.id });
-		const note1 = await Note.save({ title: 'A20', parent_id: folder1.id });
-		const note2 = await Note.save({ title: 'A100', parent_id: folder1.id });
-		const note3 = await Note.save({ title: 'égalité', parent_id: folder1.id });
-		const note4 = await Note.save({ title: 'z', parent_id: folder1.id });
 
-		Setting.setValue('titleNaturalSort', false);
 		const sortedNotes = await Note.previews(folder1.id, {
 			fields: ['id', 'title'],
 			order: [{ by: 'title', dir: 'ASC' }],
 		});
+		expect(sortedNotes.length).toBe(0);
 
-		expect(sortedNotes.length).toBe(5);
-		expect(sortedNotes[0].id).toBe(note2.id);
-		expect(sortedNotes[1].id).toBe(note1.id);
-		expect(sortedNotes[2].id).toBe(note0.id);
-		expect(sortedNotes[3].id).toBe(note4.id);
-		expect(sortedNotes[4].id).toBe(note3.id);
+		const note0 = await Note.save({ title: 'A3', parent_id: folder1.id, is_todo: false });
+		const note1 = await Note.save({ title: 'A20', parent_id: folder1.id, is_todo: false });
+		const note2 = await Note.save({ title: 'A100', parent_id: folder1.id, is_todo: false });
+		const note3 = await Note.save({ title: 'égalité', parent_id: folder1.id, is_todo: false });
+		const note4 = await Note.save({ title: 'z', parent_id: folder1.id, is_todo: false });
 
-		Setting.setValue('titleNaturalSort', true);
 		const sortedNotes2 = await Note.previews(folder1.id, {
 			fields: ['id', 'title'],
 			order: [{ by: 'title', dir: 'ASC' }],
 		});
-
 		expect(sortedNotes2.length).toBe(5);
 		expect(sortedNotes2[0].id).toBe(note0.id);
 		expect(sortedNotes2[1].id).toBe(note1.id);
 		expect(sortedNotes2[2].id).toBe(note2.id);
 		expect(sortedNotes2[3].id).toBe(note3.id);
 		expect(sortedNotes2[4].id).toBe(note4.id);
+
+		const todo3 = Note.changeNoteType(note3, 'todo');
+		const todo4 = Note.changeNoteType(note4, 'todo');
+		await Note.save(todo3);
+		await Note.save(todo4);
+
+		const sortedNotes3 = await Note.previews(folder1.id, {
+			fields: ['id', 'title'],
+			order: [{ by: 'title', dir: 'ASC' }],
+			uncompletedTodosOnTop: true,
+		});
+		expect(sortedNotes3.length).toBe(5);
+		expect(sortedNotes3[0].id).toBe(note3.id);
+		expect(sortedNotes3[1].id).toBe(note4.id);
+		expect(sortedNotes3[2].id).toBe(note0.id);
+		expect(sortedNotes3[3].id).toBe(note1.id);
+		expect(sortedNotes3[4].id).toBe(note2.id);
 	}));
 
 });

--- a/packages/app-cli/tests/models_Note.ts
+++ b/packages/app-cli/tests/models_Note.ts
@@ -271,4 +271,39 @@ describe('models_Note', function() {
 		expect(result).toBe(`[](:/${note1.id})`);
 	}));
 
+	it('should perform natural sorting', (async () => {
+		const folder1 = await Folder.save({});
+		const note0 = await Note.save({ title: 'A3', parent_id: folder1.id });
+		const note1 = await Note.save({ title: 'A20', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'A100', parent_id: folder1.id });
+		const note3 = await Note.save({ title: 'égalité', parent_id: folder1.id });
+		const note4 = await Note.save({ title: 'z', parent_id: folder1.id });
+
+		Setting.setValue('titleNaturalSort', false);
+		const sortedNotes = await Note.previews(folder1.id, {
+			fields: ['id', 'title'],
+			order: [{ by: 'title', dir: 'ASC' }],
+		});
+
+		expect(sortedNotes.length).toBe(5);
+		expect(sortedNotes[0].id).toBe(note2.id);
+		expect(sortedNotes[1].id).toBe(note1.id);
+		expect(sortedNotes[2].id).toBe(note0.id);
+		expect(sortedNotes[3].id).toBe(note4.id);
+		expect(sortedNotes[4].id).toBe(note3.id);
+
+		Setting.setValue('titleNaturalSort', true);
+		const sortedNotes2 = await Note.previews(folder1.id, {
+			fields: ['id', 'title'],
+			order: [{ by: 'title', dir: 'ASC' }],
+		});
+
+		expect(sortedNotes2.length).toBe(5);
+		expect(sortedNotes2[0].id).toBe(note0.id);
+		expect(sortedNotes2[1].id).toBe(note1.id);
+		expect(sortedNotes2[2].id).toBe(note2.id);
+		expect(sortedNotes2[3].id).toBe(note3.id);
+		expect(sortedNotes2[4].id).toBe(note4.id);
+	}));
+
 });

--- a/packages/app-mobile/android/app/build.gradle
+++ b/packages/app-mobile/android/app/build.gradle
@@ -109,7 +109,7 @@ def enableProguardInReleaseBuilds = false
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
  * Whether to enable the Hermes VM.

--- a/packages/app-mobile/android/app/build.gradle
+++ b/packages/app-mobile/android/app/build.gradle
@@ -109,6 +109,9 @@ def enableProguardInReleaseBuilds = false
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
  */
+ 
+// We need the intl variant to support natural sorting of notes.
+// https://github.com/laurent22/joplin/pull/4272
 def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**

--- a/packages/lib/models/Note.js
+++ b/packages/lib/models/Note.js
@@ -395,7 +395,7 @@ class Note extends BaseItem {
 			if ('limit' in tempOptions) tempOptions.limit -= uncompletedTodos.length;
 			const theRest = await this.search(tempOptions);
 
-			if (tempOptions.order[0].by == 'title' && Setting.value('titleNaturalSort')) {
+			if (tempOptions.order.length > 0 && tempOptions.order[0].by == 'title' && Setting.value('titleNaturalSort')) {
 				theRest.sort((a, b) => this.naturalSortCompare(a.title, b.title, tempOptions.order[0].dir));
 			}
 
@@ -412,7 +412,7 @@ class Note extends BaseItem {
 
 		const results = await this.search(options);
 
-		if (options.order[0].by == 'title' && Setting.value('titleNaturalSort')) {
+		if (options.order.length > 0 && options.order[0].by == 'title' && Setting.value('titleNaturalSort')) {
 			results.sort((a, b) => this.naturalSortCompare(a.title, b.title, options.order[0].dir));
 		}
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -613,6 +613,17 @@ class Setting extends BaseModel {
 				},
 			},
 
+			titleNaturalSort: {
+				value: false,
+				type: SettingItemType.Bool,
+				section: 'note',
+				public: true,
+				label: () => _('When sorting notes by title, use natural sorting'),
+				description: () => {
+					return _('Given notes with titles, e.g., A9 and A10, natural sorting orders A9 before A10');
+				},
+			},
+
 			'plugins.states': {
 				value: '',
 				type: SettingItemType.Object,

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -613,17 +613,6 @@ class Setting extends BaseModel {
 				},
 			},
 
-			titleNaturalSort: {
-				value: false,
-				type: SettingItemType.Bool,
-				section: 'note',
-				public: true,
-				label: () => _('When sorting notes by title, use natural sorting'),
-				description: () => {
-					return _('Given notes with titles, e.g., A9 and A10, natural sorting orders A9 before A10');
-				},
-			},
-
 			'plugins.states': {
 				value: '',
 				type: SettingItemType.Object,


### PR DESCRIPTION
This is a feature that I needed and I think it could be useful for some people. This change creates a setting item and added title natural sorting logics to both after loading from database and when sorting is called.

It is still preliminary, e.g. I still need to figure out how to sort after the setting is saved. For now, one needs to click the notebook to tigger sorting.