### PR TITLE
Desktop: [Performance] Reduces the time of switching notes to a quarter.

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -8,7 +8,7 @@ import NoteEditor from '../NoteEditor/NoteEditor';
 import NoteContentPropertiesDialog from '../NoteContentPropertiesDialog';
 import ShareNoteDialog from '../ShareNoteDialog';
 import CommandService from '@joplin/lib/services/CommandService';
-import { PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import Sidebar from '../Sidebar/Sidebar';
 import UserWebview from '../../services/plugins/UserWebview';
 import UserWebviewDialog from '../../services/plugins/UserWebviewDialog';
@@ -53,6 +53,7 @@ interface LayerModalState {
 
 interface Props {
 	plugins: PluginStates;
+	pluginHtmlContents: PluginHtmlContents;
 	pluginsLoaded: boolean;
 	hasNotesBeingSaved: boolean;
 	dispatch: Function;
@@ -723,12 +724,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 				}
 			} else {
 				const { view, plugin } = viewInfo;
+				const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 				return <UserWebview
 					key={view.id}
 					viewId={view.id}
 					themeId={this.props.themeId}
-					html={view.html}
+					html={html}
 					scripts={view.scripts}
 					pluginId={plugin.id}
 					borderBottom={true}
@@ -762,12 +764,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 			const { plugin, view } = info;
 			if (view.containerType !== ContainerType.Dialog) continue;
 			if (!view.opened) continue;
+			const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 			output.push(<UserWebviewDialog
 				key={view.id}
 				viewId={view.id}
 				themeId={this.props.themeId}
-				html={view.html}
+				html={html}
 				scripts={view.scripts}
 				pluginId={plugin.id}
 				buttons={view.buttons}
@@ -863,6 +866,7 @@ const mapStateToProps = (state: AppState) => {
 		selectedNoteId: state.selectedNoteIds.length === 1 ? state.selectedNoteIds[0] : null,
 		pluginsLegacy: state.pluginsLegacy,
 		plugins: state.pluginService.plugins,
+		pluginHtmlContents: state.pluginService.pluginHtmlContents,
 		customCss: state.customCss,
 		editorNoteStatuses: state.editorNoteStatuses,
 		hasNotesBeingSaved: stateUtils.hasNotesBeingSaved(state),

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, useMemo } from 'react';
 
 // eslint-disable-next-line no-unused-vars
-import { EditorCommand, NoteBodyEditorProps, ResourceInfos } from '../../utils/types';
+import { EditorCommand, NoteBodyEditorProps } from '../../utils/types';
 import { commandAttachFileToBody, handlePasteEvent } from '../../utils/resourceHandling';
 import { ScrollOptions, ScrollOptionTypes } from '../../utils/types';
 import { CommandValue } from '../../utils/types';
@@ -48,7 +48,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 	const [renderedBody, setRenderedBody] = useState<RenderedBody>(defaultRenderedBody()); // Viewer content
 	const renderedContentKey = useRef('');
-	const renderedResourceInfos = useRef<ResourceInfos>({});
 
 	const [webviewReady, setWebviewReady] = useState(false);
 
@@ -622,7 +621,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 			if (cancelled) return;
 			renderedContentKey.current = props.contentKey;
-			renderedResourceInfos.current = props.resourceInfos;
 			setRenderedBody(result);
 		}, interval);
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -390,7 +390,7 @@ function NoteEditor(props: NoteEditorProps) {
 		content: formNote.body,
 		contentMarkupLanguage: formNote.markup_language,
 		contentOriginalCss: formNote.originalCss,
-		resourceInfos: resourceInfos,
+		resourceInfos: resourceInfos.current,
 		htmlToMarkdown: htmlToMarkdown,
 		markupToHtml: markupToHtml,
 		allAssets: allAssets,

--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -1,6 +1,7 @@
 import time from './time';
 import Setting from './models/Setting';
 import { filename, fileExtension } from './path-utils';
+import { Buffer } from 'buffer';
 const md5 = require('md5');
 
 export interface Stat {
@@ -143,7 +144,7 @@ export default class FsDriverBase {
 	// or assign to option using .bind(fsDriver())
 	public async cacheCssToFile(cssStrings: string[]) {
 		const cssString = Array.isArray(cssStrings) ? cssStrings.join('\n') : cssStrings;
-		const cssFilePath = `${Setting.value('tempDir')}/${md5(cssString)}.css`;
+		const cssFilePath = `${Setting.value('tempDir')}/${md5(Buffer.from(cssString))}.css`;
 		if (!(await this.exists(cssFilePath))) {
 			await this.writeFile(cssFilePath, cssString, 'utf8');
 		}

--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -143,7 +143,7 @@ export default class FsDriverBase {
 	// or assign to option using .bind(fsDriver())
 	public async cacheCssToFile(cssStrings: string[]) {
 		const cssString = Array.isArray(cssStrings) ? cssStrings.join('\n') : cssStrings;
-		const cssFilePath = `${Setting.value('tempDir')}/${md5(escape(cssString))}.css`;
+		const cssFilePath = `${Setting.value('tempDir')}/${md5(cssString)}.css`;
 		if (!(await this.exists(cssFilePath))) {
 			await this.writeFile(cssFilePath, cssString, 'utf8');
 		}

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -259,7 +259,7 @@ export default class CommandService extends BaseService {
 
 		if (!whenClauseContext) whenClauseContext = this.currentWhenClauseContext();
 
-		const exp = new WhenClause(command.runtime.enabledCondition, this.devMode_);
+		const exp = WhenClause.get(command.runtime.enabledCondition, this.devMode_);
 		return exp.evaluate(whenClauseContext);
 	}
 

--- a/packages/lib/services/plugins/reducer.ts
+++ b/packages/lib/services/plugins/reducer.ts
@@ -33,14 +33,24 @@ export interface PluginStates {
 	[key: string]: PluginState;
 }
 
+export interface PluginHtmlContent {
+	[viewId: string]: string;
+}
+
+export interface PluginHtmlContents {
+	[pluginId: string]: PluginHtmlContent;
+}
+
 export interface State {
 	plugins: PluginStates;
+	pluginHtmlContents: PluginHtmlContents;
 }
 
 export const stateRootKey = 'pluginService';
 
 export const defaultState: State = {
 	plugins: {},
+	pluginHtmlContents: {},
 };
 
 export const utils = {
@@ -139,7 +149,12 @@ const reducer = (draftRoot: Draft<any>, action: any) => {
 
 		case 'PLUGIN_VIEW_PROP_SET':
 
-			(draft.plugins[action.pluginId].views[action.id] as any)[action.name] = action.value;
+			if (action.name !== 'html') {
+				(draft.plugins[action.pluginId].views[action.id] as any)[action.name] = action.value;
+			} else {
+				draft.pluginHtmlContents[action.pluginId] ??= {};
+				draft.pluginHtmlContents[action.pluginId][action.id] = action.value;
+			}
 			break;
 
 		case 'PLUGIN_VIEW_PROP_PUSH':

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -448,7 +448,7 @@ export default class MdToHtml {
 			this.lastCodeHighlightCacheKey_ = options.codeHighlightCacheKey;
 		}
 
-		const cacheKey = md5(escape(body + this.customCss_ + JSON.stringify(options) + JSON.stringify(options.theme)));
+		const cacheKey = md5(body + this.customCss_ + JSON.stringify(options));
 		const cachedOutput = this.cachedOutputs_[cacheKey];
 		if (cachedOutput) return cachedOutput;
 

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -5,8 +5,8 @@ import setupLinkify from './MdToHtml/setupLinkify';
 import validateLinks from './MdToHtml/validateLinks';
 import { ItemIdToUrlHandler } from './utils';
 import { RenderResult, RenderResultPluginAsset } from './MarkupToHtml';
-import { Options as NoteStyleOptions } from './noteStyle';
 import { Buffer } from 'buffer';
+import { Options as NoteStyleOptions } from './noteStyle';
 
 const MarkdownIt = require('markdown-it');
 const md5 = require('md5');

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -6,6 +6,7 @@ import validateLinks from './MdToHtml/validateLinks';
 import { ItemIdToUrlHandler } from './utils';
 import { RenderResult, RenderResultPluginAsset } from './MarkupToHtml';
 import { Options as NoteStyleOptions } from './noteStyle';
+import { Buffer } from 'buffer';
 
 const MarkdownIt = require('markdown-it');
 const md5 = require('md5');
@@ -448,7 +449,7 @@ export default class MdToHtml {
 			this.lastCodeHighlightCacheKey_ = options.codeHighlightCacheKey;
 		}
 
-		const cacheKey = md5(body + this.customCss_ + JSON.stringify(options));
+		const cacheKey = md5(Buffer.from(body + this.customCss_ + JSON.stringify(options)));
 		const cachedOutput = this.cachedOutputs_[cacheKey];
 		if (cachedOutput) return cachedOutput;
 


### PR DESCRIPTION
This PR is the replacement of PR #5632. It fixes some performance bugs and bottlenecks. As the result, the time of switching notes is reduced to a quarter.

Besides, plugins which update their panels when a note is switched (such as Note tab and Outline) are also greatly lightweighted. 

Performance improvement on note switching
- Redundant component updates (MainScreen, MenuBar, Sidebar, and so on) are reduced by separating view's html property from props.plugins.
- `WhenClause` is lightweighted. In a menu bar and tool bars, it is frequently used. Performance analysis shows `WhenClause` constructor and `WhenClause.evaluate()` are ones of major performance bottlenecks.
- Updates of CodeMirror rendering on rendering body and resource info are reduced.
- <s>Redundant html escapes are reduced.</s> Slow escapes for `md5()` are replaced.