### PR TITLE
Toggle math highlighting in editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -68,7 +68,7 @@ export default function useJoplinMode(CodeMirror: any) {
 
 					if (state.openCharacter === '$$' && blockPos !== -1) nextTokenPos = blockPos;
 					if (state.openCharacter === '$' && inlinePos !== -1) nextTokenPos = inlinePos;
-				} else if (!currentState.code) {
+				} else if (!currentState.code && Setting.value('markdown.plugin.katex')) {
 					const blockPos = findToken(stream, blockKatexOpenRE);
 					const inlinePos = findToken(stream, inlineKatexOpenRE);
 


### PR DESCRIPTION
This disables math highlighting when katex rendering is turned off.

I intend to make a few more changes to the markdown parser here but I'm just getting re-acquainted with it now.