### PR TITLE
Mobile: Resolves #1141: Create / move sub notebook

### DIFF
--- a/packages/app-mobile/components/action-button.js
+++ b/packages/app-mobile/components/action-button.js
@@ -58,6 +58,15 @@ class ActionButtonComponent extends React.Component {
 		this.newNoteNavigate(this.props.parentFolderId, false);
 	}
 
+	newFolder_press() {
+		this.props.dispatch({
+			type: 'NAV_GO',
+			routeName: 'Folder',
+			folderId: null,
+			parent_id: this.props.parentFolderId,
+		});
+	}
+
 	renderIconMultiStates() {
 		const button = this.props.buttons[this.state.buttonIndex];
 		return <Icon name={button.icon} style={styles.actionButtonIcon} />;
@@ -73,6 +82,15 @@ class ActionButtonComponent extends React.Component {
 
 		if (this.props.addFolderNoteButtons) {
 			if (this.props.folders.length) {
+				buttons.push({
+					title: _('New notebook'),
+					onPress: () => {
+						this.newFolder_press();
+					},
+					color: '#9b59b6',
+					icon: 'md-folder-open',
+				});
+
 				buttons.push({
 					title: _('New to-do'),
 					onPress: () => {

--- a/packages/app-mobile/components/screens/folder.js
+++ b/packages/app-mobile/components/screens/folder.js
@@ -45,6 +45,9 @@ class FolderScreenComponent extends BaseScreenComponent {
 	UNSAFE_componentWillMount() {
 		if (!this.props.folderId) {
 			const folder = Folder.new();
+			if (this.props.parent_id) {
+				folder.parent_id = this.props.parent_id;
+			}
 			this.setState({
 				folder: folder,
 				lastSavedFolder: Object.assign({}, folder),
@@ -80,7 +83,6 @@ class FolderScreenComponent extends BaseScreenComponent {
 
 	async saveFolderButton_press() {
 		let folder = Object.assign({}, this.state.folder);
-
 		try {
 			folder = await Folder.save(folder, { userSideValidation: true });
 		} catch (error) {
@@ -122,6 +124,7 @@ const FolderScreen = connect(state => {
 	return {
 		folderId: state.selectedFolderId,
 		themeId: state.settings.theme,
+		parent_id: state.parent_id,
 	};
 })(FolderScreenComponent);
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -228,11 +228,11 @@ const appReducer = (state = appDefaultState, action: any) => {
 				const currentRoute = state.route;
 
 				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
-				// If the route *name* is the same (even if the other parameters are different), we
-				// overwrite the last route in the history with the current one. If the route name
-				// is different, we push a new history entry.
+					// If the route *name* is the same (even if the other parameters are different), we
+					// overwrite the last route in the history with the current one. If the route name
+					// is different, we push a new history entry.
 					if (currentRoute.routeName == action.routeName) {
-					// nothing
+						// nothing
 					} else {
 						navHistory.push(currentRoute);
 					}
@@ -262,6 +262,7 @@ const appReducer = (state = appDefaultState, action: any) => {
 				if ('folderId' in action) {
 					newState.selectedFolderId = action.folderId;
 					newState.notesParentType = 'Folder';
+					newState.parent_id = action.parent_id;
 				}
 
 				if ('tagId' in action) {
@@ -759,30 +760,31 @@ class AppComponent extends React.Component {
 
 		return (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
-				<SideMenu
-					menu={sideMenuContent}
-					edgeHitWidth={5}
-					menuPosition={menuPosition}
-					onChange={(isOpen: boolean) => this.sideMenu_change(isOpen)}
-					onSliding={(percent: number) => {
-						this.props.dispatch({
-							type: 'SIDE_MENU_OPEN_PERCENT',
-							value: percent,
-						});
-					}}
-				>
-					<StatusBar barStyle={statusBarStyle} />
-					<MenuContext style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
+				<MenuContext style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
+					<SideMenu
+						menu={sideMenuContent}
+						edgeHitWidth={5}
+						menuPosition={menuPosition}
+						onChange={(isOpen: boolean) => this.sideMenu_change(isOpen)}
+						onSliding={(percent: number) => {
+							this.props.dispatch({
+								type: 'SIDE_MENU_OPEN_PERCENT',
+								value: percent,
+							});
+						}}
+					>
+						<StatusBar barStyle={statusBarStyle} />
+
 						<SafeAreaView style={{ flex: 1 }}>
 							<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 								<AppNav screens={appNavInit} />
 							</View>
 							<DropdownAlert ref={(ref: any) => this.dropdownAlert_ = ref} tapToCloseEnabled={true} />
-							<Animated.View pointerEvents='none' style={{ position: 'absolute', backgroundColor: 'black', opacity: this.state.sideMenuContentOpacity, width: '100%', height: '120%' }}/>
+							<Animated.View pointerEvents='none' style={{ position: 'absolute', backgroundColor: 'black', opacity: this.state.sideMenuContentOpacity, width: '100%', height: '120%' }} />
 						</SafeAreaView>
-					</MenuContext>
-				</SideMenu>
-			</View>
+					</SideMenu>
+				</MenuContext>
+			</View >
 		);
 	}
 }


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Related to https://github.com/laurent22/joplin/pull/1141. Started from scratch as it should be easier than merging from 3000 commits behind.

Folder move is done in the side menu directly instead of re-using `Dropdown` for following reasons:
- Other folder operations such as rename and delete are also done there
- The dropdown could be confusing whether it is moving a folder or note

Move mode screen:
![image](https://user-images.githubusercontent.com/32349750/108593285-3081ff00-73b6-11eb-95ed-5784bdaaf36e.png)

I also have to change the folder long press action to show a context menu as `Alert` could not show more than 3 buttons.

Any comments or advice are welcomed. Hope I didn't break any rules.  
