### PR TITLE
Desktop: Update the docs about pre-release feature

### DIFF
--- a/readme/prereleases.md
+++ b/readme/prereleases.md
@@ -6,4 +6,4 @@ You can help the development of Joplin by choosing to receive these early releas
 
 In general it is safe to use these pre-releases as they do not include any experimental or unstable features. Hundreds of users run them without any issue. Moreover even if you do find an issue, you can report it and it is usually fixed very quickly as these bugs are given the highest priority.
 
-To have access to these pre-releases, simply go to [Configuration &gt; General](https://github.com/laurent22/joplin/blob/dev/readme/config_screen.md) and tick the box "**Get pre-releases when checking for updates**".
+To have access to these pre-releases, simply go to [Configuration &gt; Application](https://github.com/laurent22/joplin/blob/dev/readme/config_screen.md) and tick the box "**Get pre-releases when checking for updates**".


### PR DESCRIPTION

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

## Why

Update a latest situation for pre-release checkbox at Config page.

Currently pre-release checkbox feature is placed `Configuration > Application` not `Configuration >  General`

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/2786333/156203352-9e42ba5e-82b0-40a3-a928-205e46f47444.png">



