### PR TITLE
Desktop: Resolves #6035: Fix global search causing text overwriting

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
@@ -8,6 +8,7 @@ export default function useEditorSearch(CodeMirror: any) {
 	const [scrollbarMarks, setScrollbarMarks] = useState(null);
 	const [previousKeywordValue, setPreviousKeywordValue] = useState(null);
 	const [previousIndex, setPreviousIndex] = useState(null);
+	const [previousSearchTimestamp, setPreviousSearchTimestamp] = useState(0);
 	const [overlayTimeout, setOverlayTimeout] = useState(null);
 	const overlayTimeoutRef = useRef(null);
 	overlayTimeoutRef.current = overlayTimeout;
@@ -90,7 +91,7 @@ export default function useEditorSearch(CodeMirror: any) {
 
 	CodeMirror.defineExtension('setMarkers', function(keywords: any, options: any) {
 		if (!options) {
-			options = { selectedIndex: 0 };
+			options = { selectedIndex: 0, searchTimestamp: 0 };
 		}
 
 		clearMarkers();
@@ -107,9 +108,7 @@ export default function useEditorSearch(CodeMirror: any) {
 			const searchTerm = getSearchTerm(keyword);
 
 			// We only want to scroll the first keyword into view in the case of a multi keyword search
-			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex ||
-				// If there is only one choice, scrollTo should be true. The below is a dummy of nMatches === 1.
-				options.selectedIndex === 0);
+			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex || options.searchTimestamp !== previousSearchTimestamp);
 
 			const match = highlightSearch(this, searchTerm, options.selectedIndex, scrollTo);
 			if (match) marks.push(match);
@@ -117,6 +116,7 @@ export default function useEditorSearch(CodeMirror: any) {
 
 		setMarkers(marks);
 		setPreviousIndex(options.selectedIndex);
+		setPreviousSearchTimestamp(options.searchTimestamp);
 
 		// SEARCHOVERLAY
 		// We only want to highlight all matches when there is only 1 search term


### PR DESCRIPTION
As briefly mentioned in a [comment in the report thread](https://github.com/laurent22/joplin/issues/6035#issuecomment-1016231963), this bug was the nasty combination of 2 changes. One which made the highlight also select, and the other which ensured that the scroll-to functionality would happen even for searches with a single result. The selection works perfectly fine, but when combined with a bug in the second change (the scroll-to became not discriminant enough and was called frequently) it caused this more visible bug. This is a fix for the frequent scroll/selection issue, the selection code is left unchanged.

The previous fix was to always jump if there's only a single result but this combined with the change to make searches selected meant that many users were accidentally deleting text when it was re-selected.
This commit fixes that problem by replacing the simple single-result-fix with one that observes the last search time to decide when to jump.

b98e64c can be restored after this change.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
