### PR TITLE
Mobile: Beta editor: Resolves #6808: Convert empty bolded regions to bold-italic regions

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/markdownCommands.test.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/markdownCommands.test.ts
@@ -55,6 +55,24 @@ describe('markdownCommands', () => {
 		expect(editor.state.doc.toString()).toBe('Testing...');
 	});
 
+	it('for a cursor, bolding, then italicizing, should produce a bold-italic region', () => {
+		const initialDocText = '';
+		const editor = createEditor(
+			initialDocText, EditorSelection.cursor(0)
+		);
+
+		toggleBolded(editor);
+		toggleItalicized(editor);
+		expect(editor.state.doc.toString()).toBe('******');
+
+		editor.dispatch(editor.state.replaceSelection('Test'));
+		expect(editor.state.doc.toString()).toBe('***Test***');
+
+		toggleItalicized(editor);
+		editor.dispatch(editor.state.replaceSelection(' Test'));
+		expect(editor.state.doc.toString()).toBe('***Test*** Test');
+	});
+
 	it('toggling math should both create and navigate out of math regions', () => {
 		const initialDocText = 'Testing... ';
 		const editor = createEditor(initialDocText, EditorSelection.cursor(initialDocText.length));

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/markdownCommands.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/markdownCommands.ts
@@ -27,7 +27,7 @@ export const toggleItalicized: Command = (view: EditorView): boolean => {
 	let handledBoldItalicRegion = false;
 
 	// Bold-italic regions' starting and ending patterns are similar to italicized regions.
-	// Use custom logic:
+	// Thus, we need additional logic to convert bold regions to bold-italic regions.
 	view.dispatch(view.state.changeByRange((sel: SelectionRange) => {
 		const changes: ChangeSpec[] = [];
 
@@ -55,7 +55,7 @@ export const toggleItalicized: Command = (view: EditorView): boolean => {
 					insert: '**',
 				});
 
-				// Move to the center of the bold-italic region:
+				// Move to the center of the bold-italic region (**|**** -> ***|***)
 				sel = EditorSelection.cursor(sel.to + 1);
 				handledBoldItalicRegion = true;
 			}


### PR DESCRIPTION
# Summary
 * Previously, pressing bold, then italic first created `**|**` (where `|` represents the cursor), then moved the cursor over one character (resulting in `***|*`).
 * This PR causes an empty bold region to become a bold-italic region after pressing the italicize button.

Resolves #6808

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
