### PR TITLE
Desktop: Resolves #6085 Add initial support for XDG Folder Specs

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -689,7 +689,8 @@ export default class BaseApplication {
 		} else if (process && process.env && process.env.PORTABLE_EXECUTABLE_DIR) {
 			output = `${process.env.PORTABLE_EXECUTABLE_DIR}/JoplinProfile`;
 		} else {
-			output = `${os.homedir()}/.config/${Setting.value('appName')}`;
+			const configFolder = process.env.XDG_CONFIG_HOME || `${os.homedir()}/.config`;
+			output = `${configFolder}/${Setting.value('appName')}`;
 		}
 
 		return toSystemSlashes(output, 'linux');


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

This resolves #6085

This change adds the ability for Joplin to use the existing environment variables for XDG Base Directory Specifications. This allows the application to be flexible in alternate runtime environments such as flatpak, while additionally allowing the user to customize the default location of the profile directory according to their own XDG location preferences. 

This is just the initial change for the main folder. Ideally, further pull requests will implement more granular directory specifications such as XDG_CACHE_HOME, and XDG_DATA_HOME