### PR TITLE
Docs: Add section to FAQ about appimages not starting

### DIFF
--- a/readme/faq.md
+++ b/readme/faq.md
@@ -20,9 +20,15 @@ You can pass [arguments](https://github.com/laurent22/joplin/blob/dev/Joplin_ins
 
 <pre><code style="word-break: break-all">wget -O - https://raw.githubusercontent.com/laurent22/joplin/dev/Joplin_install_and_update.sh | bash -s -- --argument1 --argument2</code></pre>
 
+## Desktop application will not launch on Linux
+
+If you downloaded the AppImage directly did not install via the recommended script then it may not be currently allowed to execute (see [AppImage User Guide](https://docs.appimage.org/introduction/quickstart.html#how-to-run-an-AppImage))
+
+If execution permissions are present then your system may not have the `libfuse2` library that AppImages require to run. This is inherent to the AppImage format and not Joplin specifically. For more info see [this forum thread](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173) which has further detail on the issue and an [Ubuntu specific fix](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173/12).
+
 ## How can I edit my note in an external text editor?
 
-The editor command (may include arguments) defines which editor will be used to open a note. If none is provided it will try to auto-detect the default editor. If this does nothing or you want to change it for Joplin, you need to configure it in the Preferences -> Text editor command.
+The editiior command (may include arguments) defines which editor will be used to open a note. If none is provided it will try to auto-detect the default editor. If this does nothing or you want to change it for Joplin, you need to configure it in the Preferences -> Text editor command.
 
 Some example configurations are: (comments after #)
 

--- a/readme/faq.md
+++ b/readme/faq.md
@@ -28,7 +28,7 @@ If execution permissions are present then your system may not have the `libfuse2
 
 ## How can I edit my note in an external text editor?
 
-The editiior command (may include arguments) defines which editor will be used to open a note. If none is provided it will try to auto-detect the default editor. If this does nothing or you want to change it for Joplin, you need to configure it in the Preferences -> Text editor command.
+The editor command (may include arguments) defines which editor will be used to open a note. If none is provided it will try to auto-detect the default editor. If this does nothing or you want to change it for Joplin, you need to configure it in the Preferences -> Text editor command.
 
 Some example configurations are: (comments after #)
 

--- a/readme/faq.md
+++ b/readme/faq.md
@@ -22,9 +22,9 @@ You can pass [arguments](https://github.com/laurent22/joplin/blob/dev/Joplin_ins
 
 ## Desktop application will not launch on Linux
 
-If you downloaded the AppImage directly did not install via the recommended script then it may not be currently allowed to execute (see [AppImage User Guide](https://docs.appimage.org/introduction/quickstart.html#how-to-run-an-AppImage)).
+If you downloaded the AppImage directly and therefore did not install via the recommended script then it may not be currently allowed to execute and needs to have these permissions set manually (see [AppImage User Guide](https://docs.appimage.org/introduction/quickstart.html#how-to-run-an-AppImage)).
 
-If execution permissions are present then your system may not have the `libfuse2` library that AppImages require to run. This is inherent to the AppImage format and not Joplin specifically. For more info see [this forum thread](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173) which has further detail on the issue and an [Ubuntu specific fix](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173/12).
+If execution permissions are correct and it still does not launch then your system may not have the `libfuse2` library that AppImages require to run. This library requirement is inherent to the AppImage format and not Joplin specifically. For more info see [this forum thread](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173) which has further detail on the issue and an [Ubuntu specific fix](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173/12).
 
 ## How can I edit my note in an external text editor?
 

--- a/readme/faq.md
+++ b/readme/faq.md
@@ -22,7 +22,7 @@ You can pass [arguments](https://github.com/laurent22/joplin/blob/dev/Joplin_ins
 
 ## Desktop application will not launch on Linux
 
-If you downloaded the AppImage directly did not install via the recommended script then it may not be currently allowed to execute (see [AppImage User Guide](https://docs.appimage.org/introduction/quickstart.html#how-to-run-an-AppImage))
+If you downloaded the AppImage directly did not install via the recommended script then it may not be currently allowed to execute (see [AppImage User Guide](https://docs.appimage.org/introduction/quickstart.html#how-to-run-an-AppImage)).
 
 If execution permissions are present then your system may not have the `libfuse2` library that AppImages require to run. This is inherent to the AppImage format and not Joplin specifically. For more info see [this forum thread](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173) which has further detail on the issue and an [Ubuntu specific fix](https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173/12).
 


### PR DESCRIPTION
Mostly surrounding questions popping up on forums and GH since `libfuse2` was removed from new Ubuntu releases (and potentially other distros in the near future).
As a "user friendly" distro people may not be able to easily diagnose this so I think links to what we know should be provided to help.
Of course because it is a very generic sounding issue I've also added a link to the official "how to run an appimage" documentation on setting permissions.
Libfuse specific lines can/should be removed once proper support for static runtime changes and/or fuse3 support is added to appimagekit and Joplin releases a new version on it.

See:
https://discourse.joplinapp.org/t/appimage-incompatibility-in-ubuntu-22-04/25173
https://discourse.joplinapp.org/t/ubuntu-issues/25974
https://discourse.joplinapp.org/t/joplin-only-works-in-terminal-no-gui/26170
https://github.com/laurent22/joplin/issues/6612
