### PR TITLE
Resolved issue #4519

### DIFF
--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -69,7 +69,7 @@ export function friendlySafeFilename(e: string, maxLength: number = null) {
 	// Although Windows supports paths up to 255 characters, but that includes the filename and its
 	// parent directory path. Also there's generally no good reason for dir or file names
 	// to be so long, so keep it at 50, which should prevent various errors.
-	if (maxLength === null) maxLength = 50;
+	if (maxLength === null) maxLength = 100;
 	if (!e || !e.replace) return _('Untitled');
 
 	let output = '';


### PR DESCRIPTION
**PROBLEM:**
The file name gets truncated when exported in markdown format and  if the length of the file name exceeds 50 characters.

**SOLUTION:**
Previously the max length of file name was 50 characters. To resolve the issue increased the **maxLength** to 100.

**MANUAL TEST TO CHECK WHETHER FILE NAME IS TRUNCATED OR NOT:**
1. Create a new Note with any title whose length is greater than 50.
2. Export the created note in markdown format in any one of the folder.
3. Check whether the file name is truncated or not in the folder.