### PR TITLE
Desktop: Add case insensitive sorting for Note Attachments tool

### DIFF
--- a/packages/app-desktop/gui/ResourceScreen.tsx
+++ b/packages/app-desktop/gui/ResourceScreen.tsx
@@ -153,6 +153,7 @@ class ResourceScreenComponent extends React.Component<Props, State> {
 			order: [{
 				by: getSortingOrderColumn(sorting.order),
 				dir: sorting.type,
+				caseInsensitive: true,
 			}],
 			limit: MAX_RESOURCES,
 			fields: ['title', 'id', 'size', 'file_extension'],


### PR DESCRIPTION
Update to add case insensitive sorting to _Tools->Note Attachments..._

See - [Discourse](https://discourse.joplinapp.org/t/a-feature-request/13486/5?u=daeraxa) for original discussion and analysis of the issue.

The Note Attachments tool is taking case into account when sorting which is only really a problem for the _Title_ column (see image, _Title_ is sorted asc. and lowercase starting filenames are appearing below the end of the uppercase ones. This only really affects user experience and ease of reviewing when using the tool.
![image](https://user-images.githubusercontent.com/58074586/103384965-5266b000-4af0-11eb-8f14-495078af3576.png)

The idea is to add case insensitivity to the sorting so that 'x' will immediately follow 'X' etc.

I'm new to this so please be gentle if I've made a horrible mistake, please let me know what I can do to review/test/fix.