### PR TITLE
Desktop: [Performance] Halves time of switching notes

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -874,7 +874,7 @@ const mapStateToProps = (state: AppState) => {
 		pluginMenus: stateUtils.selectArrayShallow({ array: pluginUtils.viewsByType(state.pluginService.plugins, 'menu') }, 'menuBar.pluginMenus'),
 		['spellChecker.language']: state.settings['spellChecker.language'],
 		['spellChecker.enabled']: state.settings['spellChecker.enabled'],
-		plugins: state.pluginService.plugins,
+		plugins: pluginUtils.menuProps(state.pluginService.plugins),
 		customCss: state.customCss,
 	};
 };

--- a/packages/lib/services/WhenClause.ts
+++ b/packages/lib/services/WhenClause.ts
@@ -83,13 +83,15 @@ export default class WhenClause {
 		if (this.validate_) this.validate(context);
 
 		const subContext: any = {};
+		let hasSubContext = false;
 
 		for (const k in this.expression_.subExpressions) {
 			const subExp = this.expression_.subExpressions[k];
 			subContext[k] = this.rules(subExp).evaluate(this.createContext(context));
+			hasSubContext = true;
 		}
 
-		const fullContext = { ...context, ...subContext };
+		const fullContext = hasSubContext ? { ...context, ...subContext } : context;
 		return this.rules(this.expression_.compiledText).evaluate(this.createContext(fullContext));
 	}
 

--- a/packages/lib/services/plugins/reducer.ts
+++ b/packages/lib/services/plugins/reducer.ts
@@ -44,13 +44,17 @@ export const defaultState: State = {
 	plugins: {},
 };
 
-const filterOutHtml = (o: any) => {
-	const n: any = {};
-	for (const key in o) {
-		if (key === 'html') continue;
-		n[key] = o[key] instanceof Object ? filterOutHtml(o[key]) : o[key];
+const filterOutHtml = (o: any): any => {
+	if (o instanceof Array) {
+		return o.map(filterOutHtml);
+	} else if (o instanceof Object) {
+		const n = { ...o };
+		delete n.html;
+		for (const k of Object.keys(n)) n[k] = filterOutHtml(n[k]);
+		return n;
+	} else {
+		return o;
 	}
-	return n;
 };
 
 const deepMemoize: (o: any)=> any = createSelectorCreator(


### PR DESCRIPTION
This PR fixes one performance bug and improves performance on MenuBar as described later. As the result, the time of switching notes is halved.

Two popular plugins, Note Tabs plugin and Outline plugin, are affected by this bug. So, many people using them would benefit from this PR.

Performance Bug: 
- SYMPTOM
	- When switching notes, unnecessary updates of MenuBar always happen, if a plugin rewrites its html content. 
- CAUSE
	- One of the dependencies of useEffect of MenuBar is not appropriate. So, whenever a plugin updates html in its panel, MenuBar is always updated. 

Performance Improvement:
- In a menu bar and tool bars, `WhenClause` is frequently used. Performance analysis shows `WhenCaluse.evaluate()` is one of major performance bottlenecks that can be improved. This PR makes the method lightweight.
