### PR TITLE
Desktop: Performance: reduces the overhead of using MenuBar's API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -774,6 +774,9 @@ packages/app-desktop/gui/style/StyledMessage.js.map
 packages/app-desktop/gui/style/StyledTextInput.d.ts
 packages/app-desktop/gui/style/StyledTextInput.js
 packages/app-desktop/gui/style/StyledTextInput.js.map
+packages/app-desktop/gui/utils/MenuBarUtils.d.ts
+packages/app-desktop/gui/utils/MenuBarUtils.js
+packages/app-desktop/gui/utils/MenuBarUtils.js.map
 packages/app-desktop/gui/utils/NoteListUtils.d.ts
 packages/app-desktop/gui/utils/NoteListUtils.js
 packages/app-desktop/gui/utils/NoteListUtils.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -762,6 +762,9 @@ packages/app-desktop/gui/style/StyledMessage.js.map
 packages/app-desktop/gui/style/StyledTextInput.d.ts
 packages/app-desktop/gui/style/StyledTextInput.js
 packages/app-desktop/gui/style/StyledTextInput.js.map
+packages/app-desktop/gui/utils/MenuBarUtils.d.ts
+packages/app-desktop/gui/utils/MenuBarUtils.js
+packages/app-desktop/gui/utils/MenuBarUtils.js.map
 packages/app-desktop/gui/utils/NoteListUtils.d.ts
 packages/app-desktop/gui/utils/NoteListUtils.js
 packages/app-desktop/gui/utils/NoteListUtils.js.map

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -2,6 +2,7 @@ import Logger from '@joplin/lib/Logger';
 import { PluginMessage } from './services/plugins/PluginRunner';
 import shim from '@joplin/lib/shim';
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import { ipcMainOnSetMenuBarMenuItemProps } from './gui/utils/MenuBarUtils';
 
 const { BrowserWindow, Tray, screen } = require('electron');
 const url = require('url');
@@ -195,6 +196,8 @@ export default class ElectronAppWrapper {
 				this.quit();
 			}
 		});
+
+		ipcMainOnSetMenuBarMenuItemProps();
 
 		// This handler receives IPC messages from a plugin or from the main window,
 		// and forwards it to the main window or the plugin window.

--- a/packages/app-desktop/gui/utils/MenuBarUtils.ts
+++ b/packages/app-desktop/gui/utils/MenuBarUtils.ts
@@ -1,0 +1,54 @@
+import { ipcMain, Menu } from 'electron';
+import { ipcRenderer } from 'electron';
+
+export interface MenuItemPropsMap { [menuItemId: string]: { [key: string]: any } }
+
+const channel = 'setMenuBarMenuItemProps';
+
+// This function can be called only in Electron's main process.
+export function ipcMainOnSetMenuBarMenuItemProps() {
+
+	const setMenuBarMenuItemPropsListener = (_event: any, args: any) => {
+		// Message to change multiple properties of multiple MenuItems at once.
+		// It is very time-consumig to change a MenuItem's property from the renderer process,
+		// because of IPC overheads. This message enables to reduce such overheads by
+		// packing multiple operations into one message.
+		if (args && typeof args === 'object') {
+			const menuItemPropsMap: MenuItemPropsMap = args;
+			const menu = Menu.getApplicationMenu();
+			if (menu) {
+				for (const [id, props] of Object.entries(menuItemPropsMap)) {
+					const menuItem = menu.getMenuItemById(id);
+					if (!menuItem || !props || typeof props !== 'object') continue;
+					for (const [key, value] of Object.entries(props)) {
+						if (key !== 'visible' && key !== 'enabled' && key !== 'checked') continue;
+						menuItem[key] = !!value;
+					}
+				}
+			}
+		}
+	};
+
+	ipcMain.on(channel, setMenuBarMenuItemPropsListener);
+
+	// returns a function removing this listener
+	return () => ipcMain.off(channel, setMenuBarMenuItemPropsListener);
+}
+
+// The following function can be called in any process.
+
+export function prepareMenuItemChecked(propsMap: MenuItemPropsMap, menuItemId: string, value: boolean) {
+	(propsMap[menuItemId] ??= {}).checked = value;
+}
+
+export function prepareMenuItemEnabled(propsMap: MenuItemPropsMap, menuItemId: string, value: boolean) {
+	(propsMap[menuItemId] ??= {}).enabled = value;
+}
+
+export function prepareMenuItemVisible(propsMap: MenuItemPropsMap, menuItemId: string, value: boolean) {
+	(propsMap[menuItemId] ??= {}).visible = value;
+}
+
+export function setMenuBarMenuItemProps(propsMap: MenuItemPropsMap) {
+	ipcRenderer.send(channel, propsMap);
+}


### PR DESCRIPTION
This PR is one of PRs resolving issue #6386. It reduces the overhead of using the following MenuBar's APIs.

- Changing  `enabled`, `checked` and `visible` properties of `MenuItem`
- `Menu.setApplicationMenu()`

## Problem

The view (A) in the following Performance Analyzer image shows note switching between notebooks. In this view, re-rendering MenuBar takes a fair part of the total time. Especially, there are four MenuBar's `scheduleUpdate()` calles for re-rendering. They are heavy, and their total time is 245 msec.

![pa-compare-menubar](https://user-images.githubusercontent.com/16041683/165752503-123e33ae-f03c-4bcd-b98c-d64d3b579201.PNG)

## Cause

As illustrated below, Electron's MenuBar is in a different process from the React's rendering process. So, using MenuBar's API from React codes involves ipc and has a very large overhead. Besides, since MenuBar is out of React's efficient rendering system, it should be carefully updated.

![image](https://user-images.githubusercontent.com/16041683/165752621-82c2e69f-de87-4283-9c88-701ad27bc487.png)

Since `scheduleUpdate()` has many MenuBar's API calls, it involves many ipc calls and so it's heavy.

In addition, each re-rendering of MenuBar, its native counter part in Electron is always reconstructed. It also costs high.

## Treatment

This PR provides two treatments.

### Treatment 1

To make `scheduleUpdate()` lighter, this PR provides convenience functions that enable changing multiple MenuItems' properties at once. The functions are implemented in app-desktop/gui/util/MenuBarUtils.ts.

### Treatment 2

Currently, MenuBar always reconstructs itself when re-rendered. It's redundant. 
This PR makes MenuBar being reconstructed only when its content is changed.

## Result

The view (B) of the above Performance Analyzer images shows the execution time of MenuBar's `scheduleUpdate()` becomes so reduced that it cannot visually observed.
