### PR TITLE
via IPC, have webview insert and focus on a dummy element at top of content

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -146,7 +146,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 					if (props.visiblePanes.indexOf('editor') >= 0) {
 						editorRef.current.focus();
 					} else {
-						webviewRef.current.wrappedInstance.focus();
+						webviewRef.current.wrappedInstance.send('doFocus');
 					}
 				} else {
 					commandProcessed = false;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -146,7 +146,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 					if (props.visiblePanes.indexOf('editor') >= 0) {
 						editorRef.current.focus();
 					} else {
-						webviewRef.current.wrappedInstance.send('doFocus');
+						// If we just call wrappedInstance.focus() then the iframe is focused,
+						// but not its content, such that scrolling up / down with arrow keys fails
+						webviewRef.current.wrappedInstance.send('focus');
 					}
 				} else {
 					commandProcessed = false;

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -146,8 +146,8 @@ class NoteTextViewerComponent extends React.Component<Props, any> {
 	send(channel: string, arg0: any = null, arg1: any = null) {
 		const win = this.webviewRef_.current.contentWindow;
 
-		if (channel === 'doFocus') {
-			win.postMessage({ target: 'webview', name: 'doFocus', data: {} }, '*');
+		if (channel === 'focus') {
+			win.postMessage({ target: 'webview', name: 'focus', data: {} }, '*');
 		}
 
 		if (channel === 'setHtml') {

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -146,6 +146,10 @@ class NoteTextViewerComponent extends React.Component<Props, any> {
 	send(channel: string, arg0: any = null, arg1: any = null) {
 		const win = this.webviewRef_.current.contentWindow;
 
+		if (channel === 'doFocus') {
+			win.postMessage({ target: 'webview', name: 'doFocus', data: {} }, '*');
+		}
+
 		if (channel === 'setHtml') {
 			win.postMessage({ target: 'webview', name: 'setHtml', data: { html: arg0, options: arg1 } }, '*');
 		}

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -197,10 +197,10 @@
 
 		let checkAllImageLoadedIID_ = null;
 
-		ipc.doFocus = (event) => {
+		ipc.focus = (event) => {
 			// JIT insert a dummy element to focus, if we haven't already
-			if (! document.getElementById('focus_dummy')) {
-				const focusDummy = "<div id='focus_dummy' style='width: 0; height: 0; overflow: hidden'><a href='#'>focus dummy</a></div>"
+			if (! document.getElementById('joplin-content-focus-dummy')) {
+				const focusDummy = "<div id='joplin-content-focus-dummy' style='width: 0; height: 0; overflow: hidden'><a href='#'>focus dummy</a></div>"
 				contentElement.insertAdjacentHTML("afterbegin", focusDummy);
 			}
 			contentElement.firstElementChild.firstElementChild.focus();

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -198,12 +198,14 @@
 		let checkAllImageLoadedIID_ = null;
 
 		ipc.focus = (event) => {
-			// JIT insert a dummy element to focus, if we haven't already
-			if (! document.getElementById('joplin-content-focus-dummy')) {
-				const focusDummy = "<div id='joplin-content-focus-dummy' style='width: 0; height: 0; overflow: hidden'><a href='#'>focus dummy</a></div>"
+			const dummyID = 'joplin-content-focus-dummy';
+			if (! document.getElementById(dummyID)) {
+				const focusDummy = '<div style="width: 0; height: 0; overflow: hidden"><a id="' + dummyID + '" href="#">focus dummy</a></div>';
 				contentElement.insertAdjacentHTML("afterbegin", focusDummy);
 			}
-			contentElement.firstElementChild.firstElementChild.focus();
+			const scrollTop = contentElement.scrollTop;
+			document.getElementById(dummyID).focus();
+			contentElement.scrollTop = scrollTop;
 		}
 
 		ipc.setHtml = (event) => {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -197,6 +197,15 @@
 
 		let checkAllImageLoadedIID_ = null;
 
+		ipc.doFocus = (event) => {
+			// JIT insert a dummy element to focus, if we haven't already
+			if (! document.getElementById('focus_dummy')) {
+				const focusDummy = "<div id='focus_dummy' style='width: 0; height: 0; overflow: hidden'><a href='#'>focus dummy</a></div>"
+				contentElement.insertAdjacentHTML("afterbegin", focusDummy);
+			}
+			contentElement.firstElementChild.firstElementChild.focus();
+		}
+
 		ipc.setHtml = (event) => {
 			const html = event.html;
 


### PR DESCRIPTION
Issue https://github.com/laurent22/joplin/issues/2810 was resolved by PR https://github.com/laurent22/joplin/pull/4537 -- Cmd-Shift-B now puts focus on the iframe hosting the note body / rendered Markdown

However, this focus doesn't correctly capture keyboard input -- using the up / down arrows to scroll fails

This PR uses IPC to request the container focus on an invisible anchor inserted at the top of the rendered Markdown. With focus on this contained element, the keyboard input works and arrow keys scroll.

The content's scrollTop is noted before and restored after focus (otherwise, the content would be scrolled to the top).

I have play-tested using hotkeys to

* repeatedly move focus among list, title, and body; arrow keys work in body
* focus to list, arrow down to select another note, back to body
* focus to list, arrow up a previous note, back to body (note that scroll position is maintained)

I do not have an explanation for *why* simply focusing the container does not correctly capture / direct keystrokes. In trying to figure this out, I tried adding onblur / onfocus / onkeydown handlers to the host app body and to the container body. Whether using the existing simple "focus" or this IPC mechanism, I see that

* main body is blurred, container body is focused
* keydown is registered by container, and not by body
