### PR TITLE
Mobile, Desktop: Fixes #3991: Added RTL support for CodeMirror and Preview.

### DIFF
--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -30,6 +30,9 @@
 				background: #CF3F00;
 				color: white;
 			}
+			.CodeMirror-line  {
+				unicode-bidi: plaintext;
+			}
 		</style>
 	</head>
 	<body>

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -30,6 +30,11 @@
 				background: #CF3F00;
 				color: white;
 			}
+			
+			/*
+				Adds support for RTL text in the note body. It automatically detects the direction using the content.
+				Issue: https://github.com/laurent22/joplin/issues/3991
+			*/
 			.CodeMirror-line  {
 				unicode-bidi: plaintext;
 			}

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -80,6 +80,11 @@ export default function(theme: any) {
 		p, h1, h2, h3, h4, h5, h6, ul, table {
 			margin-top: .6em;
 			margin-bottom: .65em;
+
+			/*
+				Adds support for RTL text in the note body. It automatically detects the direction using the content.
+				Issue: https://github.com/laurent22/joplin/issues/3991
+			*/
 			unicode-bidi: plaintext;
 		}
 		h1, h2, h3, h4, h5, h6 {

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -80,6 +80,7 @@ export default function(theme: any) {
 		p, h1, h2, h3, h4, h5, h6, ul, table {
 			margin-top: .6em;
 			margin-bottom: .65em;
+			unicode-bidi: plaintext;
 		}
 		h1, h2, h3, h4, h5, h6 {
 			line-height: 1.5em;


### PR DESCRIPTION
Resolves #3991 

# Changes
- Added simple CSS line `unicode-bidi: plaintext;` to both CodeMirror styling and noteStyle file which defines how notes look on all platforms.

This was suggested by someone over at MarkdownIt repo:  https://github.com/markdown-it/markdown-it/issues/635#issuecomment-582064491 

It automatically decides whether a line should be RTL or LTR depending on the content. It's still pretty annoying/buggy when you mix RTL with LTR in the same line though so I wouldn't recommend doing that.

This obviously can't be unit tested, so Screenshots will have to do!

# Before Screenshots
![image](https://user-images.githubusercontent.com/8184424/114068399-2a7caa80-989e-11eb-95a1-5e7c15e9ddc5.png)
![image](https://user-images.githubusercontent.com/8184424/114068408-2e103180-989e-11eb-9d6b-f45adf4bc1d7.png)
![image](https://user-images.githubusercontent.com/8184424/114068424-30728b80-989e-11eb-9ab2-08369d2c557c.png)
![image](https://user-images.githubusercontent.com/8184424/114068433-336d7c00-989e-11eb-9e6e-ccd8fa006806.png)
> **^ Notice on mobile, the editor ALREADY looks fine,**

# After Screenshots
![image](https://user-images.githubusercontent.com/8184424/114068603-644db100-989e-11eb-928c-d78e8ba277b8.png)
![image](https://user-images.githubusercontent.com/8184424/114068615-66b00b00-989e-11eb-8b2d-77ccc6a632f9.png)
![image](https://user-images.githubusercontent.com/8184424/114068619-69126500-989e-11eb-81e6-2ecee8d69edb.png)
