### PR TITLE
Documentation: Default S3 permissions require 'GetObject'

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ To add a **Bucket Policy** from the AWS S3 Web Console, navigate to the **Permis
             "Action": [
                   "s3:ListBucket",
                   "s3:GetBucketLocation",
+                  "s3:GetObject",
                   "s3:DeleteObject",
                   "s3:DeleteObjectVersion",
                   "s3:PutObject"


### PR DESCRIPTION
Attempting to synchronise without `GetObject` partially succeeds: it pushes changes into S3 but fails at the next step when it tries to fetch.