### PR TITLE
Mobile: Upgrade react-native-share

### DIFF
--- a/packages/app-mobile/package-lock.json
+++ b/packages/app-mobile/package-lock.json
@@ -7308,9 +7308,9 @@
       }
     },
     "react-native-share": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-4.0.2.tgz",
-      "integrity": "sha512-2dbeyBx8bQoOu0V2fsj3xNv3Mta9KwGRUT/Yvb+SBRtwX3YSwYC65DqRPk1L1CeO7ABxiXZaEaL1MM7LIDuGSA=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-5.1.3.tgz",
+      "integrity": "sha512-d61vVz3B3qjltnC9QBOdvbOvEEIogpYtZ5LeGJ/f+Kqeu70DUoilVJ80MMzqKBcfPlJM6GPq3YyyF0qLNJ0G3w=="
     },
     "react-native-side-menu": {
       "version": "1.1.3",

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -43,7 +43,7 @@
     "react-native-popup-menu": "^0.10.0",
     "react-native-quick-actions": "^0.3.13",
     "react-native-securerandom": "^1.0.0-rc.0",
-    "react-native-share": "^4.0.2",
+    "react-native-share": "^5.1.3",
     "react-native-side-menu": "^1.1.3",
     "react-native-sqlite-storage": "^5.0.0",
     "react-native-vector-icons": "^7.1.0",


### PR DESCRIPTION
I have made a change in `react-native-share` https://github.com/react-native-share/react-native-share/pull/968. This PR is to use this change for Joplin.

This may help with sharing attachments from Joplin to other apps on Android 11. I say "may" because in my tests with emulator it resolved issues with sharing to some apps, but there was at least one app for which this change made no apparent difference.
Might be that the target needs to support Android 11 too.