### PR TITLE
Desktop: Fixes #5549: Cannot jump if local search count is one

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
@@ -107,7 +107,9 @@ export default function useEditorSearch(CodeMirror: any) {
 			const searchTerm = getSearchTerm(keyword);
 
 			// We only want to scroll the first keyword into view in the case of a multi keyword search
-			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex);
+			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex ||
+				// If there is only one choice, scrollTo should be true. The below is a dummy of nMatches === 1.
+				options.selectedIndex === 0);
 
 			const match = highlightSearch(this, searchTerm, options.selectedIndex, scrollTo);
 			if (match) marks.push(match);


### PR DESCRIPTION
This PR fixes the issue #5549: Desktop: Doesn't jump to the local search result if its count is one.


The cause of the bug is that scrolling to the specified local search result is enabled only if a keyword is changed or a search result index is changed. If the search result count is one, there is no chance that an index is changed.

To fix the bug, scrolling should be enabled if the search result count is 1.

Implementation Note:
- Since the search result count is unknown when the condition is judged, a dummy condition (index is zero) is used.