### PR TITLE
Mobile: fix items shared to android not saved

### DIFF
--- a/packages/app-mobile/components/screens/notes.js
+++ b/packages/app-mobile/components/screens/notes.js
@@ -98,9 +98,9 @@ class NotesScreenComponent extends BaseScreenComponent {
 	}
 
 	async componentDidMount() {
+		BackButtonService.addHandler(this.backHandler);
 		await this.refreshNotes();
 		AppState.addEventListener('change', this.onAppStateChange_);
-		BackButtonService.addHandler(this.backHandler);
 	}
 
 	async componentWillUnmount() {


### PR DESCRIPTION
Reported on the forum https://discourse.joplinapp.org/t/items-shared-to-android-not-saved/12321/41

I have added some extra logging and found that a shared note was not saved because NoteScreenComponent's back handler was not called, and this is where the note is saved.

Instead I saw that Note**s**ScreenComponent's back handler was being called because it was registered later.

I think this is what's happening:
* NotesScreenComponents mounts, the execution gets to
```
await this.refreshNotes();
```
and suspends
* Then shareHandler starts and opens a new note screen, NoteScreenComponent mounts and its back handler is registered
* Eventually the execution of `NotesScreenComponent.componenDidMount` from step 1 is resumed and its back handler is registered last.
* Now when the user goes back the wrong handler is called and the note is not saved.

The fix is very simple -- just add the handler as soon as notes screen mounts.