### PR TITLE
Docs: fixes #5975: update editorCommandDeclarations link

### DIFF
--- a/packages/lib/services/plugins/api/JoplinCommands.ts
+++ b/packages/lib/services/plugins/api/JoplinCommands.ts
@@ -17,7 +17,7 @@ import { Command } from './types';
  *
  * * [Main screen commands](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/gui/MainScreen/commands)
  * * [Global commands](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/commands)
- * * [Editor commands](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/gui/NoteEditor/commands/editorCommandDeclarations.ts)
+ * * [Editor commands](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts)
  *
  * To view what arguments are supported, you can open any of these files
  * and look at the `execute()` command.


### PR DESCRIPTION
Fixes #5975

The links were broken, looks like one changed the file location of `editorCommandDeclarations.ts` and forgot to update the js-docs.

No worries, I god this 💪 😃 