### PR TITLE
Desktop: Fix #5850: Focuses an editor after local search is closed

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
@@ -64,7 +64,7 @@ export default function useEditorSearch(CodeMirror: any) {
 		}
 
 		if (match) {
-			if (scrollTo) cm.scrollIntoView(match);
+			if (scrollTo) cm.setSelection(match.from, match.to);
 			return cm.markText(match.from, match.to, { className: 'cm-search-marker-selected' });
 		}
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useNoteSearchBar.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useNoteSearchBar.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import Logger from '@joplin/lib/Logger';
 import { SearchMarkers } from './useSearchMarkers';
+const CommandService = require('@joplin/lib/services/CommandService').default;
 
 const logger = Logger.create('useNoteSearchBar');
 
@@ -70,6 +71,7 @@ export default function useNoteSearchBar() {
 	const onClose = useCallback(() => {
 		setShowLocalSearch(false);
 		setLocalSearch(defaultLocalSearch());
+		void CommandService.instance().execute('focusElementNoteBody');		
 	}, []);
 
 	const setResultCount = useCallback((count: number) => {

--- a/packages/app-desktop/gui/NoteEditor/utils/useNoteSearchBar.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useNoteSearchBar.ts
@@ -71,7 +71,7 @@ export default function useNoteSearchBar() {
 	const onClose = useCallback(() => {
 		setShowLocalSearch(false);
 		setLocalSearch(defaultLocalSearch());
-		void CommandService.instance().execute('focusElementNoteBody');		
+		void CommandService.instance().execute('focusElementNoteBody');
 	}, []);
 
 	const setResultCount = useCallback((count: number) => {


### PR DESCRIPTION
This PR fixes issue #5850.

Implemented features:
- When a local search is executed, the current highlighted search result is selected (with a cursor move).
- After the local search bar is closed, Markdown Editor is focused.