### PR TITLE
Desktop: Fix #5872: Markdown search no longer scrolls to result 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -191,7 +191,6 @@ function Editor(props: EditorProps, ref: any) {
 		cm.on('drop', editor_drop);
 		cm.on('dragover', editor_drag);
 		cm.on('refresh', props.onResize);
-		cm.on('update', props.onResize);
 
 		// It's possible for searchMarkers to be available before the editor
 		// In these cases we set the markers asap so the user can see them as
@@ -206,7 +205,6 @@ function Editor(props: EditorProps, ref: any) {
 			cm.off('drop', editor_drop);
 			cm.off('dragover', editor_drag);
 			cm.off('refresh', props.onResize);
-			cm.off('update', props.onResize);
 			editorParent.current.removeChild(cm.getWrapperElement());
 			setEditor(null);
 		};


### PR DESCRIPTION
This PR fixes #5872, 'Markdown search no longer scrolls to result'.

The cause of the bug is that excessive negating of scroll events was performed. Concretely, scroll events caused by local searches were ignored, and their positions were reverted. Some other programmatic scrolling caused by CodeMirror was also affected. For example, page up/down didn't work in most cases.

This PR fixes the excessive negating.