### PR TITLE
Desktop: Resolves #4759: Added focus to editor.

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -90,6 +90,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 	const addListItem = useCallback((string1, defaultText = '') => {
 		if (editorRef.current) {
+			editorRef.current.focus();
 			if (editorRef.current.somethingSelected()) {
 				editorRef.current.wrapSelectionsByLine(string1);
 			} else if (editorRef.current.getCursor('anchor').ch !== 0) {
@@ -325,7 +326,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		let cancelled = false;
 
 		async function loadScripts() {
-			const scriptsToLoad: {src: string; id: string; loaded: boolean}[] = [
+			const scriptsToLoad: { src: string; id: string; loaded: boolean }[] = [
 				{
 					src: 'node_modules/codemirror/addon/dialog/dialog.css',
 					id: 'codemirrorDialogStyle',
@@ -650,7 +651,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 			const menu = new Menu();
 
-			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
+			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection();
 
 			menu.append(
 				new MenuItem({


### PR DESCRIPTION
Fixes #4759 

### Problem: 

When adding a checkbox to the MD editor through the command palette, the focus isn't shifted back to the editor.

### Solution:

The editor should be focused after closing the command palette and before adding the checkbox or any other list item.

### Manual Test to check if the focus shifts to the editor:

1. Open a note.
2. Open Command Palette by clicking ctrl+shift+p.
3. Type the command ": CheckBox" and click enter.
4. A checkbox will be added at the cursor location.
the focus should shift to the MD editor.