### PR TITLE
Desktop: Speed up WebDAV/Nextcloud sync by ~30% (or even more)

### DIFF
--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -481,7 +481,7 @@ function shimInit(sharp = null, keytar = null, React = null) {
 	shim.httpAgent_ = null;
 
 	shim.httpAgent = url => {
-		if (shim.isLinux() && !shim.httpAgent) {
+		if (shim.isLinux() && !shim.httpAgent_) {
 			const AgentSettings = {
 				keepAlive: true,
 				maxSockets: 1,


### PR DESCRIPTION
(Sorry for the catchy title, couldn't help myself.)

Due to a typo Keep-Alive wasn't sent so each time http connection has to be re-established from scratch).
I have tested this with a server in my local network using plain http and got these results:
* Before the change
```
21:10:38: CommandService::execute: synchronize false
...
21:13:34: Sync: finished: Synchronisation finished [1614978638697]
```
almost exactly 3 minutes

* After the change
```
21:21:15: CommandService::execute: synchronize false
...
21:23:19: Sync: finished: Synchronisation finished [1614979275473]
```
~2 minutes, so 30% speedup. For https I expect the effect would be even greater. Not too bad for a one-symbol change.

Total synced volume was 188,621,312 bytes, items:
```
main-html.js:48 21:23:19: Operations completed: 
main-html.js:48 21:23:19: createRemote: 1264
main-html.js:48 21:23:19: fetchingTotal: 1265
main-html.js:48 21:23:19: fetchingProcessed: 1265
main-html.js:48 21:23:19: Total folders: 27
main-html.js:48 21:23:19: Total notes: 850
main-html.js:48 21:23:19: Total resources: 187
```

PS
Why is Linux-only? And why is httpAgent only used for WebDAV?