### PR TITLE
Desktop: Fixes #4398: Wrong background color for toolbar table button

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -447,12 +447,17 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox .tox-button--naked:hover:not(:disabled) {
 				background-color: ${theme.backgroundColor} !important;
 			}
-
+			
+			.tox .tox-tbtn:focus {
+				background-color: ${theme.backgroundColor3}
+			}
+			
 			.tox .tox-tbtn:hover {
 				color: ${theme.colorHover3} !important;
 				fill: ${theme.colorHover3} !important;
 				background-color: ${theme.backgroundColorHover3}
-			}
+			}			
+			
 
 			.tox .tox-tbtn {
 				width: ${theme.toolbarHeight}px;


### PR DESCRIPTION
The problem was with the table button remaining focused after closing the table