### PR TITLE
macOS: add CM shortcut delWrappedLineLeft

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
@@ -171,6 +171,7 @@ export default function useKeymap(CodeMirror: any) {
 				'Cmd-Right': 'goLineRightSmart',
 				'Alt-Backspace': 'delGroupBefore',
 				'Alt-Delete': 'delGroupAfter',
+				'Cmd-Backspace': 'delWrappedLineLeft',
 
 				'fallthrough': 'basic',
 			};


### PR DESCRIPTION
This is usually set by default in CodeMirror on macOS. This change just adds it back.

/ref https://discourse.joplinapp.org/t/command-backspace-to-delete-line-macos/20285?u=tessus