### PR TITLE
All : Resolves #5582 : fixed wrong cased variable name

### DIFF
--- a/packages/lib/testing/test-utils-synchronizer.ts
+++ b/packages/lib/testing/test-utils-synchronizer.ts
@@ -12,7 +12,7 @@ export async function allNotesFolders() {
 
 async function remoteItemsByTypes(types: number[]) {
 	const list = await fileApi().list('', { includeDirs: false, syncItemsOnly: true });
-	if (list.has_more) throw new Error('Not implemented!!!');
+	if (list.hasMore) throw new Error('Not implemented!!!');
 	const files = list.items;
 
 	const output = [];


### PR DESCRIPTION
https://github.com/laurent22/joplin/commit/ccf9882452d4f7e1311cac1601e741247436307c
Perhaps this was the commit that caused failure of a test and hence preventing `npm install` in the repository 
Simply changing a the variable to camelCase allowed successfull installation of packages and build of app
resolves #5583 