### PR TITLE
Desktop: Fix #5918: Scroll jumps when images are rendered in Markdown Editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
@@ -7,6 +7,7 @@ export default function useScrollHandler(editorRef: any, webviewRef: any, onScro
 	const ignoreNextEditorScrollTime_ = useRef(Date.now());
 	const ignoreNextEditorScrollEventCount_ = useRef(0);
 	const delayedSetEditorPercentScrollTimeoutID_ = useRef(null);
+	const lastResizeHeight_ = useRef(NaN);
 
 	// Ignores one next scroll event for a short time.
 	const ignoreNextEditorScrollEvent = () => {
@@ -90,8 +91,7 @@ export default function useScrollHandler(editorRef: any, webviewRef: any, onScro
 	}, [scheduleOnScroll]);
 
 	const editor_scroll = useCallback(() => {
-		if (isNextEditorScrollEventIgnored()) return;
-
+		const ignored = isNextEditorScrollEventIgnored();
 		const cm = editorRef.current;
 		if (isCodeMirrorReady(cm)) {
 			const editorPercent = Math.max(0, Math.min(1, cm.getScrollPercent()));
@@ -104,7 +104,9 @@ export default function useScrollHandler(editorRef: any, webviewRef: any, onScro
 				// calculates GUI-independent line-based percent
 				const percent = translateScrollPercentE2L(cm, editorPercent);
 				scrollPercent_.current = percent;
-				setViewerPercentScroll(percent);
+				if (!ignored) {
+					setViewerPercentScroll(percent);
+				}
 			}
 		}
 	}, [setViewerPercentScroll]);
@@ -117,8 +119,14 @@ export default function useScrollHandler(editorRef: any, webviewRef: any, onScro
 	}, []);
 
 	const editor_resize = useCallback((cm) => {
-		if (cm) {
-			restoreEditorPercentScroll();
+		if (isCodeMirrorReady(cm)) {
+			// Only when resized, the scroll position is restored.
+			const info = cm.getScrollInfo();
+			const height = info.height - info.clientHeight;
+			if (height !== lastResizeHeight_.current) {
+				restoreEditorPercentScroll();
+				lastResizeHeight_.current = height;
+			}
 		}
 	}, []);
 


### PR DESCRIPTION
This PR fixes #5918. That is, it suppresses unexpected scroll jumps when images are rendered in Markdown Editor. The symptom may happen if CodeMirror.refresh() is called while Markdown Editor is scrolling.

This PR mitigates the symptom of Rich Markdown 0.8.1 or before. The details are described in #5918.

Implementation Notes:
- The scroll position variable used for restoring when resized is updated more frequently.
- Resizing CodeMirror's `refresh` event are distinguished from refreshing `refresh` events as possible.
