### PR TITLE
Desktop: Linux: Prevent Desktop Environments to launch a new window

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -219,7 +219,8 @@ then
 	Type=Application
 	Categories=Office;
 	MimeType=x-scheme-handler/joplin;
-	X-GNOME-SingleWindow=true
+	X-GNOME-SingleWindow=true // should be removed eventually as it was upstream to be an XDG specification
+	SingleMainWindow=true
 	EOF
     
     # Update application icons


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name
"SingleMainWindow" in
https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53.

This prevents Desktop Environments such as KDE and Gnome
to not display the menu item to open in a new window in apps that
don't support that.
