### PR TITLE
Doc: Update toc_plugin.md

### DIFF
--- a/packages/app-cli/tests/support/plugins/toc/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/toc/src/index.ts
@@ -42,13 +42,13 @@ joplin.plugins.register({
 	onStart: async function() {
 		const panels = joplin.views.panels;
 
-		const view = await (panels as any).create();
+		const view = await panels.create("panel_1");
 
 		await panels.setHtml(view, 'Loading...');
 		await panels.addScript(view, './webview.js');
 		await panels.addScript(view, './webview.css');
 
-		panels.onMessage(view, (message:any) => {
+		await panels.onMessage(view, (message:any) => {
 			if (message.name === 'scrollToHash') {
 				joplin.commands.execute('scrollToHash', message.hash)
 			}
@@ -88,7 +88,7 @@ joplin.plugins.register({
 			updateTocView();
 		});
 
-		joplin.workspace.onNoteContentChange(() => {
+		joplin.workspace.onNoteChange(() => {
 			updateTocView();
 		});
 
@@ -97,8 +97,8 @@ joplin.plugins.register({
 			label: 'Toggle TOC',
 			iconName: 'fas fa-drum',
 			execute: async () => {
-				const isVisible = await (panels as any).visible(view);
-				(panels as any).show(view, !isVisible);
+				const isVisible = await panels.visible(view);
+				await panels.show(view, !isVisible);
 			},
 		});
 

--- a/readme/api/tutorials/toc_plugin.md
+++ b/readme/api/tutorials/toc_plugin.md
@@ -66,7 +66,7 @@ joplin.plugins.register({
 
 		// This event will be triggered when the content of the note changes
 		// as you also want to update the TOC in this case.
-		await joplin.workspace.onNoteContentChange(() => {
+		await joplin.workspace.onNoteChange(() => {
 			updateTocView();
 		});
 
@@ -171,7 +171,7 @@ joplin.plugins.register({
 
 	onStart: async function() {
 		// Create the panel object
-		const panel = await joplin.views.panels.create();
+		const panel = await joplin.views.panels.create('panel_1');
 
 		// Set some initial content while the TOC is being created
 		await joplin.views.panels.setHtml(panel, 'Loading...');
@@ -228,7 +228,7 @@ Now run the plugin again and you should see the TOC dynamically updating as you 
 In order to better integrate the TOC to Joplin, you might want to style it using CSS. To do so, first add a `webview.css` file next to `index.ts`, then you will need to let Joplin know about this file. This is done using the `addScript()` function (which is also used to add JavaScript files as we'll see later), like so:
 
 ```typescript
-const panel = await joplin.views.panels.create();
+const panel = await joplin.views.panels.create('panel_1');
  // Add the CSS file to the view, right after it has been created:
 await joplin.views.panels.addScript(panel, './webview.css');
 ```
@@ -261,8 +261,7 @@ The next step is to make the TOC interactive so that when the user clicks on a l
 
 ```typescript
 // In index.ts
-
-const panel = joplin.views.createWebviewPanel();
+const panel = await joplin.views.panels.create('panel_1');
 await joplin.views.panels.addScript(panel, './webview.css');
 await joplin.views.panels.addScript(panel, './webview.js'); // Add the JS file
 ```
@@ -314,7 +313,7 @@ Then from the plugin, in `src/index.ts`, you can listen to this message using th
 ```typescript
 joplin.plugins.register({
 	onStart: async function() {
-		const panel = await joplin.views.panels.create();
+		const panel = await joplin.views.panels.create('panel_1');
 
 		// ...
 


### PR DESCRIPTION
Change joplin.workspace.onNoteContentChange to joplin.workspace.onNoteChange as the former is deprecated.

Change joplin.views.panels.create() to joplin.views.panels.create('panel_1') as it needs an string id now.

Change joplin.views.createWebviewPanel() to joplin.views.panels.create('panel_1') as the former dosn't exist anymore.
