### PR TITLE
Desktop: Resolves #6172: Fix checkbox

### DIFF
--- a/Assets/TinyMCE/JoplinLists/src/main/ts/Plugin.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/Plugin.ts
@@ -9,11 +9,13 @@ import PluginManager from 'tinymce/core/api/PluginManager';
 import * as Api from './api/Api';
 import * as Commands from './api/Commands';
 import * as Keyboard from './core/Keyboard';
+import * as Mouse from './core/Mouse'
 import * as Buttons from './ui/Buttons';
 
 export default function () {
   PluginManager.add('joplinLists', function (editor) {
     Keyboard.setup(editor);
+    Mouse.setup(editor);
     Buttons.register(editor);
     Commands.register(editor);
 

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
@@ -9,7 +9,6 @@ import * as ToggleList from '../actions/ToggleList';
 import { indentListSelection, outdentListSelection, flattenListSelection } from '../actions/Indendation';
 import { addJoplinChecklistCommands } from '../listModel/JoplinListUtil';
 
-
 const queryListCommandState = function (editor, listName) {
   return function () {
     const parentList = editor.dom.getParent(editor.selection.getStart(), 'UL,OL,DL');
@@ -49,8 +48,6 @@ const register = function (editor) {
   editor.addQueryStateHandler('InsertDefinitionList', queryListCommandState(editor, 'DL'));
 
   addJoplinChecklistCommands(editor, ToggleList);
-
-
 };
 
 export {

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
@@ -7,7 +7,7 @@
 
 import * as ToggleList from '../actions/ToggleList';
 import { indentListSelection, outdentListSelection, flattenListSelection } from '../actions/Indendation';
-import { addJoplinChecklistCommands, isJoplinChecklistItem } from '../listModel/JoplinListUtil';
+import { addJoplinChecklistCommands } from '../listModel/JoplinListUtil';
 
 
 const queryListCommandState = function (editor, listName) {
@@ -50,25 +50,7 @@ const register = function (editor) {
 
   addJoplinChecklistCommands(editor, ToggleList);
 
-  const editorClickHandler = (event) => {
-    if (!isJoplinChecklistItem(event.target)) return;
 
-    // We only process the click if it's within the checkbox itself (and not the label).
-    // That checkbox, based on
-    // the current styling is in the negative margin, so offsetX is negative when clicking
-    // on the checkbox itself, and positive when clicking on the label. This is strongly
-    // dependent on how the checkbox is styled, so if the style is changed, this might need
-    // to be updated too.
-    // For the styling, see:
-    // packages/renderer/MdToHtml/rules/checkbox.ts
-    //
-    // The previous solution was to use "pointer-event: none", which mostly work, however
-    // it means that links are no longer clickable when they are within the checkbox label.
-    if (event.offsetX >= 0) return;
-
-    editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
-  }
-  editor.on('click', editorClickHandler);
 };
 
 export {

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/api/Commands.ts
@@ -7,7 +7,8 @@
 
 import * as ToggleList from '../actions/ToggleList';
 import { indentListSelection, outdentListSelection, flattenListSelection } from '../actions/Indendation';
-import { addJoplinChecklistCommands } from '../listModel/JoplinListUtil';
+import { addJoplinChecklistCommands, isJoplinChecklistItem } from '../listModel/JoplinListUtil';
+
 
 const queryListCommandState = function (editor, listName) {
   return function () {
@@ -48,6 +49,26 @@ const register = function (editor) {
   editor.addQueryStateHandler('InsertDefinitionList', queryListCommandState(editor, 'DL'));
 
   addJoplinChecklistCommands(editor, ToggleList);
+
+  const editorClickHandler = (event) => {
+    if (!isJoplinChecklistItem(event.target)) return;
+
+    // We only process the click if it's within the checkbox itself (and not the label).
+    // That checkbox, based on
+    // the current styling is in the negative margin, so offsetX is negative when clicking
+    // on the checkbox itself, and positive when clicking on the label. This is strongly
+    // dependent on how the checkbox is styled, so if the style is changed, this might need
+    // to be updated too.
+    // For the styling, see:
+    // packages/renderer/MdToHtml/rules/checkbox.ts
+    //
+    // The previous solution was to use "pointer-event: none", which mostly work, however
+    // it means that links are no longer clickable when they are within the checkbox label.
+    if (event.offsetX >= 0) return;
+
+    editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
+  }
+  editor.on('click', editorClickHandler);
 };
 
 export {

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/core/Mouse.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/core/Mouse.ts
@@ -1,0 +1,26 @@
+import { isJoplinChecklistItem } from '../listModel/JoplinListUtil';
+
+
+const setup = function (editor) {
+    const editorClickHandler = (event) => {
+        if (!isJoplinChecklistItem(event.target)) return;
+
+        // We only process the click if it's within the checkbox itself (and not the label).
+        // That checkbox, based on
+        // the current styling is in the negative margin, so offsetX is negative when clicking
+        // on the checkbox itself, and positive when clicking on the label. This is strongly
+        // dependent on how the checkbox is styled, so if the style is changed, this might need
+        // to be updated too.
+        // For the styling, see:
+        // packages/renderer/MdToHtml/rules/checkbox.ts
+        //
+        // The previous solution was to use "pointer-event: none", which mostly work, however
+        // it means that links are no longer clickable when they are within the checkbox label.
+        if (event.offsetX >= 0) return;
+
+        editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
+    }
+    editor.on('click', editorClickHandler);
+};
+
+export { setup };

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/ui/Buttons.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/ui/Buttons.ts
@@ -10,7 +10,7 @@ import * as Settings from '../api/Settings';
 import * as NodeType from '../core/NodeType';
 import Editor from 'tinymce/core/api/Editor';
 import { isCustomList } from '../core/Util';
-import { findContainerListTypeFromEvent, isJoplinChecklistItem } from '../listModel/JoplinListUtil';
+import { findContainerListTypeFromEvent } from '../listModel/JoplinListUtil';
 
 const findIndex = function (list, predicate) {
   for (let index = 0; index < list.length; index++) {
@@ -38,37 +38,11 @@ const listState = function (editor: Editor, listName, options:any = {}) {
       buttonApi.setActive(listType === options.listType && lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
     };
 
-    const editorClickHandler = (event) => {
-      if (!isJoplinChecklistItem(event.target)) return;
-
-      // We only process the click if it's within the checkbox itself (and not the label). 
-      // That checkbox, based on
-      // the current styling is in the negative margin, so offsetX is negative when clicking
-      // on the checkbox itself, and positive when clicking on the label. This is strongly
-      // dependent on how the checkbox is styled, so if the style is changed, this might need
-      // to be updated too.
-      // For the styling, see:
-      // packages/renderer/MdToHtml/rules/checkbox.ts
-      //
-      // The previous solution was to use "pointer-event: none", which mostly work, however
-      // it means that links are no longer clickable when they are within the checkbox label.
-      if (event.offsetX >= 0) return;
-
-      editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
-    }
-
-    if (options.listType === 'joplinChecklist') {
-      editor.on('click', editorClickHandler);
-    }
-
     editor.on('NodeChange', nodeChangeHandler);
 
     return () => {
-      if (options.listType === 'joplinChecklist') {
-        editor.off('click', editorClickHandler);
-      }
       editor.off('NodeChange', nodeChangeHandler);
-    } 
+    }
   };
 };
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
@@ -2057,6 +2057,16 @@
       editor.addQueryStateHandler('InsertOrderedList', queryListCommandState(editor, 'OL'));
       editor.addQueryStateHandler('InsertDefinitionList', queryListCommandState(editor, 'DL'));
       addJoplinChecklistCommands(editor, ToggleList);
+      
+      var editorClickHandler = function (event) {
+        if (!isJoplinChecklistItem(event.target))
+          return;
+        if (event.offsetX >= 0)
+          return;
+        editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
+      };
+      editor.on('click', editorClickHandler);
+
     };
 
     var setupTabKey = function (editor) {
@@ -2100,21 +2110,9 @@
           var listType = findContainerListTypeFromEvent(e);
           buttonApi.setActive(listType === options.listType && lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
         };
-        var editorClickHandler = function (event) {
-          if (!isJoplinChecklistItem(event.target))
-            return;
-          if (event.offsetX >= 0)
-            return;
-          editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
-        };
-        if (options.listType === 'joplinChecklist') {
-          editor.on('click', editorClickHandler);
-        }
+
         editor.on('NodeChange', nodeChangeHandler);
         return function () {
-          if (options.listType === 'joplinChecklist') {
-            editor.off('click', editorClickHandler);
-          }
           editor.off('NodeChange', nodeChangeHandler);
         };
       };

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
@@ -2057,7 +2057,6 @@
       editor.addQueryStateHandler('InsertOrderedList', queryListCommandState(editor, 'OL'));
       editor.addQueryStateHandler('InsertDefinitionList', queryListCommandState(editor, 'DL'));
       addJoplinChecklistCommands(editor, ToggleList);
-      
       var editorClickHandler = function (event) {
         if (!isJoplinChecklistItem(event.target))
           return;
@@ -2066,7 +2065,6 @@
         editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
       };
       editor.on('click', editorClickHandler);
-
     };
 
     var setupTabKey = function (editor) {
@@ -2110,7 +2108,6 @@
           var listType = findContainerListTypeFromEvent(e);
           buttonApi.setActive(listType === options.listType && lists.length > 0 && lists[0].nodeName === listName && !isCustomList(lists[0]));
         };
-
         editor.on('NodeChange', nodeChangeHandler);
         return function () {
           editor.off('NodeChange', nodeChangeHandler);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js
@@ -2057,14 +2057,6 @@
       editor.addQueryStateHandler('InsertOrderedList', queryListCommandState(editor, 'OL'));
       editor.addQueryStateHandler('InsertDefinitionList', queryListCommandState(editor, 'DL'));
       addJoplinChecklistCommands(editor, ToggleList);
-      var editorClickHandler = function (event) {
-        if (!isJoplinChecklistItem(event.target))
-          return;
-        if (event.offsetX >= 0)
-          return;
-        editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
-      };
-      editor.on('click', editorClickHandler);
     };
 
     var setupTabKey = function (editor) {
@@ -2084,6 +2076,17 @@
         setupTabKey(editor);
       }
       setup(editor);
+    };
+
+    var setup$2 = function (editor) {
+      var editorClickHandler = function (event) {
+        if (!isJoplinChecklistItem(event.target))
+          return;
+        if (event.offsetX >= 0)
+          return;
+        editor.execCommand('ToggleJoplinChecklistItem', false, { element: event.target });
+      };
+      editor.on('click', editorClickHandler);
     };
 
     var findIndex = function (list, predicate) {
@@ -2153,6 +2156,7 @@
     function Plugin () {
       PluginManager.add('joplinLists', function (editor) {
         setup$1(editor);
+        setup$2(editor);
         register$1(editor);
         register(editor);
         return get(editor);


### PR DESCRIPTION
As described in #6172, clicking on a checkbox does nothing when using the WYSIWYG editor if the checkbox button is hidden from the toolbar. 
The reason is that the click listener is defined in the `onSetup` function of the toolbar checkbox button. When the button is hidden, the click listener is disabled.
To fix it, I moved the click listener outside the `onSetup` function to make it is always active.
