### PR TITLE
Clarify where to go to enable markdown plugins

### DIFF
--- a/readme/markdown.md
+++ b/readme/markdown.md
@@ -138,9 +138,9 @@ It is generally recommended to enter the notes as Markdown as it makes the notes
 
 ### Markdown Plugins
 
-Joplin supports a number of plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These plugins are listed below. Unlike regular plugins, markdown plugins must be enabled in the markdown section of the options screen. Note: not all of the plugins are enabled by default, if the enable field is 'no' below, then open the option screen to enable the plugin. Plugins can be disabled in the same manner.
+Joplin supports a number of plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These plugins are listed below. Unlike regular plugins, Markdown plugins must be enabled in the markdown section of the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/config_screen.md). Not all of the plugins are enabled by default, if the "enabled" field is 'no' below, then open the option screen to enable the plugin. Plugins can be disabled in the same manner.
 
-Note that the functionality added by these plugins is not part of the CommonMark spec so, while they will all work within Joplin, it is not guaranteed that they will work in other Markdown readers. Often this is not an issue but keep it in mind if you require compatibility with other Markdown applications.
+The functionality added by these plugins is not part of the CommonMark spec so, while they will all work within Joplin, it is not guaranteed that they will work in other Markdown readers. Often this is not an issue but keep it in mind if you require compatibility with other Markdown applications.
 
 | Plugin | Syntax | Description | Enabled | Screenshot |
 |--------|--------|-------------|---------|------------|

--- a/readme/markdown.md
+++ b/readme/markdown.md
@@ -138,7 +138,7 @@ It is generally recommended to enter the notes as Markdown as it makes the notes
 
 ### Markdown Plugins
 
-Joplin supports a number of markdown plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These markdown plugins are listed below. Note: not all of the markdown plugins are enabled by default, if the enable field is 'no' below, then open the option screen to enable the markdown plugin (`options/Markdown`, just below `options/Plugins`). Plugins can be disabled in the same manner.
+Joplin supports a number of plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These plugins are listed below. Unlike regular plugins, markdown plugins must be enabled in the markdown section of the options screen. Note: not all of the plugins are enabled by default, if the enable field is 'no' below, then open the option screen to enable the plugin. Plugins can be disabled in the same manner.
 
 Note that the functionality added by these plugins is not part of the CommonMark spec so, while they will all work within Joplin, it is not guaranteed that they will work in other Markdown readers. Often this is not an issue but keep it in mind if you require compatibility with other Markdown applications.
 

--- a/readme/markdown.md
+++ b/readme/markdown.md
@@ -136,9 +136,9 @@ It is generally recommended to enter the notes as Markdown as it makes the notes
 
 	This is <s>strikethrough text</s> mixed with regular **Markdown**.
 
-### Plugins
+### Markdown Plugins
 
-Joplin supports a number of plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These plugins are listed below. Note: not all of the plugins are enabled by default, if the enable field is 'no' below, then open the option screen to enable the plugin. Plugins can be disabled in the same manner.
+Joplin supports a number of markdown plugins that can be toggled on/off to enable/disable markdown features on top of the standard Markdown features you would expect. These markdown plugins are listed below. Note: not all of the markdown plugins are enabled by default, if the enable field is 'no' below, then open the option screen to enable the markdown plugin (`options/Markdown`, just below `options/Plugins`). Plugins can be disabled in the same manner.
 
 Note that the functionality added by these plugins is not part of the CommonMark spec so, while they will all work within Joplin, it is not guaranteed that they will work in other Markdown readers. Often this is not an issue but keep it in mind if you require compatibility with other Markdown applications.
 


### PR DESCRIPTION
A new user on his first day might lose 3 hours trying to enable, say, the Fountain plugin, after seeing it's actually *not* in the plugins list. What is called "plugins" here, are actually *markdown plugins*, completely different from the main type of plugins. To enable a markdown plugin, user should not search for it in the "plugins" section of the options, but go to the "markdown" section of the options, and just tick the right box.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
