### PR TITLE
Clipper: add an open newly created note button

### DIFF
--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -70,8 +70,8 @@ class AppComponent extends Component {
 			const content = Object.assign({}, this.props.clippedContent);
 			content.tags = this.state.selectedTags.join(',');
 			content.parent_id = this.props.selectedFolderId;
-			const newNoteId = await bridge().sendContentToJoplin(content);
-			this.setState({ newNoteId });
+			const response = await bridge().sendContentToJoplin(content);
+			this.setState({ newNoteId: response.id });
 		};
 
 		this.contentTitle_change = (event) => {
@@ -406,13 +406,18 @@ class AppComponent extends Component {
 
 		const openNewNoteButton = () => {
 
-			if (this.state.newNoteId === null) {
-				return undefined;
-			} else {
+			if (!this.state.newNoteId) { return null; } else {
 				return (
-					// The jopin:// link must be opened in a new tab. When it's opened for  the first time, a system popup will ask for the user's permission.
-					// The popup is too small to show the permission and the user will not be able to see the buttons.
-					<a className="Button" href={`joplin://x-callback-url/openNote?id=${this.state.newNoteId}`} target="_blank"> Open newly created note</a>
+					// The jopin:// link must be opened in a new tab. When it's opened for the first time, a system dialog will ask for the user's permission.
+					// The system diaglog is too big to fit into the popup so user will not be able to see the dialog buttons and get stuck.
+					<a
+						className="Button"
+						href={`joplin://x-callback-url/openNote?id=${encodeURIComponent(this.state.newNoteId)}`}
+						target="_blank"
+						onClick={() => this.setState({ newNoteId: null })}
+					>
+          Open newly created note
+					</a>
 				);
 			}
 		};

--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -63,13 +63,15 @@ class AppComponent extends Component {
 			contentScriptLoaded: false,
 			selectedTags: [],
 			contentScriptError: '',
+			newNoteId: null,
 		});
 
-		this.confirm_click = () => {
+		this.confirm_click = async () => {
 			const content = Object.assign({}, this.props.clippedContent);
 			content.tags = this.state.selectedTags.join(',');
 			content.parent_id = this.props.selectedFolderId;
-			bridge().sendContentToJoplin(content);
+			const newNoteId = await bridge().sendContentToJoplin(content);
+			this.setState({ newNoteId });
 		};
 
 		this.contentTitle_change = (event) => {
@@ -402,6 +404,19 @@ class AppComponent extends Component {
 			);
 		};
 
+		const openNewNoteButton = () => {
+
+			if (this.state.newNoteId === null) {
+				return undefined;
+			} else {
+				return (
+					// The jopin:// link must be opened in a new tab. When it's opened for  the first time, a system popup will ask for the user's permission.
+					// The popup is too small to show the permission and the user will not be able to see the buttons.
+					<a className="Button" href={`joplin://x-callback-url/openNote?id=${this.state.newNoteId}`} target="_blank"> Open newly created note</a>
+				);
+			}
+		};
+
 		const tagDataListOptions = [];
 		for (let i = 0; i < this.props.tags.length; i++) {
 			const tag = this.props.tags[i];
@@ -437,6 +452,7 @@ class AppComponent extends Component {
 				</div>
 				{ warningComponent }
 				{ previewComponent }
+				{ openNewNoteButton() }
 				{ clipperStatusComp() }
 			</div>
 		);

--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -409,7 +409,7 @@ class AppComponent extends Component {
 			if (!this.state.newNoteId) { return null; } else {
 				return (
 					// The jopin:// link must be opened in a new tab. When it's opened for the first time, a system dialog will ask for the user's permission.
-					// The system diaglog is too big to fit into the popup so user will not be able to see the dialog buttons and get stuck.
+					// The system dialog is too big to fit into the popup so the user will not be able to see the dialog buttons and get stuck.
 					<a
 						className="Button"
 						href={`joplin://x-callback-url/openNote?id=${encodeURIComponent(this.state.newNoteId)}`}

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -467,7 +467,7 @@ class Bridge {
 
 			this.dispatch({ type: 'CONTENT_UPLOAD', operation: { uploading: false, success: true } });
 
-			return response.id;
+			return response;
 		} catch (error) {
 			if (error.message === '{"error":"Duplicate Nounce"}') {
 				this.dispatch({ type: 'CONTENT_UPLOAD', operation: { uploading: false, success: true } });

--- a/packages/app-clipper/popup/src/bridge.js
+++ b/packages/app-clipper/popup/src/bridge.js
@@ -463,9 +463,11 @@ class Bridge {
 			// This is the perfect Heisenbug - it happens always when opening the popup the first time EXCEPT
 			// when the debugger is open. Then everything is working fine and the bug NEVER EVER happens,
 			// so it's impossible to understand what's going on.
-			await this.clipperApiExec('POST', 'notes', { nounce: this.nounce_++ }, content);
+			const response = await this.clipperApiExec('POST', 'notes', { nounce: this.nounce_++ }, content);
 
 			this.dispatch({ type: 'CONTENT_UPLOAD', operation: { uploading: false, success: true } });
+
+			return response.id;
 		} catch (error) {
 			if (error.message === '{"error":"Duplicate Nounce"}') {
 				this.dispatch({ type: 'CONTENT_UPLOAD', operation: { uploading: false, success: true } });


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

This PR adds a button after you click "Confirm" in the clipper. This button allow you to open the newly created note in Joplin using the `joplin://` link. This streamlines the clipping process because the user no longer need to switch to the Joplin Desktop app and search for the new note. 

![screenshot_2022-02-26_19-44-28](https://user-images.githubusercontent.com/3250983/155857001-1cf6db1a-6b9a-499f-a0db-12e1dc4b5bb4.png)
 

