### PR TITLE
Linux Install: SUID sandbox helper install patch

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -160,8 +160,19 @@ else
 fi
 DESKTOP=${DESKTOP,,}  # convert to lower case
 
+# Detect distribution environment
+DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
 #-----------------------------------------------------
 echo 'Create Desktop icon...'
+# Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
+# It is present in Debian 10 Buster. A (temporary) patch will be applied at .desktop file
+if [ "$DISTVER" = "Debian10" ]
+then
+  SANDBOXPARAM=" --no-sandbox"
+else
+  SANDBOXPARAM=""
+fi
+
 # Initially only desktop environments that were confirmed to use desktop files stored in
 # `.local/share/desktop` had a desktop file created.
 # However some environments don't return a desktop BUT still support these desktop files
@@ -177,7 +188,7 @@ then
 
     # On some systems this directory doesn't exist by default
     mkdir -p ~/.local/share/applications
-    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;" >> ~/.local/share/applications/appimagekit-joplin.desktop
+    echo -e "[Desktop Entry]\nEncoding=UTF-8\nName=Joplin\nComment=Joplin for Desktop\nExec=${HOME}/.joplin/Joplin.AppImage${SANDBOXPARAM}\nIcon=joplin\nStartupWMClass=Joplin\nType=Application\nCategories=Office;" >> ~/.local/share/applications/appimagekit-joplin.desktop
     # Update application icons
     [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications && update-desktop-database ~/.local/share/icons
     print "${COLOR_GREEN}OK${COLOR_RESET}"


### PR DESCRIPTION
Electron framework has a problem due to kernel params in Debian 10 Buster.
This is a (temporary (I hope)) patch to disable sandboxing in the .desktop file for that distro.