### PR TITLE
Mobile: Fixes #6328: Mobile/Beta Editor: null is not an object/Clicking undo when the editor is closed 

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -315,7 +315,6 @@ function NoteEditor(props: Props, ref: any) {
 		};
 	}, [html]);
 
-
 	const onMessage = useCallback((event: any) => {
 		const data = event.nativeEvent.data;
 

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -27,6 +27,7 @@ export interface SelectionChangeEvent {
 type ChangeEventHandler = (event: ChangeEvent)=> void;
 type UndoRedoDepthChangeHandler = (event: UndoRedoDepthChangeEvent)=> void;
 type SelectionChangeEventHandler = (event: SelectionChangeEvent)=> void;
+type disableBetaUndoRedoHandler = ()=> void;
 
 interface Props {
 	themeId: number;
@@ -37,6 +38,7 @@ interface Props {
 	onChange: ChangeEventHandler;
 	onSelectionChange: SelectionChangeEventHandler;
 	onUndoRedoDepthChange: UndoRedoDepthChangeHandler;
+	disableBetaUndoRedo: disableBetaUndoRedoHandler;
 }
 
 function fontFamilyFromSettings() {
@@ -314,6 +316,13 @@ function NoteEditor(props: Props, ref: any) {
 			cancelled = true;
 		};
 	}, [html]);
+
+	useEffect(() => {
+
+		return () => {
+			props.disableBetaUndoRedo();
+		};
+	}, []);
 
 	const onMessage = useCallback((event: any) => {
 		const data = event.nativeEvent.data;

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -27,7 +27,6 @@ export interface SelectionChangeEvent {
 type ChangeEventHandler = (event: ChangeEvent)=> void;
 type UndoRedoDepthChangeHandler = (event: UndoRedoDepthChangeEvent)=> void;
 type SelectionChangeEventHandler = (event: SelectionChangeEvent)=> void;
-type disableBetaUndoRedoHandler = ()=> void;
 
 interface Props {
 	themeId: number;
@@ -38,7 +37,6 @@ interface Props {
 	onChange: ChangeEventHandler;
 	onSelectionChange: SelectionChangeEventHandler;
 	onUndoRedoDepthChange: UndoRedoDepthChangeHandler;
-	disableBetaUndoRedo: disableBetaUndoRedoHandler;
 }
 
 function fontFamilyFromSettings() {
@@ -317,12 +315,6 @@ function NoteEditor(props: Props, ref: any) {
 		};
 	}, [html]);
 
-	useEffect(() => {
-
-		return () => {
-			props.disableBetaUndoRedo();
-		};
-	}, []);
 
 	const onMessage = useCallback((event: any) => {
 		const data = event.nativeEvent.data;

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -237,7 +237,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.onBodyViewerCheckboxChange = this.onBodyViewerCheckboxChange.bind(this);
 		this.onBodyChange = this.onBodyChange.bind(this);
 		this.onUndoRedoDepthChange = this.onUndoRedoDepthChange.bind(this);
-		this.disableBetaUndoRedo = this.disableBetaUndoRedo.bind(this);
 	}
 
 	private useEditorBeta(): boolean {
@@ -1048,13 +1047,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		void this.saveOneProperty('body', newBody);
 	}
 
-	disableBetaUndoRedo() {
-		this.setState({ undoRedoButtonState: {
-			canUndo: false,
-			canRedo: false,
-		} });
-	}
-
 	render() {
 		if (this.state.isLoading) {
 			return (
@@ -1145,7 +1137,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					onSelectionChange={this.body_selectionChange}
 					onUndoRedoDepthChange={this.onUndoRedoDepthChange}
 					style={this.styles().bodyTextInput}
-					disableBetaUndoRedo={this.disableBetaUndoRedo}
+					// disableBetaUndoRedo={this.disableBetaUndoRedo}
 				/>;
 			}
 		}
@@ -1210,8 +1202,8 @@ class NoteScreenComponent extends BaseScreenComponent {
 					onSaveButtonPress={this.saveNoteButton_press}
 					showSideMenuButton={false}
 					showSearchButton={false}
-					showUndoButton={this.state.undoRedoButtonState.canUndo || this.state.undoRedoButtonState.canRedo}
-					showRedoButton={this.state.undoRedoButtonState.canRedo}
+					showUndoButton={(this.state.undoRedoButtonState.canUndo || this.state.undoRedoButtonState.canRedo) && this.state.mode === 'edit'}
+					showRedoButton={this.state.undoRedoButtonState.canRedo && this.state.mode === 'edit'}
 					undoButtonDisabled={!this.state.undoRedoButtonState.canUndo && this.state.undoRedoButtonState.canRedo}
 					onUndoButtonPress={this.screenHeader_undoButtonPress}
 					onRedoButtonPress={this.screenHeader_redoButtonPress}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -237,6 +237,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.onBodyViewerCheckboxChange = this.onBodyViewerCheckboxChange.bind(this);
 		this.onBodyChange = this.onBodyChange.bind(this);
 		this.onUndoRedoDepthChange = this.onUndoRedoDepthChange.bind(this);
+		this.disableBetaUndoRedo = this.disableBetaUndoRedo.bind(this);
 	}
 
 	private useEditorBeta(): boolean {
@@ -1047,6 +1048,13 @@ class NoteScreenComponent extends BaseScreenComponent {
 		void this.saveOneProperty('body', newBody);
 	}
 
+	disableBetaUndoRedo() {
+		this.setState({ undoRedoButtonState: {
+			canUndo: false,
+			canRedo: false,
+		} });
+	}
+
 	render() {
 		if (this.state.isLoading) {
 			return (
@@ -1137,6 +1145,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					onSelectionChange={this.body_selectionChange}
 					onUndoRedoDepthChange={this.onUndoRedoDepthChange}
 					style={this.styles().bodyTextInput}
+					disableBetaUndoRedo={this.disableBetaUndoRedo}
 				/>;
 			}
 		}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1137,7 +1137,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 					onSelectionChange={this.body_selectionChange}
 					onUndoRedoDepthChange={this.onUndoRedoDepthChange}
 					style={this.styles().bodyTextInput}
-					// disableBetaUndoRedo={this.disableBetaUndoRedo}
 				/>;
 			}
 		}


### PR DESCRIPTION
# Summary

This fixes #6328.

I noticed that while using the regular editor, the undo and redo buttons are not displayed in view mode( when viewing a note). However, when using the beta editor, the undo button still shows up. We get the null is not an object error because we're tying to undo a change when the beta editor has been unmounted.

I modified the Beta Editor to set `canUndo` and `canRedo` to `false` before it is unmounted. This way, the undo and redo buttons don't show up and we can't get that error. This is the same way the regular editor works.

### Steps to Manually Test:

- Enable the beta editor
- Save settings
- Open a note
- Make multiple changes, then undo a change 
- Now redo a change (The undo and redo button should appear and be working fine)
- Now, go back to view mode (The undo and redo buttons should disappear)

I also tested that my changes did not break the undo and redo functionality of the regular editor. However I did not test this on an IOS device.


