### PR TITLE
All: Resolves #6370: Makes rendered tables horizontally scroll-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1923,6 +1923,9 @@ packages/renderer/MdToHtml/rules/sanitize_html.js.map
 packages/renderer/MdToHtml/rules/source_map.d.ts
 packages/renderer/MdToHtml/rules/source_map.js
 packages/renderer/MdToHtml/rules/source_map.js.map
+packages/renderer/MdToHtml/rules/table.d.ts
+packages/renderer/MdToHtml/rules/table.js
+packages/renderer/MdToHtml/rules/table.js.map
 packages/renderer/MdToHtml/setupLinkify.d.ts
 packages/renderer/MdToHtml/setupLinkify.js
 packages/renderer/MdToHtml/setupLinkify.js.map

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -65,6 +65,7 @@ const rules: RendererRules = {
 	fountain: require('./MdToHtml/rules/fountain').default,
 	mermaid: require('./MdToHtml/rules/mermaid').default,
 	source_map: require('./MdToHtml/rules/source_map').default,
+	table: require('./MdToHtml/rules/table').default,
 };
 
 const uslug = require('@joplin/fork-uslug');

--- a/packages/renderer/MdToHtml/rules/table.ts
+++ b/packages/renderer/MdToHtml/rules/table.ts
@@ -1,0 +1,12 @@
+function plugin(markdownIt: any) {
+	markdownIt.renderer.rules.table_open = function () {
+		return `<div style="overflow: auto;"><table>`
+	};
+	markdownIt.renderer.rules.table_close = function () {
+		return `</table></div>`
+	};
+}
+
+export default {
+	plugin,
+};


### PR DESCRIPTION
> Published note uses whole screen width and horizontal scrollbar appears for when note is wider than screen / window  
> 
> ![image](https://user-images.githubusercontent.com/77495103/162613950-6b368f79-abec-42db-8868-1f92e435c739.png)
> _From #6370's demo at https://6fuqvfoay2.joplinusercontent.com/shares/OtCqIj65cMWCDbFuifIJjJ_

The issue was primarily because of tables being too wide for the page.

One naive solution would be to make the entire `#rendered-md` container horizontally scroll-able using `overflow: auto;` — which can still be done as a fallback — but it makes it clunkier to use as you'd have to scroll all the way to the end of the document to use the horizontal scrollbar.

The better approach would be to make each individual element be horizontally scroll-able when too wide. Elements already behave like this, e.g. code blocks, but tables have always been outliers when it came to styling.

Adding `overflow: auto` directly to a table doesn't work.

This PR wraps a `<div>` with `overflow: auto;` around every table, making them horizontally scroll-able.

> ![Screenshot](https://user-images.githubusercontent.com/77495103/162613826-cb95a764-8f29-432a-a77a-546fdf67ae65.png)
> _Example using a table from #6370_
