### PR TITLE
Mobile: When attaching a file to a note set correct title and extension

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -635,8 +635,8 @@ class NoteScreenComponent extends BaseScreenComponent {
 		let resource = Resource.new();
 		resource.id = uuid.create();
 		resource.mime = mimeType;
-		resource.title = pickerResponse.fileName ? pickerResponse.fileName : '';
-		resource.file_extension = safeFileExtension(fileExtension(pickerResponse.fileName ? pickerResponse.fileName : localFilePath));
+		resource.title = pickerResponse.name ? pickerResponse.name : '';
+		resource.file_extension = safeFileExtension(fileExtension(pickerResponse.name ? pickerResponse.name : localFilePath));
 
 		if (!resource.mime) resource.mime = 'application/octet-stream';
 


### PR DESCRIPTION
The PickerResponse object does not have a `fileName` field ([see the doc](https://github.com/rnmods/react-native-document-picker#result)) so an attached resource may end up with an empty title and a broken extension on Android where the url might look like `content://com.android.providers.downloads.documents/document/123`