### PR TITLE
Desktop: add an option to renew the API token

### DIFF
--- a/packages/app-desktop/gui/ClipperConfigScreen.jsx
+++ b/packages/app-desktop/gui/ClipperConfigScreen.jsx
@@ -43,7 +43,7 @@ class ClipperConfigScreenComponent extends React.Component {
 	renewToken_click() {
 		if (confirm(_('Are you sure you want to renew the authorisation token?'))) {
 			void EncryptionService.instance()
-				.randomHexString(64)
+				.generateApiToken()
 				.then((token: string) => {
 					Setting.setValue('api.token', token);
 				});

--- a/packages/app-desktop/gui/ClipperConfigScreen.jsx
+++ b/packages/app-desktop/gui/ClipperConfigScreen.jsx
@@ -70,6 +70,10 @@ class ClipperConfigScreenComponent extends React.Component {
 			backgroundColor: theme.backgroundColor,
 		};
 
+		const tokenStyle = {
+			fontFamily: 'monospace',
+		};
+
 		const webClipperStatusComps = [];
 
 		if (this.props.clipperServerAutoStart) {
@@ -142,7 +146,7 @@ class ClipperConfigScreenComponent extends React.Component {
 							<p style={theme.h1Style}>{_('Advanced options')}</p>
 							<p style={theme.textStyle}>{_('Authorisation token:')}</p>
 							<p style={apiTokenStyle}>
-								{this.props.apiToken}{' '}
+								<span style={tokenStyle}>{this.props.apiToken}{' '}</span>
 								<a style={theme.urlStyle} href="#" onClick={this.copyToken_click}>
 									{_('Copy token')}
 								</a>

--- a/packages/app-desktop/gui/ClipperConfigScreen.jsx
+++ b/packages/app-desktop/gui/ClipperConfigScreen.jsx
@@ -7,6 +7,7 @@ const ClipperServer = require('@joplin/lib/ClipperServer');
 const Setting = require('@joplin/lib/models/Setting').default;
 const { clipboard } = require('electron');
 const ExtensionBadge = require('./ExtensionBadge.min');
+const EncryptionService = require('@joplin/lib/services/EncryptionService').default;
 
 class ClipperConfigScreenComponent extends React.Component {
 	constructor() {
@@ -37,6 +38,16 @@ class ClipperConfigScreenComponent extends React.Component {
 		clipboard.writeText(this.props.apiToken);
 
 		alert(_('Token has been copied to the clipboard!'));
+	}
+
+	renewToken_click() {
+		if (confirm(_('Are you sure you want to renew the authorisation token?'))) {
+			void EncryptionService.instance()
+				.randomHexString(64)
+				.then((token: string) => {
+					Setting.setValue('api.token', token);
+				});
+		}
 	}
 
 	render() {
@@ -137,6 +148,11 @@ class ClipperConfigScreenComponent extends React.Component {
 								</a>
 							</p>
 							<p style={theme.textStyle}>{_('This authorisation token is only needed to allow third-party applications to access Joplin.')}</p>
+							<div>
+								<button key="renew_button" style={buttonStyle} onClick={this.renewToken_click}>
+									{_('Renew token')}
+								</button>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -776,7 +776,7 @@ export default class BaseApplication {
 
 		if (!Setting.value('api.token')) {
 			void EncryptionService.instance()
-				.randomHexString(64)
+				.generateApiToken()
 				.then((token: string) => {
 					Setting.setValue('api.token', token);
 				});

--- a/packages/lib/services/EncryptionService.ts
+++ b/packages/lib/services/EncryptionService.ts
@@ -254,6 +254,10 @@ export default class EncryptionService {
 	// 	sjcl.random.addEntropy(hexSeed, 1024, 'shim.randomBytes');
 	// }
 
+	async generateApiToken() {
+		return await this.randomHexString(64);
+	}
+
 	async randomHexString(byteCount: number) {
 		const bytes: any[] = await shim.randomBytes(byteCount);
 		return bytes


### PR DESCRIPTION
It came up a few times that there wasn't a way to renew the token. Now there is. ;-)

![image](https://user-images.githubusercontent.com/223439/113526186-014ed800-9587-11eb-903a-93c158964111.png)

<img width="418" alt="image" src="https://user-images.githubusercontent.com/223439/113526391-e29d1100-9587-11eb-94cb-931dfebec54b.png">


