### PR TITLE
Desktop: Fix #5694: Sync-scroll supports notes markuped in html

### DIFF
--- a/packages/app-desktop/gui/utils/SyncScrollMap.ts
+++ b/packages/app-desktop/gui/utils/SyncScrollMap.ts
@@ -61,7 +61,7 @@ export class SyncScrollMapper {
 		}
 		// Since getBoundingClientRect() returns a relative position,
 		// the offset of the origin is needed to get its aboslute position.
-		const offset = doc.getElementById('rendered-md').getBoundingClientRect().top;
+		const offset = doc.getElementById('rendered-md')?.getBoundingClientRect().top;
 		if (!offset) return null;
 		// Mapping information between editor's lines and viewer's elements is
 		// embedded into elements by the renderer.


### PR DESCRIPTION
Sync-scroll didn't consider notes markup-ed in html.
By this fix, notes markup-ed in html are supported. 

Limitation:
- The new sync-scroll feature (recently introduced) is not enabled for html-markup notes, and  the old sync-scroll is used. Because they don't have mapping information between source code lines and html elements.