### PR TITLE
Readme : GSOC 2021 : Project Ideas : Fixed a Typo in the Paste Special Section

### DIFF
--- a/readme/gsoc2021/ideas.md
+++ b/readme/gsoc2021/ideas.md
@@ -66,7 +66,7 @@ Potential Mentor(s): [PackElend](https://discourse.joplinapp.org/u/PackElend), [
 
 ## 5. Paste special
 
-A plugin that will allow pasting special text into Joplin and have it converted to Markdown. For example, paste an Excel or CSV table, and have it converted to a Markdown table. Paste some HTML or PDF text and again have it converted to formatted Markdown. This could be one plugin, or a collection of plugins, one for eadch "paste special" operation.
+A plugin that will allow pasting special text into Joplin and have it converted to Markdown. For example, paste an Excel or CSV table, and have it converted to a Markdown table. Paste some HTML or PDF text and again have it converted to formatted Markdown. This could be one plugin, or a collection of plugins, one for each "paste special" operation.
 
 Expected Outcome: One or more plugins that allow pasting special text.
 


### PR DESCRIPTION
README: GSOC 2021 : Project Ideas: Paste Special :  

There is a typo in the spelling of the Paste Special Project Idea in this Documentation.
Previously it was written as : eadch, and I have changed it into : each

