### PR TITLE
Server: Fix latest database migration selection

### DIFF
--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -338,7 +338,7 @@ export function isUniqueConstraintError(error: any): boolean {
 
 export async function latestMigration(db: DbConnection): Promise<any> {
 	try {
-		const result = await db('knex_migrations').select('name').orderBy('id', 'asc').first();
+		const result = await db('knex_migrations').select('name').orderBy('id', 'desc').first();
 		return result;
 	} catch (error) {
 		// If the database has never been initialized, we return null, so


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

This fixes a bug where the "latest migration" in startup logs would always show the initial database migration name instead of the actual latest one.
