### PR TITLE
Desktop: Allow electron flag to disable smooth scrolling

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -277,6 +277,13 @@ export default class BaseApplication {
 				continue;
 			}
 
+			if (arg === '--disable-smooth-scrolling') {
+				// Electron-specific flag - ignore it
+				// Allows users to disable smooth scrolling
+				argv.splice(0, 1);
+				continue;
+			}
+
 			if (arg.length && arg[0] === '-') {
 				throw new JoplinError(_('Unknown flag: %s', arg), 'flagError');
 			} else {


### PR DESCRIPTION
Passthrough the electron flag to disable smooth scrolling.