### PR TITLE
Desktop: how to get the extension

### DIFF
--- a/readme/clipper.md
+++ b/readme/clipper.md
@@ -1,8 +1,9 @@
 # Joplin Web Clipper
 
-The Web Clipper is a browser extension that allows you to save web pages and screenshots from your browser. To start using it, open the Joplin desktop application, go to the **Web Clipper Options** and follow the instructions.
+The Web Clipper is a browser extension that allows you to save web pages and screenshots from your browser. To start using it, download the relevent extention from the following list:
 
-<img src="https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/WebExtensionScreenshot.png" style="max-width: 50%; border: 1px solid gray;">
+- [chrome](https://chrome.google.com/webstore/detail/joplin-web-clipper/alofnhikmmkdbbbgpnglcpdollgjjfek)
+- [firebox](https://addons.mozilla.org/en-US/firefox/addon/joplin-web-clipper/)
 
 # Troubleshooting the web clipper service
 


### PR DESCRIPTION
The readme refers to the desktop app to start using the web clipper extension but I couldn't find any mention of it on my local Joplin installed app (OSX).

So I've removed that paragraph and added links to chrome and firefox extensions.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
