### PR TITLE
Desktop: Resolves #4766: ENTER key no longer submits dialogs when a textarea is focused.

### DIFF
--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -39,6 +39,18 @@ joplin.plugins.register({
 
 		const result3 = await dialogs.open(handle3);
 		console.info('Got result: ' + JSON.stringify(result3));		
+		
+		
+		const handle4 = await dialogs.create('myDialog4');
+		await dialogs.setHtml(handle4, `
+		<p>Testing dialog with textarea element</p>
+		<form name="user">
+			Text: <textarea name="text"></textarea>
+		</form>
+		`);
+
+		const result4 = await dialogs.open(handle4);
+		console.info('Got result: ' + JSON.stringify(result4));		
 	},
 
 });

--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -34,23 +34,14 @@ joplin.plugins.register({
 			Name: <input type="text" name="name"/>
 			<br/>
 			Email: <input type="text" name="email"/>
+			<br/>
+			Description: <textarea name="desc"></textarea>
 		</form>
 		`);
 
 		const result3 = await dialogs.open(handle3);
 		console.info('Got result: ' + JSON.stringify(result3));		
 		
-		
-		const handle4 = await dialogs.create('myDialog4');
-		await dialogs.setHtml(handle4, `
-		<p>Testing dialog with textarea element</p>
-		<form name="user">
-			Text: <textarea name="text"></textarea>
-		</form>
-		`);
-
-		const result4 = await dialogs.open(handle4);
-		console.info('Got result: ' + JSON.stringify(result4));		
 	},
 
 });

--- a/packages/app-desktop/services/plugins/hooks/useSubmitHandler.ts
+++ b/packages/app-desktop/services/plugins/hooks/useSubmitHandler.ts
@@ -15,7 +15,13 @@ export default function(frameWindow: any, onSubmit: Function, onDismiss: Functio
 			}
 
 			if (event.key === 'Enter') {
-				if (onSubmit) onSubmit();
+				//
+				// Disable enter key from submitting when a text area is in focus!
+				// https://github.com/laurent22/joplin/issues/4766
+				//
+				if (frameWindow.document.activeElement.tagName != 'TEXTAREA') {
+					if (onSubmit) onSubmit();
+				}
 			}
 		}
 


### PR DESCRIPTION
Resolves #4766 by preventing the onSubmit function to be called (if exists) when ENTER key is pressed while a textarea is active. 

I've tested this by adding a 4th dialog to the demo dialogs plugin that has just a text area and indeed pressing ENTER whilst it's focused didn't submit. However, the rest of the forms submitted on ENTER normally. *(Including the text area one when textarea not in focus)*

I'm not sure how to "properly" add a feature test to this. Not sure if it's even possible as I couldn't find any existing tests for plugin system at all. 
I haven't worked with unit tests in a way that interacts with UI before frankly so lmk if there's anything I missed!