### PR TITLE
Desktop: Fix issue #5953: search bar focus

### DIFF
--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -23,6 +23,7 @@ interface Props {
 	dispatch?: Function;
 	selectedNoteId: string;
 	isFocused?: boolean;
+	searches?: any[];
 }
 
 function SearchBar(props: Props) {
@@ -138,6 +139,20 @@ function SearchBar(props: Props) {
 		}
 	}, [props.notesParentType, onExitSearch]);
 
+
+	useEffect(() => {
+		if (props.notesParentType === 'Search' || props.isFocused) {
+			// console.warn("search bar just mounted but search active isFocused:",props.isFocused,"searches:",props.searches,'parentType:',props.notesParentType);
+			if (props.isFocused) {
+				props.dispatch({
+					type: 'FOCUS_CLEAR',
+					field: 'globalSearch',
+				});
+			}
+			void onExitSearch(true);
+		}
+	}, []);
+
 	return (
 		<Root className="search-bar">
 			<SearchInput
@@ -159,6 +174,7 @@ const mapStateToProps = (state: AppState) => {
 		notesParentType: state.notesParentType,
 		selectedNoteId: stateUtils.selectedNoteId(state),
 		isFocused: state.focusedField === 'globalSearch',
+		searches: state.searches,
 	};
 };
 

--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -138,7 +138,8 @@ function SearchBar(props: Props) {
 		}
 	}, [props.notesParentType, onExitSearch]);
 
-
+	// When the searchbar is remounted, exit the search if it was previously open
+	// or else other buttons stay hidden (e.g. when opening Layout Editor and closing it)
 	useEffect(() => {
 		if (props.notesParentType === 'Search' || props.isFocused) {
 			if (props.isFocused) {

--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -140,6 +140,7 @@ function SearchBar(props: Props) {
 
 	// When the searchbar is remounted, exit the search if it was previously open
 	// or else other buttons stay hidden (e.g. when opening Layout Editor and closing it)
+	// https://github.com/laurent22/joplin/issues/5953
 	useEffect(() => {
 		if (props.notesParentType === 'Search' || props.isFocused) {
 			if (props.isFocused) {

--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -23,7 +23,6 @@ interface Props {
 	dispatch?: Function;
 	selectedNoteId: string;
 	isFocused?: boolean;
-	searches?: any[];
 }
 
 function SearchBar(props: Props) {
@@ -142,7 +141,6 @@ function SearchBar(props: Props) {
 
 	useEffect(() => {
 		if (props.notesParentType === 'Search' || props.isFocused) {
-			// console.warn("search bar just mounted but search active isFocused:",props.isFocused,"searches:",props.searches,'parentType:',props.notesParentType);
 			if (props.isFocused) {
 				props.dispatch({
 					type: 'FOCUS_CLEAR',
@@ -174,7 +172,6 @@ const mapStateToProps = (state: AppState) => {
 		notesParentType: state.notesParentType,
 		selectedNoteId: stateUtils.selectedNoteId(state),
 		isFocused: state.focusedField === 'globalSearch',
-		searches: state.searches,
 	};
 };
 


### PR DESCRIPTION
# Fixes: [Desktop] Sort & new note/todo buttons do not reappear

 Resolves [#5953](https://github.com/laurent22/joplin/issues/5953)

> [Reported by atomlib on discord](https://discord.com/channels/610762468960239627/610762468960239629/927461889053712384):
> 
> > Typically when I place cursor inside the Search… field to type something, these buttons on the right disappear to make space for the input. After I remove input focus from the Search… field, they reappear again.
> 
> > However, if I go to View → Change application layout while I had input focus in the Search… field, the buttons do not reappear on focus being lost. They will appear only if I place the cursor inside the field and remove the focus from the input field.

### Problem

I found out that the searchBar gets remounted every time pages like layoutEditor or settings are loaded.

### Fix

I have added necessary hook to initialise the local state properly on remount.

## Demo (after fix): 

![joplin-pr1-demo](https://user-images.githubusercontent.com/44570278/148785404-eb7ad9e1-31e5-4a6a-9b1d-6699b087293a.gif)

