### PR TITLE
Server: fix Docker build

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -20,8 +20,8 @@ RUN mkdir /home/$user/logs
 # and build TypeScript files, but we don't have the TypeScript files at
 # this point)
 
-RUN npm install --ignore-scripts
 COPY --chown=$user:$user package*.json ./
+RUN npm install --ignore-scripts
 
 # To take advantage of the Docker cache, we first copy all the package.json
 # and package-lock.json files, as they rarely change, and then bootstrap


### PR DESCRIPTION
With the change in this file, the build is currently failing with the following:

```
Step 20/31 : COPY --chown=$user:$user packages/fork-htmlparser2 ./packages/fork-htmlparser2
 ---> Using cache
 ---> 27c3a2786a88
Step 21/31 : RUN npm run bootstrap
 ---> Running in 57794bc04013

> root@ bootstrap /home/joplin
> lerna bootstrap --no-ci

sh: 1: lerna: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! root@ bootstrap: `lerna bootstrap --no-ci`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the root@ bootstrap script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/joplin/.npm/_logs/2021-01-17T13_28_08_331Z-debug.log
The command '/bin/sh -c npm run bootstrap' returned a non-zero code: 1
```

Swapping around the COPY and RUN commands fixes this issue.