### PR TITLE
follow-up to commit 0f23277

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -78,7 +78,7 @@ const commands = [
 	require('./gui/NoteEditor/commands/showRevisions'),
 	require('./gui/NoteList/commands/focusElementNoteList'),
 	require('./gui/NoteListControls/commands/focusSearch'),
-	require('./gui/SideBar/commands/focusElementSideBar'),
+	require('./gui/Sidebar/commands/focusElementSideBar'),
 ];
 
 // Commands that are not tied to any particular component.


### PR DESCRIPTION
There was one oversight during the path changes. In `app.js` the require should be:

require('./gui/Sidebar/commands/focusElementSideBar'),
