### PR TITLE
Desktop: Add "X-GNOME-SingleWindow=true" to the desktop file

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -219,6 +219,7 @@ then
 	Type=Application
 	Categories=Office;
 	MimeType=x-scheme-handler/joplin;
+	X-GNOME-SingleWindow=true
 	EOF
     
     # Update application icons


### PR DESCRIPTION
Since this commit (https://github.com/KDE/plasma-workspace/commit/ebd2acd98ecdb9d115b01bd01f532390376152f7),
Plasma Desktop will check "X-GNOME-SingleWindow" property to determine
whether to show "Open New Window" action in the context menu of a task.

Joplin cannot launch a new instance or open a new window, so add the
property and set it to true to hide the action.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
