### PR TITLE
Desktop: Fixes #4853: leftExtraToobarContainer and tox-header-container don't overlap

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -139,6 +139,16 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	const [draggingStarted, setDraggingStarted] = useState(false);
 	const [leftExtraToolbarWidth, setLeftExtraToolbarWidth] = useState(null);
 
+	const widthObserver = useRef(
+		new ResizeObserver((entries: ResizeObserverEntry[]) => {
+			entries.forEach((entry: ResizeObserverEntry) => {
+				if (entry.target.id === 'leftExtraToolbarContainer') {
+					setLeftExtraToolbarWidth((entry.target as HTMLElement).offsetWidth);
+				}
+			});
+		})
+	);
+
 	const props_onMessage = useRef(null);
 	props_onMessage.current = props.onMessage;
 
@@ -175,8 +185,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	};
 
 	useEffect(() => {
-		setLeftExtraToolbarWidth(document.getElementById('leftExtraToolbarContainer').offsetWidth);
-	}, [props.noteToolbarButtonInfos]);
+		const leftExtraToolbarContaier = document.getElementById('leftExtraToolbarContainer');
+		widthObserver.current.observe(leftExtraToolbarContaier);
+
+		return () => {
+			widthObserver.current.unobserve(leftExtraToolbarContaier);
+		};
+	}, [widthObserver]);
 
 	const insertResourcesIntoContent = useCallback(async (filePaths: string[] = null, options: any = null) => {
 		const resourceMd = await commandAttachFileToBody('', filePaths, options);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -137,6 +137,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	const [scriptLoaded, setScriptLoaded] = useState(false);
 	const [editorReady, setEditorReady] = useState(false);
 	const [draggingStarted, setDraggingStarted] = useState(false);
+	const [leftExtraToolbarWidth, setLeftExtraToolbarWidth] = useState(null);
 
 	const props_onMessage = useRef(null);
 	props_onMessage.current = props.onMessage;
@@ -172,6 +173,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			if (editor && editor.getDoc()) editor.getDoc().dispatchEvent(new Event('joplin-noteDidUpdate'));
 		}, 10);
 	};
+
+	useEffect(() => {
+		setLeftExtraToolbarWidth(document.getElementById('leftExtraToolbarContainer').offsetWidth);
+	}, [props.noteToolbarButtonInfos]);
 
 	const insertResourcesIntoContent = useCallback(async (filePaths: string[] = null, options: any = null) => {
 		const resourceMd = await commandAttachFileToBody('', filePaths, options);
@@ -396,7 +401,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		document.head.appendChild(element);
 		element.appendChild(document.createTextNode(`
 			.joplin-tinymce .tox-editor-header {
-				padding-left: ${document.getElementById('leftExtraToolbarContainer').offsetWidth}px;
+				padding-left: ${leftExtraToolbarWidth}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
 			
@@ -508,7 +513,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		return () => {
 			document.head.removeChild(element);
 		};
-	}, [editorReady, props.themeId, props.noteToolbarButtonInfos]);
+	}, [editorReady, props.themeId, leftExtraToolbarWidth]);
 
 	// -----------------------------------------------------------------------------------------
 	// Enable or disable the editor

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -396,7 +396,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		document.head.appendChild(element);
 		element.appendChild(document.createTextNode(`
 			.joplin-tinymce .tox-editor-header {
-				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
+				padding-left: ${document.getElementById('leftExtraToolbarContainer').offsetWidth}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
 			
@@ -508,7 +508,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		return () => {
 			document.head.removeChild(element);
 		};
-	}, [editorReady, props.themeId]);
+	}, [editorReady, props.themeId, props.noteToolbarButtonInfos]);
 
 	// -----------------------------------------------------------------------------------------
 	// Enable or disable the editor
@@ -1133,7 +1133,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		}
 
 		return (
-			<div style={styles.leftExtraToolbarContainer}>
+			<div style={styles.leftExtraToolbarContainer} id='leftExtraToolbarContainer'>
 				{buttons}
 			</div>
 		);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
@@ -37,7 +37,7 @@ export default function styles(props: NoteBodyEditorProps) {
 			},
 			leftExtraToolbarContainer: {
 				...extraToolbarContainer,
-				width: 80,
+				width: 'auto',
 				left: 0,
 			},
 			rightExtraToolbarContainer: {

--- a/packages/app-desktop/package-lock.json
+++ b/packages/app-desktop/package-lock.json
@@ -2293,6 +2293,12 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+      "integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+      "dev": true
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -99,6 +99,7 @@
     "@types/node": "^14.14.6",
     "@types/react": "16.9.55",
     "@types/react-redux": "^7.1.9",
+    "@types/resize-observer-browser": "^0.1.5",
     "@types/styled-components": "^5.1.4",
     "ajv": "^6.5.0",
     "app-builder-bin": "^1.9.11",


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes: #4853 

# The Change
Two files are updated: `packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts` and `packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx`. In `styles/index.ts`, the width of `leftExtraToobarContainer` is changed to `'auto'`, so that it can take the full width it needs.

In `TinyMCE/TinyMCE.tsx`, the lines are updated :
1. At line no. 1136, the `leftExtraToolbarContainer` div is given an id `leftExtraToolbarContainer`. 
2. At line no. 399, `padding-left` of `tox-editor-header` is changed to 
```
padding-left: ${document.getElementById('leftExtraToolbarContainer').offsetWidth}px;
```
so that `padding-left` is updated dynamically according to the current width of `leftExtraToolbarContainer`. 
3. At line 511, `props.noteToolbarButtonInfos` is added  to the `useEffect` dependency array so that it is executed whenever the `ToolbarButtons` gets updated( the title changes ). 


# Output

### Before the change
![joplin_external_editing_issue](https://user-images.githubusercontent.com/59690052/115101523-8e6c3680-9f62-11eb-9c7f-bb0522015be2.png)

### After the change
https://user-images.githubusercontent.com/59690052/115980594-999b1400-a5ab-11eb-8d2e-691e1cac2923.mp4

# Testing
 1. Manually Testing: Tested manually, the video clip is attached above.
 2. Automated Testing: Sorry, I couldn't find a good way to add a test for it. Maybe, it could be somehow tested using the Jest `render` method( and we need to pass the props also ), but I need a guide in that case. 