### PR TITLE
All: fixes #5801: links in flowchart Mermaid diagrams

### DIFF
--- a/packages/app-desktop/gui/note-viewer/lib.js
+++ b/packages/app-desktop/gui/note-viewer/lib.js
@@ -202,6 +202,7 @@ document.addEventListener('click', function(event) {
 		if (webviewLib.handleInternalLink(event, anchor)) return;
 		event.preventDefault();
 		if (anchor.getAttribute('href')) webviewLib.options_.postMessage(anchor.getAttribute('href'));
+		if (anchor.getAttribute('xlink:href')) webviewLib.options_.postMessage(anchor.getAttribute('xlink:href'));
 		return;
 	}
 

--- a/packages/app-desktop/gui/note-viewer/lib.js
+++ b/packages/app-desktop/gui/note-viewer/lib.js
@@ -202,6 +202,7 @@ document.addEventListener('click', function(event) {
 		if (webviewLib.handleInternalLink(event, anchor)) return;
 		event.preventDefault();
 		if (anchor.getAttribute('href')) webviewLib.options_.postMessage(anchor.getAttribute('href'));
+		// Depending on the chart type, the generated SVG contains an anchor element with xlink:href attribute.
 		if (anchor.getAttribute('xlink:href')) webviewLib.options_.postMessage(anchor.getAttribute('xlink:href'));
 		return;
 	}

--- a/packages/lib/renderers/webviewLib.js
+++ b/packages/lib/renderers/webviewLib.js
@@ -104,6 +104,7 @@ document.addEventListener('click', function(event) {
 		if (webviewLib.handleInternalLink(event, anchor)) return;
 		event.preventDefault();
 		if (anchor.getAttribute('href')) webviewLib.options_.postMessage(anchor.getAttribute('href'));
+		if (anchor.getAttribute('xlink:href')) webviewLib.options_.postMessage(anchor.getAttribute('xlink:href'));
 		return;
 	}
 

--- a/packages/lib/renderers/webviewLib.js
+++ b/packages/lib/renderers/webviewLib.js
@@ -104,6 +104,7 @@ document.addEventListener('click', function(event) {
 		if (webviewLib.handleInternalLink(event, anchor)) return;
 		event.preventDefault();
 		if (anchor.getAttribute('href')) webviewLib.options_.postMessage(anchor.getAttribute('href'));
+		// Depending on the chart type, the generated SVG contains an anchor element with xlink:href attribute.
 		if (anchor.getAttribute('xlink:href')) webviewLib.options_.postMessage(anchor.getAttribute('xlink:href'));
 		return;
 	}


### PR DESCRIPTION
fix by @jg1969

I've tested the fix on Desktop. Running `npm run buildInjectedJs` did not create any files in the `app-mobile` dir.

This fix is for flowchart diagrams. Links already work for `graph` diagrams.

fixes #5801