### PR TITLE
Android quick actions fix

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -27,7 +27,7 @@ import { setLocale, closestSupportedLocale, defaultLocale } from '@joplin/lib/lo
 import SyncTargetJoplinServer from '@joplin/lib/SyncTargetJoplinServer';
 import SyncTargetOneDrive from '@joplin/lib/SyncTargetOneDrive';
 
-const { AppState, Keyboard, NativeModules, BackHandler, Animated, View, StatusBar } = require('react-native');
+const { AppState, Keyboard, NativeModules, BackHandler, Animated, View, StatusBar, Platform } = require('react-native');
 
 const DropdownAlert = require('react-native-dropdownalert').default;
 const AlarmServiceDriver = require('./services/AlarmServiceDriver').default;
@@ -557,7 +557,9 @@ async function initialize(dispatch: Function) {
 			});
 		}
 
-		setUpQuickActions(dispatch, folderId);
+		if (Platform.OS === 'ios') {
+			setUpQuickActions(dispatch, folderId);
+		}
 	} catch (error) {
 		alert(`Initialization error: ${error.message}`);
 		reg.logger().error('Initialization error:', error);
@@ -674,6 +676,10 @@ class AppComponent extends React.Component {
 			} else {
 				reg.logger().info('Cannot handle share - default folder id is not set');
 			}
+		}
+
+		if (Platform.OS === 'android') {
+			setUpQuickActions(this.props.dispatch, this.props.selectedFolderId);
 		}
 	}
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -27,7 +27,7 @@ import { setLocale, closestSupportedLocale, defaultLocale } from '@joplin/lib/lo
 import SyncTargetJoplinServer from '@joplin/lib/SyncTargetJoplinServer';
 import SyncTargetOneDrive from '@joplin/lib/SyncTargetOneDrive';
 
-const { AppState, Keyboard, NativeModules, BackHandler, Animated, View, StatusBar, Platform } = require('react-native');
+const { AppState, Keyboard, NativeModules, BackHandler, Animated, View, StatusBar } = require('react-native');
 
 const DropdownAlert = require('react-native-dropdownalert').default;
 const AlarmServiceDriver = require('./services/AlarmServiceDriver').default;
@@ -556,10 +556,6 @@ async function initialize(dispatch: Function) {
 				folderId: folder.id,
 			});
 		}
-
-		if (Platform.OS === 'ios') {
-			setUpQuickActions(dispatch, folderId);
-		}
 	} catch (error) {
 		alert(`Initialization error: ${error.message}`);
 		reg.logger().error('Initialization error:', error);
@@ -678,9 +674,7 @@ class AppComponent extends React.Component {
 			}
 		}
 
-		if (Platform.OS === 'android') {
-			setUpQuickActions(this.props.dispatch, this.props.selectedFolderId);
-		}
+		setUpQuickActions(this.props.dispatch, this.props.selectedFolderId);
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
The issue was reported on the forum here https://discourse.joplinapp.org/t/items-shared-to-android-not-saved/12321/17

When the app is in the background and the user triggers a quick action, in some cases the listener that is set here
https://github.com/laurent22/joplin/blob/ccbc329cbf806e9b6db6d37f8c837629ee6c3a60/packages/app-mobile/setUpQuickActions.ts#L52

is not being called. I suspect that Android creates a new activity but then react-native attaches the existing JS context to it, but this is just a guess. In any case moving quick actions set up to `componentDidMount` fixes it as this method is always called.

For iOS I left everything as it was, since I have no way to ensure this change does not break anything there.