### PR TITLE
Desktop: Resolves #6100: Implement context menu for mermaid graphs

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -35,6 +35,9 @@ export default function useMessageHandler(scrollWhenReady: any, setScrollWhenRea
 			const menu = await contextMenu({
 				itemType: arg0 && arg0.type,
 				resourceId: arg0.resourceId,
+				resourceFilename: arg0.resourceFilename,
+				resourceURL: arg0.resourceURL,
+				resourceContent: arg0.resourceContent,
 				textToCopy: arg0.textToCopy,
 				linkToCopy: arg0.linkToCopy || null,
 				htmlToCopy: '',

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -589,15 +589,14 @@
 			let element = event.target;
 
 			// To handle right clicks on resource icons
-			if (element && !element.getAttribute('data-resource-id')) element = element.parentElement;
-
-			if(element.classList.contains('mermaid')) {
-				var svgString = new XMLSerializer().serializeToString(element);
+			let mermaidElement = element.closest('.mermaid');
+			if(mermaidElement) {
+				const svgString = new XMLSerializer().serializeToString(mermaidElement);
 				// Remove any characters outside the Latin1 range
-				var decoded = unescape(encodeURIComponent(svgString));
+				const decoded = unescape(encodeURIComponent(svgString));
 				// Now we can use btoa to convert the svg to base64
-				var base64 = btoa(decoded);
-				var dataUrl = `data:image/svg+xml;base64,${base64}`;
+				const base64 = btoa(decoded);
+				const dataUrl = `data:image/svg+xml;base64,${base64}`;
 				ipcProxySendToHost('contextMenu', {
 						type: 'resource',
 						resourceContent: svgString,
@@ -605,6 +604,9 @@
 						resourceFilename: 'Mermaid export.svg',
 					});
 			}
+
+			if (element && !element.getAttribute('data-resource-id')) element = element.parentElement;
+
 
 			if (element && element.getAttribute('data-resource-id')) {
 				ipcProxySendToHost('contextMenu', {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -591,6 +591,21 @@
 			// To handle right clicks on resource icons
 			if (element && !element.getAttribute('data-resource-id')) element = element.parentElement;
 
+			if(element.classList.contains('mermaid')) {
+				var svgString = new XMLSerializer().serializeToString(element);
+				// Remove any characters outside the Latin1 range
+				var decoded = unescape(encodeURIComponent(svgString));
+				// Now we can use btoa to convert the svg to base64
+				var base64 = btoa(decoded);
+				var dataUrl = `data:image/svg+xml;base64,${base64}`;
+				ipcProxySendToHost('contextMenu', {
+						type: 'resource',
+						resourceContent: svgString,
+						resourceURL: dataUrl,
+						resourceFilename: 'Mermaid export.svg',
+					});
+			}
+
 			if (element && element.getAttribute('data-resource-id')) {
 				ipcProxySendToHost('contextMenu', {
 					type: element.getAttribute('src') ? 'image' : 'resource',


### PR DESCRIPTION
This adds a new feature to export mermaid graphs as discussed [here](https://github.com/laurent22/joplin/issues/6100).

Supported platforms: `Desktop`

### Demo

![Screenshot 2022-02-07 at 2 14 59 PM](https://user-images.githubusercontent.com/44570278/152756044-26c46fec-21d1-4f2c-b0f5-e59cb00721e6.png)

### How to use

-  Add a mermaid graph in a note.
-  Right click on the mermaid graph, you will now see a context menu with 2 options:
  -  `Save as..` : this opens a save dialog and lets you save the image as `svg` format.
  -  `Copy path to clipboard` : This copies a valid SVG data URI for browsers to clipboard that can be used to easily embed the graph in other texts without having to bother about files.

