### PR TITLE
CLI: Fixes #4808: Fixed spacebar turning non-todo note into todo

### DIFF
--- a/packages/app-cli/app/app.js
+++ b/packages/app-cli/app/app.js
@@ -328,7 +328,7 @@ class Application extends BaseApplication {
 			{ keys: ['n'], type: 'function', command: 'next_link' },
 			{ keys: ['b'], type: 'function', command: 'previous_link' },
 			{ keys: ['o'], type: 'function', command: 'open_link' },
-			{ keys: [' '], command: 'todo toggle $n' },
+			{ keys: [' '], command: 'todo toggleToDO $n' },
 			{ keys: ['tc'], type: 'function', command: 'toggle_console' },
 			{ keys: ['tm'], type: 'function', command: 'toggle_metadata' },
 			{ keys: ['/'], type: 'prompt', command: 'search ""', cursorPosition: -2 },

--- a/packages/app-cli/app/app.js
+++ b/packages/app-cli/app/app.js
@@ -328,7 +328,7 @@ class Application extends BaseApplication {
 			{ keys: ['n'], type: 'function', command: 'next_link' },
 			{ keys: ['b'], type: 'function', command: 'previous_link' },
 			{ keys: ['o'], type: 'function', command: 'open_link' },
-			{ keys: [' '], command: 'todo toggleToDO $n' },
+			{ keys: [' '], command: 'todo toggleTodo $n' },
 			{ keys: ['tc'], type: 'function', command: 'toggle_console' },
 			{ keys: ['tm'], type: 'function', command: 'toggle_metadata' },
 			{ keys: ['/'], type: 'prompt', command: 'search ""', cursorPosition: -2 },

--- a/packages/app-cli/app/command-todo.js
+++ b/packages/app-cli/app/command-todo.js
@@ -11,7 +11,7 @@ class Command extends BaseCommand {
 	}
 
 	description() {
-		return _('<todo-command> can either be "toggle" or "clear". Use "toggle" to toggle the given to-do between completed and uncompleted state (If the target is a regular note it will be converted to a to-do). Use "clear" to convert the to-do back to a regular note.');
+		return _('<todo-command> can either be "toggle" or "clear" or toggleTodo. Use "toggle" to toggle the given to-do between completed and uncompleted state (If the target is a regular note it will be converted to a to-do). Use "clear" to convert the to-do back to a regular note. "toggleTodo" is same as toggle but it only acts on to-do ');
 	}
 
 	async action(args) {
@@ -37,7 +37,7 @@ class Command extends BaseCommand {
 				}
 			} else if (action == 'clear') {
 				toSave.is_todo = 0;
-			} else if (action == 'toggleToDO') {
+			} else if (action == 'toggleTodo') {
 				if (note.is_todo) {
 					toSave.todo_completed = note.todo_completed ? 0 : time.unixMs();
 				} else { return; }

--- a/packages/app-cli/app/command-todo.js
+++ b/packages/app-cli/app/command-todo.js
@@ -37,6 +37,10 @@ class Command extends BaseCommand {
 				}
 			} else if (action == 'clear') {
 				toSave.is_todo = 0;
+			} else if (action == 'toggleToDO') {
+				if (note.is_todo) {
+					toSave.todo_completed = note.todo_completed ? 0 : time.unixMs();
+				} else { return; }
 			}
 
 			await Note.save(toSave);


### PR DESCRIPTION
## Changes
Declared a new command toggleTodo and assigned it to spacebar.
this new command only works on todos and keeps notes unaffected.

I also noticed that this command is not getting suggested when user starts typing `todo toggle` which is a desired behaviour in my opinion; since primary purpose of this command is to handle `spacebar` keypress.
## Manual test
In the video below ; look at the bottom panel (where commands are executed) to know when spacebar was pressed
![terminalFix ](https://user-images.githubusercontent.com/63918341/114662322-1d384380-9d16-11eb-8a78-81bedcce7c6e.gif)

 
> I was not able to provide automated tests because of not being able to figure out the way to implement them here.
