### PR TITLE
Color of date-time text in "Set Alarm" changed to match theme

### DIFF
--- a/packages/app-mobile/components/SelectDateTimeDialog.tsx
+++ b/packages/app-mobile/components/SelectDateTimeDialog.tsx
@@ -103,7 +103,7 @@ export default class SelectDateTimeDialog extends React.PureComponent<any, any> 
 		return (
 			<View style={{ flex: 0, margin: 20, alignItems: 'center' }}>
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
-					{ this.state.date && <Text style={{ ...theme.normalText, marginRight: 10 }}>{time.formatDateToLocal(this.state.date)}</Text> }
+					{ this.state.date && <Text style={{ ...theme.normalText,color: theme.color, marginRight: 10 }}>{time.formatDateToLocal(this.state.date)}</Text> }
 					<Button title="Set date" onPress={this.onSetDate} />
 				</View>
 				<DateTimePickerModal


### PR DESCRIPTION
### Description
I have changed the `renderContent` method in file `components/SelectDateTimeDialog.tsx`. Date-time text now receives the color prop from global theme to handle changes in color as per the app theme.

Fixes #6234 

### Type of Change:


- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)