### PR TITLE
Android: Fixes #6732: Don't reload the application on screen rotation

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -65,8 +65,7 @@
 			android:label="@string/app_name"
 			android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
 			android:launchMode="singleTask"
-			android:windowSoftInputMode="adjustResize"
-			android:exported="true">
+			android:windowSoftInputMode="adjustResize">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,11 @@
 					This is recommended in the React docs: https://reactnavigation.org/docs/deep-linking. In practice, "singleTask" and "singleTop" are
 					largely similar, but "singleTask" is more strict in preventing multiple instances of the app from being created if another app
 					explicitly requests it.
+
+		2022-08-12: Added `screenLayout` and `smallestScreenSize` to `android:configChanges`.
+					This prevents the application from being re-constructed on
+					screen orientation change/window resizes on some devices.
+					See https://github.com/laurent22/joplin/pull/6737.
 		-->
 
 		<activity

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.cozic.joplin"
-    android:installLocation="auto">
+	package="net.cozic.joplin"
+	android:installLocation="auto">
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -8,7 +8,7 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
-    <!-- Make these features optional to enable Chromebooks -->
+	<!-- Make these features optional to enable Chromebooks -->
 	<!-- https://github.com/laurent22/joplin/issues/37 -->
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
@@ -63,9 +63,10 @@
 		<activity
 			android:name=".MainActivity"
 			android:label="@string/app_name"
-			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
 			android:launchMode="singleTask"
-				android:windowSoftInputMode="adjustResize">
+			android:windowSoftInputMode="adjustResize"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -93,6 +94,6 @@
 		</activity>
 		<!-- /SHARE EXTENSION -->
 
-    </application>
+	</application>
 
 </manifest>


### PR DESCRIPTION
# Summary
 * This PR replaces `android:configChanges` with its value in a new-from-template `react-native` project. On my tablet, this resolves #6732.
 * The space-to-tab conversion on several lines is the result of opening `AndroidManifest.xml` in Android Studio.

# Testing plan
(On Android)
1. Deploy a copy of the app from AndroidStudio
2. Open a note
3. Enter edit mode
4. Rotate the screen

**On `origin/dev`**: On my tablet, after step 4, the app exits edit mode and scrolls to the top of the note (the app is partially reloaded). With this PR, the app stays in edit mode.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
