### PR TITLE
Mobile: Add sync status icon

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -842,12 +842,12 @@ packages/app-mobile/components/BackButtonDialogBox.js.map
 packages/app-mobile/components/CameraView.d.ts
 packages/app-mobile/components/CameraView.js
 packages/app-mobile/components/CameraView.js.map
-packages/app-mobile/components/Dropdown.d.ts
-packages/app-mobile/components/Dropdown.js
-packages/app-mobile/components/Dropdown.js.map
 packages/app-mobile/components/CustomButton.d.ts
 packages/app-mobile/components/CustomButton.js
 packages/app-mobile/components/CustomButton.js.map
+packages/app-mobile/components/Dropdown.d.ts
+packages/app-mobile/components/Dropdown.js
+packages/app-mobile/components/Dropdown.js.map
 packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.d.ts
 packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.js
 packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.js.map
@@ -929,6 +929,9 @@ packages/app-mobile/components/SelectDateTimeDialog.js.map
 packages/app-mobile/components/SideMenu.d.ts
 packages/app-mobile/components/SideMenu.js
 packages/app-mobile/components/SideMenu.js.map
+packages/app-mobile/components/SyncStatusIcon.d.ts
+packages/app-mobile/components/SyncStatusIcon.js
+packages/app-mobile/components/SyncStatusIcon.js.map
 packages/app-mobile/components/getResponsiveValue.d.ts
 packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/getResponsiveValue.js.map
@@ -1148,6 +1151,9 @@ packages/lib/commands/synchronize.js.map
 packages/lib/components/EncryptionConfigScreen/utils.d.ts
 packages/lib/components/EncryptionConfigScreen/utils.js
 packages/lib/components/EncryptionConfigScreen/utils.js.map
+packages/lib/components/shared/synchronizeButtonPress.d.ts
+packages/lib/components/shared/synchronizeButtonPress.js
+packages/lib/components/shared/synchronizeButtonPress.js.map
 packages/lib/database-driver-better-sqlite.d.ts
 packages/lib/database-driver-better-sqlite.js
 packages/lib/database-driver-better-sqlite.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -918,6 +918,9 @@ packages/app-mobile/components/SelectDateTimeDialog.js.map
 packages/app-mobile/components/SideMenu.d.ts
 packages/app-mobile/components/SideMenu.js
 packages/app-mobile/components/SideMenu.js.map
+packages/app-mobile/components/SyncStatusIcon.d.ts
+packages/app-mobile/components/SyncStatusIcon.js
+packages/app-mobile/components/SyncStatusIcon.js.map
 packages/app-mobile/components/getResponsiveValue.d.ts
 packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/getResponsiveValue.js.map
@@ -1137,6 +1140,9 @@ packages/lib/commands/synchronize.js.map
 packages/lib/components/EncryptionConfigScreen/utils.d.ts
 packages/lib/components/EncryptionConfigScreen/utils.js
 packages/lib/components/EncryptionConfigScreen/utils.js.map
+packages/lib/components/shared/synchronizeButtonPress.d.ts
+packages/lib/components/shared/synchronizeButtonPress.js
+packages/lib/components/shared/synchronizeButtonPress.js.map
 packages/lib/database-driver-better-sqlite.d.ts
 packages/lib/database-driver-better-sqlite.js
 packages/lib/database-driver-better-sqlite.js.map

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { StyledRoot, StyledAddButton, StyledShareIcon, StyledHeader, StyledHeade
 import { ButtonLevel } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
 import InteropService from '@joplin/lib/services/interop/InteropService';
-import Synchronizer from '@joplin/lib/Synchronizer';
+import Synchronizer, { SyncReport } from '@joplin/lib/Synchronizer';
 import Setting from '@joplin/lib/models/Setting';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import InteropServiceHelper from '../../InteropServiceHelper';
@@ -46,7 +46,7 @@ interface Props {
 	selectedSmartFilterId: string;
 	decryptionWorker: any;
 	resourceFetcher: any;
-	syncReport: any;
+	syncReport: SyncReport;
 	tags: any[];
 	syncStarted: boolean;
 	plugins: PluginStates;

--- a/packages/app-mobile/components/ScreenHeader.tsx
+++ b/packages/app-mobile/components/ScreenHeader.tsx
@@ -1,7 +1,7 @@
 const React = require('react');
 
 import { connect } from 'react-redux';
-import { PureComponent, Component } from 'react';
+import { PureComponent, Component, ReactElement } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView, Dimensions, ViewStyle } from 'react-native';
 const Icon = require('react-native-vector-icons/Ionicons').default;
 const { BackButtonService } = require('../services/back-button.js');
@@ -70,6 +70,7 @@ interface ScreenHeaderProps {
 	showSearchButton?: boolean;
 	showContextMenuButton?: boolean;
 	showBackButton?: boolean;
+	syncStatusIcon?: ReactElement;
 
 	saveButtonDisabled?: boolean;
 	showSaveButton?: boolean;
@@ -644,6 +645,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 					{deleteButtonComp}
 					{duplicateButtonComp}
 					{sortButtonComp}
+					{this.props.syncStatusIcon ?? null}
 					{menuComp}
 				</View>
 				{warningComps}
@@ -656,7 +658,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		);
 	}
 
