### PR TITLE
Desktop: Resolves #4750 Disappearing text in markdown editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -886,6 +886,9 @@ packages/lib/locale.js.map
 packages/lib/markdownUtils.d.ts
 packages/lib/markdownUtils.js
 packages/lib/markdownUtils.js.map
+packages/lib/markdownUtils.test.d.ts
+packages/lib/markdownUtils.test.js
+packages/lib/markdownUtils.test.js.map
 packages/lib/markupLanguageUtils.d.ts
 packages/lib/markupLanguageUtils.js
 packages/lib/markupLanguageUtils.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -873,6 +873,9 @@ packages/lib/locale.js.map
 packages/lib/markdownUtils.d.ts
 packages/lib/markdownUtils.js
 packages/lib/markdownUtils.js.map
+packages/lib/markdownUtils.test.d.ts
+packages/lib/markdownUtils.test.js
+packages/lib/markdownUtils.test.js.map
 packages/lib/markupLanguageUtils.d.ts
 packages/lib/markupLanguageUtils.js
 packages/lib/markupLanguageUtils.js.map

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useListIdent.ts
@@ -155,14 +155,18 @@ export default function useListIdent(CodeMirror: any) {
 		// otherwise fallback on the default codemirror behavior
 		if (ranges.length === 1) {
 			const line = cm.getLine(anchor.line);
+			// if cursor on 0th line set previousLine=''
+			const previousLine = anchor.line ? cm.getLine(anchor.line - 1) : '';
 
 			if (markdownUtils.isEmptyListItem(line)) {
 				const tokens = cm.getLineTokens(anchor.line);
 				//  A empty list item with an indent will have whitespace as the first token
 				if (tokens.length > 1 && tokens[0].string.match(/^\s/)) {
 					cm.execCommand('smartListUnindent');
-				} else {
+				} else if (markdownUtils.isListItem(previousLine)) {
 					cm.replaceRange('', { line: anchor.line, ch: 0 }, anchor);
+				} else { // perform normal enter key operation
+					cm.replaceRange('\n', anchor);
 				}
 				return;
 			}

--- a/packages/lib/.gitignore
+++ b/packages/lib/.gitignore
@@ -1,1 +1,2 @@
 plugin_types/
+markdownUtils.test.js

--- a/packages/lib/markdownUtils.test.ts
+++ b/packages/lib/markdownUtils.test.ts
@@ -5,7 +5,7 @@ describe('Should detect list items', () => {
 		expect(markdownUtils.isListItem('- lorem ipsum')).toBe(true);
 	});
 	test('should detect `+ lorem ipsum` as list item ', () => {
-		expect(markdownUtils.isListItem('+ ')).toBe(true);
+		expect(markdownUtils.isListItem('+ lorem ipsum')).toBe(true);
 	});
 	test('should detect `* lorem ipsum` as list item ', () => {
 		expect(markdownUtils.isListItem('* lorem ipsum')).toBe(true);
@@ -18,17 +18,17 @@ describe('Should detect list items', () => {
 	test('should detect `1) lorem ipsum` as list item ', () => {
 		expect(markdownUtils.isListItem('1) lorem ipsum')).toBe(true);
 	});
-
+	// checkbox list
 	test('should detect `+ [x] lorem ipsum` as list item ', () => {
-		expect(markdownUtils.isListItem('1) lorem ipsum')).toBe(true);
+		expect(markdownUtils.isListItem('+ [x] lorem ipsum')).toBe(true);
 	});
 
-
+	// ordered list
 	test('should NOT detect `-lorem ipsum` as list item ', () => {
 		expect(markdownUtils.isListItem('-lorem ipsum')).toBe(false);
 	});
 	test('should NOT detect `+lorem ipsum` as list item ', () => {
-		expect(markdownUtils.isListItem('+')).toBe(false);
+		expect(markdownUtils.isListItem('+lorem ipsum')).toBe(false);
 	});
 	test('should NOT detect `*lorem ipsum` as list item ', () => {
 		expect(markdownUtils.isListItem('*lorem ipsum')).toBe(false);
@@ -42,10 +42,9 @@ describe('Should detect list items', () => {
 		expect(markdownUtils.isListItem('1)lorem ipsum')).toBe(false);
 	});
 
-	test('should NOT detect `+ [x]lorem ipsum` as list item ', () => {
-		expect(markdownUtils.isListItem('1)lorem ipsum')).toBe(false);
+	test('should NOT detect `+[x]lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('+[x]lorem ipsum')).toBe(false);
 	});
-
 	// Empty list detection
 	test('should detect `- ` as empty list item ', () => {
 		expect(markdownUtils.isEmptyListItem('- ')).toBe(true);
@@ -64,12 +63,12 @@ describe('Should detect list items', () => {
 	test('should detect `1) ` as empty list item ', () => {
 		expect(markdownUtils.isEmptyListItem('1) ')).toBe(true);
 	});
-
+	// checkbox list
 	test('should detect `+ [x] ` as empty list item ', () => {
-		expect(markdownUtils.isEmptyListItem('1) ')).toBe(true);
+		expect(markdownUtils.isEmptyListItem('+ [x] ')).toBe(true);
 	});
 
-
+	// unordered list
 	test('should NOT detect `-` as empty list item ', () => {
 		expect(markdownUtils.isEmptyListItem('-')).toBe(false);
 	});
@@ -87,9 +86,9 @@ describe('Should detect list items', () => {
 	test('should NOT detect `1)` as empty list item ', () => {
 		expect(markdownUtils.isEmptyListItem('1)')).toBe(false);
 	});
-
+	// checbox list
 	test('should NOT detect `+ [x]` as empty list item ', () => {
-		expect(markdownUtils.isEmptyListItem('1)')).toBe(false);
+		expect(markdownUtils.isEmptyListItem('+ [x]')).toBe(false);
 	});
 
 });

--- a/packages/lib/markdownUtils.test.ts
+++ b/packages/lib/markdownUtils.test.ts
@@ -1,0 +1,95 @@
+import markdownUtils from './markdownUtils';
+
+describe('Should detect list items', () => {
+	test('should detect `- lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('- lorem ipsum')).toBe(true);
+	});
+	test('should detect `+ lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('+ ')).toBe(true);
+	});
+	test('should detect `* lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('* lorem ipsum')).toBe(true);
+	});
+
+	// ordered list
+	test('should detect `1. lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1. lorem ipsum')).toBe(true);
+	});
+	test('should detect `1) lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1) lorem ipsum')).toBe(true);
+	});
+
+	test('should detect `+ [x] lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1) lorem ipsum')).toBe(true);
+	});
+
+
+	test('should NOT detect `-lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('-lorem ipsum')).toBe(false);
+	});
+	test('should NOT detect `+lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('+')).toBe(false);
+	});
+	test('should NOT detect `*lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('*lorem ipsum')).toBe(false);
+	});
+
+	// ordered list
+	test('should NOT detect `1.lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1.lorem ipsum')).toBe(false);
+	});
+	test('should NOT detect `1)lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1)lorem ipsum')).toBe(false);
+	});
+
+	test('should NOT detect `+ [x]lorem ipsum` as list item ', () => {
+		expect(markdownUtils.isListItem('1)lorem ipsum')).toBe(false);
+	});
+
+	// Empty list detection
+	test('should detect `- ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('- ')).toBe(true);
+	});
+	test('should detect `+ ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('+ ')).toBe(true);
+	});
+	test('should detect `* ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('* ')).toBe(true);
+	});
+
+	// ordered list
+	test('should detect `1. ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1. ')).toBe(true);
+	});
+	test('should detect `1) ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1) ')).toBe(true);
+	});
+
+	test('should detect `+ [x] ` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1) ')).toBe(true);
+	});
+
+
+	test('should NOT detect `-` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('-')).toBe(false);
+	});
+	test('should NOT detect `+` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('+')).toBe(false);
+	});
+	test('should NOT detect `*` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('*')).toBe(false);
+	});
+
+	// ordered list
+	test('should NOT detect `1.` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1.')).toBe(false);
+	});
+	test('should NOT detect `1)` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1)')).toBe(false);
+	});
+
+	test('should NOT detect `+ [x]` as empty list item ', () => {
+		expect(markdownUtils.isEmptyListItem('1)')).toBe(false);
+	});
+
+});

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -5,7 +5,7 @@ const MarkdownIt = require('markdown-it');
 
 // Taken from codemirror/addon/edit/continuelist.js
 const listRegex = /^(\s*)([*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]\s))(\s*)/;
-const emptyListRegex = /^(\s*)([*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
+const emptyListRegex = /^(\s*)([*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s+)$/;
 
 export interface MarkdownTableHeader {
 	name: string;


### PR DESCRIPTION
Both Implementations according to
[This Guidance](https://github.com/laurent22/joplin/issues/4750#issuecomment-808965096) by calebJohn
## Changes
**Previously**: typing "-" and pressing enter would delete "-" (similar for all list symbols);
**Now**: only auto inserted list elements are deleted on pressing enter.
## Tests
### Manual
- I manually tested it by creating an ordered as well as unordered list.
- I also tested by creating list through different syntax `+ , - , * , 1. ,1)`
- tested checkbox list of Joplin.
### Automated
Tests for list and empty list detection added;
looking for more automated tests ideas . 