### PR TITLE
Desktop: Fixes #5947: Incorrect build instruction in documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,10 +18,9 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 ## Required dependencies
 
-- Install Node 16+ - https://nodejs.org/en/
-  - [Enable Yarn](https://yarnpkg.com/getting-started/install) (automatically enabled since Node 17+): `corepack enable`
+- Install Node 16+. On Windows, also install the build tools - https://nodejs.org/en/
+  - [Enable Yarn](https://yarnpkg.com/getting-started/install): `corepack enable`
 - macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon [may require libvips](https://github.com/laurent22/joplin/pull/5966#issuecomment-1007158597) - `brew install vips`.
-- Windows: Install Windows Build Tools (optional since Node 16.13.1) - `yarn global add windows-build-tools --vs2015`
 - Linux: Install dependencies - `sudo apt install build-essential libnss3 libsecret-1-dev python rsync`
 
 ## Building

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,10 +18,10 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 ## Required dependencies
 
-- Install node 16+ - https://nodejs.org/en/
-  - [Enable yarn](https://yarnpkg.com/getting-started/install): `corepack enable`
+- Install Node 16+ - https://nodejs.org/en/
+  - [Enable Yarn](https://yarnpkg.com/getting-started/install) (automatically enabled since Node 17+): `corepack enable`
 - macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon [may require libvips](https://github.com/laurent22/joplin/pull/5966#issuecomment-1007158597) - `brew install vips`.
-- Windows: Install Windows Build Tools - `yarn install -g windows-build-tools --vs2015`
+- Windows: Install Windows Build Tools (optional since Node 16.13.1) - `yarn global add windows-build-tools --vs2015`
 - Linux: Install dependencies - `sudo apt install build-essential libnss3 libsecret-1-dev python rsync`
 
 ## Building


### PR DESCRIPTION
Updated command and pre-requisite for installing Windows Build Tools.
`windows-build-tools` is now deprecated since Node 16: ["Please note that the official Node.js for Windows installer can now automatically install the required tools."](https://github.com/felixrieseberg/windows-build-tools#readme)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
