### PR TITLE
Desktop: Fixes #6394: Removes false positive dependencies in plugin prop

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -8,7 +8,7 @@ import NoteEditor from '../NoteEditor/NoteEditor';
 import NoteContentPropertiesDialog from '../NoteContentPropertiesDialog';
 import ShareNoteDialog from '../ShareNoteDialog';
 import CommandService from '@joplin/lib/services/CommandService';
-import { PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import Sidebar from '../Sidebar/Sidebar';
 import UserWebview from '../../services/plugins/UserWebview';
 import UserWebviewDialog from '../../services/plugins/UserWebviewDialog';
@@ -53,6 +53,7 @@ interface LayerModalState {
 
 interface Props {
 	plugins: PluginStates;
+	pluginHtmlContents: PluginHtmlContents;
 	pluginsLoaded: boolean;
 	hasNotesBeingSaved: boolean;
 	dispatch: Function;
@@ -723,12 +724,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 				}
 			} else {
 				const { view, plugin } = viewInfo;
+				const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 				return <UserWebview
 					key={view.id}
 					viewId={view.id}
 					themeId={this.props.themeId}
-					html={view.html}
+					html={html}
 					scripts={view.scripts}
 					pluginId={plugin.id}
 					borderBottom={true}
@@ -762,12 +764,13 @@ class MainScreenComponent extends React.Component<Props, State> {
 			const { plugin, view } = info;
 			if (view.containerType !== ContainerType.Dialog) continue;
 			if (!view.opened) continue;
+			const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 			output.push(<UserWebviewDialog
 				key={view.id}
 				viewId={view.id}
 				themeId={this.props.themeId}
-				html={view.html}
+				html={html}
 				scripts={view.scripts}
 				pluginId={plugin.id}
 				buttons={view.buttons}
@@ -865,6 +868,7 @@ const mapStateToProps = (state: AppState) => {
 		selectedNoteId: state.selectedNoteIds.length === 1 ? state.selectedNoteIds[0] : null,
 		pluginsLegacy: state.pluginsLegacy,
 		plugins: state.pluginService.plugins,
+		pluginHtmlContents: state.pluginService.pluginHtmlContents,
 		customCss: state.customCss,
 		editorNoteStatuses: state.editorNoteStatuses,
 		hasNotesBeingSaved: stateUtils.hasNotesBeingSaved(state),

--- a/packages/lib/services/plugins/reducer.ts
+++ b/packages/lib/services/plugins/reducer.ts
@@ -33,14 +33,24 @@ export interface PluginStates {
 	[key: string]: PluginState;
 }
 
+export interface PluginHtmlContent {
+	[viewId: string]: string;
+}
+
+export interface PluginHtmlContents {
+	[pluginId: string]: PluginHtmlContent;
+}
+
 export interface State {
 	plugins: PluginStates;
+	pluginHtmlContents: PluginHtmlContents;
 }
 
 export const stateRootKey = 'pluginService';
 
 export const defaultState: State = {
 	plugins: {},
+	pluginHtmlContents: {},
 };
 
 export const utils = {
@@ -139,7 +149,12 @@ const reducer = (draftRoot: Draft<any>, action: any) => {
 
 		case 'PLUGIN_VIEW_PROP_SET':
 
-			(draft.plugins[action.pluginId].views[action.id] as any)[action.name] = action.value;
+			if (action.name !== 'html') {
+				(draft.plugins[action.pluginId].views[action.id] as any)[action.name] = action.value;
+			} else {
+				draft.pluginHtmlContents[action.pluginId] ??= {};
+				draft.pluginHtmlContents[action.pluginId][action.id] = action.value;
+			}
 			break;
 
 		case 'PLUGIN_VIEW_PROP_PUSH':


### PR DESCRIPTION
This PR is a subset of PR #5770. Its feature is as below, and fixes issue #6394.
- Redundant component updates (MainScreen, MenuBar, Sidebar, and so on) are reduced by separating view's html property from props.plugins.

The detail is described in #5770.
