### PR TITLE
Desktop: Fix Linux Installer for LDME4 Debbie

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -162,11 +162,13 @@ DESKTOP=${DESKTOP,,}  # convert to lower case
 
 # Detect distribution environment
 DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
+DISTCODENAME=$(lsb_release -cs)
 #-----------------------------------------------------
 echo 'Create Desktop icon...'
 # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
 # It is present in Debian 10 Buster. A (temporary) patch will be applied at .desktop file
-if [ "$DISTVER" = "Debian10" ]
+# Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
+if [ "$DISTVER" = "Debian10" ] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ]
 then
   SANDBOXPARAM=" --no-sandbox"
 else


### PR DESCRIPTION
Use --no-sandbox option for Linux Mint LDME 4 Debbie as well.

Linux Mint LDME 4 Debbie is based on Debian 10 and therefore the same hack with --no-sandbox is requried.
Resolves #5105


