### PR TITLE
Desktop: Fixes #4658: Added a copy button and prevented showing default context menu

### DIFF
--- a/packages/app-desktop/gui/NotePropertiesDialog.jsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.jsx
@@ -8,6 +8,7 @@ const Note = require('@joplin/lib/models/Note').default;
 const formatcoords = require('formatcoords');
 const bridge = require('electron').remote.require('./bridge').default;
 const shim = require('@joplin/lib/shim').default;
+const { clipboard } = require('electron');
 
 class NotePropertiesDialog extends React.Component {
 	constructor() {
@@ -317,6 +318,12 @@ class NotePropertiesDialog extends React.Component {
 					this.editPropertyButtonClick(key, value);
 				};
 				editCompIcon = 'fa-edit';
+			}
+
+			// Add the copy icon and the 'copy on click' event
+			if (key === 'id') {
+				editCompIcon = 'fa-copy';
+				editCompHandler = () => clipboard.writeText(value);
 			}
 		}
 


### PR DESCRIPTION
## Description
This is a quick but not long-term fix to the issue [#4658](https://github.com/laurent22/joplin/issues/4658).
@roman-r-m @laurent22 @CalebJohn 

## What has been done
- Added a copy button next to the **ID** field.
- Prevented showing the default context menu when right-clicking on the **ID** value.

## Screenshot
![Screenshot](https://i.ibb.co/P101kjf/Screenshot-from-2021-03-28-12-26-53.png)

## Things to notice

```
const { clipboard } = require('electron');
.
.
.

clipboard.writeText(value);
```

This is by no means the best way to implement the functionality and there should be some sort of abstraction that hides away the details of electron clipboard object. I very much encourage people who have more knowledge to modify this. However, in the meantime, this is the quickest way to do it.

## Possible improvements
- Add a tooltip to the copy button for a better user experience.
- Add a small dialog that indicates the text has been copied successfully.
