### PR TITLE
Docs: Fix a typo in JoplinViewsDialogs.ts comments

### DIFF
--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -5,7 +5,7 @@ import { ButtonSpec, ViewHandle, DialogResult } from './types';
 
 /**
  * Allows creating and managing dialogs. A dialog is modal window that
- * contains a webview and a row of buttons. You can update the update the
+ * contains a webview and a row of buttons. You can update the
  * webview using the `setHtml` method. Dialogs are hidden by default and
  * you need to call `open()` to open them. Once the user clicks on a
  * button, the `open` call will return an object indicating what button was


### PR DESCRIPTION
Just fixed a small typo in the comments.