### PR TITLE
Fix Desktop: Synced note is not updated in display #5582

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -110,7 +110,7 @@ function NoteEditor(props: NoteEditorProps) {
 				const savedNote: any = await Note.save(note);
 
 				setFormNote((prev: FormNote) => {
-					return { ...prev, user_updated_time: savedNote.user_updated_time };
+					return { ...prev, user_updated_time: savedNote.user_updated_time, hasChanged: false };
 				});
 
 				void ExternalEditWatcher.instance().updateNoteFile(savedNote);


### PR DESCRIPTION
This PR fixes #5582.

The cause of the bug is `hasChanged` flag of a note is not cleared after the note is saved. So, when sync-ed, a note in Editor is considered as *being edited* and is not updated. 