### PR TITLE
Build extension

### DIFF
--- a/packages/app-clipper/package.json
+++ b/packages/app-clipper/package.json
@@ -2,7 +2,8 @@
   "name": "@joplin/app-clipper",
   "private": true,
   "scripts": {
-    "postinstall": "cd popup && npm install"
+    "postinstall": "cd popup && npm install",
+    "start": "cd popup && npm run watch"
   },
   "version": "1.0.8",
   "description": "Joplin Web Clipper",

--- a/packages/app-clipper/popup/package.json
+++ b/packages/app-clipper/popup/package.json
@@ -57,7 +57,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js SKIP_PREFLIGHT_CHECK",
     "test": "node scripts/test.js --env=jsdom",
-    "watch": "cra-build-watch",
+    "watch": "cra-build-watch --after-rebuild-hook 'node ../../tools/build-extension.js'",
     "postinstall": "node postinstall.js && npm run build"
   },
   "devDependencies": {

--- a/packages/tools/build-extension.js
+++ b/packages/tools/build-extension.js
@@ -1,0 +1,75 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const clipperDir = path.resolve(__dirname, '../app-clipper');
+
+async function copyDir(baseSourceDir, dirName, baseDestDir) {
+	// Example: `app-clipper/content_scripts` will be copied to to `app-clipper/build/chrome/content_scripts` and `app-clipper/build/firefox/content_scripts.
+	await fs.mkdirp(`${baseDestDir}/${dirName}`);
+	// Copy
+	await fs.copy(`${baseSourceDir}/${dirName}`, `${baseDestDir}/${dirName}`);
+}
+
+async function copyToDestinationFolder(destinationDirectory) {
+	const extensionContent = {
+		files: ['background.js', 'manifest.json'],
+		directories: ['popup/build', 'content_scripts', 'icons'],
+	};
+	const { files, directories } = extensionContent;
+	for (const dir of directories) {
+		await copyDir(clipperDir, dir, destinationDirectory);
+	}
+	for (const file of files) {
+		await fs.copy(`${clipperDir}/${file}`, `${destinationDirectory}/${file}`);
+	}
+	await fs.remove(`${destinationDirectory}/popup/build/manifest.json`);
+}
+
+async function main() {
+	// Methods to remove the `persistent` key in Firefox extension and `gecko` key in Chrome extension
+	const manifestConfig = {
+		chrome: {
+			removeManifestKeys: (manifest) => {
+				manifest = Object.assign({}, manifest);
+				delete manifest.applications;
+				return manifest;
+			},
+		},
+		firefox: {
+			removeManifestKeys: (manifest) => {
+				manifest = Object.assign({}, manifest);
+				delete manifest.background.persistent;
+				return manifest;
+			},
+		},
+	};
+	for (const browser in manifestConfig) {
+		const configMethod = manifestConfig[browser];
+		const distDir = `${clipperDir}/build/${browser}`;
+		// Delete the current build folder for the extension. Siliently exit if it doesn't exist.
+		await fs.remove(distDir);
+		// Create the build folder again.
+		await fs.mkdirp(distDir);
+		await copyToDestinationFolder(distDir);
+		const manifestText = await fs.readFile(`${distDir}/manifest.json`, 'utf-8');
+		let manifest = JSON.parse(manifestText);
+		// Call the methods to remove keys that will be unrecognized by either Chrome or Firefox to avoid getting error warning.
+		if (configMethod.removeManifestKeys) { manifest = configMethod.removeManifestKeys(manifest); }
+		await fs.writeFile(
+			`${distDir}/manifest.json`,
+			JSON.stringify(manifest, null, 4)
+		);
+	}
+}
+
+main()
+	.then(() =>
+		console.log(
+			`Created unpacked extension for Chrome and Firefox at ${clipperDir}/dev directory`
+		)
+	)
+	.catch((error) => {
+		console.error('Fatal error');
+		console.error(error);
+		process.exit(1);
+	});


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
This PR introduces a faster way to build the extension with a short npm script: `npm start`. That's all. I think it will lessen the cognitive load and typing required to start the development workflow, and some people in the community may find it helpful.

Assume that users have installed all the required dependencies, here is a comparison between the build process with the current script versus the new script that this PR introduces.

### Old script

https://user-images.githubusercontent.com/28924121/116230992-80988b80-a782-11eb-922f-afc226d4d1c6.mp4

1. Run `cd joplin/packages/app-clipper/popup`.
2. Run`npm run watch`.
3. Go to the relevant extension management page and drop the `app-clipper` folder to install the extension. This folder weighs *196.7mb*.
4. Get an error “Unrecognized key 'application' in manifest.json file" from Chrome and "Unrecognized key 'persistent' in manifest.json file" from Firefox. These errors don't impact the extension, but they are potentially confusing for new contributors or developers who get back to the project after a long time.

### New script

https://user-images.githubusercontent.com/28924121/116231160-b9d0fb80-a782-11eb-80df-a25579255fb1.mp4

1. Run `cd joplin/packages/app-clipper`.
2. Run `npm start`.
3. Go the extension management page and drop the `app-clipper/build/chrome` or `app-clipper/build/firefox` folder. Either folders weighs **3mb**.
4. No error warning from either Chrome or Firefox.

Here is a tree diagram of the `app-clipper` folder before and after running this new start script.

![extension-tree](https://user-images.githubusercontent.com/28924121/116231390-ff8dc400-a782-11eb-8c55-67549cb24d25.jpg)

I understand that these changes don't fix a particular issue, but they don't introduce a new dependency, and many improvements in development are based on small, incremental changes anyway. I was just solving my own problems as I went and figured it would be best to contribute back.
