### PR TITLE
All: Fixes #6278: Fixed two async function calls.

### DIFF
--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -704,7 +704,7 @@ export default class Note extends BaseItem {
 		const note = await super.save(o, options);
 
 		const changeSource = options && options.changeSource ? options.changeSource : null;
-		void ItemChange.add(BaseModel.TYPE_NOTE, note.id, isNew ? ItemChange.TYPE_CREATE : ItemChange.TYPE_UPDATE, changeSource, beforeNoteJson);
+		await ItemChange.add(BaseModel.TYPE_NOTE, note.id, isNew ? ItemChange.TYPE_CREATE : ItemChange.TYPE_UPDATE, changeSource, beforeNoteJson);
 
 		if (dispatchUpdateAction) {
 			this.dispatch({
@@ -742,7 +742,7 @@ export default class Note extends BaseItem {
 			const changeSource = options && options.changeSource ? options.changeSource : null;
 			for (let i = 0; i < processIds.length; i++) {
 				const id = processIds[i];
-				void ItemChange.add(BaseModel.TYPE_NOTE, id, ItemChange.TYPE_DELETE, changeSource, beforeChangeItems[id]);
+				await ItemChange.add(BaseModel.TYPE_NOTE, id, ItemChange.TYPE_DELETE, changeSource, beforeChangeItems[id]);
 
 				this.dispatch({
 					type: 'NOTE_DELETE',


### PR DESCRIPTION
This PR adds `await` to two async function calls. 

It fixes two issues:

- `item_changes` table may not be properly updated when importing notes. 
- (#6278) Not all notes are imported, even if the CLI output suggests all notes have been found and imported. 

Both issues happen when using the CLI commands, e.g. `joplin import`. The process may finish too soon such that the callbacks may not have an opportunity to execute.

I tested a few enex files with CLI (an example is included in #6278).
I didn't test on other platforms,  but I think they are all affected.

