### PR TITLE
Server: Add support for built-in sync locks

### DIFF
--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -142,7 +142,7 @@ export default class JoplinServerApi {
 		}
 
 		if (sessionId) headers['X-API-AUTH'] = sessionId;
-		headers['X-API-MIN-VERSION'] = '2.1.4';
+		headers['X-API-MIN-VERSION'] = '2.6.0'; // Need server 2.6 for new lock support
 
 		const fetchOptions: any = {};
 		fetchOptions.headers = headers;

--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -253,8 +253,12 @@ export default class JoplinServerApi {
 			const output = await loadResponseJson();
 			return output;
 		} catch (error) {
-			if (error.code !== 404) {
+			// Don't print error info for file not found (handled by the
+			// driver), or lock-acquisition errors because it's handled by
+			// LockHandler.
+			if (![404, 'hasExclusiveLock', 'hasSyncLock'].includes(error.code)) {
 				logger.warn(this.requestToCurl_(url, fetchOptions));
+				logger.warn('Code:', error.code);
 				logger.warn(error);
 			}
 

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -177,6 +177,12 @@ export default class Synchronizer {
 		return !!report && !!report.errors && !!report.errors.length;
 	}
 
+	private static completionTime(report: any): string {
+		const duration = report.completedTime - report.startTime;
+		if (duration > 1000) return `${Math.round(duration / 1000)}s`;
+		return `${duration}ms`;
+	}
+
 	static reportToLines(report: any) {
 		const lines = [];
 		if (report.createLocal) lines.push(_('Created local items: %d.', report.createLocal));
@@ -187,7 +193,7 @@ export default class Synchronizer {
 		if (report.deleteRemote) lines.push(_('Deleted remote items: %d.', report.deleteRemote));
 		if (report.fetchingTotal && report.fetchingProcessed) lines.push(_('Fetched items: %d/%d.', report.fetchingProcessed, report.fetchingTotal));
 		if (report.cancelling && !report.completedTime) lines.push(_('Cancelling...'));
-		if (report.completedTime) lines.push(_('Completed: %s (%s)', time.formatMsToLocal(report.completedTime), `${Math.round((report.completedTime - report.startTime) / 1000)}s`));
+		if (report.completedTime) lines.push(_('Completed: %s (%s)', time.formatMsToLocal(report.completedTime), this.completionTime(report)));
 		if (this.reportHasErrors(report)) lines.push(_('Last error: %s', report.errors[report.errors.length - 1].toString().substr(0, 500)));
 
 		return lines;

--- a/packages/lib/file-api-driver-joplinServer.ts
+++ b/packages/lib/file-api-driver-joplinServer.ts
@@ -2,7 +2,7 @@ import { MultiPutItem } from './file-api';
 import JoplinError from './JoplinError';
 import JoplinServerApi from './JoplinServerApi';
 import { trimSlashes } from './path-utils';
-import { Lock, LockType } from './services/synchronizer/LockHandler';
+import { Lock, LockClientType, LockType } from './services/synchronizer/LockHandler';
 
 // All input paths should be in the format: "path/to/file". This is converted to
 // "root:/path/to/file:" when doing the API call.
@@ -201,15 +201,43 @@ export default class FileApiDriverJoplinServer {
 		throw new Error('Not supported');
 	}
 
-	public async acquireLock(type: LockType, clientType: string, clientId: string): Promise<Lock> {
+	// private lockClientTypeToId(clientType:AppType):number {
+	// 	if (clientType === AppType.Desktop) return 1;
+	// 	if (clientType === AppType.Mobile) return 2;
+	// 	if (clientType === AppType.Cli) return 3;
+	// 	throw new Error('Invalid client type: ' + clientType);
+	// }
+
+	// private lockTypeToId(lockType:LockType):number {
+	// 	if (lockType === LockType.None) return 0; // probably not possible?
+	// 	if (lockType === LockType.Sync) return 1;
+	// 	if (lockType === LockType.Exclusive) return 2;
+	// 	throw new Error('Invalid lock type: ' + lockType);
+	// }
+
+	// private lockClientIdTypeToType(clientType:number):AppType {
+	// 	if (clientType === 1) return AppType.Desktop;
+	// 	if (clientType === 2) return AppType.Mobile;
+	// 	if (clientType === 3) return AppType.Cli;
+	// 	throw new Error('Invalid client type: ' + clientType);
+	// }
+
+	// private lockIdToType(lockType:number):LockType {
+	// 	if (lockType === 0) return LockType.None; // probably not possible?
+	// 	if (lockType === 1) return LockType.Sync;
+	// 	if (lockType === 2) return LockType.Exclusive;
+	// 	throw new Error('Invalid lock type: ' + lockType);
+	// }
+
+	public async acquireLock(type: LockType, clientType: LockClientType, clientId: string): Promise<Lock> {
 		return this.api().exec('POST', 'api/locks', null, {
 			type,
-			clientType: clientType,
+			clientType,
 			clientId: clientId,
 		});
 	}
 
-	public async releaseLock(type: LockType, clientType: string, clientId: string) {
+	public async releaseLock(type: LockType, clientType: LockClientType, clientId: string) {
 		await this.api().exec('DELETE', `api/locks/${type}_${clientType}_${clientId}`);
 	}
 

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -5,6 +5,7 @@ import time from './time';
 
 const { isHidden } = require('./path-utils');
 import JoplinError from './JoplinError';
+import { Lock, LockType } from './services/synchronizer/LockHandler';
 const ArrayUtils = require('./ArrayUtils');
 const { sprintf } = require('sprintf-js');
 const Mutex = require('async-mutex').Mutex;
@@ -36,7 +37,7 @@ export interface RemoteItem {
 
 export interface PaginatedList {
 	items: RemoteItem[];
-	has_more: boolean;
+	hasMore: boolean;
 	context: any;
 }
 
@@ -128,6 +129,10 @@ class FileApi {
 	// server-side).
 	public get supportsAccurateTimestamp(): boolean {
 		return !!this.driver().supportsAccurateTimestamp;
+	}
+
+	public get supportsLocks(): boolean {
+		return !!this.driver().supportsLocks;
 	}
 
 	async fetchRemoteDateOffset_() {
@@ -349,6 +354,22 @@ class FileApi {
 		logger.debug(`delta ${this.fullPath(path)}`);
 		return tryAndRepeat(() => this.driver_.delta(this.fullPath(path), options), this.requestRepeatCount());
 	}
+
+	public async acquireLock(type: LockType, clientType: string, clientId: string): Promise<Lock> {
+		if (!this.supportsLocks) throw new Error('Sync target does not support built-in locks');
+		return tryAndRepeat(() => this.driver_.acquireLock(type, clientType, clientId), this.requestRepeatCount());
+	}
+
+	public async releaseLock(type: LockType, clientType: string, clientId: string) {
+		if (!this.supportsLocks) throw new Error('Sync target does not support built-in locks');
+		return tryAndRepeat(() => this.driver_.releaseLock(type, clientType, clientId), this.requestRepeatCount());
+	}
+
+	public async listLocks() {
+		if (!this.supportsLocks) throw new Error('Sync target does not support built-in locks');
+		return tryAndRepeat(() => this.driver_.listLocks(), this.requestRepeatCount());
+	}
+
 }
 
 function basicDeltaContextFromOptions_(options: any) {

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -5,7 +5,7 @@ import time from './time';
 
 const { isHidden } = require('./path-utils');
 import JoplinError from './JoplinError';
-import { Lock, LockType } from './services/synchronizer/LockHandler';
+import { Lock, LockClientType, LockType } from './services/synchronizer/LockHandler';
 const ArrayUtils = require('./ArrayUtils');
 const { sprintf } = require('sprintf-js');
 const Mutex = require('async-mutex').Mutex;
@@ -355,12 +355,12 @@ class FileApi {
 		return tryAndRepeat(() => this.driver_.delta(this.fullPath(path), options), this.requestRepeatCount());
 	}
 
-	public async acquireLock(type: LockType, clientType: string, clientId: string): Promise<Lock> {
+	public async acquireLock(type: LockType, clientType: LockClientType, clientId: string): Promise<Lock> {
 		if (!this.supportsLocks) throw new Error('Sync target does not support built-in locks');
 		return tryAndRepeat(() => this.driver_.acquireLock(type, clientType, clientId), this.requestRepeatCount());
 	}
 
-	public async releaseLock(type: LockType, clientType: string, clientId: string) {
+	public async releaseLock(type: LockType, clientType: LockClientType, clientId: string) {
 		if (!this.supportsLocks) throw new Error('Sync target does not support built-in locks');
 		return tryAndRepeat(() => this.driver_.releaseLock(type, clientType, clientId), this.requestRepeatCount());
 	}

--- a/packages/lib/services/synchronizer/LockHandler.ts
+++ b/packages/lib/services/synchronizer/LockHandler.ts
@@ -3,6 +3,7 @@ import shim from '../../shim';
 
 import JoplinError from '../../JoplinError';
 import time from '../../time';
+import { FileApi } from '../../file-api';
 const { fileExtension, filename } = require('../../path-utils');
 
 export enum LockType {
@@ -12,11 +13,67 @@ export enum LockType {
 }
 
 export interface Lock {
+	id?: string;
 	type: LockType;
 	clientType: string;
 	clientId: string;
 	updatedTime?: number;
 }
+
+function lockIsActive(lock: Lock, currentDate: Date, lockTtl: number): boolean {
+	return currentDate.getTime() - lock.updatedTime < lockTtl;
+}
+
+export function lockNameToObject(name: string, updatedTime: number = null): Lock {
+	const p = name.split('_');
+
+	return {
+		type: p[0] as LockType,
+		clientType: p[1],
+		clientId: p[2],
+		updatedTime: updatedTime,
+	};
+}
+
+export function hasActiveLock(locks: Lock[], currentDate: Date, lockTtl: number, lockType: LockType, clientType: string = null, clientId: string = null) {
+	const lock = activeLock(locks, currentDate, lockTtl, lockType, clientType, clientId);
+	return !!lock;
+}
+
+// Finds if there's an active lock for this clientType and clientId and returns it.
+// If clientType and clientId are not specified, returns the first active lock
+// of that type instead.
+export function activeLock(locks: Lock[], currentDate: Date, lockTtl: number, lockType: LockType, clientType: string = null, clientId: string = null) {
+	if (lockType === LockType.Exclusive) {
+		const activeLocks = locks
+			.slice()
+			.filter((lock: Lock) => lockIsActive(lock, currentDate, lockTtl) && lock.type === lockType)
+			.sort((a: Lock, b: Lock) => {
+				if (a.updatedTime === b.updatedTime) {
+					return a.clientId < b.clientId ? -1 : +1;
+				}
+				return a.updatedTime < b.updatedTime ? -1 : +1;
+			});
+
+		if (!activeLocks.length) return null;
+		const lock = activeLocks[0];
+
+		if (clientType && clientType !== lock.clientType) return null;
+		if (clientId && clientId !== lock.clientId) return null;
+		return lock;
+	} else if (lockType === LockType.Sync) {
+		for (const lock of locks) {
+			if (lock.type !== lockType) continue;
+			if (clientType && lock.clientType !== clientType) continue;
+			if (clientId && lock.clientId !== clientId) continue;
+			if (lockIsActive(lock, currentDate, lockTtl)) return lock;
+		}
+		return null;
+	}
+
+	throw new Error(`Unsupported lock type: ${lockType}`);
+}
+
 
 export interface AcquireLockOptions {
 	// In theory, a client that tries to acquire an exclusive lock shouldn't
@@ -55,14 +112,16 @@ export interface LockHandlerOptions {
 	lockTtl?: number;
 }
 
+export const lockDefaultTtl = 1000 * 60 * 3;
+
 export default class LockHandler {
 
-	private api_: any = null;
+	private api_: FileApi = null;
 	private refreshTimers_: RefreshTimers = {};
 	private autoRefreshInterval_: number = 1000 * 60;
-	private lockTtl_: number = 1000 * 60 * 3;
+	private lockTtl_: number = lockDefaultTtl;
 
-	constructor(api: any, options: LockHandlerOptions = null) {
+	public constructor(api: FileApi, options: LockHandlerOptions = null) {
 		if (!options) options = {};
 
 		this.api_ = api;
@@ -78,6 +137,10 @@ export default class LockHandler {
 	// use the same lock max age.
 	public set lockTtl(v: number) {
 		this.lockTtl_ = v;
+	}
+
+	public get useBuiltInLocks() {
+		return this.api_.supportsLocks;
 	}
 
 	private lockFilename(lock: Lock) {
@@ -97,17 +160,15 @@ export default class LockHandler {
 	}
 
 	private lockFileToObject(file: any): Lock {
-		const p = filename(file.path).split('_');
-
-		return {
-			type: p[0],
-			clientType: p[1],
-			clientId: p[2],
-			updatedTime: file.updated_time,
-		};
+		return lockNameToObject(filename(file.path), file.updated_time);
 	}
 
 	async locks(lockType: LockType = null): Promise<Lock[]> {
+		if (this.useBuiltInLocks) {
+			const locks = (await this.api_.listLocks()).items;
+			return locks;
+		}
+
 		const result = await this.api_.list(Dirnames.Locks);
 		if (result.hasMore) throw new Error('hasMore not handled'); // Shouldn't happen anyway
 
@@ -123,51 +184,6 @@ export default class LockHandler {
 		return output;
 	}
 
-	private lockIsActive(lock: Lock, currentDate: Date): boolean {
-		return currentDate.getTime() - lock.updatedTime < this.lockTtl;
-	}
-
-	async hasActiveLock(lockType: LockType, clientType: string = null, clientId: string = null) {
-		const lock = await this.activeLock(lockType, clientType, clientId);
-		return !!lock;
-	}
-
-	// Finds if there's an active lock for this clientType and clientId and returns it.
-	// If clientType and clientId are not specified, returns the first active lock
-	// of that type instead.
-	async activeLock(lockType: LockType, clientType: string = null, clientId: string = null) {
-		const locks = await this.locks(lockType);
-		const currentDate = await this.api_.remoteDate();
-
-		if (lockType === LockType.Exclusive) {
-			const activeLocks = locks
-				.slice()
-				.filter((lock: Lock) => this.lockIsActive(lock, currentDate))
-				.sort((a: Lock, b: Lock) => {
-					if (a.updatedTime === b.updatedTime) {
-						return a.clientId < b.clientId ? -1 : +1;
-					}
-					return a.updatedTime < b.updatedTime ? -1 : +1;
-				});
-
-			if (!activeLocks.length) return null;
-			const activeLock = activeLocks[0];
-
-			if (clientType && clientType !== activeLock.clientType) return null;
-			if (clientId && clientId !== activeLock.clientId) return null;
-			return activeLock;
-		} else if (lockType === LockType.Sync) {
-			for (const lock of locks) {
-				if (clientType && lock.clientType !== clientType) continue;
-				if (clientId && lock.clientId !== clientId) continue;
-				if (this.lockIsActive(lock, currentDate)) return lock;
-			}
-			return null;
-		}
-
-		throw new Error(`Unsupported lock type: ${lockType}`);
-	}
-
 	private async saveLock(lock: Lock) {
 		await this.api_.put(this.lockFilePath(lock), JSON.stringify(lock));
 	}
@@ -178,12 +194,17 @@ export default class LockHandler {
 	}
 
 	private async acquireSyncLock(clientType: string, clientId: string): Promise<Lock> {
+		if (this.useBuiltInLocks) return this.api_.acquireLock(LockType.Sync, clientType, clientId);
+
 		try {
 			let isFirstPass = true;
 			while (true) {
+				const locks = await this.locks();
+				const currentDate = await this.currentDate();
+
 				const [exclusiveLock, syncLock] = await Promise.all([
-					this.activeLock(LockType.Exclusive),
-					this.activeLock(LockType.Sync, clientType, clientId),
+					activeLock(locks, currentDate, this.lockTtl, LockType.Exclusive),
+					activeLock(locks, currentDate, this.lockTtl, LockType.Sync, clientType, clientId),
 				]);
 
 				if (exclusiveLock) {
@@ -222,6 +243,8 @@ export default class LockHandler {
 	}
 
 	private async acquireExclusiveLock(clientType: string, clientId: string, options: AcquireLockOptions = null): Promise<Lock> {
+		if (this.useBuiltInLocks) return this.api_.acquireLock(LockType.Exclusive, clientType, clientId);
+
 		// The logic to acquire an exclusive lock, while avoiding race conditions is as follow:
 		//
 		// - Check if there is a lock file present
@@ -252,9 +275,12 @@ export default class LockHandler {
 
 		try {
 			while (true) {
+				const locks = await this.locks();
+				const currentDate = await this.currentDate();
+
 				const [activeSyncLock, activeExclusiveLock] = await Promise.all([
-					this.activeLock(LockType.Sync),
-					this.activeLock(LockType.Exclusive),
+					activeLock(locks, currentDate, this.lockTtl, LockType.Sync),
+					activeLock(locks, currentDate, this.lockTtl, LockType.Exclusive),
 				]);
 
 				if (activeSyncLock) {
@@ -299,7 +325,11 @@ export default class LockHandler {
 		return [lock.type, lock.clientType, lock.clientId].join('_');
 	}
 
-	startAutoLockRefresh(lock: Lock, errorHandler: Function): string {
+	public async currentDate() {
+		return this.api_.remoteDate();
+	}
+
+	public startAutoLockRefresh(lock: Lock, errorHandler: Function): string {
 		const handle = this.autoLockRefreshHandle(lock);
 		if (this.refreshTimers_[handle]) {
 			throw new Error(`There is already a timer refreshing this lock: ${handle}`);
@@ -321,10 +351,11 @@ export default class LockHandler {
 			this.refreshTimers_[handle].inProgress = true;
 
 			let error = null;
-			const hasActiveLock = await this.hasActiveLock(lock.type, lock.clientType, lock.clientId);
 			if (!this.refreshTimers_[handle]) return defer(); // Timeout has been cleared
 
-			if (!hasActiveLock) {
+			const locks = await this.locks(lock.type);
+
+			if (!hasActiveLock(locks, await this.currentDate(), this.lockTtl, lock.type, lock.clientType, lock.clientId)) {
 				// If the previous lock has expired, we shouldn't try to acquire a new one. This is because other clients might have performed
 				// in the meantime operations that invalidates the current operation. For example, another client might have upgraded the
 				// sync target in the meantime, so any active operation should be cancelled here. Or if the current client was upgraded
@@ -384,6 +415,11 @@ export default class LockHandler {
 	}
 
 	public async releaseLock(lockType: LockType, clientType: string, clientId: string) {
+		if (this.useBuiltInLocks) {
+			await this.api_.releaseLock(lockType, clientType, clientId);
+			return;
+		}
+
 		await this.api_.delete(this.lockFilePath({
 			type: lockType,
 			clientType: clientType,

--- a/packages/lib/services/synchronizer/LockHandler.ts
+++ b/packages/lib/services/synchronizer/LockHandler.ts
@@ -112,14 +112,14 @@ export interface LockHandlerOptions {
 	lockTtl?: number;
 }
 
-export const lockDefaultTtl = 1000 * 60 * 3;
+export const defaultLockTtl = 1000 * 60 * 3;
 
 export default class LockHandler {
 
 	private api_: FileApi = null;
 	private refreshTimers_: RefreshTimers = {};
 	private autoRefreshInterval_: number = 1000 * 60;
-	private lockTtl_: number = lockDefaultTtl;
+	private lockTtl_: number = defaultLockTtl;
 
 	public constructor(api: FileApi, options: LockHandlerOptions = null) {
 		if (!options) options = {};

--- a/packages/lib/services/synchronizer/MigrationHandler.ts
+++ b/packages/lib/services/synchronizer/MigrationHandler.ts
@@ -1,4 +1,4 @@
-import LockHandler, { LockType } from './LockHandler';
+import LockHandler, { LockClientType, LockType } from './LockHandler';
 import { Dirnames } from './utils/types';
 import BaseService from '../BaseService';
 import migration1 from './migrations/1';
@@ -33,11 +33,11 @@ export default class MigrationHandler extends BaseService {
 
 	private api_: FileApi = null;
 	private lockHandler_: LockHandler = null;
-	private clientType_: string;
+	private clientType_: LockClientType;
 	private clientId_: string;
 	private db_: JoplinDatabase;
 
-	public constructor(api: FileApi, db: JoplinDatabase, lockHandler: LockHandler, clientType: string, clientId: string) {
+	public constructor(api: FileApi, db: JoplinDatabase, lockHandler: LockHandler, clientType: LockClientType, clientId: string) {
 		super();
 		this.api_ = api;
 		this.db_ = db;

--- a/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
+++ b/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
@@ -1,4 +1,4 @@
-import LockHandler, { LockType, LockHandlerOptions, Lock } from '../../services/synchronizer/LockHandler';
+import LockHandler, { LockType, LockHandlerOptions, Lock, activeLock } from '../../services/synchronizer/LockHandler';
 import { isNetworkSyncTarget, fileApi, setupDatabaseAndSynchronizer, synchronizer, switchClient, msleep, expectThrow, expectNotThrow } from '../../testing/test-utils';
 
 // For tests with memory of file system we can use low intervals to make the tests faster.
@@ -46,6 +46,8 @@ describe('synchronizer_LockHandler', function() {
 	}));
 
 	it('should not use files that are not locks', (async () => {
+		if (lockHandler().useBuiltInLocks) return; // Doesn't make sense with built-in locks
+
 		await fileApi().put('locks/desktop.ini', 'a');
 		await fileApi().put('locks/exclusive.json', 'a');
 		await fileApi().put('locks/garbage.json', 'a');
@@ -75,10 +77,10 @@ describe('synchronizer_LockHandler', function() {
 	it('should auto-refresh a lock', (async () => {
 		const handler = newLockHandler({ autoRefreshInterval: 100 * timeoutMultipler });
 		const lock = await handler.acquireLock(LockType.Sync, 'desktop', '111');
-		const lockBefore = await handler.activeLock(LockType.Sync, 'desktop', '111');
+		const lockBefore = activeLock(await handler.locks(), new Date(), handler.lockTtl, LockType.Sync, 'desktop', '111');
 		handler.startAutoLockRefresh(lock, () => {});
 		await msleep(500 * timeoutMultipler);
-		const lockAfter = await handler.activeLock(LockType.Sync, 'desktop', '111');
+		const lockAfter = activeLock(await handler.locks(), new Date(), handler.lockTtl, LockType.Sync, 'desktop', '111');
 		expect(lockAfter.updatedTime).toBeGreaterThan(lockBefore.updatedTime);
 		handler.stopAutoLockRefresh(lock);
 	}));
@@ -95,11 +97,14 @@ describe('synchronizer_LockHandler', function() {
 			autoLockError = error;
 		});
 
-		await msleep(250 * timeoutMultipler);
+		try {
+			await msleep(250 * timeoutMultipler);
 
-		expect(autoLockError.code).toBe('lockExpired');
-
-		handler.stopAutoLockRefresh(lock);
+			expect(autoLockError).toBeTruthy();
+			expect(autoLockError.code).toBe('lockExpired');
+		} finally {
+			handler.stopAutoLockRefresh(lock);
+		}
 	}));
 
 	it('should not allow sync locks if there is an exclusive lock', (async () => {
@@ -112,6 +117,7 @@ describe('synchronizer_LockHandler', function() {
 
 	it('should not allow exclusive lock if there are sync locks', (async () => {
 		const lockHandler = newLockHandler({ lockTtl: 1000 * 60 * 60 });
+		if (lockHandler.useBuiltInLocks) return; // Tested server side
 
 		await lockHandler.acquireLock(LockType.Sync, 'mobile', '111');
 		await lockHandler.acquireLock(LockType.Sync, 'mobile', '222');
@@ -123,6 +129,7 @@ describe('synchronizer_LockHandler', function() {
 
 	it('should allow exclusive lock if the sync locks have expired', (async () => {
 		const lockHandler = newLockHandler({ lockTtl: 500 * timeoutMultipler });
+		if (lockHandler.useBuiltInLocks) return; // Tested server side
 
 		await lockHandler.acquireLock(LockType.Sync, 'mobile', '111');
 		await lockHandler.acquireLock(LockType.Sync, 'mobile', '222');
@@ -138,74 +145,44 @@ describe('synchronizer_LockHandler', function() {
 		const lockHandler = newLockHandler();
 
 		{
-			const lock1: Lock = { type: LockType.Exclusive, clientId: '1', clientType: 'd' };
-			const lock2: Lock = { type: LockType.Exclusive, clientId: '2', clientType: 'd' };
-			await lockHandler.saveLock_(lock1);
-			await msleep(100);
-			await lockHandler.saveLock_(lock2);
+			const locks: Lock[] = [
+				{
+					type: LockType.Exclusive,
+					clientId: '1',
+					clientType: 'd',
+					updatedTime: Date.now(),
+				},
+			];
 
-			const activeLock = await lockHandler.activeLock(LockType.Exclusive);
-			expect(activeLock.clientId).toBe('1');
+			await msleep(100);
+
+			locks.push({
+				type: LockType.Exclusive,
+				clientId: '2',
+				clientType: 'd',
+				updatedTime: Date.now(),
+			});
+
+			const lock = activeLock(locks, new Date(), lockHandler.lockTtl, LockType.Exclusive);
+			expect(lock.clientId).toBe('1');
 		}
 	}));
 
-	it('should ignore locks by same client when trying to acquire exclusive lock', (async () => {
-		const lockHandler = newLockHandler();
-
-		await lockHandler.acquireLock(LockType.Sync, 'desktop', '111');
-
-		await expectThrow(async () => {
-			await lockHandler.acquireLock(LockType.Exclusive, 'desktop', '111', { clearExistingSyncLocksFromTheSameClient: false });
-		}, 'hasSyncLock');
-
-		await expectNotThrow(async () => {
-			await lockHandler.acquireLock(LockType.Exclusive, 'desktop', '111', { clearExistingSyncLocksFromTheSameClient: true });
-		});
-
-		const activeLock = await lockHandler.activeLock(LockType.Exclusive);
-		expect(activeLock.clientId).toBe('111');
-	}));
-
-	// it('should not have race conditions', (async () => {
+	// it('should ignore locks by same client when trying to acquire exclusive lock', (async () => {
 	// 	const lockHandler = newLockHandler();
 
-	// 	const clients = [];
-	// 	for (let i = 0; i < 20; i++) {
-	// 		clients.push({
-	// 			id: 'client' + i,
-	// 			type: 'desktop',
-	// 		});
-	// 	}
+	// 	await lockHandler.acquireLock(LockType.Sync, 'desktop', '111');
 
-	// 	for (let loopIndex = 0; loopIndex < 1000; loopIndex++) {
-	// 		const promises:Promise<void | Lock>[] = [];
-	// 		for (let clientIndex = 0; clientIndex < clients.length; clientIndex++) {
-	// 			const client = clients[clientIndex];
+	// 	await expectThrow(async () => {
+	// 		await lockHandler.acquireLock(LockType.Exclusive, 'desktop', '111', { clearExistingSyncLocksFromTheSameClient: false });
+	// 	}, 'hasSyncLock');
 
-	// 			promises.push(
-	// 				lockHandler.acquireLock(LockType.Exclusive, client.type, client.id).catch(() => {})
-	// 			);
+	// 	await expectNotThrow(async () => {
+	// 		await lockHandler.acquireLock(LockType.Exclusive, 'desktop', '111', { clearExistingSyncLocksFromTheSameClient: true });
+	// 	});
 
-	// 			// if (gotLock) {
-	// 			// 	await msleep(100);
-	// 			// 	const locks = await lockHandler.locks(LockType.Exclusive);
-	// 			// 	console.info('=======================================');
-	// 			// 	console.info(locks);
-	// 			// 	lockHandler.releaseLock(LockType.Exclusive, client.type, client.id);
-	// 			// }
-
-	// 			// await msleep(500);
-	// 		}
-
-	// 		const result = await Promise.all(promises);
-	// 		const locks = result.filter((lock:any) => !!lock);
-
-	// 		expect(locks.length).toBe(1);
-	// 		const lock:Lock = locks[0] as Lock;
-	// 		const allLocks = await lockHandler.locks();
-	// 		console.info('================================', allLocks);
-	// 		lockHandler.releaseLock(LockType.Exclusive, lock.clientType, lock.clientId);
-	// 	}
+	// 	const lock = activeLock(await lockHandler.locks(), new Date(), lockHandler.lockTtl, LockType.Exclusive);
+	// 	expect(lock.clientId).toBe('111');
 	// }));
 
 });

--- a/packages/lib/services/synchronizer/synchronizer_MigrationHandler.test.ts
+++ b/packages/lib/services/synchronizer/synchronizer_MigrationHandler.test.ts
@@ -5,7 +5,7 @@
 //
 // These tests work by a taking a sync target snapshot at a version n and upgrading it to n+1.
 
-import LockHandler from './LockHandler';
+import LockHandler, { LockClientType } from './LockHandler';
 import MigrationHandler from './MigrationHandler';
 import { Dirnames } from './utils/types';
 import { setSyncTargetName, fileApi, synchronizer, decryptionWorker, encryptionService, setupDatabaseAndSynchronizer, switchClient, expectThrow, expectNotThrow, db } from '../../testing/test-utils';
@@ -28,7 +28,7 @@ function lockHandler(): LockHandler {
 
 function migrationHandler(clientId: string = 'abcd'): MigrationHandler {
 	if (migrationHandler_) return migrationHandler_;
-	migrationHandler_ = new MigrationHandler(fileApi(), db(), lockHandler(), 'desktop', clientId);
+	migrationHandler_ = new MigrationHandler(fileApi(), db(), lockHandler(), LockClientType.Desktop, clientId);
 	return migrationHandler_;
 }
 

--- a/packages/lib/testing/test-utils-synchronizer.ts
+++ b/packages/lib/testing/test-utils-synchronizer.ts
@@ -12,7 +12,7 @@ export async function allNotesFolders() {
 
 async function remoteItemsByTypes(types: number[]) {
 	const list = await fileApi().list('', { includeDirs: false, syncItemsOnly: true });
-	if (list.has_more) throw new Error('Not implemented!!!');
+	if (list.hasMore) throw new Error('Not implemented!!!');
 	const files = list.items;
 
 	const output = [];

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
     "devDropTables": "node dist/app.js --env dev --drop-tables",
     "devDropDb": "node dist/app.js --env dev --drop-db",
     "start": "node dist/app.js",
-    "generateTypes": "rm -f db-buildTypes.sqlite && npm run start -- --migrate-latest --env buildTypes && node dist/tools/generateTypes.js && mv db-buildTypes.sqlite schema.sqlite",
+    "generateTypes": "rm -f db-buildTypes.sqlite && npm run start -- --env buildTypes migrate latest && node dist/tools/generateTypes.js && mv db-buildTypes.sqlite schema.sqlite",
     "tsc": "tsc --project tsconfig.json",
     "test": "jest --verbose=false",
     "test-ci": "npm run test",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joplin/server",
-  "version": "2.5.9",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "start-dev": "npm run build && nodemon --config nodemon.json --ext ts,js,mustache,css,tsx dist/app.js --env dev",

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -116,6 +116,10 @@ export const clientType = (db: DbConnection): DatabaseConfigClient => {
 	return db.client.config.client;
 };
 
+export const returningSupported = (db: DbConnection) => {
+	return clientType(db) === DatabaseConfigClient.PostgreSQL;
+};
+
 export const isPostgres = (db: DbConnection) => {
 	return clientType(db) === DatabaseConfigClient.PostgreSQL;
 };

--- a/packages/server/src/models/LockModel.test.ts
+++ b/packages/server/src/models/LockModel.test.ts
@@ -1,6 +1,6 @@
-import { defaultLockTtl, LockType } from '@joplin/lib/services/synchronizer/LockHandler';
 import { ErrorConflict } from '../utils/errors';
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession, expectHttpError } from '../utils/testing/testUtils';
+import { LockType, LockClientType, defaultLockTtl } from '@joplin/lib/services/synchronizer/LockHandler';
 
 describe('LockModel', function() {
 
@@ -24,18 +24,18 @@ describe('LockModel', function() {
 		const t1 = new Date('2020-01-01').getTime();
 		jest.setSystemTime(t1);
 
-		await models().lock().acquireLock(user.id, LockType.Sync, 'desktop', '1111');
-		await models().lock().acquireLock(user.id, LockType.Sync, 'desktop', '2222');
+		await models().lock().acquireLock(user.id, LockType.Sync, LockClientType.Desktop, '1111');
+		await models().lock().acquireLock(user.id, LockType.Sync, LockClientType.Desktop, '2222');
 
 		// First confirm that it's not possible to acquire an exclusive lock if
 		// there are sync locks.
-		await expectHttpError(async () => models().lock().acquireLock(user.id, LockType.Exclusive, 'desktop', '3333'), ErrorConflict.httpCode);
+		await expectHttpError(async () => models().lock().acquireLock(user.id, LockType.Exclusive, LockClientType.Desktop, '3333'), ErrorConflict.httpCode);
 
 		jest.setSystemTime(t1 + defaultLockTtl + 1);
 
 		// Now that the sync locks have expired check that it's possible to
 		// acquire a sync lock.
-		const exclusiveLock = await models().lock().acquireLock(user.id, LockType.Exclusive, 'desktop', '3333');
+		const exclusiveLock = await models().lock().acquireLock(user.id, LockType.Exclusive, LockClientType.Desktop, '3333');
 		expect(exclusiveLock).toBeTruthy();
 
 		jest.useRealTimers();
@@ -45,13 +45,13 @@ describe('LockModel', function() {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 
-		await models().lock().acquireLock(user1.id, LockType.Sync, 'desktop', '1111');
+		await models().lock().acquireLock(user1.id, LockType.Sync, LockClientType.Desktop, '1111');
 
 		// If user 1 tries to get an exclusive lock, it should fail
-		await expectHttpError(async () => models().lock().acquireLock(user1.id, LockType.Exclusive, 'desktop', '3333'), ErrorConflict.httpCode);
+		await expectHttpError(async () => models().lock().acquireLock(user1.id, LockType.Exclusive, LockClientType.Desktop, '3333'), ErrorConflict.httpCode);
 
 		// But it should work for user 2
-		const exclusiveLock = await models().lock().acquireLock(user2.id, LockType.Exclusive, 'desktop', '3333');
+		const exclusiveLock = await models().lock().acquireLock(user2.id, LockType.Exclusive, LockClientType.Desktop, '3333');
 		expect(exclusiveLock).toBeTruthy();
 	});
 

--- a/packages/server/src/models/LockModel.test.ts
+++ b/packages/server/src/models/LockModel.test.ts
@@ -1,0 +1,58 @@
+import { defaultLockTtl, LockType } from '@joplin/lib/services/synchronizer/LockHandler';
+import { ErrorConflict } from '../utils/errors';
+import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession, expectHttpError } from '../utils/testing/testUtils';
+
+describe('LockModel', function() {
+
+	beforeAll(async () => {
+		await beforeAllDb('LockModel');
+	});
+
+	afterAll(async () => {
+		await afterAllTests();
+	});
+
+	beforeEach(async () => {
+		await beforeEachDb();
+	});
+
+	test('should allow exclusive lock if the sync locks have expired', async function() {
+		jest.useFakeTimers('modern');
+
+		const { user } = await createUserAndSession(1);
+
+		const t1 = new Date('2020-01-01').getTime();
+		jest.setSystemTime(t1);
+
+		await models().lock().acquireLock(user.id, LockType.Sync, 'desktop', '1111');
+		await models().lock().acquireLock(user.id, LockType.Sync, 'desktop', '2222');
+
+		// First confirm that it's not possible to acquire an exclusive lock if
+		// there are sync locks.
+		await expectHttpError(async () => models().lock().acquireLock(user.id, LockType.Exclusive, 'desktop', '3333'), ErrorConflict.httpCode);
+
+		jest.setSystemTime(t1 + defaultLockTtl + 1);
+
+		// Now that the sync locks have expired check that it's possible to
+		// acquire a sync lock.
+		const exclusiveLock = await models().lock().acquireLock(user.id, LockType.Exclusive, 'desktop', '3333');
+		expect(exclusiveLock).toBeTruthy();
+
+		jest.useRealTimers();
+	});
+
+	test('should keep user locks separated', async function() {
+		const { user: user1 } = await createUserAndSession(1);
+		const { user: user2 } = await createUserAndSession(2);
+
+		await models().lock().acquireLock(user1.id, LockType.Sync, 'desktop', '1111');
+
+		// If user 1 tries to get an exclusive lock, it should fail
+		await expectHttpError(async () => models().lock().acquireLock(user1.id, LockType.Exclusive, 'desktop', '3333'), ErrorConflict.httpCode);
+
+		// But it should work for user 2
+		const exclusiveLock = await models().lock().acquireLock(user2.id, LockType.Exclusive, 'desktop', '3333');
+		expect(exclusiveLock).toBeTruthy();
+	});
+
+});

--- a/packages/server/src/models/LockModel.ts
+++ b/packages/server/src/models/LockModel.ts
@@ -2,7 +2,7 @@ import BaseModel, { UuidType } from './BaseModel';
 import { Uuid } from '../services/database/types';
 import { LockType, Lock, LockClientType, defaultLockTtl, activeLock } from '@joplin/lib/services/synchronizer/LockHandler';
 import { Value } from './KeyValueModel';
-import { ErrorConflict } from '../utils/errors';
+import { ErrorConflict, ErrorUnprocessableEntity } from '../utils/errors';
 import uuidgen from '../utils/uuidgen';
 
 export default class LockModel extends BaseModel<Lock> {
@@ -17,7 +17,7 @@ export default class LockModel extends BaseModel<Lock> {
 		return UuidType.Native;
 	}
 
-	private get lockTtl() {
+	public get lockTtl() {
 		return this.lockTtl_;
 	}
 
@@ -27,17 +27,39 @@ export default class LockModel extends BaseModel<Lock> {
 		return v ? JSON.parse(v) : [];
 	}
 
+	protected async validate(lock: Lock): Promise<Lock> {
+		if (![LockType.Sync, LockType.Exclusive].includes(lock.type)) throw new ErrorUnprocessableEntity(`Invalid lock type: ${lock.type}`);
+		if (![LockClientType.Desktop, LockClientType.Mobile, LockClientType.Cli].includes(lock.clientType)) throw new ErrorUnprocessableEntity(`Invalid lock client type: ${lock.clientType}`);
+		if (lock.clientId.length > 64) throw new ErrorUnprocessableEntity(`Invalid client ID length: ${lock.clientId}`);
+		return lock;
+	}
+
+	private expireLocks(locks: Lock[]): Lock[] {
+		const cutOffTime = Date.now() - this.lockTtl;
+
+		const output: Lock[] = [];
+
+		for (const lock of locks) {
+			if (lock.updatedTime > cutOffTime) {
+				output.push(lock);
+			}
+		}
+
+		return output;
+	}
+
 	private async acquireSyncLock(userId: Uuid, clientType: LockClientType, clientId: string): Promise<Lock> {
 		const userKey = `locks::${userId}`;
 		let output: Lock = null;
 
 		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
 			let locks: Lock[] = value ? JSON.parse(value as string) : [];
+			locks = this.expireLocks(locks);
 
-			const libExclusiveLock = activeLock(locks, new Date(), this.lockTtl, LockType.Exclusive);
+			const exclusiveLock = activeLock(locks, new Date(), this.lockTtl, LockType.Exclusive);
 
-			if (libExclusiveLock) {
-				throw new ErrorConflict(`Cannot acquire lock because there is already an exclusive lock for client: ${libExclusiveLock.clientType} #${libExclusiveLock.clientId}`, 'hasExclusiveLock');
+			if (exclusiveLock) {
+				throw new ErrorConflict(`Cannot acquire lock because there is already an exclusive lock for client: ${exclusiveLock.clientType} #${exclusiveLock.clientId}`, 'hasExclusiveLock');
 			}
 
 			const syncLock = activeLock(locks, new Date(), this.lockTtl, LockType.Sync, clientType, clientId);
@@ -73,6 +95,7 @@ export default class LockModel extends BaseModel<Lock> {
 
 		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
 			let locks: Lock[] = value ? JSON.parse(value as string) : [];
+			locks = this.expireLocks(locks);
 
 			const exclusiveLock = activeLock(locks, new Date(), this.lockTtl, LockType.Exclusive);
 
@@ -92,13 +115,13 @@ export default class LockModel extends BaseModel<Lock> {
 				}
 			}
 
-			const libSyncLock = activeLock(locks, new Date(), this.lockTtl, LockType.Sync);
+			const syncLock = activeLock(locks, new Date(), this.lockTtl, LockType.Sync);
 
-			if (libSyncLock) {
-				if (libSyncLock.clientId === clientId) {
-					locks = locks.filter(l => l.id !== libSyncLock.id);
+			if (syncLock) {
+				if (syncLock.clientId === clientId) {
+					locks = locks.filter(l => l.id !== syncLock.id);
 				} else {
-					throw new ErrorConflict(`Cannot acquire exclusive lock because there is an active sync lock for client: ${libSyncLock.clientType} #${libSyncLock.clientId}`, 'hasSyncLock');
+					throw new ErrorConflict(`Cannot acquire exclusive lock because there is an active sync lock for client: ${syncLock.clientType} #${syncLock.clientId}`, 'hasSyncLock');
 				}
 			}
 
@@ -119,6 +142,8 @@ export default class LockModel extends BaseModel<Lock> {
 	}
 
 	public async acquireLock(userId: Uuid, type: LockType, clientType: LockClientType, clientId: string): Promise<Lock> {
+		await this.validate({ type, clientType, clientId });
+
 		if (type === LockType.Sync) {
 			return this.acquireSyncLock(userId, clientType, clientId);
 		} else {
@@ -126,15 +151,18 @@ export default class LockModel extends BaseModel<Lock> {
 		}
 	}
 
-	public async releaseLock(userId: Uuid, lockType: LockType, clientType: LockClientType, clientId: string) {
+	public async releaseLock(userId: Uuid, type: LockType, clientType: LockClientType, clientId: string) {
+		await this.validate({ type, clientType, clientId });
+
 		const userKey = `locks::${userId}`;
 
 		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
-			const locks: Lock[] = value ? JSON.parse(value as string) : [];
+			let locks: Lock[] = value ? JSON.parse(value as string) : [];
+			locks = this.expireLocks(locks);
 
 			for (let i = locks.length - 1; i >= 0; i--) {
 				const lock = locks[i];
-				if (lock.type === lockType && lock.clientType === clientType && lock.clientId === clientId) {
+				if (lock.type === type && lock.clientType === clientType && lock.clientId === clientId) {
 					locks.splice(i, 1);
 				}
 			}

--- a/packages/server/src/models/LockModel.ts
+++ b/packages/server/src/models/LockModel.ts
@@ -1,13 +1,13 @@
 import BaseModel, { UuidType } from './BaseModel';
 import { Uuid } from '../services/database/types';
-import { Lock, LockType, lockDefaultTtl, activeLock } from '@joplin/lib/services/synchronizer/LockHandler';
+import { Lock, LockType, defaultLockTtl, activeLock } from '@joplin/lib/services/synchronizer/LockHandler';
 import { Value } from './KeyValueModel';
 import { ErrorConflict } from '../utils/errors';
 import uuidgen from '../utils/uuidgen';
 
 export default class LockModel extends BaseModel<Lock> {
 
-	private lockTtl_: number = lockDefaultTtl;
+	private lockTtl_: number = defaultLockTtl;
 
 	protected get tableName(): string {
 		return 'locks';
@@ -18,8 +18,6 @@ export default class LockModel extends BaseModel<Lock> {
 	}
 
 	// TODO: validate lock when acquiring and releasing
-	// TODO: test "should allow exclusive lock if the sync locks have expired"
-	// TODO: test "should not allow exclusive lock if there are sync locks"
 
 	private get lockTtl() {
 		return this.lockTtl_;

--- a/packages/server/src/models/LockModel.ts
+++ b/packages/server/src/models/LockModel.ts
@@ -1,0 +1,150 @@
+import BaseModel, { UuidType } from './BaseModel';
+import { Uuid } from '../services/database/types';
+import { Lock, LockType, lockDefaultTtl, activeLock } from '@joplin/lib/services/synchronizer/LockHandler';
+import { Value } from './KeyValueModel';
+import { ErrorConflict } from '../utils/errors';
+import uuidgen from '../utils/uuidgen';
+
+export default class LockModel extends BaseModel<Lock> {
+
+	private lockTtl_: number = lockDefaultTtl;
+
+	protected get tableName(): string {
+		return 'locks';
+	}
+
+	protected uuidType(): UuidType {
+		return UuidType.Native;
+	}
+
+	// TODO: validate lock when acquiring and releasing
+	// TODO: test "should allow exclusive lock if the sync locks have expired"
+	// TODO: test "should not allow exclusive lock if there are sync locks"
+
+	private get lockTtl() {
+		return this.lockTtl_;
+	}
+
+	public async allLocks(userId: Uuid): Promise<Lock[]> {
+		const userKey = `locks::${userId}`;
+		const v = await this.models().keyValue().value<string>(userKey);
+		return v ? JSON.parse(v) : [];
+	}
+
+	private async acquireSyncLock(userId: Uuid, clientType: string, clientId: string): Promise<Lock> {
+		const userKey = `locks::${userId}`;
+		let output: Lock = null;
+
+		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
+			let locks: Lock[] = value ? JSON.parse(value as string) : [];
+
+			const exclusiveLock = activeLock(locks, new Date(), this.lockTtl, LockType.Exclusive);
+
+			if (exclusiveLock) {
+				throw new ErrorConflict(`Cannot acquire lock because there is already an exclusive lock for client: ${exclusiveLock.clientType} #${exclusiveLock.clientId}`, 'hasExclusiveLock');
+			}
+
+			const syncLock = activeLock(locks, new Date(), this.lockTtl, LockType.Sync, clientType, clientId);
+
+			if (syncLock) {
+				output = {
+					...syncLock,
+					updatedTime: Date.now(),
+				};
+
+				locks = locks.map(l => l.id === syncLock.id ? output : l);
+			} else {
+				output = {
+					id: uuidgen(),
+					type: LockType.Sync,
+					clientId,
+					clientType,
+					updatedTime: Date.now(),
+				};
+
+				locks.push(output);
+			}
+
+			return JSON.stringify(locks);
+		});
+
+		return output;
+	}
+
+	private async acquireExclusiveLock(userId: Uuid, clientType: string, clientId: string): Promise<Lock> {
+		const userKey = `locks::${userId}`;
+		let output: Lock = null;
+
+		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
+			let locks: Lock[] = value ? JSON.parse(value as string) : [];
+
+			const exclusiveLock = activeLock(locks, new Date(), this.lockTtl, LockType.Exclusive);
+
+			if (exclusiveLock) {
+				if (exclusiveLock.clientId === clientId) {
+					locks = locks.filter(l => l.id !== exclusiveLock.id);
+					output = {
+						...exclusiveLock,
+						updatedTime: Date.now(),
+					};
+
+					locks.push(output);
+
+					return JSON.stringify(locks);
+				} else {
+					throw new ErrorConflict(`Cannot acquire lock because there is already an exclusive lock for client: ${exclusiveLock.clientType} #${exclusiveLock.clientId}`, 'hasExclusiveLock');
+				}
+			}
+
+			const syncLock = activeLock(locks, new Date(), this.lockTtl, LockType.Sync);
+
+			if (syncLock) {
+				if (syncLock.clientId === clientId) {
+					locks = locks.filter(l => l.id !== syncLock.id);
+				} else {
+					throw new ErrorConflict(`Cannot acquire exclusive lock because there is an active sync lock for client: ${syncLock.clientType} #${syncLock.clientId}`, 'hasSyncLock');
+				}
+			}
+
+			output = {
+				id: uuidgen(),
+				type: LockType.Exclusive,
+				clientId,
+				clientType,
+				updatedTime: Date.now(),
+			};
+
+			locks.push(output);
+
+			return JSON.stringify(locks);
+		});
+
+		return output;
+	}
+
+	public async acquireLock(userId: Uuid, type: LockType, clientType: string, clientId: string): Promise<Lock> {
+		if (type === LockType.Sync) {
+			return this.acquireSyncLock(userId, clientType, clientId);
+		} else {
+			return this.acquireExclusiveLock(userId, clientType, clientId);
+		}
+	}
+
+	public async releaseLock(userId: Uuid, lockType: LockType, clientType: string, clientId: string) {
+		const userKey = `locks::${userId}`;
+
+		await this.models().keyValue().readThenWrite(userKey, async (value: Value) => {
+			const locks: Lock[] = value ? JSON.parse(value as string) : [];
+
+			for (let i = locks.length - 1; i >= 0; i--) {
+				const lock = locks[i];
+				if (lock.type === lockType && lock.clientType === clientType && lock.clientId === clientId) {
+					locks.splice(i, 1);
+				}
+			}
+
+			return JSON.stringify(locks);
+		});
+	}
+
+}

--- a/packages/server/src/models/factory.ts
+++ b/packages/server/src/models/factory.ts
@@ -72,6 +72,7 @@ import SubscriptionModel from './SubscriptionModel';
 import UserFlagModel from './UserFlagModel';
 import EventModel from './EventModel';
 import { Config } from '../utils/types';
+import LockModel from './LockModel';
 
 export class Models {
 
@@ -145,6 +146,10 @@ export class Models {
 
 	public event() {
 		return new EventModel(this.db_, newModelFactory, this.config_);
+	}
+
+	public lock() {
+		return new LockModel(this.db_, newModelFactory, this.config_);
 	}
 
 }

--- a/packages/server/src/routes/api/debug.ts
+++ b/packages/server/src/routes/api/debug.ts
@@ -2,9 +2,10 @@ import config from '../../config';
 import { clearDatabase, createTestUsers, CreateTestUsersOptions } from '../../tools/debugTools';
 import { bodyFields } from '../../utils/requestUtils';
 import Router from '../../utils/Router';
-import { RouteType } from '../../utils/types';
+import { Env, RouteType } from '../../utils/types';
 import { SubPath } from '../../utils/routeUtils';
 import { AppContext } from '../../utils/types';
+import { ErrorForbidden } from '../../utils/errors';
 
 const router = new Router(RouteType.Api);
 
@@ -17,7 +18,10 @@ interface Query {
 }
 
 router.post('api/debug', async (_path: SubPath, ctx: AppContext) => {
+	if (config().env !== Env.Dev) throw new ErrorForbidden();
+
 	const query: Query = (await bodyFields(ctx.req)) as Query;
+	const models = ctx.joplin.models;
 
 	console.info(`Action: ${query.action}`);
 
@@ -32,6 +36,10 @@ router.post('api/debug', async (_path: SubPath, ctx: AppContext) => {
 
 	if (query.action === 'clearDatabase') {
 		await clearDatabase(ctx.joplin.db);
+	}
+
+	if (query.action === 'clearKeyValues') {
+		await models.keyValue().deleteAll();
 	}
 });
 

--- a/packages/server/src/routes/api/locks.ts
+++ b/packages/server/src/routes/api/locks.ts
@@ -1,0 +1,32 @@
+import { lockNameToObject, LockType } from '@joplin/lib/services/synchronizer/LockHandler';
+import { bodyFields } from '../../utils/requestUtils';
+import Router from '../../utils/Router';
+import { SubPath } from '../../utils/routeUtils';
+import { AppContext, RouteType } from '../../utils/types';
+
+const router = new Router(RouteType.Api);
+
+interface PostFields {
+	type: LockType;
+	clientType: string;
+	clientId: string;
+}
+
+router.post('api/locks', async (_path: SubPath, ctx: AppContext) => {
+	const fields = await bodyFields<PostFields>(ctx.req);
+	return ctx.joplin.models.lock().acquireLock(ctx.joplin.owner.id, fields.type, fields.clientType, fields.clientId);
+});
+
+router.del('api/locks/:id', async (path: SubPath, ctx: AppContext) => {
+	const lock = lockNameToObject(path.id);
+	await ctx.joplin.models.lock().releaseLock(ctx.joplin.owner.id, lock.type, lock.clientType, lock.clientId);
+});
+
+router.get('api/locks', async (_path: SubPath, ctx: AppContext) => {
+	return {
+		items: await ctx.joplin.models.lock().allLocks(ctx.joplin.owner.id),
+		has_more: false,
+	};
+});
+
+export default router;

--- a/packages/server/src/routes/api/locks.ts
+++ b/packages/server/src/routes/api/locks.ts
@@ -1,4 +1,4 @@
-import { lockNameToObject, LockType } from '@joplin/lib/services/synchronizer/LockHandler';
+import { LockType, LockClientType, lockNameToObject } from '@joplin/lib/services/synchronizer/LockHandler';
 import { bodyFields } from '../../utils/requestUtils';
 import Router from '../../utils/Router';
 import { SubPath } from '../../utils/routeUtils';
@@ -8,7 +8,7 @@ const router = new Router(RouteType.Api);
 
 interface PostFields {
 	type: LockType;
-	clientType: string;
+	clientType: LockClientType;
 	clientId: string;
 }
 

--- a/packages/server/src/routes/routes.ts
+++ b/packages/server/src/routes/routes.ts
@@ -10,6 +10,7 @@ import apiSessions from './api/sessions';
 import apiShares from './api/shares';
 import apiShareUsers from './api/share_users';
 import apiUsers from './api/users';
+import apiLocks from './api/locks';
 
 import indexChanges from './index/changes';
 import indexHelp from './index/help';
@@ -41,6 +42,7 @@ const routes: Routers = {
 	'api/share_users': apiShareUsers,
 	'api/shares': apiShares,
 	'api/users': apiUsers,
+	'api/locks': apiLocks,
 
 	'changes': indexChanges,
 	'home': indexHome,

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -79,8 +79,8 @@ export class ErrorUnprocessableEntity extends ApiError {
 export class ErrorConflict extends ApiError {
 	public static httpCode: number = 409;
 
-	public constructor(message: string = 'Conflict') {
-		super(message, ErrorConflict.httpCode);
+	public constructor(message: string = 'Conflict', code: string = undefined) {
+		super(message, ErrorConflict.httpCode, code);
 		Object.setPrototypeOf(this, ErrorConflict.prototype);
 	}
 }


### PR DESCRIPTION
This is to speed up synchronisation and reduce database load, by reducing the number of lock requests and by avoiding many SQL "LIKE" queries (which were needed to retrieve all the locks of a user). Performance improvement should be significant on databases that have many items.

For now, the lock backend is the database, but it could potentially be moved to any key/value store to reduce the db load further.

# Perf

**With native lock 325ms - 2 requests**

2021-11-02 10:50:53: App: POST /api/locks (8ms)
2021-11-02 10:50:53: App: DELETE /api/locks/1_3_9fda9b06bde6435cb06ffcb2ebf8be3c (6ms)

**With regular 430ms - 4 requests**

2021-11-02 10:49:59: App: GET /api/items/root:/locks/*:/children (2ms)
2021-11-02 10:49:59: App: PUT /api/items/root:/locks/1_3_9fda9b06bde6435cb06ffcb2ebf8be3c.json:/content (29ms)
2021-11-02 10:49:59: App: GET /api/items/root:/locks/*:/children (2ms)
2021-11-02 10:49:59: App: DELETE /api/items/root:/locks/1_3_9fda9b06bde6435cb06ffcb2ebf8be3c.json: (31ms)