### PR TITLE
Server: Resolves #5790: Do not set the auth option when authUser or authPassword is set

### DIFF
--- a/packages/server/src/services/EmailService.ts
+++ b/packages/server/src/services/EmailService.ts
@@ -1,6 +1,7 @@
 import Logger from '@joplin/lib/Logger';
 import BaseService from './BaseService';
 import Mail = require('nodemailer/lib/mailer');
+import SMTPTransport = require('nodemailer/lib/smtp-transport');
 import { createTransport } from 'nodemailer';
 import { Email, EmailSender } from '../services/database/types';
 import { errorToString } from '../utils/errors';
@@ -24,16 +25,18 @@ export default class EmailService extends BaseService {
 				if (!this.senderInfo(EmailSender.NoReply).email) {
 					throw new Error('No-reply email must be set for email service to work (Set env variable MAILER_NOREPLY_EMAIL)');
 				}
-
-				this.transport_ = createTransport({
+				const options: SMTPTransport.Options = {
 					host: this.config.mailer.host,
 					port: this.config.mailer.port,
 					secure: this.config.mailer.secure,
-					auth: {
+				};
+				if (this.config.mailer.authUser || this.config.mailer.authPassword) {
+					options.auth = {
 						user: this.config.mailer.authUser,
 						pass: this.config.mailer.authPassword,
-					},
-				});
+					};
+				}
+				this.transport_ = createTransport(options);
 
 				await this.transport_.verify();
 				logger.info('Transporter is operational - service will be enabled');


### PR DESCRIPTION
Even when `config.mailer.authUser` and `config.mailer.authPassword` are empty, joplin server still configures the `auth` option on the `SMTPTransport`.

This pull request, changes this behavior by only setting the auth option when  both config.mailer.authUser and config.mailer.authPassword have a value (and are thus set using the environment variables). This allows the EmailService to be used when no authentication to the SMTP server is required.