### PR TITLE
- All: Resolves #4313: Quick onedrive delta fix

### DIFF
--- a/packages/lib/file-api-driver-onedrive.js
+++ b/packages/lib/file-api-driver-onedrive.js
@@ -220,9 +220,8 @@ class FileApiDriverOneDrive {
 		};
 
 		const freshStartDelta = () => {
-			// Business Accounts are only allowed to make delta requests to the root. For some reason /delta gives an error for personal accounts and :/delta an error for business accounts
 			const accountProperties = this.api_.accountProperties_;
-			const url = (accountProperties.accountType === 'business') ? `/drives/${accountProperties.driveId}/root/delta` : `${this.makePath_(path)}:/delta`;
+			const url = `/drives/${accountProperties.driveId}/root/delta`;
 			const query = this.itemFilter_();
 			query.select += ',deleted';
 			return { url: url, query: query };


### PR DESCRIPTION
Quick fix for #4313

Onedrive currently gives always an "Resync required" error when making a delta request to a specific directory but not when making a request to the root. I will open an issue later at the Onedrive api docs and when it is working again we can revert the changes of this pr again as it is more efficient to make the request to the folder than filtering the delta response to only get the changes for the joplin folder. But it is definitely much better to filter the request than making a full resync each time.  