### PR TITLE
Desktop: Partially fixes #4602: Remove timestamp while copying images

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -397,6 +397,12 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,12 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js.map

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -414,9 +414,11 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox .tox-dialog__footer {
 				background-color: ${theme.backgroundColor} !important;
 			}
+
 			.tox .tox-editor-header {
 				border: none;
 			}
+
 			.tox .tox-tbtn,
 			.tox .tox-tbtn svg,
 			.tox .tox-dialog__header,
@@ -429,6 +431,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				color: ${theme.color3} !important;
 				fill: ${theme.color3} !important;
 			}
+
 			.tox .tox-statusbar a,
 			.tox .tox-statusbar__path-item,
 			.tox .tox-statusbar__wordcount,
@@ -437,10 +440,12 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				fill: ${theme.color};
 				opacity: 0.7;
 			}
+
 			.tox .tox-tbtn--enabled,
 			.tox .tox-tbtn--enabled:hover {
 				background-color: ${theme.selectedColor};
 			}
+
 			.tox .tox-button--naked:hover:not(:disabled) {
 				background-color: ${theme.backgroundColor} !important;
 			}
@@ -455,6 +460,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				background-color: ${theme.backgroundColorHover3}
 			}			
 			
+
 			.tox .tox-tbtn {
 				width: ${theme.toolbarHeight}px;
 				height: ${theme.toolbarHeight}px;
@@ -462,29 +468,36 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				min-height: ${theme.toolbarHeight}px;
 				margin: 0;
 			}
+
+
 			.tox .tox-tbtn[aria-haspopup=true] {
 				width: ${theme.toolbarHeight + 15}px;
 				min-width: ${theme.toolbarHeight + 15}px;
 			}
+
 			.tox .tox-tbtn > span,
 			.tox .tox-tbtn:active > span,
 			.tox .tox-tbtn:hover > span {
 				transform: scale(0.8);
 			}
+
 			.tox .tox-toolbar__primary,
 			.tox .tox-toolbar__overflow {
 				background: none;
 				background-color: ${theme.backgroundColor3} !important;
 			}
+
 			.tox-tinymce,
 			.tox .tox-toolbar__group,
 			.tox.tox-tinymce-aux .tox-toolbar__overflow,
 			.tox .tox-dialog__footer {
 				border: none !important;
 			}
+
 			.tox-tinymce {
 				border-top: none !important;
 			}
+
 			.joplin-tinymce .tox-toolbar__group {
 				background-color: ${theme.backgroundColor3};
 				padding-top: ${theme.toolbarPadding}px;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -12,8 +12,8 @@ import usePluginServiceRegistration from '../../utils/usePluginServiceRegistrati
 import { utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import { _, closestSupportedLocale } from '@joplin/lib/locale';
 import useContextMenu from './utils/useContextMenu';
+import getCopyableContent from './utils/getCopyableContent';
 import shim from '@joplin/lib/shim';
-import HtmlUtils from '@joplin/lib/htmlUtils';
 
 const { MarkupToHtml } = require('@joplin/renderer');
 const taboverride = require('taboverride');
@@ -1040,18 +1040,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 		async function onCopy(event: any) {
 			const copiedContent = editor.selection.getContent();
-
-			// We need to remove extra url params from the image URLs while copying
-			// because some offline edtors do not show the image if there is
-			// an extra parameter in it's path.
-			// Related to - https://github.com/laurent22/joplin/issues/4602
-			const removeParametersFromUrl = (url: string) => {
-				const imageSrc = new URL(url);
-				return imageSrc.protocol === 'file:' ? imageSrc.origin + imageSrc.pathname : imageSrc.toString();
-			};
-
-			const updatedContent = HtmlUtils.replaceImageUrls(copiedContent, removeParametersFromUrl);
-			clipboard.writeHTML(updatedContent);
+			const copyableContent = getCopyableContent(copiedContent);
+			clipboard.writeHTML(copyableContent);
 			event.preventDefault();
 		}
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -399,7 +399,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
-
+			
 			.tox .tox-toolbar,
 			.tox .tox-toolbar__overflow,
 			.tox .tox-toolbar__primary,
@@ -414,11 +414,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox .tox-dialog__footer {
 				background-color: ${theme.backgroundColor} !important;
 			}
-
 			.tox .tox-editor-header {
 				border: none;
 			}
-
 			.tox .tox-tbtn,
 			.tox .tox-tbtn svg,
 			.tox .tox-dialog__header,
@@ -431,7 +429,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				color: ${theme.color3} !important;
 				fill: ${theme.color3} !important;
 			}
-
 			.tox .tox-statusbar a,
 			.tox .tox-statusbar__path-item,
 			.tox .tox-statusbar__wordcount,
@@ -440,27 +437,24 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				fill: ${theme.color};
 				opacity: 0.7;
 			}
