### PR TITLE
Bring editor katex highlight in line with renderer

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -20,8 +20,8 @@ export default function useJoplinMode(CodeMirror: any) {
 		const markdownMode = CodeMirror.getMode(config, markdownConfig);
 		const stex = CodeMirror.getMode(config, { name: 'stex', inMathMode: true });
 
-		const inlineKatexOpenRE = /(?<!\S)\$(?=[^\s$].*?[^\\\s$]\$(?![^\s!"#%&'()*+,\-.:;<=>?@[\]^_`{|}~]))/;
-		const inlineKatexCloseRE = /(?<![\\\s$])\$(?![^\s!"#%&'()*+,\-.:;<=>?@[\]^_`{|}~])/;
+		const inlineKatexOpenRE = /(?<!\\)\$(?=[^\s$].*?[^\\\s$]\$(?![0-9]))/;
+		const inlineKatexCloseRE = /(?<![\\\s$])\$(?![0-9])/;
 		const blockKatexOpenRE = /(?<!\S)\$\$/;
 		const blockKatexCloseRE = /(?<![\\\s])\$\$/;
 


### PR DESCRIPTION
Followup to #4554 

This makes the situational highlighting of inline katex identical to the renderer as far as I can tell.

I didn't change block highlighting because it's a bit tricky with the CodeMirror parser and users aren't likely to accidentally use semi-valid katex block syntax.