### PR TITLE
Server: Load environment values from files for Docker Secrets/Configs

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -102,7 +102,7 @@ async function main() {
 
 	if (!defaultEnvVariables[env]) throw new Error(`Invalid env: ${env}`);
 
-	const envVariables = parseEnv(process.env, defaultEnvVariables[env]);
+	const envVariables = await parseEnv(process.env, defaultEnvVariables[env]);
 
 	const app = new Koa();
 

--- a/packages/server/src/utils/testing/testUtils.ts
+++ b/packages/server/src/utils/testing/testUtils.ts
@@ -80,7 +80,7 @@ export async function beforeAllDb(unitName: string, createDbOptions: CreateDbOpt
 	// sudo docker compose -f docker-compose.db-dev.yml up
 
 	if (process.env.JOPLIN_TESTS_SERVER_DB === 'pg') {
-		await initConfig(Env.Dev, parseEnv({
+		await initConfig(Env.Dev, await parseEnv({
 			DB_CLIENT: 'pg',
 			POSTGRES_DATABASE: unitName,
 			POSTGRES_USER: 'joplin',
@@ -90,7 +90,7 @@ export async function beforeAllDb(unitName: string, createDbOptions: CreateDbOpt
 			tempDir: tempDir,
 		});
 	} else {
-		await initConfig(Env.Dev, parseEnv({
+		await initConfig(Env.Dev, await parseEnv({
 			SQLITE_DATABASE: createdDbPath_,
 			SUPPORT_EMAIL: 'testing@localhost',
 		}), {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
This PR adds support for loading environment settings from paths. This allows native integration of [Docker Secrets](https://docs.docker.com/engine/swarm/secrets/) or [Docker Configs](https://docs.docker.com/engine/swarm/configs/), which allows keeping sensitive data outside of a Compose file or script.

Please let me know if you need any changes! 🙂 