### PR TITLE
Desktop: Hide completed Todos from search result when showCompletedTodos is toggled

### DIFF
--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -49,7 +49,7 @@ export default class SearchEngineUtils {
 		// handle it here by checking if `user_updated_time` IS NOT NULL. Was causing this
 		// issue: https://discourse.joplinapp.org/t/how-to-recover-corrupted-database/9367
 		if (noteIds.length !== notes.length) {
-			const results1: any[] = [];
+			const results1: any = [];
 			const filtered_notes = sortedNotes.filter(n => n);
 			if (!Setting.value('showCompletedTodos')) {
 				for (let i = 0 ; i < filtered_notes.length ; i++) {
@@ -63,7 +63,7 @@ export default class SearchEngineUtils {
 				return filtered_notes;
 			}
 		} else {
-			const results2: any[] = [];
+			const results2: any = [];
 			if (!Setting.value('showCompletedTodos')) {
 				for (let i = 0 ; i < sortedNotes.length ; i++) {
 					if (sortedNotes[i].todo_completed) {

--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -48,12 +48,12 @@ export default class SearchEngineUtils {
 		// references to notes that don't exist. Not clear how it can happen, but anyway
 		// handle it here by checking if `user_updated_time` IS NOT NULL. Was causing this
 		// issue: https://discourse.joplinapp.org/t/how-to-recover-corrupted-database/9367
-		if ( noteIds.length !== notes.length ) {
-			const results1 : any[] = [];
-			const filtered_notes = sortedNotes.filter (n => n);
-			if ( !Setting.value('showCompletedTodos') ) {
-				for ( let i = 0 ; i < filtered_notes.length ; i++ ) {
-					if ( filtered_notes[i].todo_completed ) {
+		if (noteIds.length !== notes.length) {
+			const results1: any[] = [];
+			const filtered_notes = sortedNotes.filter(n => n);
+			if (!Setting.value('showCompletedTodos')) {
+				for (let i = 0 ; i < filtered_notes.length ; i++) {
+					if (filtered_notes[i].todo_completed) {
 						continue;
 					}
 					results1.push(filtered_notes[i]);
@@ -63,16 +63,16 @@ export default class SearchEngineUtils {
 				return filtered_notes;
 			}
 		} else {
-			const results2 : any[] = [];
-			if ( !Setting.value('showCompletedTodos') ) {
-				for ( let i = 0 ; i < sortedNotes.length ; i++ ) {
-					if ( sortedNotes[i].todo_completed ) {
+			const results2: any[] = [];
+			if (!Setting.value('showCompletedTodos')) {
+				for (let i = 0 ; i < sortedNotes.length ; i++) {
+					if (sortedNotes[i].todo_completed) {
 						continue;
 					}
 					results2.push(sortedNotes[i]);
 				}
 				return results2;
-			}else{
+			} else {
 				return sortedNotes;
 			}
 		}

--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -1,5 +1,6 @@
 import SearchEngine from './SearchEngine';
 import Note from '../../models/Note';
+import Setting from '../../models/Setting';
 
 export default class SearchEngineUtils {
 	static async notesForQuery(query: string, options: any = null) {
@@ -48,11 +49,32 @@ export default class SearchEngineUtils {
 		// handle it here by checking if `user_updated_time` IS NOT NULL. Was causing this
 		// issue: https://discourse.joplinapp.org/t/how-to-recover-corrupted-database/9367
 		if (noteIds.length !== notes.length) {
-			// remove null objects
-			return sortedNotes.filter(n => n);
+			const results1:any[] = [];
+			const filtered_notes = sortedNotes.filter(n => n);
+			if(!Setting.value('showCompletedTodos')){
+				for(let i=0;i<filtered_notes.length;i++){
+					if(filtered_notes[i].todo_completed){
+						continue;
+					}
+					results1.push(filtered_notes[i]);
+				}
+				return results1;
+			} else {
+				return filtered_notes;
+			}
 		} else {
-			return sortedNotes;
+			const results2:any[] = [];
+			if(!Setting.value('showCompletedTodos')){
+				for(let i=0;i<sortedNotes.length;i++){
+					if(sortedNotes[i].todo_completed){
+						continue;
+					}
+					results2.push(sortedNotes[i]);
+				}
+				return results2;
+			}else{
+				return sortedNotes;
+			}
 		}
-
 	}
 }

--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -48,12 +48,12 @@ export default class SearchEngineUtils {
 		// references to notes that don't exist. Not clear how it can happen, but anyway
 		// handle it here by checking if `user_updated_time` IS NOT NULL. Was causing this
 		// issue: https://discourse.joplinapp.org/t/how-to-recover-corrupted-database/9367
-		if (noteIds.length !== notes.length) {
-			const results1:any[] = [];
-			const filtered_notes = sortedNotes.filter(n => n);
-			if(!Setting.value('showCompletedTodos')){
-				for(let i=0;i<filtered_notes.length;i++){
-					if(filtered_notes[i].todo_completed){
+		if ( noteIds.length !== notes.length ) {
+			const results1 : any[] = [];
+			const filtered_notes = sortedNotes.filter (n => n);
+			if ( !Setting.value('showCompletedTodos') ) {
+				for ( let i = 0 ; i < filtered_notes.length ; i++ ) {
+					if ( filtered_notes[i].todo_completed ) {
 						continue;
 					}
 					results1.push(filtered_notes[i]);
@@ -63,10 +63,10 @@ export default class SearchEngineUtils {
 				return filtered_notes;
 			}
 		} else {
-			const results2:any[] = [];
-			if(!Setting.value('showCompletedTodos')){
-				for(let i=0;i<sortedNotes.length;i++){
-					if(sortedNotes[i].todo_completed){
+			const results2 : any[] = [];
+			if ( !Setting.value('showCompletedTodos') ) {
+				for ( let i = 0 ; i < sortedNotes.length ; i++ ) {
+					if ( sortedNotes[i].todo_completed ) {
 						continue;
 					}
 					results2.push(sortedNotes[i]);


### PR DESCRIPTION
Before the sorted search results are returned, a for loop checks whether the sorted list has completed todos and removes them in case the showCompletedTodos option is toggled.
Not sure if this is still a hacky fix
Fixes #4581
