### PR TITLE
Desktop: Fixes alt text not appearing in html

### DIFF
--- a/packages/app-cli/tests/md_to_html/image_with_alt_title.html
+++ b/packages/app-cli/tests/md_to_html/image_with_alt_title.html
@@ -1,0 +1,4 @@
+<img src=":/39e66095b2cd427e9f13464487514d2e" alt="">
+<img src=":/39e66095b2cd427e9f13464487514d2e" alt="" title="some-title">
+<img src=":/39e66095b2cd427e9f13464487514d2e" alt="some-alt-text">
+<img src=":/39e66095b2cd427e9f13464487514d2e" alt="some-alt-text" title="some-title">

--- a/packages/app-cli/tests/md_to_html/image_with_alt_title.md
+++ b/packages/app-cli/tests/md_to_html/image_with_alt_title.md
@@ -1,0 +1,4 @@
+![](:/39e66095b2cd427e9f13464487514d2e)
+![](:/39e66095b2cd427e9f13464487514d2e "some-title")
+![some-alt-text](:/39e66095b2cd427e9f13464487514d2e)
+![some-alt-text](:/39e66095b2cd427e9f13464487514d2e "some-title")

--- a/packages/renderer/MdToHtml/rules/image.ts
+++ b/packages/renderer/MdToHtml/rules/image.ts
@@ -11,9 +11,9 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 		const token = tokens[idx];
 		const src = utils.getAttr(token.attrs, 'src');
 		const title = utils.getAttr(token.attrs, 'title');
-		const alt = token.content;
 
 		if (!Resource.isResourceUrl(src) || ruleOptions.plainResourceRendering) return defaultRender(tokens, idx, options, env, self);
+
 		const r = utils.imageReplacement(ruleOptions.ResourceModel, src, ruleOptions.resources, ruleOptions.resourceBaseUrl, ruleOptions.itemIdToUrl);
 		if (typeof r === 'string') return r;
 		if (r) {
@@ -29,7 +29,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 
 				js = ` ontouchstart="${touchStart}" ontouchend="${cancel}" ontouchcancel="${cancel}" ontouchmove="${cancel}"`;
 			}
-			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title, alt: alt }))}${js}/>`;
+			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title, alt: token.content }))}${js}/>`;
 		}
 		return defaultRender(tokens, idx, options, env, self);
 	};

--- a/packages/renderer/MdToHtml/rules/image.ts
+++ b/packages/renderer/MdToHtml/rules/image.ts
@@ -11,9 +11,9 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 		const token = tokens[idx];
 		const src = utils.getAttr(token.attrs, 'src');
 		const title = utils.getAttr(token.attrs, 'title');
+		const alt = token.content;
 
 		if (!Resource.isResourceUrl(src) || ruleOptions.plainResourceRendering) return defaultRender(tokens, idx, options, env, self);
-
 		const r = utils.imageReplacement(ruleOptions.ResourceModel, src, ruleOptions.resources, ruleOptions.resourceBaseUrl, ruleOptions.itemIdToUrl);
 		if (typeof r === 'string') return r;
 		if (r) {
@@ -29,8 +29,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 
 				js = ` ontouchstart="${touchStart}" ontouchend="${cancel}" ontouchcancel="${cancel}" ontouchmove="${cancel}"`;
 			}
-
-			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title }))}${js}/>`;
+			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title, alt: alt }))}${js}/>`;
 		}
 		return defaultRender(tokens, idx, options, env, self);
 	};


### PR DESCRIPTION

- Desktop: Fixes #5803 : Added alt text in images' html

Fixes #5803 : After adding images in Joplin the HTML was not showing alt text. 

For testing I added an image with alt text as nature-image.jpg.
![added-alt-text2](https://user-images.githubusercontent.com/77744862/149631891-b4acd475-50bf-48d9-b07b-32293d8b009a.png)

 


