### PR TITLE
fixed link to general Summer of Code introduction

### DIFF
--- a/readme/gsoc2022/ideas.md
+++ b/readme/gsoc2022/ideas.md
@@ -1,6 +1,6 @@
 # GSoC 2022 Ideas
 
-2022 is Joplin third round at Google Summer of Code. Detailed information on how to get involved and apply are given in the [general Summer of Code introduction](https://joplinapp.org/gsoc2022/index/)
+2022 is Joplin third round at Google Summer of Code. Detailed information on how to get involved and apply are given in the [general Summer of Code introduction](https://joplinapp.org/gsoc2022/)
 
 **These are all proposals! We are open to new ideas you might have!!** Do you have an awesome idea you want to work on with Joplin but that is not among the ideas below? That's cool. We love that! But please do us a favour: Get in touch with a mentor early on and make sure your project is realistic and within the scope of Joplin. This year's themes are:
 


### PR DESCRIPTION
changed  [general Summer of Code introduction](https://joplinapp.org/gsoc2022/index/) to [general Summer of Code introduction](https://joplinapp.org/gsoc2022/)

