### PR TITLE
Remove orphaned word on Line 17 of server_sharing.md

### DIFF
--- a/readme/spec/server_sharing.md
+++ b/readme/spec/server_sharing.md
@@ -14,7 +14,7 @@ The rendering engine is the same as the main applications, which allows us to us
 
 ### Attached resources
 
-Any resource attached to the note is also shared - so for example images will be displayed, and it will be possible to open any attached PDF. This 
+Any resource attached to the note is also shared - so for example images will be displayed, and it will be possible to open any attached PDF. 
 
 ### Linked note
 


### PR DESCRIPTION
Line 17 had " This" tacked onto the back like someone started writing something or removed something and left remnants. This simply removes that extra word.