### PR TITLE
Desktop: Fixes #6503: Fixed DropboxLoginScreen button doesn't respect dark mode

### DIFF
--- a/packages/app-desktop/gui/DropboxLoginScreen.tsx
+++ b/packages/app-desktop/gui/DropboxLoginScreen.tsx
@@ -37,6 +37,8 @@ class DropboxLoginScreenComponent extends React.Component<any, any> {
 
 		const inputStyle = Object.assign({}, theme.inputStyle, { width: 500 });
 
+		const buttonStyle = Object.assign({}, theme.buttonStyle, { marginRight: 10 });
+
 		return (
 			<div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
 				<div style={containerStyle}>
@@ -49,7 +51,7 @@ class DropboxLoginScreenComponent extends React.Component<any, any> {
 					<p>
 						<input type="text" value={this.state.authCode} onChange={this.shared_.authCodeInput_change} style={inputStyle} />
 					</p>
-					<button disabled={this.state.checkingAuthToken} onClick={this.shared_.submit_click}>
+					<button disabled={this.state.checkingAuthToken} style={buttonStyle} onClick={this.shared_.submit_click}>
 						{_('Submit')}
 					</button>
 				</div>


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Before:

![image](https://user-images.githubusercontent.com/10289737/168413276-18c3b197-470f-4c41-9f1c-aa482275e257.png)


After:
![dropbox](https://user-images.githubusercontent.com/10289737/168413230-78225ed7-4fc1-4bdd-90c2-6c3df602a410.png)


