### PR TITLE
Desktop: Add ability to provide custom sizing for dialogs.

### DIFF
--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -54,8 +54,7 @@ joplin.plugins.register({
 			Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
 		</p>
 		`);
-		let tmpDlg: any = dialogs; // Temporary cast to use new properties.
-		await tmpDlg.fitToContent(handle4, false);
+		await (dialogs as any).fitToContent(handle4, false);
 		await dialogs.open(handle4);
 
 	},

--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -55,9 +55,7 @@ joplin.plugins.register({
 		</p>
 		`);
 		let tmpDlg: any = dialogs; // Temporary cast to use new properties.
-		await tmpDlg.useCustomSizing(handle4, true);
-		await tmpDlg.setCustomWidth(handle4, '60vw');
-		await tmpDlg.setCustomHeight(handle4, '40vh');
+		await tmpDlg.fitToContent(handle4, false);
 		await dialogs.open(handle4);
 
 	},

--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -42,6 +42,24 @@ joplin.plugins.register({
 		const result3 = await dialogs.open(handle3);
 		console.info('Got result: ' + JSON.stringify(result3));		
 		
+
+		const handle4 = await dialogs.create('myDialog4');
+		await dialogs.setHtml(handle4, `
+		<h1>This dialog tests dynamic sizing</h1>
+		<h3>Resize the window and the dialog should resize accordingly</h3>
+		<p>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+			Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+			Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+		</p>
+		`);
+		let tmpDlg: any = dialogs; // Temporary cast to use new properties.
+		await tmpDlg.useCustomSizing(handle4, true);
+		await tmpDlg.setCustomWidth(handle4, '60vw');
+		await tmpDlg.setCustomHeight(handle4, '40vh');
+		await dialogs.open(handle4);
+
 	},
 
 });

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -779,6 +779,9 @@ class MainScreenComponent extends React.Component<Props, State> {
 				scripts={view.scripts}
 				pluginId={plugin.id}
 				buttons={view.buttons}
+				useCustomSizing={view.useCustomSizing}
+				customWidth={view.customWidth}
+				customHeight={view.customHeight}
 			/>);
 		}
 

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -779,9 +779,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				scripts={view.scripts}
 				pluginId={plugin.id}
 				buttons={view.buttons}
-				useCustomSizing={view.useCustomSizing}
-				customWidth={view.customWidth}
-				customHeight={view.customHeight}
+				fitToContent={view.fitToContent}
 			/>);
 		}
 

