### PR TITLE
Desktop: Add keyboard shortcuts for inserting lists

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -734,6 +734,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						});
 					}
 
+					editor.addShortcut('Meta+Shift+7', '', () => editor.execCommand('InsertOrderedList'));
+					editor.addShortcut('Meta+Shift+8', '', () => editor.execCommand('InsertUnorderedList'));
+					editor.addShortcut('Meta+Shift+9', '', () => editor.execCommand('InsertJoplinChecklist'));
+
 					// setupContextMenu(editor);
 
 					// TODO: remove event on unmount?


### PR DESCRIPTION
See also the feature request at https://github.com/tinymce/tinymce/issues/6700. I later realized that Joplin has its own `lists.js` plugin, so I implemented it there.

Tested manually on Linux (KDE), it works.

Open questions:

- [ ] Should I reflect these changes in `Assets/TinyMCE/JoplinLists/src/main/ts/...`?
- [x] (Obsolete) Should I move the new lines to line 2055 instead (under the `addCommand()` calls)? There, they would be active even when `hasPlugin(editor, 'advlist')` -- not sure what that is and so I'm not sure which one makes sense. I.e. only add the keyboard shortcut if the button exists, or always?
- [ ] Should these keyboard shortcuts be advertised somewhere (same goes for bold, insert link, etc.), e.g. in the button tooltips?
- [ ] Should I add the same shortcuts for the Markdown editor (maybe someone can give a code pointer)?