### PR TITLE
Add note about pCloud WebDAV not being supported.

### DIFF
--- a/readme/faq.md
+++ b/readme/faq.md
@@ -126,8 +126,8 @@ In this case, [make sure you enter the correct WebDAV URL](https://github.com/la
 
 ### The following WebDAV hosts are not supported
 
-- Jianguoyun.com (see [Github issue](https://github.com/laurent22/joplin/issues/4294))
-- pCloud (webdav.pcloud.com, ewebdav.pcloud.com), due to issues with pCloud's WebDAV implementation. See [Forum thread](https://discourse.joplinapp.org/t/feature-request-pcloud-synchronisation/3530/51)
+- Jianguoyun (see [Github issue](https://github.com/laurent22/joplin/issues/4294))
+- pCloud (see [Forum thread](https://discourse.joplinapp.org/t/feature-request-pcloud-synchronisation/3530/51))
 
 ### Nextcloud sync is not working
 

--- a/readme/faq.md
+++ b/readme/faq.md
@@ -127,6 +127,7 @@ In this case, [make sure you enter the correct WebDAV URL](https://github.com/la
 ### The following WebDAV hosts are not supported
 
 - Jianguoyun.com (see [Github issue](https://github.com/laurent22/joplin/issues/4294))
+- pCloud (webdav.pcloud.com, ewebdav.pcloud.com), due to issues with pCloud's WebDAV implementation. See [Forum thread](https://discourse.joplinapp.org/t/feature-request-pcloud-synchronisation/3530/51)
 
 ### Nextcloud sync is not working
 


### PR DESCRIPTION
Add note about pCloud WebDAV not being supported, due to faulty implementation, as noted in discussion at https://discourse.joplinapp.org/t/feature-request-pcloud-synchronisation/3530/51 and in various other places.

I will try and pester pCloud to fix their WebDAV in the meantime.
