### PR TITLE
Plugins: Resolves #4801: Added check so plugin update won't occur if new version is non-compliant

### DIFF
--- a/packages/app-cli/tests/services/plugins/RepositoryApi.ts
+++ b/packages/app-cli/tests/services/plugins/RepositoryApi.ts
@@ -1,6 +1,6 @@
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
 import shim from '@joplin/lib/shim';
-import { setupDatabaseAndSynchronizer, switchClient, supportDir, createTempDir } from '../../test-utils';
+import { createTempDir, setupDatabaseAndSynchronizer, supportDir, switchClient } from '../../test-utils';
 
 async function newRepoApi(): Promise<RepositoryApi> {
 	const repo = new RepositoryApi(`${supportDir}/pluginRepo`, await createTempDir());
@@ -49,6 +49,8 @@ describe('services_plugins_RepositoryApi', function() {
 	it('should tell if a plugin can be updated', (async () => {
 		const api = await newRepoApi();
 		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0')).toBe(true);
+		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0', '1.5')).toBe(false);
+		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0', '1.7')).toBe(true);
 		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.2')).toBe(false);
 		expect(await api.pluginCanBeUpdated('does.not.exist', '1.0.0')).toBe(false);
 	}));

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -119,10 +119,13 @@ export default class RepositoryApi {
 		return output;
 	}
 
-	public async pluginCanBeUpdated(pluginId: string, installedVersion: string): Promise<boolean> {
+	public async pluginCanBeUpdated(pluginId: string, installedVersion: string, currentJoplinVersion: string = undefined): Promise<boolean> {
 		const manifest = (await this.manifests()).find(m => m.id === pluginId);
 		if (!manifest) return false;
-		return compareVersions(installedVersion, manifest.version) < 0;
+		const appVersion = currentJoplinVersion ?? process.env.npm_package_version;
+		const newVersionExists = compareVersions(installedVersion, manifest.version) == -1;
+		const joplinVersionIsCompatible = compareVersions(manifest.app_min_version, appVersion) == -1;
+		return newVersionExists && joplinVersionIsCompatible;
 	}
 
 }


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Resolves #4801.

`pluginCanBeUpdated` handles checks to see if a new plugin version exists, and allows for an update if that is the case. I added a check in this function to make sure that the `app_min_version` of a plugin's update is below the current joplin version. This differs from the original behavior where `app_min_version` is only checked on initial install.

I also added some tests to make sure that a non-compliant update is rejected, and that a compliant one is still accepted. This required me to add a parameter to `pluginCanBeUpdated` which allows for the joplin version to be overridden versus  what's in `package.json`.