### PR TITLE
Desktop: Fixed color inconsistency of links in CodeMirror Editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -465,6 +465,10 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 				color: ${theme.color};
 			}
 
+			div.CodeMirror span.cm-variable-2, div.CodeMirror span.cm-variable-3, div.CodeMirror span.cm-keyword {
+				color: ${theme.color};
+			}
+
 			div.CodeMirror span.cm-quote {
 				color: ${theme.color};
 				opacity: ${theme.blockQuoteOpacity};
@@ -477,10 +481,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 			div.CodeMirror span.cm-url {
 				color: ${theme.urlColor};
 				opacity: 0.5;
-			}
-
-			div.CodeMirror span.cm-variable-2, div.CodeMirror span.cm-variable-3, div.CodeMirror span.cm-keyword {
-				color: ${theme.color};
 			}
 
 			div.CodeMirror span.cm-comment {


### PR DESCRIPTION
Color of links when they are in a list is inconsistent with their color outside of a list. As shown below:
![before](https://user-images.githubusercontent.com/5058349/164955862-8b8da2ef-eaa8-4bec-aac6-042cf66f2e69.png)

This can be fixed simply by changing the order of CodeMirror CSS declaration:
![after](https://user-images.githubusercontent.com/5058349/164955879-a464c684-e634-4523-a7ad-e50b9834a486.png)

This PR does exactly that.