### PR TITLE
Documentation: Improved Linux notifications instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ In the desktop and mobile apps, an alarm can be associated with any to-do. It wi
 
 - **Windows**: >= 8. Make sure the Action Center is enabled on Windows. Task bar balloon for Windows < 8. Growl as fallback. Growl takes precedence over Windows balloons.
 - **macOS**: >= 10.8 or Growl if earlier.
-- **Linux**: `notify-osd` or `libnotify-bin` installed (Ubuntu should have this by default). Growl otherwise
+- **Linux**: `notify-send` tool, delivered through packages `notify-osd`, `libnotify-bin` or `libnotify-tools`. GNOME should have this by default, but install `libnotify-tools` if using KDE Plasma.
 
 See [documentation and flow chart for reporter choice](https://github.com/mikaelbr/node-notifier/blob/master/DECISION_FLOW.md)
 


### PR DESCRIPTION
I use OpenSUSE Tumbleweed as my Linux distribution with KDE Plasma as my desktop environment and I couldn't get notifications to work even after following the instructions on README (installing `notify-osd`) and checking the `node-notifier` library. After investigating using debug mode I discovered that `libnotify-tools` was the right repository to get the `notify-send` tool to actually make it work. I hope that changing this line of code could get Linux users to fix this error easier on their distro. BTW I removed the part about `growl` because it is a retired project specific to old MacOS.