### PR TITLE
Desktop: Changed note sort buttons to 3px radius 

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -36,7 +36,7 @@ const StyledButton = styled(Button)`
 
 const StyledPairButtonL = styled(Button)`
 	margin-left: 8px;
-	border-radius: 5px 0 0 5px;
+	border-radius: 3px 0 0 3px;
 	min-width: ${(props: any) => buttonSizePx(props)}px;
 	max-width: ${(props: any) => buttonSizePx(props)}px;
 `;
@@ -44,7 +44,7 @@ const StyledPairButtonL = styled(Button)`
 const StyledPairButtonR = styled(Button)`
 	min-width: 8px;
 	margin-left: 0px;
-	border-radius: 0 5px 5px 0;
+	border-radius: 0 3px 3px 0;
 	border-width: 1px 1px 1px 0;
 	width: auto;
 `;


### PR DESCRIPTION
Relates to addition of note sorting in https://github.com/laurent22/joplin/pull/5437/
Noticed that the border radius of the new buttons (5px) was off compared to the original two & the search box (3px) so have amended the values to remain consistent with the rest of the theme.
### 5px buttons
![image](https://user-images.githubusercontent.com/58074586/142892394-895ffca9-0a05-408d-8d45-e31a6dfad595.png)
### 3px buttons
![image](https://user-images.githubusercontent.com/58074586/142892483-afa2c5f0-0c04-45fa-b62d-a10e028f31f5.png)
