### PR TITLE
Desktop: use app.whenReady() instead of polling

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -224,14 +224,7 @@ export default class ElectronAppWrapper {
 	async waitForElectronAppReady() {
 		if (this.electronApp().isReady()) return Promise.resolve();
 
-		return new Promise((resolve) => {
-			const iid = setInterval(() => {
-				if (this.electronApp().isReady()) {
-					clearInterval(iid);
-					resolve();
-				}
-			}, 10);
-		});
+		return this.electronApp().whenReady();
 	}
 
 	async quit() {


### PR DESCRIPTION
According to Electron documentation [here](https://www.electronjs.org/docs/api/app#event-ready)

It is recommended to

> call app.whenReady() to get a Promise that is fulfilled when Electron is initialized.

I think it is better to use this instead of doing setInterval and checking for the value of app.isReady() every 10 milliseconds. Although this is a tiny fix, but it removes some ambiguity and makes the code more clean and efficient. 