### PR TITLE
Android: Beta editor: Enable spellcheck by default

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -302,7 +302,10 @@ export function initCodeMirror(
 				decoratorExtension,
 
 				EditorView.lineWrapping,
-				EditorView.contentAttributes.of({ autocapitalize: 'sentence' }),
+				EditorView.contentAttributes.of({
+					autocapitalize: 'sentence',
+					spellcheck: 'true',
+				}),
 				EditorView.updateListener.of((viewUpdate: ViewUpdate) => {
 					notifyDocChanged(viewUpdate);
 					notifySelectionChange(viewUpdate);


### PR DESCRIPTION
# Summary
 * Enables spellcheck in the beta editor
 * This seems to only cause red underlines to show up on Android — not iOS. I don't know why this is.
     * Disabling `contentEditable`, setting `spellcheck` to `true`, modifying the `aria-role` property, then re-enabling `contentEditable` in the iOS Safari developer tools (or some similar process) seemed to make the red underlines appear... A future PR may fix spellcheck in iOS. 

![](https://user-images.githubusercontent.com/46334387/186307389-4c9d35b5-0303-4127-a078-53c929601180.png)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
