### PR TITLE
Desktop: Fixes #4697: Prevent Goto anything from changing notebooks

### DIFF
--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -732,9 +732,15 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 		case 'FOLDER_AND_NOTE_SELECT':
 			{
-				changeSelectedFolder(draft, action);
 				const noteSelectAction = Object.assign({}, action, { type: 'NOTE_SELECT' });
-				changeSelectedNotes(draft, noteSelectAction);
+
+				if (draft.notesParentType === 'SmartFilter' && draft.selectedSmartFilterId === ALL_NOTES_FILTER_ID) {
+					// we don't want to change folder when 'All Notes' filter is on
+					changeSelectedNotes(draft, noteSelectAction);
+				} else {
+					changeSelectedFolder(draft, action);
+					changeSelectedNotes(draft, noteSelectAction);
+				}
 			}
 			break;
 


### PR DESCRIPTION
Prevent Goto anything from changing notebooks when 'All Notes' is selected.

Fixes #4697

### How to test
1. Click on `All Notes` .
2. open goto anything.
3. Now search for a note from a different notebook. 
4. `All notes` stays selected and just the note is switched.

Here's a video showing UI interaction after the changes.
Works as usual when All Notes isn't selected and do not change notebooks when it is.

https://user-images.githubusercontent.com/17108695/112754381-7b1c1a00-8ff9-11eb-9a00-086f80394976.mp4

