### PR TITLE
Add section about restoreNoteRevision command to FAQ for note restoration

### DIFF
--- a/readme/faq.md
+++ b/readme/faq.md
@@ -70,6 +70,7 @@ When changing the WebDAV URL, make sure that the new location has the same exact
 If you know the `NOTE_ID` and have note history enabled you can run the command `restoreNoteRevision` from the command palette e.g. `restoreNoteRevision 66457326a6ba4adeb4be8ce05e37af0d`. Joplin will then confirm if the restore was successful and place the note in a "Restored Note" notebook.
 If you do not know the `NOTE_ID` then you can find this within the Joplin sqlite database as the `item_id` within the `deleted_items` or `revisions` tables. It will require some manual checking of the `title_diff` and `body_diff` fields to check if the `ITEM/NOTE_ID` you are targeting is the correct one.
 You should first take a copy of the database to avoid making any accidental changes in the live one.
+For further information go [here](https://discourse.joplinapp.org/t/restoring-deleted-notes/21304).
 
 ## How can I easily enter Markdown tags in Android?
 


### PR DESCRIPTION
Based on forum topics:
https://discourse.joplinapp.org/t/deleted-copies-of-notes-deleted-all-files-original-and-cloned/21281
https://discourse.joplinapp.org/t/please-document-better-how-to-recover-notes/19619

Simplified guide, the full "idiots guide" approach is better suited to the wiki section as a how-to but having a basic explanation of how to use the command and that it exists can at least provide a starting point.
