### PR TITLE
Android: Accept self-signed http certs

### DIFF
--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/CustomClientFactory.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/CustomClientFactory.java
@@ -1,0 +1,65 @@
+package net.cozic.joplin;
+
+import com.facebook.react.modules.network.OkHttpClientFactory;
+import com.facebook.react.modules.network.ReactCookieJarContainer;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.OkHttpClient;
+
+public class CustomClientFactory implements OkHttpClientFactory {
+    private static final String TAG = "OkHttpClientFactory";
+    @Override
+    public OkHttpClient createNewNetworkModuleClient() {
+        try {
+            // Create a trust manager that does not validate certificate chains
+            final TrustManager[] trustAllCerts = new TrustManager[]{
+                    new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                        }
+
+                        @Override
+                        public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                        }
+
+                        @Override
+                        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                            return new java.security.cert.X509Certificate[]{};
+                        }
+                    }
+            };
+
+            // Install the all-trusting trust manager
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+            // Create an ssl socket factory with our all-trusting manager
+            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+
+
+            OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                    .connectTimeout(0, TimeUnit.MILLISECONDS).readTimeout(0, TimeUnit.MILLISECONDS)
+                    .writeTimeout(0, TimeUnit.MILLISECONDS).cookieJar(new ReactCookieJarContainer());
+            builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
+            builder.hostnameVerifier(new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true;
+                }
+            });
+
+            OkHttpClient okHttpClient = builder.build();
+            return okHttpClient;
+        } catch (Exception e) {
+            //Log.e(TAG, e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -9,6 +9,7 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.facebook.soloader.SoLoader;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -68,6 +69,7 @@ public class MainApplication extends Application implements ReactApplication {
     }
     
     SoLoader.init(this, /* native exopackage */ false);
+    OkHttpClientProvider.setOkHttpClientFactory(new CustomClientFactory());
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
 
     // To allow debugging the webview using the Chrome developer tools.


### PR DESCRIPTION
I have a nextcloud server instance with self-signed https cert. The android client sync doesn't work with that. I searched around and found many users have the same problem but without a clear solution. I know this is mentioned in the FAQ but it is ambiguous and doesn't work for me at least.
This is the fix I copied from: https://stackoverflow.com/questions/36289125/react-native-fetch-from-https-server-with-self-signed-certificate
I'm not an android developer and just managed to test the code with Joplin. it works for me. With this fix, there is no need to install any cert nor any other steps on Android device. To my limited knowledge, it seems that this code skips all the cert validation. I don't know if there is a better way to handle this. So please feel free to drop this pull request or make improvements to handle this better.
