### PR TITLE
Desktop: Fixes #4658: Fixes context menu for popup modals

### DIFF
--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -153,7 +153,7 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	const readTimeLabel = _('Read time: %s min', formatReadTime(strippedReadTime));
 
 	return (
-		<div style={theme.dialogModalLayer}>
+		<div style={theme.dialogModalLayer} className="dialog-modal">
 			<div style={theme.dialogBox}>
 				<div style={dialogBoxHeadingStyle}>{_('Statistics')}</div>
 				<table>

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -638,6 +638,12 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	// It might be buggy, refer to the below issue
 	// https://github.com/laurent22/joplin/pull/3974#issuecomment-718936703
 	useEffect(() => {
+
+		function isDialogModalOpen() {
+			const dialogModal = document.getElementsByClassName('dialog-modal');
+			return dialogModal.length > 0;
+		}
+
 		function pointerInsideEditor(x: number, y: number) {
 			const elements = document.getElementsByClassName('codeMirrorEditor');
 			if (!elements.length) return null;
@@ -647,6 +653,26 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 		function onContextMenu(_event: any, params: any) {
 			if (!pointerInsideEditor(params.x, params.y)) return;
+
+			if (isDialogModalOpen()) {
+				const selection = document.getSelection().toString();
+
+				if (selection.length > 0) {
+					const menu = new Menu();
+					menu.append(
+						new MenuItem({
+							label: _('Copy'),
+							enabled: true,
+							click: async () => {
+								await clipboard.writeText(selection);
+							},
+						})
+					);
+
+					menu.popup();
+				}
+				return;
+			}
 
 			const menu = new Menu();
 

--- a/packages/app-desktop/gui/NotePropertiesDialog.jsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.jsx
@@ -371,7 +371,7 @@ class NotePropertiesDialog extends React.Component {
 		}
 
 		return (
-			<div style={theme.dialogModalLayer}>
+			<div style={theme.dialogModalLayer} className="dialog-modal">
 				<div style={theme.dialogBox}>
 					<div style={theme.dialogTitle}>{_('Note properties')}</div>
 					<div>{noteComps}</div>

--- a/packages/app-desktop/gui/ShareNoteDialog.tsx
+++ b/packages/app-desktop/gui/ShareNoteDialog.tsx
@@ -210,7 +210,7 @@ export default function ShareNoteDialog(props: ShareNoteDialogProps) {
 	rootStyle.width = '50%';
 
 	return (
-		<div style={theme.dialogModalLayer}>
+		<div style={theme.dialogModalLayer} className="dialog-modal">
 			<div style={rootStyle}>
 				<div style={theme.dialogTitle}>{_('Share Notes')}</div>
 				{renderNoteList(notes)}

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -522,7 +522,7 @@ class Dialog extends React.PureComponent<Props, State> {
 		const helpComp = !this.state.showHelp ? null : <div style={style.help}>{_('Type a note title or part of its content to jump to it. Or type # followed by a tag name, or @ followed by a notebook name. Or type : to search for commands.')}</div>;
 
 		return (
-			<div onClick={this.modalLayer_onClick} style={theme.dialogModalLayer}>
+			<div onClick={this.modalLayer_onClick} style={theme.dialogModalLayer} className="dialog-modal">
 				<div style={style.dialogBox}>
 					{helpComp}
 					<div style={style.inputHelpWrapper}>


### PR DESCRIPTION
### Issue:

Wrong context menu on popup modals. Refer #4658 

### Cause:

Since there is no context menu for NoteProperties modal (or any other modals like NoteContentProperties), the context menu for CodeEditor is getting triggered.

### Solution:

Add 'Copy' option to the context menu when a modal is open and there is a text selection available
![joplin context menu](https://user-images.githubusercontent.com/55804983/112864675-ac6a1800-90d5-11eb-99fc-5a5a35833eb4.PNG)

@laurent22 @PackElend @roman-r-m  Please let me know, if there is any better way to know if a dialog is open.
