### PR TITLE
Mobile: Fixes #6324: Beta Editor: Support inserting attachments

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -15,14 +15,27 @@ export interface UndoRedoDepthChangeEvent {
 	redoDepth: number;
 }
 
+export interface Selection {
+	start: number;
+	end: number;
+}
+
+export interface SelectionChangeEvent {
+	selection: Selection;
+}
+
 type ChangeEventHandler = (event: ChangeEvent)=> void;
 type UndoRedoDepthChangeHandler = (event: UndoRedoDepthChangeEvent)=> void;
+type SelectionChangeEventHandler = (event: SelectionChangeEvent)=> void;
 
 interface Props {
 	themeId: number;
 	initialText: string;
+	initialSelection?: Selection;
 	style: any;
+
 	onChange: ChangeEventHandler;
+	onSelectionChange: SelectionChangeEventHandler;
 	onUndoRedoDepthChange: UndoRedoDepthChangeHandler;
 }
 
@@ -212,11 +225,15 @@ function NoteEditor(props: Props, ref: any) {
 	const [source, setSource] = useState(undefined);
 	const webviewRef = useRef(null);
 
+	const setInitialSelectionJS = props.initialSelection ? `
+		cm.select(${props.initialSelection.start}, ${props.initialSelection.end});
+	` : '';
+
 	const injectedJavaScript = `
 		function postMessage(name, data) {
 			window.ReactNativeWebView.postMessage(JSON.stringify({
 				data,
-				name,	
+				name,
 			}));
 		}
 
@@ -227,7 +244,7 @@ function NoteEditor(props: Props, ref: any) {
 		// This variable is not used within this script
 		// but is called using "injectJavaScript" from
 		// the wrapper component.
-		let cm = null;
+		window.cm = null;
 
 		try {
 			${shim.injectedJs('codeMirrorBundle')};
@@ -237,6 +254,7 @@ function NoteEditor(props: Props, ref: any) {
 			const initialText = ${JSON.stringify(props.initialText)};
 
 			cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, theme);
+			${setInitialSelectionJS}
 		} catch (e) {
 			window.ReactNativeWebView.postMessage("error:" + e.message + ": " + JSON.stringify(e))
 		} finally {
@@ -254,6 +272,14 @@ function NoteEditor(props: Props, ref: any) {
 			},
 			redo: function() {
 				webviewRef.current.injectJavaScript('cm.redo(); true;');
+			},
+			select: (anchor: number, head: number) => {
+				webviewRef.current.injectJavaScript(
+					`cm.select(${JSON.stringify(anchor)}, ${JSON.stringify(head)}); true;`
+				);
+			},
+			insertText: (text: string) => {
+				webviewRef.current.injectJavaScript(`cm.insertText(${JSON.stringify(text)}); true;`);
 			},
 		};
 	});
@@ -300,6 +326,10 @@ function NoteEditor(props: Props, ref: any) {
 			onUndoRedoDepthChange: (event: UndoRedoDepthChangeEvent) => {
 				console.info('onUndoRedoDepthChange', event);
 				props.onUndoRedoDepthChange(event);
+			},
+
+			onSelectionChange: (event: SelectionChangeEvent) => {
+				props.onSelectionChange(event);
 			},
 		};
 


### PR DESCRIPTION
# Summary
Adds support for inserting attachments at the cursor position in the beta editor and preserving the selection after closing/re-opening the editor (within the same note).

Be sure to test this on an iOS device! I've only tested it on Android.

# 

Resolves #6324.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
