### PR TITLE
Server: Switch to node:16-bullseye and add python to the image to support building on non amd64 platforms

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,11 @@
 # https://versatile.nl/blog/deploying-lerna-web-apps-with-docker
 
-FROM node:16
+FROM node:16-bullseye
+
+RUN apt-get update \
+    && apt-get install -y \
+    python \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN echo "Node: $(node --version)"
 RUN echo "Npm: $(npm --version)"


### PR DESCRIPTION
The issue is that node:12 (which uses buildpack-deps:buster) uses quite old libs, among them glibc ..
Now a bunch of the node deps can pull down prebuild libs (especially this was an issue with sqlite) ..
But on armv7 (ie raspberry pi devices) these prebuilt libraries do not exist, and building them from source
requires newer libraries.

Also to instal sqlite from source python seems to be needed.

Also took the opportunity to apply some best practices and merged the layers for the apt installs and cleaned the caches afterwards.

---

This may be a bit of a controversial switch to use node-build, but unfortunately there doesn't seem to be official ubuntu based node base images to use instead of node:12 .. so this may need to be it .. alternate thoughts are welcome :)