### PR TITLE
Desktop: Fixes #4658: Fixes context menu for popup modals

### DIFF
--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, MouseEventHandler } from 'react';
 import { _ } from '@joplin/lib/locale';
 const { themeStyle } = require('@joplin/lib/theme');
 const DialogButtonRow = require('./DialogButtonRow.min');
@@ -11,6 +11,7 @@ interface NoteContentPropertiesDialogProps {
 	text: string;
 	markupLanguage: number;
 	onClose: Function;
+	onContextMenu: MouseEventHandler;
 }
 
 interface TextPropertiesMap {
@@ -153,7 +154,7 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	const readTimeLabel = _('Read time: %s min', formatReadTime(strippedReadTime));
 
 	return (
-		<div style={theme.dialogModalLayer}>
+		<div style={theme.dialogModalLayer} onContextMenu={props.onContextMenu}>
 			<div style={theme.dialogBox}>
 				<div style={dialogBoxHeadingStyle}>{_('Statistics')}</div>
 				<table>

--- a/packages/app-desktop/gui/NotePropertiesDialog.jsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.jsx
@@ -371,7 +371,7 @@ class NotePropertiesDialog extends React.Component {
 		}
 
 		return (
-			<div style={theme.dialogModalLayer}>
+			<div style={theme.dialogModalLayer} onContextMenu={this.props.onContextMenu}>
 				<div style={theme.dialogBox}>
 					<div style={theme.dialogTitle}>{_('Note properties')}</div>
 					<div>{noteComps}</div>

--- a/packages/app-desktop/gui/ShareNoteDialog.tsx
+++ b/packages/app-desktop/gui/ShareNoteDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, MouseEventHandler } from 'react';
 import JoplinServerApi from '@joplin/lib/JoplinServerApi';
 import { _, _n } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
@@ -16,6 +16,7 @@ interface ShareNoteDialogProps {
 	themeId: number;
 	noteIds: Array<string>;
 	onClose: Function;
+	onContextMenu: MouseEventHandler;
 }
 
 interface SharesMap {
@@ -210,7 +211,7 @@ export default function ShareNoteDialog(props: ShareNoteDialogProps) {
 	rootStyle.width = '50%';
 
 	return (
-		<div style={theme.dialogModalLayer}>
+		<div style={theme.dialogModalLayer} onContextMenu={props.onContextMenu}>
 			<div style={rootStyle}>
 				<div style={theme.dialogTitle}>{_('Share Notes')}</div>
 				{renderNoteList(notes)}


### PR DESCRIPTION
### Issue:

Wrong context menu on popup modals. Refer #4658 

### Cause:

Since there is no context menu for NoteProperties modal (or any other modals like NoteContentProperties), the context menu for CodeEditor is getting triggered.

### Solution:

Giving a `onContextMenu` handler to the modal dialogs and preventing it from bubbling up to the contextMenu handler of CodeMirror editor.

 Add 'Copy' option to the context menu when a modal is open and there is a text selection available. 
![joplin context menu](https://user-images.githubusercontent.com/55804983/112864675-ac6a1800-90d5-11eb-99fc-5a5a35833eb4.PNG)

Addressing the feedback of previous PR. #4763 