### PR TITLE
Mobile: Fixes #3564: Width of Move Note Dropdown now adjusts based of content

### DIFF
--- a/packages/app-mobile/components/Dropdown.js
+++ b/packages/app-mobile/components/Dropdown.js
@@ -86,7 +86,7 @@ class Dropdown extends React.Component {
 		if (this.props.labelTransform && this.props.labelTransform === 'trim') headerLabel = headerLabel.trim();
 
 		const closeList = () => {
-			this.props.hasOwnProperty('onClose') && this.props.onClose();
+			if (this.props.onClose()) this.props.onClose();
 			this.setState({ listVisible: false });
 		};
 
@@ -116,7 +116,7 @@ class Dropdown extends React.Component {
 					onPress={() => {
 						this.updateHeaderCoordinates();
 						this.setState({ listVisible: true });
-						this.props.hasOwnProperty('onOpen') && this.props.onOpen();
+						if (this.props.onOpen()) this.props.onOpen();
 					}}
 				>
 					<Text ellipsizeMode="tail" numberOfLines={1} style={headerStyle}>

--- a/packages/app-mobile/components/Dropdown.js
+++ b/packages/app-mobile/components/Dropdown.js
@@ -38,10 +38,9 @@ class Dropdown extends React.Component {
 		const listTop = Math.min(maxListTop, this.state.headerSize.y + this.state.headerSize.height);
 
 		const wrapperStyle = {
-			width: this.state.headerSize.width,
 			height: listHeight + 2, // +2 for the border (otherwise it makes the scrollbar appear)
 			marginTop: listTop,
-			marginLeft: this.state.headerSize.x,
+			alignSelf: 'center',
 		};
 
 		const itemListStyle = Object.assign({}, this.props.itemListStyle ? this.props.itemListStyle : {}, {
@@ -87,6 +86,7 @@ class Dropdown extends React.Component {
 		if (this.props.labelTransform && this.props.labelTransform === 'trim') headerLabel = headerLabel.trim();
 
 		const closeList = () => {
+			this.props.hideShowUndoRedoButton();
 			this.setState({ listVisible: false });
 		};
 
@@ -116,6 +116,7 @@ class Dropdown extends React.Component {
 					onPress={() => {
 						this.updateHeaderCoordinates();
 						this.setState({ listVisible: true });
+						this.props.hideShowUndoRedoButton();
 					}}
 				>
 					<Text ellipsizeMode="tail" numberOfLines={1} style={headerStyle}>

--- a/packages/app-mobile/components/Dropdown.js
+++ b/packages/app-mobile/components/Dropdown.js
@@ -86,7 +86,7 @@ class Dropdown extends React.Component {
 		if (this.props.labelTransform && this.props.labelTransform === 'trim') headerLabel = headerLabel.trim();
 
 		const closeList = () => {
-			this.props.hideShowUndoRedoButton();
+			this.props.hasOwnProperty('hideShowUndoRedoButton') && this.props.hideShowUndoRedoButton();
 			this.setState({ listVisible: false });
 		};
 
@@ -116,7 +116,7 @@ class Dropdown extends React.Component {
 					onPress={() => {
 						this.updateHeaderCoordinates();
 						this.setState({ listVisible: true });
-						this.props.hideShowUndoRedoButton();
+						this.props.hasOwnProperty('hideShowUndoRedoButton') && this.props.hideShowUndoRedoButton();
 					}}
 				>
 					<Text ellipsizeMode="tail" numberOfLines={1} style={headerStyle}>

--- a/packages/app-mobile/components/Dropdown.js
+++ b/packages/app-mobile/components/Dropdown.js
@@ -86,7 +86,7 @@ class Dropdown extends React.Component {
 		if (this.props.labelTransform && this.props.labelTransform === 'trim') headerLabel = headerLabel.trim();
 
 		const closeList = () => {
-			this.props.hasOwnProperty('hideShowUndoRedoButton') && this.props.hideShowUndoRedoButton();
+			this.props.hasOwnProperty('onClose') && this.props.onClose();
 			this.setState({ listVisible: false });
 		};
 
@@ -116,7 +116,7 @@ class Dropdown extends React.Component {
 					onPress={() => {
 						this.updateHeaderCoordinates();
 						this.setState({ listVisible: true });
-						this.props.hasOwnProperty('hideShowUndoRedoButton') && this.props.hideShowUndoRedoButton();
+						this.props.hasOwnProperty('onOpen') && this.props.onOpen();
 					}}
 				>
 					<Text ellipsizeMode="tail" numberOfLines={1} style={headerStyle}>

--- a/packages/app-mobile/components/SelectDateTimeDialog.tsx
+++ b/packages/app-mobile/components/SelectDateTimeDialog.tsx
@@ -103,7 +103,7 @@ export default class SelectDateTimeDialog extends React.PureComponent<any, any> 
 		return (
 			<View style={{ flex: 0, margin: 20, alignItems: 'center' }}>
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
-					{ this.state.date && <Text style={{ ...theme.normalText, marginRight: 10 }}>{time.formatDateToLocal(this.state.date)}</Text> }
+					{ this.state.date && <Text style={{ ...theme.normalText,color: theme.color, marginRight: 10 }}>{time.formatDateToLocal(this.state.date)}</Text> }
 					<Button title="Set date" onPress={this.onSetDate} />
 				</View>
 				<DateTimePickerModal

--- a/packages/app-mobile/components/screen-header.js
+++ b/packages/app-mobile/components/screen-header.js
@@ -29,7 +29,10 @@ class ScreenHeaderComponent extends React.PureComponent {
 	constructor() {
 		super();
 		this.styles_ = {};
+		this.state = { titleModalActive: false };
+		this.hideShowUndoRedoButton = this.hideShowUndoRedoButton.bind(this);
 	}
+
 
 	styles() {
 		const themeId = Setting.value('theme');
@@ -171,6 +174,12 @@ class ScreenHeaderComponent extends React.PureComponent {
 		NavService.go('Search');
 	}
 
+	hideShowUndoRedoButton() {
+		this.setState(prevState => ({
+			titleModalActive: !prevState.titleModalActive,
+		}));
+	}
+
 	async duplicateButton_press() {
 		const noteIds = this.props.selectedNoteIds;
 
@@ -256,7 +265,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 		}
 
 		const renderTopButton = (options) => {
-			if (!options.visible) return null;
+			if (!options.visible || this.state.titleModalActive) return null;
 
 			const icon = <Icon name={options.iconName} style={this.styles().topIcon} />;
 			const viewStyle = options.disabled ? this.styles().iconButtonDisabled : this.styles().iconButton;
@@ -422,6 +431,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 							color: theme.color,
 							fontSize: theme.fontSize,
 						}}
+						hideShowUndoRedoButton={this.hideShowUndoRedoButton}
 						onValueChange={async (folderId, itemIndex) => {
 							// If onValueChange is specified, use this as a callback, otherwise do the default
 							// which is to take the selectedNoteIds from the state and move them to the

--- a/packages/app-mobile/components/screen-header.js
+++ b/packages/app-mobile/components/screen-header.js
@@ -424,7 +424,6 @@ class ScreenHeaderComponent extends React.PureComponent {
 							color: theme.color,
 							fontSize: theme.fontSize,
 						}}
-						hideShowUndoRedoButton={this.hideShowUndoRedoButton}
 						onOpen={() => {
 							this.setState({
 								showUndoRedoButtons: false,

--- a/packages/app-mobile/components/screen-header.js
+++ b/packages/app-mobile/components/screen-header.js
@@ -29,8 +29,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 	constructor() {
 		super();
 		this.styles_ = {};
-		this.state = { titleModalActive: false };
-		this.hideShowUndoRedoButton = this.hideShowUndoRedoButton.bind(this);
+		this.state = { showUndoRedoButtons: true };
 	}
 
 
@@ -174,12 +173,6 @@ class ScreenHeaderComponent extends React.PureComponent {
 		NavService.go('Search');
 	}
 
-	hideShowUndoRedoButton() {
-		this.setState(prevState => ({
-			titleModalActive: !prevState.titleModalActive,
-		}));
-	}
-
 	async duplicateButton_press() {
 		const noteIds = this.props.selectedNoteIds;
 
@@ -265,7 +258,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 		}
 
 		const renderTopButton = (options) => {
-			if (!options.visible || this.state.titleModalActive) return null;
+			if (!options.visible || !this.state.showUndoRedoButtons) return null;
 
 			const icon = <Icon name={options.iconName} style={this.styles().topIcon} />;
 			const viewStyle = options.disabled ? this.styles().iconButtonDisabled : this.styles().iconButton;
@@ -432,6 +425,16 @@ class ScreenHeaderComponent extends React.PureComponent {
 							fontSize: theme.fontSize,
 						}}
 						hideShowUndoRedoButton={this.hideShowUndoRedoButton}
+						onOpen={() => {
+							this.setState({
+								showUndoRedoButtons: false,
+							});
+						}}
+						onClose={() => {
+							this.setState({
+								showUndoRedoButtons: true,
+							});
+						}}
 						onValueChange={async (folderId, itemIndex) => {
 							// If onValueChange is specified, use this as a callback, otherwise do the default
 							// which is to take the selectedNoteIds from the state and move them to the


### PR DESCRIPTION
### Description
Width of Move Note Dropdown now does not gets the width of `title` but adjusts based on content. The Undo and Redo buttons are hidden when `Dropdown Modal` is active. Previously also Undo and Redo buttons were inaccessible when Modal is active so hiding them maintains a uniformity. A state `showUndoRedoButtons` is added in `screen-header.js` which is changed by `onOpen` and `onClose` handlers by `Dropdown.js`  through `props`. So when the user clicks on Dropdown, if undo-redo buttons are active they will be hidden, and Dropdown will use width based on content. If Modal is closed, Undo and Redo buttons will again appear.

Previously:
![image](https://user-images.githubusercontent.com/55127997/159340398-9517487d-fd83-4dc2-8ced-764f5a1e8f02.png) ![image](https://user-images.githubusercontent.com/55127997/159338738-d77220a6-ddbd-45d2-aa9d-918feac0f1bd.png)


Fixes #3564 

### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)