### PR TITLE
app-mobile: Fix the memory leak and lag increasing with time

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -10,6 +10,7 @@ import NoteEditor, { ChangeEvent, UndoRedoDepthChangeEvent } from '../NoteEditor
 const FileViewer = require('react-native-file-viewer').default;
 const React = require('react');
 const { Platform, Keyboard, View, TextInput, StyleSheet, Linking, Image, Share, PermissionsAndroid } = require('react-native');
+const NoLagTextInput = require('react-native-no-lag-text-input');
 const { connect } = require('react-redux');
 // const { MarkdownEditor } = require('@joplin/lib/../MarkdownEditor/index.js');
 const RNFS = require('react-native-fs');
@@ -1109,7 +1110,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 			if (!this.useEditorBeta()) {
 				bodyComponent = (
-					<TextInput
+					<NoLagTextInput
 						autoCapitalize="sentences"
 						style={this.styles().bodyTextInput}
 						ref="noteBodyTextField"


### PR DESCRIPTION
Issue https://github.com/laurent22/joplin/issues/1493
All credit goes to original creator of library https://github.com/bdokimakis/react-native-no-lag-text-input

- Replace all instances of TextInput with NoLagTextInput
Results : Before patch, heavy lag after 3-4 minutes of typing which keeps increasing very fast with time until device becomes unresponsive
After patch, negligible lag, tested by typing for 15 minutes, and very minimal affect on responsiveness after very long note

TODO: After typing very long note (5+ pages text) and pressing back key to see rendered note, and then going to edit, then the lag appears. Not heavy lag and doesn't increase with time but there is a little more input delay than regular.
Signed-off-by: Shivam Kumar <kumar.shivam.jarvis@gmail.com>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
