### PR TITLE
Docs: Fix a typo in Joplin Dialogs API

### DIFF
--- a/docs/api/references/plugin_api/classes/joplinviewsdialogs.html
+++ b/docs/api/references/plugin_api/classes/joplinviewsdialogs.html
@@ -68,7 +68,7 @@
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
 						<p>Allows creating and managing dialogs. A dialog is modal window that
-							contains a webview and a row of buttons. You can update the update the
+							contains a webview and a row of buttons. You can update the
 							webview using the <code>setHtml</code> method. Dialogs are hidden by default and
 							you need to call <code>open()</code> to open them. Once the user clicks on a
 							button, the <code>open</code> call will return an object indicating what button was


### PR DESCRIPTION
Just fixed a small typo in the documentation of Joplin Dialogs API Documentation.