### PR TITLE
Desktop: fix toolbar position

### DIFF
--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -23,6 +23,7 @@ class ToolbarBaseComponent extends React.Component<Props, any> {
 			backgroundColor: theme.backgroundColor3,
 			padding: theme.toolbarPadding,
 			paddingRight: theme.mainPadding,
+			marginLeft: -theme.editorPaddingLeft,
 		}, this.props.style);
 
 		const groupStyle: any = {


### PR DESCRIPTION
This is a follow-up to this commit: 0e57baf5b9f5bea1d6228140b88c99772ca6123f

The editor-toolbar is now too far right.

Currently:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/223439/103464409-70efc580-4d01-11eb-8010-41ee9859f44d.png">

After my change:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/223439/103464658-7e0db400-4d03-11eb-838e-ba28bcd210e8.png">
