### PR TITLE
Desktop: Fixes #6276: Added horizontal scroll to tag list

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -96,6 +96,7 @@ function NoteEditor(props: NoteEditorProps) {
 	// before loading it in this editor.
 	// const waitingToSaveNote = props.noteId && formNote.id !== props.noteId && props.editorNoteStatuses[props.noteId] === 'saving';
 
+
 	const styles = styles_(props);
 
 	function scheduleSaveNote(formNote: FormNote) {
@@ -564,7 +565,7 @@ function NoteEditor(props: NoteEditorProps) {
 				<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
 					{renderSearchBar()}
 				</div>
-				<div className="tag-bar" style={{ paddingLeft: theme.editorPaddingLeft, display: 'flex', flexDirection: 'row', alignItems: 'center', height: 40 }}>
+				<div className="tag-bar" style={{ paddingLeft: theme.editorPaddingLeft, display: 'flex', flexDirection: 'row', alignItems: 'center', height: 40, overflowX: 'scroll', overflowY: 'hidden' }}>
 					{renderTagButton()}
 					{renderTagBar()}
 				</div>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

## Desktop:
Prior to this fix, the tag list would be truncated to screen width (Although, the number of tags required to notice such behavior differs for different screen sizes, a large number of tag list that exceeds the screen width would cause this issue). This wouldn't allow the user to add a new tag from the bottom bar of the Note editor, because he is unable to scroll to the end to access the button, nor, is he able to view other tags beyond the screen width. This PR fixes #6277  by adding an overflow attribute and setting its value to `scroll`, only adding overflow on X-axis, strangely added a scrollbar on the Y-axis too, hence to avoid unnecessary scroll bars, `overflowY` was explicitly set to `hidden`.

### Tests:
I had written a basic unit test to test the rendering of this component, but unfortunately was unable to run the test, due to some errors, issue posted [here](https://discourse.joplinapp.org/t/how-to-test-a-component-for-desktop-app/24387) with no response yet, I'll actively look for a response or try finding a fix myself and add it once it is found. However, since this is a minor fix, I did some manual testing, and here are the scenarios to verify the same:

1) Add fewer tags to an existing note/todo, so that the tag list does not overflow beyond the screen width.
**Expected behavior:** `Click to add tags...` button visible, and no scrollbar visible.
**Actual behavior:** `Click to add tags...` button visible, and no scrollbar visible.

2) Add a large number of tags to an existing note/todo, so that the tag list exceeds the screen width.
**Expected behavior:** `Click to add tags...` button not visible initially, but able to locate by scrolling horizontally across the tag list, at the bottom bar of Notes editor. Horizontal scroll bar visible.
**Actual behavior:** `Click to add tags...` button not visible initially, but able to locate by scrolling horizontally across the tag list, at the bottom bar of Notes editor. Horizontal scroll bar visible.

3) Add fewer tags to an existing note/todo, so that the tag list does not overflow beyond the screen width.
**Expected behavior:** `Click to add tags...` button visible, and no scrollbar visible.
**Actual behavior:** `Click to add tags...` button visible, and no scrollbar visible.

4) Add a large number of tags for a newly created note/todo, so that the tag list exceeds the screen width.
**Expected behavior:** `Click to add tags...` button not visible initially, but able to locate by scrolling horizontally across the tag list, at the bottom bar of Notes editor. Horizontal scroll bar visible.
**Actual behavior:** `Click to add tags...` button not visible initially, but able to locate by scrolling horizontally across the tag list, at the bottom bar of Notes editor. Horizontal scroll bar visible.

These are the possible scenarios I could manually test and think of, and I feel this covers all the cases. If there is anything missing, I'd be glad to take a look at it.