### PR TITLE
Desktop: Place code-block background in the back

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -483,7 +483,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				border-radius: .25em;
 			}
 
-			div.CodeMirror pre.cm-jn-code-block {
+			div.CodeMirror div.cm-jn-code-block {
 				background-color: ${theme.codeBackgroundColor};
 				padding-right: .2em;
 				padding-left: .2em;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -128,11 +128,11 @@ export default function useJoplinMode(CodeMirror: any) {
 				} else if (state.outer.thisLine && state.outer.thisLine.fencedCodeEnd) {
 					state.inCodeBlock = false;
 					isMonospace = true;
-					token = `${token} line-cm-jn-code-block`;
+					token = `${token} line-background-cm-jn-code-block`;
 				} else if (state.outer.code === -1 || state.inCodeBlock) {
 					state.inCodeBlock = true;
 					isMonospace = true;
-					token = `${token} line-cm-jn-code-block`;
+					token = `${token} line-background-cm-jn-code-block`;
 				} else if (stream.pos > 0 && stream.string[stream.pos - 1] === '`' &&
 										!!token && token.includes('comment')) {
 					// This grabs the closing backtick for inline Code
@@ -184,7 +184,7 @@ export default function useJoplinMode(CodeMirror: any) {
 
 				state.inTable = false;
 
-				if (state.inCodeBlock) return 'line-cm-jn-code-block';
+				if (state.inCodeBlock) return 'line-background-cm-jn-code-block';
 
 				return null;
 			},


### PR DESCRIPTION
Followup to fix an issue introduced in #5314

Instead of applying the code block class to the line itself, this changes it to create a CodeMirror background element. This is the correct way to apply line backgrounds in CodeMirror, but I had a brain fart the other day. 

I've tested this by selecting a code block, as well as searching withing a code block. Should be good now!