### PR TITLE
Mobile: Add long-press tooltips

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -838,6 +838,9 @@ packages/app-mobile/PluginAssetsLoader.js.map
 packages/app-mobile/components/BackButtonDialogBox.d.ts
 packages/app-mobile/components/BackButtonDialogBox.js
 packages/app-mobile/components/BackButtonDialogBox.js.map
+packages/app-mobile/components/ButtonWithTooltip.d.ts
+packages/app-mobile/components/ButtonWithTooltip.js
+packages/app-mobile/components/ButtonWithTooltip.js.map
 packages/app-mobile/components/CameraView.d.ts
 packages/app-mobile/components/CameraView.js
 packages/app-mobile/components/CameraView.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -828,6 +828,9 @@ packages/app-mobile/PluginAssetsLoader.js.map
 packages/app-mobile/components/BackButtonDialogBox.d.ts
 packages/app-mobile/components/BackButtonDialogBox.js
 packages/app-mobile/components/BackButtonDialogBox.js.map
+packages/app-mobile/components/ButtonWithTooltip.d.ts
+packages/app-mobile/components/ButtonWithTooltip.js
+packages/app-mobile/components/ButtonWithTooltip.js.map
 packages/app-mobile/components/CameraView.d.ts
 packages/app-mobile/components/CameraView.js
 packages/app-mobile/components/CameraView.js.map

