### PR TITLE
Desktop: Fixes panels overflowing window

### DIFF
--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -11,9 +11,6 @@ import { StyledWrapperRoot, StyledMoveOverlay, MoveModeRootWrapper, MoveModeRoot
 import { Resizable } from 're-resizable';
 const EventEmitter = require('events');
 
-const itemMinWidth = 20;
-const itemMinHeight = 20;
-
 interface onResizeEvent {
 	layout: LayoutItem;
 }
@@ -66,8 +63,10 @@ function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: Lay
 				onResize={onResize as any}
 				onResizeStop={onResizeStop as any}
 				enable={enable}
-				minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
-				minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}
+				minWidth={sizes[item.key].min.width}
+				minHeight={sizes[item.key].min.height}
+				maxWidth={sizes[item.key].max.width}
+				maxHeight={sizes[item.key].max.height}
 			>
 				{children}
 			</Resizable>
@@ -112,14 +111,18 @@ function ResizableLayout(props: Props) {
 		function onResizeStart() {
 			setResizedItem({
 				key: item.key,
-				initialWidth: sizes[item.key].width,
-				initialHeight: sizes[item.key].height,
+				initialSize: sizes[item.key].current,
+				maxSize: sizes[item.key].max,
+				minSize: sizes[item.key].min,
 			});
 		}
 
 		function onResize(_event: any, direction: string, _refToElement: any, delta: any) {
-			const newWidth = Math.max(itemMinWidth, resizedItem.initialWidth + delta.width);
-			const newHeight = Math.max(itemMinHeight, resizedItem.initialHeight + delta.height);
+			let newWidth = Math.max(resizedItem.minSize.width, resizedItem.initialSize.width + delta.width);
+			let newHeight = Math.max(resizedItem.minSize.height, resizedItem.initialSize.height + delta.height);
+
+			newWidth = Math.min(newWidth, resizedItem.maxSize.width);
+			newHeight = Math.min(newHeight, resizedItem.maxSize.height);
 
 			const newSize: any = {};
 

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -32,7 +32,7 @@ function itemVisible(item: LayoutItem, moveMode: boolean) {
 	return item.visible !== false;
 }
 
-function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, resizeMaxSize: Size | null, onResizeStart: Function, onResize: Function, onResizeStop: Function, children: any[], isLastChild: boolean, moveMode: boolean): any {
+function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, resizedItemMaxSize: Size | null, onResizeStart: Function, onResize: Function, onResizeStop: Function, children: any[], isLastChild: boolean, moveMode: boolean): any {
 	const style: any = {
 		display: itemVisible(item, moveMode) ? 'flex' : 'none',
 		flexDirection: item.direction,
@@ -65,8 +65,8 @@ function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: Lay
 				enable={enable}
 				minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
 				minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}
-				maxWidth={resizeMaxSize?.width}
-				maxHeight={resizeMaxSize?.height}
+				maxWidth={resizedItemMaxSize?.width}
+				maxHeight={resizedItemMaxSize?.height}
 			>
 				{children}
 			</Resizable>
@@ -143,7 +143,7 @@ function ResizableLayout(props: Props) {
 			setResizedItem(null);
 		}
 
-		const resizeMaxSize = item.key === resizedItem?.key ? resizedItem.maxSize : null;
+		const resizedItemMaxSize = item.key === resizedItem?.key ? resizedItem.maxSize : null;
 		if (!item.children) {
 			const size = itemSize(item, parent, sizes, false);
 
@@ -156,7 +156,7 @@ function ResizableLayout(props: Props) {
 
 			const wrapper = renderItemWrapper(comp, item, parent, size, props.moveMode);
 
-			return renderContainer(item, parent, sizes, resizeMaxSize, onResizeStart, onResize, onResizeStop, [wrapper], isLastChild, props.moveMode);
+			return renderContainer(item, parent, sizes, resizedItemMaxSize, onResizeStart, onResize, onResizeStop, [wrapper], isLastChild, props.moveMode);
 		} else {
 			const childrenComponents = [];
 			for (let i = 0; i < item.children.length; i++) {
@@ -164,7 +164,7 @@ function ResizableLayout(props: Props) {
 				childrenComponents.push(renderLayoutItem(child, item, sizes, isVisible && itemVisible(child, props.moveMode), i === item.children.length - 1));
 			}
 
-			return renderContainer(item, parent, sizes, resizeMaxSize, onResizeStart, onResize, onResizeStop, childrenComponents, isLastChild, props.moveMode);
+			return renderContainer(item, parent, sizes, resizedItemMaxSize, onResizeStart, onResize, onResizeStop, childrenComponents, isLastChild, props.moveMode);
 		}
 	}
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -2,9 +2,15 @@ import { useMemo } from 'react';
 import { LayoutItem, Size } from './types';
 
 const dragBarThickness = 5;
+const itemMinWidth = 40;
+const itemMinHeight = 40;
 
 export interface LayoutItemSizes {
-	[key: string]: Size;
+	[key: string]: {
+		min: Size;
+		max: Size;
+		current: Size;
+	};
 }
 
 // Container always take the full space while the items within it need to
@@ -17,8 +23,8 @@ export function itemSize(item: LayoutItem, parent: LayoutItem | null, sizes: Lay
 	const bottomGap = !isContainer && (item.resizableBottom || parentResizableBottom) ? dragBarThickness : 0;
 
 	return {
-		width: ('width' in item ? item.width : sizes[item.key].width) - rightGap,
-		height: ('height' in item ? item.height : sizes[item.key].height) - bottomGap,
+		width: sizes[item.key].current.width - rightGap,
+		height: sizes[item.key].current.height - bottomGap,
 	};
 }
 
@@ -38,6 +44,10 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 	const noWidthChildren: any[] = [];
 	const noHeightChildren: any[] = [];
 
+	// The minimum space required for items with no defined size
+	let noWidthChildrenMinWidth = 0;
+	let noHeightChildrenMinHeight = 0;
+
 	for (const child of item.children) {
 		let w = 'width' in child ? child.width : null;
 		let h = 'height' in child ? child.height : null;
@@ -46,18 +56,59 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 			h = 0;
 		}
 
-		sizes[child.key] = { width: w, height: h };
+		sizes[child.key] = {
+			min: {
+				width: child.minWidth || itemMinWidth,
+				height: child.minHeight || itemMinHeight,
+			},
+			max: { width: w, height: h },
+			current: { width: w, height: h },
+		};
+
 		if (w !== null) remainingSize.width -= w;
 		if (h !== null) remainingSize.height -= h;
-		if (w === null) noWidthChildren.push({ item: child, parent: item });
-		if (h === null) noHeightChildren.push({ item: child, parent: item });
+		if (w === null) {
+			noWidthChildren.push({ item: child, parent: item });
+			noWidthChildrenMinWidth += child.minWidth || itemMinWidth;
+		}
+		if (h === null) {
+			noHeightChildren.push({ item: child, parent: item });
+			noHeightChildrenMinHeight += child.minHeight || itemMinHeight;
+		}
+	}
+
+	if (remainingSize.width < noWidthChildrenMinWidth) {
+		// There is not enough space, the largest item will be made smaller
+		let widestChild = item.children[0].key;
+		for (const child of item.children) {
+			if (!child.visible) continue;
+			if (sizes[child.key].current.width > sizes[widestChild].current.width) widestChild = child.key;
+		}
+
+		const dw = Math.abs(remainingSize.width - noWidthChildrenMinWidth);
+		sizes[widestChild].current.width -= dw;
+		sizes[widestChild].max.width -= dw;
+		remainingSize.width += dw;
+	}
+
+	if (remainingSize.height < noHeightChildrenMinHeight) {
+		let tallestChild = item.children[0].key;
+		for (const child of item.children) {
+			if (!child.visible) continue;
+			if (sizes[child.key].current.height > sizes[tallestChild].current.height) tallestChild = child.key;
+		}
+
+		const dh = Math.abs(remainingSize.height - noHeightChildrenMinHeight);
+		sizes[tallestChild].current.height -= dh;
+		sizes[tallestChild].max.height -= dh;
+		remainingSize.height += dh;
 	}
 
 	if (noWidthChildren.length) {
 		const w = item.direction === 'row' ? Math.floor(remainingSize.width / noWidthChildren.length) : parentSize.width;
 		for (const child of noWidthChildren) {
 			const finalWidth = w;
-			sizes[child.item.key].width = finalWidth;
+			sizes[child.item.key].current.width = finalWidth;
 		}
 	}
 
@@ -65,11 +116,15 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 		const h = item.direction === 'column' ? Math.floor(remainingSize.height / noHeightChildren.length) : parentSize.height;
 		for (const child of noHeightChildren) {
 			const finalHeight = h;
-			sizes[child.item.key].height = finalHeight;
+			sizes[child.item.key].current.height = finalHeight;
 		}
 	}
 
 	for (const child of item.children) {
+		// This will be used by Resizable to limit the item sizes while resizing
+		sizes[child.key].max.width += remainingSize.width - noWidthChildrenMinWidth;
+		sizes[child.key].max.height += remainingSize.height - noHeightChildrenMinHeight;
+
 		const childrenSizes = calculateChildrenSizes(child, parent, sizes, makeAllVisible);
 		sizes = { ...sizes, ...childrenSizes };
 	}
@@ -84,8 +139,9 @@ export default function useLayoutItemSizes(layout: LayoutItem, makeAllVisible: b
 		if (!('width' in layout) || !('height' in layout)) throw new Error('width and height are required on layout root');
 
 		sizes[layout.key] = {
-			width: layout.width,
-			height: layout.height,
+			min: { width: layout.width, height: layout.height },
+			max: { width: layout.width, height: layout.height },
+			current: { width: layout.width, height: layout.height },
 		};
 
 		sizes = calculateChildrenSizes(layout, null, sizes, makeAllVisible);

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -118,6 +118,7 @@ function calculateChildrenSizes(item: LayoutItem, parent: LayoutItem | null, siz
 }
 
 // Gives the maximum available space for this item that it can take up during resizing
+// availableSize = totalSize - ( [size of items with set size, except for the current item] + [minimum size of items with no set size] )
 export function calculateMaxSizeAvailableForItem(item: LayoutItem, parent: LayoutItem, sizes: LayoutItemSizes): Size {
 	const availableSize: Size = { ...sizes[parent.key] };
 


### PR DESCRIPTION
Fixes #4864 (specifically the issue [raised in this comment](https://github.com/laurent22/joplin/issues/4864#issuecomment-843288171), the original seems to have been fixed already).

The problem was that the layout logic had no way to handle maximum sizes, so if a panel was too big it simply overflowed and could even push other panes completely off-screen (see recordings below).

My fix is to add a extra logic to `useLayoutItemSizes()`, which
1. keeps track of the minimum space that should be reserved, such that all panels are visible (using the `minWidth`/`minHeight` props or `40px` per pane if not defined)
2. if the panes with definite size don't leave enough room, makes the largest one smaller
3. calculates a maximum possible size for each pane

The calculated max size is then passed to the `Resizable` component, so that it's enforced during resizing. I thought the cleanest way to do this is to extend the `sizes` object, which keeps the calculated size of each item. It now also contains their minimum and maximum sizes.

I included a few unit tests which hopefully cover all the new functionality.

Steps to check manually
---

Resizing with the mouse
1. Open Joplin
2. Resize the note list, as wide as it goes
Without the fix, the note editor is pushed off-screen. With the fix, it should stop when the note editor becomes only 40px wide.

Resizing the window
1. Open Joplin and maximize it
2. Resize the note list, really wide
3. Unmaximize Joplin
Without the fix, the note editor suddenly becomes invisible. With the fix, it should be visible and 40px wide (its minimum size).

Screen recordings
---

Before
![panel-nonworking-manres](https://user-images.githubusercontent.com/7415668/118897684-17341480-b90b-11eb-9a70-91d4b156a0ff.gif)

After
![panel-working-manres opt](https://user-images.githubusercontent.com/7415668/118897906-94f82000-b90b-11eb-9e9c-ec4394af85eb.gif)
