### PR TITLE
All: Don't automatically sign it to onedrive

### DIFF
--- a/packages/lib/onedrive-api.ts
+++ b/packages/lib/onedrive-api.ts
@@ -89,6 +89,7 @@ export default class OneDriveApi {
 			scope: 'files.readwrite offline_access sites.readwrite.all',
 			response_type: 'code',
 			redirect_uri: redirectUri,
+			prompt: 'login',
 		};
 		return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${stringify(query)}`;
 	}


### PR DESCRIPTION
When a user selects onedrive as sync target, onedrive currently tries to automatically sign in the user. The problem however is that the autologin procedure from onedrive is weird - it seems when a user is signed in to a personal and a business account, onedrive always picks the business account. But even if this were not the case, a user might still want to choose a different account than used in a previous browser session (on a work pc you might be logged in to your business account in the browser, but you might still want to use your personal account for joplin). This has been reported a couple of times on the forum: 
 
https://discourse.joplinapp.org/t/how-can-i-choose-which-onedrive-account-to-auth-on-win10/9016/6
https://discourse.joplinapp.org/t/option-to-re-authenticate-with-onedrive/12415
https://discourse.joplinapp.org/t/onedrive-sync-question/11653

By adding the `prompt = login` query to the login url, users always have to choose the account to use for joplin. When the user is already logged in to one or multiple accounts, the accounts are still shown as suggestion in the browser (in future a login therefore would require one more click but as this is not a daily task, this is imo negligible). 

I haven't tested on mobile but I don't see why it shouldn't work there when it works on desktop. 