### PR TITLE
Desktop: wrapped the IIFE's

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
@@ -32,7 +32,7 @@
     var none = function () {
       return NONE;
     };
-    var NONE = function () {
+   var NONE = (function () {
       var eq = function (o) {
         return o.isNone();
       };
@@ -75,7 +75,7 @@
         Object.freeze(me);
       }
       return me;
-    }();
+    }());
     var some = function (a) {
       var constant_a = constant(a);
       var self = function () {

--- a/packages/app-desktop/main-html.js
+++ b/packages/app-desktop/main-html.js
@@ -31,7 +31,7 @@ const React = require('react');
 const nodeSqlite = require('sqlite3');
 
 if (bridge().env() === 'dev') {
-	const newConsole = function(oldConsole) {
+	const newConsole = (function(oldConsole) {
 		const output = {};
 		const fnNames = ['assert', 'clear', 'context', 'count', 'countReset', 'debug', 'dir', 'dirxml', 'error', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'memory', 'profile', 'profileEnd', 'table', 'time', 'timeEnd', 'timeLog', 'timeStamp', 'trace', 'warn'];
 		for (const fnName of fnNames) {
@@ -51,7 +51,7 @@ if (bridge().env() === 'dev') {
 			}
 		}
 		return output;
-	}(window.console);
+	}(window.console));
 
 	window.console = newConsole;
 }

--- a/packages/fork-sax/examples/example.js
+++ b/packages/fork-sax/examples/example.js
@@ -12,7 +12,7 @@ var fs = require('fs'),
 sax.EVENTS.forEach(function (ev) {
   loose['on' + ev] = inspector(ev)
 })
-loose.onend = function () {
+loose.onend = (function () {
   console.error('end')
   console.error(loose)
 }
@@ -25,4 +25,4 @@ loose.onend = function () {
     xml = xml.substr(c)
     process.nextTick(arguments.callee)
   } else loose.close()
-})()
+}))()


### PR DESCRIPTION
we can immediately invoke function expressions, but not function declarations. A common technique to create an immediately-invoked function expression (IIFE) is to wrap a function declaration in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.

this is a bad practice👇

```
var x = function () { 
    return {
        y: 1 
    };
}(); // unwrapped
```
this is a recommended practice 👇
```
var x = (function () {
    return {
        y: 1 
    };
}()); // wrapped expression
```