### PR TITLE
Desktop: Resolves #1656: Add confirmation modal to E2EE

### DIFF
--- a/packages/app-desktop/gui/dialogs.ts
+++ b/packages/app-desktop/gui/dialogs.ts
@@ -1,13 +1,13 @@
-const smalltalk = require('smalltalk');
+import modals from './modal/modals';
 
 class Dialogs {
 	async alert(message: string, title = '') {
-		await smalltalk.alert(title, message);
+		await modals.alert(title, message);
 	}
 
 	async confirm(message: string, title = '', options: any = {}) {
 		try {
-			await smalltalk.confirm(title, message, options);
+			await modals.confirm(title, message, options);
 			return true;
 		} catch (error) {
 			return false;
@@ -18,7 +18,7 @@ class Dialogs {
 		if (options === null) options = {};
 
 		try {
-			const answer = await smalltalk.prompt(title, message, defaultValue, options);
+			const answer = await modals.prompt(title, message, defaultValue, options);
 			return answer;
 		} catch (error) {
 			return null;

--- a/packages/app-desktop/gui/dialogs.ts
+++ b/packages/app-desktop/gui/dialogs.ts
@@ -24,6 +24,17 @@ class Dialogs {
 			return null;
 		}
 	}
+
+	async promptWithConfirmation(message: string, title = '', defaultValue = '', options: any = null) {
+		if (options === null) options = {};
+
+		try {
+			const answer = await modals.promptWithConfirmation(title, message, defaultValue, options);
+			return answer;
+		} catch (error) {
+			return null;
+		}
+	}
 }
 
 const dialogs = new Dialogs();

--- a/packages/app-desktop/gui/modal/createModal.ts
+++ b/packages/app-desktop/gui/modal/createModal.ts
@@ -1,0 +1,117 @@
+import { ReactElement } from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+
+type CallbackType = {
+    (): void;
+    (value: any): void;
+};
+
+interface OnCallback {
+    onSubmit: CallbackType;
+    onDismiss: CallbackType;
+}
+
+export interface RenderFunctionProps extends OnCallback {
+    show: boolean;
+}
+
+type RenderFunction = (props: RenderFunctionProps)=> ReactElement;
+
+interface Options {
+    destructionDelay?: number;
+}
+
+const DEFAULT_DESTRUCTION_DELAY = 300;
+const DEFAULT_OPTIONS = {
+	destructionDelay: DEFAULT_DESTRUCTION_DELAY,
+};
+
+const noop = () => {};
+
+export default function createModal(renderModal: RenderFunction, options: Options = {}): Promise<unknown> {
+	const { destructionDelay } = { ...DEFAULT_OPTIONS, ...options };
+	const container = document.createElement('div');
+	let handleKeyDownRef: any;
+	document.body.appendChild(container);
+	function onKeyDown(onSubmit: CallbackType, onDismiss: CallbackType) {
+		return function handleKeyDown(e: KeyboardEvent) {
+			const defaultBehaviourInputs = ['select', 'button', 'textarea'];
+			const focusable = container.querySelectorAll('button, input, select, textarea');
+			const firstFocusable = focusable[0];
+			const lastFocusable = focusable[focusable.length - 1];
+			const okButton = container.querySelector('#modal-ok');
+			const activeElement = document.activeElement;
+			const keyCode = e.keyCode;
+			const KEY = {
+				ENTER: 13,
+				ESC: 27,
+				TAB: 9,
+			};
+
+			if (e.ctrlKey || e.altKey) {
+				return;
+			}
+
+			switch (keyCode) {
+			case KEY.TAB:
+				if (e.shiftKey && e.target === firstFocusable) {
+					(lastFocusable as HTMLElement).focus();
+					e.preventDefault();
+				} else if (e.target === lastFocusable) {
+					(firstFocusable as HTMLElement).focus();
+					e.preventDefault();
+				}
+				break;
+			case KEY.ESC:
+				onDismiss();
+				break;
+			case KEY.ENTER:
+				if (activeElement && defaultBehaviourInputs.indexOf(activeElement.tagName.toLowerCase()) !== -1) {
+					return;
+				}
+				(okButton as HTMLButtonElement).click();
+				e.preventDefault();
+				break;
+			}
+		};
+	}
+
+
+	function addListeners({ onSubmit, onDismiss }: OnCallback) {
+		handleKeyDownRef = onKeyDown(onSubmit, onDismiss);
+		document.addEventListener('keydown', handleKeyDownRef, true);
+	}
+
+	function removeListeners() {
+		document.removeEventListener('keydown', handleKeyDownRef, true);
+	}
+
+	function displayModal({ onSubmit, onDismiss }: OnCallback) {
+		render(renderModal({ onSubmit, onDismiss, show: true }), container);
+		addListeners({ onSubmit, onDismiss });
+	}
+
+	function hideModal({ onSubmit, onDismiss }: OnCallback, callback: ()=> void) {
+		removeListeners();
+		render(renderModal({ onSubmit, onDismiss, show: false }), container, callback);
+	}
+
+	function destroyModal() {
+		unmountComponentAtNode(container);
+		document.body.removeChild(container);
+	}
+
+	const confirmation = new Promise((resolve,reject) => {
+		const onSubmit = (value = true) => resolve(value);
+		const onDismiss = (value = false) => reject(value);
+		displayModal({ onSubmit, onDismiss });
+	});
+
+	return confirmation.finally(() => {
+		const onSubmit = noop;
+		const onDismiss = noop;
+		hideModal({ onSubmit, onDismiss }, () => {
+			setTimeout(destroyModal, destructionDelay);
+		});
+	});
+}

--- a/packages/app-desktop/gui/modal/createModal.ts
+++ b/packages/app-desktop/gui/modal/createModal.ts
@@ -33,7 +33,7 @@ export default function createModal(renderModal: RenderFunction, options: Option
 	const container = document.createElement('div');
 	let handleKeyDownRef: any;
 	document.body.appendChild(container);
-	function onKeyDown(onSubmit: CallbackType, onDismiss: CallbackType) {
+	function onKeyDown(onDismiss: CallbackType) {
 		return function handleKeyDown(e: KeyboardEvent) {
 			const defaultBehaviourInputs = ['select', 'button', 'textarea'];
 			const focusable = container.querySelectorAll('button, input, select, textarea');
@@ -77,8 +77,8 @@ export default function createModal(renderModal: RenderFunction, options: Option
 	}
 
 
-	function addListeners({ onSubmit, onDismiss }: OnCallback) {
-		handleKeyDownRef = onKeyDown(onSubmit, onDismiss);
+	function addListeners({ onDismiss }: OnCallback) {
+		handleKeyDownRef = onKeyDown(onDismiss);
 		document.addEventListener('keydown', handleKeyDownRef, true);
 	}
 

--- a/packages/app-desktop/gui/modal/modals.tsx
+++ b/packages/app-desktop/gui/modal/modals.tsx
@@ -1,7 +1,8 @@
+import { _ } from '@joplin/lib/locale';
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import createModal, { RenderFunctionProps } from './createModal';
-import { RootStyle, StyledActionArea, StyledButonStrip, StyledButton, StyledCloseButton, StyledContentArea, StyledHeader, StyledInput, StyledPage } from './styles';
+import { RootStyle, StyledActionArea, StyledButonStrip, StyledButton, StyledCloseButton, StyledContentArea, StyledError, StyledHeader, StyledInput, StyledInputSeparator, StyledLabel, StyledPage } from './styles';
 
 type HTMLInputTypes = 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
 type ModalOptions = {
@@ -16,14 +17,15 @@ type ModalProps = OtherProps & RenderFunctionProps;
 type PromptModalProps = ModalProps & PromptOtherProps & RenderFunctionProps;
 
 interface OtherProps {
-  title: string;
-  message: string;
-  options?: ModalOptions;
+	themeId?: number;
+	title: string;
+	message: string;
+	options?: ModalOptions;
 }
 
 interface PromptOtherProps {
-  defaultValue?: string;
-  options?: PromptOptions;
+	defaultValue?: string;
+	options?: PromptOptions;
 }
 
 const CloseIcon = () =><i className={'fas fa-times'}></i>;
@@ -38,12 +40,53 @@ const PromptModal = ({ show, onSubmit,onDismiss, title, message, options, defaul
 				<StyledHeader>{title}</StyledHeader>
 				<StyledContentArea>
 					{message}
+					<StyledInputSeparator></StyledInputSeparator>
 					<StyledInput autoFocus type={type} value={input} onChange={(e: any) => setInput(e.target.value)} />
 				</StyledContentArea>
 				<StyledActionArea>
 					<StyledButonStrip>
-						<StyledButton id='modal-ok' tabIndex={0} onClick ={() =>onSubmit(input)}>{ok || 'OK'}</StyledButton>
-						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || 'Cancel'}</StyledButton>
+						<StyledButton id='modal-ok' tabIndex={0} onClick ={() =>onSubmit(input)}>{ok || _('OK')}</StyledButton>
+						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || _('Cancel')}</StyledButton>
+					</StyledButonStrip>
+				</StyledActionArea>
+			</StyledPage>
+		</RootStyle>
+	);
+};
+
+const PromptWithConfirmationModal = ({ show, onSubmit,onDismiss, title, message, options, defaultValue }: PromptModalProps) => {
+	const [input, setInput] = useState(defaultValue || '');
+	const [confirmInput, setConfirmInput] = useState(defaultValue || '');
+	const [error, setError] = useState('');
+	const { ok,cancel,type } = options;
+
+	useEffect(() => {
+		if (input !== confirmInput) {
+			setError(_('Fields do not match'));
+		} else {
+			setError('');
+		}
+	}, [input, confirmInput]);
+
+	if (!show) return (null);
+	return (
+		<RootStyle>
+			<StyledPage>
+				<StyledCloseButton onClick={() => onDismiss()}><CloseIcon/></StyledCloseButton>
+				<StyledHeader>{title}</StyledHeader>
+				<StyledContentArea>
+					<p>{message}</p>
+					<StyledInputSeparator></StyledInputSeparator>
+					<StyledLabel>Password:</StyledLabel>
+					<StyledInput autoFocus type={type} value={input} onChange={(e: any) => setInput(e.target.value)} />
+					<StyledLabel>Confirm password:</StyledLabel>
+					<StyledInput type={type} value={confirmInput} onChange={(e: any) => setConfirmInput(e.target.value)} />
+					<StyledError>{error}</StyledError>
+				</StyledContentArea>
+				<StyledActionArea>
+					<StyledButonStrip>
+						<StyledButton disabled={error} id='modal-ok' tabIndex={0} onClick ={() =>onSubmit(input)}>{ok || _('OK')}</StyledButton>
+						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || _('Cancel')}</StyledButton>
 					</StyledButonStrip>
 				</StyledActionArea>
 			</StyledPage>
@@ -64,8 +107,8 @@ const ConfirmModal = ({ show, onSubmit,onDismiss, title,message, options }: Moda
 				</StyledContentArea>
 				<StyledActionArea>
 					<StyledButonStrip>
-						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || 'OK'}</StyledButton>
-						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || 'Cancel'}</StyledButton>
+						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || _('OK')}</StyledButton>
+						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || _('Cancel')}</StyledButton>
 					</StyledButonStrip>
 				</StyledActionArea>
 			</StyledPage>
@@ -86,7 +129,7 @@ const AlertModal = ({ show, onSubmit,onDismiss,title,message, options }: ModalPr
 				</StyledContentArea>
 				<StyledActionArea>
 					<StyledButonStrip>
-						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || 'OK'}</StyledButton>
+						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || _('OK')}</StyledButton>
 					</StyledButonStrip>
 				</StyledActionArea>
 			</StyledPage>
@@ -98,6 +141,9 @@ const AlertModal = ({ show, onSubmit,onDismiss,title,message, options }: ModalPr
 const modals = {
 	prompt: async (title: string,message: string, defaultValue?: any, options?: PromptOptions) => {
 		return await createModal((props) => (<PromptModal {...props} title={title} message={message} defaultValue={defaultValue} options={options} />));
+	},
+	promptWithConfirmation: async (title: string,message: string, defaultValue?: any, options?: PromptOptions) => {
+		return await createModal((props) => (<PromptWithConfirmationModal {...props} title={title} message={message} defaultValue={defaultValue} options={options} />));
 	},
 	confirm: async (title: string,message: string, options?: ModalOptions) => {
 		return await createModal((props) => (<ConfirmModal {...props} title={title} message={message} options={options} />));

--- a/packages/app-desktop/gui/modal/modals.tsx
+++ b/packages/app-desktop/gui/modal/modals.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { useState } from 'react';
+import createModal, { RenderFunctionProps } from './createModal';
+import { RootStyle, StyledActionArea, StyledButonStrip, StyledButton, StyledCloseButton, StyledContentArea, StyledHeader, StyledInput, StyledPage } from './styles';
+
+type HTMLInputTypes = 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
+type ModalOptions = {
+  ok?: string;
+  cancel?: string;
+};
+type PromptOptions = ModalOptions & {
+  type: HTMLInputTypes;
+};
+
+type ModalProps = OtherProps & RenderFunctionProps;
+type PromptModalProps = ModalProps & PromptOtherProps & RenderFunctionProps;
+
+interface OtherProps {
+  title: string;
+  message: string;
+  options?: ModalOptions;
+}
+
+interface PromptOtherProps {
+  defaultValue?: string;
+  options?: PromptOptions;
+}
+
+const CloseIcon = () =><i className={'fas fa-times'}></i>;
+const PromptModal = ({ show, onSubmit,onDismiss, title, message, options, defaultValue }: PromptModalProps) => {
+	const [input, setInput] = useState(defaultValue || '');
+	const { ok,cancel,type } = options;
+	if (!show) return (null);
+	return (
+		<RootStyle>
+			<StyledPage>
+				<StyledCloseButton onClick={() => onDismiss()}><CloseIcon/></StyledCloseButton>
+				<StyledHeader>{title}</StyledHeader>
+				<StyledContentArea>
+					{message}
+					<StyledInput autoFocus type={type} value={input} onChange={(e: any) => setInput(e.target.value)} />
+				</StyledContentArea>
+				<StyledActionArea>
+					<StyledButonStrip>
+						<StyledButton id='modal-ok' tabIndex={0} onClick ={() =>onSubmit(input)}>{ok || 'OK'}</StyledButton>
+						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || 'Cancel'}</StyledButton>
+					</StyledButonStrip>
+				</StyledActionArea>
+			</StyledPage>
+		</RootStyle>
+	);
+};
+
+const ConfirmModal = ({ show, onSubmit,onDismiss, title,message, options }: ModalProps) => {
+	const { ok,cancel } = options;
+	if (!show) return (null);
+	return (
+		<RootStyle>
+			<StyledPage>
+				<StyledCloseButton onClick={() => onDismiss()}><CloseIcon/></StyledCloseButton>
+				<StyledHeader>{title}</StyledHeader>
+				<StyledContentArea>
+					{message}
+				</StyledContentArea>
+				<StyledActionArea>
+					<StyledButonStrip>
+						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || 'OK'}</StyledButton>
+						<StyledButton tabIndex={1} onClick ={() =>onDismiss()}>{cancel || 'Cancel'}</StyledButton>
+					</StyledButonStrip>
+				</StyledActionArea>
+			</StyledPage>
+		</RootStyle>
+	);
+};
+
+const AlertModal = ({ show, onSubmit,onDismiss,title,message, options }: ModalProps) => {
+	const { ok } = options;
+	if (!show) return (null);
+	return (
+		<RootStyle>
+			<StyledPage>
+				<StyledCloseButton onClick={() => onDismiss()}><CloseIcon/></StyledCloseButton>
+				<StyledHeader>{title}</StyledHeader>
+				<StyledContentArea>
+					{message}
+				</StyledContentArea>
+				<StyledActionArea>
+					<StyledButonStrip>
+						<StyledButton id='modal-ok' autoFocus tabIndex={0} onClick ={() =>onSubmit(true)}>{ok || 'OK'}</StyledButton>
+					</StyledButonStrip>
+				</StyledActionArea>
+			</StyledPage>
+		</RootStyle>
+	);
+};
+
+
+const modals = {
+	prompt: async (title: string,message: string, defaultValue?: any, options?: PromptOptions) => {
+		return await createModal((props) => (<PromptModal {...props} title={title} message={message} defaultValue={defaultValue} options={options} />));
+	},
+	confirm: async (title: string,message: string, options?: ModalOptions) => {
+		return await createModal((props) => (<ConfirmModal {...props} title={title} message={message} options={options} />));
+	},
+	alert: async (title: string,message: string, options?: ModalOptions) => {
+		return await createModal((props) => (<AlertModal {...props} title={title} message={message} options={options} />));
+	},
+};
+
+
+export default modals;
+
+

--- a/packages/app-desktop/gui/modal/styles/index.ts
+++ b/packages/app-desktop/gui/modal/styles/index.ts
@@ -1,7 +1,7 @@
-import styled from 'styled-components';
+const styled = require('styled-components').default;
 
 export const RootStyle = styled.div`
-    background-color: ${props => props.theme.color};
+    background-color: rgba(0,0,0,0.5);
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -49,7 +49,6 @@ export const StyledInput = styled.input`
     box-sizing: border-box;
     font: inherit;
     margin: 0;
-    margin-top: 1em;
     min-height: 2em;
     padding: 3px;
     outline: none;
@@ -58,6 +57,19 @@ export const StyledInput = styled.input`
         border-color: rgb(77, 144, 254);
         outline: none;
     }
+`;
+
+export const StyledLabel = styled.label`
+    margin: 0.4em 0;
+    display: block;
+`;
+export const StyledInputSeparator = styled.div`
+    margin-top: 1em;
+`;
+export const StyledError = styled.small`
+    display: block;
+    color: red;
+    margin-top: 10px;
 `;
 
 export const StyledButonStrip = styled.div`

--- a/packages/app-desktop/gui/modal/styles/index.ts
+++ b/packages/app-desktop/gui/modal/styles/index.ts
@@ -1,0 +1,123 @@
+import styled from 'styled-components';
+
+export const RootStyle = styled.div`
+    background-color: ${props => props.theme.color};
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    transition: 200ms opacity;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
+    padding: 20px;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 100;
+`;
+
+export const StyledHeader = styled.header`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 500px;
+    user-select: none;
+    color: #333;
+    font-size: 120%;
+    font-weight: bold;
+    margin: 0;
+    padding: 14px 17px;
+    text-shadow: white 0 1px 2px;
+`;
+
+export const StyledContentArea = styled.div`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 6px 17px;
+    position: relative;
+`;
+
+export const StyledActionArea = styled.div`
+    padding: 14px 17px;
+`;
+
+export const StyledInput = styled.input`
+    width: 100%;
+    border: 1px solid #bfbfbf;
+    border-radius: 2px;
+    box-sizing: border-box;
+    font: inherit;
+    margin: 0;
+    margin-top: 1em;
+    min-height: 2em;
+    padding: 3px;
+    outline: none;
+    &:enabled:focus {
+        transition: border-color 200ms;
+        border-color: rgb(77, 144, 254);
+        outline: none;
+    }
+`;
+
+export const StyledButonStrip = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+`;
+
+export const StyledPage = styled.div`
+    max-width: 30em;
+    border-radius: 3px;
+    background: white;
+    box-shadow: 0 4px 23px 5px rgba(0, 0, 0, .2), 0 2px 6px rgba(0, 0, 0, .15);
+    color: #333;
+    min-width: 400px;
+    padding: 0;
+    position: relative;
+    z-index: 0;
+`;
+
+export const StyledButton = styled.button`
+    min-height: 2em;
+    min-width: 4em;
+    appearance: none;
+    user-select: none;
+    background-image: linear-gradient(#ededed, #ededed 38%, #dedede);
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    border-radius: 2px;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08), inset 0 1px 2px rgba(255, 255, 255, 0.75);
+    color: #444;
+    font: inherit;
+    margin: 0 1px 0 10px;
+    text-shadow: 0 1px 0 rgb(240, 240, 240);
+    &::-moz-focus-inner{
+        border: 0;
+    }
+    &:enabled:active {
+        background-image: linear-gradient(#e7e7e7, #e7e7e7 38%, #d7d7d7);
+        box-shadow: none;
+        text-shadow: none;
+    }
+    &:enabled:focus {
+        transition: border-color 200ms;
+        border-color: rgb(77, 144, 254);
+        outline: none;
+    }
+`;
+
+export const StyledCloseButton = styled.div`
+    background-position: center;
+    background-repeat: no-repeat;
+    height: 14px;
+    position: absolute;
+    right: 7px;
+    top: 7px;
+    width: 14px;
+    z-index: 1;
+`;
+
+export const StyledProgress = styled.div`
+    display: block;
+    width: 100%;
+`;

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -124,6 +124,7 @@
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@joplin/lib": "^1.0.9",
     "@joplin/renderer": "^1.0.17",
+    "@types/react-dom": "^17.0.2",
     "async-mutex": "^0.1.3",
     "codemirror": "^5.56.0",
     "color": "^3.1.2",


### PR DESCRIPTION
As smalltalk didn't allow for custom modals I replaced it with my own implementation.

UI:
The other modals look the same as before.
![Password Confirmation](https://user-images.githubusercontent.com/23507174/111155109-af74ec80-859c-11eb-9fdb-8a197887a757.gif)
