### PR TITLE
Desktop: Fixes #4658 : Add context menu for NoteProperties and prevents focus on background editors

### DIFF
--- a/packages/app-desktop/gui/NotePropertiesDialog.jsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.jsx
@@ -44,6 +44,7 @@ class NotePropertiesDialog extends React.Component {
 	}
 
 	componentDidMount() {
+		this.dialogRef.current.focus();
 		this.loadNote(this.props.noteId);
 	}
 
@@ -398,7 +399,7 @@ class NotePropertiesDialog extends React.Component {
 	}
 
 	pointerInsideDialogBox(x, y) {
-		const elements = document.getElementsByClassName('note-properties-dialog');
+		const elements = document.getElementsByClassName('note-properties-overlay');
 		if (!elements.length) return null;
 		const rect = convertToScreenCoordinates(Setting.value('windowContentZoomFactor'), elements[0].getBoundingClientRect());
 		return rect.x < x && rect.y < y && rect.right > x && rect.bottom > y;
@@ -411,9 +412,15 @@ class NotePropertiesDialog extends React.Component {
 		const menu = new Menu();
 		const selectionObject = window.getSelection();
 		const hasSelectedText = this.dialogRef.current && !!selectionObject.toString();
-		const isEditable = (selectionObject.anchorNode.parentNode.getAttribute('iscontenteditable') === 'true' ||
-		selectionObject.anchorNode.getAttribute('iscontenteditable') === 'true') ? true : false;
 
+		let isEditable;
+		if (selectionObject.anchorNode.nodeType === 3) {
+			// For text only divs
+			isEditable = false;
+		} else {
+			isEditable = (selectionObject.anchorNode.parentNode.getAttribute('iscontenteditable') === 'true' ||
+		selectionObject.anchorNode.getAttribute('iscontenteditable') === 'true') ? true : false;
+		}
 		menu.append(
 			// Allow Cut functionality only for editable fields
 			new MenuItem({
@@ -463,8 +470,8 @@ class NotePropertiesDialog extends React.Component {
 		}
 
 		return (
-			<div style={theme.dialogModalLayer}>
-				<div ref={this.dialogRef} className='note-properties-dialog' style={theme.dialogBox} onContextMenu={this.onContextMenu}>
+			<div className='note-properties-overlay' ref={this.dialogRef} style={theme.dialogModalLayer} onContextMenu={this.onContextMenu}>
+				<div className='note-properties-dialog' style={theme.dialogBox} >
 					<div style={theme.dialogTitle}>{_('Note properties')}</div>
 					<div>{noteComps}</div>
 					<DialogButtonRow themeId={this.props.themeId} okButtonRef={this.okButton} onClick={this.buttonRow_click}/>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes #4658 in a robust way.

**Problem**
While trying to copy the contents of `NoteProperties`, the focus shifts to the context menu of the Editor running in the background, which was either `CodeMirror` or `TinyMCE`.

**Solution**

Step 1. Placing the focus on the `NoteProperties` dialog box only, when live.
Step 2. Creating a context menu specific to the dialog box, with functionalities `Cut`, `Copy` and `Paste` while making a distinction between read-only and read/write fields and whether a highlighted text is selected.

**Unit tests**
There are no unit tests for `.jsx` files (UI files) where focus, highlighted text, and context-menus are involved,and hence this require a manual testing procedure.

**Manual Testing Process (after merging)**

1. Open any Note and select the Note Properties icon. Check if the `NoteProperties` dialog box appears listing every field property of the note.
2. While the dialog box is live, Right-click on the background outside the dialog and check that none of the functionalities(`Cut / Copy / Paste`) is allowed. 
3. Right-click on any fields without highlighting any text should also allow none of the functionalities.
4. Highlighting the read-only fields like _Markdown_ , _ID_ should allow only the `Copy` functionality. Not highlighting any text on read-only fields shouldn't allow any functionality.
5. Right-click on _Updated_, _Created_ and _URL_ should allow the `Paste` option when none of the text is highlighted. When the values are highlighted, then all the 3 options should be allowed. 
6. Values changed after `Cut/Paste` should get updated even after closing the dialog box. This can be checked by reopening it again and checking the value.
7. `Cut` functionality shouldn't keep the field values on _Updated_ and _Created_ empty. In case of `Cut` in these fields, the value should be updated to the latest timestamp.


**After Adding Functionality**


https://user-images.githubusercontent.com/22571664/113049394-380ca300-91c1-11eb-9904-ec15d0b593c8.mp4

