### PR TITLE
Desktop: Linux: Remove dependency on lsb_release from install script

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -182,9 +182,9 @@ if command -v lsb_release &> /dev/null; then
   DISTCODENAME=$(lsb_release -cs)
   #-----------------------------------------------------
   # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
-  # It is present in Debian 10 Buster. A (temporary) patch will be applied at .desktop file
+  # It is present in Debian 1X. A (temporary) patch will be applied at .desktop file
   # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
-  if [ "$DISTVER" = "Debian10" ] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ]
+  if [ $DISTVER =~ Debian1. ] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ]
   then
     SANDBOXPARAM=" --no-sandbox"
   fi

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -176,6 +176,7 @@ echo 'Create Desktop icon...'
 # Detect distribution environment, and apply --no-sandbox fix
 SANDBOXPARAM=""
 # lsb_release isn't available on some platforms (e.g. opensuse)
+# The equivalent of lsb_release in OpenSuse is the file /usr/lib/os-release
 if command -v lsb_release &> /dev/null; then
   DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
   DISTCODENAME=$(lsb_release -cs)

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -171,19 +171,22 @@ else
 fi
 DESKTOP=${DESKTOP,,}  # convert to lower case
 
-# Detect distribution environment
-DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
-DISTCODENAME=$(lsb_release -cs)
-#-----------------------------------------------------
 echo 'Create Desktop icon...'
-# Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
-# It is present in Debian 10 Buster. A (temporary) patch will be applied at .desktop file
-# Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
-if [ "$DISTVER" = "Debian10" ] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ]
-then
-  SANDBOXPARAM=" --no-sandbox"
-else
-  SANDBOXPARAM=""
+
+# Detect distribution environment, and apply --no-sandbox fix
+SANDBOXPARAM=""
+# lsb_release isn't available on some platforms (e.g. opensuse)
+if command -v lsb_release &> /dev/null; then
+  DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
+  DISTCODENAME=$(lsb_release -cs)
+  #-----------------------------------------------------
+  # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
+  # It is present in Debian 10 Buster. A (temporary) patch will be applied at .desktop file
+  # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
+  if [ "$DISTVER" = "Debian10" ] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ]
+  then
+    SANDBOXPARAM=" --no-sandbox"
+  fi
 fi
 
 # Initially only desktop environments that were confirmed to use desktop files stored in


### PR DESCRIPTION
Fixes #5240 

The lsb_release module is used to detect certain platforms that need the `--no-sandbox` flag. This isn't needed for most platforms, and some platforms (notably openSUSE) don't have the lsb_release binary and don't need it.