### PR TITLE
Mobile: Change the rotation direction of the sync icon on mobile

### DIFF
--- a/packages/app-mobile/components/side-menu-content.js
+++ b/packages/app-mobile/components/side-menu-content.js
@@ -30,7 +30,7 @@ class SideMenuContentComponent extends Component {
 		this.syncIconRotationValue = new Animated.Value(0);
 		this.syncIconRotation = this.syncIconRotationValue.interpolate({
 			inputRange: [0, 1],
-			outputRange: ['360deg', '0deg'],
+			outputRange: ['0deg', '360deg'],
 		});
 	}
 


### PR DESCRIPTION
I noticed that on my iPhone the Sync icon spins the opposite direction as it does on my desktop. 

This code is untested because I downloaded joplin source and I can run it in my Xcode BUT:

- I cannot get the sync icon to rotate in the simulator even with a successful WebDAV sync target
- I cannot figure out how to get app changes to reload in Xcode (tried to just remove the icon to test that and it didn't work) EDIT: eventually got this working by runing the simulator, and editing the files while the sim was running. 
- I could not figure out how to get the code from dev -> prod (I wondered if somehow the animation was tied to that) EDIT: I tried this, but got hung up on an arch problem and decided that I wasn't gonna push further.

If anyone has guidance on the above, I'm happy to contribute docs fixes to help make it clearer to others who might want to contribute.

----
If this ordering doesn't work, I suspect that It may need a -360deg.

Hoping that someone with a proper test env and more experience can validate this and merge it as it should be really simple :)
