### PR TITLE
Desktop: Add monospace enforcement for certain elements

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -478,7 +478,7 @@ class Application extends BaseApplication {
 	updateEditorFont() {
 		const fontFamilies = [];
 		if (Setting.value('style.editor.fontFamily')) fontFamilies.push(`"${Setting.value('style.editor.fontFamily')}"`);
-		fontFamilies.push('monospace');
+		fontFamilies.push('sans-serif');
 
 		// The '*' and '!important' parts are necessary to make sure Russian text is displayed properly
 		// https://github.com/laurent22/joplin/issues/155

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -478,7 +478,7 @@ class Application extends BaseApplication {
 	updateEditorFont() {
 		const fontFamilies = [];
 		if (Setting.value('style.editor.fontFamily')) fontFamilies.push(`"${Setting.value('style.editor.fontFamily')}"`);
-		fontFamilies.push('sans-serif');
+		fontFamilies.push('Avenir, Arial, sans-serif');
 
 		// The '*' and '!important' parts are necessary to make sure Russian text is displayed properly
 		// https://github.com/laurent22/joplin/issues/155

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -412,6 +412,11 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				padding-right: 10px !important;
 			}
 
+			/* This enforces monospace for certain elements (code, tables, etc.) */
+			.cm-jn-monospace {
+				font-family: monospace !important;
+			}
+
 			.cm-header-1 {
 				font-size: 1.5em;
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -377,7 +377,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			`.CodeMirror-selected {
 				background: #6b6b6b !important;
 			}` : '';
-		const monospaceFont = Setting.value('style.editor.monospaceFontFamily');
+		const monospaceFonts = [];
+		if (Setting.value('style.editor.monospaceFontFamily')) monospaceFonts.push(`"${Setting.value('style.editor.monospaceFontFamily')}"`);
+		monospaceFonts.push('monospace');
 
 		const element = document.createElement('style');
 		element.setAttribute('id', 'codemirrorStyle');
@@ -415,7 +417,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 			/* This enforces monospace for certain elements (code, tables, etc.) */
 			.cm-jn-monospace {
-				font-family: ${monospaceFont}, monospace !important;
+				font-family: ${monospaceFonts.join(', ')} !important;
 			}
 
 			.cm-header-1 {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -377,6 +377,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			`.CodeMirror-selected {
 				background: #6b6b6b !important;
 			}` : '';
+		const monospaceFont = Setting.value('style.editor.monospaceFontFamily');
 
 		const element = document.createElement('style');
 		element.setAttribute('id', 'codemirrorStyle');
@@ -414,7 +415,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 			/* This enforces monospace for certain elements (code, tables, etc.) */
 			.cm-jn-monospace {
-				font-family: monospace !important;
+				font-family: ${monospaceFont}, monospace !important;
 			}
 
 			.cm-header-1 {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -112,14 +112,20 @@ export default function useJoplinMode(CodeMirror: any) {
 				// //////// End Markdown //////////
 
 				// //////// Monospace //////////
+				let isMonospace = false;
 				// After being passed to the markdown mode we can check if the
 				// code state variables are set
+				// Code Block
 				if (state.outer.code || (state.outer.thisLine && state.outer.thisLine.fencedCodeEnd)) {
-					token = `${token} jn-monospace`;
+					isMonospace = true;
 				}
-				// Task lists also have enforced monospace
+				// Indented Code
+				if (state.outer.indentedCode) {
+					isMonospace = true;
+				}
+				// Task lists
 				if (state.outer.taskList || state.outer.taskOpen || state.outer.taskClosed) {
-					token = `${token} jn-monospace`;
+					isMonospace = true;
 				}
 
 				// Any line that contains a | is potentially a table row
@@ -132,11 +138,13 @@ export default function useJoplinMode(CodeMirror: any) {
 
 					// Treat all lines that start with | as a table row
 					if (state.inTable || stream.string[0] === '|') {
-						token = `${token} jn-monospace`;
+						isMonospace = true;
 					}
 				} else {
 					state.inTable = false;
 				}
+
+				if (isMonospace) { token = `${token} jn-monospace`; }
 				// //////// End Monospace //////////
 
 				return token;

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -137,6 +137,30 @@ const markdownUtils = {
 		return output.join('\n');
 	},
 
+	countTableColumns(line: string) {
+		if (!line) return 0;
+
+		const trimmed = line.trim();
+		let pipes = (line.match(/\|/g) || []).length;
+
+		if (trimmed[0] === '|') { pipes -= 1; }
+		if (trimmed[trimmed.length - 1] === '|') { pipes -= 1; }
+
+		return pipes + 1;
+	},
+
+	matchingTableDivider(header: string, divider: string) {
+		if (!header || !divider) return false;
+
+		const invalidChars = divider.match(/[^\s\-:|]/g);
+
+		if (invalidChars) { return false; }
+
+		const columns = markdownUtils.countTableColumns(header);
+		const cols = markdownUtils.countTableColumns(divider);
+		return cols > 0 && (cols >= columns);
+	},
+
 	titleFromBody(body: string) {
 		if (!body) return '';
 		const mdLinkRegex = /!?\[([^\]]+?)\]\(.+?\)/g;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -867,8 +867,7 @@ class Setting extends BaseModel {
 						section: 'appearance',
 						label: () => _('Editor font family'),
 						description: () =>
-							_('If the font ' +
-						'is incorrect or empty, it will default to a generic monospace font.'),
+							_('If the font is incorrect or empty, it will default to a generic monospace font.'),
 						storage: SettingStorage.File,
 					},
 			'style.editor.monospaceFontFamily': {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -860,7 +860,7 @@ class Setting extends BaseModel {
 						},
 						storage: SettingStorage.File,
 					}) : {
-						value: '',
+						value: 'Open Sans',
 						type: SettingItemType.String,
 						public: true,
 						appTypes: ['desktop'],

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -867,10 +867,22 @@ class Setting extends BaseModel {
 						section: 'appearance',
 						label: () => _('Editor font family'),
 						description: () =>
-							_('This should be a *monospace* font or some elements will render incorrectly. If the font ' +
+							_('If the font ' +
 						'is incorrect or empty, it will default to a generic monospace font.'),
 						storage: SettingStorage.File,
 					},
+			'style.editor.monospaceFontFamily': {
+				value: '',
+				type: SettingItemType.String,
+				public: true,
+				appTypes: ['desktop'],
+				section: 'appearance',
+				label: () => _('Editor monospace font family'),
+				description: () =>
+					_('This should be a *monospace* font or some elements will render incorrectly. If the font ' +
+				'is incorrect or empty, it will default to a generic monospace font.'),
+				storage: SettingStorage.File,
+			},
 
 			'ui.layout': { value: {}, type: SettingItemType.Object, storage: SettingStorage.File, public: false, appTypes: ['desktop'] },
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -860,7 +860,7 @@ class Setting extends BaseModel {
 						},
 						storage: SettingStorage.File,
 					}) : {
-						value: 'Open Sans',
+						value: '',
 						type: SettingItemType.String,
 						public: true,
 						appTypes: ['desktop'],


### PR DESCRIPTION
This adds forced monospace for Tables, Code blocks and Checkboxes in the CodeMirror editor. 

This was briefly [discussed on the forum](https://discourse.joplinapp.org/t/plugin-rich-markdown/15053/71)

For checkboxes and code blocks, I piggy back on the CodeMirror highlighting and add the monospace class.

For tables I couldn't do that. Instead table check for a valid header, and then enter table mode. This just means that all lines following the valid header will be monospace until a line is reached that does not contain a '|' character.

I also enforce monospace on any line that begins with a '|', the assumption being that those lines are likely going to become a part of a table, and it's better to start writing in monospace rather than snapping to monospace once the header is finished.

Something I haven't done yet is to add a setting that enables this behaviour. I'm not sure if it will be necessary.
We'll at least need a way for the user to specify which monospace font they want to use.