### PR TITLE
Desktop: build universal app for macOS X

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -75,7 +75,10 @@
     },
     "mac": {
       "icon": "../../Assets/macOs.icns",
-      "target": "dmg",
+      "target": {
+        "target": "default",
+        "arch": "universal"
+      },
       "hardenedRuntime": true,
       "entitlements": "./build-mac/entitlements.mac.inherit.plist"
     },


### PR DESCRIPTION
This PR will make the Joplin desktop app running in both intel and M1 chip both natively.

This is an electron feature support from version 11.0.0.


## How do I test it?
Currently, Apple Silicon applications only run on Apple Silicon hardware, which isn't commercially available at the time.

PS: I've use it in my silicon version Macbook pro for several days.

## reference
- https://www.electronjs.org/blog/apple-silicon/