### PR TITLE
Android: Fixes #5987: Cursor hard to see in dark mode

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror.ts
@@ -36,25 +36,53 @@ function logMessage(...msg: any[]) {
 //
 // https://github.com/codemirror/theme-one-dark/blob/main/src/one-dark.ts
 //
+// For a tutorial, see:
+//
+// https://codemirror.net/6/examples/styling/#themes
+//
 // Use Safari developer tools to view the content of the CodeMirror iframe while
 // the app is running. It seems that what appears as ".ͼ1" in the CSS is the
 // equivalent of "&" in the theme object. So to target ".ͼ1.cm-focused", you'd
 // use '&.cm-focused' in the theme.
 const createTheme = (theme: any): Extension => {
+	const isDarkTheme = theme.appearance === 'dark';
+
+	const baseGlobalStyle: Record<string, string> = {
+		color: theme.color,
+		backgroundColor: theme.backgroundColor,
+		fontFamily: theme.fontFamily,
+		fontSize: `${theme.fontSize}px`,
+	};
+	const baseCursorStyle: Record<string, string> = { };
+	const baseContentStyle: Record<string, string> = { };
+	const baseSelectionStyle: Record<string, string> = { };
+
+	// If we're in dark mode, the caret and selection are difficult to see.
+	// Adjust them appropriately
+	if (isDarkTheme) {
+		// Styling the caret requires styling both the caret itself
+		// and the CodeMirror caret.
+		// See https://codemirror.net/6/examples/styling/#themes
+		baseContentStyle.caretColor = 'white';
+		baseCursorStyle.borderLeftColor = 'white';
+
+		baseSelectionStyle.backgroundColor = '#6b6b6b';
+	}
+
 	const baseTheme = EditorView.baseTheme({
-		'&': {
-			color: theme.color,
-			backgroundColor: theme.backgroundColor,
-			fontFamily: theme.fontFamily,
-			fontSize: `${theme.fontSize}px`,
-		},
+		'&': baseGlobalStyle,
+
+		// These must be !important or more specific than CodeMirror's built-ins
+		'.cm-content': baseContentStyle,
+		'&.cm-focused .cm-cursor': baseCursorStyle,
+		'&.cm-focused .cm-selectionBackground, ::selection': baseSelectionStyle,
 
 		'&.cm-focused': {
 			outline: 'none',
 		},
 	});
 
-	const appearanceTheme = EditorView.theme({}, { dark: theme.appearance === 'dark' });
+	const appearanceTheme = EditorView.theme({}, { dark: isDarkTheme });
 
 	const baseHeadingStyle = {
 		fontWeight: 'bold',

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -31,6 +31,7 @@ function fontFamilyFromSettings() {
 	return [f, 'sans-serif'].join(', ');
 }
 
+// Obsolete with CodeMirror 6. See ./CodeMirror.ts for styling.
 // function useCss(themeId:number):string {
 // 	const [css, setCss] = useState('');
 


### PR DESCRIPTION
# Summary
Changes CodeMirror6 cursor and selection colors in dark mode. Fixes #5987. ~~**Edit**: Fixes https://github.com/laurent22/joplin/issues/6316~~

<details><summary><b>Screenshots</b></summary>

## Before
![Very faint, green selection on a dark background](https://user-images.githubusercontent.com/46334387/159428104-b7e2fb9e-a972-45c9-af4e-1646f378473b.png)
![Very faint cursor on a dark background](https://user-images.githubusercontent.com/46334387/159428297-00d8b590-c414-48dc-838b-0a60d3c20e91.png)

## After
![Note editor showing light-grey-highlighted text](https://user-images.githubusercontent.com/46334387/159427625-fe201714-6bed-4d2b-a6fa-a99f781b6499.png)
![Light cursor on dark background](https://user-images.githubusercontent.com/46334387/159427776-cbe4b46e-fa02-45ee-900c-3d320626c488.png)

----

</details>


# Testing
Before testing, please run `yarn buildInjectedJs` from the `/packages/app-mobile` directory.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
