### PR TITLE
Desktop: Fixes #6416: Switching a note using Sidebar is slow and grayed out

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -12,6 +12,7 @@ import useWindowCommandHandler from './utils/useWindowCommandHandler';
 import useDropHandler from './utils/useDropHandler';
 import useMarkupToHtml from './utils/useMarkupToHtml';
 import useFormNote, { OnLoadEvent } from './utils/useFormNote';
+import useEffectiveNoteId from './utils/useEffectiveNoteId';
 import useFolder from './utils/useFolder';
 import styles_ from './styles';
 import { NoteEditorProps, FormNote, ScrollOptions, ScrollOptionTypes, OnChangeEvent, NoteBodyEditorProps, AllAssetsOptions } from './utils/types';
@@ -65,17 +66,7 @@ function NoteEditor(props: NoteEditorProps) {
 		setTitleHasBeenManuallyChanged(false);
 	}, []);
 
-	// When a notebook is changed without any selected note,
-	// no note is selected for a moment, and then a new note gets selected.
-	// In this short transient period, the last displayed note id should temporarily
-	// be used to prevent NoteEditor's body from being unmounted.
-	const lastDisplayedNoteId = useRef<string>(null);
-	const whenNoteIdIsTransientlyAbsent = !props.noteId && props.notes.length > 0;
-	const effectiveNoteId = whenNoteIdIsTransientlyAbsent ? lastDisplayedNoteId.current : props.noteId;
-
-	useEffect(() => {
-		if (props.noteId) lastDisplayedNoteId.current = props.noteId;
-	}, [props.noteId]);
+	const effectiveNoteId = useEffectiveNoteId(props);
 
 	const { formNote, setFormNote, isNewNote, resourceInfos } = useFormNote({
 		syncStarted: props.syncStarted,

--- a/packages/app-desktop/gui/NoteEditor/utils/useEffectiveNoteId.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useEffectiveNoteId.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { NoteEditorProps } from './types';
+
+export default function useEffectiveNoteId(props: NoteEditorProps) {
+	// When a notebook is changed without any selected note,
+	// no note is selected for a moment, and then a new note gets selected.
+	// In this short transient period, the last displayed note id should temporarily
+	// be used to prevent NoteEditor's body from being unmounted.
+	// See https://github.com/laurent22/joplin/issues/6416
+	// and https://github.com/laurent22/joplin/pull/6430 for details.
+
+	const lastDisplayedNoteId = useRef<string>(null);
+	const whenNoteIdIsTransientlyAbsent = !props.noteId && props.notes.length > 0;
+	const effectiveNoteId = whenNoteIdIsTransientlyAbsent ? lastDisplayedNoteId.current : props.noteId;
+
+	useEffect(() => {
+		if (props.noteId) lastDisplayedNoteId.current = props.noteId;
+	}, [props.noteId]);
+
+	return effectiveNoteId;
+}


### PR DESCRIPTION
This PR fixes issue #6416.

Features:
- Makes note switching using SideBar faster by preventing scripts from reloaded
- Prevents NoteEditor from grayed out when note switches using SideBar

Description:
- When a notebook is changed without any selected note, no note is selected for a moment, and then a new note gets selected.
- In this short transient period with no note, `NoteEditor.renderNoNote()` is called, and then its body (Editor/Viewer) is unmounted. So, NoteEditor becomes grayed out, and scripts in Editor/Viewer gets reloaded.
- To prevent them, in the transient period, the id of the last displayed note will be temporarily kept until the id of a new note arrives.