### PR TITLE
Doc: Add libvips dependency for Apple Silicon build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 - Install node 16+ - https://nodejs.org/en/
   - [Enable yarn](https://yarnpkg.com/getting-started/install): `corepack enable`
-- macOS: Install Cocoapods - `brew install cocoapods`
+- macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon may require libvips - `brew install vips`.
 - Windows: Install Windows Build Tools - `yarn install -g windows-build-tools --vs2015`
 - Linux: Install dependencies - `sudo apt install build-essential libnss3 libsecret-1-dev python rsync`
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 - Install node 16+ - https://nodejs.org/en/
   - [Enable yarn](https://yarnpkg.com/getting-started/install): `corepack enable`
-- macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon may require libvips - `brew install vips`.
+- macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon [may require libvips](https://github.com/laurent22/joplin/pull/5966#issuecomment-1007158597) - `brew install vips`.
 - Windows: Install Windows Build Tools - `yarn install -g windows-build-tools --vs2015`
 - Linux: Install dependencies - `sudo apt install build-essential libnss3 libsecret-1-dev python rsync`
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Thanks to [this thread](https://discourse.joplinapp.org/t/unable-to-build-on-macos-apple-silicon/22624/4) for solving my issue. I figured this should be in the build instructions.