### PR TITLE
All: Resolves #6266: Filter keywords casesensetive

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1639,6 +1639,9 @@ packages/lib/services/searchengine/SearchEngineUtils.js.map
 packages/lib/services/searchengine/SearchEngineUtils.test.d.ts
 packages/lib/services/searchengine/SearchEngineUtils.test.js
 packages/lib/services/searchengine/SearchEngineUtils.test.js.map
+packages/lib/services/searchengine/SearchFilter.test.d.ts
+packages/lib/services/searchengine/SearchFilter.test.js
+packages/lib/services/searchengine/SearchFilter.test.js.map
 packages/lib/services/searchengine/filterParser.d.ts
 packages/lib/services/searchengine/filterParser.js
 packages/lib/services/searchengine/filterParser.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1629,6 +1629,9 @@ packages/lib/services/searchengine/SearchEngineUtils.js.map
 packages/lib/services/searchengine/SearchEngineUtils.test.d.ts
 packages/lib/services/searchengine/SearchEngineUtils.test.js
 packages/lib/services/searchengine/SearchEngineUtils.test.js.map
+packages/lib/services/searchengine/SearchFilter.test.d.ts
+packages/lib/services/searchengine/SearchFilter.test.js
+packages/lib/services/searchengine/SearchFilter.test.js.map
 packages/lib/services/searchengine/filterParser.d.ts
 packages/lib/services/searchengine/filterParser.js
 packages/lib/services/searchengine/filterParser.js.map

--- a/packages/lib/services/searchengine/SearchFilter.test.ts
+++ b/packages/lib/services/searchengine/SearchFilter.test.ts
@@ -1,19 +1,19 @@
 /* @typescript-eslint/prefer-const */
 
-const time = require('../../time').default;
-const { setupDatabaseAndSynchronizer, supportDir, db, createNTestNotes, switchClient } = require('../../testing/test-utils.js');
-const SearchEngine = require('../../services/searchengine/SearchEngine').default;
-const Note = require('../../models/Note').default;
-const Folder = require('../../models/Folder').default;
-const Tag = require('../../models/Tag').default;
-const shim = require('../../shim').default;
-const ResourceService = require('../../services/ResourceService').default;
+import time from '@joplin/lib/time';
+import { setupDatabaseAndSynchronizer, supportDir, db, createNTestNotes, switchClient } from '@joplin/lib/testing//test-utils';
+import SearchEngine from '@joplin/lib/services/searchengine/SearchEngine';
+import Note from '@joplin/lib/models/Note';
+import Folder from '@joplin/lib/models/Folder';
+import Tag from '@joplin/lib/models/Tag';
+import shim from '@joplin/lib/shim';
+import ResourceService from '@joplin/lib/services/ResourceService';
+import { NoteEntity } from '@joplin/lib/services/database/types';
 
 
 let engine: any = null;
 
