### PR TITLE
Docs: use onNoteChange()  instead of onNoteContentChange() in the plugins API documentation

### DIFF
--- a/docs/api/tutorials/toc_plugin/index.html
+++ b/docs/api/tutorials/toc_plugin/index.html
@@ -458,7 +458,7 @@ joplin.plugins.register({
 
 		// This event will be triggered when the content of the note changes
 		// as you also want to update the TOC in this case.
-		await joplin.workspace.onNoteContentChange(() =&gt; {
+		await joplin.workspace.onNoteChange(() =&gt; {
 			updateTocView();
 		});
 


### PR DESCRIPTION
As mentioned [Here](https://joplinapp.org/api/references/plugin_api/classes/joplinworkspace.html#onnotecontentchange), the method `onNoteContentChange()` is deprecated and should be replaced by `onNoteChange()`. However, the former was still being used in the documentation.