### PR TITLE
Docs: Update themes in GSoC index.md and a typo correction

### DIFF
--- a/readme/gsoc2022/index.md
+++ b/readme/gsoc2022/index.md
@@ -2,9 +2,8 @@
 
 Joplin has a young but well proven history. All contributors, Joplin users and developers are welcome to participate in the hopefully third year Summer of Code program with Joplin. This year the main themes will be:
 
-- **Plugin development** - implementing new features using Joplin's plugin system.
-- **External desktop applications** - build external Joplin applications by retrieving, creating or modifying notes via the Data API.
-- **External server applications** - leverage the Joplin Server API to provide online features to Joplin users.
+- **Mobile and tablet development** - we want to improve the mobile/tablet application on iOS and Android.
+- **Plugin and external apps** - leverage the Joplin API to create plugins and external apps.
 - And you are welcome to suggest your own ideas.
 
 Mentors, administrators and contributors: read [Summer of Code](https://developers.google.com/open-source/gsoc) occasionally. Also read the [Summer of Code FAQ](https://developers.google.com/open-source/gsoc/faq).

--- a/readme/gsoc2022/pull_request_guidelines.md
+++ b/readme/gsoc2022/pull_request_guidelines.md
@@ -6,7 +6,7 @@ Due to our limited resources and in order to give everyone a chance to submit a 
 
 2. Each contributor **may only create one pull request at a time**. Once your pull request has been merged, you can post a second one. We have this rule in place due to our limited resources - if everyone was allowed to post multiple pull requests we will not be able to review them properly. It is also better for you because you only need to care about one PR - so spend time making sure it is as good as it can be - make sure it works well, has test units, documentation and screenshots (if relevant).
 
-3. If the pull request has serious issues, or would require a significant rewrite to be acceptable, we might closed it and you will not be allowed to open a new one. So **please be careful when posting a PR**.
+3. If the pull request has serious issues, or would require a significant rewrite to be acceptable, we might close it and you will not be allowed to open a new one. So **please be careful when posting a PR**.
 
 4. **If you are borrowing code, please disclose it**. It is fine and sometimes even recommended to borrow code, but we need to know about it to assess your work. If we find out that your pull request contains a lot of code copied from elsewhere, we will close the pull request.
 


### PR DESCRIPTION
This years themes are in the index as well as the ideas page so I've copied the themes from ideas to index to keep them consistent.
Also corrected a small typo in the guidelines.