### PR TITLE
Desktop: Resolves #4911: Adding a tag in all notes leads to select first note

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -565,6 +565,9 @@ export default class BaseApplication {
 		// https://github.com/laurent22/joplin/issues/3754
 		if (['TAG_SELECT', 'TAG_DELETE', 'TAG_UPDATE_ONE', 'NOTE_TAG_REMOVE'].includes(action.type)) {
 			refreshNotes = true;
+			if (newState.notesParentType === 'SmartFilter') {
+				refreshNotesUseSelectedNoteId = true;
+			}
 		}
 
 		if (action.type == 'SEARCH_SELECT' || action.type === 'SEARCH_DELETE') {

--- a/packages/lib/reducer.test.js
+++ b/packages/lib/reducer.test.js
@@ -590,6 +590,45 @@ describe('reducer', function() {
 		expect(state.selectedNoteIds[0]).toEqual(notes[1].id);
 	});
 
+	it('should record last selected notes when all notes filter is on', async () => {
+		const folders = await createNTestFolders(2);
+		const notes = [];
+		for (let i = 0; i < folders.length; i++) {
+			notes.push(...await createNTestNotes(2, folders[i]));
+		}
+
+		// Initialize state with selected note at 0 index
+		let state = initTestState(folders, [0], notes.slice(), [0]);
+
+		// Turn on 'All Notes' filter
+		state = reducer(state, { type: 'SMART_FILTER_SELECT', id: ALL_NOTES_FILTER_ID });
+
+		// Building the history to test HISTORY_BACKWARD and HISTORY_FORWARD when All Notes filter is on.
+		state = goToNote(notes, [3], state);
+		state = goToNote(notes, [1], state);
+		state = goToNote(notes, [2], state);
+
+		expect(state.selectedNoteIds[0]).toEqual(notes[2].id);
+
+		state = goBackWard(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[1].id);
+
+		state = goBackWard(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[3].id);
+
+		state = goBackWard(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[0].id);
+
+		state = goForward(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[3].id);
+
+		state = goForward(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[1].id);
+
+		state = goForward(state);
+		expect(state.selectedNoteIds[0]).toEqual(notes[2].id);
+	});
+
 	// tests for NOTE_UPDATE_ALL about issue #5447
 	it('should not change selectedNoteIds object when selections are not changed', async () => {
 		const folders = await createNTestFolders(1);


### PR DESCRIPTION
 Desktop: Resolves #4911: Adding a tag in all notes leads to select first note

Problem:
When "All notes" is selected and a tag is added to a note from the note list. whatever the currently focused note be, it's changing to the first note in the list.

Solution:
I noticed that whenever I select All Notes Smart Filter the Note that was selectedPreviously was also selected after All notes are selected with other notes name on the sidebar. But when i add a tag while ALL Notes is selected it adds tag but select first note instead of note that was previously open because after refreshing notes refreshNotesUseSelectedNoteId was passed false.

Demo:-

https://user-images.githubusercontent.com/53316345/147403919-a092cf20-9383-4a3e-a0d6-31950f6f6cfb.mov


