### PR TITLE
Mobile: Fixes #4268: Fix downloading resource files from S3 with RN

### DIFF
--- a/packages/app-mobile/index.js
+++ b/packages/app-mobile/index.js
@@ -44,3 +44,6 @@ LogBox.ignoreLogs([
 ]);
 
 AppRegistry.registerComponent('Joplin', () => Root);
+
+// Using streams on react-native requires to polyfill process.nextTick()
+global.process.nextTick = setImmediate;

--- a/packages/app-mobile/package-lock.json
+++ b/packages/app-mobile/package-lock.json
@@ -8379,6 +8379,27 @@
         "emitter-component": "^1.1.1"
       }
     },
+    "stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "requires": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "stream-buffers": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -53,14 +53,15 @@
     "redux": "4.0.0",
     "rn-fetch-blob": "^0.12.0",
     "stream": "0.0.2",
+    "stream-browserify": "^3.0.0",
     "string-natural-compare": "^2.0.2",
     "timers": "^0.1.1",
     "valid-url": "^1.0.9"
   },
   "devDependencies": {
-    "@joplin/tools": "^1.0.9",
     "@babel/core": "^7.11.6",
     "@babel/runtime": "^7.11.2",
+    "@joplin/tools": "^1.0.9",
     "@types/node": "^14.14.6",
     "@types/react": "^16.9.55",
     "execa": "^4.0.0",


### PR DESCRIPTION
This fixes a problem with the S3 synchronization code using the
shim.fsDriver().writeBinaryFile() which is not implemented in
fs-driver-rn.js (React Native).

Tested with AVD Android 10.0 target.

