### PR TITLE
Desktop: Resolves #5915: Fix tag input overflow and white space in the bottom.

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.jsx
+++ b/packages/app-desktop/gui/PromptDialog.jsx
@@ -56,7 +56,7 @@ class PromptDialog extends React.Component {
 			top: 0,
 			left: 0,
 			width: width,
-			height: height - paddingTop,
+			height: height,
 			backgroundColor: 'rgba(0,0,0,0.6)',
 			display: visible ? 'flex' : 'none',
 			alignItems: 'flex-start',
@@ -109,6 +109,8 @@ class PromptDialog extends React.Component {
 			input: provided =>
 				Object.assign(provided, {
 					minWidth: '20px',
+					maxWidth: width * 0.45,
+					overflow: 'scroll',
 					color: theme.color,
 				}),
 			menu: provided =>

--- a/packages/app-desktop/gui/ToolbarButton/ToolbarButton.tsx
+++ b/packages/app-desktop/gui/ToolbarButton/ToolbarButton.tsx
@@ -46,6 +46,7 @@ export default function ToolbarButton(props: Props) {
 
 	return (
 		<StyledRoot
+			style={{ cursor: 'pointer' }}
 			className={classes.join(' ')}
 			disabled={!isEnabled}
 			title={tooltip}

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -256,6 +256,7 @@ function addExtraStyles(style: any) {
 
 	style.clickableTextStyle = Object.assign({}, style.textStyle, {
 		userSelect: 'none',
+		cursor: 'pointer',
 	});
 
 	style.textStyle2 = Object.assign({}, style.textStyle,


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
1. This Fixes the overflow problem in  #5915 . Added a max width so the input box can't grow more. Working is normal and large view, but not on when the window is less than 500px (No idea why), practically no one will use such small window.
2. Converted the cursor to pointer in the add tag button.
3. Fixed : ```height: height - paddingTop``` Due to this their was some white space left in the bottom of the Prompt Dialog Box.
![photo_2022-01-10 02 35 31](https://user-images.githubusercontent.com/71817691/148700967-49934324-c4d6-469b-a95d-8cb73836339c.jpeg)

### Tested on:
MacOS Monterey
Manjaro

<img width="1264" alt="Screenshot 2022-01-09 at 11 02 14 PM" src="https://user-images.githubusercontent.com/71817691/148700991-75737fb0-08b7-4d63-9f66-8d785febf138.png">
