### PR TITLE
Docs: Fixed a typo in the api documentation

### DIFF
--- a/docs/api/references/rest_api/index.html
+++ b/docs/api/references/rest_api/index.html
@@ -508,7 +508,7 @@ async function fetchAllNotes() {
 <p>For example, to retrieve the notebook named <code>recipes</code>: <strong>GET /search?query=recipes&amp;type=folder</strong></p>
 <p>To retrieve all the tags that start with <code>project-</code>: <strong>GET /search?query=project-*&amp;type=tag</strong></p>
 <h1>Item type IDs<a name="item-type-ids" href="#item-type-ids" class="heading-anchor">🔗</a></h1>
-<p>Item type IDs might be refered to in certain object you will retrieve from the API. This is the correspondance between name and ID:</p>
+<p>Item type IDs might be referred to in certain object you will retrieve from the API. This is the correspondance between name and ID:</p>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Docs: Fixed a typo in the api documentation previously it was  "refered" , and i updated it to "referred" .
