### PR TITLE
Desktop: Resolves #5955: update note on notes change (i.e. via API)

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -67,6 +67,7 @@ function NoteEditor(props: NoteEditorProps) {
 
 	const { formNote, setFormNote, isNewNote, resourceInfos } = useFormNote({
 		syncStarted: props.syncStarted,
+		notes: props.notes,
 		noteId: props.noteId,
 		isProvisional: props.isProvisional,
 		titleInputRef: titleInputRef,


### PR DESCRIPTION
This is a proposal to fix #5955.
- I'm passing the `notes` to the `useFormNote` as it is updated when there is an update i.e. via API.
- In there I'm re-using the sync hook to also listen to the notes changes.
- Then I'm checking whether the note actually changed (body/title/ids/todo)
- I'm checking whether the current opened note is older than the loaded note
- Then updating the currently opened note with the note that was changed in the background

I tried testing several scenarios manually. But as I'd to remove the `prevSyncStarted` check (which made sure the code only ran after a sync was actually finished), I'd ask you to test the sync behaviour as well and don't just rely on me as I'm new to the code. Can you please let me know how to test merge/sync conflicts in Joplin? To see whether that's still working?

---
Side note: I also thought about an alternative implementation. And I've no preferences, to be honest. The alternative would go like this: instead, replicate the sync code but listen to something like apiStarted instead and add those states and events to the redux store as and under the rest/routes/notes.ts on PUT dispatch the started event and on finish dispatch the completed event. However, that requires a bigger change including the base store. So I did not go that route as it feels cleaner not to. Let me know what you prefer. Cheers 🥂 