### PR TITLE
Desktop: Fix White space in the bottom of Add Tag Prompt

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.jsx
+++ b/packages/app-desktop/gui/PromptDialog.jsx
@@ -56,7 +56,7 @@ class PromptDialog extends React.Component {
 			top: 0,
 			left: 0,
 			width: width,
-			height: height - paddingTop,
+			height: height,
 			backgroundColor: 'rgba(0,0,0,0.6)',
 			display: visible ? 'flex' : 'none',
 			alignItems: 'flex-start',


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
When the Add Tag Prompt is open, some white space are left at the bottom due to ```height: height - paddingTop,```.
which  is used in root and cause the hight to become smaller than the original.

<img width="1194" alt="Screenshot 2022-01-10 at 11 09 47 PM" src="https://user-images.githubusercontent.com/71817691/148814299-4383381d-980b-4bd0-b75e-e53019d618f4.png">

After Removing:
<img width="1194" alt="Screenshot 2022-01-10 at 11 10 22 PM" src="https://user-images.githubusercontent.com/71817691/148814307-5c789ed1-f3b9-4cc1-8406-04b483653591.png">

