### PR TITLE
Docs: GSoC 2022 - Add settings sync idea

### DIFF
--- a/readme/gsoc2022/ideas.md
+++ b/readme/gsoc2022/ideas.md
@@ -156,6 +156,15 @@ Difficulty Level: High
 
 Skills Required: TypeScript, JavaScript, Electron.
 
+## 14. Client settings sync
+
+Whenever settings are changed on one client these are not replicated to other clients connected to the same sync target.
+This project would be about creating synchronisation between clients to allow a single configuration rather than having to set them up separately on each e.g. keyboard shortcuts, installed plugins, Markdown plugins, note history etc.
+
+Difficulty Level: High
+
+Skills Required: TypeScript, JavaScript
+
 # More info
 
 - Make sure you read the [Joplin Google Summer of Code Introduction](https://joplinapp.org/gsoc2022/index/)


### PR DESCRIPTION
Add settings sync idea to GSoC ideas - discussed previously:

> The plugin ecosystem at this point is starting to become fairly essential to the way that people use Joplin so having to mirror settings over 2 or more devices can start to become a chore - particularly things like notebook sorting orders let alone the myriad of plugin settings.
> So basically an option to sync the settings (and the client info with it would be a bonus) rather than having to keep doing the same setup multiple times.