### PR TITLE
Server: Adding the possibility of connecting to the DB over a secure connection

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,11 +41,10 @@ function databaseHostFromEnv(runningInDocker: boolean, env: EnvVariables): strin
 }
 
 function databaseSSLConfigFromEnv(env: EnvVariables): object {
-	if (env.POSTGRES_SSL_ENABLE === "true") {
-		if (env.POSTGRES_SSL_VERIFY === "false") {
+	if (env.POSTGRES_SSL_ENABLE === 'true') {
+		if (env.POSTGRES_SSL_VERIFY === 'false') {
 			return { rejectUnauthorized: false };
-		}
-		else {
+		} else {
 			return { rejectUnauthorized: true };
 		}
 	}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,8 +13,8 @@ export interface EnvVariables {
 	POSTGRES_USER?: string;
 	POSTGRES_HOST?: string;
 	POSTGRES_PORT?: string;
-        POSTGRES_SSL_ENABLE?: boolean;
-        POSTGRES_SSL_VERIFY?: boolean;
+	POSTGRES_SSL_ENABLE?: boolean;
+	POSTGRES_SSL_VERIFY?: boolean;
 
 	SQLITE_DATABASE?: string;
 }
@@ -41,14 +41,14 @@ function databaseHostFromEnv(runningInDocker: boolean, env: EnvVariables): strin
 }
 
 function databaseSSLConfigFromEnv(env: EnvVariables): object {
-        if (env.POSTGRES_SSL_ENABLE || false) {
-            if (env.POSTGRES_SSL_VERIFY === true) {
-                return { rejectUnauthorized: true }
-            } else {
-                return { rejectUnauthorized: false }
-            }
-        }
-        return null;
+	if (env.POSTGRES_SSL_ENABLE || false) {
+		if (env.POSTGRES_SSL_VERIFY === true) {
+			return { rejectUnauthorized: true };
+		} else {
+			return { rejectUnauthorized: false };
+		}
+	}
+	return null;
 }
 
 function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables): DatabaseConfig {
@@ -60,7 +60,7 @@ function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables): Dat
 			password: env.POSTGRES_PASSWORD || 'joplin',
 			port: env.POSTGRES_PORT ? Number(env.POSTGRES_PORT) : 5432,
 			host: databaseHostFromEnv(runningInDocker, env) || 'localhost',
-                        ssl: databaseSSLConfigFromEnv(env),
+			ssl: databaseSSLConfigFromEnv(env),
 		};
 	}
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,8 +13,8 @@ export interface EnvVariables {
 	POSTGRES_USER?: string;
 	POSTGRES_HOST?: string;
 	POSTGRES_PORT?: string;
-	POSTGRES_SSL_ENABLE?: boolean;
-	POSTGRES_SSL_VERIFY?: boolean;
+	POSTGRES_SSL_ENABLE?: string;
+	POSTGRES_SSL_VERIFY?: string;
 
 	SQLITE_DATABASE?: string;
 }
