### PR TITLE
PDF viewer: Fix: Page Number box

### DIFF
--- a/packages/pdf-viewer/common.css
+++ b/packages/pdf-viewer/common.css
@@ -84,15 +84,3 @@ hr {
 [data-theme="dark"] .dark-bg {
 	background-color: rgb(54, 54, 54);
 }
-
-.page-canvas {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-}
-
-.textLayer {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-}


### PR DESCRIPTION
PR #6843 hid the pdf page number box.

## Before
![Screen Shot 2022-09-13 at 9 08 06 PM](https://user-images.githubusercontent.com/44570278/189946055-bceabaf1-a361-4900-9090-17e311b4aee4.png)


## After
![Screen Shot 2022-09-13 at 9 07 19 PM](https://user-images.githubusercontent.com/44570278/189946092-90c564e0-a95a-41b7-b29f-cfe02e1bcab7.png)

Removing these styles completely since page works well even without these and instead caused this issue.