### PR TITLE
Server: Resolves #5222: Allow overriding MAILER_SECURE, default to false

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -146,7 +146,7 @@ function mailerConfigFromEnv(env: EnvVariables): MailerConfig {
 		enabled: env.MAILER_ENABLED !== '0',
 		host: env.MAILER_HOST || '',
 		port: Number(env.MAILER_PORT || 587),
-		secure: !!Number(env.MAILER_SECURE) || true,
+		secure: env.MAILER_SECURE === '1',
 		authUser: env.MAILER_AUTH_USER || '',
 		authPassword: env.MAILER_AUTH_PASSWORD || '',
 		noReplyName: env.MAILER_NOREPLY_NAME || '',


### PR DESCRIPTION
Fixes #5222

- Set MAILER_SECURE default to false to align with nodemailer default.
- Any value other an an explicit "1" is interpreted as false.

WHY:
- MAILER_SECURE enables a forced SSL mode (SMTPS) often seen on port 465 but the default port number given is 587 which usually implies STARTTLS, not SMTPS. The two are not compatible so one value needs to change to make the default workable.
- As previously written there was no way to set it to false, thus making STARTTLS impossible to use. With this
setup both options can be used as required in the installation environment.
- This is a simpler and smaller change than #5369 
- I've set the default to false since STARTTLS is still the most widely available encryption method even though the recommendation seems to be moving towards SMTPS. It's also the default for the underlying library and provides the most compatibility right now. Someone running a well behaved SMTPS server will likely know they want to force it but anyone running the more common STARTTLS setup will be very confused when the server tries to talk TLS and produces garbage logs.