### PR TITLE
#6691 Update known problems for macOS with external links

### DIFF
--- a/readme/external_links.md
+++ b/readme/external_links.md
@@ -12,4 +12,4 @@ To create a link, right click a note, a folder, or a tag in the sidebar and sele
 
 ## Known problems
 
-On macOS if Joplin isn't running it will start but it won't open the note.
+On macOS if Joplin isn't running it will start but it won't open the note. If Joplin is running but on a different space as the external link, then Joplin will come to the foreground but without displaying the note.


### PR DESCRIPTION
[Working in multiple spaces on Mac](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac) creates a similar problem as not having running Joplin.
