### PR TITLE
Documentation: Update download.md

### DIFF
--- a/readme/download.md
+++ b/readme/download.md
@@ -1,28 +1,26 @@
-# Download Joplin
+# Downloading Joplin...
 
 <div class="intro">
-Thank you for downloading the Joplin desktop app!
-
-If your download didn't start, <a href="#" class="download-click-here">click here</a>.
+Your download of **[Joplin for Mac]** is in progress. If your download didn't start, <a href="#" class="download-click-here">click here</a>.
 
 </div>
 
 <div class="get-it-desktop">
 
-## Get it on desktop
-
+## Joplin App for Desktop
+  
 Access your notes on Windows, macOS or Linux.
 
 <!-- DESKTOP-DOWNLOAD-LINKS --><a href='https://github.com/laurent22/joplin/releases/download/v2.1.8/Joplin-Setup-2.1.8.exe'><img alt='Get it on Windows' width="134px" src='https://joplinapp.org/images/BadgeWindows.png'/></a> <a href='https://github.com/laurent22/joplin/releases/download/v2.1.8/Joplin-2.1.8.dmg'><img alt='Get it on macOS' width="134px" src='https://joplinapp.org/images/BadgeMacOS.png'/></a> <a href='https://github.com/laurent22/joplin/releases/download/v2.1.8/Joplin-2.1.8.AppImage'><img alt='Get it on Linux' width="134px" src='https://joplinapp.org/images/BadgeLinux.png'/></a><!-- DESKTOP-DOWNLOAD-LINKS -->
 
 </div>
 
-## Get it on mobile
+## Joplin App for Mobile
 
-To access your notes on your mobile or tablet, get the Android or iOS apps!
+Access your notes on your phone or tablet from the Android and iOS apps.
 
 <!-- MOBILE-DOWNLOAD-LINKS --><a href='https://play.google.com/store/apps/details?id=net.cozic.joplin&utm_source=GitHub&utm_campaign=README&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' height="40px" src='https://joplinapp.org/images/BadgeAndroid.png'/></a> <a href='https://itunes.apple.com/us/app/joplin/id1315599797'><img alt='Get it on the App Store' height="40px" src='https://joplinapp.org/images/BadgeIOS.png'/></a><!-- MOBILE-DOWNLOAD-LINKS -->
 
-## More download options
+## More Joplin Versions
 
-For other download options, such as the portable application, terminal application or Android APK file, please [follow this link](https://github.com/laurent22/joplin/blob/dev/README.md#installation).
+For other options, such as the portable application, terminal application or Android APK file, see the [full installation details](https://github.com/laurent22/joplin/blob/dev/README.md#installation).

--- a/readme/download.md
+++ b/readme/download.md
@@ -1,8 +1,7 @@
 # Downloading Joplin...
 
 <div class="intro">
-Your download of **[Joplin for Mac]** is in progress. If your download didn't start, <a href="#" class="download-click-here">click here</a>.
-
+Your download of <span class="downloaded-filename">Joplin</span> is in progress. If your download didn't start, <a href="#" class="download-click-here">click here</a>.
 </div>
 
 <div class="get-it-desktop">


### PR DESCRIPTION
https://discourse.joplinapp.org/t/poll-what-should-joplin-tagline-be/18487/31

Note: 
- I changed the headline to "Downloading Joplin..." to make it clear that something was happening. Should probably be "Download Joplin" if the download doesn't start immediately.
- I added a placeholder for **[Joplin for Mac]** that I would want to be replaced with the OS you are downloading on
- I think the "Joplin App for Desktop" section should stay, even when you are able to auto download. That shows the user that Joplin is available on multiple OSs.

