### PR TITLE
Desktop: Fixes #4754: Roboto font in plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The Web Clipper is a browser extension that allows you to save web pages and scr
 	- [Data API](https://github.com/laurent22/joplin/blob/dev/readme/api/references/rest_api.md)
 	- [Plugin manifest](https://github.com/laurent22/joplin/blob/dev/readme/api/references/plugin_manifest.md)
 	- [Plugin loading rules](https://github.com/laurent22/joplin/blob/dev/readme/api/references/plugin_loading_rules.md)
+	- [Plugin theming](https://github.com/laurent22/joplin/blob/dev/readme/api/references/plugin_theming.md)
 
 - Development
 

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -10,7 +10,6 @@
 		<title>Joplin</title>
 		<link rel="stylesheet" href="style.css">
 		<link rel="stylesheet" href="style/icons/style.css">
-		<!-- TODO: Remove once all icons have been swapped -->
 		<link rel="stylesheet" href="node_modules/@fortawesome/fontawesome-free/css/all.min.css">
 		<link rel="stylesheet" href="node_modules/react-datetime/css/react-datetime.css">
 		<link rel="stylesheet" href="node_modules/smalltalk/css/smalltalk.css">

--- a/packages/app-desktop/services/plugins/UserWebviewIndex.html
+++ b/packages/app-desktop/services/plugins/UserWebviewIndex.html
@@ -3,6 +3,9 @@
 <head>
 	<meta charset="UTF-8">
 	<script src="UserWebviewIndex.js"></script>
+	<link rel="stylesheet" href="../../style/icons/style.css">
+	<link rel="stylesheet" href="../../node_modules/@fortawesome/fontawesome-free/css/all.min.css">
+	<link rel="stylesheet" href="../../node_modules/roboto-fontface/css/roboto/roboto-fontface.css">
 	<style>
 		html {
 			overflow: hidden;

--- a/readme/api/references/plugin_theming.md
+++ b/readme/api/references/plugin_theming.md
@@ -1,0 +1,51 @@
+# Plugin theming
+
+## CSS
+
+Plugins add custom content to the UI using
+[webview panels](https://joplinapp.org/api/references/plugin_api/classes/joplinviewspanels.html).
+The HTML content of a a panel is styled with CSS.
+
+To keep the look and feel of a plugin consistent with the rest of the Joplin UI,
+you are automatically provided with variables derived from the current theme.
+
+Variables follow the naming convention `--joplin-{property}` and are used
+in your plugin's stylesheet as shown here.
+
+```css
+/* webview.css */
+.container {
+	color: var(--joplin-color);
+	font-family: var(--joplin-font-family);
+}
+```
+
+## Icons
+
+In addition to variables, you have access to a set of standard font assets that ship with Joplin.
+These include:
+
+* [Roboto](https://fonts.google.com/specimen/Roboto?preview.text_type=custom) - (the standard UI font, `font-family` referenced above)
+* [Font Awesome](https://fontawesome.com/icons?d=gallery&p=2&m=free) - icon library
+* [icoMoon](https://icomoon.io/#preview-free) - icon library (subset, see [style.css](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/style/icons/style.css))
+
+To display an icon, use CSS and HTML like the following.
+
+```css
+/* style icons to match the theme */
+.toolbarIcon {
+    font-size: var(--joplin-toolbar-icon-size);
+}
+.primary {
+    color: var(--joplin-color);
+}
+.secondary {
+    color: var(--joplin-color-2);
+}
+```
+
+```html
+<i class="toolbarIcon primary fas fa-music"></i> Font Awesome music icon
+<br />
+<i class="toolbarIcon secondary icon-notebooks"></i> icoMoon notebook icon
+```


### PR DESCRIPTION
This change links the Roboto, Icomoon, and Font-Awesome stylesheets into the index.html used by all plugins.

This makes the fonts available to all plugins, w/out the plugin needed to package and ship the font.

I tested manually by comparing the presentation of Joplin with the Favorites and Outline plugins installed. Without this change, Outline displays incorrectly. With it, both plugins have the correct presentation.

# Before

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/60824/112758775-e5ef3600-8fa4-11eb-9619-7794ba0fc0b9.png">

# After

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/60824/112758788-f56e7f00-8fa4-11eb-9c9e-c6fe361f062b.png">

