### PR TITLE
Removed the Menu tag.

### DIFF
--- a/docs/desktop/index.html
+++ b/docs/desktop/index.html
@@ -317,7 +317,7 @@ https://github.com/laurent22/joplin/blob/dev/readme/desktop.md
 		<ul>
 			<li class=""><a href="https:&#x2F;&#x2F;joplinapp.org/" title="Home"><i class="fa fa-home"></i></a></li>
 			<li><a href="https://discourse.joplinapp.org" title="Forum">Forum</a></li>
-			<li><a class="help" href="#" title="Menu">Menu</a></li>
+<!-- 			<li><a class="help" href="#" title="Menu">Menu</a></li> -->
 			<li><a class="gsoc" href="https://joplinapp.org/gsoc2021/index/" title="Google Summer of Code 2021">GSoC 2021</a></li>
 		</ul>
 		<div class="nav-right">


### PR DESCRIPTION
On the website the "menu" link in the top doesn't do anything, as the menu is made permanent, so commenting that will help!
resolves #4560

![image](https://user-images.githubusercontent.com/56785486/110790493-1a6dad00-8297-11eb-9485-f179e69d7b24.png)
 
