### PR TITLE
Desktop: Resolves #5367 : Do not remove leading/trailing whitespaces from codeblocks wysiwyg

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -88,7 +88,7 @@ export default function openEditDialog(editor: any, markupToHtml: any, dispatchD
 		},
 		onSubmit: async (dialogApi: any) => {
 			const newSource = newBlockSource(dialogApi.getData().languageInput, dialogApi.getData().codeTextArea, source);
-			const md = `${newSource.openCharacters}${newSource.content.trim()}${newSource.closeCharacters}`;
+			const md = `${newSource.openCharacters}${newSource.content}${newSource.closeCharacters}`;
 			const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, md, { bodyOnly: true });
 
 			// markupToHtml will return the complete editable HTML, but we only


### PR DESCRIPTION
While Taking Input for codeblock the input dialog trims whitespaces from beginning and end of the block .
This PR modifies Input dialogue to not remove them .
also since the`openEditDialog`  is only being used for code-blocks so I think it is alright to send untrimmed input from it .
 closes #5367 