### PR TITLE
Server: Remove node user and install gosu

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -9,10 +9,6 @@ RUN apt-get update \
     python \
     && rm -rf /var/lib/apt/lists/*
 
-# Download the init tool Tini and make it executable for use in the final image
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
-RUN chmod u+x /tini
-
 # Enables Yarn
 RUN corepack enable
 
@@ -57,13 +53,21 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 
 FROM node:16-bullseye-slim
 
+RUN apt-get update \
+    && apt-get install -y \
+    gosu tini \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG user=joplin
 RUN useradd --create-home --shell /bin/bash $user
-
-USER $user
+RUN userdel -r node
 
 COPY --chown=$user:$user --from=builder /build/packages /home/$user/packages
-COPY --chown=$user:$user --from=builder /tini /usr/local/bin/tini
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN sed "s/USER/$user/g" -i /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+RUN gosu $user:$user mkdir -p /home/$user/data
 
 ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -79,7 +79,7 @@ VOLUME /home/$user/data
 # Use Tini to start Joplin Server:
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
 WORKDIR /home/$user/packages/server
-ENTRYPOINT ["tini", "--"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["node", "dist/app.js"]
 
 # Build-time metadata

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -69,6 +69,9 @@ ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1
 EXPOSE ${APP_PORT}
 
+# Volume
+VOLUME /home/$user/data
+
 # Use Tini to start Joplin Server:
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
 WORKDIR /home/$user/packages/server

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -64,7 +64,7 @@ RUN userdel -r node
 
 COPY --chown=$user:$user --from=builder /build/packages /home/$user/packages
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN sed "s/joplinUSER/$user/g" -i /usr/local/bin/entrypoint.sh
+RUN sed "s/joplinUSER/$user/g; s/1002/$(id -u $user)/g" -i /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENV NODE_ENV=production

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -67,8 +67,6 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN sed "s/USER/$user/g" -i /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN gosu $user:$user mkdir -p /home/$user/data
-
 ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1
 EXPOSE ${APP_PORT}

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -73,9 +73,6 @@ ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1
 EXPOSE ${APP_PORT}
 
-# Volume
-VOLUME /home/$user/data
-
 # Use Tini to start Joplin Server:
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
 WORKDIR /home/$user/packages/server

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -64,7 +64,7 @@ RUN userdel -r node
 
 COPY --chown=$user:$user --from=builder /build/packages /home/$user/packages
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN sed "s/USER/$user/g" -i /usr/local/bin/entrypoint.sh
+RUN sed "s/joplinUSER/$user/g" -i /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENV NODE_ENV=production

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,11 @@ if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
 	Current_id=$(id -u)
 	Current_group_id=$(id -g)
 	if [ "$USER_UID" != "$Current_id" ]; then
-		groupmod -o -g "$USER_UID" openldap
+		groupmod -o -g "$USER_UID" joplin
 		echo 'user uid is changed'
 	fi
 	if [ "$USER_UID" != "$Current_group_id" ]; then
-		groupmod -o -g "$USER_UID" openldap
+		groupmod -o -g "$USER_UID" joplin
 		echo 'user gid is changed'
 	fi
 	find $Path \! -user USER -exec chown USER '{}' +

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,11 @@ if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
 	Current_id=$(id -u)
 	Current_group_id=$(id -g)
 	if [ "$USER_UID" != "$Current_id" ]; then
-		groupmod -o -g "$USER_UID" joplin
+		groupmod -o -g "$USER_UID" USER
 		echo 'user uid is changed'
 	fi
 	if [ "$USER_UID" != "$Current_group_id" ]; then
-		groupmod -o -g "$USER_UID" joplin
+		groupmod -o -g "$USER_UID" USER
 		echo 'user gid is changed'
 	fi
 	find $Path \! -user USER -exec chown USER '{}' +

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,18 @@
 set -Eeo pipefail
 
 if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
+	USER_UID=${USER_UID:-1002}
+	USER_GID=${USER_GID:-1002}
+	Current_id=$(id -u)
+	Current_group_id=$(id -g)
+	if [ "$USER_UID" != "$Current_id" ]; then
+		groupmod -o -g "$USER_UID" openldap
+		echo 'user uid is changed'
+	fi
+	if [ "$USER_UID" != "$Current_group_id" ]; then
+		groupmod -o -g "$USER_UID" openldap
+		echo 'user gid is changed'
+	fi
 	find $Path \! -user USER -exec chown USER '{}' +
 	exec /usr/bin/tini -- /usr/sbin/gosu USER:USER "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
+	find $Path \! -user USER -exec chown USER '{}' +
+	exec /usr/bin/tini -- /usr/sbin/gosu USER:USER "$@"
+fi
+
+if [[ "$*" == node*dist/app.js* ]]; then
+	set -- /usr/bin/tini -- "$@"
+fi
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,15 +7,15 @@ if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
 	Current_id=$(id -u)
 	Current_group_id=$(id -g)
 	if [ "$USER_UID" != "$Current_id" ]; then
-		groupmod -o -g "$USER_UID" joplinUSER
+		usermod -o -u "$USER_UID" joplinUSER
 		echo 'user uid is changed'
 	fi
 	if [ "$USER_UID" != "$Current_group_id" ]; then
 		groupmod -o -g "$USER_UID" joplinUSER
 		echo 'user gid is changed'
 	fi
-	find $Path \! -user USER -exec chown joplinUSER '{}' +
-	exec /usr/bin/tini -- /usr/sbin/gosu joplinUSER:joplinyUSER "$@"
+	find $Path \! -user joplinUSER -exec chown joplinUSER '{}' +
+	exec /usr/bin/tini -- /usr/sbin/gosu joplinUSER:joplinUSER "$@"
 fi
 
 if [[ "$*" == node*dist/app.js* ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,15 +7,15 @@ if [[ "$*" == node*dist/app.js* ]] && [ "$(id -u)" = '0' ]; then
 	Current_id=$(id -u)
 	Current_group_id=$(id -g)
 	if [ "$USER_UID" != "$Current_id" ]; then
-		groupmod -o -g "$USER_UID" USER
+		groupmod -o -g "$USER_UID" joplinUSER
 		echo 'user uid is changed'
 	fi
 	if [ "$USER_UID" != "$Current_group_id" ]; then
-		groupmod -o -g "$USER_UID" USER
+		groupmod -o -g "$USER_UID" joplinUSER
 		echo 'user gid is changed'
 	fi
-	find $Path \! -user USER -exec chown USER '{}' +
-	exec /usr/bin/tini -- /usr/sbin/gosu USER:USER "$@"
+	find $Path \! -user USER -exec chown joplinUSER '{}' +
+	exec /usr/bin/tini -- /usr/sbin/gosu joplinUSER:joplinyUSER "$@"
 fi
 
 if [[ "$*" == node*dist/app.js* ]]; then


### PR DESCRIPTION
Setting up storage using binding volume had error for permission denied because the joplin user is noraml user.
This request removes node user, and add entrypoint script to read environment value which is `USER_UID` and ` USER_GID ` and change the user ` joplin` uid/gid.  The script can read [the page](https://github.com/laurent22/joplin/tree/dev/packages/server#setting-up-storage-on-a-new-installation) setting value `Path`, and change the binding volume owner.

If using the joplin/server:latest contianer and binding volume, it could show this error.
![擷取](https://user-images.githubusercontent.com/55025025/154672761-c89a0d11-bf85-428e-9051-f2cb3de5c190.PNG)
I used it in docker compose, and setting volume.
`        volumes:            
            - ./joplin-data:/home/joplin/data
`