### PR TITLE
actually toggle something ;-)

### DIFF
--- a/packages/plugins/ToggleSideBars/src/index.ts
+++ b/packages/plugins/ToggleSideBars/src/index.ts
@@ -2,6 +2,7 @@ import joplin from 'api';
 
 joplin.plugins.register({
 	onStart: async function() {
-		console.info('Test plugin started!');
+		await joplin.views.toolbarButtons.create('tsb', 'toggleSideBar', 'noteToolbar');
+		await joplin.views.toolbarButtons.create('tnl', 'toggleNoteList', 'noteToolbar');
 	},
 });

--- a/packages/plugins/ToggleSideBars/src/index.ts
+++ b/packages/plugins/ToggleSideBars/src/index.ts
@@ -2,7 +2,7 @@ import joplin from 'api';
 
 joplin.plugins.register({
 	onStart: async function() {
-		await joplin.views.toolbarButtons.create('tsb', 'toggleSideBar', 'noteToolbar');
-		await joplin.views.toolbarButtons.create('tnl', 'toggleNoteList', 'noteToolbar');
+		await joplin.views.toolbarButtons.create('toggleSideBarButton', 'toggleSideBar', 'noteToolbar');
+		await joplin.views.toolbarButtons.create('toggleNoteListButton', 'toggleNoteList', 'noteToolbar');
 	},
 });

--- a/packages/plugins/ToggleSideBars/src/manifest.json
+++ b/packages/plugins/ToggleSideBars/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "org.joplinapp.plugins.ToggleSideBars",
 	"app_min_version": "1.6",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "Note list and side bar toggle buttons",
 	"description": "Adds buttons to toggle note list and side bar",
 	"author": "Laurent Cozic",


### PR DESCRIPTION
The plugin didn't do anything, except log a message.

I thought I should fix it so that it does what it was supposed to. ;-) Hahaha.

Do we add prefix for such PRs with `Plugins: `?
