### PR TITLE
Android: Fixes #6779: Fixed android filesystem sync (resources)

### DIFF
--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/SafXModule.java
@@ -169,7 +169,10 @@ public class SafXModule extends ReactContextBaseJavaModule {
     try {
       DocumentFile doc = this.documentHelper.goToDocument(uriString, false, true);
       boolean result = doc.delete();
-      promise.resolve(result);
+      if (!result) {
+        throw new Exception("Failed to unlink file. Unknown error.");
+      }
+      promise.resolve(true);
     } catch (FileNotFoundException e) {
       promise.reject("ENOENT", e.getLocalizedMessage());
     } catch (SecurityException e) {

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/DocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/DocumentHelper.java
@@ -2,6 +2,7 @@ package com.reactnativesafx.utils;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.UriPermission;
 import android.net.Uri;
@@ -18,6 +19,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -378,6 +380,9 @@ public class DocumentHelper {
   public DocumentFile goToDocument(
       String unknownUriString, boolean createIfDirectoryNotExist, boolean includeLastSegment)
       throws SecurityException, IOException {
+    if (unknownUriString.startsWith(ContentResolver.SCHEME_FILE)) {
+      return DocumentFile.fromFile(new File(Uri.parse(unknownUriString).getPath()));
+    }
     String uriString = UriHelper.normalize(unknownUriString);
     String baseUri = "";
     String appendUri;
@@ -454,7 +459,7 @@ public class DocumentHelper {
   public void transferFile(
       String srcUri, String destUri, boolean replaceIfDestExists, boolean copy, Promise promise) {
     try {
-      DocumentFile srcDoc = this.goToDocument(srcUri, false, true);
+      DocumentFile srcDoc = this.goToDocument(UriHelper.getUnifiedUri(srcUri), false, true);
 
       if (srcDoc.isDirectory()) {
         throw new IllegalArgumentException("Cannot move directories");
@@ -462,7 +467,7 @@ public class DocumentHelper {
 
       DocumentFile destDoc;
       try {
-        destDoc = this.goToDocument(destUri, false, true);
+        destDoc = this.goToDocument(UriHelper.getUnifiedUri(destUri), false, true);
         if (!replaceIfDestExists) {
           throw new IOException("a document with the same name already exists in destination");
         }

--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/UriHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/UriHelper.java
@@ -1,5 +1,6 @@
 package com.reactnativesafx.utils;
 
+import android.content.ContentResolver;
 import android.net.Uri;
 import android.os.Build.VERSION_CODES;
 import androidx.annotation.RequiresApi;
@@ -32,5 +33,20 @@ public class UriHelper {
     // content://com.android.externalstorage.documents/tree/1707-3F0B/Ajoplin/locks/2_2_fa4f9801e9a545a58f1a6c5d3a7cfded.json
 
     return Uri.decode(normalize(uriString));
+  }
+
+  public static String getUnifiedUri(String uriString) throws Exception {
+    Uri uri = Uri.parse(uriString);
+    if (uri.getScheme() == null) {
+      uri = Uri.parse(ContentResolver.SCHEME_FILE+"://"+uriString);
+    } else if (!(uri.getScheme().equals(ContentResolver.SCHEME_FILE)  || uri.getScheme().equals(ContentResolver.SCHEME_CONTENT))) {
+      throw new Exception("Scheme not supported");
+    }
+
+    if (uri.getScheme() == null) {
+      throw new Exception("Invalid Uri: Cannot determine scheme");
+    }
+
+    return uri.toString();
   }
 }


### PR DESCRIPTION
Fixes #6779

It seems I had missed the retry part of `copy` function inside `fs-driver-rn.ts`, which were causing it to not return the proper error.

I also made sure its possible to copy files between scoped storage style and normal path style, but the functionality is limited to where the app has permission, which I assume it will work fine with joplin's use case. I tested adding a picture and syncing to make sure it works.

what concerns me more, is that the files still remain in the synced folder, even after the notes are deleted and synced. is this intended? 