### PR TITLE
Desktop: Set keep-alive for WebDAV/Nextcloud sync

### DIFF
--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -481,7 +481,7 @@ function shimInit(sharp = null, keytar = null, React = null) {
 	shim.httpAgent_ = null;
 
 	shim.httpAgent = url => {
-		if (shim.isLinux() && !shim.httpAgent_) {
+		if (!shim.httpAgent_) {
 			const AgentSettings = {
 				keepAlive: true,
 				maxSockets: 1,

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -481,7 +481,7 @@ function shimInit(sharp = null, keytar = null, React = null) {
 	shim.httpAgent_ = null;
 
 	shim.httpAgent = url => {
-		if ((shim.isLinux() || shim.isWindows()) && !shim.httpAgent_) {
+		if (!shim.httpAgent_) {
 			const AgentSettings = {
 				keepAlive: true,
 				maxSockets: 1,

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -481,7 +481,7 @@ function shimInit(sharp = null, keytar = null, React = null) {
 	shim.httpAgent_ = null;
 
 	shim.httpAgent = url => {
-		if (!shim.httpAgent_) {
+		if ((shim.isLinux() || shim.isWindows()) && !shim.httpAgent_) {
 			const AgentSettings = {
 				keepAlive: true,
 				maxSockets: 1,


### PR DESCRIPTION
This is a follow up to https://github.com/laurent22/joplin/pull/4625

I ran a test on Windows 8:
* Version 1.7.11 - no Keep-Alive
```
22:56:40: Preparing scheduled sync
...
23:03:08: Operations completed:
```
~6.5 minutes

* Dev build with Keep-Alive
```
21:33:49: Preparing scheduled sync
...
21:37:13: Operations completed
```
~3 minutes

The sync was pretty fast as the server was on the same network and did not have https. As with Linux, I expect the difference to be much higher with https enabled.