### PR TITLE
Desktop, Mobile: Fixes #4715: ordered list digits cut off

### DIFF
--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -117,7 +117,7 @@ export default function(theme: any) {
 		}
 		ul, ol {
 			padding-left: 0;
-			margin-left: 1.7em;
+			margin-left: 2.7em;
 		}
 		li {
 			margin-bottom: .4em;


### PR DESCRIPTION
Fixes #4715

Just a small change in margin-left to allow more digits to show.

I tested it in the Desktop app on Windows and it's working fine. Before, the maximum amount of digits to show was only 3, and now it's possible to show 5 digits, numbers like 14389. I also tested it in the Mobile Android app, where you could only see 2 digits before, but now it's possible to see 4 digits as a maximum.

I couldn't try it on other devices but with this change of margin, you should be able to see two more digits than before.

Some people mentioned that this should be done dynamically, but in my opinion 4 and 5 digits it's more than enough. I don't think that somebody would want to make such a long list, it's pretty unlikely to happen. Even in plain HTML this same bug happens with ordered list, so I don't think we should worry about really big numbers in a list.

One thing to note is that this change also affects unordered list, which was done on purpose, to keep things consistent. I also used em units, instead of pixels or rems, just in case the user changes the note font size somehow.

Lastly, I didn't include any automated tests, since this was a small fix that can easily be tested manually creating an ordered list starting from a big number. Something like this:

```
7219. Some text
7220. Some text
7221. Some text
```