-
 			.tox .tox-tbtn--enabled,
 			.tox .tox-tbtn--enabled:hover {
 				background-color: ${theme.selectedColor};
 			}
-
 			.tox .tox-button--naked:hover:not(:disabled) {
 				background-color: ${theme.backgroundColor} !important;
 			}
-
+			
 			.tox .tox-tbtn:focus {
 				background-color: ${theme.backgroundColor3}
 			}
-
+			
 			.tox .tox-tbtn:hover {
 				color: ${theme.colorHover3} !important;
 				fill: ${theme.colorHover3} !important;
 				background-color: ${theme.backgroundColorHover3}
-			}
-
-
+			}			
+			
 			.tox .tox-tbtn {
 				width: ${theme.toolbarHeight}px;
 				height: ${theme.toolbarHeight}px;
@@ -468,36 +462,29 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				min-height: ${theme.toolbarHeight}px;
 				margin: 0;
 			}
-
-
 			.tox .tox-tbtn[aria-haspopup=true] {
 				width: ${theme.toolbarHeight + 15}px;
 				min-width: ${theme.toolbarHeight + 15}px;
 			}
-
 			.tox .tox-tbtn > span,
 			.tox .tox-tbtn:active > span,
 			.tox .tox-tbtn:hover > span {
 				transform: scale(0.8);
 			}
-
 			.tox .tox-toolbar__primary,
 			.tox .tox-toolbar__overflow {
 				background: none;
 				background-color: ${theme.backgroundColor3} !important;
 			}
-
 			.tox-tinymce,
 			.tox .tox-toolbar__group,
 			.tox.tox-tinymce-aux .tox-toolbar__overflow,
 			.tox .tox-dialog__footer {
 				border: none !important;
 			}
-
 			.tox-tinymce {
 				border-top: none !important;
 			}
