### PR TITLE
 Desktop: Resolves #4710: Fixed "Toggle Dev Tools"

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -335,7 +335,7 @@ class Application extends BaseApplication {
 
 			case 'NOTE_DEVTOOLS_TOGGLE':
 				newState = Object.assign({}, state);
-				newState.devToolsVisible = !newState.devToolsVisible;
+				newState.devToolsVisible = !bridge().isDevToolsOpened();
 				break;
 
 			case 'NOTE_DEVTOOLS_SET':

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -76,6 +76,10 @@ export class Bridge {
 		return this.window().webContents.closeDevTools();
 	}
 
+	isDevToolsOpened() {
+		return this.window().webContents.isDevToolsOpened();
+	}
+
 	showSaveDialog(options: any) {
 		const { dialog } = require('electron');
 		if (!options) options = {};


### PR DESCRIPTION
Fixes #4710 

The problem was,  that when we close dev tools with the dev-tools cross button, the state of `newState.devToolsVisible` doesn't change. Hence a function is used to check whether the dev-tools are opened and change the state accordingly, thus correcting the **Toggle Dev Tools** button.

> I am aware it won't count towards GSoC. 