### PR TITLE
Server: Fixes #5222: Fix STARTTLS negotiation for EmailService

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -94,8 +94,8 @@ function mailerConfigFromEnv(env: EnvVariables): MailerConfig {
 	return {
 		enabled: env.MAILER_ENABLED !== '0',
 		host: env.MAILER_HOST || '',
-		port: Number(env.MAILER_PORT || 587),
-		secure: !!Number(env.MAILER_SECURE) || true,
+		port: Number(env.MAILER_PORT || 465),
+		encryption: env.MAILER_SECURE || 'smtps',
 		authUser: env.MAILER_AUTH_USER || '',
 		authPassword: env.MAILER_AUTH_PASSWORD || '',
 		noReplyName: env.MAILER_NOREPLY_NAME || '',

--- a/packages/server/src/services/EmailService.ts
+++ b/packages/server/src/services/EmailService.ts
@@ -23,7 +23,9 @@ export default class EmailService extends BaseService {
 			this.transport_ = createTransport({
 				host: this.config.mailer.host,
 				port: this.config.mailer.port,
-				secure: this.config.mailer.secure,
+				secure: (this.config.mailer.encryption == 'smtps'),
+				ignoreTLS: (this.config.mailer.encryption == 'none'),
+				requireTLS: (this.config.mailer.encryption == 'starttls'),
 				auth: {
 					user: this.config.mailer.authUser,
 					pass: this.config.mailer.authPassword,

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -70,7 +70,7 @@ export interface MailerConfig {
 	enabled: boolean;
 	host: string;
 	port: number;
-	secure: boolean;
+	encryption: string;
 	authUser: string;
 	authPassword: string;
 	noReplyName: string;


### PR DESCRIPTION
This makes MAILER_SECURE accept either `none`, `smtps`, or `starttls`, and passes the correct values to Nodemailer:

https://nodemailer.com/smtp/#tls-options

This also changes the default MAILER_PORT to 465, to be consistent with the default MAILER_SECURE value of `smtps`.

Fixes #5222.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
