### PR TITLE
Mobile: Resolves #6642: Add close button to warning dialog

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -862,6 +862,9 @@ packages/app-mobile/components/NoteEditor/NoteEditor.js.map
 packages/app-mobile/components/SelectDateTimeDialog.d.ts
 packages/app-mobile/components/SelectDateTimeDialog.js
 packages/app-mobile/components/SelectDateTimeDialog.js.map
+packages/app-mobile/components/WarningBox.d.ts
+packages/app-mobile/components/WarningBox.js
+packages/app-mobile/components/WarningBox.js.map
 packages/app-mobile/components/screens/ConfigScreen.d.ts
 packages/app-mobile/components/screens/ConfigScreen.js
 packages/app-mobile/components/screens/ConfigScreen.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -852,6 +852,9 @@ packages/app-mobile/components/NoteEditor/NoteEditor.js.map
 packages/app-mobile/components/SelectDateTimeDialog.d.ts
 packages/app-mobile/components/SelectDateTimeDialog.js
 packages/app-mobile/components/SelectDateTimeDialog.js.map
+packages/app-mobile/components/WarningBox.d.ts
+packages/app-mobile/components/WarningBox.js
+packages/app-mobile/components/WarningBox.js.map
 packages/app-mobile/components/screens/ConfigScreen.d.ts
 packages/app-mobile/components/screens/ConfigScreen.js
 packages/app-mobile/components/screens/ConfigScreen.js.map

--- a/packages/app-mobile/components/WarningBox.tsx
+++ b/packages/app-mobile/components/WarningBox.tsx
@@ -1,0 +1,62 @@
+/**
+ * A closable warning banner.
+ */
+
+const React = require('react');
+const { useState } = React;
+const { View, Text, TouchableOpacity } = require('react-native');
+
+import { _ } from '@joplin/lib/locale';
+
+export const WarningBox = (props: {
+	message: string;
+	style: any;
+	onPress: ()=> void;
+}) => {
+	const padding: number = props.style?.padding ?? 10;
+	const [visible, setVisible] = useState(true);
+
+	if (!visible) {
+		return null;
+	}
+
+	return (
+		<View style={{
+			...props.style,
+			flexDirection: 'row',
+			alignItems: 'stretch',
+			padding: 0,
+		}}>
+			<TouchableOpacity
+				style={{
+					flexGrow: 1,
+					padding: padding,
+				}}
+				onPress={() => props.onPress()}
+			>
+				<Text>{props.message}</Text>
+			</TouchableOpacity>
+			<TouchableOpacity
+				accessibilityLabel={_('Dismiss warning')}
+				accessibilityRole="button"
+				onPress={() => {
+					setVisible(false);
+				}}
+				style={{
+					width: 48,
+					alignItems: 'center',
+					justifyContent: 'center',
+					flexShrink: 0,
+				}}
+			>
+				<Text style={{
+					fontSize: 22,
+					minWidth: 40,
+				}}>⨉</Text>
+			</TouchableOpacity>
+		</View>
+	);
+};
+
+export default WarningBox;
+

--- a/packages/app-mobile/components/screen-header.js
+++ b/packages/app-mobile/components/screen-header.js
@@ -17,6 +17,8 @@ const DialogBox = require('react-native-dialogbox').default;
 const { localSyncInfoFromState } = require('@joplin/lib/services/synchronizer/syncInfoUtils');
 const { showMissingMasterKeyMessage } = require('@joplin/lib/services/e2ee/utils');
 
+import WarningBox from './WarningBox';
+
 Icon.loadFont();
 
 // Rather than applying a padding to the whole bar, it is applied to each
@@ -216,9 +218,11 @@ class ScreenHeaderComponent extends React.PureComponent {
 
 	renderWarningBox(screen, message) {
 		return (
-			<TouchableOpacity key={screen} style={this.styles().warningBox} onPress={() => this.warningBox_press({ screen: screen })} activeOpacity={0.8}>
-				<Text style={{ flex: 1 }}>{message}</Text>
-			</TouchableOpacity>
+			<WarningBox
+				key={screen}
+				style={this.styles().warningBox}
+				onPress={() => this.warningBox_press({ screen: screen })}
+				message={message}/>
 		);
 	}
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
# Summary
 * Adds an 'x' button that can be used to temporarily dismiss warning banners.
 * Fixes #6642

<center>
<img alt="Screenshot of a phone, warning dialog displaying a message. An 'X' is visible on the right side of the button." src="https://user-images.githubusercontent.com/46334387/177190513-224d8882-09e3-442e-9420-5a9ebf1319aa.jpeg" width="300px"/>
</center>


# Testing plan
1. Manually add a new warning to `screen-header.js` (see #6642 for details)
2. Run the app
3. Click the close button
4. Open a note
5. Click on the main region of the banner
6. Close the banner