### PR TITLE
Desktop: Fixes #4043: Update 'useMessageHandler.ts' to allow File-Links with German Umlauts 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -85,8 +85,8 @@ export default function useMessageHandler(scrollWhenReady: any, setScrollWhenRea
 			}
 		} else if (urlUtils.urlProtocol(msg)) {
 			if (msg.indexOf('file://') === 0) {
-				// When using the file:// protocol, openExternal doesn't work (does nothing) with URL-encoded paths
-				require('electron').shell.openExternal(urlDecode(msg));
+				// When using the file:// protocol, openPath doesn't work (does nothing) with URL-encoded paths
+				require('electron').shell.openPath(urlDecode(msg));
 			} else {
 				require('electron').shell.openExternal(msg);
 			}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

### Description 
This PR fixes the issue #4043. Currently, clicking on any File-links containing German Umlauts (on platform: windows) gives an error in the console. Most likely, the issue is with electron's `shell.openExternal()`, although the issue is fixed by using the `shell.openPath()` which opens the given local file with German Umlauts(and other special characters as well like Chinese etc.) correctly.

## Testing

### Manually testing
```
**Tests without umlaut:**
<h:/test.txt> not rendered as link
<file://h:/test.txt> ok
[local file](h:/test.txt) ok
[local file](file://h:/test.txt) ok

**Test with umlaut:**
<h:/test_with_umlaut_ä.txt> not rendered as link
<file://h:/test_with_umlaut_ä.txt> Working
<file://h:/test_with_umlaut_%C3%A4.txt>  Working (ä changed with %C3%A4 for UTF-8 encoding)
[local file with umlaut with file://...](file://h:/test_with_umlaut_ä.txt) Working

<https://de.wikipedia.org/wiki/Thomas_Müller> ok
[Wikipedia Thomas Müller](https://de.wikipedia.org/wiki/Thomas_Müller) ok
```
### Automated Testing
This is not done as this is just one line change and `shell.openPath(path)` opens the given path if the path is present in the local system. So, I think, the other developers would need to have the same file present in their local system in order to test.
