### PR TITLE
Android:  Fixes #6026: Long path in "Export profile" prevents tapping OK button

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen.tsx
@@ -531,7 +531,7 @@ class ConfigScreenComponent extends BaseScreenComponent {
 				const profileExportPrompt = (
 					<View style={this.styles().settingContainer} key="profileExport">
 						<Text style={{ ...this.styles().settingText, flex: 0 }}>Path:</Text>
-						<TextInput style={{ ...this.styles().textInput, paddingRight: 20, width: '75%' }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance} />
+						<TextInput style={{ ...this.styles().textInput, paddingRight: 20, width: '75%', marginRight: 'auto' }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance} />
 						<Button title="OK" onPress={this.exportProfileButtonPress2_} />
 					</View>
 				);

--- a/packages/app-mobile/components/screens/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen.tsx
@@ -530,9 +530,9 @@ class ConfigScreenComponent extends BaseScreenComponent {
 			if (this.state.profileExportStatus === 'prompt') {
 				const profileExportPrompt = (
 					<View style={this.styles().settingContainer} key="profileExport">
-						<Text style={{ ...this.styles().settingText, flex: 1.5 }}>Path:</Text>
-						<View style={{ flex: 7 }}><TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance} /></View>
-						<View style={{ flex: 1 }}><Button title="OK" onPress={this.exportProfileButtonPress2_} /></View>
+						<Text style={{ ...this.styles().settingText, flex: 0 }}>Path:</Text>
+						<TextInput style={{ ...this.styles().textInput, paddingRight: 20, width: '75%' }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance} />
+						<Button title="OK" onPress={this.exportProfileButtonPress2_} />
 					</View>
 				);
 

--- a/packages/app-mobile/components/screens/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen.tsx
@@ -530,9 +530,9 @@ class ConfigScreenComponent extends BaseScreenComponent {
 			if (this.state.profileExportStatus === 'prompt') {
 				const profileExportPrompt = (
 					<View style={this.styles().settingContainer} key="profileExport">
-						<Text style={this.styles().settingText}>Path:</Text>
-						<TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance}></TextInput>
-						<Button title="OK" onPress={this.exportProfileButtonPress2_}></Button>
+						<Text style={{ ...this.styles().settingText, flex: 1.5 }}>Path:</Text>
+						<View style={{ flex: 7 }}><TextInput style={{ ...this.styles().textInput, paddingRight: 20 }} onChange={(event: any) => this.setState({ profileExportPath: event.nativeEvent.text })} value={this.state.profileExportPath} placeholder="/path/to/sdcard" keyboardAppearance={theme.keyboardAppearance} /></View>
+						<View style={{ flex: 1 }}><Button title="OK" onPress={this.exportProfileButtonPress2_} /></View>
 					</View>
 				);
 


### PR DESCRIPTION
# Summary
This fixes #6026 . The ok button no longer moves out of the screen when you enter a very long export profile path.

### Steps to Manually Test:
- Open navbar
- Click "Configuration"
- Scroll down and click "Export profile"
- Type a really long path

<details>
<summary>Screenshots</summary>
<br>
Before:

![ConfigBefore](https://user-images.githubusercontent.com/30352484/161399073-3ddfb75f-7944-4331-9385-21c8f35f6c52.jpg)

After:
![ConfigAfter](https://user-images.githubusercontent.com/30352484/161399081-2e3f25aa-0aa0-448e-bf60-b52c65940b89.jpg)
</details>