### PR TITLE
Desktop: Fixes #6719. Avoid reloading loaded plugins

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useExternalPlugins.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useExternalPlugins.ts
@@ -7,6 +7,8 @@ import uuid from '@joplin/lib/uuid';
 
 import { reg } from '@joplin/lib/registry';
 
+const loadedPluginIdSet = new Set<string>();
+
 export default function useExternalPlugins(CodeMirror: any, plugins: PluginStates) {
 
 	const [options, setOptions] = useState({});
@@ -17,6 +19,10 @@ export default function useExternalPlugins(CodeMirror: any, plugins: PluginState
 
 		for (const contentScript of contentScripts) {
 			try {
+				if (loadedPluginIdSet.has(contentScript.id)) {
+					continue;
+				}
+
 				const mod = contentScript.module;
 
 				if (mod.codeMirrorResources) {
@@ -64,6 +70,8 @@ export default function useExternalPlugins(CodeMirror: any, plugins: PluginState
 				if (mod.plugin) {
 					mod.plugin(CodeMirror);
 				}
+
+				loadedPluginIdSet.add(contentScript.id);
 			} catch (error) {
 				reg.logger().error(error.toString());
 			}


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

This PR fixes #6719. It ignores the loaded plugins to avoid duplicate css.

Tested with the following plugins:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/18042424/184463956-0e98cda2-8733-4d0c-84c6-2831fb2b7f2b.png">


Before:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/18042424/184463914-248ac600-48f1-40c4-9e78-65ecdd023a40.png">

After:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/18042424/184463921-41aa5a99-7ea4-41b6-bf06-82dc23719ca0.png">
