### PR TITLE
Desktop: Check if dataTransfer is non-null on drop

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -12,7 +12,7 @@ export default function useDropHandler(dependencies: HookDependencies) {
 		const dt = event.dataTransfer;
 		const createFileURL = event.altKey;
 
-		if (dt.types.indexOf('text/x-jop-note-ids') >= 0) {
+		if (dt && dt.types.indexOf('text/x-jop-note-ids') >= 0) {
 			const noteIds = JSON.parse(dt.getData('text/x-jop-note-ids'));
 			const noteMarkdownTags = [];
 			for (let i = 0; i < noteIds.length; i++) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -9,10 +9,12 @@ export default function useDropHandler(dependencies: HookDependencies) {
 	const { editorRef } = dependencies;
 
 	return useCallback(async (event: any) => {
+		if (!event.dataTransfer) return;
+
 		const dt = event.dataTransfer;
 		const createFileURL = event.altKey;
 
-		if (dt && dt.types.indexOf('text/x-jop-note-ids') >= 0) {
+		if (dt.types.indexOf('text/x-jop-note-ids') >= 0) {
 			const noteIds = JSON.parse(dt.getData('text/x-jop-note-ids'));
 			const noteMarkdownTags = [];
 			for (let i = 0; i < noteIds.length; i++) {


### PR DESCRIPTION
https://discourse.joplinapp.org/t/cursor-moved-to-the-top-undo-history-removed/16837/6

It looks like there's a case where the dataTransfer element of the drop event is null (see the attached forum post). I don't know what causes this situation, but it makes sense to guard against it like we do for files later on in the function.