### PR TITLE
remove branch name in detached head state

### DIFF
--- a/packages/app-desktop/tools/compile-package-info.js
+++ b/packages/app-desktop/tools/compile-package-info.js
@@ -27,8 +27,7 @@ module.exports = async function() {
 		// Use stdio: 'pipe' so that execSync doesn't print error directly to stdout
 		branch = execSync('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }).toString().trim();
 		hash = execSync('git log --pretty="%h" -1', { stdio: 'pipe' }).toString().trim();
-		// The builds in CI are done from a 'detached HEAD' state
-		if (branch === 'HEAD') branch = 'dev';
+		// The builds in CI are done from a 'detached HEAD' state, thus the branch name will be 'HEAD' for Travis builds.
 	} catch (err) {
 		// Don't display error object as it's a "fatal" error, but
 		// not for us, since is it not critical information

--- a/packages/app-desktop/tools/compile-package-info.js
+++ b/packages/app-desktop/tools/compile-package-info.js
@@ -28,7 +28,7 @@ module.exports = async function() {
 		branch = execSync('git rev-parse --abbrev-ref HEAD', { stdio: 'pipe' }).toString().trim();
 		hash = execSync('git log --pretty="%h" -1', { stdio: 'pipe' }).toString().trim();
 		// The builds in CI are done from a 'detached HEAD' state
-		if (branch === 'HEAD') branch = 'master';
+		if (branch === 'HEAD') branch = 'dev';
 	} catch (err) {
 		// Don't display error object as it's a "fatal" error, but
 		// not for us, since is it not critical information

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -7,6 +7,7 @@ export default function versionInfo(packageInfo: any) {
 	let gitInfo = '';
 	if ('git' in p) {
 		gitInfo = _('Revision: %s (%s)', p.git.hash, p.git.branch);
+		if (p.git.branch === 'HEAD') gitInfo = gitInfo.slice(0, -7);
 	}
 	const copyrightText = 'Copyright © 2016-YYYY Laurent Cozic';
 	const now = new Date();


### PR DESCRIPTION
We are no longer building releases from master.
Travis CI runs from a detached HEAD state, which makes it impossible to tell the branch.

I still think that it is imoprtant to show the branch in the About window.
It helps narrowing down issues should people compile from their own branch and it helps developers to see on which branch they are running.

This change only changes the name of the branch to `dev` in a detached state.
