### PR TITLE
Desktop: Fix #5981: Scroll positions are not preserved when layout changes in v2.6.10

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -67,7 +67,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 
 	usePluginServiceRegistration(ref);
 
-	const { resetScroll, editor_scroll, setEditorPercentScroll, setViewerPercentScroll, editor_resize, getLineScrollPercent,
+	const { resetScroll, editor_scroll, setEditorPercentScroll, setViewerPercentScroll, editor_resize, editor_update, getLineScrollPercent,
 	} = useScrollHandler(editorRef, webviewRef, props.onScroll);
 
 	const codeMirror_change = useCallback((newBody: string) => {
@@ -843,6 +843,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 					onEditorPaste={onEditorPaste}
 					isSafeMode={props.isSafeMode}
 					onResize={editor_resize}
+					onUpdate={editor_update}
 				/>
 			</div>
 		);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx
@@ -94,6 +94,7 @@ export interface EditorProps {
 	onEditorPaste: any;
 	isSafeMode: boolean;
 	onResize: any;
+	onUpdate: any;
 }
 
 function Editor(props: EditorProps, ref: any) {
@@ -148,6 +149,14 @@ function Editor(props: EditorProps, ref: any) {
 		event.dataTransfer.dropEffect = 'copy';
 	}, []);
 
+	const editor_resize = useCallback((cm: any) => {
+		props.onResize(cm);
+	}, [props.onResize]);
+
+	const editor_update = useCallback((cm: any) => {
+		props.onUpdate(cm);
+	}, [props.onUpdate]);
+
 	useEffect(() => {
 		if (!editorParent.current) return () => {};
 
@@ -190,7 +199,8 @@ function Editor(props: EditorProps, ref: any) {
 		cm.on('paste', editor_paste);
 		cm.on('drop', editor_drop);
 		cm.on('dragover', editor_drag);
-		cm.on('refresh', props.onResize);
+		cm.on('refresh', editor_resize);
+		cm.on('update', editor_update);
 
 		// It's possible for searchMarkers to be available before the editor
 		// In these cases we set the markers asap so the user can see them as
@@ -204,7 +214,8 @@ function Editor(props: EditorProps, ref: any) {
 			cm.off('paste', editor_paste);
 			cm.off('drop', editor_drop);
 			cm.off('dragover', editor_drag);
-			cm.off('refresh', props.onResize);
+			cm.off('refresh', editor_resize);
+			cm.off('update', editor_update);
 			editorParent.current.removeChild(cm.getWrapperElement());
 			setEditor(null);
 		};

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -293,6 +293,8 @@
 			const restoreAndRefresh = () => {
 				scrollmap.refresh();
 				restorePercentScroll();
+				// To ensures Editor's scroll position is synced with Viewer's
+				ipcProxySendToHost('percentScroll', percentScroll_);
 			};
 			const now = Date.now();
 			if (now < restoreAndRefreshTimeout_) {


### PR DESCRIPTION
This PR  fixes the regression bug #5981 happens in v2.6.10.

To preserve Editor's scroll positions when the editor layout changes, the following are implemented:
- When heights of lines in CodeMirror are changed, Editor's scroll positions are restored.
- Uncertain scroll positions are ignored in Editor.
- When Viewer is resized, its scroll position is sent to Editor. (The reverse is not necessary.)

The details are described in #5981.