### PR TITLE
Desktop: Fixes: #4612: Fix mermaid diagrams in WYSIWYG editor

### DIFF
--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -24,6 +24,10 @@ export default {
 			const token = tokens[idx];
 			if (token.info !== 'mermaid') return defaultRender(tokens, idx, options, env, self);
 			const contentHtml = markdownIt.utils.escapeHtml(token.content);
+			// Note: The mermaid script (`contentHtml`) needs to be wrapped
+			// in a `pre` tag, otherwise in WYSIWYG mode TinyMCE removes
+			// all the white space from it, which causes mermaid to fail.
+			// See PR #4670 https://github.com/laurent22/joplin/pull/4670
 			return `
 				<div class="joplin-editable">
 					<pre class="joplin-source" data-joplin-language="mermaid" data-joplin-source-open="\`\`\`mermaid&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${contentHtml}</pre>

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -27,7 +27,7 @@ export default {
 			return `
 				<div class="joplin-editable">
 					<pre class="joplin-source" data-joplin-language="mermaid" data-joplin-source-open="\`\`\`mermaid&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${contentHtml}</pre>
-					<div class="mermaid">${contentHtml}</div>
+					<pre class="mermaid">${contentHtml}</pre>
 				</div>
 			`;
 		};


### PR DESCRIPTION
The white space in the mermaid markup is removed during parsing by TinyMCE if it's not in one of [these](https://github.com/tinymce/tinymce/blob/ad61fbbe14ce58174ef7c8635c368696c61c18fd/modules/tinymce/src/core/main/ts/api/html/Schema.ts#L471) tags and that caused mermaid to throw a syntax error.

Simply changing the wrapper tag from `div` to `pre` preserves all the newlines, without affecting any other functionality.

Here's the split view (unchanged by this PR):
![split-view](https://user-images.githubusercontent.com/7415668/111182685-71cd8f00-85af-11eb-9f53-52e8380c806c.png)

Here's the broken WYSIWYG view:
![wysiwyg-broken](https://user-images.githubusercontent.com/7415668/111182679-709c6200-85af-11eb-887d-08b60f77e5de.png)

And here's the fixed diagram:
![wysiwyg-fixed](https://user-images.githubusercontent.com/7415668/111182682-7134f880-85af-11eb-982a-fd1ad978246e.png)

