### PR TITLE
Desktop: Resolves #2810, Ctrl+Shift+B focuses on viewer when editor is not visible

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -141,7 +141,11 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 						reg.logger().warn('CodeMirror: unsupported drop item: ', cmd);
 					}
 				} else if (cmd.name === 'editor.focus') {
-					editorRef.current.focus();
+					if (props.visiblePanes.indexOf('editor') >= 0) {
+						editorRef.current.focus();
+					} else {
+						webviewRef.current.wrappedInstance.focus();
+					}
 				} else {
 					commandProcessed = false;
 				}
@@ -242,7 +246,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				return commandOutput;
 			},
 		};
-	}, [props.content, addListItem, wrapSelectionWithStrings, setEditorPercentScroll, setViewerPercentScroll, resetScroll, renderedBody]);
+	}, [props.content, props.visiblePanes, addListItem, wrapSelectionWithStrings, setEditorPercentScroll, setViewerPercentScroll, resetScroll, renderedBody]);
 
 	const onEditorPaste = useCallback(async (event: any = null) => {
 		const resourceMds = await handlePasteEvent(event);

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -114,6 +114,12 @@ class NoteTextViewerComponent extends React.Component<Props, any> {
 		this.domReady_ = false;
 	}
 
+	focus() {
+		if (this.webviewRef_.current) {
+			this.webviewRef_.current.focus();
+		}
+	}
+
 	tryInit() {
 		if (!this.initialized_ && this.webviewRef_.current) {
 			this.initWebview();


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/2810

Am familiarizing myself with the Joplin codebase and thought of this simple fix for the linked issue. It doesn't seem as if anyone is working on the issue at the moment, so I decided to submit a PR. Apologies if this PR is stepping on anyone's toes.

Decided to make the change where the editor handles the `"editor.focus"` command - every other approach seemed like it would require a lot more code.

I only pushed the fix to the `CodeMirror` component because I read on some other issues that Joplin isn't using the other editors.

Here is a short GIF displaying the behaviour from this PR:
![joplin-ctrl-shift-b](https://user-images.githubusercontent.com/8016073/107897678-91a95e80-6eee-11eb-8a7e-8aed1f376135.gif)
