### PR TITLE
Desktop: Resolves #4591: resolves change of cursor after pasting and deleting an image in TinyMCE 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -177,8 +177,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		const resourceMd = await commandAttachFileToBody('', filePaths, options);
 		if (!resourceMd) return;
 		const result = await props.markupToHtml(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, resourceMd, markupRenderOptions({ bodyOnly: true }));
-		editor.insertContent(result.html);
 		// editor.fire('joplinChange');
+		editor.selection.setContent(result.html);
+		editor.focus();
 		// dispatchDidUpdate(editor);
 	}, [props.markupToHtml, editor]);
 
@@ -916,7 +917,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	async function execOnChangeEvent() {
 		const info = nextOnChangeEventInfo.current;
 		if (!info) return;
-
 		nextOnChangeEventInfo.current = null;
 
 		const contentMd = await prop_htmlToMarkdownRef.current(info.contentMarkupLanguage, info.editor.getContent(), info.contentOriginalCss);
@@ -929,6 +929,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		});
 
 		dispatchDidUpdate(info.editor);
+		editor.focus();
 	}
 
 	// When the component unmount, we dispatch the change event


### PR DESCRIPTION
Fixes laurent22#4591

### Problem:
The cursor moves to the top of the note after image paste.

### Solution:
Made the cursor focus at the end of the note after pasting an image.

### Manual Test to check if the cursor stays where the image was pasted :

1. Open a note.
2. Shift to TinyMCE editor.
3. Write some content in it.
4. Insert an image.

The cursor should focus on where the image was inserted.