### PR TITLE
Desktop: Resolves #4554: Improve mathmode syntax highlighting

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -21,7 +21,7 @@ export default function useJoplinMode(CodeMirror: any) {
 		const stex = CodeMirror.getMode(config, { name: 'stex', inMathMode: true });
 
 		const inlineKatexOpenRE = /(?<!\S)\$(?=[^\s$].*?[^\\\s$]\$(?!\S))/;
-		const inlineKatexCloseRE = /(?<![\\\s$])\$(?!\S)/;
+		const inlineKatexCloseRE = /(?<![\\\s$])\$(?![^\s!"#%&'()*+,\-.:;<=>?@[\]^_`{|}~])/;
 		const blockKatexOpenRE = /(?<!\S)\$\$/;
 		const blockKatexCloseRE = /(?<![\\\s])\$\$/;
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -20,7 +20,7 @@ export default function useJoplinMode(CodeMirror: any) {
 		const markdownMode = CodeMirror.getMode(config, markdownConfig);
 		const stex = CodeMirror.getMode(config, { name: 'stex', inMathMode: true });
 
-		const inlineKatexOpenRE = /(?<!\S)\$(?=[^\s$].*?[^\\\s$]\$(?!\S))/;
+		const inlineKatexOpenRE = /(?<!\S)\$(?=[^\s$].*?[^\\\s$]\$(?![^\s!"#%&'()*+,\-.:;<=>?@[\]^_`{|}~]))/;
 		const inlineKatexCloseRE = /(?<![\\\s$])\$(?![^\s!"#%&'()*+,\-.:;<=>?@[\]^_`{|}~])/;
 		const blockKatexOpenRE = /(?<!\S)\$\$/;
 		const blockKatexCloseRE = /(?<![\\\s])\$\$/;


### PR DESCRIPTION
- Make closing `$` regex tolerant to punctuation characters directly after `$`

Closes #4554 
