### PR TITLE
Stale bot: Add link to forum for support/enhancements

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           # Use this to do a dry run from a pull request
           # debug-only: true
-          stale-issue-message: "Hey there, it looks like there has been no activity on this issue recently. Has the issue been fixed, or does it still require the community's attention? This issue may be closed if no further activity occurs. You may comment on the issue and I will leave it open. Thank you for your contributions."
+          stale-issue-message: "Hey there, it looks like there has been no activity on this issue recently. Has the issue been fixed, or does it still require the community's attention? If you require support or are requesting an enhancement or feature then please create a topic on the [Joplin forum](https://discourse.joplinapp.org/). This issue may be closed if no further activity occurs. You may comment on the issue and I will leave it open. Thank you for your contributions."
           days-before-stale: 30
           days-before-close: 7
           operations-per-run: 1000


### PR DESCRIPTION
Added text and a link to the forum. Stale bot message now advises that for support or enhancements/feature requests then a topic should be created.