### PR TITLE
Desktop: Removes markdown inline code padding

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -475,11 +475,12 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				color: ${theme.codeColor};
 			}
 
+			/* Negative margins are needed to componsate for the border */
 			div.CodeMirror span.cm-comment.cm-jn-inline-code {
 				border: 1px solid ${theme.codeBorderColor};
 				background-color: ${theme.codeBackgroundColor};
-				padding-right: .2em;
-				padding-left: .2em;
+				margin-left: -1px;
+				margin-right: -1px;
 				border-radius: .25em;
 			}
 


### PR DESCRIPTION
[ref](https://github.com/laurent22/joplin/pull/5314#issuecomment-900256897)

I was worried it would be hard to read without the padding, but it looks fine to me.
![image](https://user-images.githubusercontent.com/2179547/129832024-ebeaea85-7b00-4102-b813-3a0c648cc8a0.png)
