### PR TITLE
Desktop: Resolves #4827: Laggy Scrolling in Viewer

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -357,6 +357,16 @@
 			return m ? contentElement.scrollTop / m : 0;
 		}
 
+		contentElement.addEventListener('wheel', webviewLib.logEnabledEventHandler(e => {
+			// When zoomFactor is not 1 (using an HD display is a typical case), 
+			// DOM element's scrollTop is incorrectly calculated after wheel scroll events 
+			// in the layer of Electron/Chromium, as of 2021-09-23.
+			// To avoid this problem, prevent the upstream from calculating scrollTop and
+			// calculate by yourself by accumulating wheel events.
+			contentElement.scrollTop = Math.max(0, Math.min(maxScrollTop(), contentElement.scrollTop + e.deltaY));
+			e.preventDefault();
+		}));
+
 		contentElement.addEventListener('scroll', webviewLib.logEnabledEventHandler(e => {
 			// If the last scroll event was done by the user, lastScrollEventTime is set and
 			// we can use that to skip the event handling. We skip it because in that case


### PR DESCRIPTION
It's a workaround to avoid the lags occur in Markdown Viewer when zoomFactor is not 1. The lags have a high impact on users with HD displays.

The detail is described in ["Laggy Scrolling in Viewer" · Issue #4827 · laurent22/joplin](https://github.com/laurent22/joplin/issues/4827#issuecomment-925593345).
