### PR TITLE
Server: Fixes #5397: Build smaller docker image

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -5,8 +5,8 @@ ARG user=joplin
 
 ##########################################################################################
 # builder image
-# Builds joplin server in /home/$user 
-########################################################################################## 
+# Builds joplin server in /home/$user
+##########################################################################################
 FROM node:16-bullseye as builder
 
 RUN apt-get update \
@@ -82,7 +82,7 @@ RUN npm run build
 
 ##########################################################################################
 # joplin-server-dev image, uses builder as base
-########################################################################################## 
+##########################################################################################
 From builder as joplin-server-dev
 
 ARG user
@@ -113,29 +113,43 @@ LABEL org.opencontainers.image.created="$BUILD_DATE" \
 ##########################################################################################
 # small-image-builder, uses builder as base
 # Constructs a smaller directory structure in /tmp/home/$user
-########################################################################################## 
+##########################################################################################
 from builder as small-image-builder
 
 ARG user
 
-# Now prepair a smaller joplin server installation in /home/$user
-USER $user
-RUN mkdir -p /tmp/home/$user && \
-    cp -r /home/joplin/packages/server/* /tmp/home/$user/ 
-
+# Now prepare a smaller joplin server installation in /home/$user
 USER $user:$user
+RUN mkdir -p /tmp/home/$user && \
+    cp -r /home/joplin/packages/server/* /tmp/home/$user/
+
 WORKDIR /tmp/home/$user
-RUN npm install --omit dev
+
+# pack tarballs from all packages except server
+RUN rm -fR node_modules/@joplin/* && \
+    for package in /home/joplin/packages/*; do \
+        package_name=$(basename "${package}"); \
+        if [ "${package_name}" = 'server' ]; then \
+            continue;  \
+        fi; \
+        cd ${package}; \
+        echo "Packing package ${package_name}"; \
+        npm pack --pack-destination /tmp/home/$user/; \
+    done
+
+# install the packed packages
+RUN npm install --audit=false --fund=false *.tgz
+
+# prune the dependencies
+RUN npm install --omit dev --audit=false --fund=false
 
 # remove all generated .test.js and .test.js.map files, which are not needed
-
-RUN find dist -name "*.test.js*" -type f -exec rm {} \;
-
+RUN find . -name "*.test.js*" -type f -exec rm {} \;
 
 ##########################################################################################
-# joplin-server image, uses node:16-bullseye-slima as base
+# joplin-server image, uses node:16-bullseye-slim as base
 # and copies the required files from small-image-builder
-########################################################################################## 
+##########################################################################################
 FROM node:16-bullseye-slim as joplin-server
 
 # create the user account and required folders

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,13 @@
-# https://versatile.nl/blog/deploying-lerna-web-apps-with-docker
+ARG user=joplin
 
-FROM node:16-bullseye
+# https://versatile.nl/blog/deploying-lerna-web-apps-with-docker
+# https://docs.docker.com/develop/develop-images/multistage-build/
+
+##########################################################################################
+# builder image
+# Builds joplin server in /home/$user 
+########################################################################################## 
+FROM node:16-bullseye as builder
 
 RUN apt-get update \
     && apt-get install -y \
@@ -14,12 +21,9 @@ ARG user=joplin
 
 RUN useradd --create-home --shell /bin/bash $user
 USER $user
-
-ENV NODE_ENV development
-
 WORKDIR /home/$user
 
-RUN mkdir /home/$user/logs
+ENV NODE_ENV development
 
 # Install the root scripts but don't run postinstall (which would bootstrap
 # and build TypeScript files, but we don't have the TypeScript files at
@@ -75,10 +79,91 @@ COPY --chown=$user:$user packages/server ./packages/server
 
 RUN npm run build
 
+##########################################################################################
+# joplin-server-dev image, uses builder as base
+########################################################################################## 
+From builder as joplin-server-dev
+
+ARG user
+USER $user:$user
+WORKDIR /home/$user
+
+RUN mkdir /home/$user/logs
+
 ENV RUNNING_IN_DOCKER=1
+ENV NODE_ENV development
 EXPOSE ${APP_PORT}
 
 CMD [ "npm", "--prefix", "packages/server", "start" ]
+
+# Build-time metadata
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+ARG BUILD_DATE
+ARG REVISION
+ARG VERSION
+LABEL org.opencontainers.image.created="$BUILD_DATE" \
+      org.opencontainers.image.title="Joplin Server DEV" \
+      org.opencontainers.image.description="Docker image for development Joplin Server" \
+      org.opencontainers.image.url="https://joplinapp.org/" \
+      org.opencontainers.image.revision="$REVISION" \
+      org.opencontainers.image.source="https://github.com/laurent22/joplin.git" \
+      org.opencontainers.image.version="${VERSION}"
+
+##########################################################################################
+# small-image-builder, uses builder as base
+# Constructs a smaller directory structure in /tmp/home/$user
+########################################################################################## 
+from builder as small-image-builder
+
+ARG user
+
+# Now prepair a smaller joplin server installation in /home/$user
+USER $user
+RUN mkdir -p /tmp/home/$user && \
+    cp -r /home/joplin/packages/server/* /tmp/home/$user/ 
+
+USER $user:$user
+WORKDIR /tmp/home/$user
+RUN npm install --omit dev
+
+# remove all generated .test.js and .test.js.map files, which are not needed
+
+RUN find dist -name "*.test.js*" -type f -exec rm {} \;
+
+
+##########################################################################################
+# joplin-server image, uses node:16-bullseye-slima as base
+# and copies the required files from small-image-builder
+########################################################################################## 
+FROM node:16-bullseye-slim as joplin-server
+
+# create the user account and required folders
+ARG user
+RUN useradd --create-home --shell /bin/bash $user && \
+    mkdir -p /home/$user/logs && \
+    mkdir -p /home/$user/src/views && \
+    chown -R $user:$user /home/$user
+
+# switch to user $user
+USER $user:$user
+WORKDIR /home/$user
+
+# copy only all required files from the 'builder' image
+COPY --from=small-image-builder /tmp/home/$user/dist /home/$user/dist
+COPY --from=small-image-builder /tmp/home/$user/node_modules /home/$user/node_modules
+COPY --from=small-image-builder /tmp/home/$user/public /home/$user/public
+COPY --from=small-image-builder /tmp/home/$user/stripeConfig.json /home/$user/stripeConfig.json
+COPY --from=small-image-builder /tmp/home/$user/src/views /home/$user/src/views
+
+# set some environment variables
+ENV RUNNING_IN_DOCKER=1
+ENV NODE_ENV=production
+
+# expose the application port
+EXPOSE ${APP_PORT}
+
+# start the node server directly from dist/app.js
+CMD [ "node", "dist/app.js" ]
 
 # Build-time metadata
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -56,6 +56,7 @@ COPY --chown=$user:$user tsconfig.json .
 COPY --chown=$user:$user packages/turndown ./packages/turndown
 COPY --chown=$user:$user packages/turndown-plugin-gfm ./packages/turndown-plugin-gfm
 COPY --chown=$user:$user packages/fork-htmlparser2 ./packages/fork-htmlparser2
+COPY --chown=$user:$user packages/htmlpack ./packages/htmlpack
 
 # Then bootstrap only, without compiling the TypeScript files
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/fontawesome-free": "^5.15.1",
     "@joplin/lib": "~2.6",
     "@joplin/renderer": "~2.6",
+    "@joplin/tools": "~2.6",
     "@koa/cors": "^3.1.0",
     "@types/uuid": "^8.3.1",
     "bcryptjs": "^2.4.3",
@@ -58,7 +59,6 @@
     "source-map-support": "^0.5.13"
   },
   "devDependencies": {
-    "@joplin/tools": "~2.6",
     "@rmp135/sql-ts": "^1.7.0",
     "@types/fs-extra": "^8.0.0",
     "@types/jest": "^26.0.15",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -54,7 +54,8 @@
     "stripe": "^8.150.0",
     "uuid": "^8.3.2",
     "yargs": "^17.2.1",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "^4.4.2",
+    "source-map-support": "^0.5.13"
   },
   "devDependencies": {
     "@joplin/tools": "~2.6",
@@ -72,7 +73,6 @@
     "jest": "^26.6.3",
     "jsdom": "^16.4.0",
     "node-mocks-http": "^1.10.0",
-    "source-map-support": "^0.5.13",
     "typescript": "^4.1.2"
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -15,7 +15,7 @@ import ownerHandler from './middleware/ownerHandler';
 import setupAppContext from './utils/setupAppContext';
 import { initializeJoplinUtils } from './utils/joplinUtils';
 import startServices from './utils/startServices';
-import { credentialFile } from './utils/testing/testUtils';
+import { credentialFile } from './utils/testing/credentialUtils';
 import apiVersionHandler from './middleware/apiVersionHandler';
 import clickJackingHandler from './middleware/clickJackingHandler';
 import newModelFactory from './models/factory';

--- a/packages/server/src/models/items/storage/StorageDriverS3.test.ts
+++ b/packages/server/src/models/items/storage/StorageDriverS3.test.ts
@@ -2,7 +2,8 @@
 // defined in the below config file. If the credentials are missing, all the
 // tests are skipped.
 
-import { afterAllTests, beforeAllDb, beforeEachDb, readCredentialFileSync } from '../../../utils/testing/testUtils';
+import { afterAllTests, beforeAllDb, beforeEachDb } from '../../../utils/testing/testUtils';
+import { readCredentialFileSync } from '../../../utils/testing/credentialUtils';
 import { StorageDriverConfig, StorageDriverMode, StorageDriverType } from '../../../utils/types';
 import { shouldDeleteContent, shouldNotCreateItemIfContentNotSaved, shouldNotUpdateItemIfContentNotSaved, shouldSupportFallbackDriver, shouldSupportFallbackDriverInReadWriteMode, shouldThrowNotFoundIfNotExist, shouldUpdateContentStorageIdAfterSwitchingDriver, shouldWriteToContentAndReadItBack } from './testUtils';
 

--- a/packages/server/src/utils/testing/credentialUtils.ts
+++ b/packages/server/src/utils/testing/credentialUtils.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs-extra';
+
+export async function credentialFile(filename: string): Promise<string> {
+	const filePath = `${require('os').homedir()}/joplin-credentials/${filename}`;
+	if (await fs.pathExists(filePath)) return filePath;
+	return '';
+}
+
+export async function readCredentialFile(filename: string, defaultValue: string = null) {
+	const filePath = await credentialFile(filename);
+	if (!filePath) {
+		if (defaultValue === null) throw new Error(`File not found: ${filename}`);
+		return defaultValue;
+	}
+
+	const r = await fs.readFile(filePath);
+	return r.toString();
+}
+
+export function credentialFileSync(filename: string): string {
+	const filePath = `${require('os').homedir()}/joplin-credentials/${filename}`;
+	if (fs.pathExistsSync(filePath)) return filePath;
+	return '';
+}
+
+export function readCredentialFileSync(filename: string, defaultValue: string = null) {
+	const filePath = credentialFileSync(filename);
+	if (!filePath) {
+		if (defaultValue === null) throw new Error(`File not found: ${filename}`);
+		return defaultValue;
+	}
+
+	const r = fs.readFileSync(filePath);
+	return r.toString();
+}

--- a/packages/server/src/utils/testing/testUtils.ts
+++ b/packages/server/src/utils/testing/testUtils.ts
@@ -398,40 +398,6 @@ export function checkContextError(context: AppContext) {
 	}
 }
 
-export async function credentialFile(filename: string): Promise<string> {
-	const filePath = `${require('os').homedir()}/joplin-credentials/${filename}`;
-	if (await fs.pathExists(filePath)) return filePath;
-	return '';
-}
-
-export async function readCredentialFile(filename: string, defaultValue: string = null) {
-	const filePath = await credentialFile(filename);
-	if (!filePath) {
-		if (defaultValue === null) throw new Error(`File not found: ${filename}`);
-		return defaultValue;
-	}
-
-	const r = await fs.readFile(filePath);
-	return r.toString();
-}
-
-export function credentialFileSync(filename: string): string {
-	const filePath = `${require('os').homedir()}/joplin-credentials/${filename}`;
-	if (fs.pathExistsSync(filePath)) return filePath;
-	return '';
-}
-
-export function readCredentialFileSync(filename: string, defaultValue: string = null) {
-	const filePath = credentialFileSync(filename);
-	if (!filePath) {
-		if (defaultValue === null) throw new Error(`File not found: ${filename}`);
-		return defaultValue;
-	}
-
-	const r = fs.readFileSync(filePath);
-	return r.toString();
-}
-
 export async function checkThrowAsync(asyncFn: Function): Promise<any> {
 	try {
 		await asyncFn();

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -21,6 +21,7 @@ async function main() {
 
 	const pushImages = !!argv.pushImages;
 	const tagName = argv.tagName;
+	const target = (argv.buildDev ? 'joplin-server-dev' : 'joplin-server');
 	const isPreRelease = getIsPreRelease(tagName);
 	const imageVersion = getVersionFromTag(tagName, isPreRelease);
 	const buildDate = moment(new Date().getTime()).format('YYYY-MM-DDTHH:mm:ssZ');
@@ -42,12 +43,13 @@ async function main() {
 	console.info(`Running from: ${process.cwd()}`);
 
 	console.info('tagName:', tagName);
+	console.info('target:', target);
 	console.info('pushImages:', pushImages);
 	console.info('imageVersion:', imageVersion);
 	console.info('isPreRelease:', isPreRelease);
 	console.info('Docker tags:', dockerTags.join(', '));
 
-	await execCommand2(`docker build -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server .`);
+	await execCommand2(`docker build -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server --target ${target} .`);
 	for (const tag of dockerTags) {
 		await execCommand2(`docker tag "joplin/server:${imageVersion}" "joplin/server:${tag}"`);
 		if (pushImages) await execCommand2(`docker push joplin/server:${tag}`);


### PR DESCRIPTION
Fixes: #5397 

The current `joplin/server:2.6.11-beta` is **2.87 GB**, which is very large. This is due to the fact that the sources are build with `lerna` and the complete source tree (of all required local packages), and all modules to build each package are included in the build.

By building the image in multiple stages, not using 'lerna' for creating the node_modules directory, not including any dev dependencies and using a smaller node image as the base, the size of the image can be drastically reduced. The current size of the image as a result of this pull request is **444 MB**,

The smaller image, does not use the `@joplin` packages from the source tree, put pulls the published packages. This can result in a dysfunctional image, as the 'server' code can rely on code in a library that is not yet published (like adding _ntp_ to the _@joplin/lib_). To still allow testing the latest / hottest code, a `--build-dev` argument was added to the `buildServerDocker` script, to build the large development image instead. This works by specifying a _target_ in the `Dockerfile.server`.

To make the image run without the `devDependencies` installed, the `credentialFile` code was moved from `utils/testing/testUtils' to `utils/testing/credentialUtils`, as the inclusion of `testUtils` results in a lot of devDependencies.
Also `source-map-support` was moved from devDependencies to (normal) dependencies, as it is used during normal operation.



