### PR TITLE
Desktop: Fixes #4124 Note List not rendering correctly after searching and switching to a note

### DIFF
--- a/packages/app-desktop/gui/ItemList.jsx
+++ b/packages/app-desktop/gui/ItemList.jsx
@@ -69,7 +69,8 @@ class ItemList extends React.Component {
 		} else {
 			scrollTop = this.props.itemHeight * itemIndex - (this.visibleItemCount() - 1) * this.props.itemHeight;
 		}
-
+		
+		if (!this.props.visible) scrollTop = 0;
 		if (scrollTop < 0) scrollTop = 0;
 
 		this.scrollTop_ = scrollTop;

--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -481,6 +481,7 @@ class NoteListComponent extends React.Component {
 				style={style}
 				itemRenderer={this.renderItem}
 				onKeyDown={this.onKeyDown}
+				visible={this.props.visible}
 			/>
 		);
 	}


### PR DESCRIPTION


Desktop - Fixes #4124

A blank space was appearing instead of the top few notes when toggling the Notelist and switching to a different note after searching from the Command Pallete.

The problem was within the file 'ItemList.jsx'. The scroll height being calculated after toggling the notelist off was wrong because the height of the container was then zero. So when we switched to a new note and toggled the Notelist on, the scrollHeight was not updating and a blank space was apprearing instead of the top notes.

I fixed it by making sure the scrollheight(scollTop) is not calculated when the NoteList was toggled off and the note was changed. 

I am unware of how to add automated tests to this at this moment. I am learning how to do that.





