### PR TITLE
Clipper: Resolves #123: Added script to build a directory that contains the extension's files to install the extension in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bootstrapServerOnly": "lerna bootstrap --no-ci --include-dependents --include-dependencies --scope @joplin/server",
     "build": "lerna run build && npm run tsc",
     "buildApiDoc": "npm start --prefix=packages/app-cli -- apidoc ../../readme/api/references/rest_api.md",
+    "buildClipperDev": "node packages/tools/build-clipper-dev.js",
     "buildDoc": "./packages/tools/build-all.sh",
     "buildPluginDoc": "typedoc --name 'Joplin Plugin API Documentation' --mode file -theme './Assets/PluginDocTheme/' --readme './Assets/PluginDocTheme/index.md' --excludeNotExported --excludeExternals --excludePrivate --excludeProtected --out docs/api/references/plugin_api packages/lib/services/plugins/api/",
     "buildSettingJsonSchema": "npm start --prefix=packages/app-cli -- settingschema ../../docs/schema/settings.json",

--- a/packages/app-clipper/.gitignore
+++ b/packages/app-clipper/.gitignore
@@ -1,1 +1,2 @@
 dist/
+dev/

--- a/packages/tools/build-clipper-dev.js
+++ b/packages/tools/build-clipper-dev.js
@@ -1,0 +1,64 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const clipperDir = path.resolve(__dirname, '../app-clipper');
+
+async function copyDir(baseSourceDir, dirName, baseDestDir) {
+	// Create new directories at the destination directory that contains the unpacked extension
+	await fs.mkdirp(`${baseDestDir}/${dirName}`);
+	await fs.copy(`${baseSourceDir}/${dirName}`, `${baseDestDir}/${dirName}`);
+}
+
+async function copyToDev(devDir) {
+	const extensionContent = {
+		files: ['background.js', 'manifest.json'],
+		directories: ['popup/build', 'content_scripts', 'icons'],
+	};
+	const { files, directories } = extensionContent;
+	for (const dir of directories) {
+		await copyDir(clipperDir, dir, devDir);
+	}
+	for (const file of files) {
+		await fs.copy(`${clipperDir}/${file}`, `${devDir}/${file}`);
+	}
+	await fs.remove(`${devDir}/popup/build/manifest.json`);
+}
+
+async function main() {
+	const manifestConfig = {
+		chrome: {
+			removeManifestKeys: (manifest) => {
+				manifest = Object.assign({}, manifest);
+				delete manifest.applications;
+				return manifest;
+			},
+		},
+		firefox: {
+			removeManifestKeys: (manifest) => {
+				manifest = Object.assign({}, manifest);
+				delete manifest.background.persistent;
+				return manifest;
+			},
+		},
+	};
+	for (const browser in manifestConfig) {
+		const configMethod = manifestConfig[browser];
+		const devDir = `${clipperDir}/dev/${browser}`;
+		console.log(devDir);
+		await fs.remove(devDir);
+		await fs.mkdirp(devDir);
+		await copyToDev(devDir);
+		const manifestText = await fs.readFile(`${devDir}/manifest.json`, 'utf-8');
+		let manifest = JSON.parse(manifestText);
+		// Remove the `persistent` key in Firefox extension and `gecko` key in Chrome extension to avoid getting rejected by the respective browser.
+		if (configMethod.removeManifestKeys) manifest = configMethod.removeManifestKeys(manifest);
+		await fs.writeFile(`${devDir}/manifest.json`, JSON.stringify(manifest, null, 4));
+	}
+}
+
+main().then(() => console.log(`Created unpacked extension for Chrome and Firefox at ${clipperDir}/dev directory`))
+	.catch(error => {
+		console.error('Fatal error');
+		console.error(error);
+		process.exit(1);
+	});


### PR DESCRIPTION
## What do these changes do
1. Add an npm script that creates a directory at `app-clipper/dev` which contains the extension's files. This directory can then be loaded in development mode on the Extension Management page.
2. When running the script, it will do the following:
- Delete the `app-clipper/dev`. It silently quit if the directory doesn't exist.
- Create a brand new directory `app-clipper/dev`.
- Create two sub-directories named `chrome` and `firefox` inside `dev`.
- Copy the following files and directories from `app-clipper` to `app-clipper/dev`:
   - manifest.json
   - background.js
   - content_scripts
   - popup/build
   - icons 
- The manifest files for Chrome and Firefox at this point contain a key that won't be accepted by either browser. Chrome doesn't recognize `applications: gecko: id` key and Firefox doesn't accept `persistent: false` key. The script will remove those keys.
3. Now, when one makes a change to files inside `app-clipper`, run  the script above again, then go to the corresponding Extension Management page and click *Reload* button to see the changes in the locally installed extension.