### PR TITLE
All: Resolves #5444 Misinterpreted search term after filter in quotation marks

### DIFF
--- a/packages/lib/services/searchengine/filterParser.ts
+++ b/packages/lib/services/searchengine/filterParser.ts
@@ -36,6 +36,7 @@ const getTerms = (query: string, validFilters: Set<string>): Term[] => {
 			if (inQuote) {
 				terms.push(makeTerm(currentCol, currentTerm));
 				currentTerm = '';
+				currentCol = '_';
 				inQuote = false;
 			} else {
 				inQuote = true;


### PR DESCRIPTION
If a filter is written in quotation marks, the search term that follows it is also incorrectly evaluated as a filter of the same type and not as a search term. 