### PR TITLE
Desktop: Fixes #4877: Incorrect list renumbering

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.ts
@@ -2,19 +2,76 @@ import { modifyListLines } from './useCursorUtils';
 
 describe('useCursorUtils', () => {
 
-	const listWithDashes = `- item1
-- item2
-- item3`;
+	const listWithDashes = [
+		'- item1',
+		'- item2',
+		'- item3',
+	];
 
-	const listNoDashes = `item1
-item2
-item3`;
+	const listWithNoPrefixes = [
+		'item1',
+		'item2',
+		'item3',
+	];
 
-	test('should remove "- " from beggining of each line of input string', () => {
-		expect(JSON.stringify(modifyListLines(listWithDashes.split('\n'), 0, '- '))).toBe(JSON.stringify(listNoDashes.split('\n')));
+	const listWithNumbers = [
+		'1. item1',
+		'2. item2',
+		'3. item3',
+	];
+
+	const listWithOnes = [
+		'1. item1',
+		'1. item2',
+		'1. item3',
+	];
+
+	const listWithSomeNumbers = [
+		'1. item1',
+		'item2',
+		'2. item3',
+	];
+
+	const numberedListWithEmptyLines = [
+		'1. item1',
+		'2. item2',
+		'3. ' ,
+		'4. item3',
+	];
+
+	const noPrefixListWithEmptyLines = [
+		'item1',
+		'item2',
+		'' ,
+		'item3',
+	];
+
+	test('should remove "- " from beginning of each line of input string', () => {
+		expect(modifyListLines([...listWithDashes], NaN, '- ')).toStrictEqual(listWithNoPrefixes);
 	});
 
-	test('should add "- " at the beggining of each line of the input string', () => {
-		expect(JSON.stringify(modifyListLines(listNoDashes.split('\n'), 0, '- '))).toBe(JSON.stringify(listWithDashes.split('\n')));
+	test('should add "- " at the beginning of each line of the input string', () => {
+		expect(modifyListLines([...listWithNoPrefixes], NaN, '- ')).toStrictEqual(listWithDashes);
+	});
+
+	test('should remove "n. " at the beginning of each line of the input string', () => {
+		expect(modifyListLines([...listWithNumbers], 4, '1. ')).toStrictEqual(listWithNoPrefixes);
+	});
+
+	test('should add "n. " at the beginning of each line of the input string', () => {
+		expect(modifyListLines([...listWithNoPrefixes], 1, '1. ')).toStrictEqual(listWithNumbers);
+	});
+
+	test('should remove "1. " at the beginning of each line of the input string', () => {
+		expect(modifyListLines([...listWithOnes], 2, '1. ')).toStrictEqual(listWithNoPrefixes);
+	});
+
+	test('should remove "n. " from each line that has it, and ignore' +
+        ' lines which do not', () => {
+		expect(modifyListLines([...listWithSomeNumbers], 2, '2. ')).toStrictEqual(listWithNoPrefixes);
+	});
+
+	test('should add numbers to each line including empty one', () => {
+		expect(modifyListLines(noPrefixListWithEmptyLines, 1, '1. ')).toStrictEqual(numberedListWithEmptyLines);
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.ts
@@ -1,20 +1,27 @@
 import markdownUtils from '@joplin/lib/markdownUtils';
 import Setting from '@joplin/lib/models/Setting';
-export function modifyListLines(lines: string[],num: number,listSymbol: string) {
+export function modifyListLines(lines: string[], num: number, listSymbol: string) {
+	const isNotNumbered = num === 1;
 	for (let j = 0; j < lines.length; j++) {
 		const line = lines[j];
 		if (!line && j === lines.length - 1) continue;
 		// Only add the list token if it's not already there
 		// if it is, remove it
-		if (!line.startsWith(listSymbol)) {
-			if (num) {
+		if (num) {
+			const lineNum = markdownUtils.olLineNumber(line);
+			if (!lineNum && isNotNumbered) {
 				lines[j] = `${num.toString()}. ${line}`;
 				num++;
 			} else {
-				lines[j] = listSymbol + line;
+				const listToken = markdownUtils.extractListToken(line);
+				lines[j] = line.substr(listToken.length, line.length - listToken.length);
 			}
 		} else {
-			lines[j] = line.substr(listSymbol.length, line.length - listSymbol.length);
+			if (!line.startsWith(listSymbol)) {
+				lines[j] = listSymbol + line;
+			} else {
+				lines[j] = line.substr(listSymbol.length, line.length - listSymbol.length);
+			}
 		}
 	}
 	return lines;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

These changes are related to/have a minor conflict with PR #4832. Please let me know how I can help get that PR merged, then I can rebase and add some additional test cases. I would also be happy to port the testing changes over to my branch and add test cases.

Here is what I found through manual testing (the expected behavior is the behavior after this patch):

_Note_: **Case C** and **Case D** were working and continue to work, just wanted to test all the code paths.

## Case A

### Steps to Reproduce
1. Create new note
1. Enter text
    ```
    1. item1
    2. item2
    3. item3
    ```
1. Drag select all 3 lines
1. Press numbered list

### Actual
```
4. 1. item1
5. 2. item2
6. 3. item3
```

### Expected
```
item1
item2
item3
```

## Case B

### Steps to Reproduce
1. Create new note
1. Enter text
    ```
    1. item1
    2. item2
    3. item3
    ```
1. Ctrl+A
1. Press numbered list

### Actual
```
2. 1. item1
item2
3. 3. item3
```

### Expected
```
item1
item2
item3
```

## Case C

### Steps to Reproduce
1. Create new note
1. Enter text
    ```
    ```
1. Press numbered list

### Actual
```
1. List item
```

### Expected
```
1. List item
```

## Case D

### Steps to Reproduce
1. Create new note
1. Enter text
    ```
    foobar
    ```
1. Place cursor at the end of the line
1. Press numbered list

### Actual
```
foobar
1. 
```

### Expected
```
foobar
1. 
```

## Case E

### Steps to Reproduce
1. Create new note
1. Enter text
    ```
    1. item1
    1. item2
    1. item3
    ```
1. Drag select all lines or Ctrl+A
1. Press numbered list

### Actual
```
2. 1. item1
3. 1. item2
4. 1. item3
```

### Expected
```
1. item1
1. item2
1. item3
```

