### PR TITLE
Desktop: Fixes #6434 Play flac files

### DIFF
--- a/packages/lib/mime-utils-types.js
+++ b/packages/lib/mime-utils-types.js
@@ -610,7 +610,7 @@ const mimeTypes = [
 	{ t: 'audio/x-aac', e: ['aac'] },
 	{ t: 'audio/x-aiff', e: ['aif', 'aiff', 'aifc'] },
 	{ t: 'audio/x-caf', e: ['caf'] },
-	{ t: 'audio/x-flac', e: ['flac'] },
+	{ t: 'audio/flac', e: ['flac'] },
 	{ t: 'audio/x-matroska', e: ['mka'] },
 	{ t: 'audio/x-mpegurl', e: ['m3u'] },
 	{ t: 'audio/x-ms-wax', e: ['wax'] },

--- a/packages/lib/mime-utils-types.js
+++ b/packages/lib/mime-utils-types.js
@@ -610,7 +610,7 @@ const mimeTypes = [
 	{ t: 'audio/x-aac', e: ['aac'] },
 	{ t: 'audio/x-aiff', e: ['aif', 'aiff', 'aifc'] },
 	{ t: 'audio/x-caf', e: ['caf'] },
-	{ t: 'audio/flac', e: ['flac'] },
+	{ t: 'audio/x-flac', e: ['flac'] },
 	{ t: 'audio/x-matroska', e: ['mka'] },
 	{ t: 'audio/x-mpegurl', e: ['m3u'] },
 	{ t: 'audio/x-ms-wax', e: ['wax'] },

--- a/packages/renderer/MdToHtml/renderMedia.ts
+++ b/packages/renderer/MdToHtml/renderMedia.ts
@@ -31,9 +31,10 @@ export default function(link: Link, options: Options) {
 	}
 
 	if (options.audioPlayerEnabled && resource.mime.indexOf('audio/') === 0) {
+		const escapedAudioMime = escapedMime == 'audio/x-flac' ? 'audio/flac' : escapedMime;
 		return `
 			<audio class="media-player media-audio" controls>
-				<source src="${escapedResourcePath}" type="${escapedMime}">
+				<source src="${escapedResourcePath}" type="${escapedAudioMime}">
 			</audio>
 		`;
 	}

--- a/packages/renderer/MdToHtml/renderMedia.ts
+++ b/packages/renderer/MdToHtml/renderMedia.ts
@@ -31,7 +31,7 @@ export default function(link: Link, options: Options) {
 	}
 
 	if (options.audioPlayerEnabled && resource.mime.indexOf('audio/') === 0) {
-		const escapedAudioMime = escapedMime == 'audio/x-flac' ? 'audio/flac' : escapedMime;
+		const escapedAudioMime = escapedMime === 'audio/x-flac' ? 'audio/flac' : escapedMime;
 		return `
 			<audio class="media-player media-audio" controls>
 				<source src="${escapedResourcePath}" type="${escapedAudioMime}">

--- a/packages/renderer/MdToHtml/renderMedia.ts
+++ b/packages/renderer/MdToHtml/renderMedia.ts
@@ -31,6 +31,8 @@ export default function(link: Link, options: Options) {
 	}
 
 	if (options.audioPlayerEnabled && resource.mime.indexOf('audio/') === 0) {
+		// We want to support both audio/x-flac and audio/flac MIME types, but chromium only supports audio/flac
+		// https://github.com/laurent22/joplin/issues/6434
 		const escapedAudioMime = escapedMime === 'audio/x-flac' ? 'audio/flac' : escapedMime;
 		return `
 			<audio class="media-player media-audio" controls>


### PR DESCRIPTION
Fixes #6434.
There are two valid MIME types for flac: `audio/flac` and `audio/x-flac`, but chromium only supports the first one. Just changing the MIME type we are using allow us to play flac files.

Note: the MIME type is determined when attaching a file, so old files need to be reattached to be playable.
