### PR TITLE
Desktop: Resolves #6570: Fixed broken image links

### DIFF
--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -415,7 +415,7 @@ describe('models/Note', function() {
 describe('models/Note_replacePaths', function() {
 
 	function testResourceReplacment(body: string, pathsToTry: string[], expected: string) {
-		expect(Note.replacePaths(pathsToTry, body)).toBe(expected);
+		expect(Note['replaceResourceExternalToInternalLinks_'](pathsToTry, body)).toBe(expected);
 	}
 	test('Basic replacement', () => {
 		const body = '![image.png](file:///C:Users/Username/resources/849eae4dade045298c107fc706b6d2bc.png?t=1655192326803)';

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -411,3 +411,37 @@ describe('models/Note', function() {
 	}));
 
 });
+
+describe('models/Note_replacePaths', function() {
+
+	function testResourceReplacment(body: string, pathsToTry: string[], expected: string) {
+		expect(Note.replacePaths(pathsToTry, body)).toBe(expected);
+	}
+	test('Basic replacement', () => {
+		const body = '![image.png](file:///C:Users/Username/resources/849eae4dade045298c107fc706b6d2bc.png?t=1655192326803)';
+		const pathsToTry = ['file:///C:Users/Username/resources'];
+		const expected = '![image.png](:/849eae4dade045298c107fc706b6d2bc)';
+		testResourceReplacment(body, pathsToTry, expected);
+	});
+
+	test('Replacement with spaces', () => {
+		const body = '![image.png](file:///C:Users/Username%20with%20spaces/resources/849eae4dade045298c107fc706b6d2bc.png?t=1655192326803)';
+		const pathsToTry = ['file:///C:Users/Username with spaces/resources'];
+		const expected = '![image.png](:/849eae4dade045298c107fc706b6d2bc)';
+		testResourceReplacment(body, pathsToTry, expected);
+	});
+
+	test('Replacement with Non-ASCII', () => {
+		const body = '![image.png](file:///C:Users/UsernameWith%C3%A9%C3%A0%C3%B6/resources/849eae4dade045298c107fc706b6d2bc.png?t=1655192326803)';
+		const pathsToTry = ['file:///C:Users/UsernameWithéàö/resources'];
+		const expected = '![image.png](:/849eae4dade045298c107fc706b6d2bc)';
+		testResourceReplacment(body, pathsToTry, expected);
+	});
+
+	test('Replacement with Non-ASCII and spaces', () => {
+		const body = '![image.png](file:///C:Users/Username%20With%20%C3%A9%C3%A0%C3%B6/resources/849eae4dade045298c107fc706b6d2bc.png?t=1655192326803)';
+		const pathsToTry = ['file:///C:Users/Username With éàö/resources'];
+		const expected = '![image.png](:/849eae4dade045298c107fc706b6d2bc)';
+		testResourceReplacment(body, pathsToTry, expected);
+	});
+});

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -207,7 +207,7 @@ export default class Note extends BaseItem {
 		const temp = [];
 		for (const p of pathsToTry) {
 			temp.push(p);
-			temp.push(markdownUtils.escapeLinkUrl(p));
+			temp.push(encodeURI(p));
 		}
 
 		pathsToTry = temp;

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -182,7 +182,7 @@ export default class Note extends BaseItem {
 
 		const resourceDir = toForwardSlashes(Setting.value('resourceDir'));
 
-		let pathsToTry = [];
+		const pathsToTry = [];
 		if (options.useAbsolutePaths) {
 			pathsToTry.push(`file://${resourceDir}`);
 			pathsToTry.push(`file:///${resourceDir}`);
@@ -192,6 +192,11 @@ export default class Note extends BaseItem {
 			pathsToTry.push(Resource.baseRelativeDirectoryPath());
 		}
 
+		body = Note.replacePaths(pathsToTry, body);
+		return body;
+	}
+
+	static replacePaths(pathsToTry: string[], body: string) {
 		// We support both the escaped and unescaped versions because both
 		// of those paths are valid:
 		//
@@ -206,8 +211,6 @@ export default class Note extends BaseItem {
 		}
 
 		pathsToTry = temp;
-
-		// this.logger().debug('replaceResourceExternalToInternalLinks', 'options:', options, 'pathsToTry:', pathsToTry);
 
 		for (const basePath of pathsToTry) {
 			const reStrings = [
@@ -227,9 +230,6 @@ export default class Note extends BaseItem {
 			// Handles joplin://af0edffa4a60496bba1b0ba06b8fb39a
 			body = body.replace(/\(joplin:\/\/([a-zA-Z0-9]{32})\)/g, '(:/$1)');
 		}
-
-		// this.logger().debug('replaceResourceExternalToInternalLinks result', body);
-
 		return body;
 	}
 

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -192,11 +192,13 @@ export default class Note extends BaseItem {
 			pathsToTry.push(Resource.baseRelativeDirectoryPath());
 		}
 
-		body = Note.replacePaths(pathsToTry, body);
+		body = Note.replaceResourceExternalToInternalLinks_(pathsToTry, body);
 		return body;
 	}
 
-	static replacePaths(pathsToTry: string[], body: string) {
+	private static replaceResourceExternalToInternalLinks_(pathsToTry: string[], body: string) {
+		// This is a moved to a separate function for the purpose of testing only
+
 		// We support both the escaped and unescaped versions because both
 		// of those paths are valid:
 		//
@@ -211,6 +213,8 @@ export default class Note extends BaseItem {
 		}
 
 		pathsToTry = temp;
+
+		// this.logger().debug('replaceResourceExternalToInternalLinks', 'options:', options, 'pathsToTry:', pathsToTry);
 
 		for (const basePath of pathsToTry) {
 			const reStrings = [
@@ -230,6 +234,8 @@ export default class Note extends BaseItem {
 			// Handles joplin://af0edffa4a60496bba1b0ba06b8fb39a
 			body = body.replace(/\(joplin:\/\/([a-zA-Z0-9]{32})\)/g, '(:/$1)');
 		}
+		// this.logger().debug('replaceResourceExternalToInternalLinks result', body);
+
 		return body;
 	}
 


### PR DESCRIPTION
Resolves #6570.

When using the WYSIWYG editor, full paths to images are encoded using the `encodeURI` function. Non-ASCII characters contained in the path are changed. By example, `é` becomes `'%C3%A9'`. If changes are made using the WYSIWYG editor, image paths must be translated back to joplin resource id when the note is saved. The translation is using regex to find paths to resources in the note and then translate them.

However, there is an issue if the path contains non-ASCII characters. The regex tries to match a path not encoded with `encodeURI`, thus it will not match resources paths. For instance, it will try to find path containing `é` character, but the note contains a path with `'%C3%A9'`. Thus the link will not be translated back. If the note is synchronized to another device, the link will not be valid.

This was fixed by encoding the paths with `encodeURI` before the matching. Note that I replaced the `markdownUtils.escapeLinkUrl` which was used to encode spaces. It works because `encodeURI` also encodes spaces. `markdownUtils.escapeLinkUrl` also encodes parenthesis, but I don't think it is useful in this case.