### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ Thank you to everyone who've contributed to Joplin's source code!
 
 MIT License
 
-Copyright (c) 2016-2020 Laurent Cozic
+Copyright (c) 2016-2021 Laurent Cozic
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
updated the 

Copyright (c) 2016-2020 Laurent Cozic

to read 

Copyright (c) 2016-**2021** Laurent Cozic

at the bottom of the page to reflect the current year
