### PR TITLE
Desktop: Fixes #5875: Show error on sync if S3 region is not set

### DIFF
--- a/packages/lib/SyncTargetAmazonS3.js
+++ b/packages/lib/SyncTargetAmazonS3.js
@@ -98,14 +98,14 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 	// We could implement that here, but the above workaround saves some code.
 
 	static async checkConfig(options) {
-		const fileApi = await SyncTargetAmazonS3.newFileApi_(SyncTargetAmazonS3.id(), options);
-		fileApi.requestRepeatCount_ = 0;
-
 		const output = {
 			ok: false,
 			errorMessage: '',
 		};
 		try {
+			const fileApi = await SyncTargetAmazonS3.newFileApi_(SyncTargetAmazonS3.id(), options);
+			fileApi.requestRepeatCount_ = 0;
+
 			const headBucketReq = new Promise((resolve, reject) => {
 				fileApi.driver().api().send(
 

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -43,8 +43,9 @@ export const runtime = (): CommandRuntime => {
 			try {
 				sync = await reg.syncTarget().synchronizer();
 			} catch (error) {
-				reg.logger().error('Could not acquire synchroniser:');
+				reg.logger().error('Could not acquire synchronizer:');
 				reg.logger().error(error);
+				error.message = `Could not acquire synchronizer: ${error.message}`;
 				utils.store.dispatch({
 					type: 'SYNC_REPORT_UPDATE',
 					report: { errors: [error] },

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -35,7 +35,7 @@ export const runtime = (): CommandRuntime => {
 					return 'auth';
 				}
 
-				reg.logger().info('Not authentified with sync target - please check your credential.');
+				reg.logger().error('Not authentified with sync target - please check your credential.');
 				return 'error';
 			}
 
@@ -43,8 +43,8 @@ export const runtime = (): CommandRuntime => {
 			try {
 				sync = await reg.syncTarget().synchronizer();
 			} catch (error) {
-				reg.logger().info('Could not acquire synchroniser:');
-				reg.logger().info(error);
+				reg.logger().error('Could not acquire synchroniser:');
+				reg.logger().error(error);
 				utils.store.dispatch({
 					type: 'SYNC_REPORT_UPDATE',
 					report: { errors: [error] },

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -43,9 +43,9 @@ export const runtime = (): CommandRuntime => {
 			try {
 				sync = await reg.syncTarget().synchronizer();
 			} catch (error) {
-				reg.logger().error('Could not acquire synchronizer:');
+				reg.logger().error('Could not initialise synchroniser: ');
 				reg.logger().error(error);
-				error.message = `Could not acquire synchronizer: ${error.message}`;
+				error.message = `Could not initialise synchroniser: ${error.message}`;
 				utils.store.dispatch({
 					type: 'SYNC_REPORT_UPDATE',
 					report: { errors: [error] },

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -35,7 +35,7 @@ export const runtime = (): CommandRuntime => {
 					return 'auth';
 				}
 
-				reg.logger().error('Not authentified with sync target - please check your credential.');
+				reg.logger().error('Not authenticated with sync target - please check your credentials.');
 				return 'error';
 			}
 

--- a/packages/lib/commands/synchronize.ts
+++ b/packages/lib/commands/synchronize.ts
@@ -45,6 +45,10 @@ export const runtime = (): CommandRuntime => {
 			} catch (error) {
 				reg.logger().info('Could not acquire synchroniser:');
 				reg.logger().info(error);
+				utils.store.dispatch({
+					type: 'SYNC_REPORT_UPDATE',
+					report: { errors: [error] },
+				});
 				return 'error';
 			}
 

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -105,7 +105,7 @@ shared.synchronize_press = async function(comp) {
 			return 'auth';
 		}
 
-		reg.logger().info('Not authentified with sync target - please check your credential.');
+		reg.logger().error('Not authentified with sync target - please check your credential.');
 		return 'error';
 	}
 
@@ -113,8 +113,8 @@ shared.synchronize_press = async function(comp) {
 	try {
 		sync = await reg.syncTarget().synchronizer();
 	} catch (error) {
-		reg.logger().info('Could not acquire synchroniser:');
-		reg.logger().info(error);
+		reg.logger().error('Could not acquire synchroniser:');
+		reg.logger().error(error);
 		comp.props.dispatch({
 			type: 'SYNC_REPORT_UPDATE',
 			report: { errors: [error] },

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -115,6 +115,10 @@ shared.synchronize_press = async function(comp) {
 	} catch (error) {
 		reg.logger().info('Could not acquire synchroniser:');
 		reg.logger().info(error);
+		comp.props.dispatch({
+			type: 'SYNC_REPORT_UPDATE',
+			report: { errors: [error] },
+		});
 		return 'error';
 	}
 

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -113,9 +113,9 @@ shared.synchronize_press = async function(comp) {
 	try {
 		sync = await reg.syncTarget().synchronizer();
 	} catch (error) {
-		reg.logger().error('Could not acquire synchroniser:');
+		reg.logger().error('Could not initialise synchroniser: ');
 		reg.logger().error(error);
-		error.message = `Could not acquire synchronizer: ${error.message}`;
+		error.message = `Could not initialise synchroniser: ${error.message}`;
 		comp.props.dispatch({
 			type: 'SYNC_REPORT_UPDATE',
 			report: { errors: [error] },

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -105,7 +105,7 @@ shared.synchronize_press = async function(comp) {
 			return 'auth';
 		}
 
-		reg.logger().error('Not authentified with sync target - please check your credential.');
+		reg.logger().error('Not authenticated with sync target - please check your credentials.');
 		return 'error';
 	}
 

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -115,6 +115,7 @@ shared.synchronize_press = async function(comp) {
 	} catch (error) {
 		reg.logger().error('Could not acquire synchroniser:');
 		reg.logger().error(error);
+		error.message = `Could not acquire synchronizer: ${error.message}`;
 		comp.props.dispatch({
 			type: 'SYNC_REPORT_UPDATE',
 			report: { errors: [error] },


### PR DESCRIPTION
Shows an error message when syncing if the S3 region is not set
![image](https://user-images.githubusercontent.com/3250983/147510859-beec201b-3a8e-43de-9150-48b29c1a3430.png)

Also shows a message if you try to check sync config in settings:
![screenshot_2021-12-27_15-28-33](https://user-images.githubusercontent.com/3250983/147510892-f0b5f1a2-7fcc-4962-a5d3-356d391ca076.png)

I also turn a few error log from `info` to `error`.
This should fix #5875 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
