### PR TITLE
Solved Notebook icon does not show in 'Move to Notebook' dropdown menu

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -20,7 +20,8 @@ export const runtime = (comp: any): CommandRuntime => {
 			const addOptions = (folders: any[], depth: number) => {
 				for (let i = 0; i < folders.length; i++) {
 					const folder = folders[i];
-					startFolders.push({ key: folder.id, value: folder.id, label: folder.title, indentDepth: depth });
+					const folderEmoji = folder.icon ? JSON.parse(folder.icon).emoji : '';
+					startFolders.push({ key: folder.id, value: folder.id, label: `${folderEmoji} ${folder.title}` , indentDepth: depth });
 					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth);
 				}
 			};


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
- Desktop: Resolves #6292: Solved Notebook icon does not show in 'Move to Notebook' dropdown menu, by adding a line of code to add emoji(if exists) along with the title in the label.

Before:
![Screenshot from 2022-03-23 18-30-53](https://user-images.githubusercontent.com/49821470/159708089-854dff5e-aa3b-492f-8bf6-5d17fd9a009d.png)

After:
![Screenshot from 2022-03-23 18-42-50](https://user-images.githubusercontent.com/49821470/159708126-1ae52e72-6173-41ae-bd23-343305b655cf.png)



