### PR TITLE
Remove unsupported AWS IAM policy statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ To add a **Bucket Policy** from the AWS S3 Web Console, navigate to the **Permis
         {
             "Sid": "VisualEditor0",
             "Effect": "Allow",
-            "Principal": "*",
             "Action": [
                   "s3:ListBucket",
                   "s3:GetBucketLocation",


### PR DESCRIPTION
Nowadays AWS does not support policy type IDENTITY_POLICY anymore, so policy provided in `README.md` can't be created as-is.

<img width="1237" alt="Screenshot 2022-01-08 at 21 49 59" src="https://user-images.githubusercontent.com/76095/148652558-f7c5aea0-9a91-4c61-8b91-8b2f919d5922.png">

So I'm proposing this change to make everyone's life easier :)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
