### PR TITLE
Desktop: Resolves#6167 :Add distinguishing between notes with same name

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -17,15 +17,18 @@ export const runtime = (comp: any): CommandRuntime => {
 			const startFolders: any[] = [];
 			const maxDepth = 15;
 
-			const addOptions = (folders: any[], depth: number) => {
+			const addOptions = (folders: any[], depth: number, parentsPath: string) => {
 				for (let i = 0; i < folders.length; i++) {
 					const folder = folders[i];
-					startFolders.push({ key: folder.id, value: folder.id, label: folder.title, indentDepth: depth });
-					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth);
+					let folderPath;
+					if (parentsPath === '') folderPath = folder.title;
+					else folderPath = `${parentsPath} > ${folder.title}`;
+					startFolders.push({ key: folder.id, value: folder.id, label: folderPath, indentDepth: depth });
+					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth, folderPath);
 				}
 			};
 
-			addOptions(folders, 0);
+			addOptions(folders, 0, '');
 
 			comp.setState({
 				promptOptions: {


### PR DESCRIPTION
This PR is regarding issue #6167 

This makes it clear when searching for specific note, and there is multiple notes with its name
It appends the note full path for it as shown below in the GIF

**Regarding Unit Tests, I didn't find any unit tests for this part, and found it hard to unit test it since in dependent on other parts of the application, and I didn't add new functionalities which could be tested, I just added one parameter to track folder path (using parents of it)**

**I added manual testing plan as required [here](https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md#automated-tests) to make sure it didn't affect other parts**

GIF:
Functionality:
![joplin](https://user-images.githubusercontent.com/34144004/157302251-ad121710-44ed-471d-b4b2-c7b9207f7b34.gif)
 
 Make sure that the dropdown is still working as expected:
![Dropdown Work](https://user-images.githubusercontent.com/34144004/157565172-7f375dab-cd23-46b5-81f6-4014e66c1ff4.gif)

Make sure that moving notes using drag and drop is still working:
![moving](https://user-images.githubusercontent.com/34144004/157565454-3c70712c-b77a-4e68-9a5e-39cdf1a59f3e.gif)

Feature behavior in case of large strings
![LargeString](https://user-images.githubusercontent.com/34144004/157565409-7e3e0a7b-90c7-4d74-9224-b76012009a02.gif)

Feature behavior if no matches found
![NoMatch](https://user-images.githubusercontent.com/34144004/157565528-90de758b-ad63-4869-8088-46529c5674c4.gif)

Make sure that TODO note is still working (normal notes tested above): 
![TODO](https://user-images.githubusercontent.com/34144004/157565576-a8ba435a-37f9-42a4-9908-980476422579.gif)
