### PR TITLE
Desktop: Fixes #4470: Tab will indent non-empty list items

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
@@ -77,7 +77,7 @@ export default function useListIdent(CodeMirror: any) {
 					// this is an edge case for users because there is no clear intended behavior
 					// if the use multicursor with a mix of selected and not selected
 					break;
-				} else if (!markdownUtils.isListItem(line) || !markdownUtils.isEmptyListItem(line)) {
+				} else if (!markdownUtils.isListItem(line)) {
 					cm.replaceRange('\t', anchor, head);
 				} else {
 					if (markdownUtils.olLineNumber(line)) {
@@ -111,7 +111,7 @@ export default function useListIdent(CodeMirror: any) {
 					// this is an edge case for users because there is no clear intended behavior
 					// if the use multicursor with a mix of selected and not selected
 					break;
-				} else if (!markdownUtils.isListItem(line) || !markdownUtils.isEmptyListItem(line)) {
+				} else if (!markdownUtils.isListItem(line)) {
 					cm.indentLine(anchor.line, 'subtract');
 				} else {
 					const newToken = newListToken(cm, anchor.line);


### PR DESCRIPTION
Fixes #4470. There's just a bug in the condition checked for list items. I think

`!markdownUtils.isListItem(line) || !markdownUtils.isEmptyListItem(line)`

in useListIdent.ts was supposed to be

`!markdownUtils.isListItem(line) && !markdownUtils.isEmptyListItem(line)`.

Note that by definition (in [packages/lib/markdownUtils.ts](https://github.com/laurent22/joplin/blob/dev/packages/lib/markdownUtils.ts)) an `EmptyListItem` **is a** `ListItem`, so checking both is actually redundant anyway.