### PR TITLE
Fix type of PostMessageHandler

### DIFF
--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -435,7 +435,7 @@ export type Path = string[];
 // Content Script types
 // =================================================================
 
-export type PostMessageHandler = (message: any) => Promise<any>;
+export type PostMessageHandler = (message: any)=> Promise<any>;
 
 /**
  * When a content script is initialised, it receives a `context` object.

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -435,7 +435,7 @@ export type Path = string[];
 // Content Script types
 // =================================================================
 
-export type PostMessageHandler = (id: string, message: any)=> Promise<any>;
+export type PostMessageHandler = (message: any) => Promise<any>;
 
 /**
  * When a content script is initialised, it receives a `context` object.


### PR DESCRIPTION
This fix is only relevant to plugins. The correct signature is demonstrated in the [documentation][1] for CodeMirror content scripts, but not correctly typed in the code. The signature in the code matches the one used in the [documentation][2] for MarkdownIt content scripts, but that documentation uses `webviewApi.postMessage` (without documenting how to get that value) instead of `context.postMessage`. Using the documented API for CodeMirror content scripts creates a type error without the fix in this PR.

[1]: https://github.com/laurent22/joplin/blob/5ee2ffe174369d23db4eaaa23e353e8b3b08bb71/packages/lib/services/plugins/api/types.ts#L613
[2]: https://github.com/laurent22/joplin/blob/5ee2ffe174369d23db4eaaa23e353e8b3b08bb71/packages/lib/services/plugins/api/types.ts#L508