### PR TITLE
Desktop: Fixes: #4983: Low contrast on "sync target needs to be upgraded" link text

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -560,6 +560,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 					{_('The sync target needs to be upgraded before Joplin can sync. The operation may take a few minutes to complete and the app needs to be restarted. To proceed please click on the link.')}{' '}
 					<a href="#" onClick={() => onRestartAndUpgrade()}>
 						{_('Restart and upgrade')}
+					style="color:white"
 					</a>
 				</span>
 			);

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -558,9 +558,8 @@ class MainScreenComponent extends React.Component<Props, State> {
 			msg = (
 				<span>
 					{_('The sync target needs to be upgraded before Joplin can sync. The operation may take a few minutes to complete and the app needs to be restarted. To proceed please click on the link.')}{' '}
-					<a href="#" onClick={() => onRestartAndUpgrade()}>
+					<a href="#" style="color: theme.color" onClick={() => onRestartAndUpgrade()}>
 						{_('Restart and upgrade')}
-					style="color:white"
 					</a>
 				</span>
 			);

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -558,7 +558,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 			msg = (
 				<span>
 					{_('The sync target needs to be upgraded before Joplin can sync. The operation may take a few minutes to complete and the app needs to be restarted. To proceed please click on the link.')}{' '}
-					<a href="#" style="color: theme.color" onClick={() => onRestartAndUpgrade()}>
+					<a href="#" style="color: white" onClick={() => onRestartAndUpgrade()}>
 						{_('Restart and upgrade')}
 					</a>
 				</span>


### PR DESCRIPTION
Referring to issue 4983, I changed the hyperlink color to match that of the plaintext to fix the low contrast issue. The link is now white, like the rest of the text and should be legible on the blue background.


More details on the issue:
https://github.com/laurent22/joplin/issues/4983

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
