### PR TITLE
Mobile: Tests: Fix occasional failure --- Force syntax tree generation after creating editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
@@ -1,13 +1,13 @@
 import { markdown } from '@codemirror/lang-markdown';
 import { GFM as GithubFlavoredMarkdownExt } from '@lezer/markdown';
-import { indentUnit } from '@codemirror/language';
+import { forceParsing, indentUnit } from '@codemirror/language';
 import { SelectionRange, EditorSelection, EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { MarkdownMathExtension } from './markdownMathParser';
 
 // Creates and returns a minimal editor with markdown extensions
 const createEditor = (initialText: string, initialSelection: SelectionRange): EditorView => {
-	return new EditorView({
+	const editor = new EditorView({
 		doc: initialText,
 		selection: EditorSelection.create([initialSelection]),
 		extensions: [
@@ -18,6 +18,9 @@ const createEditor = (initialText: string, initialSelection: SelectionRange): Ed
 			EditorState.tabSize.of(4),
 		],
 	});
+
+	forceParsing(editor);
+	return editor;
 };
 
 export default createEditor;


### PR DESCRIPTION
# Summary
 * Tests were occasionally failing ([CI example](https://github.com/laurent22/joplin/runs/8050843683?check_suite_focus=true#step:10:2707)) due to a race condition.
    * Some tests create the CodeMirror editor and rely on the existence of a full syntax tree. Because CodeMirror generates this syntax tree in the background, occasionally, that syntax tree would not exist, causing tests to fail.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
