### PR TITLE
Desktop: Resolves #6411 multiple profiles 

### DIFF
--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -740,7 +740,7 @@ class Setting extends BaseModel {
 					return ObjectUtils.sortByValue(supportedLocalesToLanguages({ includeStats: true }));
 				},
 				storage: SettingStorage.File,
-				isGlobal: true,
+				isGlobal: false,
 			},
 			dateFormat: {
 				value: Setting.DATE_FORMAT_1,


### PR DESCRIPTION
Bug

### **- Desktop: Resolves ##6411 multiple profiles** 

This Aims to solve two Major problems ->

1> **When the  User changes his Profile language the other profiles don't get affected by this change and their language remains same.**

2> **When User switches  back to his profile he is greeted with his own set language.**

here are some screen shots with the explaination 
 
1> User changes his language(French)
![image](https://user-images.githubusercontent.com/95926324/163669214-1974616d-91a2-4309-8aea-bb223ddbc99c.png)

2>His language is reflected
![image](https://user-images.githubusercontent.com/95926324/163669281-3d60a62a-80af-4eca-ab50-55e13c336ab5.png)

3> He switches his profile
![image](https://user-images.githubusercontent.com/95926324/163669291-9e45c148-bd39-48f0-9f42-232c555625c6.png)

4>New Profile with its own language remains the same as user had set before (esperanto)
![image](https://user-images.githubusercontent.com/95926324/163669317-c571de3c-8ff3-4afe-8c28-9cc4a334adb1.png)

5>When he comes back his language remains same (French)
![image](https://user-images.githubusercontent.com/95926324/163669339-8e0f106a-dccf-4330-9923-ccd2478f19d2.png)

