### PR TITLE
All: Fixes: Wrong field removed in API search

### DIFF
--- a/packages/lib/services/searchengine/SearchEngineUtils.test.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.test.ts
@@ -83,4 +83,25 @@ describe('services_SearchEngineUtils', function() {
 			expect(rows.map(r=>r.id)).toContain(todo2.id);
 		}));
 	});
+
+	it('remove auto added fields', (async () => {
+		await Note.save({ title: 'abcd', body: 'body 1' });
+		await searchEngine.syncTables();
+
+		const testCases = [
+			['title', 'todo_due'],
+			['title', 'todo_completed'],
+			['title'],
+			['title', 'todo_completed', 'todo_due'],
+		];
+
+		for (const testCase of testCases) {
+			const rows = await SearchEngineUtils.notesForQuery('abcd', false, { fields: [...testCase] }, searchEngine);
+			testCase.push('type_');
+			expect(Object.keys(rows[0]).length).toBe(testCase.length);
+			for (const field of testCase) {
+				expect(rows[0]).toHaveProperty(field);
+			}
+		}
+	}));
 });

--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -66,8 +66,8 @@ export default class SearchEngineUtils {
 			const idx = noteIds.indexOf(filteredNotes[i].id);
 			sortedNotes[idx] = filteredNotes[i];
 			if (idWasAutoAdded) delete sortedNotes[idx].id;
-			if (isTodoCompletedAutoAdded) delete sortedNotes[idx].is_todo;
-			if (isTodoAutoAdded) delete sortedNotes[idx].todo_completed;
+			if (isTodoCompletedAutoAdded) delete sortedNotes[idx].todo_completed;
+			if (isTodoAutoAdded) delete sortedNotes[idx].is_todo;
 		}
 
 		// Note that when the search engine index is somehow corrupted, it might contain

--- a/packages/lib/services/searchengine/SearchEngineUtils.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.ts
@@ -38,10 +38,10 @@ export default class SearchEngineUtils {
 			isTodoAutoAdded = true;
 		}
 
-		let isTodoCompletedAutoAdded = false;
+		let todoCompletedAutoAdded = false;
 		if (fields.indexOf('todo_completed') < 0) {
 			fields.push('todo_completed');
-			isTodoCompletedAutoAdded = true;
+			todoCompletedAutoAdded = true;
 		}
 
 		const previewOptions = Object.assign({}, {
@@ -66,7 +66,7 @@ export default class SearchEngineUtils {
 			const idx = noteIds.indexOf(filteredNotes[i].id);
 			sortedNotes[idx] = filteredNotes[i];
 			if (idWasAutoAdded) delete sortedNotes[idx].id;
-			if (isTodoCompletedAutoAdded) delete sortedNotes[idx].todo_completed;
+			if (todoCompletedAutoAdded) delete sortedNotes[idx].todo_completed;
 			if (isTodoAutoAdded) delete sortedNotes[idx].is_todo;
 		}
 


### PR DESCRIPTION
It's kind of a shame, but I put a bug in the last fix #5007.  

If is_todo or todo_completed where added automatically, the wrong one was removed in the results.
I had not noticed this because I had always tested it in combination, so I have now added a test for the fields `id`, `is_todo` and `todo_completed`.