### PR TITLE
Desktop: Resolves #5006: Prevent AppimageLauncher ask to intergrated

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -25,6 +25,7 @@ SILENT=false
 ALLOW_ROOT=false
 SHOW_CHANGELOG=false
 INCLUDE_PRE_RELEASE=false
+LAUNCHER_ENABLE=true
 
 print() {
     if [[ "${SILENT}" == false ]] ; then
@@ -54,6 +55,7 @@ showHelp() {
     print "\t" "--force" "\t" "Always download the latest version"
     print "\t" "--silent" "\t" "Don't print any output"
     print "\t" "--prerelease" "\t" "Check for new Versions including Pre-Releases" 
+    print "\t" "--launcher-disable" "\t" "Disable AppImage Launcher ask to integrate" 
 
     if [[ ! -z $1 ]]; then
         print "\n" "${COLOR_RED}ERROR: " "$*" "${COLOR_RESET}" "\n"
@@ -76,12 +78,13 @@ while getopts "${optspec}" OPT; do
     OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
   fi
   case "${OPT}" in
-    h | help )     showHelp ;;
-    allow-root )   ALLOW_ROOT=true ;;
-    silent )       SILENT=true ;;
-    force )        FORCE=true ;;
-    changelog )    SHOW_CHANGELOG=true ;;
-    prerelease )   INCLUDE_PRE_RELEASE=true ;;
+    h | help )          showHelp ;;
+    allow-root )        ALLOW_ROOT=true ;;
+    silent )            SILENT=true ;;
+    force )             FORCE=true ;;
+    changelog )         SHOW_CHANGELOG=true ;;
+    prerelease )        INCLUDE_PRE_RELEASE=true ;;
+    launcher-disable )  LAUNCHER_ENABLE=false ;;
     [^\?]* )       showHelp "Illegal option --${OPT}"; exit 2 ;;
     \? )           showHelp "Illegal option -${OPTARG}"; exit 2 ;;
   esac
@@ -206,6 +209,13 @@ then
 
     # On some systems this directory doesn't exist by default
     mkdir -p ~/.local/share/applications
+
+    # Disable AppImageLauncher's integrate
+    APPIMAGE_LAUNCHER_ENV=""
+    if [ !LAUNCHER_ENABLE ]
+    then
+      APPIMAGE_LAUNCHER_ENV="env APPIMAGELAUNCHER_DISABLE=TRUE"
+    fi
     
     # Tabs specifically, and not spaces, are needed for indentation with Bash heredocs
     cat >> ~/.local/share/applications/appimagekit-joplin.desktop <<-EOF
@@ -213,7 +223,7 @@ then
 	Encoding=UTF-8
 	Name=Joplin
 	Comment=Joplin for Desktop
-	Exec=env APPIMAGELAUNCHER_DISABLE=TRUE ${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
+	Exec=${APPIMAGE_LAUNCHER_ENV} ${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
 	Icon=joplin
 	StartupWMClass=Joplin
 	Type=Application

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -213,7 +213,7 @@ then
 	Encoding=UTF-8
 	Name=Joplin
 	Comment=Joplin for Desktop
-	Exec=${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
+	Exec=env APPIMAGELAUNCHER_DISABLE=TRUE ${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
 	Icon=joplin
 	StartupWMClass=Joplin
 	Type=Application

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -96,8 +96,7 @@
       "category": "Office",
       "desktop": {
         "Icon": "joplin",
-        "MimeType": "x-scheme-handler/joplin;",
-        "X-AppImage-Integrate": "false"
+        "MimeType": "x-scheme-handler/joplin;"
       },
       "target": "AppImage"
     },

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -96,7 +96,8 @@
       "category": "Office",
       "desktop": {
         "Icon": "joplin",
-        "MimeType": "x-scheme-handler/joplin;"
+        "MimeType": "x-scheme-handler/joplin;",
+        "X-AppImage-Integrate": "false"
       },
       "target": "AppImage"
     },


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

If we have [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) installed. When we launcher Joplin , the launcher ask for integrated or run once. The solution is from [issue of AppImage Launcher](https://github.com/TheAssassin/AppImageLauncher/issues/338#issuecomment-649001773) which add `X-AppImage-Integrate=false` in `.desktop` file

