### PR TITLE
All: Update yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "buildParallel": "yarn workspaces foreach --verbose --interlaced --parallel --jobs 2 run build && yarn run tsc",
+    "buildParallel": "yarn workspaces foreach --verbose --interlaced --parallel --jobs 2 --topological run build && yarn run tsc",
     "buildSequential": "yarn workspaces foreach --verbose --interlaced --topological run build && yarn run tsc",
     "buildApiDoc": "yarn workspace joplin start apidoc ../../readme/api/references/rest_api.md",
     "buildCommandIndex": "gulp buildCommandIndex",


### PR DESCRIPTION
## Fixes
An issue where a fresh `yarn install` after clone fails due to post-install steps not following proper order. This is related to this [PR comment](https://github.com/laurent22/joplin/pull/6748#issuecomment-1229452934). 
As also discussed in [discord](https://discord.com/channels/610762468960239627/978228113865588746/1013788179322634250).
```
➤ YN0000: [@joplin/app-desktop]: Copying packages/pdf-viewer/dist => packages/app-desktop/vendor/lib/@joplin/pdf-viewer
➤ YN0000: [@joplin/app-desktop]: withRetry: Failed calling function - will retry (0) [Error: ENOENT: no such file or directory, lstat '/home/dae/JoplinDev/cliedit/joplin/packages/pdf-viewer/dist'] {
➤ YN0000: [@joplin/app-desktop]:   errno: -2,
➤ YN0000: [@joplin/app-desktop]:   code: 'ENOENT',
➤ YN0000: [@joplin/app-desktop]:   syscall: 'lstat',
➤ YN0000: [@joplin/app-desktop]:   path: '/home/dae/JoplinDev/cliedit/joplin/packages/pdf-viewer/dist'
➤ YN0000: [@joplin/app-desktop]: }
```
To fix this I have added a new argument `--topological` to the `buildParallel` command that was previously only added to `buildSequential`.

### -t,--topological
> Run the command after all workspaces it depends on (regular) have finished.

Documentation for the argument is [here](https://yarnpkg.com/cli/workspaces/foreach).

## References
https://yarnpkg.com/cli/workspaces/foreach
https://github.com/yarnpkg/berry/issues/2046
https://github.com/laurent22/joplin/pull/6748

