### PR TITLE
Mobile: add tags filter to note tags dialog

### DIFF
--- a/packages/app-mobile/components/screens/NoteTagsDialog.js
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.js
@@ -176,7 +176,7 @@ class NoteTagsDialogComponent extends React.Component {
 							this.setState({ newTags: value });
 						}}
 						style={this.styles().tagBoxInput}
-						placeholder="e.g. foo,bar"
+						placeholder={_('tag1,tag2,...')}
 					/>
 				</View>
 				<View style={this.styles().tagBox}>
@@ -187,7 +187,7 @@ class NoteTagsDialogComponent extends React.Component {
 						onChangeText={value => {
 							this.setState({ tagFilter: value });
 						}}
-						placeholder="Filter tags"
+						placeholder={_('Filter tags')}
 						style={this.styles().tagBoxInput}
 					/>
 				</View>

--- a/packages/app-mobile/components/screens/NoteTagsDialog.js
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.js
@@ -21,6 +21,7 @@ class NoteTagsDialogComponent extends React.Component {
 			tagListData: [],
 			newTags: '',
 			savingTags: false,
+			tagFilter: '',
 		};
 
 		const noteHasTag = tagId => {
@@ -88,6 +89,10 @@ class NoteTagsDialogComponent extends React.Component {
 		this.cancelButton_press = () => {
 			if (this.props.onCloseRequested) this.props.onCloseRequested();
 		};
+
+		this.filterTags = (allTags) => {
+			return allTags.filter((tag) => tag.title.includes(this.state.tagFilter.toLowerCase()), allTags);
+		};
 	}
 
 	UNSAFE_componentWillMount() {
@@ -140,16 +145,16 @@ class NoteTagsDialogComponent extends React.Component {
 				fontSize: 20,
 				color: theme.color,
 			},
-			newTagBox: {
+			tagBox: {
 				flexDirection: 'row',
 				alignItems: 'center',
-				paddingLeft: theme.marginLeft,
-				paddingRight: theme.marginRight,
+				paddingLeft: 10,
+				paddingRight: 10,
 				borderBottomWidth: 1,
 				borderBottomColor: theme.dividerColor,
 			},
 			newTagBoxLabel: Object.assign({}, theme.normalText, { marginRight: 8 }),
-			newTagBoxInput: Object.assign({}, theme.lineInput, { flex: 1 }),
+			tagBoxInput: Object.assign({}, theme.lineInput, { flex: 1 }),
 		};
 
 		this.styles_[themeId] = StyleSheet.create(styles);
@@ -161,7 +166,7 @@ class NoteTagsDialogComponent extends React.Component {
 
 		const dialogContent = (
 			<View style={{ flex: 1 }}>
-				<View style={this.styles().newTagBox}>
+				<View style={this.styles().tagBox}>
 					<Text style={this.styles().newTagBoxLabel}>{_('New tags:')}</Text>
 					<TextInput
 						selectionColor={theme.textSelectionColor}
@@ -170,10 +175,23 @@ class NoteTagsDialogComponent extends React.Component {
 						onChangeText={value => {
 							this.setState({ newTags: value });
 						}}
-						style={this.styles().newTagBoxInput}
+						style={this.styles().tagBoxInput}
+						placeholder="e.g. foo,bar"
 					/>
 				</View>
-				<FlatList data={this.state.tagListData} renderItem={this.renderTag} keyExtractor={this.tagKeyExtractor} />
+				<View style={this.styles().tagBox}>
+					<TextInput
+						selectionColor={theme.textSelectionColor}
+						keyboardAppearance={theme.keyboardAppearance}
+						value={this.state.tagFilter}
+						onChangeText={value => {
+							this.setState({ tagFilter: value });
+						}}
+						placeholder="Filter tags"
+						style={this.styles().tagBoxInput}
+					/>
+				</View>
+				<FlatList data={this.filterTags(this.state.tagListData)} renderItem={this.renderTag} keyExtractor={this.tagKeyExtractor} />
 			</View>
 		);
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

https://user-images.githubusercontent.com/3250983/156068396-e6b74860-78ec-4411-9f92-42f785899c43.mp4



AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
This PR adds a tag filter (the "Filter tags" input box in the screen recording below) for mobile app's note tag dialog. It helps the user search for a particular tag in the tags list. 


https://user-images.githubusercontent.com/3250983/156068396-e6b74860-78ec-4411-9f92-42f785899c43.mp4
