### PR TITLE
Mobile: Update Sync icon spin direction on mobile Fixes #4588

### DIFF
--- a/packages/app-mobile/components/side-menu-content.js
+++ b/packages/app-mobile/components/side-menu-content.js
@@ -30,7 +30,7 @@ class SideMenuContentComponent extends Component {
 		this.syncIconRotationValue = new Animated.Value(0);
 		this.syncIconRotation = this.syncIconRotationValue.interpolate({
 			inputRange: [0, 1],
-			outputRange: ['360deg', '0deg'],
+			outputRange: ['0deg', '360deg'],
 		});
 	}
 


### PR DESCRIPTION
Back with a simple fix that is now confirmed working.

This changes the icon spin direction to match desktop. I confirmed this works on iOS.

@roman-r-m could you check on Android?