### PR TITLE
Mobile: Fix incorrect field name when attaching a resource from share

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.js
+++ b/packages/lib/components/shared/note-screen-shared.js
@@ -232,7 +232,7 @@ shared.initState = async function(comp) {
 				await comp.attachFile({
 					uri: resource.uri,
 					type: resource.mimeType,
-					fileName: resource.name,
+					name: resource.name,
 				}, null);
 			}
 		}


### PR DESCRIPTION
I have changed the field name used when attaching files previously here: https://github.com/laurent22/joplin/pull/4373.

But I forgot that the same code is used for sharing:
https://github.com/laurent22/joplin/blob/a6b866cbe1362e0a6254774aec398c149592826c/packages/lib/components/shared/note-screen-shared.js#L232-L237

So the above PR fixed attaching files but broke sharing. This PR fixes that.