### PR TITLE
Select search text input when focusing it

### DIFF
--- a/packages/app-desktop/gui/NoteSearchBar.jsx
+++ b/packages/app-desktop/gui/NoteSearchBar.jsx
@@ -111,6 +111,7 @@ class NoteSearchBarComponent extends React.Component {
 
 	focus() {
 		this.refs.searchInput.focus();
+		this.refs.searchInput.select();
 	}
 
 	render() {


### PR DESCRIPTION
It has been for a while a cumbersome task of mine to clear the search text area when focusing it (i.e., `⌘F`). This aims to fix that. It only applies to the Desktop app. I have not found any open issue for it. Perhaps I was looking at the wrong place, but I have not found any tests for this GUI part.

I've made two small videos showing the change.

Before 👇 

https://user-images.githubusercontent.com/9095073/108766397-06af1080-754d-11eb-830a-5802726f2ba9.mov

After 👇 

https://user-images.githubusercontent.com/9095073/108766417-0c0c5b00-754d-11eb-9862-628e3adba4e2.mov