### PR TITLE
Desktop: Resolves #5367 : Do not remove leading/trailing whitespaces from codeblocks wysiwyg 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -88,7 +88,10 @@ export default function openEditDialog(editor: any, markupToHtml: any, dispatchD
 		},
 		onSubmit: async (dialogApi: any) => {
 			const newSource = newBlockSource(dialogApi.getData().languageInput, dialogApi.getData().codeTextArea, source);
-			const md = `${newSource.openCharacters}${newSource.content.trim()}${newSource.closeCharacters}`;
+			const isCodeblock = newSource.openCharacters.slice(0, 4) === '\n```' && newSource.closeCharacters === '\n```\n';
+			const md = isCodeblock
+				? `${newSource.openCharacters}${newSource.content}${newSource.closeCharacters}`
+				: `${newSource.openCharacters}${newSource.content.trim()}${newSource.closeCharacters}`;
 			const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, md, { bodyOnly: true });
 
 			// markupToHtml will return the complete editable HTML, but we only


### PR DESCRIPTION
# Problem solved 
whitespaces from ends were being trimmed out even for codeblocks ; it is explained in detail in #5367 

# Manual Testing
Before Fix (prod version)

![unfxed-endspaces](https://user-images.githubusercontent.com/63918341/141511084-bd90c5e2-9a6b-452b-a44e-0b77029fc190.gif)

After Fix ( dev version)
![fixed-endspaces](https://user-images.githubusercontent.com/63918341/141511196-f3debfbc-7a7e-4f87-a852-565885c97b09.gif)

# Automatic testing
I can extract out the ternary operator statement that is introduced in this pr into a new function to implement tests; but I am not sure if that is desirable or if we have a better option to write unit tests

Resolves #5367 
Related Pull Request #5589 
