### PR TITLE
Desktop: Resolves #6194: Save Notebook on enter button press

### DIFF
--- a/packages/app-desktop/gui/DialogButtonRow.tsx
+++ b/packages/app-desktop/gui/DialogButtonRow.tsx
@@ -1,5 +1,5 @@
 const React = require('react');
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 const { _ } = require('@joplin/lib/locale');
 const { themeStyle } = require('@joplin/lib/theme');
 
@@ -56,7 +56,13 @@ export default function DialogButtonRow(props: Props) {
 			cancelButton_click();
 		}
 	};
+	useEffect(() => {
+		window.addEventListener('keydown', onKeyDown);
 
+		return () => {
+			window.removeEventListener('keydown', onKeyDown);
+		};
+	}, [onKeyDown]);
 	const buttonComps = [];
 
 	if (props.customButtons) {


### PR DESCRIPTION
## Overview
When we edit or create new notebook, the popup doesn't works on keypress. More Specifically on pressing Enter key.
This pr resolves the issue #6194 

To fix this issue, an useEffect hook for adding a keypress event listener to the window was added.  When enter key is pressed, 
`okButton_click()` function gets called and the related operation takes place.