### PR TITLE
generator-joplin: Fix handle CRLF on mergeIgnoreFile

### DIFF
--- a/packages/generator-joplin/generators/app/utils.js
+++ b/packages/generator-joplin/generators/app/utils.js
@@ -41,7 +41,7 @@ function mergePackageKey(parentKey, source, dest) {
 }
 
 function mergeIgnoreFile(source, dest) {
-	const output = dest.trim().split('\n').concat(source.trim().split('\n'));
+	const output = dest.trim().split(/\r?\n/).concat(source.trim().split(/\r?\n/));
 
 	return `${output.filter(function(item, pos) {
 		if (!item) return true; // Leave blank lines

--- a/packages/generator-joplin/generators/app/utils.test.js
+++ b/packages/generator-joplin/generators/app/utils.test.js
@@ -33,6 +33,9 @@ describe('utils', () => {
 		const testCases = [
 			['line1\nline2\n', 'newline\n', 'line1\nline2\nnewline\n'],
 			['line1\nline2\n', 'line1\nnewline\n', 'line1\nline2\nnewline\n'],
+			['line1\r\nline2\r\n', 'line1\nnewline\n', 'line1\nline2\nnewline\n'],
+			['line1\nline2\n', 'line1\r\nnewline\r\n', 'line1\nline2\nnewline\n'],
+			['line1\r\nline2\r\n', 'line1\r\nnewline\r\n', 'line1\nline2\nnewline\n'],
 		];
 
 		for (const t of testCases) {


### PR DESCRIPTION
If the local ignore file has CR LF as line ending, previously equal lines from the template and local ignorefile where duplicated.