### PR TITLE
Server: Resolves #6096: Use apt to install tini to fix/enable multi-platform support

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -6,12 +6,8 @@ FROM node:16-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y \
-    python \
+    python tini \
     && rm -rf /var/lib/apt/lists/*
-
-# Download the init tool Tini and make it executable for use in the final image
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
-RUN chmod u+x /tini
 
 # Enables Yarn
 RUN corepack enable
@@ -63,7 +59,7 @@ RUN useradd --create-home --shell /bin/bash $user
 USER $user
 
 COPY --chown=$user:$user --from=builder /build/packages /home/$user/packages
-COPY --chown=$user:$user --from=builder /tini /usr/local/bin/tini
+COPY --chown=$user:$user --from=builder /usr/bin/tini /usr/local/bin/tini
 
 ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/6096

The way tini was being installed broke multi-platform (amd64, armv7, arm64) support.

```bash
# Download the init tool Tini and make it executable for use in the final image
ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
```

This is a hard reference to the amd64 version of tini, which isn't compatible with armv7 and arm64. Tini has builds for other platforms though... The easiest way to fix this is to simply use the apt package manager to install tini as that will result in retrieval of the correct binary.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