@@ -41,11 +41,12 @@ function databaseHostFromEnv(runningInDocker: boolean, env: EnvVariables): strin
 }
 
 function databaseSSLConfigFromEnv(env: EnvVariables): object {
-	if (env.POSTGRES_SSL_ENABLE || false) {
-		if (env.POSTGRES_SSL_VERIFY === true) {
-			return { rejectUnauthorized: true };
-		} else {
+	if (env.POSTGRES_SSL_ENABLE === "true") {
+		if (env.POSTGRES_SSL_VERIFY === "false") {
 			return { rejectUnauthorized: false };
+		}
+		else {
+			return { rejectUnauthorized: true };
 		}
 	}
 	return null;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,7 +13,8 @@ export interface EnvVariables {
 	POSTGRES_USER?: string;
 	POSTGRES_HOST?: string;
 	POSTGRES_PORT?: string;
-        POSTGRES_SSL_REQUIRE?: boolean;
+        POSTGRES_SSL_ENABLE?: boolean;
+        POSTGRES_SSL_VERIFY?: boolean;
 
 	SQLITE_DATABASE?: string;
 }
@@ -39,6 +40,17 @@ function databaseHostFromEnv(runningInDocker: boolean, env: EnvVariables): strin
 	return null;
 }
 
+function databaseSSLConfigFromEnv(env: EnvVariables): object {
+        if (env.POSTGRES_SSL_ENABLE || false) {
+            if (env.POSTGRES_SSL_VERIFY === true) {
+                return { rejectUnauthorized: true }
+            } else {
+                return { rejectUnauthorized: false }
+            }
+        }
+        return null;
+}
+
 function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables): DatabaseConfig {
 	if (env.DB_CLIENT === 'pg') {
 		return {
@@ -48,7 +60,7 @@ function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables): Dat
 			password: env.POSTGRES_PASSWORD || 'joplin',
 			port: env.POSTGRES_PORT ? Number(env.POSTGRES_PORT) : 5432,
 			host: databaseHostFromEnv(runningInDocker, env) || 'localhost',
-                        ssl: env.POSTGRES_SSL_REQUIRE || false,
+                        ssl: databaseSSLConfigFromEnv(env),
 		};
 	}
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,6 +13,7 @@ export interface EnvVariables {
 	POSTGRES_USER?: string;
 	POSTGRES_HOST?: string;
 	POSTGRES_PORT?: string;
+        POSTGRES_SSL_REQUIRE?: boolean;
 
 	SQLITE_DATABASE?: string;
 }
@@ -47,6 +48,7 @@ function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables): Dat
 			password: env.POSTGRES_PASSWORD || 'joplin',
 			port: env.POSTGRES_PORT ? Number(env.POSTGRES_PORT) : 5432,
 			host: databaseHostFromEnv(runningInDocker, env) || 'localhost',
+                        ssl: env.POSTGRES_SSL_REQUIRE || false,
 		};
 	}
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -31,7 +31,7 @@ export interface DbConfigConnection {
 	database?: string;
 	filename?: string;
 	password?: string;
-        ssl?: boolean;
+        ssl?: object;
 }
 
 export interface KnexDatabaseConfig {

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -31,6 +31,7 @@ export interface DbConfigConnection {
 	database?: string;
 	filename?: string;
 	password?: string;
+        ssl?: boolean;
 }
 
 export interface KnexDatabaseConfig {
@@ -62,6 +63,7 @@ export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 		connection.port = dbConfig.port;
 		connection.user = dbConfig.user;
 		connection.password = dbConfig.password;
+                connection.ssl = dbConfig.ssl;
 	}
 
 	return {

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -31,7 +31,7 @@ export interface DbConfigConnection {
 	database?: string;
 	filename?: string;
 	password?: string;
-        ssl?: object;
+	ssl?: object;
 }
 
 export interface KnexDatabaseConfig {
@@ -63,7 +63,7 @@ export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 		connection.port = dbConfig.port;
 		connection.user = dbConfig.user;
 		connection.password = dbConfig.password;
-                connection.ssl = dbConfig.ssl;
+		connection.ssl = dbConfig.ssl;
 	}
 
 	return {

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -40,6 +40,7 @@ export interface DatabaseConfig {
 	user?: string;
 	password?: string;
 	asyncStackTraces?: boolean;
+	ssl?: boolean;
 }
 
 export interface Config {

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -40,7 +40,7 @@ export interface DatabaseConfig {
 	user?: string;
 	password?: string;
 	asyncStackTraces?: boolean;
-	ssl?: boolean;
+	ssl?: object;
 }
 
 export interface Config {


### PR DESCRIPTION
As tested, currently Joplin server has no way and by default doesn't attempt to connect to a Posgres DB over a TLS-secured connection.

This PR is aiming to fix this.