### PR TITLE
Desktop: Resolves #5297: Add css classes for code in the markdown view

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -475,6 +475,20 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				color: ${theme.codeColor};
 			}
 
+			div.CodeMirror span.cm-comment.cm-jn-inline-code {
+				border: 1px solid ${theme.codeBorderColor};
+				background-color: ${theme.codeBackgroundColor};
+				padding-right: .2em;
+				padding-left: .2em;
+				border-radius: .25em;
+			}
+
+			div.CodeMirror pre.cm-jn-code-block {
+				background-color: ${theme.codeBackgroundColor};
+				padding-right: .2em;
+				padding-left: .2em;
+			}
+
 			div.CodeMirror span.cm-strong {
 				color: ${theme.colorBright};
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -7,6 +7,7 @@ interface JoplinModeState {
 	outer: any;
 	openCharacter: string;
 	inTable: boolean;
+	inCodeBlock: boolean;
 	inner: any;
 }
 
@@ -48,6 +49,7 @@ export default function useJoplinMode(CodeMirror: any) {
 					outer: CodeMirror.startState(markdownMode),
 					openCharacter: '',
 					inTable: false,
+					inCodeBlock: false,
 					inner: CodeMirror.startState(stex),
 				};
 			},
@@ -57,6 +59,7 @@ export default function useJoplinMode(CodeMirror: any) {
 					outer: CodeMirror.copyState(markdownMode, state.outer),
 					openCharacter: state.openCharacter,
 					inTable: state.inTable,
+					inCodeBlock: state.inCodeBlock,
 					inner: CodeMirror.copyState(stex, state.inner),
 				};
 			},
@@ -115,9 +118,26 @@ export default function useJoplinMode(CodeMirror: any) {
 				let isMonospace = false;
 				// After being passed to the markdown mode we can check if the
 				// code state variables are set
-				// Code Block
-				if (state.outer.code || (state.outer.thisLine && state.outer.thisLine.fencedCodeEnd)) {
+				// Code
+				if (state.outer.code > 0) {
+					// state.outer.code holds the number of preceding backticks
+					// anything > 0 backticks is an inline-code-block
+					// -1 is used for actual code blocks
 					isMonospace = true;
+					token = `${token} jn-inline-code`;
+				} else if (state.outer.thisLine && state.outer.thisLine.fencedCodeEnd) {
+					state.inCodeBlock = false;
+					isMonospace = true;
+					token = `${token} line-cm-jn-code-block`;
+				} else if (state.outer.code === -1 || state.inCodeBlock) {
+					state.inCodeBlock = true;
+					isMonospace = true;
+					token = `${token} line-cm-jn-code-block`;
+				} else if (stream.pos > 0 && stream.string[stream.pos - 1] === '`' &&
+										!!token && token.includes('comment')) {
+					// This grabs the closing backtick for inline Code
+					isMonospace = true;
+					token = `${token} jn-inline-code`;
 				}
 				// Indented Code
 				if (state.outer.indentedCode) {
@@ -163,6 +183,10 @@ export default function useJoplinMode(CodeMirror: any) {
 				}
 
 				state.inTable = false;
+
+				if (state.inCodeBlock) return 'line-cm-jn-code-block';
+
+				return null;
 			},
 
 			electricChars: markdownMode.electricChars,


### PR DESCRIPTION
Fixes #5297 

I started out just testing if we could separate the inline and block code styles, and accidentally implemented it and added proper background colours for the code blocks.

![image](https://user-images.githubusercontent.com/2179547/129471089-d1f804e6-ad38-4a33-8820-1d3f06dd86ed.png)

I tested this by mucking around with the number of backticks used, and the spacing  between them. But ultimately, this is based on the CodeMirror markdown mode variables, so it should be fairly safe, unless there is an upstream bug.