### PR TITLE
Clipper, Desktop: Resolves #6247: Clipper unable to pull and store PDFs 

### DIFF
--- a/packages/app-clipper/content_scripts/index.js
+++ b/packages/app-clipper/content_scripts/index.js
@@ -32,6 +32,15 @@
 		}
 	}
 
+	function escapeHtml(s) {
+		return s
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;');
+	}
+
 	function pageTitle() {
 		const titleElements = document.getElementsByTagName('title');
 		if (titleElements.length) return titleElements[0].text.trim();
@@ -347,7 +356,7 @@
 	}
 
 	function embedPageUrl() {
-		return `<embed src="${window.location.href}" type="${document.contentType}" />`;
+		return `<embed src="${escapeHtml(window.location.href)}" type="${escapeHtml(document.contentType)}" />`;
 	}
 
 	async function prepareCommandResponse(command) {

--- a/packages/app-clipper/content_scripts/index.js
+++ b/packages/app-clipper/content_scripts/index.js
@@ -204,6 +204,11 @@
 					}
 				}
 
+				if (nodeName === 'embed' || nodeName === 'object') {
+					const src = absoluteUrl(node.src);
+					node.setAttribute('src', src);
+				}
+
 				cleanUpElement(convertToMarkup, node, imageSizes, imageIndexes);
 			}
 		}
@@ -317,6 +322,9 @@
 	}
 
 	function readabilityProcess() {
+
+		if (isPagePdf()) throw new Error('Could not parse PDF document with Readability');
+
 		// eslint-disable-next-line no-undef
 		const readability = new Readability(documentForReadability());
 		const article = readability.parse();
@@ -327,6 +335,14 @@
 			title: article.title,
 			body: article.content,
 		};
+	}
+
+	function isPagePdf() {
+		return document.contentType == 'application/pdf';
+	}
+
+	function embedPageUrl() {
+		return `<embed src="${window.location.href}" type="${document.contentType}" />`;
 	}
 
 	async function prepareCommandResponse(command) {
@@ -374,6 +390,10 @@
 			return { name: 'isProbablyReaderable', value: ok };
 
 		} else if (command.name === 'completePageHtml') {
+
+			if (isPagePdf()) {
+				return clippedContentResponse(pageTitle(), embedPageUrl(), getImageSizes(document), getAnchorNames(document));
+			}
 
 			hardcodePreStyles(document);
 			addSvgClass(document);

--- a/packages/app-clipper/content_scripts/index.js
+++ b/packages/app-clipper/content_scripts/index.js
@@ -204,9 +204,14 @@
 					}
 				}
 