-
 			.joplin-tinymce .tox-toolbar__group {
 				background-color: ${theme.backgroundColor3};
 				padding-top: ${theme.toolbarPadding}px;
@@ -1041,18 +1028,18 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		async function onCopy(event: any) {
 			const copiedContent = editor.selection.getContent();
 
-			// We need to remove timestamps from the image URLs while copying
+			// We need to remove extra url params from the image URLs while copying
 			// because some offline edtors do not show the image if there is
-			// an extra ?t= in it's path.
+			// an extra parameter in it's path.
 			// Related to - https://github.com/laurent22/joplin/issues/4602
-			const removeTimestampFromUrl = (url: string) => {
-				const index = url.lastIndexOf('?t=');
-				return index === -1 ? url : url.substr(0, index);
+			const removeParametersFromUrl = (url: string) => {
+				const imageSrc = new URL(url);
+				return imageSrc.protocol === 'file:' ? imageSrc.origin + imageSrc.pathname : imageSrc.toString();
 			};
 
-			const updatedContent = HtmlUtils.replaceImageUrls(copiedContent, removeTimestampFromUrl);
+			const updatedContent = HtmlUtils.replaceImageUrls(copiedContent, removeParametersFromUrl);
 			clipboard.writeHTML(updatedContent);
-			if (event) event.preventDefault();
+			event.preventDefault();
 		}
 
 		function onKeyDown(event: any) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -13,6 +13,7 @@ import { utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import { _, closestSupportedLocale } from '@joplin/lib/locale';
 import useContextMenu from './utils/useContextMenu';
 import shim from '@joplin/lib/shim';
+import HtmlUtils from '@joplin/lib/htmlUtils';
 
 const { MarkupToHtml } = require('@joplin/renderer');
 const taboverride = require('taboverride');
@@ -398,7 +399,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
-			
+
 			.tox .tox-toolbar,
 			.tox .tox-toolbar__overflow,
 			.tox .tox-toolbar__primary,
@@ -448,17 +449,17 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox .tox-button--naked:hover:not(:disabled) {
 				background-color: ${theme.backgroundColor} !important;
 			}
-			
+
 			.tox .tox-tbtn:focus {
 				background-color: ${theme.backgroundColor3}
 			}
-			
+
 			.tox .tox-tbtn:hover {
 				color: ${theme.colorHover3} !important;
 				fill: ${theme.colorHover3} !important;
 				background-color: ${theme.backgroundColorHover3}
-			}			
-			
+			}
+
 
 			.tox .tox-tbtn {
 				width: ${theme.toolbarHeight}px;
@@ -1037,6 +1038,19 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			}
 		}
 
+		async function onCopy(event: any) {
+			const copiedContent = editor.selection.getContent();
+
+			const removeTimestampFromUrl = (url: string) => {
+				const index = url.lastIndexOf('?t=');
+				return index === -1 ? url : url.substr(0, index);
+			};
+
+			const updatedContent = HtmlUtils.replaceImageUrls(copiedContent, removeTimestampFromUrl);
+			clipboard.writeHTML(updatedContent);
+			if (event) event.preventDefault();
+		}
+
 		function onKeyDown(event: any) {
 			// It seems "paste as text" is handled automatically by
 			// on Windows so the code below so we need to run the below
@@ -1059,6 +1073,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		editor.on('keydown', onKeyDown);
 		editor.on('keypress', onKeypress);
 		editor.on('paste', onPaste);
+		editor.on('copy', onCopy);
 		// `compositionend` means that a user has finished entering a Chinese
 		// (or other languages that require IME) character.
 		editor.on('compositionend', onChangeHandler);
@@ -1074,6 +1089,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				editor.off('keydown', onKeyDown);
 				editor.off('keypress', onKeypress);
 				editor.off('paste', onPaste);
+				editor.off('copy', onCopy);
 				editor.off('compositionend', onChangeHandler);
 				editor.off('cut', onChangeHandler);
 				editor.off('joplinChange', onChangeHandler);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1041,6 +1041,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		async function onCopy(event: any) {
 			const copiedContent = editor.selection.getContent();
 
+			// We need to remove timestamps from the image URLs while copying
+			// because some offline edtors do not show the image if there is
+			// an extra ?t= in it's path.
+			// Related to - https://github.com/laurent22/joplin/issues/4602
 			const removeTimestampFromUrl = (url: string) => {
 				const index = url.lastIndexOf('?t=');
 				return index === -1 ? url : url.substr(0, index);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.test.ts
@@ -1,0 +1,50 @@
+import getCopyableContent from './getCopyableContent';
+
+describe('getCopyableContent', () => {
+	test('should remove parameters from local images', () => {
+		const localImage = 'file:///home/some/path/test.jpg';
+
+		const content = `<div><img src="${localImage}?a=1&b=2"></div>`;
+		const copyableContent = getCopyableContent(content);
+
+		expect(copyableContent).toEqual(`<div><img src="${localImage}"></div>`);
+	});
+
+	test('should be able to process mutiple images', () => {
+		const localImage1 = 'file:///home/some/path/test1.jpg';
+		const localImage2 = 'file:///home/some/path/test2.jpg';
+		const localImage3 = 'file:///home/some/path/test3.jpg';
+
+		const content = `
+      <div>
+        <img src="${localImage1}?a=1&b=2">
+        <img src="${localImage2}">
+        <img src="${localImage3}?t=1">
+      </div>`;
+
+		const copyableContent = getCopyableContent(content);
+		const expectedContent = `
+      <div>
+        <img src="${localImage1}">
+        <img src="${localImage2}">
+        <img src="${localImage3}">
+      </div>`;
+
+		expect(copyableContent).toEqual(expectedContent);
+	});
+
+	test('should not change parameters for images on the internet', () => {
+		const image1 = 'http://www.somelink.com/image1.jpg';
+		const image2 = 'https://www.somelink.com/image2.jpg';
+
+		const content = `
+      <div>
+        <img src="${image1}">
+        <img src="${image2}?h=12&w=15">
+      </div>`;
+
+		const copyableContent = getCopyableContent(content);
+
+		expect(copyableContent).toEqual(content);
+	});
+});

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/getCopyableContent.ts
@@ -1,0 +1,20 @@
+import HtmlUtils from '@joplin/lib/htmlUtils';
+
+export default function(htmlContent: string) {
+	// We need to remove extra url params from the image URLs while copying
+	// because some offline edtors do not show the image if there is
+	// an extra parameter in it's path.
+	// Related to - https://github.com/laurent22/joplin/issues/4602
+	const removeParametersFromUrl = (url: string) => {
+		const imageSrc = new URL(url);
+
+		// Remove parameters if it's a local image.
+		if (imageSrc.protocol === 'file:') {
+			imageSrc.search = '';
+		}
+
+		return imageSrc.toString();
+	};
+
+	return HtmlUtils.replaceImageUrls(htmlContent, removeParametersFromUrl);
+}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes part of #4602. For background please read https://github.com/laurent22/joplin/issues/4602#issuecomment-803774665.

### Explanation 

The `?t=` was actually needed to update the image when it changes in the editor. Reference -> 

https://github.com/laurent22/joplin/blob/656673ed57bd0d3a010a4d28f6852c01a0e64730/packages/lib/models/Note.ts#L164-L166

So, the best solution I could think of is removing the timestamps manually while copying (if they exist) in image tags.

### Unit Testing

I couldn't write the unit tests because I couldn't find other unit tests related to TinyMCE editor. Can someone please tell where are those written?

### Manual Testing

I tested the changes from my end and they seem to work perfectly but I would also request other members to also test the changes manually once.

#### Steps followed

1. Import an image in the joplin editor.
2. Copy the image.
3. Paste it in another offline editor (Libre Office Writer) in my case.
4. Check if image is pasted correctly.
