### PR TITLE
Android: Use native UI to select the directory for file system sync

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -748,6 +748,9 @@ packages/app-mobile/services/AlarmServiceDriver.ios.js.map
 packages/app-mobile/setUpQuickActions.d.ts
 packages/app-mobile/setUpQuickActions.js
 packages/app-mobile/setUpQuickActions.js.map
+packages/app-mobile/utils/DirectoryPicker.d.ts
+packages/app-mobile/utils/DirectoryPicker.js
+packages/app-mobile/utils/DirectoryPicker.js.map
 packages/app-mobile/utils/ShareExtension.d.ts
 packages/app-mobile/utils/ShareExtension.js
 packages/app-mobile/utils/ShareExtension.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -735,6 +735,9 @@ packages/app-mobile/services/AlarmServiceDriver.ios.js.map
 packages/app-mobile/setUpQuickActions.d.ts
 packages/app-mobile/setUpQuickActions.js
 packages/app-mobile/setUpQuickActions.js.map
+packages/app-mobile/utils/DirectoryPicker.d.ts
+packages/app-mobile/utils/DirectoryPicker.js
+packages/app-mobile/utils/DirectoryPicker.js.map
 packages/app-mobile/utils/ShareExtension.d.ts
 packages/app-mobile/utils/ShareExtension.js
 packages/app-mobile/utils/ShareExtension.js.map

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -40,7 +40,6 @@ public class MainApplication extends Application implements ReactApplication {
 
         @Override
         protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           packages.add(new SharePackage());

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -14,6 +14,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
 
+import net.cozic.joplin.directorypicker.DirectoryPickerPackage;
 import net.cozic.joplin.share.SharePackage;
 import net.cozic.joplin.ssl.SslPackage;
 
@@ -43,6 +44,7 @@ public class MainApplication extends Application implements ReactApplication {
           List<ReactPackage> packages = new PackageList(this).getPackages();
           // Packages that cannot be autolinked yet can be added manually here, for example:
           packages.add(new SharePackage());
+          packages.add(new DirectoryPickerPackage());
           packages.add(new SslPackage());
           return packages;
         }

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/directorypicker/DirectoryPickerModule.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/directorypicker/DirectoryPickerModule.java
@@ -1,0 +1,122 @@
+package net.cozic.joplin.directorypicker;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DirectoryPickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
+
+    private static final int CODE = 54321;
+    public static final String TAG = "JoplinDirPicker";
+
+    private final ReactApplicationContext reactContext;
+    private final AtomicReference<Promise> promise = new AtomicReference<>(null);
+
+    public DirectoryPickerModule(ReactApplicationContext reactContext) {
+        this.reactContext = reactContext;
+        reactContext.addActivityEventListener(this);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "DirectoryPicker";
+    }
+
+    @ReactMethod
+    public void isAvailable(Promise promise) {
+        promise.resolve(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    @ReactMethod
+    public void pick(Promise promise) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    .addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+
+            this.promise.set(promise);
+            if (!reactContext.startActivityForResult(intent, CODE, null)) {
+                promise.reject("1", "Failed to pick directory");
+                this.promise.set(null);
+            }
+        } catch (Exception e) {
+            promise.reject(e);
+            this.promise.set(null);
+        }
+    }
+
+    @Override
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        if (requestCode != CODE) {
+            return;
+        }
+        Promise promise = this.promise.getAndSet(null);
+        if (resultCode != Activity.RESULT_OK) {
+            promise.reject("2", "Cancelled");
+            return;
+        }
+        WritableMap map = Arguments.createMap();
+
+        Uri uri = data.getData();
+
+        reactContext.getContentResolver().takePersistableUriPermission(uri,
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION & Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        map.putString("uri", uri.toString());
+        map.putString("path", getFileName(uri));
+        promise.resolve(map);
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+    }
+
+    private String getFileName(Uri uri) {
+        if (ContentResolver.SCHEME_FILE.equals(uri.getScheme())) {
+            File file = new File(uri.getPath());
+            return file.getName();
+        } else if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            String name = null;
+
+            // URI examples
+            // internal: content://com.android.externalstorage.documents/tree/primary%3Ajoplin
+            // sd card:  content://com.android.externalstorage.documents/tree/1DEA-0313%3Ajoplin
+            List<String> pathSegments = uri.getPathSegments();
+            if (pathSegments.get(0).equalsIgnoreCase("tree")) {
+                String[] parts = pathSegments.get(1).split(":", 2);
+                if (parts[0].equalsIgnoreCase("primary")) {
+                    name = new File(Environment.getExternalStorageDirectory(), parts[1]).getAbsolutePath();
+                } else {
+                    name = "/storage/" + parts[0] + "/" + parts[1];
+                }
+            }
+            Log.i(TAG, "Resolved content URI " + uri + " to path " + name);
+            return name;
+        } else {
+            Log.w(TAG, "Unknown URI scheme: " + uri.getScheme());
+            return null;
+        }
+    }
+}

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/directorypicker/DirectoryPickerPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/directorypicker/DirectoryPickerPackage.java
@@ -1,0 +1,24 @@
+package net.cozic.joplin.directorypicker;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DirectoryPickerPackage implements com.facebook.react.ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new DirectoryPickerModule(reactContext));
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/packages/app-mobile/utils/DirectoryPicker.ts
+++ b/packages/app-mobile/utils/DirectoryPicker.ts
@@ -1,0 +1,18 @@
+import { Platform, NativeModules } from 'react-native';
+
+let isAvailable = false;
+if (Platform.OS === 'android') {
+	NativeModules.DirectoryPicker.isAvailable().then((res: boolean) => {
+		isAvailable = res;
+	});
+}
+
+export default {
+
+	isAvailable: (): boolean => isAvailable,
+
+	async pick(): Promise<string> {
+		return NativeModules.DirectoryPicker.pick();
+	},
+
+};


### PR DESCRIPTION
It won't allow using an external SD card because due to Android limitations writing to external storage requires using a different API which isn't supported by react-native-fs.

Demo (ignore the weird colours, I think it's from compressing the gif):

![ezgif com-gif-maker(7)](https://user-images.githubusercontent.com/995612/116471873-14df1d00-a86d-11eb-818f-9c47ba0035cb.gif)


