### PR TITLE
Desktop: Resolves #4813 : skip empty lines while converting selection to list 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -376,6 +376,9 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/types.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,9 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/types.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.js.map
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.d.ts
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js.map
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.d.ts
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.js.map

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
@@ -1,6 +1,6 @@
 import { modifyListLines } from './useCursorUtils';
 
-describe('Check list item modification', () => {
+describe('useCursorUtils', () => {
 	const num = 0;
 	let lineInitial = `- item1
 - item2

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
@@ -1,21 +1,20 @@
 import { modifyListLines } from './useCursorUtils';
 
 describe('useCursorUtils', () => {
-	const num = 0;
-	let lineInitial = `- item1
+		
+	let listWithDashes = `- item1
 - item2
 - item3`;
-	let lineFinal = `item1
+	
+	let listNoDashes = `item1
 item2
 item3`;
-	test('should remove "- " from beggining  of each line of input string', () => {
-		expect(JSON.stringify(modifyListLines(lineInitial.split('\n'), num, '- '))).toBe(JSON.stringify(lineFinal.split('\n')));
+	
+	test('should remove "- " from beggining of each line of input string', () => {
+		expect(JSON.stringify(modifyListLines(listWithDashes.split('\n'), 0, '- '))).toBe(JSON.stringify(listNoDashes.split('\n')));
 	});
+	
 	test('should add "- " at the beggining of each line of the input string', () => {
-		// swap input and expected output
-		const temp = lineInitial;
-		lineInitial = lineFinal;
-		lineFinal = temp;
-		expect(JSON.stringify(modifyListLines(lineInitial.split('\n'), num, '- '))).toBe(JSON.stringify(lineFinal.split('\n')));
+		expect(JSON.stringify(modifyListLines(listNoDashes.split('\n'), 0, '- '))).toBe(JSON.stringify(listWithDashes.split('\n')));
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
@@ -1,0 +1,21 @@
+import { modifyListLines } from './useCursorUtils';
+
+describe('Check list item modification', () => {
+	const num = 0;
+	let lineInitial = `- item1
+- item2
+- item3`;
+	let lineFinal = `item1
+item2
+item3`;
+	test('should remove "- " from beggining  of each line of input string', () => {
+		expect(JSON.stringify(modifyListLines(lineInitial.split('\n'), num, '- '))).toBe(JSON.stringify(lineFinal.split('\n')));
+	});
+	test('should add "- " at the beggining of each line of the input string', () => {
+		// swap input and expected output
+		const temp = lineInitial;
+		lineInitial = lineFinal;
+		lineFinal = temp;
+		expect(JSON.stringify(modifyListLines(lineInitial.split('\n'), num, '- '))).toBe(JSON.stringify(lineFinal.split('\n')));
+	});
+});

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -3,7 +3,7 @@ import Setting from '@joplin/lib/models/Setting';
 export function modifyListLines(lines: string[],num: number,string1: string) {
 	for (let j = 0; j < lines.length; j++) {
 		const line = lines[j];
-		if (!line) continue;
+		if (!line && j == lines.length - 1) continue;
 		// Only add the list token if it's not already there
 		// if it is, remove it
 		if (!line.startsWith(string1)) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,6 +1,24 @@
 import markdownUtils from '@joplin/lib/markdownUtils';
 import Setting from '@joplin/lib/models/Setting';
-
+export function modifyListLines(lines: string[],num: number,string1: string) {
+	for (let j = 0; j < lines.length; j++) {
+		const line = lines[j];
+		if (!line) continue;
+		// Only add the list token if it's not already there
+		// if it is, remove it
+		if (!line.startsWith(string1)) {
+			if (num) {
+				lines[j] = `${num.toString()}. ${line}`;
+				num++;
+			} else {
+				lines[j] = string1 + line;
+			}
+		} else {
+			lines[j] = line.substr(string1.length, line.length - string1.length);
+		}
+	}
+	return lines;
+}
 // Helper functions that use the cursor
 export default function useCursorUtils(CodeMirror: any) {
 
@@ -81,29 +99,12 @@ export default function useCursorUtils(CodeMirror: any) {
 			for (let i = 0; i < selectedStrings.length; i++) {
 				const selected = selectedStrings[i];
 
-				let num = markdownUtils.olLineNumber(string1);
+				const num = markdownUtils.olLineNumber(string1);
 
 				const lines = selected.split(/\r?\n/);
 				//  Save the newline character to restore it later
 				const newLines = selected.match(/\r?\n/);
-
-				for (let j = 0; j < lines.length; j++) {
-					const line = lines[j];
-					if (!line) continue;
-					// Only add the list token if it's not already there
-					// if it is, remove it
-					if (!line.startsWith(string1)) {
-						if (num) {
-							lines[j] = `${num.toString()}. ${line}`;
-							num++;
-						} else {
-							lines[j] = string1 + line;
-						}
-					} else {
-						lines[j] = line.substr(string1.length, line.length - string1.length);
-					}
-				}
-
+				modifyListLines(lines,num,string1);
 				const newLine = newLines !== null ? newLines[0] : '\n';
 				selectedStrings[i] = lines.join(newLine);
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,7 +1,6 @@
 import markdownUtils from '@joplin/lib/markdownUtils';
 import Setting from '@joplin/lib/models/Setting';
 export function modifyListLines(lines: string[],num: number,listSymbol: string) {
-	console.log(listSymbol,':string');
 	for (let j = 0; j < lines.length; j++) {
 		const line = lines[j];
 		if (!line && j === lines.length - 1) continue;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,20 +1,21 @@
 import markdownUtils from '@joplin/lib/markdownUtils';
 import Setting from '@joplin/lib/models/Setting';
-export function modifyListLines(lines: string[],num: number,string1: string) {
+export function modifyListLines(lines: string[],num: number,listSymbol: string) {
+	console.log(listSymbol,':string');
 	for (let j = 0; j < lines.length; j++) {
 		const line = lines[j];
-		if (!line && j == lines.length - 1) continue;
+		if (!line && j === lines.length - 1) continue;
 		// Only add the list token if it's not already there
 		// if it is, remove it
-		if (!line.startsWith(string1)) {
+		if (!line.startsWith(listSymbol)) {
 			if (num) {
 				lines[j] = `${num.toString()}. ${line}`;
 				num++;
 			} else {
-				lines[j] = string1 + line;
+				lines[j] = listSymbol + line;
 			}
 		} else {
-			lines[j] = line.substr(string1.length, line.length - string1.length);
+			lines[j] = line.substr(listSymbol.length, line.length - listSymbol.length);
 		}
 	}
 	return lines;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -89,6 +89,7 @@ export default function useCursorUtils(CodeMirror: any) {
 
 				for (let j = 0; j < lines.length; j++) {
 					const line = lines[j];
+					if (!line) continue;
 					// Only add the list token if it's not already there
 					// if it is, remove it
 					if (!line.startsWith(string1)) {


### PR DESCRIPTION
Before 
![before](https://user-images.githubusercontent.com/63918341/114359954-1f719500-9b92-11eb-8bff-c902659a0246.gif)
After Fix
![fixed](https://user-images.githubusercontent.com/63918341/114360045-39ab7300-9b92-11eb-8e4b-7c69eb49dba7.gif)
Steps:
1. Copy paste following content to joplin
item1  
item2  
item3  
a paragraph

2. Take cursor to beggining of document and press `shift+down arrow` thrice to select 1st 3 lines.
3. Toggle list using editor toolbar.
