### PR TITLE
Desktop: Expose prompt to plugins as a command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -356,6 +356,9 @@ packages/app-desktop/gui/MainScreen/commands/showNoteContentProperties.js.map
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.d.ts
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.js
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.js.map
+packages/app-desktop/gui/MainScreen/commands/showPrompt.d.ts
+packages/app-desktop/gui/MainScreen/commands/showPrompt.js
+packages/app-desktop/gui/MainScreen/commands/showPrompt.js.map
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.d.ts
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.js
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -342,6 +342,9 @@ packages/app-desktop/gui/MainScreen/commands/showNoteContentProperties.js.map
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.d.ts
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.js
 packages/app-desktop/gui/MainScreen/commands/showNoteProperties.js.map
+packages/app-desktop/gui/MainScreen/commands/showPrompt.d.ts
+packages/app-desktop/gui/MainScreen/commands/showPrompt.js
+packages/app-desktop/gui/MainScreen/commands/showPrompt.js.map
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.d.ts
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.js
 packages/app-desktop/gui/MainScreen/commands/showShareFolderDialog.js.map

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -74,6 +74,7 @@ const commands = [
 	require('./gui/MainScreen/commands/toggleNoteList'),
 	require('./gui/MainScreen/commands/toggleSideBar'),
 	require('./gui/MainScreen/commands/toggleVisiblePanes'),
+	require('./gui/MainScreen/commands/showPrompt'),
 	require('./gui/NoteEditor/commands/focusElementNoteBody'),
 	require('./gui/NoteEditor/commands/focusElementNoteTitle'),
 	require('./gui/NoteEditor/commands/showLocalSearch'),

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -135,6 +135,7 @@ const commands = [
 	require('./commands/openNote'),
 	require('./commands/openFolder'),
 	require('./commands/openTag'),
+	require('./commands/showPrompt'),
 ];
 
 class MainScreenComponent extends React.Component<Props, State> {

--- a/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
@@ -5,8 +5,8 @@ export const declaration: CommandDeclaration = {
 };
 
 enum PromptInputType {
-    Dropdown = 'dropdown',
-    Datetime = 'datetime',
+	Dropdown = 'dropdown',
+	Datetime = 'datetime',
 	Tags = 'tags',
 	Text = 'text',
 }

--- a/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
@@ -1,0 +1,28 @@
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+
+export const declaration: CommandDeclaration = {
+	name: 'showPrompt',
+};
+
+export const runtime = (comp: any): CommandRuntime => {
+	return {
+		execute: async (_context: CommandContext, config: any) => {
+			return new Promise((resolve) => {
+				comp.setState({
+					promptOptions: {
+						...config,
+						label: _(config.label),
+						onClose: async (answer: any, buttonType: string) => {
+							resolve({
+								answer: answer,
+								buttonType: buttonType,
+							});
+							comp.setState({ promptOptions: null });
+						},
+					},
+				});
+			});
+		},
+	};
+};

--- a/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
@@ -4,9 +4,16 @@ export const declaration: CommandDeclaration = {
 	name: 'showPrompt',
 };
 
+enum PromptInputType {
+    Dropdown = 'dropdown',
+    Datetime = 'datetime',
+	Tags = 'tags',
+	Text = 'text',
+}
+
 interface PromptConfig {
 	label: string;
-	inputType?: 'dropdown' | 'datetime' | 'tags' | 'text';
+	inputType?: PromptInputType;
 	value?: any;
 	autocomplete?: any[];
 	buttons?: string[];

--- a/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/showPrompt.ts
@@ -1,24 +1,30 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
-import { _ } from '@joplin/lib/locale';
 
 export const declaration: CommandDeclaration = {
 	name: 'showPrompt',
 };
 
+interface PromptConfig {
+	label: string;
+	inputType?: 'dropdown' | 'datetime' | 'tags' | 'text';
+	value?: any;
+	autocomplete?: any[];
+	buttons?: string[];
+}
+
 export const runtime = (comp: any): CommandRuntime => {
 	return {
-		execute: async (_context: CommandContext, config: any) => {
+		execute: async (_context: CommandContext, config: PromptConfig) => {
 			return new Promise((resolve) => {
 				comp.setState({
 					promptOptions: {
 						...config,
-						label: _(config.label),
 						onClose: async (answer: any, buttonType: string) => {
+							comp.setState({ promptOptions: null });
 							resolve({
 								answer: answer,
 								buttonType: buttonType,
 							});
-							comp.setState({ promptOptions: null });
 						},
 					},
 				});

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -47,5 +47,6 @@ export default function() {
 		'toggleSafeMode',
 		'showShareNoteDialog',
 		'showShareFolderDialog',
+		'showPrompt',
 	];
 }

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -47,6 +47,5 @@ export default function() {
 		'toggleSafeMode',
 		'showShareNoteDialog',
 		'showShareFolderDialog',
-		'showPrompt',
 	];
 }


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Adds a command to show the prompt and get the user input so that it can be used by plugins.
