### PR TITLE
Desktop: Fixes #6724: Added fix to show search all with f6 when the note list is hidden

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/commands/focusSearch.ts
+++ b/packages/app-desktop/gui/NoteListControls/commands/focusSearch.ts
@@ -1,5 +1,8 @@
-import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
+import { AppState } from '../../../app.reducer';
+import setLayoutItemProps from '../../ResizableLayout/utils/setLayoutItemProps';
+import layoutItemProp from '../../ResizableLayout/utils/layoutItemProp';
 
 export const declaration: CommandDeclaration = {
 	name: 'focusSearch',
@@ -8,7 +11,25 @@ export const declaration: CommandDeclaration = {
 
 export const runtime = (searchBarRef: any): CommandRuntime => {
 	return {
-		execute: async () => {
+		execute: async (context: CommandContext) => {
+			const layout = (context.state as AppState).mainLayout;
+
+			if (!layoutItemProp(layout, 'noteList', 'visible')) {
+				const newLayout = setLayoutItemProps(layout, 'noteList', {
+					visible: true,
+				});
+
+				// Toggling the sidebar will affect the size of most other on-screen components.
+				// Dispatching a window resize event is a bit of a hack, but it ensures that any
+				// component that watches for resizes will be accurately notified
+				window.dispatchEvent(new Event('resize'));
+
+				context.dispatch({
+					type: 'MAIN_LAYOUT_SET',
+					value: newLayout,
+				});
+			}
+
 			if (searchBarRef.current) searchBarRef.current.select();
 		},
 	};


### PR DESCRIPTION
Fixes #6724

After:
![search all note list fix](https://user-images.githubusercontent.com/42903164/184474487-d0d0c280-26b3-433c-8b00-db5100f040e5.gif)

