### PR TITLE
Server: avoid new user's password to be hashed twice

### DIFF
--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -105,7 +105,7 @@ export default class UserModel extends BaseModel<User> {
 
 		let newUser = { ...object };
 
-		if (isNew && newUser.password) newUser.password = auth.hashPassword(newUser.password);
+		if (newUser.password) newUser.password = auth.hashPassword(newUser.password);
 
 		await this.withTransaction(async () => {
 			newUser = await super.save(newUser, options);

--- a/packages/server/src/routes/index/users.ts
+++ b/packages/server/src/routes/index/users.ts
@@ -7,7 +7,6 @@ import { User } from '../../db';
 import config from '../../config';
 import { View } from '../../services/MustacheService';
 import defaultView from '../../utils/defaultView';
-import { hashPassword } from '../../utils/auth';
 
 function makeUser(isNew: boolean, fields: any): User {
 	const user: User = {};
@@ -17,7 +16,7 @@ function makeUser(isNew: boolean, fields: any): User {
 
 	if (fields.password) {
 		if (fields.password !== fields.password2) throw new ErrorUnprocessableEntity('Passwords do not match');
-		user.password = hashPassword(fields.password);
+		user.password = fields.password;
 	}
 
 	if (!isNew) user.id = fields.id;


### PR DESCRIPTION
- Issues related: n/a

`joplin-server`, built with current source code, doesn't let us log in a newly-created user, providing error message `Invalid username or password`. This is certainly due to mis-matching of the hashes of the user password.

When adding an user through Admin UI, the password will get hashed unexpectedly *twice* before registering, first in `makeUser` function `src/routes/index/user.ts`, second in `UserModel.save()` function in `src/models/UserModel.ts`, that causes mis-matching of the hashes as I mentioned above.

~So, I fixed a conditional expression in the latter function which I thought is wrong.~

~As a result of a little closer inspect, the code I submitted first was totally meaningless, so I removed the entire line.~

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
