### PR TITLE
All: improvement #3985 #3157: Also duplicate the tags when the note is duplicated

### DIFF
--- a/packages/app-cli/tests/models_Note.ts
+++ b/packages/app-cli/tests/models_Note.ts
@@ -5,6 +5,7 @@ import markdownUtils from '@joplin/lib/markdownUtils';
 const { sortedIds, createNTestNotes, setupDatabaseAndSynchronizer, switchClient, checkThrowAsync } = require('./test-utils.js');
 import Folder from '@joplin/lib/models/Folder';
 import Note from '@joplin/lib/models/Note';
+import Tag from '@joplin/lib/models/Tag';
 const ArrayUtils = require('@joplin/lib/ArrayUtils.js');
 
 async function allItems() {
@@ -123,6 +124,21 @@ describe('models_Note', function() {
 		expect(duplicatedNote.updated_time !== note1.updated_time).toBe(true);
 		expect(duplicatedNote.user_created_time !== note1.user_created_time).toBe(true);
 		expect(duplicatedNote.user_updated_time !== note1.user_updated_time).toBe(true);
+	}));
+
+	it('should duplicate a note with tags', (async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const tag1 = await Tag.save({ title: 'tag1' });
+		const tag2 = await Tag.save({ title: 'tag2' });
+		const originalNote = await Note.save({ title: 'originalNote', parent_id: folder1.id });
+		await Tag.addNote(tag1.id, originalNote.id);
+		await Tag.addNote(tag2.id, originalNote.id);
+
+		const duplicatedNote = await Note.duplicate(originalNote.id);
+		const duplicatedNoteTags = await Tag.tagsByNoteId(duplicatedNote.id);
+
+		expect(duplicatedNoteTags.find(o => o.id === tag1.id)).toBeDefined();
+		expect(duplicatedNoteTags.find(o => o.id === tag2.id)).toBeDefined();
 	}));
 
 	it('should delete a set of notes', (async () => {

--- a/packages/app-cli/tests/models_Note.ts
+++ b/packages/app-cli/tests/models_Note.ts
@@ -139,6 +139,7 @@ describe('models_Note', function() {
 
 		expect(duplicatedNoteTags.find(o => o.id === tag1.id)).toBeDefined();
 		expect(duplicatedNoteTags.find(o => o.id === tag2.id)).toBeDefined();
+		expect(duplicatedNoteTags.length).toBe(2);
 	}));
 
 	it('should delete a set of notes', (async () => {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -6,6 +6,7 @@ import shim from '../shim';
 import time from '../time';
 import markdownUtils from '../markdownUtils';
 import { NoteEntity } from '../services/database/types';
+import Tag from './Tag';
 
 const { sprintf } = require('sprintf-js');
 import Resource from './Resource';
@@ -615,7 +616,13 @@ export default class Note extends BaseItem {
 			newNote.title = title;
 		}
 
-		return this.save(newNote);
+		const newNoteSaved = await this.save(newNote);
+		const originalTags = await Tag.tagsByNoteId(noteId);
+		for (const tagToAdd of originalTags) {
+			await Tag.addNote(tagToAdd.id, newNoteSaved.id);
+		}
+
+		return this.save(newNoteSaved);
 	}
 
 	static async noteIsOlderThan(noteId: string, date: number) {


### PR DESCRIPTION
When duplicating a note, the tags are not duplicated, or is this behavior intended? 