### PR TITLE
Lib: Migrate string-utils-common to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1828,6 +1828,9 @@ packages/lib/services/synchronizer/utils/types.js.map
 packages/lib/shim.d.ts
 packages/lib/shim.js
 packages/lib/shim.js.map
+packages/lib/string-utils-common.d.ts
+packages/lib/string-utils-common.js
+packages/lib/string-utils-common.js.map
 packages/lib/testing/syncTargetUtils.d.ts
 packages/lib/testing/syncTargetUtils.js
 packages/lib/testing/syncTargetUtils.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1818,6 +1818,9 @@ packages/lib/services/synchronizer/utils/types.js.map
 packages/lib/shim.d.ts
 packages/lib/shim.js
 packages/lib/shim.js.map
+packages/lib/string-utils-common.d.ts
+packages/lib/string-utils-common.js
+packages/lib/string-utils-common.js.map
 packages/lib/testing/syncTargetUtils.d.ts
 packages/lib/testing/syncTargetUtils.js
 packages/lib/testing/syncTargetUtils.js.map

--- a/packages/lib/string-utils-common.ts
+++ b/packages/lib/string-utils-common.ts
@@ -1,11 +1,24 @@
-function pregQuote(str, delimiter = '') {
+/**
+ * Escapes the given string for use in a regular expression.
+ * @param str String to be escaped
+ * @param delimiter An additional separator character that will also be escaped, if provided.
+ * @returns a version of [str] with all regex control characters escaped.
+ */
+export function pregQuote(str: string, delimiter: string = '') {
 	return (`${str}`).replace(new RegExp(`[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\${delimiter || ''}-]`, 'g'), '\\$&');
 }
 
-function replaceRegexDiacritics(regexString) {
+/**
+ * Causes letters in the given string to match versions with different diacritics.
+ * For example, this makes 'a' match 'à', 'ä', 'ā'...
+ *
+ * @param regexString A regular expression with no character match groups (without [a-zA-Z]-style matchers).
+ * @returns an updated regular expression string.
+ */
+export function replaceRegexDiacritics(regexString: string) {
 	if (!regexString) return '';
 
-	const diacriticReplacements = {
+	const diacriticReplacements: Record<string, string> = {
 		a: '[aàáâãäåāą]',
 		A: '[AÀÁÂÃÄÅĀĄ]',
 		c: '[cçćč]',
@@ -50,6 +63,3 @@ function replaceRegexDiacritics(regexString) {
 	return output;
 }
 
-if (typeof module !== 'undefined') {
-	module.exports = { pregQuote, replaceRegexDiacritics };
-}


### PR DESCRIPTION
As with #6673, I would like to import `string-utils-common` from `rollup`-bundled files. Migrating `string-utils-common` to ES6 modules (and TypeScript) allows this.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
