### PR TITLE
Desktop: Clickable tags in Tag Bar

### DIFF
--- a/packages/app-desktop/gui/TagItem.jsx
+++ b/packages/app-desktop/gui/TagItem.jsx
@@ -1,14 +1,15 @@
 const React = require('react');
 const { connect } = require('react-redux');
 const { themeStyle } = require('@joplin/lib/theme');
+const CommandService = require('@joplin/lib/services/CommandService').default;
 
 class TagItemComponent extends React.Component {
 	render() {
 		const theme = themeStyle(this.props.themeId);
 		const style = Object.assign({}, theme.tagStyle);
-		const title = this.props.title;
+		const {title, id} = this.props;
 
-		return <span style={style}>{title}</span>;
+		return <button style={style} onClick={() => CommandService.instance().execute('openTag', id)}>{title}</button>;
 	}
 }
 

--- a/packages/app-desktop/gui/TagItem.jsx
+++ b/packages/app-desktop/gui/TagItem.jsx
@@ -7,7 +7,7 @@ class TagItemComponent extends React.Component {
 	render() {
 		const theme = themeStyle(this.props.themeId);
 		const style = Object.assign({}, theme.tagStyle);
-		const {title, id} = this.props;
+		const { title, id } = this.props;
 
 		return <button style={style} onClick={() => CommandService.instance().execute('openTag', id)}>{title}</button>;
 	}

--- a/packages/app-desktop/gui/TagList.tsx
+++ b/packages/app-desktop/gui/TagList.tsx
@@ -42,6 +42,7 @@ function TagList(props: Props) {
 		for (let i = 0; i < tags.length; i++) {
 			const props = {
 				title: tags[i].title,
+				id: tags[i].id,
 				key: tags[i].id,
 			};
 			output.push(<TagItem {...props} />);

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -227,6 +227,7 @@ function addExtraStyles(style: any) {
 		justifyContent: 'center',
 		marginRight: 8,
 		borderRadius: 100,
+		borderWidth: 0,
 	};
 
 	style.toolbarStyle = {


### PR DESCRIPTION
Tags in Tag Bar at the bottom of Note Editor become clickable. The behavior is the same with clicking a tag in Sidebar.

This feature is requested here:
  - [Clicking on Tags like on Notebooks - Features - Joplin Forum](https://discourse.joplinapp.org/t/clicking-on-tags-like-on-notebooks/11670)
  - [Suggestion - Tag label - Click to display notes sharing that tag - Features - Joplin Forum](https://discourse.joplinapp.org/t/suggestion-tag-label-click-to-display-notes-sharing-that-tag/7880)