### PR TITLE
Desktop : Resolves #4736 Note list is empty if search field is cleared.

### DIFF
--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -80,6 +80,11 @@ function SearchBar(props: Props) {
 	}, [props.selectedNoteId]);
 
 	function onChange(event: any) {
+		if (event.value.length === 0) {
+			// Revert to previous state if query string becomes empty
+			void onExitSearch();
+			return;
+		}
 		setSearchStarted(true);
 		setQuery(event.value);
 	}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes #4736.

Adds a check for an empty query string in the input onChange handler for the searchbar. 
If the query is empty, the search exits and displays all the notes in the current notebook. Focus is retained on the searchbar.

### Manual Testing : 

- Select the searchbar present in the Note List 
- Type something to get a few results
- Clear the input
- The complete list of notes in the notebook should be visible

Unaware of how to add any automated tests for this currently but the manual testing probably suffices for this. Here is a demonstration of the manual tests, before and after the fix : 

**Before :** 

![notelist-prev](https://user-images.githubusercontent.com/28067395/113768020-fb9af300-973c-11eb-98af-9ce7fede8164.gif)





**After :** 

![notelist-fix](https://user-images.githubusercontent.com/28067395/112650345-4aa97400-8e71-11eb-91de-d85fa8e2ce2b.gif)

