### PR TITLE
Remove unused condition in synchronizer

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -542,7 +542,7 @@ export default class Synchronizer {
 
 						this.logSyncOperation(action, local, remote, reason);
 
-						if (local.type_ == BaseModel.TYPE_RESOURCE && (action == 'createRemote' || action === 'updateRemote' || (action == 'itemConflict' && remote))) {
+						if (local.type_ == BaseModel.TYPE_RESOURCE && (action == 'createRemote' || action === 'updateRemote')) {
 							const localState = await Resource.localState(local.id);
 							if (localState.fetch_status !== Resource.FETCH_STATUS_DONE) {
 								// This condition normally shouldn't happen


### PR DESCRIPTION
A very minor bugfix/cleanup

Looks like a leftover from before resource conflicts were added. When the local item is a resource, the action cannot possibly be `itemConflict` but must be `resourceConflict` instead.