### PR TITLE
Lib: joplin server recusive publishing

### DIFF
--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -61,6 +61,10 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 		return `${_('Joplin Server')} (Beta)`;
 	}
 
+	public static supportsRecursiveLinkedNotes(): boolean {
+		return true;
+	}
+	
 	public async isAuthenticated() {
 		return true;
 	}


### PR DESCRIPTION
Recursive publishing of notes is [already supported by joplin server](https://github.com/laurent22/joplin/commit/29a1cc). It should be available for clients.