### PR TITLE
Desktop: Fixes #5534 and #6054: Copy/Pasted URLs are Pasted in Plain Text [WYSIWYG editor]

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -24,6 +24,7 @@ import { MarkupToHtmlOptions } from '../../utils/useMarkupToHtml';
 import { themeStyle } from '@joplin/lib/theme';
 import { loadScript } from '../../../utils/loadScript';
 import bridge from '../../../../services/bridge';
+import isUrl = require('is-url');
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 
@@ -998,8 +999,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				editor.insertContent(result.html);
 			} else {
 				const pastedText = event.clipboardData.getData('text/plain');
-
-				if (BaseItem.isMarkdownTag(pastedText)) { // Paste a link to a note
+				if (BaseItem.isMarkdownTag(pastedText) || isUrl(pastedText)) { // Paste a link to a note
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);
 				} else { // Paste regular text

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -107,6 +107,7 @@
   "devDependencies": {
     "@joplin/tools": "~2.7",
     "@testing-library/react-hooks": "^3.4.2",
+    "@types/is-url": "^1.2.30",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.6",
     "@types/react": "16.9.55",
@@ -150,6 +151,7 @@
     "fs-extra": "10.0.0",
     "highlight.js": "^10.2.1",
     "immer": "^7.0.5",
+    "is-url": "^1.2.4",
     "keytar": "^7.0.0",
     "mark.js": "^8.11.1",
     "md5": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,6 +2900,7 @@ __metadata:
     "@joplin/renderer": ~2.7
     "@joplin/tools": ~2.7
     "@testing-library/react-hooks": ^3.4.2
+    "@types/is-url": ^1.2.30
     "@types/jest": ^26.0.15
     "@types/node": ^14.14.6
     "@types/react": 16.9.55
@@ -2926,6 +2927,7 @@ __metadata:
     gulp: ^4.0.2
     highlight.js: ^10.2.1
     immer: ^7.0.5
+    is-url: ^1.2.4
     jest: ^26.6.3
     js-sha512: ^0.8.0
     keytar: ^7.0.0
@@ -5332,6 +5334,13 @@ __metadata:
   version: 1.8.1
   resolution: "@types/http-errors@npm:1.8.1"
   checksum: f0710ea284a7eb5584c5e324b1dc810bc971e1adc94deff63a0c434a8a75adc020487e3e6d511cd82cef101bbcf090b8f56995c143d123e0c374dc0f61be3a61
+  languageName: node
+  linkType: hard
+
+"@types/is-url@npm:^1.2.30":
+  version: 1.2.30
+  resolution: "@types/is-url@npm:1.2.30"
+  checksum: 81f337a7442f56d160ec0f63b2847cff368c5701f46a32c3c4fff5a1424b6afb4ad3eb7206febd26760a869680d61b7626e41f0ad652003f5783bcfda5b41d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pasting URLs in the WYSIWYG editor now pastes them as links.
Fixes #5534 and #6054.