### PR TITLE
Mobile: Fixes #5949: Scroll selection into view in beta editor when window resizes

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror.ts
@@ -26,8 +26,9 @@ interface CodeMirrorResult {
 	editor: EditorView;
 	undo: Function;
 	redo: Function;
-	select: (anchor: number, head: number)=> void;
-	insertText: (text: string)=> void;
+	select(anchor: number, head: number): void;
+	scrollSelectionIntoView(): void;
+	insertText(text: string): void;
 }
 
 function postMessage(name: string, data: any) {
@@ -228,6 +229,11 @@ export function initCodeMirror(parentElement: any, initialText: string, theme: a
 		select: (anchor: number, head: number) => {
 			editor.dispatch(editor.state.update({
 				selection: { anchor, head },
+				scrollIntoView: true,
+			}));
+		},
+		scrollSelectionIntoView: () => {
+			editor.dispatch(editor.state.update({
 				scrollIntoView: true,
 			}));
 		},

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -267,6 +267,7 @@ function NoteEditor(props: Props, ref: any) {
 			cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, theme);
 			${setInitialSelectionJS}
 
+			// Fixes https://github.com/laurent22/joplin/issues/5949
 			window.onresize = () => {
 				cm.scrollSelectionIntoView();
 			};

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -266,6 +266,10 @@ function NoteEditor(props: Props, ref: any) {
 
 			cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, theme);
 			${setInitialSelectionJS}
+
+			window.onresize = () => {
+				cm.scrollSelectionIntoView();
+			};
 		} catch (e) {
 			window.ReactNativeWebView.postMessage("error:" + e.message + ": " + JSON.stringify(e))
 		} finally {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
# Summary
 * Fixes #5949 by telling the CodeMirror editor to scroll the selection into view when the window size changes.

# Testing
 * Write a long-ish note.
 * Scroll to the top
 * Tap the last line to open the keyboard.
