### PR TITLE
All: Use latest minor release of postgres 13 in docker-compose examples

### DIFF
--- a/docker-compose.db-dev.yml
+++ b/docker-compose.db-dev.yml
@@ -6,7 +6,7 @@ version: '3'
 
 services:
     db:
-        image: postgres:13.1
+        image: postgres:13
         command: postgres -c work_mem=100000
         ports:
             - "5432:5432"
@@ -14,7 +14,7 @@ services:
             - POSTGRES_PASSWORD=joplin
             - POSTGRES_USER=joplin
             - POSTGRES_DB=joplin
-        
+     
         # Use this to specify additional Postgres
         # config parameters:
         #

--- a/docker-compose.server-dev.yml
+++ b/docker-compose.server-dev.yml
@@ -18,7 +18,7 @@ services:
             - POSTGRES_PORT=5432
             - POSTGRES_HOST=localhost
     db:
-        image: postgres:13.1
+        image: postgres:13
         ports:
             - "5432:5432"
         environment:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ version: '3'
 
 services:
     db:
-        image: postgres:13.1
+        image: postgres:13
         volumes:
             - ./data/postgres:/var/lib/postgresql/data
         ports:


### PR DESCRIPTION
I'm not sure if sticking to a specific minor version of postgres has more upsides than downsides.

https://www.postgresql.org/support/versioning/:

We always recommend that all users run the latest available minor release for whatever major version is in use.

Major versions usually change the internal format of system tables and data files. These changes are often complex, so we do not maintain backward compatibility of all stored data. A dump/reload of the database or use of the pg_upgrade module is required for major upgrades. We also recommend reading the upgrading section of the major version you are planning to upgrade to. You can upgrade from one major version to another without upgrading to intervening versions, but we recommend reading the release notes of all intervening major versions prior to doing so.

Upgrading to a minor release does not normally require a dump and restore; you can stop the database server, install the updated binaries, and restart the server. For some releases, manual changes may be required to complete the upgrade, so always read the release notes before upgrading.

While upgrading will always contain some level of risk, PostgreSQL minor releases fix only frequently-encountered bugs, security issues, and data corruption problems to reduce the risk associated with upgrading. **For minor releases, the community considers not upgrading to be riskier than upgrading.** 