### PR TITLE
Mobile (Android): Makes it impossible to have multiple instances of the app open

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,7 @@
 			android:name=".MainActivity"
 			android:label="@string/app_name"
 			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-			android:launchMode="singleTop"
+			android:launchMode="singleTask"
 				android:windowSoftInputMode="adjustResize">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,11 @@
 
 		2020-10-08: Changed back again to "singleTop" as it has worked so far. The multiple instance bug was "fixed" in a different way
 					See packages/app-mobile/root.js for more info about the bug.
+
+		2021-11-20: Changed to "singleTask" to ensure deep linking doesn't cause multiple instances.
+					This is recommended in the React docs: https://reactnavigation.org/docs/deep-linking. In practice, "singleTask" and "singleTop" are
+					largely similar, but "singleTask" is more strict in preventing multiple instances of the app from being created if another app
+					explicitly requests it.
 		-->
 
 		<activity


### PR DESCRIPTION
This changes the [`android:launchMode`](https://developer.android.com/guide/topics/manifest/activity-element#lmode) of the Android app from `singleTop` to `singleTask`, which I suspect is more appropriate for Joplin:

> `singleTop`: If an instance of the activity already exists at the top of the target task, the system routes the intent to that instance through a call to its `onNewIntent()` method, rather than creating a new instance of the activity.

> `singleTask`: The system creates the activity at the root of a new task and routes the intent to it. However, if an instance of the activity already exists, the system routes the intent to existing instance through a call to its `onNewIntent()` method, rather than creating a new one.

In other words, the current behavior is that two instances can happen sometimes, if the Android activity stack for Joplin doesn't have Joplin itself on top of it. This can happen if Joplin opened another app inside the same task, for example. Changing the behavior to `singleTask` makes it impossible for two instances of the main app to appear under any circumstances.