### PR TITLE
Docs: Add rich text editor limitation - lists within tables

### DIFF
--- a/readme/rich_text_editor.md
+++ b/readme/rich_text_editor.md
@@ -14,7 +14,7 @@ However **there is a catch**: in Joplin, notes, even when edited with this Rich 
 
 - Tables must have a header, because this is a requirement in Markdown. When you create a table, it will let you create it without a header, but under the hood it will add an empty one. And next time you open the note, this empty header will be present.
 
-- List items (bullet points, numbered lists & checkboxes) within table cells can be created but will not be saved correctly; lists within tables are not currently part of any Markdown specifications supported by Joplin.
+- List items (bullet points, numbered lists & checkboxes) within table cells can be created but will not be saved correctly; lists within tables are not currently part of any Markdown specification.
 
 - All items in a list must be of the same type, so for example all checkboxes, or all bullet points. If you require two different types, you should create two different lists separated by a horizontal rule or similar.
 

--- a/readme/rich_text_editor.md
+++ b/readme/rich_text_editor.md
@@ -14,6 +14,8 @@ However **there is a catch**: in Joplin, notes, even when edited with this Rich 
 
 - Tables must have a header, because this is a requirement in Markdown. When you create a table, it will let you create it without a header, but under the hood it will add an empty one. And next time you open the note, this empty header will be present.
 
+- List items (bullet points, numbered lists & checkboxes) within table cells can be created but will not be saved correctly; lists within tables are not currently part of any Markdown specifications supported by Joplin.
+
 - All items in a list must be of the same type, so for example all checkboxes, or all bullet points. If you require two different types, you should create two different lists separated by a horizontal rule or similar.
 
 - Special keyboard modes "vim" and "emacs" are not supported.


### PR DESCRIPTION
Based on fairly frequently asked questions and topics (linked) - proposing addition of a section saying that Markdown does not support lists within tables even though the rich text editor allows them to be created.

https://github.com/laurent22/joplin/issues/6071
https://github.com/laurent22/joplin/issues/6056
https://github.com/laurent22/joplin/issues/5575
https://discourse.joplinapp.org/t/feature-request-checkboxes-inside-a-table/23289
https://discourse.joplinapp.org/t/lists-within-a-table-list-shortcut/21859