### PR TITLE
Desktop: Added enabled check before adding to NoteListContextMenu list.

### DIFF
--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -191,9 +191,11 @@ export default class NoteListUtils {
 			const location = info.view.location;
 			if (location !== MenuItemLocation.Context && location !== MenuItemLocation.NoteListContextMenu) continue;
 
-			menu.append(
-				new MenuItem(menuUtils.commandToStatefulMenuItem(info.view.commandName, noteIds))
-			);
+			if (menuUtils.isCommandEnabled(info.view.commandName)) {
+				menu.append(
+					new MenuItem(menuUtils.commandToStatefulMenuItem(info.view.commandName, noteIds))
+				);
+			}
 		}
 
 		return menu;

--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -191,7 +191,7 @@ export default class NoteListUtils {
 			const location = info.view.location;
 			if (location !== MenuItemLocation.Context && location !== MenuItemLocation.NoteListContextMenu) continue;
 
-			if (menuUtils.isCommandEnabled(info.view.commandName)) {
+			if (cmdService.isEnabled(info.view.commandName)) {
 				menu.append(
 					new MenuItem(menuUtils.commandToStatefulMenuItem(info.view.commandName, noteIds))
 				);

--- a/packages/lib/services/commands/MenuUtils.ts
+++ b/packages/lib/services/commands/MenuUtils.ts
@@ -89,10 +89,6 @@ export default class MenuUtils {
 		return item;
 	}
 
-	public isCommandEnabled(commandName: string): boolean {
-		return this.service.isEnabled(commandName);
-	}
-
 	public commandToStatefulMenuItem(commandName: string, ...args: any[]): MenuItem {
 		return this.commandToMenuItem(commandName, () => {
 			return this.service.execute(commandName, ...args);

--- a/packages/lib/services/commands/MenuUtils.ts
+++ b/packages/lib/services/commands/MenuUtils.ts
@@ -89,6 +89,10 @@ export default class MenuUtils {
 		return item;
 	}
 
+	public isCommandEnabled(commandName: string): boolean {
+		return this.service.isEnabled(commandName);
+	}
+
 	public commandToStatefulMenuItem(commandName: string, ...args: any[]): MenuItem {
 		return this.commandToMenuItem(commandName, () => {
 			return this.service.execute(commandName, ...args);


### PR DESCRIPTION
The `enabledCondition` was simply ignored completely when adding buttons to the NoteListContextMenu. I've added the needed condition to only append commands that are enabled according to commandService's `isEnabled`.

I noticed that the code in NoteListUtils apprently is outdated ? Like it doesn't use any of the CommandService stuff about comnmandEnabled and when clauses but simply does the checks manually. I focused my changes on the plugins part and left the others.

I've tested this in my own plugin via having a command that only works with `inConflictFolder` and the button indeed now only shows for notes inside the Conflict Folder. Not the outside.  I'm not sure if unit tests are needed for this change.