### PR TITLE
Docs: Update terminal commands

### DIFF
--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -507,9 +507,8 @@ The following commands are available in [command-line mode](#command-line-mode):
 	    complete database including notebooks, notes, tags and resources.
 
 	    --format <format>      Destination format: jex (Joplin Export File), raw
-	                           (Joplin Export Directory), json (Json Export
-	                           Directory), md (Markdown), html (HTML File), html
-	                           (HTML Directory)
+	                           (Joplin Export Directory), md (Markdown), 
+				   md_frontmatter (Markdown + Front Matter)
 	    --note <note>          Exports only the given note.
 	    --notebook <notebook>  Exports only the given notebook.
 
@@ -525,8 +524,10 @@ The following commands are available in [command-line mode](#command-line-mode):
 
 	    Imports data into Joplin.
 
-	    --format <format>  Source format: auto, jex, md, raw, enex, enex
+	    --format <format>  Source format: auto, jex, md, md_frontmatter, raw,
+	    		       enex, enex
 	    -f, --force        Do not ask for confirmation.
+	    --output-format <output-format>  Output format: md, html
 
 	ls [note-pattern]
 

--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -277,469 +277,469 @@ toggle_metadata | Toggle note metadata
 
 The following commands are available in [command-line mode](#command-line-mode):
 
-  attach <note> <file>
-
-      Attaches the given file to the note.
-
-  batch <file-path>
-
-      Runs the commands contained in the text file. There should be one command
-      per line.
-
-  cat <note>
-
-      Displays the given note.
-
-      -v, --verbose  Displays the complete information about note.
-
-  config [name] [value]
-
-      Gets or sets a config value. If [value] is not provided, it will show the
-      value of [name]. If neither [name] nor [value] is provided, it will list
-      the current configuration.
-
-      -v, --verbose         Also displays unset and hidden config variables.
-      --export              Writes all settings to STDOUT as JSON including
-                            secure variables.
-      --import              Reads in JSON formatted settings from STDIN.
-      --import-file <file>  Reads in settings from <file>. <file> must contain
-                            valid JSON.
-
-  Possible keys/values:
-
-      sync.target                    Synchronisation target.
-                                     The target to synchronise to. Each sync
-                                     target may have additional parameters which
-                                     are named as `sync.NUM.NAME` (all
-                                     documented below).
-                                     Type: Enum.
-                                     Possible values: 0 ((None)), 2 (File
-                                     system), 3 (OneDrive), 5 (Nextcloud), 6
-                                     (WebDAV), 7 (Dropbox), 8 (S3 (Beta)), 9
-                                     (Joplin Server (Beta)), 10 (Joplin Cloud).
-                                     Default: 0
-
-      sync.2.path                    Directory to synchronise with (absolute
-                                     path).
-                                     Attention: If you change this location,
-                                     make sure you copy all your content to it
-                                     before syncing, otherwise all files will be
-                                     removed! See the FAQ for more details:
-                                     https://joplinapp.org/faq/
-                                     Type: string.
-
-      sync.5.path                    Nextcloud WebDAV URL.
-                                     Attention: If you change this location,
-                                     make sure you copy all your content to it
-                                     before syncing, otherwise all files will be
-                                     removed! See the FAQ for more details:
-                                     https://joplinapp.org/faq/
-                                     Type: string.
-
-      sync.5.username                Nextcloud username.
-                                     Type: string.
-
-      sync.5.password                Nextcloud password.
-                                     Type: string.
-
-      sync.6.path                    WebDAV URL.
-                                     Attention: If you change this location,
-                                     make sure you copy all your content to it
-                                     before syncing, otherwise all files will be
-                                     removed! See the FAQ for more details:
-                                     https://joplinapp.org/faq/
-                                     Type: string.
-
-      sync.6.username                WebDAV username.
-                                     Type: string.
-
-      sync.6.password                WebDAV password.
-                                     Type: string.
-
-      sync.8.path                    AWS S3 bucket.
-                                     Attention: If you change this location,
-                                     make sure you copy all your content to it
-                                     before syncing, otherwise all files will be
-                                     removed! See the FAQ for more details:
-                                     https://joplinapp.org/faq/
-                                     Type: string.
-
-      sync.8.url                     AWS S3 URL.
-                                     Type: string.
-                                     Default: "https://s3.amazonaws.com/"
-
-      sync.8.region                  AWS region.
-                                     Type: string.
-
-      sync.8.username                AWS access key.
-                                     Type: string.
-
-      sync.8.password                AWS secret key.
-                                     Type: string.
-
-      sync.8.forcePathStyle          Force path style.
-                                     Type: bool.
-                                     Default: false
-
-      sync.9.path                    Joplin Server URL.
-                                     Attention: If you change this location,
-                                     make sure you copy all your content to it
-                                     before syncing, otherwise all files will be
-                                     removed! See the FAQ for more details:
-                                     https://joplinapp.org/faq/
-                                     Type: string.
-
-      sync.9.username                Joplin Server email.
-                                     Type: string.
-
-      sync.9.password                Joplin Server password.
-                                     Type: string.
-
-      sync.10.username               Joplin Cloud email.
-                                     Type: string.
-
-      sync.10.password               Joplin Cloud password.
-                                     Type: string.
-
-      sync.maxConcurrentConnections  Max concurrent connections.
-                                     Type: int.
-                                     Default: 5
-
-      locale                         Language.
-                                     Type: Enum.
-                                     Possible values: ar (Arabic (93%)), eu
-                                     (Basque (27%)), bs_BA (Bosnian (Bosna i
-                                     Hercegovina) (67%)), bg_BG (Bulgarian
-                                     (България) (53%)), ca (Catalan (93%)),
-                                     hr_HR (Croatian (Hrvatska) (97%)), cs_CZ
-                                     (Czech (Česká republika) (89%)), da_DK
-                                     (Dansk (Danmark) (97%)), de_DE (Deutsch
-                                     (Deutschland) (97%)), et_EE (Eesti Keel
-                                     (Eesti) (51%)), en_GB (English (United
-                                     Kingdom) (100%)), en_US (English (United
-                                     States of America) (100%)), es_ES (Español
-                                     (España) (93%)), eo (Esperanto (30%)),
-                                     fi_FI (Finnish (Suomi) (93%)), fr_FR
-                                     (Français (France) (100%)), gl_ES (Galician
-                                     (España) (34%)), id_ID (Indonesian
-                                     (Indonesia) (92%)), it_IT (Italiano
-                                     (Italia) (90%)), hu_HU (Magyar
-                                     (Magyarország) (78%)), nl_BE (Nederlands
-                                     (België, Belgique, Belgien) (81%)), nl_NL
-                                     (Nederlands (Nederland) (85%)), nb_NO
-                                     (Norwegian (Norge, Noreg) (90%)), fa
-                                     (Persian (64%)), pl_PL (Polski (Polska)
-                                     (84%)), pt_BR (Português (Brasil) (94%)),
-                                     pt_PT (Português (Portugal) (84%)), ro
-                                     (Română (59%)), sl_SI (Slovenian
-                                     (Slovenija) (93%)), sv (Svenska (97%)),
-                                     th_TH (Thai (ประเทศไทย) (43%)), vi (Tiếng
-                                     Việt (90%)), tr_TR (Türkçe (Türkiye)
-                                     (93%)), uk_UA (Ukrainian (Україна) (83%)),
-                                     el_GR (Ελληνικά (Ελλάδα) (87%)), ru_RU
-                                     (Русский (Россия) (93%)), sr_RS (српски
-                                     језик (Србија) (76%)), zh_CN (中文 (简体)
-                                     (97%)), zh_TW (中文 (繁體) (90%)), ja_JP (日本語
-                                     (日本) (98%)), ko (한국어 (89%)).
-                                     Default: "en_GB"
-
-      dateFormat                     Date format.
-                                     Type: Enum.
-                                     Possible values: DD/MM/YYYY (30/01/2017),
-                                     DD/MM/YY (30/01/17), MM/DD/YYYY
-                                     (01/30/2017), MM/DD/YY (01/30/17),
-                                     YYYY-MM-DD (2017-01-30), DD.MM.YYYY
-                                     (30.01.2017), YYYY.MM.DD (2017.01.30),
-                                     YYMMDD (170130), YYYY/MM/DD (2017/01/30).
-                                     Default: "DD/MM/YYYY"
-
-      timeFormat                     Time format.
-                                     Type: Enum.
-                                     Possible values: HH:mm (20:30), h:mm A
-                                     (8:30 PM).
-                                     Default: "HH:mm"
-
-      uncompletedTodosOnTop          Uncompleted to-dos on top.
-                                     Type: bool.
-                                     Default: true
-
-      showCompletedTodos             Show completed to-dos.
-                                     Type: bool.
-                                     Default: true
-
-      notes.sortOrder.field          Sort notes by.
-                                     Type: Enum.
-                                     Possible values: user_updated_time (Updated
-                                     date), user_created_time (Created date),
-                                     title (Title), order (Custom order).
-                                     Default: "user_updated_time"
-
-      notes.sortOrder.reverse        Reverse sort order.
-                                     Type: bool.
-                                     Default: true
-
-      folders.sortOrder.field        Sort notebooks by.
-                                     Type: Enum.
-                                     Possible values: title (Title),
-                                     last_note_user_updated_time (Updated date).
-                                     Default: "title"
-
-      folders.sortOrder.reverse      Reverse sort order.
-                                     Type: bool.
-                                     Default: false
-
-      trackLocation                  Save geo-location with notes.
-                                     Type: bool.
-                                     Default: true
-
-      sync.interval                  Synchronisation interval.
-                                     Type: Enum.
-                                     Possible values: 0 (Disabled), 300 (5
-                                     minutes), 600 (10 minutes), 1800 (30
-                                     minutes), 3600 (1 hour), 43200 (12 hours),
-                                     86400 (24 hours).
-                                     Default: 300
-
-      editor                         Text editor command.
-                                     The editor command (may include arguments)
-                                     that will be used to open a note. If none
-                                     is provided it will try to auto-detect the
-                                     default editor.
-                                     Type: string.
-
-      net.customCertificates         Custom TLS certificates.
-                                     Comma-separated list of paths to
-                                     directories to load the certificates from,
-                                     or path to individual cert files. For
-                                     example: /my/cert_dir, /other/custom.pem.
-                                     Note that if you make changes to the TLS
-                                     settings, you must save your changes before
-                                     clicking on "Check synchronisation
-                                     configuration".
-                                     Type: string.
-
-      net.ignoreTlsErrors            Ignore TLS certificate errors.
-                                     Type: bool.
-                                     Default: false
-
-      sync.wipeOutFailSafe           Fail-safe.
-                                     Fail-safe: Do not wipe out local data when
-                                     sync target is empty (often the result of a
-                                     misconfiguration or bug)
-                                     Type: bool.
-                                     Default: true
-
-
-      revisionService.enabled        Enable note history.
-                                     Type: bool.
-                                     Default: true
-
-      revisionService.ttlDays        Keep note history for.
-                                     Type: int.
-                                     Default: 90
-
-      layout.folderList.factor       Notebook list growth factor.
-                                     The factor property sets how the item will
-                                     grow or shrink to fit the available space
-                                     in its container with respect to the other
-                                     items. Thus an item with a factor of 2 will
-                                     take twice as much space as an item with a
-                                     factor of 1.Restart app to see changes.
-                                     Type: int.
-                                     Default: 1
-
-      layout.noteList.factor         Note list growth factor.
-                                     The factor property sets how the item will
-                                     grow or shrink to fit the available space
-                                     in its container with respect to the other
-                                     items. Thus an item with a factor of 2 will
-                                     take twice as much space as an item with a
-                                     factor of 1.Restart app to see changes.
-                                     Type: int.
-                                     Default: 1
-
-      layout.note.factor             Note area growth factor.
-                                     The factor property sets how the item will
-                                     grow or shrink to fit the available space
-                                     in its container with respect to the other
-                                     items. Thus an item with a factor of 2 will
-                                     take twice as much space as an item with a
-                                     factor of 1.Restart app to see changes.
-                                     Type: int.
-                                     Default: 2
-
-  cp <note> [notebook]
-
-      Duplicates the notes matching <note> to [notebook]. If no notebook is
-      specified the note is duplicated in the current notebook.
-
-  done <note>
-
-      Marks a to-do as done.
-
-  e2ee <command> [path]
-
-      Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`,
-      `status`, `decrypt-file`, and `target-status`.
-
-      -p, --password <password>  Use this password as master password (For
-                                 security reasons, it is not recommended to use
-                                 this option).
-      -v, --verbose              More verbose output for the `target-status`
-                                 command
-      -o, --output <directory>   Output directory
-      --retry-failed-items       Applies to `decrypt` command - retries
-                                 decrypting items that previously could not be
-                                 decrypted.
-
-  edit <note>
-
-      Edit note.
-
-  export <path>
-
-      Exports Joplin data to the given path. By default, it will export the
-      complete database including notebooks, notes, tags and resources.
-
-      --format <format>      Destination format: jex (Joplin Export File), raw
-                             (Joplin Export Directory), md (Markdown),
-                             md_frontmatter (Markdown + Front Matter)
-      --note <note>          Exports only the given note.
-      --notebook <notebook>  Exports only the given notebook.
-
-  geoloc <note>
-
-      Displays a geolocation URL for the note.
-
-  help [command]
-
-      Displays usage information.
-
-  import <path> [notebook]
-
-      Imports data into Joplin.
-
-      --format <format>                Source format: auto, jex, md,
-                                       md_frontmatter, raw, enex, enex
-      -f, --force                      Do not ask for confirmation.
-      --output-format <output-format>  Output format: md, html
-
-  ls [note-pattern]
-
-      Displays the notes in the current notebook. Use `ls /` to display the list
-      of notebooks.
-
-      -n, --limit <num>      Displays only the first top <num> notes.
-      -s, --sort <field>     Sorts the item by <field> (eg. title, updated_time,
-                             created_time).
-      -r, --reverse          Reverses the sorting order.
-      -t, --type <type>      Displays only the items of the specific type(s).
-                             Can be `n` for notes, `t` for to-dos, or `nt` for
-                             notes and to-dos (eg. `-tt` would display only the
-                             to-dos, while `-tnt` would display notes and
-                             to-dos.
-      -f, --format <format>  Either "text" or "json"
-      -l, --long             Use long list format. Format is ID, NOTE_COUNT (for
-                             notebook), DATE, TODO_CHECKED (for to-dos), TITLE
-
-  mkbook <new-notebook>
-
-      Creates a new notebook.
-
-  mknote <new-note>
-
-      Creates a new note.
-
-  mktodo <new-todo>
-
-      Creates a new to-do.
-
-  mv <note> [notebook]
-
-      Moves the notes matching <note> to [notebook].
-
-  ren <item> <name>
-
-      Renames the given <item> (note or notebook) to <name>.
-
-  rmbook <notebook>
-
-      Deletes the given notebook.
-
-      -f, --force  Deletes the notebook without asking for confirmation.
-
-  rmnote <note-pattern>
-
-      Deletes the notes matching <note-pattern>.
-
-      -f, --force  Deletes the notes without asking for confirmation.
-
-  server <command>
-
-      Start, stop or check the API server. To specify on which port it should
-      run, set the api.port config variable. Commands are (start|stop|status).
-      This is an experimental feature - use at your own risks! It is recommended
-      that the server runs off its own separate profile so that no two CLI
-      instances access that profile at the same time. Use --profile to specify
-      the profile path.
-
-  set <note> <name> [value]
-
-      Sets the property <name> of the given <note> to the given [value].
-      Possible properties are:
-
-      parent_id (text), title (text), body (text), created_time (int),
-      updated_time (int), is_conflict (int), latitude (numeric), longitude
-      (numeric), altitude (numeric), author (text), source_url (text), is_todo
-      (int), todo_due (int), todo_completed (int), source (text),
-      source_application (text), application_data (text), order (numeric),
-      user_created_time (int), user_updated_time (int), encryption_cipher_text
-      (text), encryption_applied (int), markup_language (int), is_shared (int),
-      share_id (text), conflict_original_id (text), master_key_id (text)
-
-  status
-
-      Displays summary about the notes and notebooks.
-
-  sync
-
-      Synchronises with remote storage.
-
-      --target <target>   Sync to provided target (defaults to sync.target
-                          config value)
-      --upgrade           Upgrade the sync target to the latest version.
-      --use-lock <value>  Disable local locks that prevent multiple clients from
-                          synchronizing at the same time (Default = 1)
-
-  tag <tag-command> [tag] [note]
-
-      <tag-command> can be "add", "remove", "list", or "notetags" to assign or
-      remove [tag] from [note], to list notes associated with [tag], or to list
-      tags associated with [note]. The command `tag list` can be used to list
-      all the tags (use -l for long option).
-
-      -l, --long  Use long list format. Format is ID, NOTE_COUNT (for notebook),
-                  DATE, TODO_CHECKED (for to-dos), TITLE
-
-  todo <todo-command> <note-pattern>
-
-      <todo-command> can either be "toggle" or "clear". Use "toggle" to toggle
-      the given to-do between completed and uncompleted state (If the target is
-      a regular note it will be converted to a to-do). Use "clear" to convert
-      the to-do back to a regular note.
-
-  undone <note>
-
-      Marks a to-do as non-completed.
-
-  use <notebook>
-
-      Switches to [notebook] - all further operations will happen within this
-      notebook.
-  
-  version
-
-      Displays version information
+	attach <note> <file>
+
+	    Attaches the given file to the note.
+
+	batch <file-path>
+
+	    Runs the commands contained in the text file. There should be one command
+	    per line.
+
+	cat <note>
+
+	    Displays the given note.
+
+	    -v, --verbose  Displays the complete information about note.
+
+	config [name] [value]
+
+	    Gets or sets a config value. If [value] is not provided, it will show the
+	    value of [name]. If neither [name] nor [value] is provided, it will list
+	    the current configuration.
+
+	    -v, --verbose         Also displays unset and hidden config variables.
+	    --export              Writes all settings to STDOUT as JSON including
+	                          secure variables.
+	    --import              Reads in JSON formatted settings from STDIN.
+	    --import-file <file>  Reads in settings from <file>. <file> must contain
+	                          valid JSON.
+
+	Possible keys/values:
+
+	    sync.target                    Synchronisation target.
+	                                   The target to synchronise to. Each sync
+	                                   target may have additional parameters which
+	                                   are named as `sync.NUM.NAME` (all
+	                                   documented below).
+	                                   Type: Enum.
+	                                   Possible values: 0 ((None)), 2 (File
+	                                   system), 3 (OneDrive), 5 (Nextcloud), 6
+	                                   (WebDAV), 7 (Dropbox), 8 (S3 (Beta)), 9
+	                                   (Joplin Server (Beta)), 10 (Joplin Cloud).
+	                                   Default: 0
+
+	    sync.2.path                    Directory to synchronise with (absolute
+	                                   path).
+	                                   Attention: If you change this location,
+	                                   make sure you copy all your content to it
+	                                   before syncing, otherwise all files will be
+	                                   removed! See the FAQ for more details:
+	                                   https://joplinapp.org/faq/
+	                                   Type: string.
+
+	    sync.5.path                    Nextcloud WebDAV URL.
+	                                   Attention: If you change this location,
+	                                   make sure you copy all your content to it
+	                                   before syncing, otherwise all files will be
+	                                   removed! See the FAQ for more details:
+	                                   https://joplinapp.org/faq/
+	                                   Type: string.
+
+	    sync.5.username                Nextcloud username.
+	                                   Type: string.
+
+	    sync.5.password                Nextcloud password.
+	                                   Type: string.
+
+	    sync.6.path                    WebDAV URL.
+	                                   Attention: If you change this location,
+	                                   make sure you copy all your content to it
+	                                   before syncing, otherwise all files will be
+	                                   removed! See the FAQ for more details:
+	                                   https://joplinapp.org/faq/
+	                                   Type: string.
+
+	    sync.6.username                WebDAV username.
+	                                   Type: string.
+
+	    sync.6.password                WebDAV password.
+	                                   Type: string.
+
+	    sync.8.path                    AWS S3 bucket.
+	                                   Attention: If you change this location,
+	                                   make sure you copy all your content to it
+	                                   before syncing, otherwise all files will be
+	                                   removed! See the FAQ for more details:
+	                                   https://joplinapp.org/faq/
+	                                   Type: string.
+
+	    sync.8.url                     AWS S3 URL.
+	                                   Type: string.
+	                                   Default: "https://s3.amazonaws.com/"
+
+	    sync.8.region                  AWS region.
+	                                   Type: string.
+
+	    sync.8.username                AWS access key.
+	                                   Type: string.
+
+	    sync.8.password                AWS secret key.
+	                                   Type: string.
+
+	    sync.8.forcePathStyle          Force path style.
+	                                   Type: bool.
+	                                   Default: false
+
+	    sync.9.path                    Joplin Server URL.
+	                                   Attention: If you change this location,
+	                                   make sure you copy all your content to it
+	                                   before syncing, otherwise all files will be
+	                                   removed! See the FAQ for more details:
+	                                   https://joplinapp.org/faq/
+	                                   Type: string.
+
+	    sync.9.username                Joplin Server email.
+	                                   Type: string.
+
+	    sync.9.password                Joplin Server password.
+	                                   Type: string.
+
+	    sync.10.username               Joplin Cloud email.
+	                                   Type: string.
+
+	    sync.10.password               Joplin Cloud password.
+	                                   Type: string.
+
+	    sync.maxConcurrentConnections  Max concurrent connections.
+	                                   Type: int.
+	                                   Default: 5
+
+	    locale                         Language.
+	                                   Type: Enum.
+	                                   Possible values: ar (Arabic (93%)), eu
+	                                   (Basque (27%)), bs_BA (Bosnian (Bosna i
+	                                   Hercegovina) (67%)), bg_BG (Bulgarian
+	                                   (България) (53%)), ca (Catalan (93%)),
+	                                   hr_HR (Croatian (Hrvatska) (97%)), cs_CZ
+	                                   (Czech (Česká republika) (89%)), da_DK
+	                                   (Dansk (Danmark) (97%)), de_DE (Deutsch
+	                                   (Deutschland) (97%)), et_EE (Eesti Keel
+	                                   (Eesti) (51%)), en_GB (English (United
+	                                   Kingdom) (100%)), en_US (English (United
+	                                   States of America) (100%)), es_ES (Español
+	                                   (España) (93%)), eo (Esperanto (30%)),
+	                                   fi_FI (Finnish (Suomi) (93%)), fr_FR
+	                                   (Français (France) (100%)), gl_ES (Galician
+	                                   (España) (34%)), id_ID (Indonesian
+	                                   (Indonesia) (92%)), it_IT (Italiano
+	                                   (Italia) (90%)), hu_HU (Magyar
+	                                   (Magyarország) (78%)), nl_BE (Nederlands
+	                                   (België, Belgique, Belgien) (81%)), nl_NL
+	                                   (Nederlands (Nederland) (85%)), nb_NO
+	                                   (Norwegian (Norge, Noreg) (90%)), fa
+	                                   (Persian (64%)), pl_PL (Polski (Polska)
+	                                   (84%)), pt_BR (Português (Brasil) (94%)),
+	                                   pt_PT (Português (Portugal) (84%)), ro
+	                                   (Română (59%)), sl_SI (Slovenian
+	                                   (Slovenija) (93%)), sv (Svenska (97%)),
+	                                   th_TH (Thai (ประเทศไทย) (43%)), vi (Tiếng
+	                                   Việt (90%)), tr_TR (Türkçe (Türkiye)
+	                                   (93%)), uk_UA (Ukrainian (Україна) (83%)),
+	                                   el_GR (Ελληνικά (Ελλάδα) (87%)), ru_RU
+	                                   (Русский (Россия) (93%)), sr_RS (српски
+	                                   језик (Србија) (76%)), zh_CN (中文 (简体)
+	                                   (97%)), zh_TW (中文 (繁體) (90%)), ja_JP (日本語
+	                                   (日本) (98%)), ko (한국어 (89%)).
+	                                   Default: "en_GB"
+
+	    dateFormat                     Date format.
+	                                   Type: Enum.
+	                                   Possible values: DD/MM/YYYY (30/01/2017),
+	                                   DD/MM/YY (30/01/17), MM/DD/YYYY
+	                                   (01/30/2017), MM/DD/YY (01/30/17),
+	                                   YYYY-MM-DD (2017-01-30), DD.MM.YYYY
+	                                   (30.01.2017), YYYY.MM.DD (2017.01.30),
+	                                   YYMMDD (170130), YYYY/MM/DD (2017/01/30).
+	                                   Default: "DD/MM/YYYY"
+
+	    timeFormat                     Time format.
+	                                   Type: Enum.
+	                                   Possible values: HH:mm (20:30), h:mm A
+	                                   (8:30 PM).
+	                                   Default: "HH:mm"
+
+	    uncompletedTodosOnTop          Uncompleted to-dos on top.
+	                                   Type: bool.
+	                                   Default: true
+
+	    showCompletedTodos             Show completed to-dos.
+	                                   Type: bool.
+	                                   Default: true
+
+	    notes.sortOrder.field          Sort notes by.
+	                                   Type: Enum.
+	                                   Possible values: user_updated_time (Updated
+	                                   date), user_created_time (Created date),
+	                                   title (Title), order (Custom order).
+	                                   Default: "user_updated_time"
+
+	    notes.sortOrder.reverse        Reverse sort order.
+	                                   Type: bool.
+	                                   Default: true
+
+	    folders.sortOrder.field        Sort notebooks by.
+	                                   Type: Enum.
+	                                   Possible values: title (Title),
+	                                   last_note_user_updated_time (Updated date).
+	                                   Default: "title"
+
+	    folders.sortOrder.reverse      Reverse sort order.
+	                                   Type: bool.
+	                                   Default: false
+
+	    trackLocation                  Save geo-location with notes.
+	                                   Type: bool.
+	                                   Default: true
+
+	    sync.interval                  Synchronisation interval.
+	                                   Type: Enum.
+	                                   Possible values: 0 (Disabled), 300 (5
+	                                   minutes), 600 (10 minutes), 1800 (30
+	                                   minutes), 3600 (1 hour), 43200 (12 hours),
+	                                   86400 (24 hours).
+	                                   Default: 300
+
+	    editor                         Text editor command.
+	                                   The editor command (may include arguments)
+	                                   that will be used to open a note. If none
+	                                   is provided it will try to auto-detect the
+	                                   default editor.
+	                                   Type: string.
+
+	    net.customCertificates         Custom TLS certificates.
+	                                   Comma-separated list of paths to
+	                                   directories to load the certificates from,
+	                                   or path to individual cert files. For
+	                                   example: /my/cert_dir, /other/custom.pem.
+	                                   Note that if you make changes to the TLS
+	                                   settings, you must save your changes before
+	                                   clicking on "Check synchronisation
+	                                   configuration".
+	                                   Type: string.
+
+	    net.ignoreTlsErrors            Ignore TLS certificate errors.
+	                                   Type: bool.
+	                                   Default: false
+
+	    sync.wipeOutFailSafe           Fail-safe.
+	                                   Fail-safe: Do not wipe out local data when
+	                                   sync target is empty (often the result of a
+	                                   misconfiguration or bug)
+	                                   Type: bool.
+	                                   Default: true
+
+
+	    revisionService.enabled        Enable note history.
+	                                   Type: bool.
+	                                   Default: true
+
+	    revisionService.ttlDays        Keep note history for.
+	                                   Type: int.
+	                                   Default: 90
+
+	    layout.folderList.factor       Notebook list growth factor.
+	                                   The factor property sets how the item will
+	                                   grow or shrink to fit the available space
+	                                   in its container with respect to the other
+	                                   items. Thus an item with a factor of 2 will
+	                                   take twice as much space as an item with a
+	                                   factor of 1.Restart app to see changes.
+	                                   Type: int.
+	                                   Default: 1
+
+	    layout.noteList.factor         Note list growth factor.
+	                                   The factor property sets how the item will
+	                                   grow or shrink to fit the available space
+	                                   in its container with respect to the other
+	                                   items. Thus an item with a factor of 2 will
+	                                   take twice as much space as an item with a
+	                                   factor of 1.Restart app to see changes.
+	                                   Type: int.
+	                                   Default: 1
+
+	    layout.note.factor             Note area growth factor.
+	                                   The factor property sets how the item will
+	                                   grow or shrink to fit the available space
+	                                   in its container with respect to the other
+	                                   items. Thus an item with a factor of 2 will
+	                                   take twice as much space as an item with a
+	                                   factor of 1.Restart app to see changes.
+	                                   Type: int.
+	                                   Default: 2
+
+	cp <note> [notebook]
+
+	    Duplicates the notes matching <note> to [notebook]. If no notebook is
+	    specified the note is duplicated in the current notebook.
+
+	done <note>
+
+	    Marks a to-do as done.
+
+	e2ee <command> [path]
+
+	    Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`,
+	    `status`, `decrypt-file`, and `target-status`.
+
+	    -p, --password <password>  Use this password as master password (For
+	                               security reasons, it is not recommended to use
+	                               this option).
+	    -v, --verbose              More verbose output for the `target-status`
+	                               command
+	    -o, --output <directory>   Output directory
+	    --retry-failed-items       Applies to `decrypt` command - retries
+	                               decrypting items that previously could not be
+	                               decrypted.
+
+	edit <note>
+
+	    Edit note.
+
+	export <path>
+
+	    Exports Joplin data to the given path. By default, it will export the
+	    complete database including notebooks, notes, tags and resources.
+
+	    --format <format>      Destination format: jex (Joplin Export File), raw
+	                           (Joplin Export Directory), md (Markdown),
+	                           md_frontmatter (Markdown + Front Matter)
+	    --note <note>          Exports only the given note.
+	    --notebook <notebook>  Exports only the given notebook.
+
+	geoloc <note>
+
+	    Displays a geolocation URL for the note.
+
+	help [command]
+
+	    Displays usage information.
+
+	import <path> [notebook]
+
+	    Imports data into Joplin.
+
+	    --format <format>                Source format: auto, jex, md,
+	                                     md_frontmatter, raw, enex, enex
+	    -f, --force                      Do not ask for confirmation.
+	    --output-format <output-format>  Output format: md, html
+
+	ls [note-pattern]
+
+	    Displays the notes in the current notebook. Use `ls /` to display the list
+	    of notebooks.
+
+	    -n, --limit <num>      Displays only the first top <num> notes.
+	    -s, --sort <field>     Sorts the item by <field> (eg. title, updated_time,
+	                           created_time).
+	    -r, --reverse          Reverses the sorting order.
+	    -t, --type <type>      Displays only the items of the specific type(s).
+	                           Can be `n` for notes, `t` for to-dos, or `nt` for
+	                           notes and to-dos (eg. `-tt` would display only the
+	                           to-dos, while `-tnt` would display notes and
+	                           to-dos.
+	    -f, --format <format>  Either "text" or "json"
+	    -l, --long             Use long list format. Format is ID, NOTE_COUNT (for
+	                           notebook), DATE, TODO_CHECKED (for to-dos), TITLE
+
+	mkbook <new-notebook>
+
+	    Creates a new notebook.
+
+	mknote <new-note>
+
+	    Creates a new note.
+
+	mktodo <new-todo>
+
+	    Creates a new to-do.
+
+	mv <note> [notebook]
+
+	    Moves the notes matching <note> to [notebook].
+
+	ren <item> <name>
+
+	    Renames the given <item> (note or notebook) to <name>.
+
+	rmbook <notebook>
+
+	    Deletes the given notebook.
+
+	    -f, --force  Deletes the notebook without asking for confirmation.
+
+	rmnote <note-pattern>
+
+	    Deletes the notes matching <note-pattern>.
+
+	    -f, --force  Deletes the notes without asking for confirmation.
+
+	server <command>
+
+	    Start, stop or check the API server. To specify on which port it should
+	    run, set the api.port config variable. Commands are (start|stop|status).
+	    This is an experimental feature - use at your own risks! It is recommended
+	    that the server runs off its own separate profile so that no two CLI
+	    instances access that profile at the same time. Use --profile to specify
+	    the profile path.
+
+	set <note> <name> [value]
+
+	    Sets the property <name> of the given <note> to the given [value].
+	    Possible properties are:
+
+	    parent_id (text), title (text), body (text), created_time (int),
+	    updated_time (int), is_conflict (int), latitude (numeric), longitude
+	    (numeric), altitude (numeric), author (text), source_url (text), is_todo
+	    (int), todo_due (int), todo_completed (int), source (text),
+	    source_application (text), application_data (text), order (numeric),
+	    user_created_time (int), user_updated_time (int), encryption_cipher_text
+	    (text), encryption_applied (int), markup_language (int), is_shared (int),
+	    share_id (text), conflict_original_id (text), master_key_id (text)
+
+	status
+
+	    Displays summary about the notes and notebooks.
+
+	sync
+
+	    Synchronises with remote storage.
+
+	    --target <target>   Sync to provided target (defaults to sync.target
+	                        config value)
+	    --upgrade           Upgrade the sync target to the latest version.
+	    --use-lock <value>  Disable local locks that prevent multiple clients from
+	                        synchronizing at the same time (Default = 1)
+
+	tag <tag-command> [tag] [note]
+
+	    <tag-command> can be "add", "remove", "list", or "notetags" to assign or
+	    remove [tag] from [note], to list notes associated with [tag], or to list
+	    tags associated with [note]. The command `tag list` can be used to list
+	    all the tags (use -l for long option).
+
+	    -l, --long  Use long list format. Format is ID, NOTE_COUNT (for notebook),
+	                DATE, TODO_CHECKED (for to-dos), TITLE
+
+	todo <todo-command> <note-pattern>
+
+	    <todo-command> can either be "toggle" or "clear". Use "toggle" to toggle
+	    the given to-do between completed and uncompleted state (If the target is
+	    a regular note it will be converted to a to-do). Use "clear" to convert
+	    the to-do back to a regular note.
+
+	undone <note>
+
+	    Marks a to-do as non-completed.
+
+	use <notebook>
+
+	    Switches to [notebook] - all further operations will happen within this
+	    notebook.
+
+	version
+
+	    Displays version information
 
 # License
 

--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -277,370 +277,469 @@ toggle_metadata | Toggle note metadata
 
 The following commands are available in [command-line mode](#command-line-mode):
 
-	attach <note> <file>
-
-	    Attaches the given file to the note.
-
-	cat <note>
-
-	    Displays the given note.
-
-	    -v, --verbose  Displays the complete information about note.
-
-	config [name] [value]
-
-	    Gets or sets a config value. If [value] is not provided, it will show the
-	    value of [name]. If neither [name] nor [value] is provided, it will list
-	    the current configuration.
-
-	    -v, --verbose         Also displays unset and hidden config variables.
-	    --export              Writes all settings to STDOUT as JSON including
-	                          secure variables.
-	    --import              Reads in JSON formatted settings from STDIN.
-	    --import-file <file>  Reads in settings from <file>. <file> must contain
-	                          valid JSON.
-
-	Possible keys/values:
-
-	    sync.target                    Synchronisation target.
-	                                   The target to synchronise to. Each sync
-	                                   target may have additional parameters which
-	                                   are named as `sync.NUM.NAME` (all
-	                                   documented below).
-	                                   Type: Enum.
-	                                   Possible values: 2 (File system), 3
-	                                   (OneDrive), 4 (OneDrive Dev (For testing
-	                                   only)), 5 (Nextcloud), 6 (WebDAV), 7
-	                                   (Dropbox).
-	                                   Default: 7
-
-	    sync.2.path                    Directory to synchronise with (absolute
-	                                   path).
-	                                   Attention: If you change this location,
-	                                   make sure you copy all your content to it
-	                                   before syncing, otherwise all files will be
-	                                   removed! See the FAQ for more details:
-	                                   https://joplinapp.org/faq/
-	                                   Type: string.
-
-	    sync.5.path                    Nextcloud WebDAV URL.
-	                                   Attention: If you change this location,
-	                                   make sure you copy all your content to it
-	                                   before syncing, otherwise all files will be
-	                                   removed! See the FAQ for more details:
-	                                   https://joplinapp.org/faq/
-	                                   Type: string.
-
-	    sync.5.username                Nextcloud username.
-	                                   Type: string.
-
-	    sync.5.password                Nextcloud password.
-	                                   Type: string.
-
-	    sync.6.path                    WebDAV URL.
-	                                   Attention: If you change this location,
-	                                   make sure you copy all your content to it
-	                                   before syncing, otherwise all files will be
-	                                   removed! See the FAQ for more details:
-	                                   https://joplinapp.org/faq/
-	                                   Type: string.
-
-	    sync.6.username                WebDAV username.
-	                                   Type: string.
-
-	    sync.6.password                WebDAV password.
-	                                   Type: string.
-
-	    sync.maxConcurrentConnections  Max concurrent connections.
-	                                   Type: int.
-	                                   Default: 5
-
-	    locale                         Language.
-	                                   Please see localisation section on
-	                                   https://joplinapp.org/help/#localisation
-	                                   for info on translation completion progress
-	                                   Type: Enum.
-	                                   Possible values: ar (Arabic), eu (Basque),
-	                                   bs_BA (Bosnian), bg_BG (Bulgarian),
-	                                   ca (Catalan), hr_HR (Croatian),
-	                                   cs_CZ (Czech), da_DK (Dansk),
-	                                   de_DE (Deutsch), et_EE (Eesti Keel),
-	                                   en_GB (English (UK)), en_US (English (US)),
-	                                   es_ES (Español), eo (Esperanto),
-	                                   fi_FI (Finnish), fr_FR (Français),
-	                                   gl_ES (Galician), id_ID (Indonesian),
-	                                   it_IT (Italiano), nl_BE (Nederlands),
-	                                   nl_NL (Nederlands), nb_NO (Norwegian),
-	                                   fa (Persian), pl_PL (Polski),
-	                                   pt_PT (Português),
-	                                   pt_BR (Português (Brasil)), ro (Română),
-	                                   sl_SI (Slovenian), sv (Svenska),
-	                                   th_TH (Thai), vi (Tiếng Việt),
-	                                   tr_TR (Türkçe), el_GR (Ελληνικά),
-	                                   ru_RU (Русский), sr_RS (српски језик),
-	                                   zh_CN (中文 (简体)), zh_TW (中文 (繁體)),
-	                                   ja_JP (日本語), ko (한국말).
-	                                   Default: "en_GB"
-
-	    dateFormat                     Date format.
-	                                   Type: Enum.
-	                                   Possible values: DD/MM/YYYY (30/01/2017),
-	                                   DD/MM/YY (30/01/17), MM/DD/YYYY
-	                                   (01/30/2017), MM/DD/YY (01/30/17),
-	                                   YYYY-MM-DD (2017-01-30), DD.MM.YYYY
-	                                   (30.01.2017), YYYY.MM.DD (2017.01.30),
-	                                   YYMMDD (170130).
-	                                   Default: "DD/MM/YYYY"
-
-	    timeFormat                     Time format.
-	                                   Type: Enum.
-	                                   Possible values: HH:mm (20:30), h:mm A
-	                                   (8:30 PM).
-	                                   Default: "HH:mm"
-
-	    uncompletedTodosOnTop          Uncompleted to-dos on top.
-	                                   Type: bool.
-	                                   Default: true
-
-	    showCompletedTodos             Show completed to-dos.
-	                                   Type: bool.
-	                                   Default: true
-
-	    notes.sortOrder.field          Sort notes by.
-	                                   Type: Enum.
-	                                   Possible values: user_updated_time (Updated
-	                                   date), user_created_time (Created date),
-	                                   title (Title).
-	                                   Default: "user_updated_time"
-
-	    notes.sortOrder.reverse        Reverse sort order.
-	                                   Type: bool.
-	                                   Default: true
-
-	    folders.sortOrder.field        Sort notebooks by.
-	                                   Type: Enum.
-	                                   Possible values: title (Title),
-	                                   last_note_user_updated_time (Updated date).
-	                                   Default: "title"
-
-	    folders.sortOrder.reverse      Reverse sort order.
-	                                   Type: bool.
-	                                   Default: false
-
-	    trackLocation                  Save geo-location with notes.
-	                                   Type: bool.
-	                                   Default: true
-
-	    sync.interval                  Synchronisation interval.
-	                                   Type: Enum.
-	                                   Possible values: 0 (Disabled), 300 (5
-	                                   minutes), 600 (10 minutes), 1800 (30
-	                                   minutes), 3600 (1 hour), 43200 (12 hours),
-	                                   86400 (24 hours).
-	                                   Default: 300
-
-	    editor                         Text editor command.
-	                                   The editor command (may include arguments)
-	                                   that will be used to open a note. If none
-	                                   is provided it will try to auto-detect the
-	                                   default editor.
-	                                   Type: string.
-
-	    net.customCertificates         Custom TLS certificates.
-	                                   Comma-separated list of paths to
-	                                   directories to load the certificates from,
-	                                   or path to individual cert files. For
-	                                   example: /my/cert_dir, /other/custom.pem.
-	                                   Note that if you make changes to the TLS
-	                                   settings, you must save your changes before
-	                                   clicking on "Check synchronisation
-	                                   configuration".
-	                                   Type: string.
-
-	    net.ignoreTlsErrors            Ignore TLS certificate errors.
-	                                   Type: bool.
-	                                   Default: false
-
-	    sync.wipeOutFailSafe           Fail-safe: Do not wipe out local data when
-	                                   sync target is empty (often the result of a
-	                                   misconfiguration or bug).
-	                                   Type: bool.
-	                                   Default: true
-
-
-	    revisionService.enabled        Enable note history.
-	                                   Type: bool.
-	                                   Default: true
-
-	    revisionService.ttlDays        Keep note history for.
-	                                   Type: int.
-	                                   Default: 90
-
-	cp <note> [notebook]
-
-	    Duplicates the notes matching <note> to [notebook]. If no notebook is
-	    specified the note is duplicated in the current notebook.
-
-	done <note>
-
-	    Marks a to-do as done.
-
-	e2ee <command> [path]
-
-	    Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`,
-	    `status`, `decrypt-file` and `target-status`.
-
-	    -p, --password <password>  Use this password as master password (For
-	                               security reasons, it is not recommended to use
-	                               this option).
-	    -v, --verbose              More verbose output for the `target-status`
-	                               command
-	    -o, --output <directory>   Output directory
-
-	edit <note>
-
-	    Edit note.
-
-	export <path>
-
-	    Exports Joplin data to the given path. By default, it will export the
-	    complete database including notebooks, notes, tags and resources.
-
-	    --format <format>      Destination format: jex (Joplin Export File), raw
-	                           (Joplin Export Directory), md (Markdown),
-	                           md_frontmatter (Markdown + Front Matter)
-	    --note <note>          Exports only the given note.
-	    --notebook <notebook>  Exports only the given notebook.
-
-	geoloc <note>
-
-	    Displays a geolocation URL for the note.
-
-	help [command]
-
-	    Displays usage information.
-
-	import <path> [notebook]
-
-	    Imports data into Joplin.
-
-	    --format <format>  Source format: auto, jex, md, md_frontmatter, raw,
-	                       enex, enex
-	    -f, --force        Do not ask for confirmation.
-	    --output-format <output-format>  Output format: md, html
-
-	ls [note-pattern]
-
-	    Displays the notes in the current notebook. Use `ls /` to display the list
-	    of notebooks.
-
-	    -n, --limit <num>      Displays only the first top <num> notes.
-	    -s, --sort <field>     Sorts the item by <field> (eg. title, updated_time,
-	                           created_time).
-	    -r, --reverse          Reverses the sorting order.
-	    -t, --type <type>      Displays only the items of the specific type(s).
-	                           Can be `n` for notes, `t` for to-dos, or `nt` for
-	                           notes and to-dos (eg. `-tt` would display only the
-	                           to-dos, while `-ttd` would display notes and
-	                           to-dos.
-	    -f, --format <format>  Either "text" or "json"
-	    -l, --long             Use long list format. Format is ID, NOTE_COUNT (for
-	                           notebook), DATE, TODO_CHECKED (for to-dos), TITLE
-
-	mkbook <new-notebook>
-
-	    Creates a new notebook.
-
-	mknote <new-note>
-
-	    Creates a new note.
-
-	mktodo <new-todo>
-
-	    Creates a new to-do.
-
-	mv <note> [notebook]
-
-	    Moves the notes matching <note> to [notebook].
-
-	ren <item> <name>
-
-	    Renames the given <item> (note or notebook) to <name>.
-
-	rmbook <notebook>
-
-	    Deletes the given notebook.
-
-	    -f, --force  Deletes the notebook without asking for confirmation.
-
-	rmnote <note-pattern>
-
-	    Deletes the notes matching <note-pattern>.
-
-	    -f, --force  Deletes the notes without asking for confirmation.
-
-	server <command>
-
-	    Start, stop or check the API server. To specify on which port it should
-	    run, set the api.port config variable. Commands are (start|stop|status).
-	    This is an experimental feature - use at your own risks! It is recommended
-	    that the server runs off its own separate profile so that no two CLI
-	    instances access that profile at the same time. Use --profile to specify
-	    the profile path.
-
-	set <note> <name> [value]
-
-	    Sets the property <name> of the given <note> to the given [value].
-	    Possible properties are:
-
-	    parent_id (text), title (text), body (text), created_time (int),
-	    updated_time (int), is_conflict (int), latitude (numeric), longitude
-	    (numeric), altitude (numeric), author (text), source_url (text), is_todo
-	    (int), todo_due (int), todo_completed (int), source (text),
-	    source_application (text), application_data (text), order (int),
-	    user_created_time (int), user_updated_time (int), encryption_cipher_text
-	    (text), encryption_applied (int), markup_language (int), is_shared (int)
-
-	status
-
-	    Displays summary about the notes and notebooks.
-
-	sync
-
-	    Synchronises with remote storage.
-
-	    --target <target>  Sync to provided target (defaults to sync.target config
-	                       value)
-
-	tag <tag-command> [tag] [note]
-
-	    <tag-command> can be "add", "remove", "list", or "notetags" to assign or
-	    remove [tag] from [note], to list notes associated with [tag], or to list
-	    tags associated with [note]. The command `tag list` can be used to list
-	    all the tags (use -l for long option).
-
-	    -l, --long  Use long list format. Format is ID, NOTE_COUNT (for notebook),
-	                DATE, TODO_CHECKED (for to-dos), TITLE
-
-	todo <todo-command> <note-pattern>
-
-	    <todo-command> can either be "toggle" or "clear". Use "toggle" to toggle
-	    the given to-do between completed and uncompleted state (If the target is
-	    a regular note it will be converted to a to-do). Use "clear" to convert
-	    the to-do back to a regular note.
-
-	undone <note>
-
-	    Marks a to-do as non-completed.
-
-	use <notebook>
-
-	    Switches to [notebook] - all further operations will happen within this
-	    notebook.
-
-	version
-
-	    Displays version information
+  attach <note> <file>
+
+      Attaches the given file to the note.
+
+  batch <file-path>
+
+      Runs the commands contained in the text file. There should be one command
+      per line.
+
+  cat <note>
+
+      Displays the given note.
+
+      -v, --verbose  Displays the complete information about note.
+
+  config [name] [value]
+
+      Gets or sets a config value. If [value] is not provided, it will show the
+      value of [name]. If neither [name] nor [value] is provided, it will list
+      the current configuration.
+
+      -v, --verbose         Also displays unset and hidden config variables.
+      --export              Writes all settings to STDOUT as JSON including
+                            secure variables.
+      --import              Reads in JSON formatted settings from STDIN.
+      --import-file <file>  Reads in settings from <file>. <file> must contain
+                            valid JSON.
+
+  Possible keys/values:
+
+      sync.target                    Synchronisation target.
+                                     The target to synchronise to. Each sync
+                                     target may have additional parameters which
+                                     are named as `sync.NUM.NAME` (all
+                                     documented below).
+                                     Type: Enum.
+                                     Possible values: 0 ((None)), 2 (File
+                                     system), 3 (OneDrive), 5 (Nextcloud), 6
+                                     (WebDAV), 7 (Dropbox), 8 (S3 (Beta)), 9
+                                     (Joplin Server (Beta)), 10 (Joplin Cloud).
+                                     Default: 0
+
+      sync.2.path                    Directory to synchronise with (absolute
+                                     path).
+                                     Attention: If you change this location,
+                                     make sure you copy all your content to it
+                                     before syncing, otherwise all files will be
+                                     removed! See the FAQ for more details:
+                                     https://joplinapp.org/faq/
+                                     Type: string.
+
+      sync.5.path                    Nextcloud WebDAV URL.
+                                     Attention: If you change this location,
+                                     make sure you copy all your content to it
+                                     before syncing, otherwise all files will be
+                                     removed! See the FAQ for more details:
+                                     https://joplinapp.org/faq/
+                                     Type: string.
+
+      sync.5.username                Nextcloud username.
+                                     Type: string.
+
+      sync.5.password                Nextcloud password.
+                                     Type: string.
+
+      sync.6.path                    WebDAV URL.
+                                     Attention: If you change this location,
+                                     make sure you copy all your content to it
+                                     before syncing, otherwise all files will be
+                                     removed! See the FAQ for more details:
+                                     https://joplinapp.org/faq/
+                                     Type: string.
+
+      sync.6.username                WebDAV username.
+                                     Type: string.
+
+      sync.6.password                WebDAV password.
+                                     Type: string.
+
+      sync.8.path                    AWS S3 bucket.
+                                     Attention: If you change this location,
+                                     make sure you copy all your content to it
+                                     before syncing, otherwise all files will be
+                                     removed! See the FAQ for more details:
+                                     https://joplinapp.org/faq/
+                                     Type: string.
+
+      sync.8.url                     AWS S3 URL.
+                                     Type: string.
+                                     Default: "https://s3.amazonaws.com/"
+
+      sync.8.region                  AWS region.
+                                     Type: string.
+
+      sync.8.username                AWS access key.
+                                     Type: string.
+
+      sync.8.password                AWS secret key.
+                                     Type: string.
+
+      sync.8.forcePathStyle          Force path style.
+                                     Type: bool.
+                                     Default: false
+
+      sync.9.path                    Joplin Server URL.
+                                     Attention: If you change this location,
+                                     make sure you copy all your content to it
+                                     before syncing, otherwise all files will be
+                                     removed! See the FAQ for more details:
+                                     https://joplinapp.org/faq/
+                                     Type: string.
+
+      sync.9.username                Joplin Server email.
+                                     Type: string.
+
+      sync.9.password                Joplin Server password.
+                                     Type: string.
+
+      sync.10.username               Joplin Cloud email.
+                                     Type: string.
+
+      sync.10.password               Joplin Cloud password.
+                                     Type: string.
+
+      sync.maxConcurrentConnections  Max concurrent connections.
+                                     Type: int.
+                                     Default: 5
+
+      locale                         Language.
+                                     Type: Enum.
+                                     Possible values: ar (Arabic (93%)), eu
+                                     (Basque (27%)), bs_BA (Bosnian (Bosna i
+                                     Hercegovina) (67%)), bg_BG (Bulgarian
+                                     (България) (53%)), ca (Catalan (93%)),
+                                     hr_HR (Croatian (Hrvatska) (97%)), cs_CZ
+                                     (Czech (Česká republika) (89%)), da_DK
+                                     (Dansk (Danmark) (97%)), de_DE (Deutsch
+                                     (Deutschland) (97%)), et_EE (Eesti Keel
+                                     (Eesti) (51%)), en_GB (English (United
+                                     Kingdom) (100%)), en_US (English (United
+                                     States of America) (100%)), es_ES (Español
+                                     (España) (93%)), eo (Esperanto (30%)),
+                                     fi_FI (Finnish (Suomi) (93%)), fr_FR
+                                     (Français (France) (100%)), gl_ES (Galician
+                                     (España) (34%)), id_ID (Indonesian
+                                     (Indonesia) (92%)), it_IT (Italiano
+                                     (Italia) (90%)), hu_HU (Magyar
+                                     (Magyarország) (78%)), nl_BE (Nederlands
+                                     (België, Belgique, Belgien) (81%)), nl_NL
+                                     (Nederlands (Nederland) (85%)), nb_NO
+                                     (Norwegian (Norge, Noreg) (90%)), fa
+                                     (Persian (64%)), pl_PL (Polski (Polska)
+                                     (84%)), pt_BR (Português (Brasil) (94%)),
+                                     pt_PT (Português (Portugal) (84%)), ro
+                                     (Română (59%)), sl_SI (Slovenian
+                                     (Slovenija) (93%)), sv (Svenska (97%)),
+                                     th_TH (Thai (ประเทศไทย) (43%)), vi (Tiếng
+                                     Việt (90%)), tr_TR (Türkçe (Türkiye)
+                                     (93%)), uk_UA (Ukrainian (Україна) (83%)),
+                                     el_GR (Ελληνικά (Ελλάδα) (87%)), ru_RU
+                                     (Русский (Россия) (93%)), sr_RS (српски
+                                     језик (Србија) (76%)), zh_CN (中文 (简体)
+                                     (97%)), zh_TW (中文 (繁體) (90%)), ja_JP (日本語
+                                     (日本) (98%)), ko (한국어 (89%)).
+                                     Default: "en_GB"
+
+      dateFormat                     Date format.
+                                     Type: Enum.
+                                     Possible values: DD/MM/YYYY (30/01/2017),
+                                     DD/MM/YY (30/01/17), MM/DD/YYYY
+                                     (01/30/2017), MM/DD/YY (01/30/17),
+                                     YYYY-MM-DD (2017-01-30), DD.MM.YYYY
+                                     (30.01.2017), YYYY.MM.DD (2017.01.30),
+                                     YYMMDD (170130), YYYY/MM/DD (2017/01/30).
+                                     Default: "DD/MM/YYYY"
+
+      timeFormat                     Time format.
+                                     Type: Enum.
+                                     Possible values: HH:mm (20:30), h:mm A
+                                     (8:30 PM).
+                                     Default: "HH:mm"
+
+      uncompletedTodosOnTop          Uncompleted to-dos on top.
+                                     Type: bool.
+                                     Default: true
+
+      showCompletedTodos             Show completed to-dos.
+                                     Type: bool.
+                                     Default: true
+
+      notes.sortOrder.field          Sort notes by.
+                                     Type: Enum.
+                                     Possible values: user_updated_time (Updated
+                                     date), user_created_time (Created date),
+                                     title (Title), order (Custom order).
+                                     Default: "user_updated_time"
+
+      notes.sortOrder.reverse        Reverse sort order.
+                                     Type: bool.
+                                     Default: true
+
+      folders.sortOrder.field        Sort notebooks by.
+                                     Type: Enum.
+                                     Possible values: title (Title),
+                                     last_note_user_updated_time (Updated date).
+                                     Default: "title"
+
+      folders.sortOrder.reverse      Reverse sort order.
+                                     Type: bool.
+                                     Default: false
+
+      trackLocation                  Save geo-location with notes.
+                                     Type: bool.
+                                     Default: true
+
+      sync.interval                  Synchronisation interval.
+                                     Type: Enum.
+                                     Possible values: 0 (Disabled), 300 (5
+                                     minutes), 600 (10 minutes), 1800 (30
+                                     minutes), 3600 (1 hour), 43200 (12 hours),
+                                     86400 (24 hours).
+                                     Default: 300
+
+      editor                         Text editor command.
+                                     The editor command (may include arguments)
+                                     that will be used to open a note. If none
+                                     is provided it will try to auto-detect the
+                                     default editor.
+                                     Type: string.
+
+      net.customCertificates         Custom TLS certificates.
+                                     Comma-separated list of paths to
+                                     directories to load the certificates from,
+                                     or path to individual cert files. For
+                                     example: /my/cert_dir, /other/custom.pem.
+                                     Note that if you make changes to the TLS
+                                     settings, you must save your changes before
+                                     clicking on "Check synchronisation
+                                     configuration".
+                                     Type: string.
+
+      net.ignoreTlsErrors            Ignore TLS certificate errors.
+                                     Type: bool.
+                                     Default: false
+
+      sync.wipeOutFailSafe           Fail-safe.
+                                     Fail-safe: Do not wipe out local data when
+                                     sync target is empty (often the result of a
+                                     misconfiguration or bug)
+                                     Type: bool.
+                                     Default: true
+
+
+      revisionService.enabled        Enable note history.
+                                     Type: bool.
+                                     Default: true
+
+      revisionService.ttlDays        Keep note history for.
+                                     Type: int.
+                                     Default: 90
+
+      layout.folderList.factor       Notebook list growth factor.
+                                     The factor property sets how the item will
+                                     grow or shrink to fit the available space
+                                     in its container with respect to the other
+                                     items. Thus an item with a factor of 2 will
+                                     take twice as much space as an item with a
+                                     factor of 1.Restart app to see changes.
+                                     Type: int.
+                                     Default: 1
+
+      layout.noteList.factor         Note list growth factor.
+                                     The factor property sets how the item will
+                                     grow or shrink to fit the available space
+                                     in its container with respect to the other
+                                     items. Thus an item with a factor of 2 will
+                                     take twice as much space as an item with a
+                                     factor of 1.Restart app to see changes.
+                                     Type: int.
+                                     Default: 1
+
+      layout.note.factor             Note area growth factor.
+                                     The factor property sets how the item will
+                                     grow or shrink to fit the available space
+                                     in its container with respect to the other
+                                     items. Thus an item with a factor of 2 will
+                                     take twice as much space as an item with a
+                                     factor of 1.Restart app to see changes.
+                                     Type: int.
+                                     Default: 2
+
+  cp <note> [notebook]
+
+      Duplicates the notes matching <note> to [notebook]. If no notebook is
+      specified the note is duplicated in the current notebook.
+
+  done <note>
+
+      Marks a to-do as done.
+
+  e2ee <command> [path]
+
+      Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`,
+      `status`, `decrypt-file`, and `target-status`.
+
+      -p, --password <password>  Use this password as master password (For
+                                 security reasons, it is not recommended to use
+                                 this option).
+      -v, --verbose              More verbose output for the `target-status`
+                                 command
+      -o, --output <directory>   Output directory
+      --retry-failed-items       Applies to `decrypt` command - retries
+                                 decrypting items that previously could not be
+                                 decrypted.
+
+  edit <note>
+
+      Edit note.
+
+  export <path>
+
+      Exports Joplin data to the given path. By default, it will export the
+      complete database including notebooks, notes, tags and resources.
+
+      --format <format>      Destination format: jex (Joplin Export File), raw
+                             (Joplin Export Directory), md (Markdown),
+                             md_frontmatter (Markdown + Front Matter)
+      --note <note>          Exports only the given note.
+      --notebook <notebook>  Exports only the given notebook.
+
+  geoloc <note>
+
+      Displays a geolocation URL for the note.
+
+  help [command]
+
+      Displays usage information.
+
+  import <path> [notebook]
+
+      Imports data into Joplin.
+
+      --format <format>                Source format: auto, jex, md,
+                                       md_frontmatter, raw, enex, enex
+      -f, --force                      Do not ask for confirmation.
+      --output-format <output-format>  Output format: md, html
+
+  ls [note-pattern]
+
+      Displays the notes in the current notebook. Use `ls /` to display the list
+      of notebooks.
+
+      -n, --limit <num>      Displays only the first top <num> notes.
+      -s, --sort <field>     Sorts the item by <field> (eg. title, updated_time,
+                             created_time).
+      -r, --reverse          Reverses the sorting order.
+      -t, --type <type>      Displays only the items of the specific type(s).
+                             Can be `n` for notes, `t` for to-dos, or `nt` for
+                             notes and to-dos (eg. `-tt` would display only the
+                             to-dos, while `-tnt` would display notes and
+                             to-dos.
+      -f, --format <format>  Either "text" or "json"
+      -l, --long             Use long list format. Format is ID, NOTE_COUNT (for
+                             notebook), DATE, TODO_CHECKED (for to-dos), TITLE
+
+  mkbook <new-notebook>
+
+      Creates a new notebook.
+
+  mknote <new-note>
+
+      Creates a new note.
+
+  mktodo <new-todo>
+
+      Creates a new to-do.
+
+  mv <note> [notebook]
+
+      Moves the notes matching <note> to [notebook].
+
+  ren <item> <name>
+
+      Renames the given <item> (note or notebook) to <name>.
+
+  rmbook <notebook>
+
+      Deletes the given notebook.
+
+      -f, --force  Deletes the notebook without asking for confirmation.
+
+  rmnote <note-pattern>
+
+      Deletes the notes matching <note-pattern>.
+
+      -f, --force  Deletes the notes without asking for confirmation.
+
+  server <command>
+
+      Start, stop or check the API server. To specify on which port it should
+      run, set the api.port config variable. Commands are (start|stop|status).
+      This is an experimental feature - use at your own risks! It is recommended
+      that the server runs off its own separate profile so that no two CLI
+      instances access that profile at the same time. Use --profile to specify
+      the profile path.
+
+  set <note> <name> [value]
+
+      Sets the property <name> of the given <note> to the given [value].
+      Possible properties are:
+
+      parent_id (text), title (text), body (text), created_time (int),
+      updated_time (int), is_conflict (int), latitude (numeric), longitude
+      (numeric), altitude (numeric), author (text), source_url (text), is_todo
+      (int), todo_due (int), todo_completed (int), source (text),
+      source_application (text), application_data (text), order (numeric),
+      user_created_time (int), user_updated_time (int), encryption_cipher_text
+      (text), encryption_applied (int), markup_language (int), is_shared (int),
+      share_id (text), conflict_original_id (text), master_key_id (text)
+
+  status
+
+      Displays summary about the notes and notebooks.
+
+  sync
+
+      Synchronises with remote storage.
+
+      --target <target>   Sync to provided target (defaults to sync.target
+                          config value)
+      --upgrade           Upgrade the sync target to the latest version.
+      --use-lock <value>  Disable local locks that prevent multiple clients from
+                          synchronizing at the same time (Default = 1)
+
+  tag <tag-command> [tag] [note]
+
+      <tag-command> can be "add", "remove", "list", or "notetags" to assign or
+      remove [tag] from [note], to list notes associated with [tag], or to list
+      tags associated with [note]. The command `tag list` can be used to list
+      all the tags (use -l for long option).
+
+      -l, --long  Use long list format. Format is ID, NOTE_COUNT (for notebook),
+                  DATE, TODO_CHECKED (for to-dos), TITLE
+
+  todo <todo-command> <note-pattern>
+
+      <todo-command> can either be "toggle" or "clear". Use "toggle" to toggle
+      the given to-do between completed and uncompleted state (If the target is
+      a regular note it will be converted to a to-do). Use "clear" to convert
+      the to-do back to a regular note.
+
+  undone <note>
+
+      Marks a to-do as non-completed.
+
+  use <notebook>
+
+      Switches to [notebook] - all further operations will happen within this
+      notebook.
+  
+  version
+
+      Displays version information
 
 # License
 

--- a/readme/terminal.md
+++ b/readme/terminal.md
@@ -507,8 +507,8 @@ The following commands are available in [command-line mode](#command-line-mode):
 	    complete database including notebooks, notes, tags and resources.
 
 	    --format <format>      Destination format: jex (Joplin Export File), raw
-	                           (Joplin Export Directory), md (Markdown), 
-				   md_frontmatter (Markdown + Front Matter)
+	                           (Joplin Export Directory), md (Markdown),
+	                           md_frontmatter (Markdown + Front Matter)
 	    --note <note>          Exports only the given note.
 	    --notebook <notebook>  Exports only the given notebook.
 
@@ -525,7 +525,7 @@ The following commands are available in [command-line mode](#command-line-mode):
 	    Imports data into Joplin.
 
 	    --format <format>  Source format: auto, jex, md, md_frontmatter, raw,
-	    		       enex, enex
+	                       enex, enex
 	    -f, --force        Do not ask for confirmation.
 	    --output-format <output-format>  Output format: md, html
 


### PR DESCRIPTION
Increased scope to just replace the entire command part of the docs with current `joplin help all` output to bring it up to date (see convo).

~~Website terminal app help file for `import` and `export` commands not up to date with available options within the app (e.g. html is completely excluded from the export command, json is missing entirely and new format (md_frontmatter) had not been added).
Import also included the output format (md/html) which was also not reflected but shows in `help import`.~~

~~This should bring the terminal doc up to date for those commands (although the 2x enex commands are still confusing without context or examples but these were present before and consistent with the cli help output).~~