### PR TITLE
Desktop: Add function to check first-app-start

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -254,6 +254,14 @@ class Application extends BaseApplication {
 		}
 	}
 
+	private checkFirstAppStart(): boolean {
+		if (Setting.value('isFirstAppStart') === true) {
+			Setting.setValue('isFirstAppStart', false);
+			return true;
+		}
+		return false;
+	}
+
 	private async initPluginService() {
 		const service = PluginService.instance();
 
@@ -543,6 +551,7 @@ class Application extends BaseApplication {
 
 		bridge().addEventListener('nativeThemeUpdated', this.bridge_nativeThemeUpdated);
 
+		this.checkFirstAppStart();
 		await this.initPluginService();
 
 		this.setupContextMenu();

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1516,6 +1516,13 @@ class Setting extends BaseModel {
 				public: false,
 			},
 
+			isFirstAppStart: {
+				value: true,
+				type: SettingItemType.Bool,
+				storage: SettingStorage.File,
+				public: false,
+			},
+
 			// 'featureFlag.syncAccurateTimestamps': {
 			// 	value: false,
 			// 	type: SettingItemType.Bool,


### PR DESCRIPTION
I have added a function to check if it's first-app-start by checking newly added '`isFirstAppStart`' propery in `Setting.ts`. This will be used when installing default plugins.

As you suggested, Laurent, I tried to add this in a new separate file, so we can test it, but the code seemed too short for it. But if you think I should make a separate file, please let me know.