### PR TITLE
Desktop: Fixes #6108: add additional export menu item

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -347,6 +347,11 @@ function useMenu(props: Props) {
 				}
 			}
 
+			importItems.push({
+				label: _('Other applications...'),
+				click: () => { void bridge().openExternal('https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425'); },
+			});
+
 			exportItems.push(
 				menuItemDic.exportPdf
 			);

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -347,6 +347,7 @@ function useMenu(props: Props) {
 				}
 			}
 
+			importItems.push({ type: 'separator' });
 			importItems.push({
 				label: _('Other applications...'),
 				click: () => { void bridge().openExternal('https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425'); },


### PR DESCRIPTION
fixes #6108 

We already have `Import` as a menu item. We also don't say in the sub menu: `Import JEX`, `Import MD`, etc.
So we should use the following instead: `From other applications...` or `Other applications...` (because `from` is implied by the word `import` (as is `to` by `export`)).

But I can change the menu item name, if necessary.

`Importing from ....` is only necessary if we put this item under help. It makes less sense when having a submenuitem under `Import >`.