### PR TITLE
Desktop: Allow flags for native wayland

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -257,6 +257,20 @@ export default class BaseApplication {
 				argv.splice(0, 1);
 				continue;
 			}
+			
+			if (arg.indexOf('--enable-features=') === 0) {
+				// Electron-specific flag - ignore it
+				// Allows users to run the app on native wayland
+				argv.splice(0, 1);
+				continue;
+			}
+			
+			if (arg.indexOf('--ozone-platform=') === 0) {
+				// Electron-specific flag - ignore it
+				// Allows users to run the app on native wayland
+				argv.splice(0, 1);
+				continue;
+			}
 
 			if (arg.length && arg[0] == '-') {
 				throw new JoplinError(_('Unknown flag: %s', arg), 'flagError');

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -257,14 +257,14 @@ export default class BaseApplication {
 				argv.splice(0, 1);
 				continue;
 			}
-			
+
 			if (arg.indexOf('--enable-features=') === 0) {
 				// Electron-specific flag - ignore it
 				// Allows users to run the app on native wayland
 				argv.splice(0, 1);
 				continue;
 			}
-			
+
 			if (arg.indexOf('--ozone-platform=') === 0) {
 				// Electron-specific flag - ignore it
 				// Allows users to run the app on native wayland


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Electron >= 12 supports native wayland. These flags need to be passed directly to Electron to enable it.    

`--enable-features=UseOzonePlatform --ozone-platform=wayland`