### PR TITLE
Android: Focus note editor where tapped instead of scrolling to the end

### DIFF
--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.java
@@ -16,6 +16,7 @@ import com.facebook.soloader.SoLoader;
 
 import net.cozic.joplin.share.SharePackage;
 import net.cozic.joplin.ssl.SslPackage;
+import net.cozic.joplin.textinput.TextInputPackage;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -44,6 +45,7 @@ public class MainApplication extends Application implements ReactApplication {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           packages.add(new SharePackage());
           packages.add(new SslPackage());
+          packages.add(new TextInputPackage());
           return packages;
         }
 

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/textinput/TextInputPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/textinput/TextInputPackage.java
@@ -1,0 +1,38 @@
+package net.cozic.joplin.textinput;
+
+import android.text.Selection;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.views.textinput.ReactEditText;
+import com.facebook.react.views.textinput.ReactTextInputManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TextInputPackage implements com.facebook.react.ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new ReactTextInputManager() {
+            @Override
+            public void receiveCommand(ReactEditText reactEditText, String commandId, @Nullable ReadableArray args) {
+                if ("focus".equals(commandId) || "focusTextInput".equals(commandId)) {
+                    Selection.removeSelection(reactEditText.getText());
+                }
+                super.receiveCommand(reactEditText, commandId, args);
+            }
+        });
+    }
+}

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/textinput/TextInputPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/textinput/TextInputPackage.java
@@ -15,6 +15,31 @@ import com.facebook.react.views.textinput.ReactTextInputManager;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * This class provides a workaround for <a href="https://github.com/facebook/react-native/issues/29911">
+ *     https://github.com/facebook/react-native/issues/29911</a>
+ *
+ * The reason the editor is scrolled seems to be due to this block in
+ * <pre>android.widget.Editor#onFocusChanged:</pre>
+ *
+ * <pre>
+ *                 // The DecorView does not have focus when the 'Done' ExtractEditText button is
+ *                 // pressed. Since it is the ViewAncestor's mView, it requests focus before
+ *                 // ExtractEditText clears focus, which gives focus to the ExtractEditText.
+ *                 // This special case ensure that we keep current selection in that case.
+ *                 // It would be better to know why the DecorView does not have focus at that time.
+ *                 if (((mTextView.isInExtractedMode()) || mSelectionMoved)
+ *                         && selStart >= 0 && selEnd >= 0) {
+ *                      Selection.setSelection((Spannable)mTextView.getText(),selStart,selEnd);
+ *                 }
+ * </pre>
+ * When using native Android TextView mSelectionMoved is false so this block is skipped,
+ * with RN however it's true and this is where the scrolling comes from.
+ *
+ * The below workaround resets the selection before a focus event is passed on to the native component.
+ * This way when the above condition is reached <pre>selStart == selEnd == -1</pre> and no scrolling
+ * happens.
+ */
 public class TextInputPackage implements com.facebook.react.ReactPackage {
     @NonNull
     @Override


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/4216
Resolves https://github.com/laurent22/joplin/issues/2287

---

Related RN issue (one of): https://github.com/facebook/react-native/issues/29911

This is more of a workaround than a proper fix, I think, but judging by the lack of activity on the above issue it won't be fixed anytime soon.

I tested it and it seems to work without any negative side-effects. Maybe one side effect is that when you switch to edit mode you can't select text by dragging before tapping once to focus the editor. But this hasn't worked before anyway.

Just don't ask me to explain why it works.