### PR TITLE
Use "files" key in plugin package.json template to restrict npm pack to only include publish folder

### DIFF
--- a/packages/generator-joplin/generators/app/templates/package_TEMPLATE.json
+++ b/packages/generator-joplin/generators/app/templates/package_TEMPLATE.json
@@ -10,6 +10,9 @@
   "keywords": [
     "joplin-plugin"
   ],
+  "files": [
+    "publish"
+  ],
   "devDependencies": {
     "@types/node": "^14.0.14",
     "chalk": "^4.1.0",


### PR DESCRIPTION
Using this field in package.json restricts `npm pack` and `npm publish` to only
include the publish directory and LICENSE, README.md and not the rest of
the extraneous files, which I believe is the desired (desire-able) behavior. 

Example of `npm pack` output on my plugin before this is patch is present:

```
❯ npm pack                                                                                                                          22:46:38
npm notice
npm notice 📦  joplin-plugin-auto-alarm@1.0.7-rc5
npm notice === Tarball Contents ===
npm notice 2.1kB   .config/joplin-plugin-helpers/.github/workflows/ci.yml
npm notice 1.3kB   .config/joplin-plugin-helpers/.pre-commit-config.yaml
npm notice 308B    .config/joplin-plugin-helpers/bin/symlink-helpers
npm notice 821B    .config/joplin-plugin-helpers/bin/tag-release
npm notice 204B    .config/joplin-plugin-helpers/Earthfile
npm notice 1.1kB   .config/joplin-plugin-helpers/LICENSE
npm notice 388B    .config/joplin-plugin-helpers/Makefile
npm notice 401B    .config/joplin-plugin-helpers/README.md
npm notice 3.0kB   .github/workflows/ci.yml
npm notice 149B    .gitmodules
npm notice 1.1kB   LICENSE
npm notice 1.7kB   README.md
npm notice 51.8kB  joplin-plugin-auto-alarm-1.0.7-rc5.tgz
npm notice 946B    package.json
npm notice 23B     plugin.config.json
npm notice 191.5kB publish/io.xargs.JoplinPluginAutoAlarm.jpl
npm notice 525B    publish/io.xargs.JoplinPluginAutoAlarm.json
npm notice === Tarball Details ===
npm notice name:          joplin-plugin-auto-alarm
npm notice version:       1.0.7-rc5
npm notice filename:      joplin-plugin-auto-alarm-1.0.7-rc5.tgz
npm notice package size:  107.6 kB
npm notice unpacked size: 257.3 kB
npm notice shasum:        f9e6ac461a2bf0d81883b11157dce9fc9f61a789
npm notice integrity:     sha512-pv21w/68WUWJq[...]/Lja+tGUJoDSw==
npm notice total files:   17
npm notice
joplin-plugin-auto-alarm-1.0.7-rc5.tgz
```

After:
```
❯ npm pack                                                                                                                          22:41:39
npm notice
npm notice 📦  joplin-plugin-auto-alarm@1.0.7-rc5
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 1.7kB   README.md
npm notice 978B    package.json
npm notice 191.5kB publish/io.xargs.JoplinPluginAutoAlarm.jpl
npm notice 523B    publish/io.xargs.JoplinPluginAutoAlarm.json
npm notice === Tarball Details ===
npm notice name:          joplin-plugin-auto-alarm
npm notice version:       1.0.7-rc5
npm notice filename:      joplin-plugin-auto-alarm-1.0.7-rc5.tgz
npm notice package size:  51.8 kB
npm notice unpacked size: 195.8 kB
npm notice shasum:        38b6f34f67019454788a73b024f19fb2564a7523
npm notice integrity:     sha512-+47Pv/W5fGJCo[...]3J7jf/Vkul+YA==
npm notice total files:   5
npm notice
joplin-plugin-auto-alarm-1.0.7-rc5.tgz
```

But before I applied this patch it included a number of files unrelated to the JPL plugin itself, that were only necessary to build it.



Similarly before and after for a mainline plugin which includes extra material:

```
❯ npm pack                                                                                                                          22:48:38
npm notice
npm notice 📦  joplin-plugin-templates@2.2.0
npm notice === Tarball Contents ===
npm notice 40B     .env.example
npm notice 26B     .eslintignore
npm notice 377B    .eslintrc
npm notice 967B    .github/workflows/ci.yml
npm notice 302B    .versionrc
npm notice 7.5kB   README.md
npm notice 381B    jest.config.js
npm notice 1.6kB   package.json
npm notice 23B     plugin.config.json
npm notice 668.2kB publish/joplin.plugin.templates.jpl
npm notice 551B    publish/joplin.plugin.templates.json
npm notice 2.8kB   scripts/announceRelease.js
npm notice 62B     tests/jest-setup.js
npm notice 780B    tests/mock-joplin-api.ts
npm notice 14.5kB  tests/parser.spec.ts
npm notice 1.7kB   tests/utils/dateAndTime.spec.ts
npm notice 10.5kB  tests/utils/templates.spec.ts
npm notice === Tarball Details ===
npm notice name:          joplin-plugin-templates
npm notice version:       2.2.0
npm notice filename:      joplin-plugin-templates-2.2.0.tgz
npm notice package size:  183.6 kB
npm notice unpacked size: 710.2 kB
npm notice shasum:        001f0ce8c6a4a86cc260c0be487f8c831e072447
npm notice integrity:     sha512-vGyRGnLbGPJ9F[...]LE5RWuUPnNfww==
npm notice total files:   17
npm notice
joplin-plugin-templates-2.2.0.tgz
```

After:
```
❯ npm pack                                                                                                                          22:50:22
npm notice
npm notice 📦  joplin-plugin-templates@2.2.0
npm notice === Tarball Contents ===
npm notice 7.5kB   README.md
npm notice 1.6kB   package.json
npm notice 668.2kB publish/joplin.plugin.templates.jpl
npm notice 551B    publish/joplin.plugin.templates.json
npm notice === Tarball Details ===
npm notice name:          joplin-plugin-templates
npm notice version:       2.2.0
npm notice filename:      joplin-plugin-templates-2.2.0.tgz
npm notice package size:  178.2 kB
npm notice unpacked size: 677.8 kB
npm notice shasum:        aa19aee64538aeef7be45f72b9a9b00208899794
npm notice integrity:     sha512-1+J4sdXWxE1nI[...]u6Qx5xad1+wzQ==
npm notice total files:   4
npm notice
joplin-plugin-templates-2.2.0.tgz
```

# Summary

Assuming the use of npm packages are meant for convenient distribution and automation of plugins via NPM using the publish directory. I believe the patch is the desired behavior to avoid shipping unrelated test, build and utility files.

Please consider including this in the package.json template.