--- a/packages/app-desktop/services/plugins/UserWebview.tsx
+++ b/packages/app-desktop/services/plugins/UserWebview.tsx
@@ -21,8 +21,6 @@ export interface Props {
 	minWidth?: number;
 	minHeight?: number;
 	fitToContent?: boolean;
-	customWidth?: string;
-	customHeight?: string;
 	borderBottom?: boolean;
 	theme?: any;
 	onSubmit?: Function;
@@ -33,8 +31,8 @@ export interface Props {
 const StyledFrame = styled.iframe`
 	padding: 0;
 	margin: 0;
-	width: ${(props: any) => props.fitToContent ? `${props.width}px` : props.customWidth};
-	height: ${(props: any) => props.fitToContent ? `${props.height}px` : props.customHeight};
+	width: ${(props: any) => props.fitToContent ? `${props.width}px` : '90vw'};
+	height: ${(props: any) => props.fitToContent ? `${props.height}px` : '80vh'};
 	border: none;
 	border-bottom: ${(props: Props) => props.borderBottom ? `1px solid ${props.theme.dividerColor}` : 'none'};
 `;
@@ -145,8 +143,6 @@ function UserWebview(props: Props, ref: any) {
 		width={contentSize.width}
 		height={contentSize.height}
 		fitToContent={props.fitToContent}
-		customWidth={props.customWidth}
-		customHeight={props.customHeight}
 		ref={viewRef}
 		src="services/plugins/UserWebviewIndex.html"
 		borderBottom={props.borderBottom}

--- a/packages/app-desktop/services/plugins/UserWebview.tsx
+++ b/packages/app-desktop/services/plugins/UserWebview.tsx
@@ -21,6 +21,8 @@ export interface Props {
 	minWidth?: number;
 	minHeight?: number;
 	fitToContent?: boolean;
+	customWidth?: string;
+	customHeight?: string;
 	borderBottom?: boolean;
 	theme?: any;
 	onSubmit?: Function;
@@ -31,8 +33,8 @@ export interface Props {
 const StyledFrame = styled.iframe`
 	padding: 0;
 	margin: 0;
-	width: ${(props: any) => props.fitToContent ? `${props.width}px` : '100%'};
-	height: ${(props: any) => props.fitToContent ? `${props.height}px` : '100%'};
+	width: ${(props: any) => props.fitToContent ? `${props.width}px` : props.customWidth};
+	height: ${(props: any) => props.fitToContent ? `${props.height}px` : props.customHeight};
 	border: none;
 	border-bottom: ${(props: Props) => props.borderBottom ? `1px solid ${props.theme.dividerColor}` : 'none'};
 `;
@@ -143,6 +145,8 @@ function UserWebview(props: Props, ref: any) {
 		width={contentSize.width}
 		height={contentSize.height}
 		fitToContent={props.fitToContent}
+		customWidth={props.customWidth}
+		customHeight={props.customHeight}
 		ref={viewRef}
 		src="services/plugins/UserWebviewIndex.html"
 		borderBottom={props.borderBottom}

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -9,9 +9,7 @@ const styled = require('styled-components').default;
 
 interface Props extends UserWebviewProps {
 	buttons: ButtonSpec[];
-	useCustomSizing: boolean;
-	customWidth?: string;
-	customHeight?: string;
+	fitToContent: boolean;
 }
 
 const StyledRoot = styled.div`
@@ -116,9 +114,7 @@ export default function UserWebviewDialog(props: Props) {
 						viewId={props.viewId}
 						themeId={props.themeId}
 						borderBottom={false}
-						fitToContent={!props.useCustomSizing}
-						customWidth={props.customWidth}
-						customHeight={props.customHeight}
+						fitToContent={props.fitToContent}
 						onSubmit={onSubmit}
 						onDismiss={onDismiss}
 						onReady={onReady}

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -9,6 +9,9 @@ const styled = require('styled-components').default;
 
 interface Props extends UserWebviewProps {
 	buttons: ButtonSpec[];
+	useCustomSizing: boolean;
+	customWidth?: string;
+	customHeight?: string;
 }
 
 const StyledRoot = styled.div`
@@ -113,7 +116,9 @@ export default function UserWebviewDialog(props: Props) {
 						viewId={props.viewId}
 						themeId={props.themeId}
 						borderBottom={false}
-						fitToContent={true}
+						fitToContent={!props.useCustomSizing}
+						customWidth={props.customWidth}
+						customHeight={props.customHeight}
 						onSubmit={onSubmit}
 						onDismiss={onDismiss}
 						onReady={onReady}

--- a/packages/lib/services/plugins/WebviewController.ts
+++ b/packages/lib/services/plugins/WebviewController.ts
@@ -58,9 +58,7 @@ export default class WebviewController extends ViewController {
 				scripts: [],
 				opened: false,
 				buttons: null,
-				useCustomSizing: false,
-				customWidth: null,
-				customHeight: null,
+				fitToContent: true,
 			},
 		});
 	}
@@ -142,10 +140,6 @@ export default class WebviewController extends ViewController {
 	// ---------------------------------------------
 
 	public async open(): Promise<DialogResult> {
-		if (this.storeView.useCustomSizing === true && (this.storeView.customWidth === null || this.storeView.customHeight === null)) {
-			throw new Error('Cannot use custom sizing when either customWidth or customHeight is null.');
-		}
-
 		this.store.dispatch({
 			type: 'VISIBLE_DIALOGS_ADD',
 			name: this.handle,
@@ -180,27 +174,11 @@ export default class WebviewController extends ViewController {
 		this.setStoreProp('buttons', buttons);
 	}
 
-	public get useCustomSizing(): boolean {
-		return this.storeView.useCustomSizing;
+	public get fitToContent(): boolean {
+		return this.storeView.fitToContent;
 	}
 
-	public set useCustomSizing(useCustomSizing: boolean) {
-		this.setStoreProp('useCustomSizing', useCustomSizing);
-	}
-
-	public get customWidth(): string {
-		return this.storeView.customWidth;
-	}
-
-	public set customWidth(customWidth: string) {
-		this.setStoreProp('customWidth', customWidth);
-	}
-
-	public get customHeight(): string {
-		return this.storeView.customHeight;
-	}
-
-	public set customHeight(customHeight: string) {
-		this.setStoreProp('customHeight', customHeight);
+	public set fitToContent(fitToContent: boolean) {
+		this.setStoreProp('fitToContent', fitToContent);
 	}
 }

--- a/packages/lib/services/plugins/WebviewController.ts
+++ b/packages/lib/services/plugins/WebviewController.ts
@@ -184,9 +184,6 @@ export default class WebviewController extends ViewController {
 		return this.storeView.useCustomSizing;
 	}
 
-	/**
-	 * Toggle on whether to use the custom width/height or the automatic width/height.
-	 */
 	public set useCustomSizing(useCustomSizing: boolean) {
 		this.setStoreProp('useCustomSizing', useCustomSizing);
 	}
@@ -195,10 +192,6 @@ export default class WebviewController extends ViewController {
 		return this.storeView.customWidth;
 	}
 
-	/**
-	 * Set the custom width of the dialog.
-	 * @param customWidth - The width along with the unit. For example `100px` or `100vw`.
-	 */
 	public set customWidth(customWidth: string) {
 		this.setStoreProp('customWidth', customWidth);
 	}
@@ -207,10 +200,6 @@ export default class WebviewController extends ViewController {
 		return this.storeView.customHeight;
 	}
 
-	/**
-	 * Set the custom height of the dialog.
-	 * @param customHeight - The height along with the unit. For example `100px` or `100vw`.
-	 */
 	public set customHeight(customHeight: string) {
 		this.setStoreProp('customHeight', customHeight);
 	}

--- a/packages/lib/services/plugins/WebviewController.ts
+++ b/packages/lib/services/plugins/WebviewController.ts
@@ -58,6 +58,9 @@ export default class WebviewController extends ViewController {
 				scripts: [],
 				opened: false,
 				buttons: null,
+				useCustomSizing: false,
+				customWidth: null,
+				customHeight: null,
 			},
 		});
 	}
@@ -139,6 +142,10 @@ export default class WebviewController extends ViewController {
 	// ---------------------------------------------
 
 	public async open(): Promise<DialogResult> {
+		if (this.storeView.useCustomSizing === true && (this.storeView.customWidth === null || this.storeView.customHeight === null)) {
+			throw new Error('Cannot use custom sizing when either customWidth or customHeight is null.');
+		}
+
 		this.store.dispatch({
 			type: 'VISIBLE_DIALOGS_ADD',
 			name: this.handle,
@@ -173,4 +180,38 @@ export default class WebviewController extends ViewController {
 		this.setStoreProp('buttons', buttons);
 	}
 
+	public get useCustomSizing(): boolean {
+		return this.storeView.useCustomSizing;
+	}
+
+	/**
+	 * Toggle on whether to use the custom width/height or the automatic width/height.
+	 */
+	public set useCustomSizing(useCustomSizing: boolean) {
+		this.setStoreProp('useCustomSizing', useCustomSizing);
+	}
+
+	public get customWidth(): string {
+		return this.storeView.customWidth;
+	}
+
+	/**
+	 * Set the custom width of the dialog.
+	 * @param customWidth - The width along with the unit. For example `100px` or `100vw`.
+	 */
+	public set customWidth(customWidth: string) {
+		this.setStoreProp('customWidth', customWidth);
+	}
+
+	public get customHeight(): string {
+		return this.storeView.customHeight;
+	}
+
+	/**
+	 * Set the custom height of the dialog.
+	 * @param customHeight - The height along with the unit. For example `100px` or `100vw`.
+	 */
+	public set customHeight(customHeight: string) {
+		this.setStoreProp('customHeight', customHeight);
+	}
 }

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -98,14 +98,25 @@ export default class JoplinViewsDialogs {
 		return this.controller(handle).open();
 	}
 
+	/**
+	 * Toggle on whether to use the custom width/height or the automatic width/height.
+	 */
 	async useCustomSizing(handle: ViewHandle, status: boolean) {
 		return this.controller(handle).useCustomSizing = status;
 	}
 
+	/**
+	 * Set the custom width of the dialog.
+	 * @param value - The width along with the unit. For example `100px` or `100vw`.
+	 */
 	async setCustomWidth(handle: ViewHandle, value: string) {
 		return this.controller(handle).customWidth = value;
 	}
 
+	/**
+	 * Set the custom height of the dialog.
+	 * @param value - The height along with the unit. For example `100px` or `100vw`.
+	 */
 	async setCustomHeight(handle: ViewHandle, value: string) {
 		return this.controller(handle).customHeight = value;
 	}

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -98,4 +98,15 @@ export default class JoplinViewsDialogs {
 		return this.controller(handle).open();
 	}
 
+	async useCustomSizing(handle: ViewHandle, status: boolean) {
+		return this.controller(handle).useCustomSizing = status;
+	}
+
+	async setCustomWidth(handle: ViewHandle, value: string) {
+		return this.controller(handle).customWidth = value;
+	}
+
+	async setCustomHeight(handle: ViewHandle, value: string) {
+		return this.controller(handle).customHeight = value;
+	}
 }

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -99,25 +99,11 @@ export default class JoplinViewsDialogs {
 	}
 
 	/**
-	 * Toggle on whether to use the custom width/height or the automatic width/height.
+	 * Toggle on whether to fit the dialog size to the content or not.
+	 * When set to false, the dialog is set to 90vw and 80vh
+	 * @default true
 	 */
-	async useCustomSizing(handle: ViewHandle, status: boolean) {
-		return this.controller(handle).useCustomSizing = status;
-	}
-
-	/**
-	 * Set the custom width of the dialog.
-	 * @param value - The width along with the unit. For example `100px` or `100vw`.
-	 */
-	async setCustomWidth(handle: ViewHandle, value: string) {
-		return this.controller(handle).customWidth = value;
-	}
-
-	/**
-	 * Set the custom height of the dialog.
-	 * @param value - The height along with the unit. For example `100px` or `100vw`.
-	 */
-	async setCustomHeight(handle: ViewHandle, value: string) {
-		return this.controller(handle).customHeight = value;
+	async fitToContent(handle: ViewHandle, status: boolean) {
+		return this.controller(handle).fitToContent = status;
 	}
 }

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -103,7 +103,7 @@ export default class JoplinViewsDialogs {
 	 * When set to false, the dialog is set to 90vw and 80vh
 	 * @default true
 	 */
-	async fitToContent(handle: ViewHandle, status: boolean) {
+	async setFitToContent(handle: ViewHandle, status: boolean) {
 		return this.controller(handle).fitToContent = status;
 	}
 }

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -100,10 +100,11 @@ export default class JoplinViewsDialogs {
 
 	/**
 	 * Toggle on whether to fit the dialog size to the content or not.
-	 * When set to false, the dialog is set to 90vw and 80vh
+	 * When set to false, the dialog stretches to fill the application
+	 * window.
 	 * @default true
 	 */
-	async setFitToContent(handle: ViewHandle, status: boolean) {
+	public async setFitToContent(handle: ViewHandle, status: boolean) {
 		return this.controller(handle).fitToContent = status;
 	}
 }


### PR DESCRIPTION
This SHOULD add to the Dialogs API 3 new properties: 
- `useCustomSizing`
- `customWidth`
- `customHeight`

When `useCustomSizing` is set to false, which is the default value, the dialog sizing is automatically determined the same way as it used to. However, when it's true, the values of `customWidth` and `customHeight` are used instead to assign the values. 

The point of this change is that I'd be able to do something like: 
```js
await joplin.views.dialogs.useCustomSizing(true);
await joplin.views.dialogs.setCustomWidth('75vw');
await joplin.views.dialogs.setCustomHeight('80vw');
```

This will enable dialogs to be created with dynamic sizing.

> NOTE the units used, `vw` and `vh` and NOT absolute pixels. Although pixels can still be used, the power of this change is being able to use `vw` and `vh`

## Tests
I've no idea how to test this ngl, I've tried to create a sample plugin like the ones that exist but I have no idea how to update the typescript definitions for the plugin system. Any help would be very appreciated in this part!