### PR TITLE
All: Add Additional Time Format

### DIFF
--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -217,6 +217,7 @@ class Setting extends BaseModel {
 
 	public static TIME_FORMAT_1 = 'HH:mm';
 	public static TIME_FORMAT_2 = 'h:mm A';
+	public static TIME_FORMAT_3 = 'HH.mm';
 
 	public static SHOULD_REENCRYPT_NO = 0; // Data doesn't need to be re-encrypted
 	public static SHOULD_REENCRYPT_YES = 1; // Data should be re-encrypted
@@ -741,6 +742,7 @@ class Setting extends BaseModel {
 					const now = new Date('2017-01-30T20:30:00').getTime();
 					options[Setting.TIME_FORMAT_1] = time.formatMsToLocal(now, Setting.TIME_FORMAT_1);
 					options[Setting.TIME_FORMAT_2] = time.formatMsToLocal(now, Setting.TIME_FORMAT_2);
+					options[Setting.TIME_FORMAT_3] = time.formatMsToLocal(now, Setting.TIME_FORMAT_3);
 					return options;
 				},
 				storage: SettingStorage.File,

--- a/packages/lib/models/dateTimeFormats.test.ts
+++ b/packages/lib/models/dateTimeFormats.test.ts
@@ -39,10 +39,11 @@ describe('dateFormats', function() {
 
 		// TIME_FORMAT_1 = 'HH:mm';
 		// TIME_FORMAT_2 = 'h:mm A';
+		// TIME_FORMAT_3 = 'HH.mm';
 
 		expect(time.formatMsToLocal(now, Setting.TIME_FORMAT_1)).toBe('20:30');
 		expect(time.formatMsToLocal(now, Setting.TIME_FORMAT_2)).toBe('8:30 PM');
-
+		expect(time.formatMsToLocal(now, Setting.TIME_FORMAT_3)).toBe('20.30');
 	}));
 
 });


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

I would like to add an additional time format in the settings. This format is the format also used by Dropbox when I scan documents so I can have one date formatting for all my documents. 
