### PR TITLE
Desktop: Split code block class in two

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -484,7 +484,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				border-radius: .25em;
 			}
 
-			div.CodeMirror div.cm-jn-code-block {
+			div.CodeMirror div.cm-jn-code-block-background {
 				background-color: ${theme.codeBackgroundColor};
 				padding-right: .2em;
 				padding-left: .2em;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinMode.ts
@@ -128,11 +128,11 @@ export default function useJoplinMode(CodeMirror: any) {
 				} else if (state.outer.thisLine && state.outer.thisLine.fencedCodeEnd) {
 					state.inCodeBlock = false;
 					isMonospace = true;
-					token = `${token} line-background-cm-jn-code-block`;
+					token = `${token} line-cm-jn-code-block line-background-cm-jn-code-block-background`;
 				} else if (state.outer.code === -1 || state.inCodeBlock) {
 					state.inCodeBlock = true;
 					isMonospace = true;
-					token = `${token} line-background-cm-jn-code-block`;
+					token = `${token} line-cm-jn-code-block line-background-cm-jn-code-block-background`;
 				} else if (stream.pos > 0 && stream.string[stream.pos - 1] === '`' &&
 										!!token && token.includes('comment')) {
 					// This grabs the closing backtick for inline Code
@@ -184,7 +184,7 @@ export default function useJoplinMode(CodeMirror: any) {
 
 				state.inTable = false;
 
-				if (state.inCodeBlock) return 'line-background-cm-jn-code-block';
+				if (state.inCodeBlock) return 'line-cm-jn-code-block line-background-cm-jn-code-block-background';
 
 				return null;
 			},


### PR DESCRIPTION
I realized that the current naming will be confusing for users of the CSS who might try to change other aspects of the code block. So now it's split in two and the background element clearly has the background class.