-	public static defaultProps: Partial<ScreenHeaderProps> ={
+	public static defaultProps: Partial<ScreenHeaderProps> = {
 		menuOptions: [],
 	};
 }

--- a/packages/app-mobile/components/SyncStatusIcon.tsx
+++ b/packages/app-mobile/components/SyncStatusIcon.tsx
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import { Alert, Animated, Easing, StyleSheet, View } from 'react-native';
+import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
+const Ionicon = require('react-native-vector-icons/Ionicons').default;
+const FontAwesomeIcon = require('react-native-vector-icons/FontAwesome5').default;
+
+import { connect } from 'react-redux';
+import { AnyAction } from 'redux';
+
+import { State } from '@joplin/lib/reducer';
+import { SyncReport } from '@joplin/lib/Synchronizer';
+import CustomButton from './CustomButton';
+import { _ } from '@joplin/lib/locale';
+import { themeStyle } from '@joplin/lib/theme';
+import synchronizeButtonPress from '@joplin/lib/components/shared/synchronizeButtonPress';
+
+type DispatchEventCallback = (eventName: AnyAction)=> void;
+
+interface Props {
+	syncStarted: boolean;
+	syncReport: SyncReport;
+	isOnMobileData: boolean;
+	syncOnlyOverWifi: boolean;
+	syncTarget: number;
+
+	themeId: number;
+	noteLastModifiedTimestamp: number|null;
+	dispatch: DispatchEventCallback;
+}
+
+const SyncStatusIconComponent = (props: Props) => {
+	const styles = useStyles(props.themeId);
+	const syncAnim = useRef(new Animated.Value(0)).current;
+
+	useEffect(() => {
+		if (props.syncStarted) {
+			Animated.loop(Animated.timing(syncAnim, {
+				toValue: 360,
+				duration: 5000,
+				easing: Easing.linear,
+				useNativeDriver: true,
+			})).start();
+		} else {
+			syncAnim.stopAnimation(_endValue => {
+				syncAnim.setValue(0);
+			});
+		}
+	}, [syncAnim, props.syncStarted]);
+
+
+	const hasErrors = useMemo(() => {
+		return props.syncReport.errors && props.syncReport.errors.length > 0;
+	}, [props.syncReport?.errors]);
+
+	const onSyncButtonPress = useCallback(async () => {
+		const hadErrors = hasErrors;
+		const status = await synchronizeButtonPress(props.syncStarted, props.dispatch);
+
+		if (hadErrors && status === 'error') {
+			const errorsListCopy = props.syncReport.errors.slice();
+			const errorMessage = errorsListCopy.reverse().map(error => error.toString()).join('\n');
+			Alert.alert(
+				_('Sync error'),
+				_('Error syncing:\n%s', errorMessage)
+			);
+		}
+	}, [props.syncStarted, props.syncReport, props.dispatch, hasErrors]);
+
+	const syncingIcon = useMemo(() =>
+		<Animated.View
+			style={{
+				transform: [{
+					rotate: syncAnim.interpolate({
+						inputRange: [0, 360],
+						outputRange: ['0deg', '360deg'],
+					}),
+				}],
+			}}
+		>
+			<FontAwesomeIcon
+				style={styles.innerIcon}
+				name="sync-alt"
+			/>
+		</Animated.View>
+	, [syncAnim, styles.innerIcon]);
+
+	const syncErrorIcon = useMemo(() =>
+		<FontAwesomeIcon
+			style={styles.innerIcon}
+			name="exclamation-circle"
+		/>
+	, [styles.innerIcon]);
+
+	const syncSuccessIcon = useMemo(() =>
+		<FontAwesomeIcon
+			style={styles.innerIcon}
+			name="check"
+		/>
+	, [styles.innerIcon]);
+
+	// Determine the inner/outer icons
+	const [innerIcon, outerIconName] = useMemo((): [ReactElement|null, string] => {
+		const defaultOuterIconName = 'cloud-outline';
+
+
+		if (props.isOnMobileData && props.syncOnlyOverWifi) {
+			return [null, 'cloud-offline-outline'];
+		}
+
+		if (props.syncStarted && !props.syncReport.cancelling) {
+			return [syncingIcon, defaultOuterIconName];
+		}
+
+		// Don't show information from the previous sync target.
+		const haveNewSyncTarget = (props.syncReport.syncTarget ?? props.syncTarget) !== props.syncTarget;
+		if (haveNewSyncTarget) {
+			return [null, 'cloud-upload-outline'];
+		}
+
+		if (props.syncReport.errors && props.syncReport.errors.length > 0) {
+			return [syncErrorIcon, defaultOuterIconName];
+		}
+
+		const changesPublished = (props.syncReport.startTime ?? 0) > (props.noteLastModifiedTimestamp ?? 0);
+		console.log(props.syncReport.startTime, props.noteLastModifiedTimestamp);
+		if (changesPublished) {
+			return [syncSuccessIcon, defaultOuterIconName];
+		} else {
+			return [null, 'cloud-upload-outline'];
+		}
+	}, [
+		props.isOnMobileData, props.syncOnlyOverWifi, props.syncStarted, props.syncReport, props.syncTarget,
+		props.noteLastModifiedTimestamp,
+
+		syncErrorIcon, syncSuccessIcon, syncingIcon,
+	]);
+
+	if (!props.syncTarget) {
+		return null;
+	}
+
+	return (
+		<CustomButton
+			themeId={props.themeId}
+			description={props.syncStarted ? _('Cancel sync') : _('Sync')}
+			onPress={onSyncButtonPress}
+		>
+			<Ionicon
+				style={{
+					...styles.icon,
+					zIndex: 0,
+				}}
+				name={outerIconName}
+			/>
+			<View
+				style={{
+					position: 'absolute',
+				}}
+			>
+				{innerIcon}
+			</View>
+		</CustomButton>
+	);
+};
+
+const useStyles = (themeId: number) => {
+	return useMemo(() => {
+		const theme = themeStyle(themeId);
+		const iconStyle = {
+			fontSize: 30,
+			color: theme.color,
+		};
+
+		return StyleSheet.create({
+			icon: iconStyle,
+			innerIcon: {
+				...iconStyle,
+				transform: [{
+					scale: 0.4,
+				}],
+			},
+		});
+	}, [themeId]);
+};
+
+const SyncStatusIcon = connect((state: State) => {
+	return {
+		syncStarted: state.syncStarted,
+		syncReport: state.syncReport,
+		themeId: state.settings.theme as number,
+		isOnMobileData: state.isOnMobileData,
+		syncOnlyOverWifi: state.settings['sync.mobileWifiOnly'],
+		syncTarget: state.settings['sync.target'],
+	};
+})(SyncStatusIconComponent);
+
+export default SyncStatusIcon;

