### PR TITLE
Server: Improvement image labels

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -74,3 +74,16 @@ ENV RUNNING_IN_DOCKER=1
 EXPOSE ${APP_PORT}
 
 CMD [ "npm", "--prefix", "packages/server", "start" ]
+
+# Build-time metadata
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+LABEL org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.title="Joplin Server" \
+      org.opencontainers.image.description="Docker image for Joplin Server" \
+      org.opencontainers.image.url="https://joplinapp.org/" \
+      org.opencontainers.image.revision="$REVISION" \
+      org.opencontainers.image.source="https://github.com/laurent22/joplin.git" \
+      org.opencontainers.image.version="${VERSION}"

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -21,6 +21,7 @@ async function main() {
 	const imageVersion = getVersionFromTag(tagName, isPreRelease);
 	const buildDate = moment(new Date().getTime()).format('YYY-MM-DDTHH:mm:ssZ');
 	const revision = await execCommand2('git rev-parse --short HEAD');
+	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
 
 	process.chdir(rootDir);
 	console.info(`Running from: ${process.cwd()}`);
@@ -29,7 +30,7 @@ async function main() {
 	console.info('imageVersion:', imageVersion);
 	console.info('isPreRelease:', isPreRelease);
 
-	await execCommand2(`docker build -t "joplin/server:${imageVersion}" --build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}" -f Dockerfile.server .`);
+	await execCommand2(`docker build -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server .`);
 	await execCommand2(`docker push joplin/server:${imageVersion}`);
 
 	if (!isPreRelease) {

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -20,7 +20,12 @@ async function main() {
 	const isPreRelease = getIsPreRelease(tagName);
 	const imageVersion = getVersionFromTag(tagName, isPreRelease);
 	const buildDate = moment(new Date().getTime()).format('YYYY-MM-DDTHH:mm:ssZ');
-	const revision = await execCommand2('git rev-parse --short HEAD');
+	let revision = '';
+	try {
+		revision = await execCommand2('git rev-parse --short HEAD', { showOutput: false });
+	} catch (error) {
+		console.info('not a git repository');
+	}
 	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
 
 	process.chdir(rootDir);

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -19,7 +19,7 @@ async function main() {
 	const tagName = argv.tagName;
 	const isPreRelease = getIsPreRelease(tagName);
 	const imageVersion = getVersionFromTag(tagName, isPreRelease);
-	const buildDate = moment(new Date().getTime()).format('YYY-MM-DDTHH:mm:ssZ');
+	const buildDate = moment(new Date().getTime()).format('YYYY-MM-DDTHH:mm:ssZ');
 	const revision = await execCommand2('git rev-parse --short HEAD');
 	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
 

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -24,7 +24,7 @@ async function main() {
 	try {
 		revision = await execCommand2('git rev-parse --short HEAD', { showOutput: false });
 	} catch (error) {
-		console.info('not a git repository');
+		console.info('Could not get git commit: metadata revision field will be empty');
 	}
 	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
 


### PR DESCRIPTION
A small PR that adds labels for the docker image,  so that with docker inspect can determine which version is being used. 

`docker inspect d36f462df14e`
![grafik](https://user-images.githubusercontent.com/24863925/124397689-bb361b80-dd11-11eb-8e6c-b5bd30cb9828.png)
