### PR TITLE
Desktop: fix wording in settings

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -465,16 +465,19 @@ class Application extends BaseApplication {
 
 		// Note: Auto-update is a misnomer in the code.
 		// The code below only checks, if a new version is available.
-		const runAutoUpdateCheck = () => {
-			if (Setting.value('autoUpdateEnabled')) {
-				void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
-			}
-		};
+		// We only allow Windows and macOS users to automatically check for updates
+		if (shim.isWindows() || shim.isMac()) {
+			const runAutoUpdateCheck = () => {
+				if (Setting.value('autoUpdateEnabled')) {
+					void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+				}
+			};
 
-		// Initial check on startup
-		shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
-		// Then every x hours
-		shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
+			// Initial check on startup
+			shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
+			// Then every x hours
+			shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
+		}
 
 		this.updateTray();
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -463,20 +463,18 @@ class Application extends BaseApplication {
 
 		await this.checkForLegacyTemplates();
 
-		// Note: Auto-update currently doesn't work in Linux: it downloads the update
-		// but then doesn't install it on exit.
-		if (shim.isWindows() || shim.isMac()) {
-			const runAutoUpdateCheck = () => {
-				if (Setting.value('autoUpdateEnabled')) {
-					void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
-				}
-			};
+		// Note: Auto-update is a misnomer in the code.
+		// The code below only checks, if a new version is available.
+		const runAutoUpdateCheck = () => {
+			if (Setting.value('autoUpdateEnabled')) {
+				void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+			}
+		};
 
-			// Initial check on startup
-			shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
-			// Then every x hours
-			shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
-		}
+		// Initial check on startup
+		shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
+		// Then every x hours
+		shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
 
 		this.updateTray();
 

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1190,7 +1190,7 @@ class Setting extends BaseModel {
 			},
 
 
-			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
+			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: platform !== 'linux', appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
 			'autoUpdate.includePreReleases': { value: false, type: SettingItemType.Bool, section: 'application', storage: SettingStorage.File, public: true, appTypes: [AppType.Desktop], label: () => _('Get pre-releases when checking for updates'), description: () => _('See the pre-release page for more details: %s', 'https://joplinapp.org/prereleases') },
 			'clipperServer.autoStart': { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, public: false },
 			'sync.interval': {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1190,7 +1190,7 @@ class Setting extends BaseModel {
 			},
 
 
-			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: platform !== 'linux', appTypes: [AppType.Desktop], label: () => _('Automatically update the application') },
+			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
 			'autoUpdate.includePreReleases': { value: false, type: SettingItemType.Bool, section: 'application', storage: SettingStorage.File, public: true, appTypes: [AppType.Desktop], label: () => _('Get pre-releases when checking for updates'), description: () => _('See the pre-release page for more details: %s', 'https://joplinapp.org/prereleases') },
 			'clipperServer.autoStart': { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, public: false },
 			'sync.interval': {


### PR DESCRIPTION
Currently the wording in settings has been leading people to believe that the applications will be automatically updated.
In reality all that is done is checking for available updates.

Thus the new wording is: `Automatically check for updates`

~~For some reason this check was disabled on Linux, because during experiments with real auto-updates yielded negative results on Linux.
But since the current code only checks for updates, there is no reason to not allow this on Linux.~~

~~Laurent, as to the impact this change has on Linux (since I promised I will let you know): it allows people to enable the auto-check on Linux.~~

I have tested the change on macOS and Linux. According to the code there is no change that is Windows specific, so I am sure it has no impact on Windows.

