### PR TITLE
Mobile: Android: Fixes #6802 — duplicate mousedown events intended for CodeMirror and make .preventDefault do nothing

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -344,6 +344,8 @@ export function initCodeMirror(
 
 	// HACK: 09/02/22: Work around https://github.com/laurent22/joplin/issues/6802 by creating a copy mousedown
 	//  event to stop the Editor from calling .preventDefault on the mouse event.
+	// TODO: Track the upstream issue at https://github.com/codemirror/dev/issues/935 and remove this workaround
+	//  when the upstream bug is fixed.
 	document.body.addEventListener('mousedown', (evt) => {
 		if (!evt.isTrusted) {
 			return;

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -342,6 +342,24 @@ export function initCodeMirror(
 		parent: parentElement,
 	});
 
+	// HACK: 09/02/22: Work around https://github.com/laurent22/joplin/issues/6802 by creating a copy mousedown
+	//  event to stop the Editor from calling .preventDefault on the mouse event.
+	document.body.addEventListener('mousedown', (evt) => {
+		if (!evt.isTrusted) {
+			return;
+		}
+
+		for (let current: Record<string, any> = evt.target; current; current = current.parentElement) {
+			if (current === editor.contentDOM) {
+				evt.stopPropagation();
+
+				const copyEvent = new Event('mousedown', evt);
+				editor.contentDOM.dispatchEvent(copyEvent);
+				return;
+			}
+		}
+	}, true);
+
 	const updateSearchQuery = (newState: SearchState) => {
 		const query = new SearchQuery({
 			search: newState.searchText,

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -343,7 +343,7 @@ export function initCodeMirror(
 	});
 
 	// HACK: 09/02/22: Work around https://github.com/laurent22/joplin/issues/6802 by creating a copy mousedown
-	//  event to stop the Editor from calling .preventDefault on the mouse event.
+	//  event to prevent the Editor's .preventDefault from making the context menu not appear.
 	// TODO: Track the upstream issue at https://github.com/codemirror/dev/issues/935 and remove this workaround
 	//  when the upstream bug is fixed.
 	document.body.addEventListener('mousedown', (evt) => {
@@ -351,6 +351,7 @@ export function initCodeMirror(
 			return;
 		}
 
+		// Walk up the tree -- is evt.target or any of its parent nodes the editor's input region?
 		for (let current: Record<string, any> = evt.target; current; current = current.parentElement) {
 			if (current === editor.contentDOM) {
 				evt.stopPropagation();

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/demo.html
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/demo.html
@@ -42,7 +42,7 @@
 				},
 			};
 
-			codeMirrorBundle.initCodeMirror(parent, initialText, settings);
+			window.cm = codeMirrorBundle.initCodeMirror(parent, initialText, settings);
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
# Summary
 * This is a workaround for the upstream bug https://github.com/codemirror/dev/issues/935 that prevents a context menu from showing up on Android.
 * This works by intercepting `mousedown` events, and re-firing a copy. Because this duplicate event was not triggered directly by a user, calling `.preventDefault` on it doesn't stop Android from displaying a context menu.

Resolves #6802

# Notes
 - [x] This still needs to be tested on iOS to make sure it doesn't break things.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
