### PR TITLE
Desktop: Insert spellcheck replacement at correct location when the window is zoomed

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,4 +1,5 @@
 import markdownUtils from '@joplin/lib/markdownUtils';
+import Setting from '@joplin/lib/models/Setting';
 
 // Helper functions that use the cursor
 export default function useCursorUtils(CodeMirror: any) {
@@ -120,8 +121,12 @@ export default function useCursorUtils(CodeMirror: any) {
 			return -1;
 		};
 
+		// CodeMirror coordsChar doesn't properly scale values when zoomed
+		// we need to manually apply the zoom
+		const zoomFactor = Setting.value('windowContentZoomFactor') / 100;
+
 		const selectionText = params.selectionText;
-		const coords = this.coordsChar({ left: params.x, top: params.y });
+		const coords = this.coordsChar({ left: params.x / zoomFactor, top: params.y / zoomFactor });
 		const { anchor, head } = this.findWordAt(coords);
 		const selectedWord = this.getRange(anchor, head);
 


### PR DESCRIPTION
fixes #4317

This is caused by a bug with CodeMirror that doesn't take zoom into account when dealing with coordinates.