### PR TITLE
Add Synology WebDAV Server to WebDAV-compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ WebDAV-compatible services that are known to work with Joplin:
 - [OwnCloud](https://owncloud.org/)
 - [Seafile](https://www.seafile.com/)
 - [Stack](https://www.transip.nl/stack/)
+- [Synology WebDAV Server](https://www.synology.com/en-us/dsm/packages/WebDAVServer)
 - [WebDAV Nav](https://www.schimera.com/products/webdav-nav-server/), a macOS server.
 - [Zimbra](https://www.zimbra.com/)
 


### PR DESCRIPTION

Add Synology WebDAV Server to WebDAV-compatible service list. 