### PR TITLE
Desktop: Fixes #5686: Fixed Tags Order

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/setTags.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/setTags.ts
@@ -34,32 +34,22 @@ export const runtime = (comp: any): CommandRuntime => {
 					autocomplete: sortedTagSuggestions,
 					onClose: async (answer: any[]) => {
 						if (answer !== null) {
-							const endTagTitles = answer.map((a) => {
+							const endTagTitles = answer.map(a => {
 								return a.label.trim();
 							});
 							if (noteIds.length === 1) {
 								await Tag.setNoteTagsByTitles(noteIds[0], endTagTitles);
 							} else {
-								const startTagTitles = sortedStartTags.map((a: any) => {
-									return a.label.trim();
-								});
-								const addTags = endTagTitles.filter(
-									(value: string) => !startTagTitles.includes(value)
-								);
-								const delTags = startTagTitles.filter(
-									(value: string) => !endTagTitles.includes(value)
-								);
+								const startTagTitles = sortedStartTags.map((a: any) => { return a.label.trim(); });
+								const addTags = endTagTitles.filter((value: string) => !startTagTitles.includes(value));
+								const delTags = startTagTitles.filter((value: string) => !endTagTitles.includes(value));
 
 								// apply the tag additions and deletions to each selected note
 								for (let i = 0; i < noteIds.length; i++) {
 									const tags = await Tag.tagsByNoteId(noteIds[i]);
-									let tagTitles = tags.map((a: any) => {
-										return a.title;
-									});
+									let tagTitles = tags.map((a: any) => { return a.title; });
 									tagTitles = tagTitles.concat(addTags);
-									tagTitles = tagTitles.filter(
-										(value: string) => !delTags.includes(value)
-									);
+									tagTitles = tagTitles.filter((value: string) => !delTags.includes(value));
 									await Tag.setNoteTagsByTitles(noteIds[i], tagTitles);
 								}
 							}

--- a/packages/app-desktop/gui/MainScreen/commands/setTags.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/setTags.ts
@@ -1,8 +1,4 @@
-import {
-	CommandRuntime,
-	CommandDeclaration,
-	CommandContext,
-} from '@joplin/lib/services/CommandService';
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import Tag from '@joplin/lib/models/Tag';
 
@@ -21,25 +17,21 @@ export const runtime = (comp: any): CommandRuntime => {
 			const startTags = tags
 				.map((a: any) => {
 					return { value: a.id, label: a.title };
-				})
-				.sort((a: any, b: any) => {
-					return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
 				});
+			const sortedStartTags = Tag.sortTags(startTags);
 			const allTags = await Tag.allWithNotes();
 			const tagSuggestions = allTags
 				.map((a: any) => {
 					return { value: a.id, label: a.title };
-				})
-				.sort((a: any, b: any) => {
-					return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
 				});
+			const sortedTagSuggestions = Tag.sortTags(tagSuggestions);
 
 			comp.setState({
 				promptOptions: {
 					label: _('Add or remove tags:'),
 					inputType: 'tags',
-					value: startTags,
-					autocomplete: tagSuggestions,
+					value: sortedStartTags,
+					autocomplete: sortedTagSuggestions,
 					onClose: async (answer: any[]) => {
 						if (answer !== null) {
 							const endTagTitles = answer.map((a) => {
@@ -48,7 +40,7 @@ export const runtime = (comp: any): CommandRuntime => {
 							if (noteIds.length === 1) {
 								await Tag.setNoteTagsByTitles(noteIds[0], endTagTitles);
 							} else {
-								const startTagTitles = startTags.map((a: any) => {
+								const startTagTitles = sortedStartTags.map((a: any) => {
 									return a.label.trim();
 								});
 								const addTags = endTagTitles.filter(

--- a/packages/app-desktop/gui/MainScreen/commands/setTags.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/setTags.ts
@@ -14,24 +14,24 @@ export const runtime = (comp: any): CommandRuntime => {
 			noteIds = noteIds || context.state.selectedNoteIds;
 
 			const tags = await Tag.commonTagsByNoteIds(noteIds);
-			const startTags = tags
+			const sortedTags = Tag.sortTags(tags);
+			const startTags = sortedTags
 				.map((a: any) => {
 					return { value: a.id, label: a.title };
 				});
-			const sortedStartTags = Tag.sortTags(startTags);
 			const allTags = await Tag.allWithNotes();
-			const tagSuggestions = allTags
+			const sortedAllTags = Tag.sortTags(allTags);
+			const tagSuggestions = sortedAllTags
 				.map((a: any) => {
 					return { value: a.id, label: a.title };
 				});
-			const sortedTagSuggestions = Tag.sortTags(tagSuggestions);
 
 			comp.setState({
 				promptOptions: {
 					label: _('Add or remove tags:'),
 					inputType: 'tags',
-					value: sortedStartTags,
-					autocomplete: sortedTagSuggestions,
+					value: startTags,
+					autocomplete: tagSuggestions,
 					onClose: async (answer: any[]) => {
 						if (answer !== null) {
 							const endTagTitles = answer.map(a => {
@@ -40,7 +40,7 @@ export const runtime = (comp: any): CommandRuntime => {
 							if (noteIds.length === 1) {
 								await Tag.setNoteTagsByTitles(noteIds[0], endTagTitles);
 							} else {
-								const startTagTitles = sortedStartTags.map((a: any) => { return a.label.trim(); });
+								const startTagTitles = startTags.map((a: any) => { return a.label.trim(); });
 								const addTags = endTagTitles.filter((value: string) => !startTagTitles.includes(value));
 								const delTags = startTagTitles.filter((value: string) => !endTagTitles.includes(value));
 

--- a/packages/app-desktop/gui/MainScreen/commands/setTags.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/setTags.ts
@@ -1,6 +1,7 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import Tag from '@joplin/lib/models/Tag';
+import { TagEntity } from '@joplin/lib/services/database/types';
 
 export const declaration: CommandDeclaration = {
 	name: 'setTags',
@@ -16,13 +17,13 @@ export const runtime = (comp: any): CommandRuntime => {
 			const tags = await Tag.commonTagsByNoteIds(noteIds);
 			const sortedTags = Tag.sortTags(tags);
 			const startTags = sortedTags
-				.map((a: any) => {
+				.map((a: TagEntity) => {
 					return { value: a.id, label: a.title };
 				});
 			const allTags = await Tag.allWithNotes();
 			const sortedAllTags = Tag.sortTags(allTags);
 			const tagSuggestions = sortedAllTags
-				.map((a: any) => {
+				.map((a: TagEntity) => {
 					return { value: a.id, label: a.title };
 				});
 

--- a/packages/app-desktop/gui/MainScreen/commands/setTags.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/setTags.ts
@@ -1,4 +1,8 @@
-import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import {
+	CommandRuntime,
+	CommandDeclaration,
+	CommandContext,
+} from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import Tag from '@joplin/lib/models/Tag';
 
@@ -19,18 +23,15 @@ export const runtime = (comp: any): CommandRuntime => {
 					return { value: a.id, label: a.title };
 				})
 				.sort((a: any, b: any) => {
-					// sensitivity accent will treat accented characters as differemt
-					// but treats caps as equal
-					return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
+					return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
 				});
 			const allTags = await Tag.allWithNotes();
-			const tagSuggestions = allTags.map((a: any) => {
-				return { value: a.id, label: a.title };
-			})
+			const tagSuggestions = allTags
+				.map((a: any) => {
+					return { value: a.id, label: a.title };
+				})
 				.sort((a: any, b: any) => {
-				// sensitivity accent will treat accented characters as differemt
-				// but treats caps as equal
-					return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
+					return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
 				});
 
 			comp.setState({
@@ -41,22 +42,32 @@ export const runtime = (comp: any): CommandRuntime => {
 					autocomplete: tagSuggestions,
 					onClose: async (answer: any[]) => {
 						if (answer !== null) {
-							const endTagTitles = answer.map(a => {
+							const endTagTitles = answer.map((a) => {
 								return a.label.trim();
 							});
 							if (noteIds.length === 1) {
 								await Tag.setNoteTagsByTitles(noteIds[0], endTagTitles);
 							} else {
-								const startTagTitles = startTags.map((a: any) => { return a.label.trim(); });
-								const addTags = endTagTitles.filter((value: string) => !startTagTitles.includes(value));
-								const delTags = startTagTitles.filter((value: string) => !endTagTitles.includes(value));
+								const startTagTitles = startTags.map((a: any) => {
+									return a.label.trim();
+								});
+								const addTags = endTagTitles.filter(
+									(value: string) => !startTagTitles.includes(value)
+								);
+								const delTags = startTagTitles.filter(
+									(value: string) => !endTagTitles.includes(value)
+								);
 
 								// apply the tag additions and deletions to each selected note
 								for (let i = 0; i < noteIds.length; i++) {
 									const tags = await Tag.tagsByNoteId(noteIds[i]);
-									let tagTitles = tags.map((a: any) => { return a.title; });
+									let tagTitles = tags.map((a: any) => {
+										return a.title;
+									});
 									tagTitles = tagTitles.concat(addTags);
-									tagTitles = tagTitles.filter((value: string) => !delTags.includes(value));
+									tagTitles = tagTitles.filter(
+										(value: string) => !delTags.includes(value)
+									);
 									await Tag.setNoteTagsByTitles(noteIds[i], tagTitles);
 								}
 							}

--- a/packages/app-desktop/gui/TagList.tsx
+++ b/packages/app-desktop/gui/TagList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import { AppState } from '../app.reducer';
+import Tag from '@joplin/lib/models/Tag';
 
 const { connect } = require('react-redux');
 const { themeStyle } = require('@joplin/lib/theme');
@@ -28,11 +29,7 @@ function TagList(props: Props) {
 	}, [props.style, props.themeId]);
 
 	const tags = useMemo(() => {
-		const output = props.items.slice();
-
-		output.sort((a: any, b: any) => {
-			return a.title < b.title ? -1 : +1;
-		});
+		const output = Tag.sortTags(props.items.slice());
 
 		return output;
 	}, [props.items]);

--- a/packages/lib/components/shared/side-menu-shared.js
+++ b/packages/lib/components/shared/side-menu-shared.js
@@ -1,6 +1,7 @@
 const Folder = require('../../models/Folder').default;
 const Setting = require('../../models/Setting').default;
 const BaseModel = require('../../BaseModel').default;
+const Tag = require('../../models/Tag').default;
 
 const shared = {};
 
@@ -50,20 +51,7 @@ shared.renderFolders = function(props, renderItem) {
 };
 
 shared.renderTags = function(props, renderItem) {
-	const tags = props.tags.slice();
-	tags.sort((a, b) => {
-		// It seems title can sometimes be undefined (perhaps when syncing
-		// and before tag has been decrypted?). It would be best to find
-		// the root cause but for now that will do.
-		//
-		// Fixes https://github.com/laurent22/joplin/issues/4051
-		if (!a || !a.title || !b || !b.title) return 0;
-
-		// Note: while newly created tags are normalized and lowercase
-		// imported tags might be any case, so we need to do case-insensitive
-		// sort.
-		return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : +1;
-	});
+	const tags = Tag.sortTags(props.tags.slice());
 	const tagItems = [];
 	const order = [];
 	for (let i = 0; i < tags.length; i++) {

--- a/packages/lib/models/Tag.test.js
+++ b/packages/lib/models/Tag.test.js
@@ -156,38 +156,24 @@ describe('models/Tag', function() {
 		expect(commonTagIds.includes(tagc.id)).toBe(true);
 	}));
 
-	it('should sort tags for setTags, Sidebar and TagList', (async () => {
-		const folder1 = await Folder.save({ title: 'folder1' });
-		const note1 = await Note.save({ title: 'ma note 0', parent_id: folder1.id });
+	it('should sort tags', (async () => {
+		// test for tags with titles
+		const unsortedTags = [{ title: '@⏲15 min' },{ title: '#house' },{ title: '#coding' }, { title: '@⏲60 min' }, { title: '#wait' }, { title: '@⏲30 min' }];
+		const sortedTags = Tag.sortTags(unsortedTags);
+		expect(sortedTags).toEqual([{ title: '@⏲15 min' }, { title: '@⏲30 min' }, { title: '@⏲60 min' }, { title: '#coding' }, { title: '#house' }, { title: '#wait' }]);
 
-		// original/sorted order
-		const tag1 = await Tag.save({ title: '#coding' });
-		const tag2 = await Tag.save({ title: '#house' });
-		const tag3 = await Tag.save({ title: '#wait' });
-		const tag4 = await Tag.save({ title: '@⏲15 min' });
-		const tag5 = await Tag.save({ title: '@⏲30 min' });
-		const tag6 = await Tag.save({ title: '@⏲60 min' });
+		// test for tags without titles
+		const unsortedTags2 = [{ id: '40' } , { id: '50' }, { id: '10' }, { id: '30' }, { id: '20' }];
+		const sortedTags2 = Tag.sortTags(unsortedTags2);
+		expect(sortedTags2).toEqual([{ id: '40' } , { id: '50' }, { id: '10' }, { id: '30' }, { id: '20' }]);
 
-		await Tag.addNote(tag4.id, note1.id);
-		await Tag.addNote(tag2.id, note1.id);
-		await Tag.addNote(tag1.id, note1.id);
-		await Tag.addNote(tag6.id, note1.id);
-		await Tag.addNote(tag3.id, note1.id);
-		await Tag.addNote(tag5.id, note1.id);
+		// test for tags with titles, without titles and empty tags
+		const unsortedTags3 = [{ id: '1' }, { id: '2', title: 'two' }, {}, { id: '3' }, { id: '4', title: 'four' }, { id: '5',title: 'five' }];
+		const sortedTags3 = Tag.sortTags(unsortedTags3);
+		expect(sortedTags3).toEqual([{ id: '1' }, { id: '2', title: 'two' }, {}, { id: '3' }, { id: '5', title: 'five' }, { id: '4', title: 'four' }]);
 
-		// This test checks the sorting functionality for tags in all three files(setTags, Sidebar and TagList)
-		// commonTags contains unsortedTags
-		const commonTags = await Tag.commonTagsByNoteIds([note1.id]);
-
-		// defaultTags contains only the id and title of all the unsorted tags
-		const defaultTags = commonTags.map(a => {
-			return { value: a.id, label: a.title };
-		});
-
-		// sortedTagsTitles contains the titles of all the sorted tags
-		const sortedTagsTitles = Tag.sortTags(defaultTags).map(a => a.label);
-
-		expect(sortedTagsTitles).toEqual(['@⏲15 min', '@⏲30 min', '@⏲60 min', '#coding', '#house', '#wait']);
-		expect(sortedTagsTitles).not.toEqual(['@⏲15 min', '#house','#coding', '@⏲60 min', '#wait', '@⏲30 min']);
+		// test for empty list
+		const emptyListSort = Tag.sortTags([]);
+		expect(emptyListSort).toEqual([]);
 	}));
 });

--- a/packages/lib/models/Tag.test.js
+++ b/packages/lib/models/Tag.test.js
@@ -1,20 +1,17 @@
-const {
-	setupDatabaseAndSynchronizer,
-	switchClient,
-	checkThrowAsync,
-} = require('../testing/test-utils.js');
+const { setupDatabaseAndSynchronizer, switchClient, checkThrowAsync } = require('../testing/test-utils.js');
 const Folder = require('../models/Folder').default;
 const Note = require('../models/Note').default;
 const Tag = require('../models/Tag').default;
 
 describe('models/Tag', function() {
+
 	beforeEach(async (done) => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 		done();
 	});
 
-	it('should add tags by title', async () => {
+	it('should add tags by title', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 
@@ -22,27 +19,21 @@ describe('models/Tag', function() {
 
 		const noteTags = await Tag.tagsByNoteId(note1.id);
 		expect(noteTags.length).toBe(2);
-	});
+	}));
 
-	it('should not allow renaming tag to existing tag names', async () => {
+	it('should not allow renaming tag to existing tag names', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 
 		await Tag.setNoteTagsByTitles(note1.id, ['un', 'deux']);
 
 		const tagUn = await Tag.loadByTitle('un');
-		const hasThrown = await checkThrowAsync(
-			async () =>
-				await Tag.save(
-					{ id: tagUn.id, title: 'deux' },
-					{ userSideValidation: true }
-				)
-		);
+		const hasThrown = await checkThrowAsync(async () => await Tag.save({ id: tagUn.id, title: 'deux' }, { userSideValidation: true }));
 
 		expect(hasThrown).toBe(true);
-	});
+	}));
 
-	it('should not return tags without notes', async () => {
+	it('should not return tags without notes', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
@@ -54,21 +45,13 @@ describe('models/Tag', function() {
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
-	});
+	}));
 
-	it('should return tags with note counts', async () => {
+	it('should return tags with note counts', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
-		const note2 = await Note.save({
-			title: 'ma 2nd note',
-			parent_id: folder1.id,
-		});
-		const todo1 = await Note.save({
-			title: 'todo 1',
-			parent_id: folder1.id,
-			is_todo: 1,
-			todo_completed: 1590085027710,
-		});
+		const note2 = await Note.save({ title: 'ma 2nd note',parent_id: folder1.id });
+		const todo1 = await Note.save({ title: 'todo 1', parent_id: folder1.id, is_todo: 1, todo_completed: 1590085027710 });
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
 		await Tag.setNoteTagsByTitles(note2.id, ['un']);
 		await Tag.setNoteTagsByTitles(todo1.id, ['un']);
@@ -94,26 +77,14 @@ describe('models/Tag', function() {
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
-	});
+	}));
 
-	it('should load individual tags with note count', async () => {
+	it('should load individual tags with note count', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
-		const note2 = await Note.save({
-			title: 'ma 2nd note',
-			parent_id: folder1.id,
-		});
-		const todo1 = await Note.save({
-			title: 'todo 2',
-			parent_id: folder1.id,
-			is_todo: 1,
-			todo_completed: 1590085027710,
-		});
-		const todo2 = await Note.save({
-			title: 'todo 2',
-			parent_id: folder1.id,
-			is_todo: 1,
-		});
+		const note2 = await Note.save({ title: 'ma 2nd note', parent_id: folder1.id });
+		const todo1 = await Note.save({ title: 'todo 2', parent_id: folder1.id, is_todo: 1, todo_completed: 1590085027710 });
+		const todo2 = await Note.save({ title: 'todo 2', parent_id: folder1.id, is_todo: 1 });
 		const tag = await Tag.save({ title: 'mytag' });
 		await Tag.addNote(tag.id, note1.id);
 
@@ -129,31 +100,19 @@ describe('models/Tag', function() {
 		tagWithCount = await Tag.loadWithCount(tag.id);
 		expect(tagWithCount.note_count).toBe(4);
 		expect(tagWithCount.todo_completed_count).toBe(1);
-	});
+	}));
 
-	it('should get common tags for set of notes', async () => {
+	it('should get common tags for set of notes', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const taga = await Tag.save({ title: 'mytaga' });
 		const tagb = await Tag.save({ title: 'mytagb' });
 		const tagc = await Tag.save({ title: 'mytagc' });
 		await Tag.save({ title: 'mytagd' });
 
-		const note0 = await Note.save({
-			title: 'ma note 0',
-			parent_id: folder1.id,
-		});
-		const note1 = await Note.save({
-			title: 'ma note 1',
-			parent_id: folder1.id,
-		});
-		const note2 = await Note.save({
-			title: 'ma note 2',
-			parent_id: folder1.id,
-		});
-		const note3 = await Note.save({
-			title: 'ma note 3',
-			parent_id: folder1.id,
-		});
+		const note0 = await Note.save({ title: 'ma note 0', parent_id: folder1.id });
+		const note1 = await Note.save({ title: 'ma note 1', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'ma note 2', parent_id: folder1.id });
+		const note3 = await Note.save({ title: 'ma note 3', parent_id: folder1.id });
 
 		await Tag.addNote(taga.id, note1.id);
 
@@ -173,41 +132,33 @@ describe('models/Tag', function() {
 		commonTags = await Tag.commonTagsByNoteIds([]);
 		expect(commonTags.length).toBe(0);
 
-		commonTags = await Tag.commonTagsByNoteIds([
-			note0.id,
-			note1.id,
-			note2.id,
-			note3.id,
-		]);
-		let commonTagIds = commonTags.map((t) => t.id);
+		commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
+		let commonTagIds = commonTags.map(t => t.id);
 		expect(commonTagIds.length).toBe(0);
 
 		commonTags = await Tag.commonTagsByNoteIds([note1.id, note2.id, note3.id]);
-		commonTagIds = commonTags.map((t) => t.id);
+		commonTagIds = commonTags.map(t => t.id);
 		expect(commonTagIds.length).toBe(1);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note2.id, note3.id]);
-		commonTagIds = commonTags.map((t) => t.id);
+		commonTagIds = commonTags.map(t => t.id);
 		expect(commonTagIds.length).toBe(2);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 		expect(commonTagIds.includes(tagb.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note3.id]);
 
-		commonTagIds = commonTags.map((t) => t.id);
+		commonTagIds = commonTags.map(t => t.id);
 		expect(commonTags.length).toBe(3);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 		expect(commonTagIds.includes(tagb.id)).toBe(true);
 		expect(commonTagIds.includes(tagc.id)).toBe(true);
-	});
+	}));
 
-	it('should sort tags in promptDialog', async () => {
+	it('should sort tags for setTags, Sidebar and TagList', (async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
-		const note1 = await Note.save({
-			title: 'ma note 0',
-			parent_id: folder1.id,
-		});
+		const note1 = await Note.save({ title: 'ma note 0', parent_id: folder1.id });
 
 		// original/sorted order
 		const tag1 = await Tag.save({ title: '#coding' });
@@ -224,58 +175,19 @@ describe('models/Tag', function() {
 		await Tag.addNote(tag3.id, note1.id);
 		await Tag.addNote(tag5.id, note1.id);
 
-		const commonTags = await Tag.commonTagsByNoteIds([note1.id]); // commonTags has unsorted tags
-		// sortDefaultTags are shown as default values when the promptDialog is opened
-		const sortDefaultTagsTitles = commonTags
-			.map((a) => {
-				return { value: a.id, label: a.title };
-			})
-			.sort((a, b) => {
-				return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
-			})
-			.map((a) => a.label);
-		expect(sortDefaultTagsTitles).toEqual([
-			'#coding',
-			'#house',
-			'#wait',
-			'@⏲15 min',
-			'@⏲30 min',
-			'@⏲60 min',
-		]);
-		expect(sortDefaultTagsTitles).not.toEqual([
-			'@⏲15 min',
-			'#house',
-			'#coding',
-			'@⏲60 min',
-			'#wait',
-			'@⏲30 min',
-		]);
+		// This test checks the sorting functionality for tags in all three files(setTags, Sidebar and TagList)
+		// commonTags contains unsortedTags
+		const commonTags = await Tag.commonTagsByNoteIds([note1.id]);
 
-		const allTags = await Tag.allWithNotes(); // allTags has unsorted tags
-		// sortTagSuggestions are shown in the dropdown menu of promptDialog
-		const sortTagSuggestionsTitles = allTags
-			.map((a) => {
-				return { value: a.id, label: a.title };
-			})
-			.sort((a, b) => {
-				return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
-			})
-			.map((a) => a.label);
-		expect(sortTagSuggestionsTitles).toEqual([
-			'#coding',
-			'#house',
-			'#wait',
-			'@⏲15 min',
-			'@⏲30 min',
-			'@⏲60 min',
-		]);
-		expect(sortTagSuggestionsTitles).not.toEqual([
-			'@⏲15 min',
-			'#house',
-			'#coding',
-			'@⏲60 min',
-			'#wait',
-			'@⏲30 min',
-		]);
-	});
+		// defaultTags contains only the id and title of all the unsorted tags
+		const defaultTags = commonTags.map(a => {
+			return { value: a.id, label: a.title };
+		});
+
+		// sortedTagsTitles contains the titles of all the sorted tags
+		const sortedTagsTitles = Tag.sortTags(defaultTags).map(a => a.label);
+
+		expect(sortedTagsTitles).toEqual(['@⏲15 min', '@⏲30 min', '@⏲60 min', '#coding', '#house', '#wait']);
+		expect(sortedTagsTitles).not.toEqual(['@⏲15 min', '#house','#coding', '@⏲60 min', '#wait', '@⏲30 min']);
+	}));
 });

--- a/packages/lib/models/Tag.test.js
+++ b/packages/lib/models/Tag.test.js
@@ -1,17 +1,20 @@
-const { setupDatabaseAndSynchronizer, switchClient, checkThrowAsync } = require('../testing/test-utils.js');
+const {
+	setupDatabaseAndSynchronizer,
+	switchClient,
+	checkThrowAsync,
+} = require('../testing/test-utils.js');
 const Folder = require('../models/Folder').default;
 const Note = require('../models/Note').default;
 const Tag = require('../models/Tag').default;
 
 describe('models/Tag', function() {
-
 	beforeEach(async (done) => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 		done();
 	});
 
-	it('should add tags by title', (async () => {
+	it('should add tags by title', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 
@@ -19,21 +22,27 @@ describe('models/Tag', function() {
 
 		const noteTags = await Tag.tagsByNoteId(note1.id);
 		expect(noteTags.length).toBe(2);
-	}));
+	});
 
-	it('should not allow renaming tag to existing tag names', (async () => {
+	it('should not allow renaming tag to existing tag names', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 
 		await Tag.setNoteTagsByTitles(note1.id, ['un', 'deux']);
 
 		const tagUn = await Tag.loadByTitle('un');
-		const hasThrown = await checkThrowAsync(async () => await Tag.save({ id: tagUn.id, title: 'deux' }, { userSideValidation: true }));
+		const hasThrown = await checkThrowAsync(
+			async () =>
+				await Tag.save(
+					{ id: tagUn.id, title: 'deux' },
+					{ userSideValidation: true }
+				)
+		);
 
 		expect(hasThrown).toBe(true);
-	}));
+	});
 
-	it('should not return tags without notes', (async () => {
+	it('should not return tags without notes', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
@@ -45,13 +54,21 @@ describe('models/Tag', function() {
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
-	}));
+	});
 
-	it('should return tags with note counts', (async () => {
+	it('should return tags with note counts', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
-		const note2 = await Note.save({ title: 'ma 2nd note', parent_id: folder1.id });
-		const todo1 = await Note.save({ title: 'todo 1', parent_id: folder1.id, is_todo: 1, todo_completed: 1590085027710 });
+		const note2 = await Note.save({
+			title: 'ma 2nd note',
+			parent_id: folder1.id,
+		});
+		const todo1 = await Note.save({
+			title: 'todo 1',
+			parent_id: folder1.id,
+			is_todo: 1,
+			todo_completed: 1590085027710,
+		});
 		await Tag.setNoteTagsByTitles(note1.id, ['un']);
 		await Tag.setNoteTagsByTitles(note2.id, ['un']);
 		await Tag.setNoteTagsByTitles(todo1.id, ['un']);
@@ -77,14 +94,26 @@ describe('models/Tag', function() {
 
 		tags = await Tag.allWithNotes();
 		expect(tags.length).toBe(0);
-	}));
+	});
 
-	it('should load individual tags with note count', (async () => {
+	it('should load individual tags with note count', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
-		const note2 = await Note.save({ title: 'ma 2nd note', parent_id: folder1.id });
-		const todo1 = await Note.save({ title: 'todo 2', parent_id: folder1.id, is_todo: 1, todo_completed: 1590085027710 });
-		const todo2 = await Note.save({ title: 'todo 2', parent_id: folder1.id, is_todo: 1 });
+		const note2 = await Note.save({
+			title: 'ma 2nd note',
+			parent_id: folder1.id,
+		});
+		const todo1 = await Note.save({
+			title: 'todo 2',
+			parent_id: folder1.id,
+			is_todo: 1,
+			todo_completed: 1590085027710,
+		});
+		const todo2 = await Note.save({
+			title: 'todo 2',
+			parent_id: folder1.id,
+			is_todo: 1,
+		});
 		const tag = await Tag.save({ title: 'mytag' });
 		await Tag.addNote(tag.id, note1.id);
 
@@ -100,19 +129,31 @@ describe('models/Tag', function() {
 		tagWithCount = await Tag.loadWithCount(tag.id);
 		expect(tagWithCount.note_count).toBe(4);
 		expect(tagWithCount.todo_completed_count).toBe(1);
-	}));
+	});
 
-	it('should get common tags for set of notes', (async () => {
+	it('should get common tags for set of notes', async () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const taga = await Tag.save({ title: 'mytaga' });
 		const tagb = await Tag.save({ title: 'mytagb' });
 		const tagc = await Tag.save({ title: 'mytagc' });
 		await Tag.save({ title: 'mytagd' });
 
-		const note0 = await Note.save({ title: 'ma note 0', parent_id: folder1.id });
-		const note1 = await Note.save({ title: 'ma note 1', parent_id: folder1.id });
-		const note2 = await Note.save({ title: 'ma note 2', parent_id: folder1.id });
-		const note3 = await Note.save({ title: 'ma note 3', parent_id: folder1.id });
+		const note0 = await Note.save({
+			title: 'ma note 0',
+			parent_id: folder1.id,
+		});
+		const note1 = await Note.save({
+			title: 'ma note 1',
+			parent_id: folder1.id,
+		});
+		const note2 = await Note.save({
+			title: 'ma note 2',
+			parent_id: folder1.id,
+		});
+		const note3 = await Note.save({
+			title: 'ma note 3',
+			parent_id: folder1.id,
+		});
 
 		await Tag.addNote(taga.id, note1.id);
 
@@ -132,28 +173,109 @@ describe('models/Tag', function() {
 		commonTags = await Tag.commonTagsByNoteIds([]);
 		expect(commonTags.length).toBe(0);
 
-		commonTags = await Tag.commonTagsByNoteIds([note0.id, note1.id, note2.id, note3.id]);
-		let commonTagIds = commonTags.map(t => t.id);
+		commonTags = await Tag.commonTagsByNoteIds([
+			note0.id,
+			note1.id,
+			note2.id,
+			note3.id,
+		]);
+		let commonTagIds = commonTags.map((t) => t.id);
 		expect(commonTagIds.length).toBe(0);
 
 		commonTags = await Tag.commonTagsByNoteIds([note1.id, note2.id, note3.id]);
-		commonTagIds = commonTags.map(t => t.id);
+		commonTagIds = commonTags.map((t) => t.id);
 		expect(commonTagIds.length).toBe(1);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note2.id, note3.id]);
-		commonTagIds = commonTags.map(t => t.id);
+		commonTagIds = commonTags.map((t) => t.id);
 		expect(commonTagIds.length).toBe(2);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 		expect(commonTagIds.includes(tagb.id)).toBe(true);
 
 		commonTags = await Tag.commonTagsByNoteIds([note3.id]);
 
-		commonTagIds = commonTags.map(t => t.id);
+		commonTagIds = commonTags.map((t) => t.id);
 		expect(commonTags.length).toBe(3);
 		expect(commonTagIds.includes(taga.id)).toBe(true);
 		expect(commonTagIds.includes(tagb.id)).toBe(true);
 		expect(commonTagIds.includes(tagc.id)).toBe(true);
-	}));
+	});
 
+	it('should sort tags in promptDialog', async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({
+			title: 'ma note 0',
+			parent_id: folder1.id,
+		});
+
+		// original/sorted order
+		const tag1 = await Tag.save({ title: '#coding' });
+		const tag2 = await Tag.save({ title: '#house' });
+		const tag3 = await Tag.save({ title: '#wait' });
+		const tag4 = await Tag.save({ title: '@⏲15 min' });
+		const tag5 = await Tag.save({ title: '@⏲30 min' });
+		const tag6 = await Tag.save({ title: '@⏲60 min' });
+
+		await Tag.addNote(tag4.id, note1.id);
+		await Tag.addNote(tag2.id, note1.id);
+		await Tag.addNote(tag1.id, note1.id);
+		await Tag.addNote(tag6.id, note1.id);
+		await Tag.addNote(tag3.id, note1.id);
+		await Tag.addNote(tag5.id, note1.id);
+
+		const commonTags = await Tag.commonTagsByNoteIds([note1.id]); // commonTags has unsorted tags
+		// sortDefaultTags are shown as default values when the promptDialog is opened
+		const sortDefaultTagsTitles = commonTags
+			.map((a) => {
+				return { value: a.id, label: a.title };
+			})
+			.sort((a, b) => {
+				return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
+			})
+			.map((a) => a.label);
+		expect(sortDefaultTagsTitles).toEqual([
+			'#coding',
+			'#house',
+			'#wait',
+			'@⏲15 min',
+			'@⏲30 min',
+			'@⏲60 min',
+		]);
+		expect(sortDefaultTagsTitles).not.toEqual([
+			'@⏲15 min',
+			'#house',
+			'#coding',
+			'@⏲60 min',
+			'#wait',
+			'@⏲30 min',
+		]);
+
+		const allTags = await Tag.allWithNotes(); // allTags has unsorted tags
+		// sortTagSuggestions are shown in the dropdown menu of promptDialog
+		const sortTagSuggestionsTitles = allTags
+			.map((a) => {
+				return { value: a.id, label: a.title };
+			})
+			.sort((a, b) => {
+				return a.label.toLowerCase() < b.label.toLowerCase() ? -1 : +1;
+			})
+			.map((a) => a.label);
+		expect(sortTagSuggestionsTitles).toEqual([
+			'#coding',
+			'#house',
+			'#wait',
+			'@⏲15 min',
+			'@⏲30 min',
+			'@⏲60 min',
+		]);
+		expect(sortTagSuggestionsTitles).not.toEqual([
+			'@⏲15 min',
+			'#house',
+			'#coding',
+			'@⏲60 min',
+			'#wait',
+			'@⏲30 min',
+		]);
+	});
 });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -217,7 +217,7 @@ export default class Tag extends BaseItem {
 		});
 	}
 
-	static sortTags(tags: any) {
+	static sortTags(tags: TagEntity[]) {
 		if (tags[0].title) {
 			return tags.sort((a: any,b: any)=>{
 				// It seems title can sometimes be undefined (perhaps when syncing and before tag has been decrypted?). It would be best to find the root cause but for now that will do.
@@ -228,13 +228,6 @@ export default class Tag extends BaseItem {
 				// imported tags might be any case, so we need to do case-insensitive
 				// sort.
 				return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
-			});
-		}
-
-		if (tags[0].label) {
-			return tags.sort((a: any, b: any) => {
-				if (!a || !a.label || !b || !b.label) return 0;
-				return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
 			});
 		}
 	}

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -216,4 +216,27 @@ export default class Tag extends BaseItem {
 			return tag;
 		});
 	}
+
+	static sortTags(tags: any) {
+		if (tags[0].title) {
+			return tags.sort((a: any,b: any)=>{
+				// It seems title can sometimes be undefined (perhaps when syncing and before tag has been decrypted?). It would be best to find the root cause but for now that will do.
+				// Fixes https://github.com/laurent22/joplin/issues/4051
+				if (!a || !a.title || !b || !b.title) return 0;
+
+				// Note: while newly created tags are normalized and lowercase
+				// imported tags might be any case, so we need to do case-insensitive
+				// sort.
+				return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
+			});
+		}
+
+		if (tags[0].label) {
+			return tags.sort((a: any, b: any) => {
+				if (!a || !a.label || !b || !b.label) return 0;
+				return a.label.localeCompare(b.label, undefined, { sensitivity: 'accent' });
+			});
+		}
+	}
+
 }

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -218,18 +218,16 @@ export default class Tag extends BaseItem {
 	}
 
 	static sortTags(tags: TagEntity[]) {
-		if (tags[0].title) {
-			return tags.sort((a: any,b: any)=>{
-				// It seems title can sometimes be undefined (perhaps when syncing and before tag has been decrypted?). It would be best to find the root cause but for now that will do.
-				// Fixes https://github.com/laurent22/joplin/issues/4051
-				if (!a || !a.title || !b || !b.title) return 0;
+		return tags.sort((a: any,b: any)=>{
+			// It seems title can sometimes be undefined (perhaps when syncing and before tag has been decrypted?). It would be best to find the root cause but for now that will do.
+			// Fixes https://github.com/laurent22/joplin/issues/4051
+			if (!a || !a.title || !b || !b.title) return 0;
 
-				// Note: while newly created tags are normalized and lowercase
-				// imported tags might be any case, so we need to do case-insensitive
-				// sort.
-				return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
-			});
-		}
+			// Note: while newly created tags are normalized and lowercase
+			// imported tags might be any case, so we need to do case-insensitive
+			// sort.
+			return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
+		});
 	}
 
 }

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -218,7 +218,7 @@ export default class Tag extends BaseItem {
 	}
 
 	static sortTags(tags: TagEntity[]) {
-		return tags.sort((a: any,b: any)=>{
+		return tags.sort((a: TagEntity,b: TagEntity) => {
 			// It seems title can sometimes be undefined (perhaps when syncing and before tag has been decrypted?). It would be best to find the root cause but for now that will do.
 			// Fixes https://github.com/laurent22/joplin/issues/4051
 			if (!a || !a.title || !b || !b.title) return 0;


### PR DESCRIPTION
This fixes the bug #5686; The tag order between left panel and windows tag is different.
![tags order](https://user-images.githubusercontent.com/90026187/153363103-7d2b9bf6-0455-4e2a-b926-96eaf0e26949.jpg)
Whenever tags starting with emoji, #, @ were added then the order for tags in the promptDialog dropdown menu and sidebar TAGS section were different.

The cause of the bug was that different sorting logic was used in the sidebar tags section and setTags.ts (the sort method in this file is used to sort tags in the promptDialog dropdown menu).

To fix this I did the following, removed the old sort method in setTags.ts and added the sort method which was used in the side-menu-shared.js (this sort method is used to sort tags in the sidebar). As the sort methods are same the outputs are also the same. I have also added the unit test.
 