### PR TITLE
Server: Add docker major, minor and beta version tags

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -21,8 +21,8 @@ This will start the server, which will listen on port **22300** on **localhost**
 
 The following tags are available:
 
-- `latest` are always the most recent released version
-- `beta` are always the most recent beta released version
+- `latest` is always the most recent released version
+- `beta` is always the most recent beta released version
 - Major versions, such as `2`, `2-beta`
 - Specific minor versions, such as `2.1`, `2.2`, `2.3-beta`
 - Specific patch versions, such as `2.0.4`, `2.2.8-beta`

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -17,6 +17,16 @@ docker run --env-file .env -p 22300:22300 joplin/server:latest
 
 This will start the server, which will listen on port **22300** on **localhost**. By default it will use SQLite, which allows you to test the app without setting up a database. To run it for production though, you'll want to connect the container to a database, as described below.
 
+## Supported docker tags
+
+The following tags are available:
+
+- `latest` are always the most recent released version
+- `beta` are always the most recent beta released version
+- Major versions, such as `2`, `2-beta`
+- Specific minor versions, such as `2.1`, `2.2`, `2.3-beta`
+- Specific patch versions, such as `2.0.4`, `2.2.8-beta`
+
 ## Setup the database
 
 You can setup the container to either use an existing PostgreSQL server, or connect it to a new one using docker-compose

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -27,7 +27,7 @@ async function main() {
 		console.info('Could not get git commit: metadata revision field will be empty');
 	}
 	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
-	const dockerTags = [];
+	const dockerTags: string[] = [];
 	const versionPart = imageVersion.split('.');
 	dockerTags.push(isPreRelease ? 'beta' : 'latest');
 	dockerTags.push(versionPart[0] + (isPreRelease ? '-beta' : ''));

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -27,6 +27,12 @@ async function main() {
 		console.info('Could not get git commit: metadata revision field will be empty');
 	}
 	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
+	const dockerTags = [];
+	const versionPart = imageVersion.split('.');
+	dockerTags.push(isPreRelease ? 'beta' : 'latest');
+	dockerTags.push(versionPart[0] + (isPreRelease ? '-beta' : ''));
+	dockerTags.push(`${versionPart[0]}.${versionPart[1]}${isPreRelease ? '-beta' : ''}`);
+	dockerTags.push(imageVersion);
 
 	process.chdir(rootDir);
 	console.info(`Running from: ${process.cwd()}`);
@@ -34,13 +40,12 @@ async function main() {
 	console.info('tagName:', tagName);
 	console.info('imageVersion:', imageVersion);
 	console.info('isPreRelease:', isPreRelease);
+	console.info('Docker tags:', dockerTags.join(', '));
 
 	await execCommand2(`docker build -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server .`);
-	await execCommand2(`docker push joplin/server:${imageVersion}`);
-
-	if (!isPreRelease) {
-		await execCommand2(`docker tag "joplin/server:${imageVersion}" "joplin/server:latest"`);
-		await execCommand2('docker push joplin/server:latest');
+	for (const tag of dockerTags) {
+		await execCommand2(`docker tag "joplin/server:${imageVersion}" "joplin/server:${tag}"`);
+		await execCommand2(`docker push joplin/server:${tag}`);
 	}
 }
 


### PR DESCRIPTION
Add docker tags for major, minor and beta version

- `latest` are always the most recent released version
- `beta` are always the most recent beta released version
- Major versions, such as `2`, `2-beta`
- Specific minor versions, such as `2.1`, `2.2`, `2.3-beta`
- Specific patch versions, such as `2.0.4`, `2.2.8-beta`

Is the content of the docker hub page updated automatically?