### PR TITLE
Server: persist db data: add volume to docker-compose.server.yml

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,15 +8,14 @@ version: '3'
 
 services:
     db:
-        image: postgres:13.1
-        ports:
-            - "5432:5432"
+        image: postgres:13
         restart: unless-stopped
         environment:
-            - APP_PORT=22300
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_DB=${POSTGRES_DATABASE}
+        volumes:
+            - ./postgres-data:/var/lib/postgresql/data
     app:
         image: joplin/server:latest
         depends_on:


### PR DESCRIPTION
- adding a volume to store database content
- don't forward postgres port on localhost - it is only being accessed in the docker network by the app container -> useless to have it forwarded to localhost
- remove APP_PORT env var from db container - afaik not used
- point to major release of postgres
