### PR TITLE
Desktop: fix built application - eventManager path

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -62,7 +62,7 @@ import ShareService from '@joplin/lib/services/share/ShareService';
 import checkForUpdates from './checkForUpdates';
 import { AppState } from './app.reducer';
 import syncDebugLog from '@joplin/lib/services/synchronizer/syncDebugLog';
-import eventManager from '../lib/eventManager';
+import eventManager from '@joplin/lib/eventManager';
 // import { runIntegrationTests } from '@joplin/lib/services/e2ee/ppkTestUtils';
 
 const pluginClasses = [


### PR DESCRIPTION
Fix issue from forums (https://discourse.joplinapp.org/t/built-app-doesnt-start/22884/) where the built app was failing:

```
Uncaught Error: Cannot find module '../lib/eventManager'
Require stack:
- /tmp/.mount_JoplinD3eYGv/resources/app.asar/app.js
- /tmp/.mount_JoplinD3eYGv/resources/app.asar/index.html
    at Module._resolveFilename (internal/modules/cjs/loader.js:892)
    at Function.o._resolveFilename (electron/js2c/renderer_init.js:29)
    at Module._load (internal/modules/cjs/loader.js:737)
    at Function.f._load (electron/js2c/asar_bundle.js:5)
    at Function.o._load (electron/js2c/renderer_init.js:29)
    at Module.require (internal/modules/cjs/loader.js:964)
    at require (internal/modules/cjs/helpers.js:88)
    at Object.<anonymous> (app.ts:65)
    at Object.<anonymous> (app.ts:601)
    at Module._compile (internal/modules/cjs/loader.js:1083)
```

Updated path allows built app to run normally.