-				if (nodeName === 'embed' || nodeName === 'object') {
+				if (nodeName === 'embed') {
 					const src = absoluteUrl(node.src);
 					node.setAttribute('src', src);
+				}
+
+				if (nodeName === 'object') {
+					const data = absoluteUrl(node.data);
+					node.setAttribute('data', data);
 				}
 
 				cleanUpElement(convertToMarkup, node, imageSizes, imageIndexes);

--- a/packages/lib/HtmlToMd.ts
+++ b/packages/lib/HtmlToMd.ts
@@ -2,18 +2,20 @@ const TurndownService = require('@joplin/turndown');
 const turndownPluginGfm = require('@joplin/turndown-plugin-gfm').gfm;
 import markdownUtils from './markdownUtils';
 
+const pdfUrlRegex = /[\s\S]*?\.pdf$/i;
+
 export interface ParseOptions {
 	anchorNames?: string[];
 	preserveImageTagsWithSize?: boolean;
 	baseUrl?: string;
 	disableEscapeContent?: boolean;
-	loadPdfs?: boolean;
+	convertEmbeddedPdfsToLinks?: boolean;
 }
 
 export default class HtmlToMd {
 
 	public parse(html: string, options: ParseOptions = {}) {
-		const turndown = new TurndownService({
+		const turndownOpts: any = {
 			headingStyle: 'atx',
 			anchorNames: options.anchorNames ? options.anchorNames.map(n => n.trim().toLowerCase()) : [],
 			codeBlockStyle: 'fenced',
@@ -23,25 +25,38 @@ export default class HtmlToMd {
 			strongDelimiter: '**',
 			br: '',
 			disableEscapeContent: 'disableEscapeContent' in options ? options.disableEscapeContent : false,
-		});
+		};
+		if (options.convertEmbeddedPdfsToLinks) {
+			// Turndown ignores empty <object> tags, so we need to handle this case seperately
+			// https://github.com/mixmark-io/turndown/issues/293#issuecomment-588984202
+			turndownOpts.blankReplacement = (content: string, node: any) => {
+				if (node.matches('object')) {
+					return pdfRule.replacement(content, node, {});
+				}
+				return '\n\n';
+			};
+		}
+		const turndown = new TurndownService(turndownOpts);
 		turndown.use(turndownPluginGfm);
 		turndown.remove('script');
 		turndown.remove('style');
 		const pdfRule = {
 			filter: ['embed', 'object'],
 			replacement: function(_content: string, node: any, _options: any) {
-				if (node.getAttribute('src') && (node.getAttribute('type') === 'application/pdf' || node.getAttribute('src').endsWith('.pdf'))) {
-					// We are adding _pdf: prefix so that we can later distingish them from normal links and create resources for them.
-					return `[${node.getAttribute('src')}](_pdf:${node.getAttribute('src')})`;
+				// We are setting embedded_pdf as name so that we can later distingish them from normal links and create resources for them.
+				if (node.matches('embed') && node.getAttribute('src') && pdfUrlRegex.test(node.getAttribute('src'))) {
+					return `[embedded_pdf](${node.getAttribute('src')})`;
+				} else if (node.matches('object') && node.getAttribute('data') && pdfUrlRegex.test(node.getAttribute('data'))) {
+					return `[embedded_pdf](${node.getAttribute('data')})`;
 				}
 				return '';
 			},
 		};
-		if (options.loadPdfs) {
+		if (options.convertEmbeddedPdfsToLinks) {
 			turndown.addRule('pdf', pdfRule);
 		}
 		let md = turndown.turndown(html);
-		if (options.baseUrl) md = markdownUtils.prependBaseUrl(md, options.baseUrl, (url: string) => options.loadPdfs ? !url.startsWith('_pdf:') : true);
+		if (options.baseUrl) md = markdownUtils.prependBaseUrl(md, options.baseUrl);
 		return md;
 	}
 

--- a/packages/lib/HtmlToMd.ts
+++ b/packages/lib/HtmlToMd.ts
@@ -30,7 +30,7 @@ export default class HtmlToMd {
 		const pdfRule = {
 			filter: ['embed', 'object'],
 			replacement: function(_content: string, node: any, _options: any) {
-				if (node.getAttribute('type') === 'application/pdf' && node.getAttribute('src')) {
+				if (node.getAttribute('src') && (node.getAttribute('type') === 'application/pdf' || node.getAttribute('src').endsWith('.pdf'))) {
 					// We are adding _pdf: prefix so that we can later distingish them from normal links and create resources for them.
 					return `[${node.getAttribute('src')}](_pdf:${node.getAttribute('src')})`;
 				}

--- a/packages/lib/htmlUtils.ts
+++ b/packages/lib/htmlUtils.ts
@@ -47,13 +47,13 @@ class HtmlUtils {
 	}
 
 	// Returns the **encoded** URLs, so to be useful they should be decoded again before use.
-	private extractUrls(regex: RegExp, html: string, urlKey = 2) {
+	private extractUrls(regex: RegExp, html: string) {
 		if (!html) return [];
 
 		const output = [];
 		let matches;
 		while ((matches = regex.exec(html))) {
-			output.push(matches[urlKey]);
+			output.push(matches[2]);
 		}
 
 		return output.filter(url => !!url);

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -61,9 +61,10 @@ const markdownUtils = {
 		return url;
 	},
 
-	prependBaseUrl(md: string, baseUrl: string) {
+	prependBaseUrl(md: string, baseUrl: string, test?: Function) {
 		// eslint-disable-next-line no-useless-escape
 		return md.replace(/(\]\()([^\s\)]+)(.*?\))/g, (_match: any, before: string, url: string, after: string) => {
+			if (test && !test(url)) return `${before}${url}${after}`;
 			return before + urlUtils.prependBaseUrl(url, baseUrl) + after;
 		});
 	},
@@ -108,6 +109,10 @@ const markdownUtils = {
 
 	extractImageUrls(md: string) {
 		return markdownUtils.extractFileUrls(md,true);
+	},
+
+	extractPdfUrls(md: string) {
+		return markdownUtils.extractFileUrls(md, false).filter((url) => url.startsWith('_pdf:')).map((url) => url.slice(5));
 	},
 
 	// The match results has 5 items

--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -77,13 +77,15 @@ const markdownUtils = {
 		const tokens = markdownIt.parse(md, env);
 		const output: string[] = [];
 
-		let linkType = onlyType || 'any';
+		let linkType = onlyType;
 		if (linkType === 'pdf') linkType = 'link_open';
 
 		const searchUrls = (tokens: any[]) => {
 			for (let i = 0; i < tokens.length; i++) {
 				const token = tokens[i];
-				if ((linkType === 'any' && (token.type === 'link_open' || token.type === 'image')) || (linkType != 'any' && token.type === linkType)) {
+				if ((!onlyType && (token.type === 'link_open' || token.type === 'image')) || (!!onlyType && token.type === onlyType) || (onlyType == 'pdf' && token.type === 'link_open')) {
+					// Pdf embeds are a special case, they are represented as 'link_open' tokens but are marked with 'embedded_pdf' as link name by the parser
+					// We are making sure if its in the proper pdf link format, only then we add it to the list
 					if (onlyType === 'pdf' && !(tokens.length > i + 1 && tokens[i + 1].type === 'text' && tokens[i + 1].content === 'embedded_pdf')) continue;
 					for (let j = 0; j < token.attrs.length; j++) {
 						const a = token.attrs[j];

--- a/packages/lib/markupLanguageUtils.ts
+++ b/packages/lib/markupLanguageUtils.ts
@@ -28,6 +28,17 @@ export class MarkupLanguageUtils {
 		return urls;
 	}
 
+	public extractPdfUrls(language: MarkupLanguage, text: string): string[] {
+		let urls: string[] = [];
+		if (language === MarkupLanguage.Any) {
+			urls = urls.concat(this.lib_(MarkupLanguage.Markdown).extractPdfUrls(text));
+			urls = urls.concat(this.lib_(MarkupLanguage.Html).extractPdfUrls(text));
+		} else {
+			urls = this.lib_(language).extractPdfUrls(text);
+		}
+		return urls;
+	}
+
 	// Create a new MarkupToHtml instance while injecting options specific to Joplin
 	// desktop and mobile applications.
 	public newMarkupToHtml(_plugins: PluginStates = null, options: Options = null) {

--- a/packages/lib/services/rest/Api.test.ts
+++ b/packages/lib/services/rest/Api.test.ts
@@ -436,13 +436,18 @@ describe('services_rest_Api', function() {
 		const tests = [
 			{
 				language: MarkupToHtml.MARKUP_LANGUAGE_HTML,
-				body: '<div> <img src="https://example.com/img.png" /> <embed src="https://example.com/sample.pdf" type="application/pdf" /> </div>',
-				result: ['https://example.com/img.png','https://example.com/sample.pdf'],
+				body: '<div> <img src="https://example.com/img.png" /> <embed src="https://example.com/sample.pdf"/> <object data="https://example.com/file.PDF"></object> </div>',
+				result: ['https://example.com/img.png', 'https://example.com/sample.pdf', 'https://example.com/file.PDF'],
 			},
 			{
 				language: MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN,
-				body: 'test text \n ![img 1](https://example.com/img1.png) [pdf 1](_pdf:https://example.com/sample1.pdf)',
-				result: ['https://example.com/img1.png','https://example.com/sample1.pdf'],
+				body: 'test text \n ![img 1](https://example.com/img1.png) [embedded_pdf](https://example.com/sample1.pdf) [embedded_pdf](https://example.com/file.PDF)',
+				result: ['https://example.com/img1.png', 'https://example.com/sample1.pdf', 'https://example.com/file.PDF'],
+			},
+			{
+				language: MarkupToHtml.MARKUP_LANGUAGE_HTML,
+				body: '<div> <embed src="https://example.com/sample"/> <embed /> <object data="https://example.com/file.pdfff"></object> <a href="https://test.com/file.pdf">Link</a> </div>',
+				result: [],
 			},
 		];
 		tests.forEach((test) => {

--- a/packages/lib/services/rest/Api.test.ts
+++ b/packages/lib/services/rest/Api.test.ts
@@ -1,5 +1,6 @@
 import { PaginationOrderDir } from '../../models/utils/types';
 import Api, { RequestMethod } from '../../services/rest/Api';
+import { extractMediaUrls } from './routes/notes';
 import shim from '../../shim';
 import { setupDatabaseAndSynchronizer, switchClient, checkThrowAsync, db, msleep, supportDir } from '../../testing/test-utils';
 import Folder from '../../models/Folder';
@@ -9,6 +10,7 @@ import Tag from '../../models/Tag';
 import NoteTag from '../../models/NoteTag';
 import ResourceService from '../../services/ResourceService';
 import SearchEngine from '../../services/searchengine/SearchEngine';
+const { MarkupToHtml } = require('@joplin/renderer');
 
 const createFolderForPagination = async (num: number, time: number) => {
 	await Folder.save({
@@ -375,6 +377,42 @@ describe('services_rest_Api', function() {
 		}));
 
 		expect(response.body).toBe('**Bold text**');
+	}));
+
+	it('should extract media urls from body', (() => {
+		const tests = [
+			{
+				language: MarkupToHtml.MARKUP_LANGUAGE_HTML,
+				body: '<div> <img src="https://example.com/img.png" /> <embed src="https://example.com/sample.pdf" type="application/pdf" /> </div>',
+				result: ['https://example.com/img.png','https://example.com/sample.pdf'],
+			},
+			{
+				language: MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN,
+				body: 'test text \n ![img 1](https://example.com/img1.png) [pdf 1](_pdf:https://example.com/sample1.pdf)',
+				result: ['https://example.com/img1.png','https://example.com/sample1.pdf'],
+			},
+		];
+		tests.forEach((test) => {
+			const urls = extractMediaUrls(test.language, test.body);
+			expect(urls).toEqual(test.result);
+		});
+	}));
+
+	it('should create notes with pdf embeds', (async () => {
+		let response = null;
+		const f = await Folder.save({ title: 'pdf test1' });
+
+		response = await api.route(RequestMethod.POST, 'notes', null, JSON.stringify({
+			title: 'testing PDF embeds',
+			parent_id: f.id,
+			body_html: `<div> <embed src="file://${supportDir}/welcome.pdf" type="application/pdf" /> </div>`,
+		}));
+
+		const resources = await Resource.all();
+		expect(resources.length).toBe(1);
+
+		const resource = resources[0];
+		expect(response.body.indexOf(resource.id) >= 0).toBe(true);
 	}));
 
 	it('should handle tokens', (async () => {

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -89,6 +89,7 @@ async function requestNoteToNote(requestNote: any) {
 			output.body = await htmlToMdParser().parse(`<div>${requestNote.body_html}</div>`, {
 				baseUrl: baseUrl,
 				anchorNames: requestNote.anchor_names ? requestNote.anchor_names : [],
+				loadPdfs: true,
 			});
 			output.markup_language = MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN;
 		}
@@ -143,25 +144,32 @@ async function buildNoteStyleSheet(stylesheets: any[]) {
 	return output;
 }
 
-async function tryToGuessImageExtFromMimeType(response: any, imagePath: string) {
+async function tryToGuessExtFromMimeType(response: any, mediaPath: string) {
 	const mimeType = mimeTypeFromHeaders(response.headers);
-	if (!mimeType) return imagePath;
+	if (!mimeType) return mediaPath;
 
 	const newExt = mimeUtils.toFileExtension(mimeType);
-	if (!newExt) return imagePath;
+	if (!newExt) return mediaPath;
 
-	const newImagePath = `${imagePath}.${newExt}`;
-	await shim.fsDriver().move(imagePath, newImagePath);
+	const newImagePath = `${mediaPath}.${newExt}`;
+	await shim.fsDriver().move(mediaPath, newImagePath);
 	return newImagePath;
 }
 
-async function downloadImage(url: string /* , allowFileProtocolImages */) {
+async function downloadMediaFile(url: string /* , allowFileProtocolImages */) {
+
 	const tempDir = Setting.value('tempDir');
 
 	// The URL we get to download have been extracted from the Markdown document
 	url = markdownUtils.unescapeLinkUrl(url);
 
 	const isDataUrl = url && url.toLowerCase().indexOf('data:') === 0;
+
+	// PDFs and other heavy resoucres are often served as seperate files insted of data urls, its very unlikely to encounter a pdf as a data url
+	if (isDataUrl && !url.toLowerCase().startsWith('data:image/')) {
+		reg.logger().warn(`Resources in data URL format is only supported for images ${url}`);
+		return '';
+	}
 
 	const name = isDataUrl ? md5(`${Math.random()}_${Date.now()}`) : filename(url);
 	let fileExt = isDataUrl ? mimeUtils.toFileExtension(mimeUtils.fromDataUrl(url)) : safeFileExtension(fileExtension(url).toLowerCase());
@@ -170,38 +178,38 @@ async function downloadImage(url: string /* , allowFileProtocolImages */) {
 
 	// Append a UUID because simply checking if the file exists is not enough since
 	// multiple resources can be downloaded at the same time (race condition).
-	let imagePath = `${tempDir}/${safeFilename(name)}_${uuid.create()}${fileExt}`;
+	let mediaPath = `${tempDir}/${safeFilename(name)}_${uuid.create()}${fileExt}`;
 
 	try {
 		if (isDataUrl) {
-			await shim.imageFromDataUrl(url, imagePath);
+			await shim.imageFromDataUrl(url, mediaPath);
 		} else if (urlUtils.urlProtocol(url).toLowerCase() === 'file:') {
 			// Can't think of any reason to disallow this at this point
 			// if (!allowFileProtocolImages) throw new Error('For security reasons, this URL with file:// protocol cannot be downloaded');
 			const localPath = fileUriToPath(url);
-			await shim.fsDriver().copy(localPath, imagePath);
+			await shim.fsDriver().copy(localPath, mediaPath);
 		} else {
-			const response = await shim.fetchBlob(url, { path: imagePath, maxRetry: 1 });
+			const response = await shim.fetchBlob(url, { path: mediaPath, maxRetry: 1 });
 
 			// If we could not find the file extension from the URL, try to get it
 			// now based on the Content-Type header.
-			if (!fileExt) imagePath = await tryToGuessImageExtFromMimeType(response, imagePath);
+			if (!fileExt) mediaPath = await tryToGuessExtFromMimeType(response, mediaPath);
 		}
-		return imagePath;
+		return mediaPath;
 	} catch (error) {
 		reg.logger().warn(`Cannot download image at ${url}`, error);
 		return '';
 	}
 }
 
-async function downloadImages(urls: string[] /* , allowFileProtocolImages:boolean */) {
+async function downloadMediaFiles(urls: string[] /* , allowFileProtocolImages:boolean */) {
 	const PromisePool = require('es6-promise-pool');
 
 	const output: any = {};
 
 	const downloadOne = async (url: string) => {
-		const imagePath = await downloadImage(url); // , allowFileProtocolImages);
-		if (imagePath) output[url] = { path: imagePath, originalUrl: url };
+		const mediaPath = await downloadMediaFile(url); // , allowFileProtocolImages);
+		if (mediaPath) output[url] = { path: mediaPath, originalUrl: url };
 	};
 
 	let urlIndex = 0;
@@ -245,27 +253,36 @@ async function removeTempFiles(urls: string[]) {
 	}
 }
 
-function replaceImageUrlsByResources(markupLanguage: number, md: string, urls: any, imageSizes: any) {
+function replaceUrlsByResources(markupLanguage: number, md: string, urls: any, imageSizes: any) {
 	const imageSizesIndexes: any = {};
 
 	if (markupLanguage === MarkupToHtml.MARKUP_LANGUAGE_HTML) {
-		return htmlUtils.replaceImageUrls(md, (imageUrl: string) => {
-			const urlInfo: any = urls[imageUrl];
-			if (!urlInfo || !urlInfo.resource) return imageUrl;
+		return htmlUtils.replaceMediaUrls(md, (url: string) => {
+			const urlInfo: any = urls[url];
+			if (!urlInfo || !urlInfo.resource) return url;
 			return Resource.internalUrl(urlInfo.resource);
 		});
 	} else {
 		// eslint-disable-next-line no-useless-escape
-		return md.replace(/(!\[.*?\]\()([^\s\)]+)(.*?\))/g, (_match: any, before: string, imageUrl: string, after: string) => {
-			const urlInfo = urls[imageUrl];
-			if (!urlInfo || !urlInfo.resource) return before + imageUrl + after;
+		return md.replace(/(!?\[.*?\]\()([^\s\)]+)(.*?\))/g, (_match: any, before: string, url: string, after: string) => {
+			let type = 'link';
+			if (url.startsWith('_pdf:')) {
+				url = url.slice(5);
+				type = 'pdf';
+			} else if (before.startsWith('![')) {
+				type = 'image';
+			}
+
+			const urlInfo = urls[url];
+			if (type === 'link' || !urlInfo || !urlInfo.resource) return before + url + after;
 			if (!(urlInfo.originalUrl in imageSizesIndexes)) imageSizesIndexes[urlInfo.originalUrl] = 0;
 
 			const resourceUrl = Resource.internalUrl(urlInfo.resource);
 			const imageSizesCollection = imageSizes[urlInfo.originalUrl];
 
 			if (!imageSizesCollection) {
-				// In some cases, we won't find the image size information for that particular URL. Normally
+				// Either its not an image or we don't know the size of the image
+				// In some cases, we won't find the image size information for that particular image URL. Normally
 				// it will only happen when using the "Clip simplified page" feature, which can modify the
 				// image URLs (for example it will select a smaller size resolution). In that case, it's
 				// fine to return the image as-is because it has already good dimensions.
@@ -282,6 +299,13 @@ function replaceImageUrlsByResources(markupLanguage: number, md: string, urls: a
 			}
 		});
 	}
+}
+
+export function extractMediaUrls(markupLanguage: number, text: string): string[] {
+	const urls: string[] = [];
+	urls.push(...ArrayUtils.unique(markupLanguageUtils.extractImageUrls(markupLanguage, text)));
+	urls.push(...ArrayUtils.unique(markupLanguageUtils.extractPdfUrls(markupLanguage, text)));
+	return urls;
 }
 
 // Note must have been saved first
@@ -328,17 +352,17 @@ export default async function(request: Request, id: string = null, link: string 
 
 		let note: any = await requestNoteToNote(requestNote);
 
-		const imageUrls = ArrayUtils.unique(markupLanguageUtils.extractImageUrls(note.markup_language, note.body));
+		const mediaUrls = extractMediaUrls(note.markup_language, note.body);
 
-		reg.logger().info(`Request (${requestId}): Downloading images: ${imageUrls.length}`);
+		reg.logger().info(`Request (${requestId}): Downloading media files: ${mediaUrls.length}`);
 
-		let result = await downloadImages(imageUrls); // , allowFileProtocolImages);
+		let result = await downloadMediaFiles(mediaUrls); // , allowFileProtocolImages);
 
 		reg.logger().info(`Request (${requestId}): Creating resources from paths: ${Object.getOwnPropertyNames(result).length}`);
 
 		result = await createResourcesFromPaths(result);
 		await removeTempFiles(result);
-		note.body = replaceImageUrlsByResources(note.markup_language, note.body, result, imageSizes);
+		note.body = replaceUrlsByResources(note.markup_language, note.body, result, imageSizes);
 
 		reg.logger().info(`Request (${requestId}): Saving note...`);
 

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -151,9 +151,9 @@ async function tryToGuessExtFromMimeType(response: any, mediaPath: string) {
 	const newExt = mimeUtils.toFileExtension(mimeType);
 	if (!newExt) return mediaPath;
 
-	const newImagePath = `${mediaPath}.${newExt}`;
-	await shim.fsDriver().move(mediaPath, newImagePath);
-	return newImagePath;
+	const newMediaPath = `${mediaPath}.${newExt}`;
+	await shim.fsDriver().move(mediaPath, newMediaPath);
+	return newMediaPath;
 }
 
 async function downloadMediaFile(url: string /* , allowFileProtocolImages */) {


### PR DESCRIPTION
As discussed in #6247 this PR has 2 major objective:

- Clipper identifies embedded pdfs in the page and saves them as resources.
- When we open a pdf file in browser and run clipper, it correctly saves the pdf file as a note.

## How to check it out

- Open the links [embedded pdf](https://pdfobject.com/) and [pdf file](http://www.doiserbia.nb.rs/img/doi/1450-5339/2008/1450-53390801039K.pdf) in the browser.
- Open the clipper plugin on each page and select any `clip page` option.
- Check the newly created note which must contain the pdfs. 
- If you chose a HTML option you will see a `<a>` link. You wont be able to preview it from the note itself but your pdf has been saved and clicking on the link will open the pdf. If you chose a Markdown option you should be able to see the preview of the pdf as well.

## Screenshots 

### Original page with embedded PDF
![Screenshot 2022-04-09 at 6 55 07 PM](https://user-images.githubusercontent.com/44570278/162578425-4d7c3a8a-baeb-480d-adc4-48c97d5bf12b.png)

### Clipped as Markdown
![Screenshot 2022-04-09 at 6 54 52 PM](https://user-images.githubusercontent.com/44570278/162578437-6b1fda91-4a30-444f-8840-9b52325d3e49.png)

### Clipped as HTML
![Screenshot 2022-04-09 at 6 56 14 PM](https://user-images.githubusercontent.com/44570278/162578431-1325a388-6015-4ee8-9c19-0a69d4df84ad.png)

### A raw .pdf page clipped into a note (markdown clipped)
![Screenshot 2022-04-09 at 6 57 58 PM](https://user-images.githubusercontent.com/44570278/162578439-dcd3f263-7afd-434a-84de-d8c12f181e82.png)


## Implementation notes

### For saving as HTML

We check for `<embed>` and `<object>` tags for pdf embeds since this is the standard way of web to embed them, and after converting them to resources we replace those tags to `<a>` links since `<embed>` and `<object>` tags are disabled in the renderer due to security reasons (CVE-2020-15930). 

### For saving as Markdown

We covert `<embed>`, `<object>` tags to its appropriate alternative in md i.e  into`[name](url)`. But this causes an issue since this conversion happens before their resources are created, and since in md there's no way to distinguish a normal link and a pdf embed this raises the question of which link tags should be converted to resources and which ones are to be left as it is. We cannot just convert all pdf links (i.e ending with `.pdf` ext) into a resource since it might just happen to be a normal hyperlink in the original page. As a solution I decided to append a `_pdf:` marker in front of the pdf links temporarily that needs to converted to resources, later once all the resources are created we remove the marker and url and it gets replaced with the new internal links to the resources thus the marker is invisible to the end user or any other parts of the system.

### Clipping a raw `.pdf` file

To make this work we are checking the `content-type` of the page on clipper and if it happens to be of type `application/pdf` we are sending the body of the note as `<embed src="[page url]" type="application/pdf" />` instead of trying to parse the document any further.

## Unit tests

2 new unit tests are added to `Api.text.ts` of `lib` package.
- should extract media urls from body
- should create notes with pdf embeds

The last one almost covers the whole PR.
