### PR TITLE
Desktop: Resolves 4155: Don’t unpin from taskbar on update

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -67,7 +67,7 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true,
+      "allowToChangeInstallationDirectory": false,
       "differentialPackage": false
     },
     "portable": {


### PR DESCRIPTION
Disallow changing the installation directory during updates (still allowed on fresh installs). This setting removes existing shortcuts, and unpins Joplin from Start, taskbar, and other surfaces in Windows.

Here’s the relevant code from electron-builder:
https://github.com/electron-userland/electron-builder/blob/2dda5fcb45d99a0a991d195a2f577e3dbca775eb/packages/electron-builder-lib/templates/nsis/include/installer.nsh#L252-L257

Resolves 4155.