### PR TITLE
Bugfix/update currently openned node

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -67,7 +67,7 @@ function NoteEditor(props: NoteEditorProps) {
 
 	const { formNote, setFormNote, isNewNote, resourceInfos } = useFormNote({
 		syncStarted: props.syncStarted,
-		notes: props.notes,
+		updatedTime: props.notes.find(n => n.id === props.noteId)?.updated_time,
 		noteId: props.noteId,
 		isProvisional: props.isProvisional,
 		titleInputRef: titleInputRef,

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -67,6 +67,7 @@ function NoteEditor(props: NoteEditorProps) {
 
 	const { formNote, setFormNote, isNewNote, resourceInfos } = useFormNote({
 		syncStarted: props.syncStarted,
+		notes: props.notes,
 		noteId: props.noteId,
 		isProvisional: props.isProvisional,
 		titleInputRef: titleInputRef,


### PR DESCRIPTION
As the [Previous PR (6024)](https://github.com/laurent22/joplin/pull/6024) was closed due to long inactivity, here is my second try with updates according to what @laurent22 wrote.

This will fix https://github.com/laurent22/joplin/issues/5955.

- I'm passing the current note's update time to the useFormNote to see when there is an update i.e. via API.
- In there I'm re-using the sync hook to also listen to the note's time changes.
- Then update the currently opened note with the note that was changed in the background as with a sync.

Note: I tested several scenarios manually. But as I had to remove the prevSyncStarted (which made sure the code only ran after a sync was actually finished), I'd ask you to test the sync behaviour as well and don't just rely on me as I'm new to the code. Or let me know how to test that myself. Thanks.

Cheers 🥂