--- a/packages/app-mobile/components/ButtonWithTooltip.tsx
+++ b/packages/app-mobile/components/ButtonWithTooltip.tsx
@@ -1,0 +1,155 @@
+//
+// A button with a long-press action. Long-pressing the button displays a tooltip
+//
+
+const React = require('react');
+import { themeStyle } from '@joplin/lib/theme';
+import { Theme } from '@joplin/lib/themes/type';
+import { Component, useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { View, Text, Pressable, ViewStyle, Animated } from 'react-native';
+
+interface TooltipProps {
+	theme: Theme;
+	text: string;
+	visible: boolean;
+}
+
+const Tooltip = (props: TooltipProps) => {
+	const [tooltipY, setTooltipY] = useState(0);
+	const [tooltipOnTop, setTooltipOnTop] = useState(true);
+	const [tooltipRemoved, setTooltipRemoved] = useState(true);
+	const tooltipRef = useRef<View>(null);
+	const opacityAnimation = useRef(new Animated.Value(0)).current;
+
+	// Fade in/out
+	useEffect(() => {
+		if (props.visible) {
+			setTooltipRemoved(false);
+		}
+
+		Animated.timing(
+			opacityAnimation,
+			{
+				toValue: props.visible ? 1.0 : 0.0,
+				duration: 150,
+				useNativeDriver: true,
+			}
+		).start(() => {
+			setTooltipRemoved(!props.visible);
+		});
+	}, [opacityAnimation, props.visible]);
+
+	const onTooltipLayout = useCallback(() => {
+		tooltipRef.current?.measure((_x, y, _width, height, _pageX, pageY) => {
+			if ((pageY - y) - height < 0) {
+				setTooltipOnTop(false);
+			}
+			setTooltipY(-height);
+		});
+	}, []);
+
+	const tooltipPosition: ViewStyle = {};
+	if (tooltipOnTop) {
+		tooltipPosition.top = tooltipY;
+	} else {
+		tooltipPosition.bottom = tooltipY;
+	}
+
+	if (tooltipRemoved) {
+		return null;
+	}
+
+	return (
+		<Animated.View
+			onLayout={onTooltipLayout}
+			ref={tooltipRef}
+			style={{
+				position: 'absolute',
+				backgroundColor: props.theme.backgroundColor2,
+				opacity: opacityAnimation,
+				...tooltipPosition,
+			}}
+		>
+			<Text style={{
+				color: props.theme.color2,
+				padding: 3,
+				textAlign: 'center',
+			}}>{props.text}</Text>
+		</Animated.View>
+	);
+};
+
+interface ButtonProps {
+	onClick: ()=> void;
+	description: string;
+	children: Component[];
+	themeId: number;
+
+	// Additional accessibility information. See View.accessibilityHint
+	accessibilityHint?: string;
+	disabled?: boolean;
+
+	style?: ViewStyle;
+	contentStyle?: ViewStyle;
+	pressedStyle?: ViewStyle;
+}
+
+const ButtonWithTooltip = (props: ButtonProps) => {
+	const themeData = useMemo(() => themeStyle(props.themeId), [props.themeId]);
+	const [tooltipVisible, setTooltipVisible] = useState(false);
+	const [pressed, setPressed] = useState(false);
+
+	const tooltip = (
+		<Tooltip
+			theme={themeData}
+			text={props.description}
+			visible={tooltipVisible}
+		/>
+	);
+
+	const contentStyle = useMemo((): ViewStyle => {
+		return {
+			...props.contentStyle,
+			...(pressed ? { opacity: 0.5 } : { }),
+			...(pressed ? props.pressedStyle : { }),
+		};
+	}, [pressed, props.style, props.pressedStyle]);
+
+	const onPressIn = useCallback(() => {
+		setPressed(true);
+	}, []);
+	const onPressOut = useCallback(() => {
+		setPressed(false);
+		setTooltipVisible(false);
+	}, []);
+	const onLongPress = useCallback(() => {
+		setTooltipVisible(true);
+	}, []);
+
+	const button = (
+		<Pressable
+			onPress={props.onClick}
+
+			onPressIn={onPressIn}
+			onLongPress={onLongPress}
+			onPressOut={onPressOut}
+
+			style={ props.style }
+
+			disabled={ props.disabled ?? false }
+
+			accessibilityLabel={props.description}
+			accessibilityHint={props.accessibilityHint}
+			accessibilityRole={'button'}
+		>
+			<View style={contentStyle}>
+				{ props.children }
+			</View>
+			{ tooltip }
+		</Pressable>
+	);
+
+	return button;
+};
+
+export default ButtonWithTooltip;

--- a/packages/app-mobile/components/screen-header.js
+++ b/packages/app-mobile/components/screen-header.js
@@ -16,6 +16,7 @@ const { dialogs } = require('../utils/dialogs.js');
 const DialogBox = require('react-native-dialogbox').default;
 const { localSyncInfoFromState } = require('@joplin/lib/services/synchronizer/syncInfoUtils');
 const { showMissingMasterKeyMessage } = require('@joplin/lib/services/e2ee/utils');
+import ButtonWithTooltip from './ButtonWithTooltip';
 
 Icon.loadFont();
 
@@ -223,6 +224,7 @@ class ScreenHeaderComponent extends React.PureComponent {
 	}
 
 	render() {
+		const themeId = Setting.value('theme');
 		function sideMenuButton(styles, onPress) {
 			return (
 				<TouchableOpacity
@@ -283,20 +285,24 @@ class ScreenHeaderComponent extends React.PureComponent {
 			const viewStyle = options.disabled ? this.styles().iconButtonDisabled : this.styles().iconButton;
 
 			return (
-				<TouchableOpacity
-					onPress={options.onPress}
+				<ButtonWithTooltip
+					onClick={options.onClick}
 					style={{ padding: 0 }}
+					themeId={themeId}
 					disabled={!!options.disabled}
-					accessibilityRole="button">
-					<View style={viewStyle}>{icon}</View>
-				</TouchableOpacity>
+					description={options.description}
+					contentStyle={viewStyle}
+				>
+					{icon}
+				</ButtonWithTooltip>
 			);
 		};
 
 		const renderUndoButton = () => {
 			return renderTopButton({
 				iconName: 'arrow-undo-circle-sharp',
-				onPress: this.props.onUndoButtonPress,
+				description: _('Undo'),
+				onClick: this.props.onUndoButtonPress,
 				visible: this.props.showUndoButton,
 				disabled: this.props.undoButtonDisabled,
 			});
@@ -305,72 +311,73 @@ class ScreenHeaderComponent extends React.PureComponent {
 		const renderRedoButton = () => {
 			return renderTopButton({
 				iconName: 'arrow-redo-circle-sharp',
-				onPress: this.props.onRedoButtonPress,
+				description: _('Redo'),
+				onClick: this.props.onRedoButtonPress,
 				visible: this.props.showRedoButton,
 			});
 		};
 
-		function selectAllButton(styles, onPress) {
+		function selectAllButton(styles, onClick) {
 			return (
-				<TouchableOpacity
-					onPress={onPress}
+				<ButtonWithTooltip
+					onClick={onClick}
 
-					accessibilityLabel={_('Select all')}
-					accessibilityRole="button">
-					<View style={styles.iconButton}>
-						<Icon name="md-checkmark-circle-outline" style={styles.topIcon} />
-					</View>
-				</TouchableOpacity>
+					themeId={themeId}
+					description={_('Select all')}
+					contentStyle={styles.iconButton}
+				>
+					<Icon name="md-checkmark-circle-outline" style={styles.topIcon} />
+				</ButtonWithTooltip>
 			);
 		}
 
-		function searchButton(styles, onPress) {
+		function searchButton(styles, onClick) {
 			return (
-				<TouchableOpacity
-					onPress={onPress}
+				<ButtonWithTooltip
+					onClick={onClick}
 
-					accessibilityLabel={_('Search')}
-					accessibilityRole="button">
-					<View style={styles.iconButton}>
-						<Icon name="md-search" style={styles.topIcon} />
-					</View>
-				</TouchableOpacity>
+					description={_('Search')}
+					themeId={themeId}
+					contentStyle={styles.iconButton}
+				>
+					<Icon name="md-search" style={styles.topIcon} />
+				</ButtonWithTooltip>
 			);
 		}
 
-		function deleteButton(styles, onPress, disabled) {
+		function deleteButton(styles, onClick, disabled) {
 			return (
-				<TouchableOpacity
-					onPress={onPress}
+				<ButtonWithTooltip
+					onClick={onClick}
 					disabled={disabled}
 
-					accessibilityLabel={_('Delete')}
+					themeId={themeId}
+					description={_('Delete')}
 					accessibilityHint={
 						disabled ? null : _('Delete selected notes')
 					}
-					accessibilityRole="button">
-					<View style={disabled ? styles.iconButtonDisabled : styles.iconButton}>
-						<Icon name="md-trash" style={styles.topIcon} />
-					</View>
-				</TouchableOpacity>
+					contentStyle={disabled ? styles.iconButtonDisabled : styles.iconButton}
+				>
+					<Icon name="md-trash" style={styles.topIcon} />
+				</ButtonWithTooltip>
 			);
 		}
 
-		function duplicateButton(styles, onPress, disabled) {
+		function duplicateButton(styles, onClick, disabled) {
 			return (
-				<TouchableOpacity
-					onPress={onPress}
+				<ButtonWithTooltip
+					onClick={onClick}
 					disabled={disabled}
 
-					accessibilityLabel={_('Duplicate')}
+					themeId={themeId}
+					description={_('Duplicate')}
 					accessibilityHint={
 						disabled ? null : _('Duplicate selected notes')
 					}
-					accessibilityRole="button">
-					<View style={disabled ? styles.iconButtonDisabled : styles.iconButton}>
-						<Icon name="md-copy" style={styles.topIcon} />
-					</View>
-				</TouchableOpacity>
+					contentStyle={disabled ? styles.iconButtonDisabled : styles.iconButton}
+				>
+					<Icon name="md-copy" style={styles.topIcon} />
+				</ButtonWithTooltip>
 			);
 		}
 
@@ -424,7 +431,6 @@ class ScreenHeaderComponent extends React.PureComponent {
 		}
 
 		const createTitleComponent = (disabled) => {
-			const themeId = Setting.value('theme');
 			const theme = themeStyle(themeId);
 			const folderPickerOptions = this.props.folderPickerOptions;
 


### PR DESCRIPTION
# Summary
 * Adds a long-press action to some buttons that displays a tooltip
 * See [the associated discussion](https://discourse.joplinapp.org/t/feature-request-tooltips-on-mobile/26700)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
