### PR TITLE
Desktop: Performance: fixes false dependencies between MainScreen and UserWebview

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -8,7 +8,7 @@ import NoteEditor from '../NoteEditor/NoteEditor';
 import NoteContentPropertiesDialog from '../NoteContentPropertiesDialog';
 import ShareNoteDialog from '../ShareNoteDialog';
 import CommandService from '@joplin/lib/services/CommandService';
-import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+import { PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import Sidebar from '../Sidebar/Sidebar';
 import UserWebview from '../../services/plugins/UserWebview';
 import UserWebviewDialog from '../../services/plugins/UserWebviewDialog';
@@ -53,7 +53,6 @@ interface LayerModalState {
 
 interface Props {
 	plugins: PluginStates;
-	pluginHtmlContents: PluginHtmlContents;
 	pluginsLoaded: boolean;
 	hasNotesBeingSaved: boolean;
 	dispatch: Function;
@@ -724,13 +723,11 @@ class MainScreenComponent extends React.Component<Props, State> {
 				}
 			} else {
 				const { view, plugin } = viewInfo;
-				const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 				return <UserWebview
 					key={view.id}
 					viewId={view.id}
 					themeId={this.props.themeId}
-					html={html}
 					scripts={view.scripts}
 					pluginId={plugin.id}
 					borderBottom={true}
@@ -764,13 +761,11 @@ class MainScreenComponent extends React.Component<Props, State> {
 			const { plugin, view } = info;
 			if (view.containerType !== ContainerType.Dialog) continue;
 			if (!view.opened) continue;
-			const html = this.props.pluginHtmlContents[plugin.id]?.[view.id] ?? '';
 
 			output.push(<UserWebviewDialog
 				key={view.id}
 				viewId={view.id}
 				themeId={this.props.themeId}
-				html={html}
 				scripts={view.scripts}
 				pluginId={plugin.id}
 				buttons={view.buttons}
@@ -868,7 +863,6 @@ const mapStateToProps = (state: AppState) => {
 		selectedNoteId: state.selectedNoteIds.length === 1 ? state.selectedNoteIds[0] : null,
 		pluginsLegacy: state.pluginsLegacy,
 		plugins: state.pluginService.plugins,
-		pluginHtmlContents: state.pluginService.pluginHtmlContents,
 		customCss: state.customCss,
 		editorNoteStatuses: state.editorNoteStatuses,
 		hasNotesBeingSaved: stateUtils.hasNotesBeingSaved(state),

--- a/packages/app-desktop/services/plugins/UserWebview.tsx
+++ b/packages/app-desktop/services/plugins/UserWebview.tsx
@@ -9,11 +9,14 @@ import useWebviewToPluginMessages from './hooks/useWebviewToPluginMessages';
 import useScriptLoader from './hooks/useScriptLoader';
 import Logger from '@joplin/lib/Logger';
 import styled from 'styled-components';
+import { AppState } from '../../app.reducer';
 
+const { connect } = require('react-redux');
 const logger = Logger.create('UserWebview');
 
 export interface Props {
-	html: string;
+	forwardedRef?: any;
+	html?: string;
 	scripts: string[];
 	pluginId: string;
 	viewId: string;
@@ -59,7 +62,8 @@ function serializeForms(document: any) {
 	return output;
 }
 
-function UserWebview(props: Props, ref: any) {
+function UserWebview(props: Props) {
+	const ref = props.forwardedRef;
 	const minWidth = props.minWidth ? props.minWidth : 200;
 	const minHeight = props.minHeight ? props.minHeight : 20;
 
@@ -149,4 +153,15 @@ function UserWebview(props: Props, ref: any) {
 	></StyledFrame>;
 }
 
-export default forwardRef(UserWebview);
+const mapStateToProps = (state: AppState, ownProps: Props) => {
+	const pluginHtmlContents = state.pluginService.pluginHtmlContents;
+	const html = pluginHtmlContents?.[ownProps.pluginId]?.[ownProps.viewId] ?? '';
+	return {
+		html: html,
+	};
+};
+
+// Since only redux v6 and higher support connect() for forwardRef of function component,
+// a component wrapped by connect() is passed to forwardRef() to support mapStateToProps.
+const ConnectedUserWebview = connect(mapStateToProps)(UserWebview);
+export default forwardRef((props: Props, ref) => <ConnectedUserWebview {...props} forwardedRef={ref} />);

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -110,7 +110,6 @@ export default function UserWebviewDialog(props: Props) {
 				<UserWebViewWrapper>
 					<UserWebview
 						ref={webviewRef}
-						html={props.html}
 						scripts={props.scripts}
 						pluginId={props.pluginId}
 						viewId={props.viewId}


### PR DESCRIPTION
This PR is one of PRs resolving issue #6386 and improves various UI responses. 

MainScreenComponent has pluginHtmlContents property in its props, but it is needed not by MainScreenComponent itself but by UserWebview and UserWebviewDialog. This false dependency causes redundant re-rendering. Because when pluginHtmlContents property changes, MainScreenComponent is re-rendered, and then its children components (almost all except MenuBar) are also re-rendered.

Treatments in this PR:
- pluginHtmlContents is removed from MainScreenComponent.
- A dependency between MainScreenComponents and UserWebview/UserWebviewDialog, i.e. html property are removed in MainScreenComponent.
- html property is directly referred by UserWebview through mapStateToProps.