### PR TITLE
Desktop: Fix wrong variable name

### DIFF
--- a/packages/app-cli/tests/support/plugins/dialog/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/src/index.ts
@@ -54,7 +54,7 @@ joplin.plugins.register({
 			Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
 		</p>
 		`);
-		await (dialogs as any).fitToContent(handle4, false);
+		await (dialogs as any).setFitToContent(handle4, false);
 		await dialogs.open(handle4);
 
 	},


### PR DESCRIPTION
Simply fix a typo in the sample dialog.