### PR TITLE
ignore the user-data-dir flag

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -251,6 +251,12 @@ export default class BaseApplication {
 				continue;
 			}
 
+			if (arg.indexOf('--user-data-dir=') === 0) {
+				// Electron-specific flag. Allows users to run the app with chromedriver.
+				argv.splice(0, 1);
+				continue;
+			}
+
 			if (arg.length && arg[0] == '-') {
 				throw new JoplinError(_('Unknown flag: %s', arg), 'flagError');
 			} else {


### PR DESCRIPTION
This change allows users to run the app together with chromedriver. The flag is passed by chromedriver and can't be suppressed there. In #2084 a related flag was ignored.