### PR TITLE
iOS: Fixes #3607: keyboards won't cover last line of note

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1142,6 +1142,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					placeholder={_('Add body')}
 					placeholderTextColor={theme.colorFaded}
 					// need some extra padding for iOS so that the keyboard won't cover last line of the note
+					// see https://github.com/laurent22/joplin/issues/3607
 					paddingBottom={ Platform.OS === 'ios' ? 40 : 0}
 				/>
 			);

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1141,6 +1141,8 @@ class NoteScreenComponent extends BaseScreenComponent {
 					keyboardAppearance={theme.keyboardAppearance}
 					placeholder={_('Add body')}
 					placeholderTextColor={theme.colorFaded}
+					// need some extra padding for iOS so that the keyboard won't cover last line of the note
+					paddingBottom={ Platform.OS === 'ios' ? 40 : 0}
 				/>
 			);
 		}


### PR DESCRIPTION
This PR doesn't have test units. It's a one-line-code UI bug fix that prevents keyboard on iOS (iPhone in particular) from covering the last line of note.

I did the following manual test on iPhone 12, iPhone 11 Pro Max, iPhone SE:
1. Create a new note
2. Type multiple lines of text (enough to fill one page)
3. Try to scroll to the bottom of the note when editing, making sure that the last line is visible & editable