### PR TITLE
Clipper: scroll to bottom when preview appears

### DIFF
--- a/packages/app-clipper/popup/src/App.js
+++ b/packages/app-clipper/popup/src/App.js
@@ -63,6 +63,7 @@ class AppComponent extends Component {
 			contentScriptLoaded: false,
 			selectedTags: [],
 			contentScriptError: '',
+			scrollToBottom: false,
 		});
 
 		this.confirm_click = () => {
@@ -77,12 +78,14 @@ class AppComponent extends Component {
 				type: 'CLIPPED_CONTENT_TITLE_SET',
 				text: event.currentTarget.value,
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipSimplified_click = () => {
 			bridge().sendCommandToActiveTab({
 				name: 'simplifiedPageHtml',
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipComplete_click = () => {
@@ -90,6 +93,7 @@ class AppComponent extends Component {
 				name: 'completePageHtml',
 				preProcessFor: 'markdown',
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipCompleteHtml_click = () => {
@@ -97,18 +101,21 @@ class AppComponent extends Component {
 				name: 'completePageHtml',
 				preProcessFor: 'html',
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipSelection_click = () => {
 			bridge().sendCommandToActiveTab({
 				name: 'selectedHtml',
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipUrl_click = () => {
 			bridge().sendCommandToActiveTab({
 				name: 'pageUrl',
 			});
+			this.setState({ scrollToBottom: true });
 		};
 
 		this.clipScreenshot_click = async () => {
@@ -231,6 +238,9 @@ class AppComponent extends Component {
 				lastRef = ref;
 			}
 			if (lastRef) lastRef.focus();
+		}
+		if (this.state.scrollToBottom) {
+			window.scrollTo({ left: 0, top: document.body.scrollHeight, behavior: 'smooth' });
 		}
 	}
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

The clipper popup has a fixed height. Currently when a user click "Clip <something>" they need to manually scroll to the bottom to see the preview and the "Confirm" button. This PR will scroll automatically when a "Clip <something>" button is clicked, so the user can see the "Confirm" button immediately. 