### PR TITLE
Desktop: update Electron to 10.2.0

### DIFF
--- a/packages/app-desktop/package-lock.json
+++ b/packages/app-desktop/package-lock.json
@@ -5718,9 +5718,9 @@
       }
     },
     "electron": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-10.1.6.tgz",
-      "integrity": "sha512-Wyiq5Fy64KAa51i72m+5zayYKSm9O5lnittUdaElAn3PAzGl3yDifYO2QsXR7k/iKxWVSROOPzf43mXYytL67Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-10.2.0.tgz",
+      "integrity": "sha512-GBUyq8dwUqXPkCTkoID+eZ5Pm9GFlLUd2eSoGe8UOaHeW68SgCf5t75/uGHraQ1OIz/0qniyH5M4ebWEHGppyQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -5729,9 +5729,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.5.tgz",
-          "integrity": "sha512-Wgdl27uw/jUYUFyajUGKSjDNGxmJrZi9sjeG6UJImgUtKbJoO9aldx+1XODN1EpNDX9DirvbvHHmTsNlb8GwMA==",
+          "version": "12.19.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.11.tgz",
+          "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
           "dev": true
         }
       }
@@ -8205,18 +8205,21 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-          "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+          "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
           "dev": true,
           "optional": true
         },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -104,7 +104,7 @@
     "app-builder-bin": "^1.9.11",
     "babel-cli": "^6.26.0",
     "babel-preset-react": "^6.24.1",
-    "electron": "^10.1.6",
+    "electron": "^10.2.0",
     "electron-builder": "22.9.1",
     "electron-notarize": "^1.0.0",
     "electron-rebuild": "^2.3.2",


### PR DESCRIPTION
Might fix https://discourse.joplinapp.org/t/white-windows-after-hibernation/12344, but I'm just guessing here.

It's just a minor bump, so there are no breaking changes.

```
Release Notes for v10.2.0
Fixes

    Added Electron DLLs like libGLESv2.dll to symbol server. #26964 (Also in 9, 11, 12)
    Fixed systemPreferences.effectiveAppearance returning systemPreferences.getAppLevelAppearance(). #26882 (Also in 9, 11, 12)
    Fixed an issue that a message box in GTK contains no buttons. #26915 (Also in 11, 12)
    Fixed an issue where event.reply could sometimes not deliver a reply to an IPC message when cross-site iframes were present. #26927 (Also in 9, 11, 12)
    Fixed an occasional crash on Windows related to NativeViewHost::SetParentAccessible. #26949 (Also in 9, 11, 12)

Other Changes

    Security: backport fix for 1150649. #26896
    Security: backported fix for 1137603. #26892
    Security: backported fix for 1141350. #26894
    Security: backported the fix to CVE-2020-16014: Use after free in PPAPI. #26855
    Security: backported the fix to CVE-2020-16023: Use after free in WebCodecs. #26832
    Security: backported the fix to CVE-2020-16024: Heap buffer overflow in UI. #26830
    Security: backported the fix to heap-buffer-overflow in gfx::internal::StyleIterator::GetTextBreakingRange. #26866

Release Notes for v10.1.7
Fixes

    Fixed <webview> render-process-gone event dispatch. #26577
    Fixed an issue where IsMaximized would incorrectly return false for some windows on Windows. #26779 (Also in 12)
    Fixed an issue where draggable regions in BrowserWindow causes BrowserView to become draggable in non-correspondent places. #26753 (Also in 11, 12)
    Fixed an issue where some buttons were un-clickable in some BrowserViews with draggable regions enabled. #26744 (Also in 9, 11)
    Fixed an issue whereby a corrupted async_hooks stack would crash the renderer when throwing some errors in the renderer process. #26747 (Also in 9, 11)
    Fixed uncaught promise rejection when creating webContents with javascript disabled. #26871 (Also in 11, 12)

Other Changes

    Security: backported the fix to CVE-2020-16015: Insufficient data validation in WASM. #26858
    Security: backported the fix to CVE-2020-16022: Insufficient policy enforcement in networking. #26860

Unknown

    Re-enable Rosetta on Apple Silicon devices. #26569 (Also in 7.3, 8, 9, 11)
```
