### PR TITLE
CLI: Fixes #4808: Fixed spacebar turning non-todo note into todo

### DIFF
--- a/packages/app-cli/app/command-todo.js
+++ b/packages/app-cli/app/command-todo.js
@@ -29,12 +29,8 @@ class Command extends BaseCommand {
 				id: note.id,
 			};
 
-			if (action == 'toggle') {
-				if (!note.is_todo) {
-					toSave = Note.toggleIsTodo(note);
-				} else {
-					toSave.todo_completed = note.todo_completed ? 0 : time.unixMs();
-				}
+			if (action == 'toggle' && note.is_todo) {
+				toSave.todo_completed = note.todo_completed ? 0 : time.unixMs();
 			} else if (action == 'clear') {
 				toSave.is_todo = 0;
 			}

--- a/packages/app-cli/app/command-todo.js
+++ b/packages/app-cli/app/command-todo.js
@@ -11,7 +11,7 @@ class Command extends BaseCommand {
 	}
 
 	description() {
-		return _('<todo-command> can either be "toggle" or "clear". Use "toggle" to toggle the given to-do between completed and uncompleted state (If the target is a regular note it will be converted to a to-do). Use "clear" to convert the to-do back to a regular note.');
+		return _('<todo-command> can either be "toggle" or "clear". Use "toggle" to toggle the given to-do between completed and uncompleted state (If the target is a regular note then nothing happens). Use "clear" to convert the to-do back to a regular note.');
 	}
 
 	async action(args) {
@@ -25,7 +25,7 @@ class Command extends BaseCommand {
 
 			this.encryptionCheck(note);
 
-			let toSave = {
+			const toSave = {
 				id: note.id,
 			};
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes #4808.

### Changes
Simply removes logic in `command-todo.js` which sets `node.is_todo` to true if executed on a non-todo note.
