### PR TITLE
Mobile/iOS: Resolves #6685: Respect system accessibility font size in rendered markdown

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
@@ -139,6 +139,17 @@ export default function useSource(noteBody: string, noteMarkupLanguage: number, 
 			js.push('}');
 			js.push('true;');
 
+			// iOS doesn't automatically adjust the WebView's font size to match users'
+			// accessibility settings. To do this, we need to tell it to match the system font.
+			// See https://github.com/ionic-team/capacitor/issues/2748#issuecomment-612923135
+			const iOSSpecificCss = `
+				@media screen {
+					:root body {
+						font: -apple-system-body;
+					}
+				}
+			`;
+
 			html =
 				`
 				<!DOCTYPE html>
@@ -146,6 +157,9 @@ export default function useSource(noteBody: string, noteMarkupLanguage: number, 
 					<head>
 						<meta charset="UTF-8">
 						<meta name="viewport" content="width=device-width, initial-scale=1">
+						<style>
+							${shim.mobilePlatform() === 'ios' ? iOSSpecificCss : ''}
+						</style>
 						${assetsToHeaders(result.pluginAssets, { asHtml: true })}
 					</head>
 					<body>

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/theme.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/theme.ts
@@ -26,11 +26,20 @@ const createTheme = (theme: any): Extension[] => {
 	const baseGlobalStyle: Record<string, string> = {
 		color: theme.color,
 		backgroundColor: theme.backgroundColor,
-		fontFamily: theme.fontFamily,
-		fontSize: `${theme.fontSize}px`,
+
+		// On iOS, apply system font scaling (e.g. font scaling
+		// set in accessibility settings).
+		font: '-apple-system-body',
 	};
 	const baseCursorStyle: Record<string, string> = { };
-	const baseContentStyle: Record<string, string> = { };
+	const baseContentStyle: Record<string, string> = {
+		fontFamily: theme.fontFamily,
+
+		// To allow accessibility font scaling, we also need to set the
+		// fontSize to a value in `em`s (relative scaling relative to
+		// parent font size).
+		fontSize: `${theme.fontSize}em`,
+	};
 	const baseSelectionStyle: Record<string, string> = { };
 
 	// If we're in dark mode, the caret and selection are difficult to see.

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -88,7 +88,7 @@ function useHtml(css: string): string {
 function editorTheme(themeId: number) {
 	return {
 		...themeStyle(themeId),
-		fontSize: 15,
+		fontSize: 0.85, // em
 		fontFamily: fontFamilyFromSettings(),
 	};
 }

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -51,6 +51,10 @@ function useCss(themeId: number): string {
 			:root {
 				background-color: ${theme.backgroundColor};
 			}
+
+			body {
+				font-size: 13pt;
+			}
 		`;
 	}, [themeId]);
 }


### PR DESCRIPTION
# Summary
On iOS, loads additional CSS that sets the font family of the body to `-apple-system-body`. This scales the font size in the `WebView` with the accessibility system settings.

Fixes #6685

# See also
 * https://discourse.joplinapp.org/t/increase-font-size-in-ipad-app/26576/8
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

# Testing plan
## iOS
1. Enable the beta editor and open a note (viewing mode)
2. Click the edit button
3. Click the back arrow
4. Check the 'Larger accessibility sizes' box in `System Settings → Accessibility → Display & Text Size → Larger Accessibility Sizes`
5. Also in `System Settings → Accessibility → Display & Text Size → Larger Accessibility Sizes`, increase the font size
6. In Joplin, click the edit button
7. Click the back arrow

In steps 6 and 7, the font size in both the editor and viewer should be larger than in steps 1 and 2.

## Android
1. Enable the beta editor and open a note
2. Click the edit button
3. Click the back button
4. Increase the font size in `Settings → Display → Font size`
5. Navigate back to the note
6. Click `edit` again

As above, in steps 5 and 6, the font size should be larger than in steps 1 and 2.