### PR TITLE
Server: Support for multi platform builds (initial refactor)

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -112,6 +112,14 @@ jobs:
           sudo apt-get update || true
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
+          # the next line enables multi-architecture support for docker, it basically makes it use qemu for non native platforms
+          # See https://hub.docker.com/r/tonistiigi/binfmt for more info
+          docker run --privileged --rm tonistiigi/binfmt --install all
+
+          # this just prints the info about what platforms are supported in the builder (can help debugging if something isn't working right)
+          # and also proves the above worked properly
+          sudo docker buildx ls
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2

--- a/packages/tools/.gitignore
+++ b/packages/tools/.gitignore
@@ -4,3 +4,6 @@ patreon_oauth_token.txt
 *.po~
 *.mo
 *.mo~
+
+/helpers.js
+/helpers.test.js

--- a/packages/tools/buildServerDocker.ts
+++ b/packages/tools/buildServerDocker.ts
@@ -1,5 +1,6 @@
 import { execCommand2, rootDir } from './tool-utils';
 import * as moment from 'moment';
+import { flatten, normalizePlatform } from './helpers';
 
 export function getVersionFromTag(tagName: string, isPreRelease: boolean): string {
 	if (tagName.indexOf('server-') !== 0) throw new Error(`Invalid tag: ${tagName}`);
@@ -15,44 +16,108 @@ export function getIsPreRelease(_tagName: string): boolean {
 	// return tagName.indexOf('-beta') > 0;
 }
 
+async function getRevision() {
+	try {
+		return await execCommand2('git rev-parse --short HEAD', { showStdout: false });
+	} catch (error) {
+		console.info('Could not get git commit: metadata revision field will be empty');
+		return '';
+	}
+}
+
+interface BuildMeta {
+	tagName: string;
+	isPreRelease: boolean;
+	buildDate: string;
+	imageVersion: string;
+	revision: string;
+}
+
+async function determineMeta(tagName: string): Promise<BuildMeta> {
+	const isPreRelease = getIsPreRelease(tagName);
+	const buildDate = moment(new Date().getTime()).format('YYYY-MM-DDTHH:mm:ssZ');
+	const imageVersion = getVersionFromTag(tagName, isPreRelease);
+	const revision = await getRevision();
+
+	return {
+		tagName,
+		isPreRelease,
+		buildDate,
+		imageVersion,
+		revision,
+	};
+}
+
+async function determineTags(meta: BuildMeta) {
+	const versionPart = meta.imageVersion.split('.');
+
+	const dockerTags: string[] = [];
+	dockerTags.push(meta.isPreRelease ? 'beta' : 'latest');
+	dockerTags.push(versionPart[0] + (meta.isPreRelease ? '-beta' : ''));
+	dockerTags.push(`${versionPart[0]}.${versionPart[1]}${meta.isPreRelease ? '-beta' : ''}`);
+	dockerTags.push(meta.imageVersion);
+
+	return dockerTags;
+}
+
 async function main() {
 	const argv = require('yargs').argv;
 	if (!argv.tagName) throw new Error('--tag-name not provided');
 
-	const pushImages = !!argv.pushImages;
-	const tagName = argv.tagName;
-	const isPreRelease = getIsPreRelease(tagName);
-	const imageVersion = getVersionFromTag(tagName, isPreRelease);
-	const buildDate = moment(new Date().getTime()).format('YYYY-MM-DDTHH:mm:ssZ');
-	let revision = '';
-	try {
-		revision = await execCommand2('git rev-parse --short HEAD', { showStdout: false });
-	} catch (error) {
-		console.info('Could not get git commit: metadata revision field will be empty');
-	}
-	const buildArgs = `--build-arg BUILD_DATE="${buildDate}" --build-arg REVISION="${revision}" --build-arg VERSION="${imageVersion}"`;
-	const dockerTags: string[] = [];
-	const versionPart = imageVersion.split('.');
-	dockerTags.push(isPreRelease ? 'beta' : 'latest');
-	dockerTags.push(versionPart[0] + (isPreRelease ? '-beta' : ''));
-	dockerTags.push(`${versionPart[0]}.${versionPart[1]}${isPreRelease ? '-beta' : ''}`);
-	dockerTags.push(imageVersion);
-
 	process.chdir(rootDir);
 	console.info(`Running from: ${process.cwd()}`);
 
-	console.info('tagName:', tagName);
+	const pushImages = !!argv.pushImages;
+
+	const meta = await determineMeta(argv.tagName);
+	const dockerTags = await determineTags(meta);
+
+	console.info('tagName:', meta.tagName);
 	console.info('pushImages:', pushImages);
-	console.info('imageVersion:', imageVersion);
-	console.info('isPreRelease:', isPreRelease);
+	console.info('imageVersion:', meta.imageVersion);
+	console.info('isPreRelease:', meta.isPreRelease);
 	console.info('Docker tags:', dockerTags.join(', '));
 
-	await execCommand2(`docker build --progress=plain -t "joplin/server:${imageVersion}" ${buildArgs} -f Dockerfile.server .`);
+	const info = await buildSinglePlatform('linux/amd64', {
+		buildArgs: {
+			BUILD_DATE: meta.buildDate,
+			REVISION: meta.revision,
+			VERSION: meta.imageVersion,
+		},
+		imageVersion: meta.imageVersion,
+	});
 
 	for (const tag of dockerTags) {
-		await execCommand2(`docker tag "joplin/server:${imageVersion}" "joplin/server:${tag}"`);
+		await execCommand2(['docker', 'tag', `joplin/server:${info.tag}`, `joplin/server:${tag}`]);
 		if (pushImages) await execCommand2(`docker push joplin/server:${tag}`);
 	}
+}
+
+interface BuildSinglePlatformOptions {
+	buildArgs: Record<string, string>;
+	imageVersion: string;
+}
+
+async function buildSinglePlatform(platform: string, options: BuildSinglePlatformOptions) {
+	const buildArgs = flatten(Object.keys(options.buildArgs).map((k) => ['--build-arg', `${k}=${options.buildArgs[k]}`]));
+	const normalizedPlatform = normalizePlatform(platform);
+	const tag = `${options.imageVersion}-${normalizedPlatform}`;
+
+	const command = [
+		'docker', 'build',
+		'--progress=plain',
+		'--platform', platform,
+		'-t', `joplin/server:${tag}`,
+		...buildArgs,
+		'-f', 'Dockerfile.server',
+		'.',
+	];
+
+	await execCommand2(command);
+
+	return {
+		tag,
+	};
 }
 
 if (require.main === module) {

--- a/packages/tools/helpers.test.ts
+++ b/packages/tools/helpers.test.ts
@@ -1,0 +1,20 @@
+import * as helpers from './helpers';
+
+describe('helpers', function() {
+
+	describe('flatten', function() {
+		test('should flatten 2d array', function() {
+			const input = [['1', '2'], ['3', '4'], ['5', 6], [null, undefined]];
+			const expected = ['1', '2', '3', '4', '5', 6, null, undefined];
+			const actual = helpers.flatten(input);
+			expect(actual).toEqual(expected);
+		});
+	});
+
+	describe('normalizePlatform', function() {
+		test('should replace slashes with dashes', function() {
+			expect(helpers.normalizePlatform('linux/amd64')).toEqual('linux-amd64');
+		});
+	});
+
+});

--- a/packages/tools/helpers.ts
+++ b/packages/tools/helpers.ts
@@ -1,0 +1,8 @@
+
+export function flatten<T>(array: (T | T[])[]): T[] {
+	return [].concat(...array);
+}
+
+export function normalizePlatform(platform: string) {
+	return platform.replace(/\//g, '-');
+}

--- a/packages/tools/tool-utils.ts
+++ b/packages/tools/tool-utils.ts
@@ -203,7 +203,7 @@ export async function execCommand2(command: string | string[], options: ExecComm
 	args.splice(0, 1);
 	const promise = execa(executableName, args);
 	if (options.showStdout) promise.stdout.pipe(process.stdout);
-	if (options.showStderr) promise.stdout.pipe(process.stderr);
+	if (options.showStderr) promise.stderr.pipe(process.stderr);
 	const result = await promise;
 	return result.stdout.trim();
 }


### PR DESCRIPTION
This brings back a bunch of the changes from my previous PR, this doesn't actually add ARM support YET, but it moves the code around a bit to make it easier to add that in. I plan to introduce this in a few layers just so entire large PRs don't need to get rolled back.

Previous PR: #5338

I brought back the somewhat contentious pattern of using a `Record<string,string>` to represent buildArgs (I think that's a way nicer way to specify that a string and it allows the more generic code to take care of formatting it all cleanly :) Feel free to object :)
