### PR TITLE
Mobile: Fixes #5482: Removes title multiline and contentsize related code to prevent multiline titles

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1106,6 +1106,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 						autoCapitalize="sentences"
 						style={this.styles().bodyTextInput}
 						ref="noteBodyTextField"
+						multiline={true}
 						value={note.body}
 						onChangeText={(text: string) => this.body_changeText(text)}
 						onSelectionChange={this.body_selectionChange}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -93,9 +93,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 		this.doFocusUpdate_ = false;
 
-		// iOS doesn't support multiline text fields properly so disable it
-		this.enableMultilineTitle_ = Platform.OS !== 'ios';
-
 		this.saveButtonHasBeenShown_ = false;
 
 		this.styles_ = {};
@@ -231,7 +228,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.onAlarmDialogAccept = this.onAlarmDialogAccept.bind(this);
 		this.onAlarmDialogReject = this.onAlarmDialogReject.bind(this);
 		this.todoCheckbox_change = this.todoCheckbox_change.bind(this);
-		this.titleTextInput_contentSizeChange = this.titleTextInput_contentSizeChange.bind(this);
 		this.title_changeText = this.title_changeText.bind(this);
 		this.undoRedoService_stackChange = this.undoRedoService_stackChange.bind(this);
 		this.screenHeader_undoButtonPress = this.screenHeader_undoButtonPress.bind(this);
@@ -389,7 +385,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 			paddingBottom: 10, // Added for iOS (Not needed for Android??)
 		};
 
-		if (this.enableMultilineTitle_) styles.titleTextInput.height = this.state.titleTextInputHeight;
 		if (this.state.HACK_webviewLoadingState === 1) styles.titleTextInput.marginTop = 1;
 
 		this.styles_[cacheKey] = StyleSheet.create(styles);
@@ -971,13 +966,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		await this.saveOneProperty('todo_completed', checked ? time.unixMs() : 0);
 	}
 
-	titleTextInput_contentSizeChange(event: any) {
-		if (!this.enableMultilineTitle_) return;
-
-		const height = event.nativeEvent.contentSize.height;
-		this.setState({ titleTextInputHeight: height });
-	}
-
 	scheduleFocusUpdate() {
 		if (this.focusUpdateIID_) shim.clearTimeout(this.focusUpdateIID_);
 
@@ -1118,7 +1106,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 						autoCapitalize="sentences"
 						style={this.styles().bodyTextInput}
 						ref="noteBodyTextField"
-						multiline={true}
 						value={note.body}
 						onChangeText={(text: string) => this.body_changeText(text)}
 						onSelectionChange={this.body_selectionChange}
@@ -1178,8 +1165,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 			<View style={titleContainerStyle}>
 				{isTodo && <Checkbox style={this.styles().checkbox} checked={!!Number(note.todo_completed)} onChange={this.todoCheckbox_change} />}
 				<TextInput
-					onContentSizeChange={this.titleTextInput_contentSizeChange}
-					multiline={this.enableMultilineTitle_}
 					ref="titleTextField"
 					underlineColorAndroid="#ffffff00"
 					autoCapitalize="sentences"


### PR DESCRIPTION
Fix for https://github.com/laurent22/joplin/issues/5482

Removes code related to `enableMultilineTitle` and `titleTextInput_contentSizeChange` as no longer required if titles can no longer have changeable heights.

Checked with Android simulator in both regular and beta editors - can no longer create carriage returns/new lines in title lines. Don't currently have ability to compile for iOS but this was previously not enabled for iOS anyway so not expecting any behaviour changes.