### PR TITLE
Improve error reporting around WebDAV XML parsing error

### DIFF
--- a/packages/lib/WebDavApi.js
+++ b/packages/lib/WebDavApi.js
@@ -121,13 +121,13 @@ class WebDavApi {
 			attrValueProcessors: [attrValueProcessor],
 		};
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			parseXmlString(xml, options, (error, result) => {
 				if (error) {
-					resolve(null); // Error handled by caller which will display the XML text (or plain text) if null is returned from this function
-					return;
+					reject(error);
+				} else {
+					resolve(result);
 				}
-				resolve(result);
 			});
 		});
 	}


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/5188

This should make it clear what was the actual parsing error. Right now this is not transparent at all.