### PR TITLE
Desktop: Fixes #4529: Ghost panel and resizing issues

### DIFF
--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -20,6 +20,22 @@ describe('useLayoutItemSizes', () => {
 		expect(layout.isRoot).toBe(true);
 	});
 
+	test('should strecth the last visible child item if all siblings have fixed size', () => {
+		const layout: LayoutItem = validateLayout({
+			key: 'root',
+			width: 200,
+			height: 100,
+			direction: LayoutItemDirection.Row,
+			children: [
+				{ key: 'col1', width: 50 },
+				{ key: 'col2', width: 50 },
+				{ key: 'col3', width: 70, visible: false },
+			],
+		});
+
+		expect(layout.children[1]).not.toHaveProperty('width');
+	});
+
 	test('should give item sizes', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -20,7 +20,7 @@ describe('useLayoutItemSizes', () => {
 		expect(layout.isRoot).toBe(true);
 	});
 
-	test('should strecth the last visible child item if all siblings have fixed size', () => {
+	test('should strecth the last visible child item if all siblings have fixed size and the last child is not visible', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',
 			width: 200,
@@ -33,7 +33,31 @@ describe('useLayoutItemSizes', () => {
 			],
 		});
 
-		expect(layout.children[1]).not.toHaveProperty('width');
+		expect(layout.children).toEqual([
+			{ key: 'col1', width: 50 },
+			{ key: 'col2' },
+			{ key: 'col3', width: 70, visible: false },
+		]);
+	});
+
+	test('should strecth the last child item if all siblings have fixed size', () => {
+		const layout: LayoutItem = validateLayout({
+			key: 'root',
+			width: 200,
+			height: 100,
+			direction: LayoutItemDirection.Row,
+			children: [
+				{ key: 'col1', width: 50 },
+				{ key: 'col2', width: 50 },
+				{ key: 'col3', width: 70 },
+			],
+		});
+
+		expect(layout.children).toEqual([
+			{ key: 'col1', width: 50 },
+			{ key: 'col2', width: 50 },
+			{ key: 'col3' },
+		]);
 	});
 
 	test('should give item sizes', () => {

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -33,31 +33,17 @@ describe('useLayoutItemSizes', () => {
 			],
 		});
 
-		expect(layout.children).toEqual([
-			{
-				key: 'col1',
-				width: 50,
-				resizableRight: true,
-				resizableBottom: false,
-				direction: 'column',
-				visible: true,
-			},
-			{
-				key: 'col2',
-				resizableRight: false,
-				resizableBottom: false,
-				direction: 'column',
-				visible: true,
-			},
-			{
-				key: 'col3',
-				width: 70,
-				resizableRight: true,
-				resizableBottom: false,
-				direction: 'column',
-				visible: false,
-			},
-		]);
+		const col1 = layout.children.find(c => c.key === 'col1');
+		expect(col1.width).toBe(50);
+		expect(col1.visible).toBe(true);
+
+		const col2 = layout.children.find(c => c.key === 'col2');
+		expect(col2).not.toHaveProperty('width');
+		expect(col2.visible).toBe(true);
+
+		const col3 = layout.children.find(c => c.key === 'col3');
+		expect(col3.width).toBe(70);
+		expect(col3.visible).toBe(false);
 	});
 
 	test('should stretch the last child item if all siblings have fixed size', () => {
@@ -73,31 +59,17 @@ describe('useLayoutItemSizes', () => {
 			],
 		});
 
-		expect(layout.children).toEqual([
-			{
-				key: 'col1',
-				width: 50,
-				resizableRight: true,
-				resizableBottom: false,
-				direction: 'column',
-				visible: true,
-			},
-			{
-				key: 'col2',
-				width: 50,
-				resizableRight: true,
-				resizableBottom: false,
-				direction: 'column',
-				visible: true,
-			},
-			{
-				key: 'col3',
-				resizableRight: false,
-				resizableBottom: false,
-				direction: 'column',
-				visible: true,
-			},
-		]);
+		const col1 = layout.children.find(c => c.key === 'col1');
+		expect(col1.width).toBe(50);
+		expect(col1.visible).toBe(true);
+
+		const col2 = layout.children.find(c => c.key === 'col2');
+		expect(col2.width).toBe(50);
+		expect(col2.visible).toBe(true);
+
+		const col3 = layout.children.find(c => c.key === 'col3');
+		expect(col3).not.toHaveProperty('width');
+		expect(col3.visible).toBe(true);
 	});
 
 	test('should give item sizes', () => {

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -34,9 +34,29 @@ describe('useLayoutItemSizes', () => {
 		});
 
 		expect(layout.children).toEqual([
-			{ key: 'col1', width: 50 },
-			{ key: 'col2' },
-			{ key: 'col3', width: 70, visible: false },
+			{
+				key: 'col1',
+				width: 50,
+				resizableRight: true,
+				resizableBottom: false,
+				direction: 'column',
+				visible: true,
+			},
+			{
+				key: 'col2',
+				resizableRight: false,
+				resizableBottom: false,
+				direction: 'column',
+				visible: true,
+			},
+			{
+				key: 'col3',
+				width: 70,
+				resizableRight: true,
+				resizableBottom: false,
+				direction: 'column',
+				visible: false,
+			},
 		]);
 	});
 
