### PR TITLE
Desktop: Resolves #5364: Disable inline code background in vim mode

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -381,6 +381,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			`.CodeMirror-selected {
 				background: #6b6b6b !important;
 			}` : '';
+		// Vim mode draws a fat cursor in the background, we don't want to add background colors
+		// to the inline code in this case (it would hide the cursor)
+		const codeBackgroundColor = Setting.value('editor.keyboardMode') !== 'vim' ? theme.codeBackgroundColor : 'inherit';
 		const monospaceFonts = [];
 		if (Setting.value('style.editor.monospaceFontFamily')) monospaceFonts.push(`"${Setting.value('style.editor.monospaceFontFamily')}"`);
 		monospaceFonts.push('monospace');
@@ -476,9 +479,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			}
 
 			/* Negative margins are needed to componsate for the border */
-			div.CodeMirror span.cm-comment.cm-jn-inline-code {
+			div.CodeMirror span.cm-comment.cm-jn-inline-code:not(.cm-search-marker):not(.cm-fat-cursor-mark):not(.cm-search-marker-selected):not(.CodeMirror-selectedtext) {
 				border: 1px solid ${theme.codeBorderColor};
-				background-color: ${theme.codeBackgroundColor};
+				background-color: ${codeBackgroundColor};
 				margin-left: -1px;
 				margin-right: -1px;
 				border-radius: .25em;


### PR DESCRIPTION
fixes #5364 

This issue turned out to be related to a couple small issues with inline code when the editor isn't in spellcheck mode. Unfortunately, I forgot to toggle the spellcheck mode when initially testing this, so a few things were missed. 

Searching also broken 
Before:
![image](https://user-images.githubusercontent.com/2179547/130366678-adcb32d7-c19b-4746-b85f-c06068054610.png)

After:
![image](https://user-images.githubusercontent.com/2179547/130366808-9fe64488-c807-4491-b125-c27bd04290e7.png)


Selection could have looked better
Before:
![image](https://user-images.githubusercontent.com/2179547/130366734-aa07d574-1864-45e2-bfb4-f4cae0ed63ea.png)

After:
![image](https://user-images.githubusercontent.com/2179547/130366823-d95045a9-2193-47dc-b40c-f241efd94950.png)


And vim mode

Before:
![image](https://user-images.githubusercontent.com/2179547/130366788-0511e13d-4024-4b9a-9511-bb1651e048bc.png)


After:
![image](https://user-images.githubusercontent.com/2179547/130366768-7098d343-fb97-49b0-abcc-c23315b4f940.png)