--- a/packages/app-mobile/components/SyncStatusIcon.tsx
+++ b/packages/app-mobile/components/SyncStatusIcon.tsx
@@ -40,8 +40,8 @@ const SyncStatusIconComponent = (props: Props) => {
 				easing: Easing.linear,
 				useNativeDriver: true,
 			}));
-			animation.start();
 
+			animation.start();
 			return () => {
 				animation.stop();
 			};

--- a/packages/app-mobile/components/SyncStatusIcon.tsx
+++ b/packages/app-mobile/components/SyncStatusIcon.tsx
@@ -34,16 +34,23 @@ const SyncStatusIconComponent = (props: Props) => {
 
 	useEffect(() => {
 		if (props.syncStarted) {
-			Animated.loop(Animated.timing(syncAnim, {
+			const animation = Animated.loop(Animated.timing(syncAnim, {
 				toValue: 360,
 				duration: 5000,
 				easing: Easing.linear,
 				useNativeDriver: true,
-			})).start();
+			}));
+			animation.start();
+
+			return () => {
+				animation.stop();
+			};
 		} else {
 			syncAnim.stopAnimation(_endValue => {
 				syncAnim.setValue(0);
 			});
+
+			return () => { };
 		}
 	}, [syncAnim, props.syncStarted]);
 

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -46,6 +46,7 @@ import ShareExtension from '../../utils/ShareExtension.js';
 import CameraView from '../CameraView';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import Logger from '@joplin/lib/Logger';
+import SyncStatusIcon from '../SyncStatusIcon';
 const urlUtils = require('@joplin/lib/urlUtils');
 
 const emptyArray: any[] = [];
@@ -72,6 +73,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 			fromShare: false,
 			showCamera: false,
 			noteResources: {},
+			lastSaveScheduledTimestamp: null,
 
 			// HACK: For reasons I can't explain, when the WebView is present, the TextInput initially does not display (It's just a white rectangle with
 			// no visible text). It will only appear when tapping it or doing certain action like selecting text on the webview. The bug started to
@@ -510,6 +512,10 @@ class NoteScreenComponent extends BaseScreenComponent {
 	}
 
 	scheduleSave() {
+		this.setState({
+			lastSaveScheduledTimestamp: time.unixMs(),
+		});
+
 		this.saveActionQueue(this.state.note.id).push(this.makeSaveAction());
 	}
 
@@ -1192,6 +1198,10 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 		const noteTagDialog = !this.state.noteTagDialogShown ? null : <NoteTagsDialog onCloseRequested={this.noteTagDialog_closeRequested} />;
 
+		const syncStatusIcon = <SyncStatusIcon
+			noteLastModifiedTimestamp={this.state.lastSaveScheduledTimestamp}
+		/>;
+
 		return (
 			<View style={this.rootStyle(this.props.themeId).root}>
 				<ScreenHeader
@@ -1207,6 +1217,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					undoButtonDisabled={!this.state.undoRedoButtonState.canUndo && this.state.undoRedoButtonState.canRedo}
 					onUndoButtonPress={this.screenHeader_undoButtonPress}
 					onRedoButtonPress={this.screenHeader_redoButtonPress}
+					syncStatusIcon={syncStatusIcon}
 				/>
 				{titleComp}
 				{bodyComponent}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -47,6 +47,32 @@ function isCannotSyncError(error: any): boolean {
 	return false;
 }
 
+export interface SyncReport {
+	// Number of local items created/updated/deleted
+	createLocal?: number;
+	updateLocal?: number;
+	deleteLocal?: number;
+
+	// Number of remote items created/updated/deleted
+	createRemote?: number;
+	updateRemote?: number;
+	deleteRemote?: number;
+
+	fetchingTotal?: number;
+	fetchingProcessed?: number;
+
+	cancelling?: boolean;
+
+	// Timestamp (in ms) at which the sync finished/started
+	// Timestamps use time.unixMs()
+	completedTime?: number;
+	startTime?: number;
+
+	syncTarget?: number;
+
+	errors?: any[];
+}
+
 export default class Synchronizer {
 
 	public static verboseMode: boolean = true;
@@ -167,17 +193,17 @@ export default class Synchronizer {
 		}
 	}
 
-	private static reportHasErrors(report: any): boolean {
+	private static reportHasErrors(report: SyncReport): boolean {
 		return !!report && !!report.errors && !!report.errors.length;
 	}
 
-	private static completionTime(report: any): string {
+	private static completionTime(report: SyncReport): string {
 		const duration = report.completedTime - report.startTime;
 		if (duration > 1000) return `${Math.round(duration / 1000)}s`;
 		return `${duration}ms`;
 	}
 
-	static reportToLines(report: any) {
+	public static reportToLines(report: SyncReport) {
 		const lines = [];
 		if (report.createLocal) lines.push(_('Created local items: %d.', report.createLocal));
 		if (report.updateLocal) lines.push(_('Updated local items: %d.', report.updateLocal));
@@ -379,6 +405,7 @@ export default class Synchronizer {
 		const throwOnError = options.throwOnError === true;
 
 		const syncTargetId = this.api().syncTargetId();
+		this.progressReport_.syncTarget = syncTargetId;
 
 		this.syncTargetIsLocked_ = false;
 		this.cancelling_ = false;

--- a/packages/lib/components/shared/synchronizeButtonPress.ts
+++ b/packages/lib/components/shared/synchronizeButtonPress.ts
@@ -1,0 +1,64 @@
+import { AnyAction } from 'redux';
+import Setting from '../../models/Setting';
+const { reg } = require('../../registry');
+
+type OnDispatchCallback = (event: AnyAction)=> void;
+type ActionDescription = 'cancel' | 'init' | 'sync' | 'auth' | 'error';
+
+export const synchronizeButtonPress = async (
+	syncStarted: boolean,
+	dispatch: OnDispatchCallback
+): Promise<ActionDescription> => {
+	const action = syncStarted ? 'cancel' : 'start';
+
+	if (!Setting.value('sync.target')) {
+		dispatch({
+			type: 'SIDE_MENU_CLOSE',
+		});
+
+		dispatch({
+			type: 'NAV_GO',
+			routeName: 'Config',
+			sectionName: 'sync',
+		});
+
+		return 'init';
+	}
+
+	if (!(await reg.syncTarget().isAuthenticated())) {
+		if (reg.syncTarget().authRouteName()) {
+			dispatch({
+				type: 'NAV_GO',
+				routeName: reg.syncTarget().authRouteName(),
+			});
+			return 'auth';
+		}
+
+		reg.logger().error('Not authenticated with sync target - please check your credentials.');
+		return 'error';
+	}
+
+	let sync = null;
+	try {
+		sync = await reg.syncTarget().synchronizer();
+	} catch (error) {
+		reg.logger().error('Could not initialise synchroniser: ');
+		reg.logger().error(error);
+		error.message = `Could not initialise synchroniser: ${error.message}`;
+		dispatch({
+			type: 'SYNC_REPORT_UPDATE',
+			report: { errors: [error] },
+		});
+		return 'error';
+	}
+
+	if (action === 'cancel') {
+		sync.cancel();
+		return 'cancel';
+	} else {
+		reg.scheduleSync(0);
+		return 'sync';
+	}
+};
+
+export default synchronizeButtonPress;

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -7,6 +7,7 @@ import BaseModel from './BaseModel';
 import { Store } from 'redux';
 import { ProfileConfig } from './services/profileConfig/types';
 import * as ArrayUtils from './ArrayUtils';
+import { SyncReport } from './Synchronizer';
 const fastDeepEqual = require('fast-deep-equal');
 const { ALL_NOTES_FILTER_ID } = require('./reserved-ids');
 const { createSelectorCreator, defaultMemoize } = require('reselect');
@@ -73,7 +74,7 @@ export interface State {
 	screens: any;
 	historyCanGoBack: boolean;
 	syncStarted: boolean;
-	syncReport: any;
+	syncReport: SyncReport;
 	searchQuery: string;
 	settings: any;
 	sharedData: any;
@@ -96,6 +97,7 @@ export interface State {
 	hasEncryptedItems: boolean;
 	needApiAuth: boolean;
 	profileConfig: ProfileConfig;
+	isOnMobileData?: boolean;
 
 	// Extra reducer keys go here:
 	pluginService: PluginServiceState;


### PR DESCRIPTION
# Summary
 * [Feature discussion](https://discourse.joplinapp.org/t/mobile-display-sync-status-while-in-edit-view/27034/4)
 * Adds an icon button that shows whether changes made in the mobile editor haven't been synced to the server.

# Testing plan
1. In "configuration", disable syncing
2. Edit a note.
    - The "sync status" icon should be invisible
3. In "configuration", set a cloud service as the sync target
4. Open a note.
    - The sync icon should be a "push" icon before changes are made/have been pushed to the server 
5. Push the "sync" button
    - After syncing, the icon should contain a checkmark.
6. Edit the note
    - After making a change, but before syncing, the button should contain a "push icon" again 
7. Press the "sync" button
8. In "configuration", enable syncing with the filesystem, but with an empty/invalid output directory
9. Open a note and press the "sync" button.
    - After pressing the button once, the cloud should contain an exclamation point.
    - Attempting to sync again should display an error message.

# Screenshots

 - When up-to-date
     - ![Outlined cloud with a checkmark](https://user-images.githubusercontent.com/46334387/187069514-e276a3df-fa98-49b4-958e-a3e3d486c753.jpg)

 - While syncing
     - ![Outlined cloud with a 'syncing' symbol](https://user-images.githubusercontent.com/46334387/187069584-91b46c39-f531-4e60-ac44-caea330eb6cf.jpg)

 - When changes can be pushed
     - ![Outlined cloud with an upward-pointing arrow](https://user-images.githubusercontent.com/46334387/187069623-1e1f178b-5e91-4ecb-926e-55106aaadde1.jpg)

 - After sync errors
     - ![Outlined cloud containing an exclamation point](https://user-images.githubusercontent.com/46334387/187069659-1f447a7b-6fbc-4a02-8365-60b137dd3e29.jpg)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
