### PR TITLE
Desktop: Resolves #5916: Fix Search Icon OverFlow

### DIFF
--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -15,6 +15,7 @@ export const Root = styled.div`
 	position: relative;
 	display: flex;
 	width: 100%;
+	min-width: 30px;
 `;
 
 interface Props {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:


Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

The search icon in the Desktop app is overflowing from the SearchBox as mentioned in #5916.

So, I added min-width to 30px, so the input box can't get smaller then 30px.



https://user-images.githubusercontent.com/71817691/148622196-7f7a477e-d2cd-4953-9c88-7c7df16108d9.mp4


