### PR TITLE
Docs : api : references : rest_api  : fixed a typo in the Index.html …

### DIFF
--- a/docs/api/references/rest_api/index.html
+++ b/docs/api/references/rest_api/index.html
@@ -511,7 +511,7 @@ async function fetchAllNotes() {
 <p>For example, to retrieve the notebook named <code>recipes</code>: <strong>GET /search?query=recipes&amp;type=folder</strong></p>
 <p>To retrieve all the tags that start with <code>project-</code>: <strong>GET /search?query=project-*&amp;type=tag</strong></p>
 <h1>Item type IDs<a name="item-type-ids" href="#item-type-ids" class="heading-anchor">🔗</a></h1>
-<p>Item type IDs might be refered to in certain object you will retrieve from the API. This is the correspondance between name and ID:</p>
+<p>Item type IDs might be referred to in certain object you will retrieve from the API. This is the correspondance between name and ID:</p>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Fixed a typo in the Docs of Data API. Previously , in the ID Types section : it is spelled as refered and I have update it as referred.
