### PR TITLE
Desktop: Fixes #5178: NoteListItem's height can be properly styled using CSS for v2.8+

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -454,6 +454,8 @@ const NoteListComponent = (props: Props) => {
 	}, []);
 
 	useEffect(() => {
+		// When a note list item is styled by userchrome.css, its height is reflected.
+		// Ref. https://github.com/laurent22/joplin/pull/6542
 		const noteItem = Object.values<any>(itemAnchorRefs_.current)[0]?.current;
 		const actualItemHeight = noteItem?.getHeight() ?? 0;
 		if (actualItemHeight >= 8) { // To avoid generating too many narrow items

--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -55,7 +55,7 @@ const NoteListComponent = (props: Props) => {
 		};
 	}, []);
 
-	const itemHeight = 34;
+	const [itemHeight, setItemHeight] = useState(34);
 
 	const focusItemIID_ = useRef<any>(null);
 	const noteListRef = useRef(null);
@@ -452,6 +452,14 @@ const NoteListComponent = (props: Props) => {
 			CommandService.instance().componentUnregisterCommands(commands);
 		};
 	}, []);
+
+	useEffect(() => {
+		const noteItem = Object.values<any>(itemAnchorRefs_.current)[0]?.current;
+		const actualItemHeight = noteItem?.getHeight() ?? 0;
+		if (actualItemHeight >= 8) { // To avoid generating too many narrow items
+			setItemHeight(actualItemHeight);
+		}
+	});
 
 	const renderEmptyList = () => {
 		if (props.notes.length) return null;

--- a/packages/app-desktop/gui/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem.tsx
@@ -73,6 +73,7 @@ function NoteListItem(props: NoteListItemProps, ref: any) {
 			focus: function() {
 				if (anchorRef.current) anchorRef.current.focus();
 			},
+			getHeight: () => anchorRef.current?.clientHeight,
 		};
 	});
 


### PR DESCRIPTION
The bug reported in issue #5178 is fixed.
This PR is the replacement of PR #5271 and is for the refactored NoteList function component in v2.8+.

The following spec is the same with the before, but its implementation is more effecient, because it's based on the efficiency of the React function component.

### Specification

When the height of NoteListItem is styled using `userchrome.css` as below, the number of displayed note items is correctly calcurated, and there is no unused dead area in the NoteList panel.

    .note-list .list-item-container,
    .note-list .list-item-container div {
        height: 25px !important;
    }

By applying this fix, you see what people expects as below shown in issue #5178.

![joplin_bug_20210711_expected](https://user-images.githubusercontent.com/16041683/125189593-c8a05800-e273-11eb-9552-4e4bd22109e0.png)