### PR TITLE
Desktop, Fixes Right Click Menu Markdown Editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -735,7 +735,8 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			const x = params.x, y = params.y, isEditable = params.isEditable, inputFieldType = params.inputFieldType;
 			const elements = document.getElementsByClassName('codeMirrorEditor');
 
-			// inputFieldType: To avoid context-menu flickering when there is an input field above the codeMirrorEditor.
+			// inputFieldType: The input field type of CodeMirror is "textarea" so the inputFieldType = "none",
+			// and any single-line input above codeMirror has inputFieldType value according to the type of input e.g.(text = plainText, password = password, ...).
 			if (!elements.length || !isEditable || inputFieldType !== 'none') return null;
 			const rect = convertToScreenCoordinates(Setting.value('windowContentZoomFactor'), elements[0].getBoundingClientRect());
 			return rect.x < x && rect.y < y && rect.right > x && rect.bottom > y;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -731,15 +731,23 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	// It might be buggy, refer to the below issue
 	// https://github.com/laurent22/joplin/pull/3974#issuecomment-718936703
 	useEffect(() => {
-		function pointerInsideEditor(x: number, y: number) {
+		function pointerInsideEditor(params: any) {
+			const x = params.x, y = params.y, isEditable = params.isEditable, inputFieldType = params.inputFieldType;
 			const elements = document.getElementsByClassName('codeMirrorEditor');
-			if (!elements.length) return null;
+
+			// To check if codeMirrorEditor doesn't exist. --OR--
+			// If isEditable is false which means there is a blur layout on codeMirrorEditor (e.g. add hyperlink)
+			// or mouse cursor is out of codeMirrorEditor. --OR--
+			// If the context menu was invoked on an input field (isEditable: true) and the input field on codeMirrorEditor,
+			// to avoid context-menu flickering (two context-menu) by checking if is an input field or not by using inputFieldType (e.g plainText, password).
+			if (!elements.length || !isEditable || inputFieldType !== 'none') return null;
 			const rect = convertToScreenCoordinates(Setting.value('windowContentZoomFactor'), elements[0].getBoundingClientRect());
 			return rect.x < x && rect.y < y && rect.right > x && rect.bottom > y;
 		}
 
 		async function onContextMenu(_event: any, params: any) {
-			if (!pointerInsideEditor(params.x, params.y) || !params.isEditable || params.inputFieldType !== 'none') return;
+			if (!pointerInsideEditor(params)) return;
+
 			const menu = new Menu();
 
 			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -735,11 +735,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			const x = params.x, y = params.y, isEditable = params.isEditable, inputFieldType = params.inputFieldType;
 			const elements = document.getElementsByClassName('codeMirrorEditor');
 
-			// To check if codeMirrorEditor doesn't exist. --OR--
-			// If isEditable is false which means there is a blur layout on codeMirrorEditor (e.g. add hyperlink)
-			// or mouse cursor is out of codeMirrorEditor. --OR--
-			// If the context menu was invoked on an input field (isEditable: true) and the input field on codeMirrorEditor,
-			// to avoid context-menu flickering (two context-menu) by checking if is an input field or not by using inputFieldType (e.g plainText, password).
+			// inputFieldType: To avoid context-menu flickering when there is an input field above the codeMirrorEditor.
 			if (!elements.length || !isEditable || inputFieldType !== 'none') return null;
 			const rect = convertToScreenCoordinates(Setting.value('windowContentZoomFactor'), elements[0].getBoundingClientRect());
 			return rect.x < x && rect.y < y && rect.right > x && rect.bottom > y;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -731,18 +731,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	// It might be buggy, refer to the below issue
 	// https://github.com/laurent22/joplin/pull/3974#issuecomment-718936703
 	useEffect(() => {
-		let touched = false;
-
-		function touchedEditor(event: any) {
-
-			if (event.target.closest('.codeMirrorEditor') !== null) {
-				touched = true;
-			} else {
-				touched = false;
-			}
-		}
-		document.addEventListener('contextmenu', touchedEditor);
-
 		function pointerInsideEditor(x: number, y: number) {
 			const elements = document.getElementsByClassName('codeMirrorEditor');
 			if (!elements.length) return null;
@@ -751,8 +739,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		}
 
 		async function onContextMenu(_event: any, params: any) {
-			if (!pointerInsideEditor(params.x, params.y) || !touched) return;
-
+			if (!pointerInsideEditor(params.x, params.y) || !params.isEditable || params.inputFieldType !== 'none') return;
 			const menu = new Menu();
 
 			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
@@ -831,7 +818,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		bridge().window().webContents.on('context-menu', onContextMenu);
 
 		return () => {
-			document.removeEventListener('contextmenu', touchedEditor);
 			bridge().window().webContents.off('context-menu', onContextMenu);
 		};
 	}, [props.plugins]);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -731,6 +731,18 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	// It might be buggy, refer to the below issue
 	// https://github.com/laurent22/joplin/pull/3974#issuecomment-718936703
 	useEffect(() => {
+		let touched = false;
+
+		function touchedEditor(event: any) {
+
+			if (event.target.closest('.codeMirrorEditor') !== null) {
+				touched = true;
+			} else {
+				touched = false;
+			}
+		}
+		document.addEventListener('contextmenu', touchedEditor);
+
 		function pointerInsideEditor(x: number, y: number) {
 			const elements = document.getElementsByClassName('codeMirrorEditor');
 			if (!elements.length) return null;
@@ -739,7 +751,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		}
 
 		async function onContextMenu(_event: any, params: any) {
-			if (!pointerInsideEditor(params.x, params.y)) return;
+			if (!pointerInsideEditor(params.x, params.y) || !touched) return;
 
 			const menu = new Menu();
 
@@ -819,6 +831,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		bridge().window().webContents.on('context-menu', onContextMenu);
 
 		return () => {
+			document.removeEventListener('contextmenu', touchedEditor);
 			bridge().window().webContents.off('context-menu', onContextMenu);
 		};
 	}, [props.plugins]);


### PR DESCRIPTION
# Desktop, Fixes Right Click Menu Markdown Editor

## **Overview**

When adding NOTEBOOKS +, change the app layout, or enter Hyperlink.

And right-click on the blur layout at the markup editor position.

The right-click menu is still active!.

It causes some problems when you want to paste a link in the hyperlink as an example.

### Examples
![demo](https://user-images.githubusercontent.com/58605547/152896267-9cdbe387-31b4-47eb-b489-bc47469d13ae.gif)

## Solution

By checking ```isEditable``` and ```inputFieldType``` variables from ```context-menu``` event params.

If ```isEditable``` is false which means there is a blur layout on codeMirrorEditor (e.g. add hyperlink) or mouse cursor is out of codeMirrorEditor.

OR

If the context menu was invoked on an input field (isEditable: true) and the input field on codeMirrorEditor, to avoid context-menu flickering (two context-menu) by checking if is an input field or not by using ```inputFieldType``` (e.g plainText, password).
