### PR TITLE
Desktop: Fixes #4397: Fixed Broken Calendar Styling

### DIFF
--- a/packages/app-desktop/style.css
+++ b/packages/app-desktop/style.css
@@ -109,6 +109,11 @@ a {
 	}
 }
 
+.rdtPicker {
+	min-width: 250px;
+	width: auto !important;
+}
+
 .smalltalk {
 	font-family: sans-serif;
 }


### PR DESCRIPTION
Fixed the broken calendar styling as mentioned in issue : #4397  

Attaching Before- After pictures:
![image](https://user-images.githubusercontent.com/67231570/111575984-92772e00-87d5-11eb-8981-22a36e2898e8.png)

![image](https://user-images.githubusercontent.com/67231570/111576005-a0c54a00-87d5-11eb-8e04-c4f669aebe7f.png)
