### PR TITLE
All: Refresh tags when a note is moved to another folder and a new one is se…

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -107,7 +107,7 @@ function NoteEditor(props: NoteEditorProps) {
 			return async function() {
 				const note = await formNoteToNote(formNote);
 				reg.logger().debug('Saving note...', note);
-				const savedNote: any = await Note.save(note);
+				const savedNote: any = await Note.save(note, { dispatchUpdateAction: false });
 
 				setFormNote((prev: FormNote) => {
 					return { ...prev, user_updated_time: savedNote.user_updated_time };

--- a/packages/lib/components/shared/reduxSharedMiddleware.js
+++ b/packages/lib/components/shared/reduxSharedMiddleware.js
@@ -43,11 +43,8 @@ const reduxSharedMiddleware = async function(store, next, action) {
 		DecryptionWorker.instance().scheduleStart();
 	}
 
-	// 2020-10-19: Removed "NOTE_UPDATE_ONE" because there's no property in a note that
-	// should trigger a refreshing of the tags.
-	// Trying to fix this: https://github.com/laurent22/joplin/issues/3893
 	if (action.type == 'NOTE_DELETE' ||
-		// action.type == 'NOTE_UPDATE_ONE' ||
+		action.type == 'NOTE_UPDATE_ONE' ||
 		action.type == 'NOTE_UPDATE_ALL' ||
 		action.type == 'NOTE_TAG_REMOVE' ||
 		action.type == 'TAG_UPDATE_ONE') {


### PR DESCRIPTION
…lected instead.

I have checked that there's no input lag with this change, though to be fair I have not seen any lag even if I removed `dispatchUpdateAction`

Fixes #4369 & #4128