### PR TITLE
Mobile: iOS: Resolves #6805: Add setting to reduce space below markdown toolbar

### DIFF
--- a/packages/app-mobile/components/NoteEditor/MarkdownToolbar/MarkdownToolbar.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownToolbar/MarkdownToolbar.tsx
@@ -1,7 +1,7 @@
 // A toolbar for the markdown editor.
 
 const React = require('react');
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { useMemo, useState, useCallback } from 'react';
 
 // See https://oblador.github.io/react-native-vector-icons/ for a list of
@@ -20,6 +20,7 @@ import { ButtonSpec, StyleSheetData } from './types';
 import Toolbar from './Toolbar';
 import { buttonSize } from './ToolbarButton';
 import { Theme } from '@joplin/lib/themes/type';
+import Setting from '@joplin/lib/models/Setting';
 
 type OnAttachCallback = ()=> void;
 
@@ -276,38 +277,41 @@ const MarkdownToolbar = (props: MarkdownToolbarProps) => {
 		themeId: props.editorSettings.themeId,
 	};
 
-	return (
-		<>
-			<Toolbar
-				styleSheet={styleData}
-				buttons={[
-					{
-						title: _('Formatting'),
-						items: inlineFormattingBtns,
-					},
-					{
-						title: _('Headers'),
-						items: headerButtons,
-					},
-					{
-						title: _('Lists'),
-						items: listButtons,
-					},
-					{
-						title: _('Actions'),
-						items: actionButtons,
-					},
-				]}
-			/>
+	// Work around views being incorrectly positioned due to the presence of a keyboard.
+	let keyboardHeightAdjustment = 0;
+	if (keyboardVisible) {
+		if (Setting.value('editor.mobile.removeSpaceBelowToolbar')) {
+			keyboardHeightAdjustment -= 14;
+		} else if (Platform.OS === 'ios') {
+			keyboardHeightAdjustment = 16;
+		}
+	}
 
-			<View style={{
-				// The keyboard on iOS can overlap the markdown toolbar.
-				// Add additional padding to prevent this.
-				height: (
-					Platform.OS === 'ios' && keyboardVisible ? 16 : 0
-				),
-			}}/>
-		</>
+	return (
+		<Toolbar
+			styleSheet={styleData}
+			style={{
+				marginBottom: keyboardHeightAdjustment,
+			}}
+			buttons={[
+				{
+					title: _('Formatting'),
+					items: inlineFormattingBtns,
+				},
+				{
+					title: _('Headers'),
+					items: headerButtons,
+				},
+				{
+					title: _('Lists'),
+					items: listButtons,
+				},
+				{
+					title: _('Actions'),
+					items: actionButtons,
+				},
+			]}
+		/>
 	);
 };
 
@@ -353,6 +357,7 @@ const useStyles = (styleProps: any, theme: Theme) => {
 			toolbarContainer: {
 				maxHeight: '65%',
 				flexShrink: 1,
+				marginBotton: -26,
 			},
 			toolbarContent: {
 				flexGrow: 1,

--- a/packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.tsx
@@ -2,7 +2,7 @@ const React = require('react');
 
 import { _ } from '@joplin/lib/locale';
 import { ReactElement, useCallback, useState } from 'react';
-import { AccessibilityInfo, LayoutChangeEvent, ScrollView, View } from 'react-native';
+import { AccessibilityInfo, LayoutChangeEvent, ScrollView, View, ViewStyle } from 'react-native';
 import ToggleOverflowButton from './ToggleOverflowButton';
 import ToolbarButton, { buttonSize } from './ToolbarButton';
 import ToolbarOverflowRows from './ToolbarOverflowRows';
@@ -11,6 +11,7 @@ import { ButtonGroup, ButtonSpec, StyleSheetData } from './types';
 interface ToolbarProps {
 	buttons: ButtonGroup[];
 	styleSheet: StyleSheetData;
+	style?: ViewStyle;
 }
 
 // Displays a list of buttons with an overflow menu.
@@ -101,6 +102,7 @@ const Toolbar = (props: ToolbarProps) => {
 				// container. As such, we can't base the container's width on the
 				// size of its content.
 				width: '100%',
+				...props.style,
 			}}
 			onLayout={onContainerLayout}
 		>

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1039,6 +1039,19 @@ class Setting extends BaseModel {
 				isGlobal: true,
 			},
 
+			'editor.mobile.removeSpaceBelowToolbar': {
+				value: false,
+				type: SettingItemType.Bool,
+				section: 'note',
+				public: true,
+				appTypes: [AppType.Mobile],
+				label: () => _('Move markdown toolbar closer to keyboard.'),
+				description: () =>
+					_('On some devices, the markdown toolbar is too far above the keyboard. When the keyboard is open, this setting brings the toolbar closer to the bottom of the screen.'),
+				storage: SettingStorage.File,
+				isGlobal: true,
+			},
+
 			newTodoFocus: {
 				value: 'title',
 				type: SettingItemType.String,


### PR DESCRIPTION
# Summary
On different devices, the markdown toolbar is a different distance above/below the keyboard. For example, on an iPhone 13 simulator, the toolbar is, by default, **below** the keyboard. On my iPhone SE, the toolbar is well above the keyboard by default.

This PR "fixes" this issue by adding a setting to toggle whether the toolbar is shifted up or down when a keyboard is visible.

I really don't like this solution.

Resolves #6805.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
