### PR TITLE
Desktop: Fixes #4891: Solve "Resource Id not provided" error

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -163,7 +163,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	const { scrollToPercent } = useScroll({ editor, onScroll: props.onScroll });
 
 	usePluginServiceRegistration(ref);
-	useContextMenu(editor, props.plugins);
+	useContextMenu(editor, props.plugins, props.dispatch);
 
 	const dispatchDidUpdate = (editor: any) => {
 		if (dispatchDidUpdateIID_) shim.clearTimeout(dispatchDidUpdateIID_);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -39,11 +39,11 @@ interface ContextMenuActionOptions {
 
 const contextMenuActionOptions: ContextMenuActionOptions = { current: null };
 
-export default function(editor: any, plugins: PluginStates) {
+export default function(editor: any, plugins: PluginStates, dispatch: Function) {
 	useEffect(() => {
 		if (!editor) return () => {};
 
-		const contextMenuItems = menuItems();
+		const contextMenuItems = menuItems(dispatch);
 
 		function onContextMenu(_event: any, params: any) {
 			const element = contextMenuElement(editor, params.x, params.y);
@@ -110,5 +110,5 @@ export default function(editor: any, plugins: PluginStates) {
 				bridge().window().webContents.off('context-menu', onContextMenu);
 			}
 		};
-	}, [editor, plugins]);
+	}, [editor, plugins, dispatch]);
 }

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -46,8 +46,8 @@ export default function useMessageHandler(scrollWhenReady: any, setScrollWhenRea
 
 			menu.popup(bridge().window());
 		} else if (msg.indexOf('joplin://') === 0) {
-			const resourceUrlInfo = urlUtils.parseResourceUrl(msg);
-			await openItemById(resourceUrlInfo, dispatch);
+			const { itemId, hash } = urlUtils.parseResourceUrl(msg);
+			await openItemById(itemId, dispatch, hash);
 
 		} else if (urlUtils.urlProtocol(msg)) {
 			if (msg.indexOf('file://') === 0) {

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -1,13 +1,9 @@
 import { useCallback } from 'react';
 import { FormNote } from './types';
-import contextMenu from './contextMenu';
-import ResourceEditWatcher from '@joplin/lib/services/ResourceEditWatcher/index';
+import contextMenu, { openItemById } from './contextMenu';
 import { _ } from '@joplin/lib/locale';
 import CommandService from '@joplin/lib/services/CommandService';
 import PostMessageService from '@joplin/lib/services/PostMessageService';
-import BaseItem from '@joplin/lib/models/BaseItem';
-import BaseModel from '@joplin/lib/BaseModel';
-import Resource from '@joplin/lib/models/Resource';
 const bridge = require('electron').remote.require('./bridge').default;
 const { urlDecode } = require('@joplin/lib/string-utils');
 const urlUtils = require('@joplin/lib/urlUtils');
@@ -46,43 +42,13 @@ export default function useMessageHandler(scrollWhenReady: any, setScrollWhenRea
 				linkToCopy: arg0.linkToCopy || null,
 				htmlToCopy: '',
 				insertContent: () => { console.warn('insertContent() not implemented'); },
-			});
+			}, dispatch);
 
 			menu.popup(bridge().window());
 		} else if (msg.indexOf('joplin://') === 0) {
 			const resourceUrlInfo = urlUtils.parseResourceUrl(msg);
-			const itemId = resourceUrlInfo.itemId;
-			const item = await BaseItem.loadItemById(itemId);
+			await openItemById(resourceUrlInfo, dispatch);
 
-			if (!item) throw new Error(`No item with ID ${itemId}`);
-
-			if (item.type_ === BaseModel.TYPE_RESOURCE) {
-				const localState = await Resource.localState(item);
-				if (localState.fetch_status !== Resource.FETCH_STATUS_DONE || !!item.encryption_blob_encrypted) {
-					if (localState.fetch_status === Resource.FETCH_STATUS_ERROR) {
-						bridge().showErrorMessageBox(`${_('There was an error downloading this attachment:')}\n\n${localState.fetch_error}`);
-					} else {
-						bridge().showErrorMessageBox(_('This attachment is not downloaded or not decrypted yet'));
-					}
-					return;
-				}
-
-				try {
-					await ResourceEditWatcher.instance().openAndWatch(item.id);
-				} catch (error) {
-					console.error(error);
-					bridge().showErrorMessageBox(error.message);
-				}
-			} else if (item.type_ === BaseModel.TYPE_NOTE) {
-				dispatch({
-					type: 'FOLDER_AND_NOTE_SELECT',
-					folderId: item.parent_id,
-					noteId: item.id,
-					hash: resourceUrlInfo.hash,
-				});
-			} else {
-				throw new Error(`Unsupported item type: ${item.type_}`);
-			}
 		} else if (urlUtils.urlProtocol(msg)) {
 			if (msg.indexOf('file://') === 0) {
 				// When using the file:// protocol, openPath doesn't work (does nothing) with URL-encoded paths


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes: #4891 

A function `openItemById` is created inside `app-desktop/gui/NoteEditor/utils/contextMenu.ts` just to avoid duplicate code. The `useMessageHandler` hook and  `menuItems`  both use the `openItemById` function so that the user gets the same experience on `ctrl+click` or `right-click+open` a link.


# Testing
### Manual Testing
Manually tested both on markdown editor and the TinyMCE editor( with note-links, resource-links; performing both the operations: `ctrl+click` and ` right-click+open` ).

### Unit testing
Sorry ( again ), I couldn't find a way to write a unit test for it. Maybe it is possible to add a test, but I think it would be very ( very) complex ( so need some guide ).  
