### PR TITLE
Server: Enable multi platform builds

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -34,7 +34,13 @@ jobs:
               $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update || true
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+          # the next line enables multi-architecture support for docker, it basically makes it use qemu for non native platforms
+          # See https://hub.docker.com/r/tonistiigi/binfmt for more info
           docker run --privileged --rm tonistiigi/binfmt --install all
+
+          # this just prints the info about what platforms are supported in the builder (can help debugging if something isn't working right)
+          # and also proves the above worked properly
           sudo docker buildx ls
 
       - uses: actions/checkout@v2

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -34,6 +34,8 @@ jobs:
               $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update || true
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          sudo docker buildx ls
 
       - uses: actions/checkout@v2
       - uses: olegtarasov/get-tag@v2.1

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -1,6 +1,8 @@
 import { execCommand2, rootDir } from './tool-utils';
 import * as moment from 'moment';
 
+const DockerImageName = 'joplin/server';
+
 function getVersionFromTag(tagName: string, isPreRelease: boolean): string {
 	if (tagName.indexOf('server-') !== 0) throw new Error(`Invalid tag: ${tagName}`);
 	const s = tagName.split('-');
@@ -10,6 +12,14 @@ function getVersionFromTag(tagName: string, isPreRelease: boolean): string {
 
 function getIsPreRelease(tagName: string): boolean {
 	return tagName.indexOf('-beta') > 0;
+}
+
+function flatten<T>(array: (T | T[])[]): T[] {
+	return [].concat(...array);
+}
+
+function normalizePlatform(platform: string) {
+	return platform.replace(/\//g, '-');
 }
 
 async function main() {
@@ -27,7 +37,8 @@ async function main() {
 	} catch (error) {
 		console.info('Could not get git commit: metadata revision field will be empty');
 	}
-	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
+	const buildArgs = { BUILD_DATE: buildDate, REVISION: revision, VERSION: imageVersion };
+	const flattenedBuildArgs = flatten((Object.keys(buildArgs) as (keyof typeof buildArgs)[]).map((k) => ['--build-arg', `${k}=${buildArgs[k]}`]));
 	const dockerTags: string[] = [];
 	const versionPart = imageVersion.split('.');
 	dockerTags.push(isPreRelease ? 'beta' : 'latest');
@@ -44,10 +55,44 @@ async function main() {
 	console.info('isPreRelease:', isPreRelease);
 	console.info('Docker tags:', dockerTags.join(', '));
 
-	await execCommand2(`docker build -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server .`);
-	for (const tag of dockerTags) {
-		await execCommand2(`docker tag "joplin/server:${imageVersion}" "joplin/server:${tag}"`);
-		if (pushImages) await execCommand2(`docker push joplin/server:${tag}`);
+	const platforms = [
+		'linux/amd64',
+		'linux/arm64',
+		'linux/arm/v7',
+	];
+
+	// this will build a bunch of local image tags named: ${imageVersion}-${platform} with the slashes replaced with dashes
+	for (const platform of platforms) {
+		const normalizedPlatform = normalizePlatform(platform);
+		await execCommand2([
+			'docker', 'build',
+			'--platform', platform,
+			'-t', `${DockerImageName}:${imageVersion}-${normalizedPlatform}`,
+			...flattenedBuildArgs,
+			'-f', 'Dockerfile.server',
+			'.',
+		]);
+		if (pushImages) {
+			await execCommand2([
+				'docker', 'push', `${DockerImageName}:${imageVersion}-${normalizedPlatform}`,
+			]);
+		}
+	}
+
+	// now we have to create the right manifests and push them
+	if (pushImages) {
+		for (const tag of dockerTags) {
+			// manifest create requires the tags being amended in to exist on the remote, so this all can only happen if pushImages is true
+			await execCommand2([
+				'docker', 'manifest', 'create',
+				`${DockerImageName}:${tag}`,
+				...flatten(platforms.map((platform) => ['--amend', `${DockerImageName}:${imageVersion}-${normalizePlatform(platform)}`])),
+			]);
+			await execCommand2([
+				'docker', 'manifest', 'push',
+				`${DockerImageName}:${tag}`,
+			]);
+		}
 	}
 }
 

--- a/packages/tools/tool-utils.ts
+++ b/packages/tools/tool-utils.ts
@@ -147,6 +147,7 @@ export function execCommandVerbose(commandName: string, args: string[] = []) {
 interface ExecCommandOptions {
 	showInput?: boolean;
 	showOutput?: boolean;
+	showError?: boolean;
 	quiet?: boolean;
 }
 
@@ -160,6 +161,7 @@ export async function execCommand2(command: string | string[], options: ExecComm
 	options = {
 		showInput: true,
 		showOutput: true,
+		showError: true,
 		quiet: false,
 		...options,
 	};
@@ -167,6 +169,7 @@ export async function execCommand2(command: string | string[], options: ExecComm
 	if (options.quiet) {
 		options.showInput = false;
 		options.showOutput = false;
+		options.showError = false;
 	}
 
 	if (options.showInput) {
@@ -182,6 +185,7 @@ export async function execCommand2(command: string | string[], options: ExecComm
 	args.splice(0, 1);
 	const promise = execa(executableName, args);
 	if (options.showOutput) promise.stdout.pipe(process.stdout);
+	if (options.showError) promise.stderr.pipe(process.stderr);
 	const result = await promise;
 	return result.stdout.trim();
 }


### PR DESCRIPTION
Needs #5202 merged first to actually succeed building on those platforms

- extend execCommand2 to also support streaming stderr (newer docker builds output to stderr, so its a bit silent and hard to see what's going on)
- Switch up the docker build script to build multi-platform images, currently supporting amd64, armv7 and arm64
