### PR TITLE
Reset window hash to allowing clicking an anchor link more than once

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -395,6 +395,16 @@
 			}
 		}
 
+		window.addEventListener('hashchange', webviewLib.logEnabledEventHandler(e => {
+			if (!window.location.hash) return;
+
+			// The timeout is necessary to prevent a race condition and give time for the window to scroll
+			setTimeout(() => {
+				// Reset the window hash to allow clicking on the same anchor link more than once
+				window.location.hash = '';
+			}, 100);
+		}));
+
 		document.addEventListener('contextmenu', webviewLib.logEnabledEventHandler(event => {
 			let element = event.target;
 


### PR DESCRIPTION
This fixes a bug that has been reported on the forum a few times. [This is one example](https://discourse.joplinapp.org/t/a-markdown-outline-sidebar-plugin-for-joplin/13364/60?u=calebjohn) that I think will be fixed by this PR. I know there are others, but I can't find them.

To test this, create an anchor link that will jump you somewhere else in the note. Click on it, then scroll back to the link. Clicking again will do nothing before this pull, and will correctly jump after.