### PR TITLE
Desktop: Fixes #4723: Plugin Update error when plugin was installed manually

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.test.ts
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.test.ts
@@ -18,14 +18,14 @@ const onPluginSettingsChange = jest.fn();
 const itemEvent = ({
 	item: { manifest: { id: pluginId } },
 } as ItemEvent);
-const callHook = (isUpdate: boolean, pluginEnabled = true) => () => useOnInstallHandler(
+const callHook = (isUpdate: boolean, pluginEnabled = true, pluginInstalledViaGUI = true) => () => useOnInstallHandler(
 	setInstallingPluginIds,
 	{
-		[pluginId]: {
+		[pluginId]: pluginInstalledViaGUI ? {
 			enabled: pluginEnabled,
 			deleted: false,
 			hasBeenUpdated: false,
-		},
+		} : undefined,
 	},
 	repoApi,
 	onPluginSettingsChange,
@@ -82,5 +82,10 @@ describe('useOnInstallHandler', () => {
 
 		const newSettings = onPluginSettingsChange.mock.calls[0][0].value;
 		expect(newSettings[pluginId].hasBeenUpdated).toBe(true);
+	});
+
+	test('should not fail when plugin was not installed through the GUI', async () => {
+		const { result: { current: onUpdate } } = renderHook(callHook(true, true, false));
+		await onUpdate(itemEvent);
 	});
 });

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.ts
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.ts
@@ -40,7 +40,9 @@ export default function(setInstallingPluginIds: Function, pluginSettings: Plugin
 			const newSettings = produce(pluginSettings, (draft: PluginSettings) => {
 				draft[pluginId] = defaultPluginSetting();
 				if (isUpdate) {
-					if (pluginSettings[pluginId]) { draft[pluginId].enabled = pluginSettings[pluginId].enabled; }
+					if (pluginSettings[pluginId]) {
+						draft[pluginId].enabled = pluginSettings[pluginId].enabled;
+					}
 					draft[pluginId].hasBeenUpdated = true;
 				}
 			});

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.ts
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/useOnInstallHandler.ts
@@ -40,7 +40,7 @@ export default function(setInstallingPluginIds: Function, pluginSettings: Plugin
 			const newSettings = produce(pluginSettings, (draft: PluginSettings) => {
 				draft[pluginId] = defaultPluginSetting();
 				if (isUpdate) {
-					draft[pluginId].enabled = pluginSettings[pluginId].enabled;
+					if (pluginSettings[pluginId]) { draft[pluginId].enabled = pluginSettings[pluginId].enabled; }
 					draft[pluginId].hasBeenUpdated = true;
 				}
 			});


### PR DESCRIPTION
Fixes #4723 

When plugins are installed not through the GUI, the corresponding `PluginSetting` is only created when a setting is changed (plugin is disabled for example). So when the `useOnInstallHandler` hooks tries to get the enabled flag during an update, so that it can save it, the setting might still be undefined.