### PR TITLE
Desktop: Fix #5968: Default sort order lost on exit

### DIFF
--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
@@ -40,6 +40,7 @@ export default class PerFolderSortOrderService {
 		this.loadSharedSortOrder();
 		eventManager.appStateOn('notesParentType', this.onFolderSelectionMayChange.bind(this, 'notesParentType'));
 		eventManager.appStateOn('selectedFolderId', this.onFolderSelectionMayChange.bind(this, 'selectedFolderId'));
+		this.previousFolderId = Setting.value('activeFolderId');
 	}
 
 	public static isSet(folderId: string): boolean {


### PR DESCRIPTION
This fixes the bug #5968; When a notebook with its own sort order is selected and the app exits, the default (shared) sort order is lost at the next startup of the app.

The cause of the bug is that the initial notebook is not tracked. So, at the first time that notebook is switched, the cleanup of the last notebook is not performed.