### PR TITLE
Desktop: Fix Error: Cannot execute a command without a runtime

### DIFF
--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -314,6 +314,8 @@ export default class CommandService extends BaseService {
 		return (commandName.indexOf('editor.') === 0 ||
 				// These commands are grandfathered in, but in the future
 				// all editor commands should start with "editor."
+				commandName === 'insertText' ||
+				commandName === 'scrollToHash' ||
 				commandName === 'textCopy' ||
 				commandName === 'textCut' ||
 				commandName === 'textPaste' ||
@@ -328,7 +330,9 @@ export default class CommandService extends BaseService {
 				commandName === 'textCheckbox' ||
 				commandName === 'textHeading' ||
 				commandName === 'textHorizontalRule' ||
-				commandName === 'insertDateTime'
+				commandName === 'insertDateTime' ||
+				commandName === 'selectedText' ||
+				commandName === 'replaceSelection'
 		);
 	}
 

--- a/packages/lib/services/commands/ToolbarButtonUtils.ts
+++ b/packages/lib/services/commands/ToolbarButtonUtils.ts
@@ -33,6 +33,19 @@ export default class ToolbarButtonUtils {
 		return this.service_;
 	}
 
+	private isEditorCommand(commandName: string) {
+		return CommandService.isEditorCommand(commandName) && !(
+			// These commands are attached to the editor runtime,
+			// but they either handle focus themselves or don't need
+			// to focus the editor
+			commandName === 'textLink' ||
+			commandName === 'insertText' ||
+			commandName === 'scrollToHash' ||
+			commandName === 'selectedText' ||
+			commandName === 'replaceSelection'
+		);
+	}
+
 	private commandToToolbarButton(commandName: string, whenClauseContext: any): ToolbarButtonInfo {
 		const newEnabled = this.service.isEnabled(commandName, whenClauseContext);
 		const newTitle = this.service.title(commandName);
@@ -54,8 +67,7 @@ export default class ToolbarButtonUtils {
 			enabled: newEnabled,
 			onClick: async () => {
 				void this.service.execute(commandName);
-				// WARNING:  textLink is a special case because it handles it's own focus
-				if (CommandService.isEditorCommand(commandName) && commandName !== 'textLink') {
+				if (this.isEditorCommand(commandName)) {
 					void this.service.execute('editor.focus');
 				}
 			},


### PR DESCRIPTION
fixes #4338 #4340 #4339

There is some [discussion here](https://github.com/laurent22/joplin/pull/4303#discussion_r555277583).

@laurent22 the fix I've introduced here is to keep the focus code as a special case (which it always needed because of commands like `textLink`) and extended the `isEditorCommand` function to cover all editor commands that do not start with `editor.`.

I understand if you think this is an ugly solution (although it is an extension of what we were doing previously). And I'm open to having a discussion about what would be a cleaner way to deal with this.