### PR TITLE
Mobile: Fix unable to show multiple WebViews at once

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -36,6 +36,10 @@ type OnFileUpdateCallback = (event: SourceFileUpdateEvent)=> void;
 interface Props {
 	themeId: number;
 
+	// A name to be associated with the WebView (e.g. NoteEditor)
+	// This name should be unique.
+	webviewInstanceId: string;
+
 	// If HTML is still being loaded, [html] should be an empty string.
 	html: string;
 
@@ -81,7 +85,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	useEffect(() => {
 		let cancelled = false;
 		async function createHtmlFile() {
-			const tempFile = `${Setting.value('resourceDir')}/NoteEditor.html`;
+			const tempFile = `${Setting.value('resourceDir')}/${props.webviewInstanceId}.html`;
 			await shim.fsDriver().writeFile(tempFile, props.html, 'utf8');
 			if (cancelled) return;
 
@@ -110,7 +114,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 		return () => {
 			cancelled = true;
 		};
-	}, [props.html, props.onFileUpdate]);
+	}, [props.html, props.webviewInstanceId, props.onFileUpdate]);
 
 	// - `setSupportMultipleWindows` must be `true` for security reasons:
 	//   https://github.com/react-native-webview/react-native-webview/releases/tag/v11.0.0

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -89,6 +89,7 @@ export default function NoteBodyViewer(props: Props) {
 	return (
 		<View style={props.style}>
 			<ExtendedWebView
+				webviewInstanceId='NoteBodyViewer'
 				themeId={props.themeId}
 				style={webViewStyle}
 				html={html}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -374,6 +374,7 @@ function NoteEditor(props: Props, ref: any) {
 				...props.contentStyle,
 			}}>
 				<ExtendedWebView
+					webviewInstanceId='NoteEditor'
 					themeId={props.themeId}
 					ref={webviewRef}
 					html={html}


### PR DESCRIPTION
# Summary
 * Fixes an issue [reported on the Joplin forum](https://discourse.joplinapp.org/t/joplin-mobile-tablet-layout/25775/21?u=personalizedrefriger)

Before this PR, `ExtendedWebView` always wrote html to `NoteEditor.html`, regardless of what the WebView was being used for.

As a result, if multiple `ExtendedWebView`s were created at roughly the same time, all `ExtendedWebView`s would use the same file and thus display the same content.

# Other possible solutions
 * With this change, a `webviewInstanceId` is required to separate WebViews. An alternative solution would be to create a new temporary file for each instance of the WebView. If we do this, these temporary files would need to be cleaned up/deleted when exiting the application.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
