### PR TITLE
Desktop: Fixes #6108: add additional export menu item

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -3,7 +3,7 @@ import { PluginMessage } from './services/plugins/PluginRunner';
 import shim from '@joplin/lib/shim';
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 
-const { BrowserWindow, Tray, screen } = require('electron');
+const { BrowserWindow, Tray, screen, globalShortcut } = require('electron');
 const url = require('url');
 const path = require('path');
 const { dirname } = require('@joplin/lib/path-utils');
@@ -347,6 +347,15 @@ export default class ElectronAppWrapper {
 		return false;
 	}
 
+	toggleWindowVisilibity() {
+		if (this.win_.isVisible()) {
+			this.win_.hide();
+		} else {
+			this.win_.setVisibleOnAllWorkspaces(true);
+			this.win_.show();
+		}
+	}
+
 	async start() {
 		// Since we are doing other async things before creating the window, we might miss
 		// the "ready" event. So we use the function below to make sure that the app is ready.
@@ -357,8 +366,17 @@ export default class ElectronAppWrapper {
 
 		this.createWindow();
 
+		const registerGlobalShortcut = globalShortcut.register('CommandOrControl+Alt+J', () => {
+			this.toggleWindowVisilibity();
+		});
+
+		if (!registerGlobalShortcut) {
+			console.warn('Could not register global shortcut');
+		}
+
 		this.electronApp_.on('before-quit', () => {
 			this.willQuitApp_ = true;
+			globalShortcut.unregisterAll();
 		});
 
 		this.electronApp_.on('window-all-closed', () => {

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -448,19 +448,16 @@ class Application extends BaseApplication {
 
 		// Note: Auto-update is a misnomer in the code.
 		// The code below only checks, if a new version is available.
-		// We only allow Windows and macOS users to automatically check for updates
-		if (shim.isWindows() || shim.isMac()) {
-			const runAutoUpdateCheck = () => {
-				if (Setting.value('autoUpdateEnabled')) {
-					void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
-				}
-			};
+		const runAutoUpdateCheck = () => {
+			if (Setting.value('autoUpdateEnabled')) {
+				void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+			}
+		};
 
-			// Initial check on startup
-			shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
-			// Then every x hours
-			shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
-		}
+		// Initial check on startup
+		shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
+		// Then every x hours
+		shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
 
 		this.updateTray();
 

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -347,6 +347,11 @@ function useMenu(props: Props) {
 				}
 			}
 
+			importItems.push({
+				label: _('Other applications...'),
+				click: () => { void bridge().openExternal('https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425'); },
+			});
+
 			exportItems.push(
 				menuItemDic.exportPdf
 			);

--- a/packages/lib/import-enex.ts
+++ b/packages/lib/import-enex.ts
@@ -625,8 +625,7 @@ export default async function importEnex(parentFolderId: string, filePath: strin
 				if (noteResource.filename) {
 					const mimeTypeFromFile = mime.fromFilename(noteResource.filename);
 					if (mimeTypeFromFile && mimeTypeFromFile !== mimeType) {
-						// Don't print statement by default because it would show up in test units
-						// console.info(`Invalid mime type "${mimeType}" for resource "${noteResource.filename}". Using "${mimeTypeFromFile}" instead.`);
+						console.info(`Invalid mime type "${mimeType}" for resource "${noteResource.filename}". Using "${mimeTypeFromFile}" instead.`);
 						mimeType = mimeTypeFromFile;
 					}
 				}

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1192,7 +1192,7 @@ class Setting extends BaseModel {
 			},
 
 
-			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: platform !== 'linux', appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
+			autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
 			'autoUpdate.includePreReleases': { value: false, type: SettingItemType.Bool, section: 'application', storage: SettingStorage.File, public: true, appTypes: [AppType.Desktop], label: () => _('Get pre-releases when checking for updates'), description: () => _('See the pre-release page for more details: %s', 'https://joplinapp.org/prereleases') },
 			'clipperServer.autoStart': { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, public: false },
 			'sync.interval': {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1271,6 +1271,7 @@ class Setting extends BaseModel {
 				label: () => 'Enable spell checking in Markdown editor? (WARNING BETA feature)',
 				description: () => 'Spell checker in the Markdown editor was previously unstable (cursor location was not stable, sometimes edits would not be saved or reflected in the viewer, etc.) however it appears to be more reliable now. If you notice any issue, please report it on GitHub or the Joplin Forum (Help -> Joplin Forum)',
 			},
+			'image.noresizing': { value: false, type: Setting.TYPE_BOOL, advanced: true, public: true, label: () => _('Do not resize images') },
 
 			'net.customCertificates': {
 				value: '',

--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -137,6 +137,7 @@ export function toFileProtocolPath(filePathEncode: string, os: string = null) {
 
 	filePathEncode = encodeURI(filePathEncode);
 	filePathEncode = filePathEncode.replace(/\+/g, '%2B'); // escape '+' with unicode
+	filePathEncode = filePathEncode.replace(/%20/g, '+'); // switch space (%20) with '+'. To comply with syntax used by joplin, see urldecode_(str) in MdToHtml.js
 	return `file://${filePathEncode.replace(/\'/g, '%27')}`; // escape '(single quote) with unicode, to prevent crashing the html view
 }
 

--- a/packages/lib/pathUtils.test.js
+++ b/packages/lib/pathUtils.test.js
@@ -69,14 +69,14 @@ describe('pathUtils', function() {
 
 	it('should create correct fileURL syntax', (async () => {
 		const testCases_win32 = [
-			['C:\\handle\\space test', 'file:///C:/handle/space%20test'],
+			['C:\\handle\\space test', 'file:///C:/handle/space+test'],
 			['C:\\escapeplus\\+', 'file:///C:/escapeplus/%2B'],
-			['C:\\handle\\single quote\'', 'file:///C:/handle/single%20quote%27'],
+			['C:\\handle\\single quote\'', 'file:///C:/handle/single+quote%27'],
 		];
 		const testCases_unixlike = [
-			['/handle/space test', 'file:///handle/space%20test'],
+			['/handle/space test', 'file:///handle/space+test'],
 			['/escapeplus/+', 'file:///escapeplus/%2B'],
-			['/handle/single quote\'', 'file:///handle/single%20quote%27'],
+			['/handle/single quote\'', 'file:///handle/single+quote%27'],
 		];
 
 		for (let i = 0; i < testCases_win32.length; i++) {

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -10,6 +10,7 @@ const mimeUtils = require('./mime-utils.js').mime;
 const Note = require('./models/Note').default;
 const Resource = require('./models/Resource').default;
 const urlValidator = require('valid-url');
+const Setting = require('./models/Setting').default;
 const { _ } = require('./locale');
 const http = require('http');
 const https = require('https');
@@ -261,7 +262,7 @@ function shimInit(options = null) {
 
 		const targetPath = Resource.fullPath(resource);
 
-		if (options.resizeLargeImages !== 'never' && ['image/jpeg', 'image/jpg', 'image/png'].includes(resource.mime)) {
+		if (options.resizeLargeImages !== 'never' && ['image/jpeg', 'image/jpg', 'image/png'].includes(resource.mime) && !Setting.value('image.noresizing')) {
 			const ok = await handleResizeImage_(filePath, targetPath, resource.mime, options.resizeLargeImages);
 			if (!ok) return null;
 		} else {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -3,5 +3,10 @@
   "version": "0.0.0",
   "description": "Sub-package to group official Joplin plugins",
   "private": true,
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
   "license": "MIT"
 }


### PR DESCRIPTION
fixes #6108 

We already have `Import` as a menu item. We also don't say in the sub menu: `Import JEX`, `Import MD`, etc.
So we should use the following instead: `From other applications...` or `Other applications...` (because `from` is implied by the word `import` (as is `to` by `export`)).

But I can change the menu item name, if necessary.

`Importing from ....` is only necessary if we put this item under help. It makes less sense when having a submenuitem under `Import >`.