### PR TITLE
Server: Switch to docker buildkit, add docker cache mounts for yarn cache & small tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ packages/generator-joplin
 packages/plugin-repo-cli
 packages/server/db-*.sqlite
 packages/server/temp
+.yarn/cache

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Build Docker Image
         env:
           BUILD_SEQUENCIAL: 1
+          DOCKER_BUILDKIT: 1
         run: |
           yarn install
           yarn run buildServerDocker --tag-name server-v0.0.0

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -112,6 +112,13 @@ jobs:
           sudo apt-get update || true
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
+          # the next line installs the emulators for arm and arm64 so we can cross-compile for them on the default x64 CI instances
+          sudo docker run --privileged --rm tonistiigi/binfmt -install arm,arm64
+
+          # this just prints the info about what platforms are supported in the builder (can help debugging if something isn't working right)
+          # and also proves the above worked properly
+          sudo docker buildx ls
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
@@ -129,4 +136,3 @@ jobs:
         run: |
           yarn install
           yarn run buildServerDocker --tag-name server-v0.0.0
-          

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,8 +1,10 @@
-FROM node:16-bullseye
+# syntax=docker/dockerfile:1.3
 
+FROM node:16-bullseye
 RUN apt-get update \
     && apt-get install -y \
     python \
+    libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Enables Yarn
@@ -14,7 +16,10 @@ RUN echo "Yarn: $(yarn --version)"
 
 ARG user=joplin
 
-RUN useradd --create-home --shell /bin/bash $user
+# also force the user's UID (we need it layer for mounting the caches, they need a numeric uid)
+ARG uid=1001
+
+RUN useradd --create-home --shell /bin/bash --uid $uid $user
 USER $user
 
 ENV NODE_ENV production
@@ -33,7 +38,17 @@ COPY --chown=$user:$user .yarnrc.yml .
 COPY --chown=$user:$user yarn.lock .
 COPY --chown=$user:$user gulpfile.js .
 
-RUN yarn install --inline-builds --mode=skip-build
+# clean up yarn's output a bit, there is a lot of spam about not finding each package in cache, that's a bit silly
+ENV YARN_PREFER_AGGREGATE_CACHE_INFO=true
+
+# force all yarn coloring off for cleaner logs
+ENV FORCE_COLOR=0
+
+# see: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
+
+RUN --mount=type=cache,id=yarn-$TARGETPLATFORM,target=/tmp/yarn-cache,uid=$uid,sharing=locked YARN_CACHE_FOLDER=/tmp/yarn-cache \
+    yarn install --inline-builds --mode=skip-build
 
 # To take advantage of the Docker cache, we first copy all the package.json
 # and package-lock.json files, as they rarely change, and then bootstrap
@@ -64,7 +79,8 @@ COPY --chown=$user:$user packages/server/package*.json ./packages/server/
 
 # Then bootstrap only, without compiling the TypeScript files
 
-RUN yarn install --inline-builds --mode=skip-build
+RUN --mount=type=cache,id=yarn-$TARGETPLATFORM,target=/tmp/yarn-cache,uid=$uid,sharing=locked YARN_CACHE_FOLDER=/tmp/yarn-cache \
+    yarn install --inline-builds --mode=skip-build
 
 # Now copy the source files. Put lib and server last as they are more likely to change.
 
@@ -83,7 +99,12 @@ COPY --chown=$user:$user packages/server ./packages/server
 # packages (but because it's already done it should be fast), and then run the
 # postinstall scripts, as well as build scripts.
 
-RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds
+# Force some arguments to sqlite to use the system installed sqlite and avoid having to build the whole thing
+ENV npm_config_build_from_source=true
+ENV npm_config_sqlite=/usr
+
+RUN --mount=type=cache,id=yarn-$TARGETPLATFORM,target=/tmp/yarn-cache,uid=$uid,sharing=locked YARN_CACHE_FOLDER=/tmp/yarn-cache \
+    BUILD_SEQUENCIAL=1 yarn install --inline-builds
 
 ENV RUNNING_IN_DOCKER=1
 EXPOSE ${APP_PORT}


### PR DESCRIPTION
This does some minor changes

1. Use docker cache mounts to cache the yarn cache in-between build steps

this does two things:
 - one it removes the cache from the final image (save image size)
 - other is to actually help re-use the caches between build steps (again if the caches were being saved into the layer that would have already worked, so this doesn't do much, but it works in connection with the above)
 
2. Install a system library for libsqlite3 and ask the build to use it (this should be shaving a good chunk from the build)
3. Add a few envs to cleanup the build output
4. Install ARM emulators in CI (in prep for cross-platform builds for ARM)
5. And enable buildkit builds in CI so some of the more advanced features of the Dockerfile actually work :)

Related to #5967 