-interface ObjectWithId { id: any }
-const ids = (array: ObjectWithId[]) => array.map(a => a.id);
+const ids = (array: NoteEntity[]) => array.map(a => a.id);
 
 describe('services_SearchFilter', function() {
 	beforeEach(async (done) => {

--- a/packages/lib/services/searchengine/SearchFilter.test.ts
+++ b/packages/lib/services/searchengine/SearchFilter.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars, prefer-const */
+/* @typescript-eslint/prefer-const */
 
 const time = require('../../time').default;
 const { setupDatabaseAndSynchronizer, supportDir, db, createNTestNotes, switchClient } = require('../../testing/test-utils.js');
@@ -105,24 +105,22 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return note matching title', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abcd', body: 'body 1' });
-				const n2 = await Note.save({ title: 'efgh', body: 'body 2' });
+				await Note.save({ title: 'efgh', body: 'body 2' });
 
 				await engine.syncTables();
-				rows = await engine.search('title: abcd', { searchType });
+				const rows = await engine.search('title: abcd', { searchType });
 
 				expect(rows.length).toBe(1);
 				expect(rows[0].id).toBe(n1.id);
 			}));
 
 			it('should return note matching negated title', (async () => {
-				let rows;
-				const n1 = await Note.save({ title: 'abcd', body: 'body 1' });
+				await Note.save({ title: 'abcd', body: 'body 1' });
 				const n2 = await Note.save({ title: 'efgh', body: 'body 2' });
 
 				await engine.syncTables();
-				rows = await engine.search('-title: abcd', { searchType });
+				const rows = await engine.search('-title: abcd', { searchType });
 
 				expect(rows.length).toBe(1);
 
@@ -130,12 +128,11 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return note matching body', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abcd', body: 'body1' });
-				const n2 = await Note.save({ title: 'efgh', body: 'body2' });
+				await Note.save({ title: 'efgh', body: 'body2' });
 
 				await engine.syncTables();
-				rows = await engine.search('body: body1', { searchType });
+				const rows = await engine.search('body: body1', { searchType });
 
 				expect(rows.length).toBe(1);
 
@@ -143,36 +140,33 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return note matching negated body', (async () => {
-				let rows;
-				const n1 = await Note.save({ title: 'abcd', body: 'body1' });
+				await Note.save({ title: 'abcd', body: 'body1' });
 				const n2 = await Note.save({ title: 'efgh', body: 'body2' });
 
 				await engine.syncTables();
-				rows = await engine.search('-body: body1', { searchType });
+				const rows = await engine.search('-body: body1', { searchType });
 
 				expect(rows.length).toBe(1);
 				expect(rows[0].id).toBe(n2.id);
 			}));
 
 			it('should return note matching title containing multiple words', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abcd xyz', body: 'body1' });
-				const n2 = await Note.save({ title: 'efgh ijk', body: 'body2' });
+				await Note.save({ title: 'efgh ijk', body: 'body2' });
 
 				await engine.syncTables();
-				rows = await engine.search('title: "abcd xyz"', { searchType });
+				const rows = await engine.search('title: "abcd xyz"', { searchType });
 
 				expect(rows.length).toBe(1);
 				expect(rows[0].id).toBe(n1.id);
 			}));
 
 			it('should return note matching body containing multiple words', (async () => {
-				let rows;
-				const n1 = await Note.save({ title: 'abcd', body: 'ho ho ho' });
+				await Note.save({ title: 'abcd', body: 'ho ho ho' });
 				const n2 = await Note.save({ title: 'efgh', body: 'foo bar' });
 
 				await engine.syncTables();
-				rows = await engine.search('body: "foo bar"', { searchType });
+				const rows = await engine.search('body: "foo bar"', { searchType });
 
 				expect(rows.length).toBe(1);
 				expect(rows[0].id).toBe(n2.id);
@@ -180,7 +174,7 @@ describe('services_SearchFilter', function() {
 
 			it('should return note matching title AND body', (async () => {
 				let rows;
-				const n1 = await Note.save({ title: 'abcd', body: 'ho ho ho' });
+				await Note.save({ title: 'abcd', body: 'ho ho ho' });
 				const n2 = await Note.save({ title: 'efgh', body: 'foo bar' });
 
 				await engine.syncTables();
@@ -234,13 +228,12 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return notes matching any negated text', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abc', body: 'def' });
 				const n2 = await Note.save({ title: 'def', body: 'ghi' });
 				const n3 = await Note.save({ title: 'ghi', body: 'jkl' });
 				await engine.syncTables();
 
-				rows = await engine.search('any:1 -abc -ghi', { searchType });
+				const rows = await engine.search('any:1 -abc -ghi', { searchType });
 				expect(rows.length).toBe(3);
 				expect(ids(rows)).toContain(n1.id);
 				expect(ids(rows)).toContain(n2.id);
@@ -248,13 +241,12 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return notes matching any negated title', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abc', body: 'def' });
 				const n2 = await Note.save({ title: 'def', body: 'ghi' });
 				const n3 = await Note.save({ title: 'ghi', body: 'jkl' });
 				await engine.syncTables();
 
-				rows = await engine.search('any:1 -title:abc -title:ghi', { searchType });
+				const rows = await engine.search('any:1 -title:abc -title:ghi', { searchType });
 				expect(rows.length).toBe(3);
 				expect(ids(rows)).toContain(n1.id);
 				expect(ids(rows)).toContain(n2.id);
@@ -262,13 +254,12 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should return notes matching any negated body', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'abc', body: 'def' });
 				const n2 = await Note.save({ title: 'def', body: 'ghi' });
 				const n3 = await Note.save({ title: 'ghi', body: 'jkl' });
 				await engine.syncTables();
 
-				rows = await engine.search('any:1 -body:xyz -body:ghi', { searchType });
+				const rows = await engine.search('any:1 -body:xyz -body:ghi', { searchType });
 				expect(rows.length).toBe(3);
 				expect(ids(rows)).toContain(n1.id);
 				expect(ids(rows)).toContain(n2.id);
@@ -276,23 +267,21 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should support phrase search', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'foo beef', body: 'bar dog' });
-				const n2 = await Note.save({ title: 'bar efgh', body: 'foo dog' });
+				await Note.save({ title: 'bar efgh', body: 'foo dog' });
 				await engine.syncTables();
 
-				rows = await engine.search('"bar dog"', { searchType });
+				const rows = await engine.search('"bar dog"', { searchType });
 				expect(rows.length).toBe(1);
 				expect(rows[0].id).toBe(n1.id);
 			}));
 
 			it('should support prefix search', (async () => {
-				let rows;
 				const n1 = await Note.save({ title: 'foo beef', body: 'bar dog' });
 				const n2 = await Note.save({ title: 'bar efgh', body: 'foo dog' });
 				await engine.syncTables();
 
-				rows = await engine.search('"bar*"', { searchType });
+				const rows = await engine.search('"bar*"', { searchType });
 				expect(rows.length).toBe(2);
 				expect(ids(rows)).toContain(n1.id);
 				expect(ids(rows)).toContain(n2.id);
@@ -375,38 +364,35 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should support filtering by notebook', (async () => {
-				let rows;
 				const folder0 = await Folder.save({ title: 'notebook0' });
 				const folder1 = await Folder.save({ title: 'notebook1' });
 				const notes0 = await createNTestNotes(5, folder0);
-				const notes1 = await createNTestNotes(5, folder1);
+				await createNTestNotes(5, folder1);
 
 				await engine.syncTables();
 
-				rows = await engine.search('notebook:notebook0', { searchType });
+				const rows = await engine.search('notebook:notebook0', { searchType });
 				expect(rows.length).toBe(5);
 				expect(ids(rows).sort()).toEqual(ids(notes0).sort());
 
 			}));
 
 			it('should support filtering by nested notebook', (async () => {
-				let rows;
 				const folder0 = await Folder.save({ title: 'notebook0' });
 				const folder00 = await Folder.save({ title: 'notebook00', parent_id: folder0.id });
 				const folder1 = await Folder.save({ title: 'notebook1' });
 				const notes0 = await createNTestNotes(5, folder0);
 				const notes00 = await createNTestNotes(5, folder00);
-				const notes1 = await createNTestNotes(5, folder1);
+				await createNTestNotes(5, folder1);
 
 				await engine.syncTables();
 
-				rows = await engine.search('notebook:notebook0', { searchType });
+				const rows = await engine.search('notebook:notebook0', { searchType });
 				expect(rows.length).toBe(10);
 				expect(ids(rows).sort()).toEqual(ids(notes0.concat(notes00)).sort());
 			}));
 
 			it('should support filtering by multiple notebooks', (async () => {
-				let rows;
 				const folder0 = await Folder.save({ title: 'notebook0' });
 				const folder00 = await Folder.save({ title: 'notebook00', parent_id: folder0.id });
 				const folder1 = await Folder.save({ title: 'notebook1' });
@@ -414,11 +400,11 @@ describe('services_SearchFilter', function() {
 				const notes0 = await createNTestNotes(5, folder0);
 				const notes00 = await createNTestNotes(5, folder00);
 				const notes1 = await createNTestNotes(5, folder1);
-				const notes2 = await createNTestNotes(5, folder2);
+				await createNTestNotes(5, folder2);
 
 				await engine.syncTables();
 
-				rows = await engine.search('notebook:notebook0 notebook:notebook1', { searchType });
+				const rows = await engine.search('notebook:notebook0 notebook:notebook1', { searchType });
 				expect(rows.length).toBe(15);
 				expect(ids(rows).sort()).toEqual(ids(notes0).concat(ids(notes00).concat(ids(notes1))).sort());
 			}));
@@ -647,7 +633,7 @@ describe('services_SearchFilter', function() {
 				let rows;
 				const t1 = await Note.save({ title: 'This is a ', body: 'todo', is_todo: 1 });
 				const t2 = await Note.save({ title: 'This is another', body: 'todo but completed', is_todo: 1, todo_completed: 1590085027710 });
-				const t3 = await Note.save({ title: 'This is NOT a ', body: 'todo' });
+				await Note.save({ title: 'This is NOT a ', body: 'todo' });
 
 				await engine.syncTables();
 
@@ -671,14 +657,13 @@ describe('services_SearchFilter', function() {
 			}));
 
 			it('should support filtering by type note', (async () => {
-				let rows;
-				const t1 = await Note.save({ title: 'This is a ', body: 'todo', is_todo: 1 });
-				const t2 = await Note.save({ title: 'This is another', body: 'todo but completed', is_todo: 1, todo_completed: 1590085027710 });
+				await Note.save({ title: 'This is a ', body: 'todo', is_todo: 1 });
+				await Note.save({ title: 'This is another', body: 'todo but completed', is_todo: 1, todo_completed: 1590085027710 });
 				const t3 = await Note.save({ title: 'This is NOT a ', body: 'todo' });
 
 				await engine.syncTables();
 
-				rows = await engine.search('type:note', { searchType });
+				const rows = await engine.search('type:note', { searchType });
 				expect(rows.length).toBe(1);
 				expect(ids(rows)).toContain(t3.id);
 			}));
@@ -687,7 +672,7 @@ describe('services_SearchFilter', function() {
 				let rows;
 				const toDo1 = await Note.save({ title: 'ToDo 1', body: 'todo', is_todo: 1, todo_due: Date.parse('2021-04-27') });
 				const toDo2 = await Note.save({ title: 'ToDo 2', body: 'todo', is_todo: 1, todo_due: Date.parse('2021-03-17') });
-				const note1 = await Note.save({ title: 'Note 1', body: 'Note' });
+				await Note.save({ title: 'Note 1', body: 'Note' });
 
 				await engine.syncTables();
 
@@ -901,8 +886,8 @@ describe('services_SearchFilter', function() {
 
 
 				const subFolder = await Folder.save({ title: 'child', parent_id: parentFolder.id });
-				const n3 = await Note.save({ title: 'task3', body: 'baz', parent_id: subFolder.id });
-				const n4 = await Note.save({ title: 'task4', body: 'blah', parent_id: subFolder.id });
+				await Note.save({ title: 'task3', body: 'baz', parent_id: subFolder.id });
+				await Note.save({ title: 'task4', body: 'blah', parent_id: subFolder.id });
 
 
 				await engine.syncTables();

--- a/packages/lib/services/searchengine/SearchFilter.test.ts
+++ b/packages/lib/services/searchengine/SearchFilter.test.ts
@@ -10,9 +10,10 @@ const shim = require('../../shim').default;
 const ResourceService = require('../../services/ResourceService').default;
 
 
-let engine = null;
+let engine: any = null;
 
-const ids = (array) => array.map(a => a.id);
+interface ObjectWithId { id: any }
+const ids = (array: ObjectWithId[]) => array.map(a => a.id);
 
 describe('services_SearchFilter', function() {
 	beforeEach(async (done) => {
@@ -199,8 +200,8 @@ describe('services_SearchFilter', function() {
 				await engine.syncTables();
 				rows = await engine.search('any:1 title: abcd body: "foo bar"', { searchType });
 				expect(rows.length).toBe(2);
-				expect(rows.map(r=>r.id)).toContain(n1.id);
-				expect(rows.map(r=>r.id)).toContain(n2.id);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
 
 				rows = await engine.search('any:1 title: wxyz body: "blah blah"', { searchType });
 				expect(rows.length).toBe(0);
@@ -217,12 +218,12 @@ describe('services_SearchFilter', function() {
 				// Note: This is NOT saying to match notes containing foo bar in title/body
 				rows = await engine.search('foo bar', { searchType });
 				expect(rows.length).toBe(2);
-				expect(rows.map(r=>r.id)).toContain(n1.id);
-				expect(rows.map(r=>r.id)).toContain(n2.id);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
 
 				rows = await engine.search('foo -bar', { searchType });
 				expect(rows.length).toBe(1);
-				expect(rows.map(r=>r.id)).toContain(n3.id);
+				expect(ids(rows)).toContain(n3.id);
 
 				rows = await engine.search('foo efgh', { searchType });
 				expect(rows.length).toBe(1);
@@ -241,9 +242,9 @@ describe('services_SearchFilter', function() {
 
 				rows = await engine.search('any:1 -abc -ghi', { searchType });
 				expect(rows.length).toBe(3);
-				expect(rows.map(r=>r.id)).toContain(n1.id);
-				expect(rows.map(r=>r.id)).toContain(n2.id);
-				expect(rows.map(r=>r.id)).toContain(n3.id);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
+				expect(ids(rows)).toContain(n3.id);
 			}));
 
 			it('should return notes matching any negated title', (async () => {
@@ -255,9 +256,9 @@ describe('services_SearchFilter', function() {
 
 				rows = await engine.search('any:1 -title:abc -title:ghi', { searchType });
 				expect(rows.length).toBe(3);
-				expect(rows.map(r=>r.id)).toContain(n1.id);
-				expect(rows.map(r=>r.id)).toContain(n2.id);
-				expect(rows.map(r=>r.id)).toContain(n3.id);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
+				expect(ids(rows)).toContain(n3.id);
 			}));
 
 			it('should return notes matching any negated body', (async () => {
@@ -269,9 +270,9 @@ describe('services_SearchFilter', function() {
 
 				rows = await engine.search('any:1 -body:xyz -body:ghi', { searchType });
 				expect(rows.length).toBe(3);
-				expect(rows.map(r=>r.id)).toContain(n1.id);
-				expect(rows.map(r=>r.id)).toContain(n2.id);
-				expect(rows.map(r=>r.id)).toContain(n3.id);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
+				expect(ids(rows)).toContain(n3.id);
 			}));
 
 			it('should support phrase search', (async () => {
@@ -922,20 +923,20 @@ describe('services_SearchFilter', function() {
 
 				rows = await engine.search(`id:${note1.id}`, { searchType });
 				expect(rows.length).toBe(1);
-				expect(rows.map(r=>r.id)).toContain(note1.id);
+				expect(ids(rows)).toContain(note1.id);
 
 				rows = await engine.search(`any:1 id:${note1.id} id:${note2.id}`, { searchType });
 				expect(rows.length).toBe(2);
-				expect(rows.map(r=>r.id)).toContain(note1.id);
-				expect(rows.map(r=>r.id)).toContain(note2.id);
+				expect(ids(rows)).toContain(note1.id);
+				expect(ids(rows)).toContain(note2.id);
 
 				rows = await engine.search(`any:0 id:${note1.id} id:${note2.id}`, { searchType });
 				expect(rows.length).toBe(0);
 
 				rows = await engine.search(`-id:${note2.id}`, { searchType });
 				expect(rows.length).toBe(2);
-				expect(rows.map(r=>r.id)).toContain(note1.id);
-				expect(rows.map(r=>r.id)).toContain(note3.id);
+				expect(ids(rows)).toContain(note1.id);
+				expect(ids(rows)).toContain(note3.id);
 			}));
 
 		});

--- a/packages/lib/services/searchengine/filterParser.ts
+++ b/packages/lib/services/searchengine/filterParser.ts
@@ -54,8 +54,8 @@ const getTerms = (query: string, validFilters: Set<string>): Term[] => {
 		}
 
 		if (c === ':' && !inQuote && !inTerm &&
-		(validFilters.has(currentTerm) || currentTerm[0] === '-' && validFilters.has(currentTerm.substr(1, currentTerm.length)))) {
-			currentCol = currentTerm;
+		(validFilters.has(currentTerm.toLowerCase()) || currentTerm[0] === '-' && validFilters.has(currentTerm.toLowerCase().substr(1, currentTerm.length)))) {
+			currentCol = currentTerm.toLowerCase();
 			currentTerm = '';
 			inTerm = true; // to ignore any other ':' before a space eg.'sourceurl:https://www.google.com'
 			continue;


### PR DESCRIPTION
Fixes #6266 that only lowercase keywords work in the search filters. 

I wanted also convert the `SearchFilter.test.js ` to TypeScript, but unfortunately I can't manage the following line.
`Parameter 'a' implicitly has an 'any' type.ts(7006)` [const ids = (array) => array.map(a => a.id); ](https://github.com/JackGruber/joplin/blob/2ecdc3596a4f74114a946b720b22cdc2c2aac7ca/packages/lib/services/searchengine/SearchFilter.test.js#L15)