### PR TITLE
Android: Set min android version to 5 / sdk 21

### DIFF
--- a/packages/app-mobile/android/build.gradle
+++ b/packages/app-mobile/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }


### PR DESCRIPTION
As per https://github.com/facebook/react-native#-requirements

> React Native apps may target iOS 11.0 and Android 5.0 (API 21) or newer

Resolves https://github.com/laurent22/joplin/issues/4585