### PR TITLE
Workarounds for Linux build errors

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,7 +24,7 @@ There are also a few forks of existing packages under the "fork-*" name.
 - macOS, Linux: Install rsync - https://nodejs.org/en/
 - macOS: Install Cocoapods - `brew install cocoapods`
 - Windows: Install Windows Build Tools - `npm install -g windows-build-tools`
-- Linux: Install dependencies - `sudo apt install libnss3 libsecret-1-dev`
+- Linux: Install dependencies - `sudo apt install libnss3 libsecret-1-dev python`
 
 ## Building
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 ## Required dependencies
 
-- Install node 10+ (but not node 15) - https://nodejs.org/en/
+- Install node 10+ - https://nodejs.org/en/
 - macOS, Linux: Install rsync - https://nodejs.org/en/
 - macOS: Install Cocoapods - `brew install cocoapods`
 - Windows: Install Windows Build Tools - `npm install -g windows-build-tools`

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 ## Required dependencies
 
-- Install node 10+ - https://nodejs.org/en/
+- Install node 10+ (but not node 15) - https://nodejs.org/en/
 - macOS, Linux: Install rsync - https://nodejs.org/en/
 - macOS: Install Cocoapods - `brew install cocoapods`
 - Windows: Install Windows Build Tools - `npm install -g windows-build-tools`

--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -19,6 +19,19 @@ If there's an error `while loading shared libraries: libgconf-2.so.4: cannot ope
 
 If you get a node-gyp related error, you might need to manually install it: `npm install -g node-gyp`.
 
+If you get unexpected `npm` dependency errors on a fresh git pull, try the following:
+- Delete the entire contents of the directory where you've cloned the Joplin repository
+- Run `git reset -hard`
+- Try `npm i` again.
+
+
+If `npm i` gives you something like the following:
+```
+node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.1/napi-v6-linux-x64.tar.gz 
+node-pre-gyp WARN Pre-built binaries not found for sqlite3@5.0.1 and node@14.15.4 (node-v83 ABI, glibc) (falling back to source compile with node-gyp)
+```
+Try `sudo apt install python` (or the `apt` equivalent for your operating system) and then run `npm i` again.
+
 If you get the error `libtool: unrecognized option '-static'`, follow the instructions [in this post](https://stackoverflow.com/a/38552393/561309) to use the correct libtool version.
 
 ## Other issues

--- a/readme/build_troubleshooting.md
+++ b/readme/build_troubleshooting.md
@@ -19,16 +19,13 @@ If there's an error `while loading shared libraries: libgconf-2.so.4: cannot ope
 
 If you get a node-gyp related error, you might need to manually install it: `npm install -g node-gyp`.
 
-If you get unexpected `npm` dependency errors on a fresh git pull, try the following:
-- Delete the entire contents of the directory where you've cloned the Joplin repository
-- Run `git reset -hard`
-- Try `npm i` again.
+If you get unexpected `npm` dependency errors on a fresh git pull, try `npm run clean`
 
-
-If `npm i` gives you something like the following:
+If `npm i` gives you a fatal error like the following:
 ```
 node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v5.0.1/napi-v6-linux-x64.tar.gz 
 node-pre-gyp WARN Pre-built binaries not found for sqlite3@5.0.1 and node@14.15.4 (node-v83 ABI, glibc) (falling back to source compile with node-gyp)
+/bin/sh: 1: python: not found
 ```
 Try `sudo apt install python` (or the `apt` equivalent for your operating system) and then run `npm i` again.
 


### PR DESCRIPTION
Added workarounds for the build issues I experienced several days back:
- `node-pre-gyp` sometimes calls an invalid URL and needs Python to build `node-sqlite3` from source
- `npm install` can be extremely fussy. `npm cache clean --force` doesn't help, so just nuking the directory and rebuilding it can make `npm` behave. (`npm rebuild` may be another alternative.)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
