### PR TITLE
Desktop: Fixes #6721: Fix exporting resources to md and md + frontmatter

### DIFF
--- a/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
@@ -446,7 +446,7 @@ describe('interop/InteropService_Exporter_Md', function() {
 		const resourceFilename = (await fs.readdir(`${exportDir()}/_resources`))[0];
 		expect(fileExtension(resourceFilename)).toBe('jpg');
 	}));
-	it('should replace spaces in resource name by underscores', (async () => {
+	it('should url encode resource links', (async () => {
 		const folder = await Folder.save({ title: 'testing' });
 		const note = await Note.save({ title: 'mynote', parent_id: folder.id });
 		await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);
@@ -461,8 +461,8 @@ describe('interop/InteropService_Exporter_Md', function() {
 			format: 'md',
 		});
 
-		const resourceFilename = (await fs.readdir(`${exportDir()}/_resources`))[0];
-		expect(resourceFilename).toBe('name_with_spaces.jpg');
+		const note_body = await shim.fsDriver().readFile(`${exportDir()}/testing/mynote.md`);
+		expect(note_body).toContain('[photo.jpg](../_resources/name%20with%20spaces.jpg)');
 	}));
 
 });

--- a/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
@@ -446,7 +446,7 @@ describe('interop/InteropService_Exporter_Md', function() {
 		const resourceFilename = (await fs.readdir(`${exportDir()}/_resources`))[0];
 		expect(fileExtension(resourceFilename)).toBe('jpg');
 	}));
-	it.only('should replace spaces in resource name by underscores', (async () => {
+	it('should replace spaces in resource name by underscores', (async () => {
 		const folder = await Folder.save({ title: 'testing' });
 		const note = await Note.save({ title: 'mynote', parent_id: folder.id });
 		await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);

--- a/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
@@ -446,5 +446,23 @@ describe('interop/InteropService_Exporter_Md', function() {
 		const resourceFilename = (await fs.readdir(`${exportDir()}/_resources`))[0];
 		expect(fileExtension(resourceFilename)).toBe('jpg');
 	}));
+	it.only('should replace spaces in resource name by underscores', (async () => {
+		const folder = await Folder.save({ title: 'testing' });
+		const note = await Note.save({ title: 'mynote', parent_id: folder.id });
+		await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);
+
+		const resource: ResourceEntity = (await Resource.all())[0];
+		await Resource.save({ id: resource.id, title: 'name with spaces.jpg' });
+
+		const service = InteropService.instance();
+
+		await service.export({
+			path: exportDir(),
+			format: 'md',
+		});
+
+		const resourceFilename = (await fs.readdir(`${exportDir()}/_resources`))[0];
+		expect(resourceFilename).toBe('name_with_spaces.jpg');
+	}));
 
 });

--- a/packages/lib/services/interop/InteropService_Exporter_Md.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.ts
@@ -51,7 +51,7 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 		const resourcePaths = this.context() && this.context().destResourcePaths ? this.context().destResourcePaths : {};
 
 		const createRelativePath = function(resourcePath: string) {
-			return markdownUtils.escapeLinkUrl(`${relativePathToRoot}_resources/${basename(resourcePath)}`);
+			return `${relativePathToRoot}_resources/${basename(resourcePath)}`;
 		};
 		return await this.replaceItemIdsByRelativePaths_(noteBody, linkedResourceIds, resourcePaths, createRelativePath);
 	}
@@ -72,7 +72,7 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 		for (let i = 0; i < linkedItemIds.length; i++) {
 			const id = linkedItemIds[i];
 			const itemPath = fn_createRelativePath(paths[id]);
-			newBody = newBody.replace(new RegExp(`:/${id}`, 'g'), itemPath);
+			newBody = newBody.replace(new RegExp(`:/${id}`, 'g'), markdownUtils.escapeLinkUrl(itemPath));
 		}
 
 		return newBody;

--- a/packages/lib/services/interop/InteropService_Exporter_Md.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.ts
@@ -51,7 +51,7 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 		const resourcePaths = this.context() && this.context().destResourcePaths ? this.context().destResourcePaths : {};
 
 		const createRelativePath = function(resourcePath: string) {
-			return `${relativePathToRoot}_resources/${basename(resourcePath)}`;
+			return markdownUtils.escapeLinkUrl(`${relativePathToRoot}_resources/${basename(resourcePath)}`);
 		};
 		return await this.replaceItemIdsByRelativePaths_(noteBody, linkedResourceIds, resourcePaths, createRelativePath);
 	}
@@ -145,9 +145,6 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 		} else if (resource.title) {
 			fileName = friendlySafeFilename(resource.title, null, true);
 		}
-
-		// Markdown link destination should not contain space characters
-		fileName = fileName.replace(/\s/g, '_');
 
 		// Fall back on the resource filename saved in the users resource folder
 		return fileName;

--- a/packages/lib/services/interop/InteropService_Exporter_Md.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.ts
@@ -147,7 +147,7 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 		}
 
 		// Markdown link destination should not contain space characters
-		fileName = fileName.replace(' ', '_');
+		fileName = fileName.replace(/\s/g, '_');
 
 		// Fall back on the resource filename saved in the users resource folder
 		return fileName;

--- a/packages/lib/services/interop/InteropService_Exporter_Md.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.ts
@@ -146,6 +146,9 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 			fileName = friendlySafeFilename(resource.title, null, true);
 		}
 
+		// Markdown link destination should not contain space characters
+		fileName = fileName.replace(' ', '_');
+
 		// Fall back on the resource filename saved in the users resource folder
 		return fileName;
 	}


### PR DESCRIPTION
Fixes #6721.
When exporting to Markdown or Markdown + Front Matter, resource filenames can contain spaces. However [markdown does not support spaces in links](https://github.github.com/gfm/#link-destination). When importing an exported file resources are not imported correctly.

We replace spaces by underscores to solve the issue.