### PR TITLE
Update fr_FR.po

### DIFF
--- a/packages/tools/locales/fr_FR.po
+++ b/packages/tools/locales/fr_FR.po
@@ -1062,7 +1062,7 @@ msgstr "Objets suppr. localement : %d."
 
 #: packages/lib/Synchronizer.ts:193
 msgid "Deleted remote items: %d."
-msgstr "Objets distants supprimés : %d."
+msgstr "Objets distants suppr. : %d."
 
 #: packages/app-cli/app/command-rmbook.js:13
 msgid "Deletes the given notebook."
@@ -4117,7 +4117,7 @@ msgstr "Objets màj localement : %d."
 
 #: packages/lib/Synchronizer.ts:191
 msgid "Updated remote items: %d."
-msgstr "Objets distants mis à jour : %d."
+msgstr "Objets distants màj : %d."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:150
 msgid "Updated: "

--- a/packages/tools/locales/fr_FR.po
+++ b/packages/tools/locales/fr_FR.po
@@ -718,7 +718,7 @@ msgstr "Déchiffrement complété."
 
 #: packages/lib/Synchronizer.ts:196
 msgid "Completed: %s (%s)"
-msgstr "Terminé : %s (%s)"
+msgstr "Fait le : %s (%s)"
 
 #: packages/app-mobile/components/screens/ConfigScreen.tsx:637
 #: packages/app-mobile/components/side-menu-content.js:316
@@ -869,7 +869,7 @@ msgstr "date de création"
 
 #: packages/lib/Synchronizer.ts:188
 msgid "Created local items: %d."
-msgstr "Objets créés localement : %d."
+msgstr "Objets local créés : %d."
 
 #: packages/lib/services/ReportService.ts:244
 msgid "Created locally"
@@ -1058,7 +1058,7 @@ msgstr ""
 
 #: packages/lib/Synchronizer.ts:192
 msgid "Deleted local items: %d."
-msgstr "Objets supprimés localement : %d."
+msgstr "Objets local supprimés : %d."
 
 #: packages/lib/Synchronizer.ts:193
 msgid "Deleted remote items: %d."
@@ -4113,7 +4113,7 @@ msgstr "date de modification"
 
 #: packages/lib/Synchronizer.ts:189
 msgid "Updated local items: %d."
-msgstr "Objets mis à jour localement : %d."
+msgstr "Objets local mis-à-jour : %d."
 
 #: packages/lib/Synchronizer.ts:191
 msgid "Updated remote items: %d."

--- a/packages/tools/locales/fr_FR.po
+++ b/packages/tools/locales/fr_FR.po
@@ -718,7 +718,7 @@ msgstr "Déchiffrement complété."
 
 #: packages/lib/Synchronizer.ts:196
 msgid "Completed: %s (%s)"
-msgstr "Fait le : %s (%s)"
+msgstr "Terminé : %s (%s)"
 
 #: packages/app-mobile/components/screens/ConfigScreen.tsx:637
 #: packages/app-mobile/components/side-menu-content.js:316
@@ -869,7 +869,7 @@ msgstr "date de création"
 
 #: packages/lib/Synchronizer.ts:188
 msgid "Created local items: %d."
-msgstr "Objets local créés : %d."
+msgstr "Objets créés localement : %d."
 
 #: packages/lib/services/ReportService.ts:244
 msgid "Created locally"
@@ -1058,7 +1058,7 @@ msgstr ""
 
 #: packages/lib/Synchronizer.ts:192
 msgid "Deleted local items: %d."
-msgstr "Objets local supprimés : %d."
+msgstr "Objets suppr. localement : %d."
 
 #: packages/lib/Synchronizer.ts:193
 msgid "Deleted remote items: %d."
@@ -4113,7 +4113,7 @@ msgstr "date de modification"
 
 #: packages/lib/Synchronizer.ts:189
 msgid "Updated local items: %d."
-msgstr "Objets local mis-à-jour : %d."
+msgstr "Objets màj localement : %d."
 
 #: packages/lib/Synchronizer.ts:191
 msgid "Updated remote items: %d."


### PR DESCRIPTION
On Android the sync status in the bottom sidebar shows double lines.  See [screenshot](https://media.discordapp.net/attachments/610762468960239629/910515087859666954/image20212.png)

I suggest a shorter version to avoid the waste of screen space:

- Objets local créés :
- Objets local mis-à-jour :
- Objets local supprimés :
- Fait le :
