### PR TITLE
Mobile: make sync icon spin again

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -42,7 +42,7 @@ const { shimInit } = require('./utils/shim-init-react.js');
 const { AppNav } = require('./components/app-nav.js');
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
-const BaseSyncTarget = require('@joplin/lib/BaseSyncTarget.js');
+import BaseSyncTarget from '@joplin/lib/BaseSyncTarget';
 const { FoldersScreenUtils } = require('@joplin/lib/folders-screen-utils.js');
 import Resource from '@joplin/lib/models/Resource';
 import Tag from '@joplin/lib/models/Tag';


### PR DESCRIPTION
Fixes #4743

Noticed that if I log `BaseSyncTarget` in `root.tsx` just before calling `reg.scheduleSync` and from inside `reg.scheduleSync` at the very first line, these are 2 different things:
* In root it's an object:
```
[object Object]
```
* In reg it's a function:
```
function BaseSyncTarget(db) {
          var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
    
          _classCallCheck(this, BaseSyncTarget);
    
          this.synchronizer_ = null;
          this.initState_ = null;
          this.logger_ = null;
          this.db_ = db;
          this.options_ = options;
        }
```
WTF Javascript???

Changing the import fixes it, and I don't even want to know why.