### PR TITLE
Mobile: Fixes #4450: Background flashes white when opening notes in the iOS app

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 
 import Setting from '@joplin/lib/models/Setting';
 import useSource from './hooks/useSource';
@@ -27,12 +27,12 @@ interface Props {
 	onLoadEnd?: Function;
 }
 
+const webViewStyle = {
+	backgroundColor: 'transparent',
+};
+
 export default function NoteBodyViewer(props: Props) {
 	const theme = themeStyle(props.themeId);
-
-	const webViewStyle: any = useMemo(() => {
-		return { backgroundColor: theme.backgroundColor };
-	}, [theme.backgroundColor]);
 
 	const dialogBoxRef = useRef(null);
 


### PR DESCRIPTION
Suggesting a fix for the the flashes of white occurring when opening notes on mobile, most visible with dark themes.

Tested on iOS.

This PR does not target desktop which also received two valuable reports as comments to the ticket:
- [OS X](https://github.com/laurent22/joplin/issues/4450#issuecomment-780287026) by @Jegber
- [Windows](https://github.com/laurent22/joplin/issues/4450#issuecomment-787198109) by @jleighton
