### PR TITLE
Desktop: Fixes #6313: Make rich text editor return/newline behaviour …

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -42,24 +42,8 @@ function markupRenderOptions(override: MarkupToHtmlOptions = null): MarkupToHtml
 	};
 }
 
-// In TinyMCE 5.2, when setting the body to '<div id="rendered-md"></div>',
-// it would end up as '<div id="rendered-md"><br/></div>' once rendered
-// (an additional <br/> was inserted).
-//
-// This behaviour was "fixed" later on, possibly in 5.6, which has this change:
-//
-// - Fixed getContent with text format returning a new line when the editor is empty #TINY-6281
-//
-// The problem is that the list plugin was, unknown to me, relying on this <br/>
-// being present. Without it, trying to add a bullet point or checkbox on an
-// empty document, does nothing. The exact reason for this is unclear
-// so as a workaround we manually add this <br> for empty documents,
-// which fixes the issue.
-//
-// Perhaps upgrading the list plugin (which is a fork of TinyMCE own list plugin)
-// would help?
-function awfulBrHack(html: string): string {
-	return html === '<div id="rendered-md"></div>' ? '<div id="rendered-md"><br/></div>' : html;
+function removeRenderedMdWrapper(html: string): string {
+	return html.replace(/<div\sid="rendered-md">([\s\S]*)<\/div>/, '$1');
 }
 
 function findEditableContainer(node: any): any {
@@ -792,7 +776,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				const result = await props.markupToHtml(props.contentMarkupLanguage, props.content, markupRenderOptions({ resourceInfos: props.resourceInfos }));
 				if (cancelled) return;
 
-				editor.setContent(awfulBrHack(result.html));
+				editor.setContent(removeRenderedMdWrapper(result.html));
 
 				if (lastOnChangeEventInfo.current.contentKey !== props.contentKey) {
 					// Need to clear UndoManager to avoid this problem:


### PR DESCRIPTION
issue here: #6313 

in rich-text-editor mode, empty note (often when we create new note or switch from markdown mode) dom still contains a 
`<div id="rendered-md"></div>` node, which will cause some strange behavior:

- press `enter` will generate a new `div` node instead of `p`
- some styles problem which is described in the issue (because of 'rendered-md' global style)
- unable to create bullet-list or todo-list, as a workaround we added `<br/>` in the `div` node

so I think it's unnecessary to keep `#rendered-md` node still exist in rich-text-editor