### PR TITLE
Desktop: Performance: fixes false dependencies between MainScreen and NoteList

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -68,7 +68,6 @@ interface Props {
 	showNeedUpgradingMasterKeyMessage: boolean;
 	showShouldReencryptMessage: boolean;
 	showInstallTemplatesPlugin: boolean;
-	focusedField: string;
 	themeId: number;
 	settingEditorCodeView: boolean;
 	pluginsLegacy: any;
@@ -692,7 +691,6 @@ class MainScreenComponent extends React.Component<Props, State> {
 					key={key}
 					resizableLayoutEventEmitter={eventEmitter}
 					visible={event.visible}
-					focusedField={this.props.focusedField}
 					size={event.size}
 					themeId={this.props.themeId}
 				/>;
@@ -861,14 +859,11 @@ const mapStateToProps = (state: AppState) => {
 		showNeedUpgradingMasterKeyMessage: !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys).length,
 		showShouldReencryptMessage: state.settings['encryption.shouldReencrypt'] >= Setting.SHOULD_REENCRYPT_YES,
 		shouldUpgradeSyncTarget: state.settings['sync.upgradeState'] === Setting.SYNC_UPGRADE_STATE_SHOULD_DO,
-		selectedFolderId: state.selectedFolderId,
-		selectedNoteId: state.selectedNoteIds.length === 1 ? state.selectedNoteIds[0] : null,
 		pluginsLegacy: state.pluginsLegacy,
 		plugins: state.pluginService.plugins,
 		customCss: state.customCss,
 		editorNoteStatuses: state.editorNoteStatuses,
 		hasNotesBeingSaved: stateUtils.hasNotesBeingSaved(state),
-		focusedField: state.focusedField,
 		layoutMoveMode: state.layoutMoveMode,
 		mainLayout: state.mainLayout,
 		startupPluginsLoaded: state.startupPluginsLoaded,

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -167,6 +167,7 @@ function NoteListControls(props: Props) {
 
 const mapStateToProps = (state: AppState) => {
 	return {
+		showNewNoteButtons: state.focusedField !== 'globalSearch',
 		sortOrderButtonsVisible: state.settings['notes.sortOrder.buttonsVisible'],
 		sortOrderField: state.settings['notes.sortOrder.field'],
 		sortOrderReverse: state.settings['notes.sortOrder.reverse'],

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -10,7 +10,6 @@ interface Props {
 	resizableLayoutEventEmitter: any;
 	size: Size;
 	visible: boolean;
-	focusedField: string;
 	themeId: number;
 }
 
@@ -34,7 +33,7 @@ export default function NoteListWrapper(props: Props) {
 
 	return (
 		<StyledRoot>
-			<NoteListControls showNewNoteButtons={props.focusedField !== 'globalSearch'} height={controlHeight} />
+			<NoteListControls height={controlHeight} />
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);


### PR DESCRIPTION
This PR is one of PRs resolving issue #6386 and improves various UI responses.

MainScreenComponent has selectedFolderId, selectedNoteId, focusedField properties in its props, but they are not needed by MainScreenComponent.

selectedFolderId and selectedNoteId are not used by any children component any more. And, focusedField is only used by NoteListWrapper and NoteListControls. These false dependencies cause redundant re-rendering. Because when one of the three properties changes, MainScreenComponent is re-rendered, and then its children components (almost all except MenuBar) are also re-rendered. This re-rendering results in not a small performance degradation.

Treatments in this PR:
- selectedFolderId, selectedNoteId, focusedField are removed from MainScreenComponent.
- focusedField is directly referred by NoteListWrapper and NoteListControls through mapStateToProps.