### PR TITLE
Mobile/iOS: Fixes #6636: Prevent HTML overscroll when opening the software keyboard

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -222,9 +222,12 @@ function NoteEditor(props: Props, ref: any) {
 
 	// - `setSupportMultipleWindows` must be `true` for security reasons:
 	//   https://github.com/react-native-webview/react-native-webview/releases/tag/v11.0.0
+	// - `scrollEnabled` prevents iOS from scrolling the document (has no effect on Android)
+	//    when the editor is focused.
 	return <WebView
 		style={props.style}
 		ref={webviewRef}
+		scrollEnabled={false}
 		useWebKit={true}
 		source={source}
 		setSupportMultipleWindows={true}


### PR DESCRIPTION
# Summary
 * Fixes #6636 
 * May also fix #5774
 * This is done by setting `scrollEnabled={false}`, [which prevents iOS from scrolling the root document within the WebView when the keyboard is opened/closed.](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#scrollenabled)

# Testing plan
 * Follow the "steps-to-reproduce" in #6636
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