@@ -54,9 +74,29 @@ describe('useLayoutItemSizes', () => {
 		});
 
 		expect(layout.children).toEqual([
-			{ key: 'col1', width: 50 },
-			{ key: 'col2', width: 50 },
-			{ key: 'col3' },
+			{
+				key: 'col1',
+				width: 50,
+				resizableRight: true,
+				resizableBottom: false,
+				direction: 'column',
+				visible: true,
+			},
+			{
+				key: 'col2',
+				width: 50,
+				resizableRight: true,
+				resizableBottom: false,
+				direction: 'column',
+				visible: true,
+			},
+			{
+				key: 'col3',
+				resizableRight: false,
+				resizableBottom: false,
+				direction: 'column',
+				visible: true,
+			},
 		]);
 	});
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -20,7 +20,7 @@ describe('useLayoutItemSizes', () => {
 		expect(layout.isRoot).toBe(true);
 	});
 
-	test('should strecth the last visible child item if all siblings have fixed size and the last child is not visible', () => {
+	test('should stretch the last visible child item if all siblings have fixed size and the last child is not visible', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',
 			width: 200,
@@ -60,7 +60,7 @@ describe('useLayoutItemSizes', () => {
 		]);
 	});
 
-	test('should strecth the last child item if all siblings have fixed size', () => {
+	test('should stretch the last child item if all siblings have fixed size', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',
 			width: 200,

--- a/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
@@ -13,30 +13,37 @@ function updateItemSize(itemIndex: number, itemDraft: LayoutItem, parent: Layout
 	}
 
 	// If all children of a container have a fixed width, the
-	// latest child should have a flexible width (i.e. no "width"
+	// latest visible child should have a flexible width (i.e. no "width"
 	// property), so that it fills up the remaining space
-	if (itemIndex === parent.children.length - 1) {
-		let allChildrenAreSized = true;
-		for (const child of parent.children) {
-			if (parent.direction === LayoutItemDirection.Row) {
-				if (!child.width) {
-					allChildrenAreSized = false;
-					break;
-				}
-			} else {
-				if (!child.height) {
-					allChildrenAreSized = false;
-					break;
-				}
-			}
+	let allChildrenAreSized = true;
+	let isThisTheLastVisible;
+	for (let i = parent.children.length - 1; i >= 0; i--) {
+		const child = parent.children[i];
+		if (!child || !child.visible) continue;
+
+		if (isThisTheLastVisible === undefined) {
+			isThisTheLastVisible = i === itemIndex;
+			if (!isThisTheLastVisible) break;
 		}
 
-		if (allChildrenAreSized) {
-			if (parent.direction === LayoutItemDirection.Row) {
-				delete itemDraft.width;
-			} else {
-				delete itemDraft.height;
+		if (parent.direction === LayoutItemDirection.Row) {
+			if (!child.width) {
+				allChildrenAreSized = false;
+				break;
 			}
+		} else {
+			if (!child.height) {
+				allChildrenAreSized = false;
+				break;
+			}
+		}
+	}
+
+	if (isThisTheLastVisible && allChildrenAreSized) {
+		if (parent.direction === LayoutItemDirection.Row) {
+			delete itemDraft.width;
+		} else {
+			delete itemDraft.height;
 		}
 	}
 }

--- a/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
@@ -3,11 +3,11 @@ import iterateItems from './iterateItems';
 import { LayoutItem, LayoutItemDirection } from './types';
 
 function isLastVisible(itemIndex: number, item: LayoutItem, parent: LayoutItem) {
-	if (!item.visible) return false;
+	if (item.visible === false) return false;
 
 	for (let i = parent.children.length - 1; i >= 0; i--) {
 		const child = parent.children[i];
-		if (child && child.visible) return i === itemIndex;
+		if (child && child.visible !== false) return i === itemIndex;
 	}
 
 	return false;
@@ -29,7 +29,7 @@ function updateItemSize(itemIndex: number, itemDraft: LayoutItem, parent: Layout
 	if (isLastVisible(itemIndex, itemDraft, parent)) {
 		let allChildrenAreSized = true;
 		for (const child of parent.children) {
-			if (!child.visible) continue;
+			if (child.visible === false) continue;
 
 			if (parent.direction === LayoutItemDirection.Row) {
 				if (!child.width) {


### PR DESCRIPTION
Fixes #4529.

The problem was that the `updateItemSize` function didn't handle non-visible items at all. It should only count items as fixed size, which are visible and it should only make visible items flexible.

To achieve this, for each item I had to find out whether it is last visible item in it's parent. For this, I loop through the sibling items in reverse order and on the first visible one check whether it's the current item. If not we break, if yes we continue looping to find out whether all siblings have a fixed size. This is a bit less efficient than how it was, but it works.

I've also included a test case in the existing test file for useLayoutItemSizes.

Steps to test manually:
---
You can use my kanban mockup plugin to quickly have a plugin panel for testing. Here's the jpl file:
[kanbanmockuptest.zip](https://github.com/laurent22/joplin/files/6332028/kanbanmockuptest.zip)

1. Load the provided test plugin, it will open a panel on startup
2. Resize the note editor
2. Close the panel with the "X" button in the top right
3. The editor will expand to fill the empty space

Screen recordings:
---

Before this fix:
![rec](https://user-images.githubusercontent.com/7415668/115382812-66383e00-a1d5-11eb-8ab8-ffa0bad8e000.gif)


After the fix:
![after](https://user-images.githubusercontent.com/7415668/115382538-1e191b80-a1d5-11eb-9218-d76e80e4bc82.gif)


