### PR TITLE
Desktop: Fixes flickering with local Note Search Bar

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -264,16 +264,16 @@
 				const markJsHackMarker_ = ' ';
 				for (let i = 0; i < elements.length; i++) {
 					if (!type) {
-						elements[i].innerHTML = elements[i].innerHTML + markJsHackMarker_;
+						elements[i].insertAdjacentHTML('beforeend', markJsHackMarker_);
 					} else if (type === 'insertBefore') {
 						elements[i].insertAdjacentHTML('beforeBegin', markJsHackMarker_);
 					}
 				}
 			}
 
-			prepareElementsForMarkJs(document.getElementsByTagName('p'));
-			prepareElementsForMarkJs(document.getElementsByTagName('div'));
-			prepareElementsForMarkJs(document.getElementsByTagName('br'), 'insertBefore');
+			prepareElementsForMarkJs(contentElement.getElementsByTagName('p'));
+			prepareElementsForMarkJs(contentElement.getElementsByTagName('div'));
+			prepareElementsForMarkJs(contentElement.getElementsByTagName('br'), 'insertBefore');
 			markJsHackMarkerInserted_ = true;
 		}
 


### PR DESCRIPTION
When intra-Note Search Bar is displayed, switching a note sometimes causes flickering. This is more likely to happen with large notes or notes with images. It sometimes happens in "Welcome to Joplin!" note as well (show in the next comment).
 
This commit fixes the above symptom.

Additionally, related to the above symptom, a fault-prone code is found in the Markdown Viewer (note-viewer/index.html). It is also fixed.
- When Note Search Bar is enabled, some top level `div` elements (that is, `joplin-container-pluginAssetsContainer`, `joplin-container-markScriptContainer` and `joplin-container-content`) are affected. They should not be touched.
- `rendered-md` div element can be unintentionally recreated. If its reference were used, it would be problematic. (But, I don't know whether concrete bugs exist or not.)