### PR TITLE
Desktop/PluginUpdate - Resolves #4801:Not allow updating to a non-compliant version 

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx
@@ -16,8 +16,9 @@ export enum InstallState {
 export enum UpdateState {
 	Idle = 1,
 	CanUpdate = 2,
-	Updating = 3,
-	HasBeenUpdated = 4,
+	NeedToUpdateApp=3,
+	Updating = 4,
+	HasBeenUpdated = 5,
 }
 
 export interface ItemEvent {
@@ -229,7 +230,15 @@ export default function(props: Props) {
 				</CellFooter>
 			);
 		}
-
+		if (props.updateState === UpdateState.NeedToUpdateApp) {
+			return (
+				<CellFooter>
+					<NeedUpgradeMessage>
+						{_('Please upgrade Joplin to upgrade this plugin')}
+					</NeedUpgradeMessage>
+				</CellFooter>
+			);
+		}
 		return (
 			<CellFooter>
 				{renderDeleteButton()}

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -243,7 +243,7 @@ export default function(props: Props) {
 			const onUpdateHandler = canBeUpdatedPluginIds[item.manifest.id] ? onUpdate : null;
 
 			let updateState = UpdateState.Idle;
-			updateState = canBeUpdatedPluginIds[item.manifest.id] ? UpdateState.Idle : UpdateState.needToUpdateApp;
+			updateState = canBeUpdatedPluginIds[item.manifest.id] ? UpdateState.Idle : UpdateState.NeedToUpdateApp;
 			if (onUpdateHandler) updateState = UpdateState.CanUpdate;
 			if (isUpdating) updateState = UpdateState.Updating;
 			if (item.hasBeenUpdated) updateState = UpdateState.HasBeenUpdated;

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -37,7 +37,7 @@ const ToolsButton = styled(Button)`
 	margin-right: 6px;
 `;
 
-const RepoApiErrorMessage = styled(StyledMessage)<any>`
+const RepoApiErrorMessage = styled(StyledMessage) <any>`
 	max-width: ${props => props.maxWidth}px;
 	margin-bottom: 10px;
 `;
@@ -93,7 +93,7 @@ export default function(props: Props) {
 	const [searchQuery, setSearchQuery] = useState('');
 	const [manifestsLoaded, setManifestsLoaded] = useState<boolean>(false);
 	const [updatingPluginsIds, setUpdatingPluginIds] = useState<Record<string, boolean>>({});
-	const [canBeUpdatedPluginIds, setCanBeUpdatedPluginIds] = useState<Record<string, boolean>>({});
+	const [canBeUpdatedPluginIds, setCanBeUpdatedPluginIds] = useState<Record<string,boolean>>({});
 	const [repoApiError, setRepoApiError] = useState<Error>(null);
 	const [fetchManifestTime, setFetchManifestTime] = useState<number>(Date.now());
 
@@ -137,7 +137,7 @@ export default function(props: Props) {
 	}, [fetchManifestTime]);
 
 	useEffect(() => {
-		if (!manifestsLoaded) return () => {};
+		if (!manifestsLoaded) return () => { };
 
 		let cancelled = false;
 
@@ -145,7 +145,9 @@ export default function(props: Props) {
 			const pluginIds = await repoApi().canBeUpdatedPlugins(pluginItems.map(p => p.manifest));
 			if (cancelled) return;
 			const conv: Record<string, boolean> = {};
-			pluginIds.forEach(id => conv[id] = true);
+			pluginIds.forEach(plugin => {
+				conv[plugin.id] = plugin.needToUpdateApp;
+			});
 			setCanBeUpdatedPluginIds(conv);
 		}
 
@@ -241,6 +243,7 @@ export default function(props: Props) {
 			const onUpdateHandler = canBeUpdatedPluginIds[item.manifest.id] ? onUpdate : null;
 
 			let updateState = UpdateState.Idle;
+			updateState = canBeUpdatedPluginIds[item.manifest.id] ? UpdateState.Idle : UpdateState.needToUpdateApp;
 			if (onUpdateHandler) updateState = UpdateState.CanUpdate;
 			if (isUpdating) updateState = UpdateState.Updating;
 			if (item.hasBeenUpdated) updateState = UpdateState.HasBeenUpdated;
@@ -299,7 +302,7 @@ export default function(props: Props) {
 	function renderRepoApiError() {
 		if (!repoApiError) return null;
 
-		return <RepoApiErrorMessage maxWidth={maxWidth} type="error">{_('Could not connect to plugin repository.')}<br/><br/>- <StyledLink href="#" onClick={() => { setFetchManifestTime(Date.now()); }}>{_('Try again')}</StyledLink><br/><br/>- <StyledLink href="#" onClick={onBrowsePlugins}>{_('Browse all plugins')}</StyledLink></RepoApiErrorMessage>;
+		return <RepoApiErrorMessage maxWidth={maxWidth} type="error">{_('Could not connect to plugin repository.')}<br /><br />- <StyledLink href="#" onClick={() => { setFetchManifestTime(Date.now()); }}>{_('Try again')}</StyledLink><br /><br />- <StyledLink href="#" onClick={onBrowsePlugins}>{_('Browse all plugins')}</StyledLink></RepoApiErrorMessage>;
 	}
 
 	function renderBottomArea() {
@@ -309,7 +312,7 @@ export default function(props: Props) {
 			<div>
 				{renderRepoApiError()}
 				<div style={{ display: 'flex', flexDirection: 'row', maxWidth }}>
-					<ToolsButton size={ButtonSize.Small} tooltip={_('Plugin tools')} iconName="fas fa-cog" level={ButtonLevel.Secondary} onClick={onToolsClick}/>
+					<ToolsButton size={ButtonSize.Small} tooltip={_('Plugin tools')} iconName="fas fa-cog" level={ButtonLevel.Secondary} onClick={onToolsClick} />
 					<div style={{ display: 'flex', flex: 1 }}>
 						{props.renderHeader(props.themeId, _('Manage your plugins'))}
 					</div>


### PR DESCRIPTION

This PR resolved #4801 .
If there is an update available for the plugin but if the updated plugin version is not compatible with current version of the Joplin then it will show an message- "Please upgrade Joplin to update this plugin".
