### PR TITLE
Desktop: toolbar horizontal scroll

### DIFF
--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-member-accessibility */
 import ToolbarButton from './ToolbarButton/ToolbarButton';
 import ToggleEditorsButton, {
 	Value,
@@ -27,7 +26,8 @@ function ToolbarBaseComponent(Props: Props) {
 		window?.addEventListener('resize', () => {
 			setTimeout(() => {
 				if (
-					childRef.current?.clientWidth > parentRef.current?.clientWidth
+					childRef.current?.clientWidth >
+					parentRef.current?.clientWidth
 				) {
 					setHorizScroll(true);
 				} else {
@@ -104,24 +104,33 @@ function ToolbarBaseComponent(Props: Props) {
 			}
 		}
 	}
+
+	const children = [
+		<div style={groupStyle}>{leftItemComps}</div>,
+		<div style={groupStyle}>{centerItemComps}</div>,
+		<div
+			style={Object.assign({}, groupStyle, {
+				flex: 1,
+				justifyContent: 'flex-end',
+			})}
+		>
+			{rightItemComps}
+		</div>,
+	];
+
+	const childStyle = { display: 'flex' };
+
 	return (
 		<div className="editor-toolbar" ref={parentRef} style={style}>
-			{React.createElement(horizScroll ? HorizontalScroll : 'div', {
-				...(horizScroll ? { reverseScroll: true } : { ref: childRef }),
-				style: { display: 'flex' },
-				children: [
-					<div style={groupStyle}>{leftItemComps}</div>,
-					<div style={groupStyle}>{centerItemComps}</div>,
-					<div
-						style={Object.assign({}, groupStyle, {
-							flex: 1,
-							justifyContent: 'flex-end',
-						})}
-					>
-						{rightItemComps}
-					</div>,
-				],
-			})}
+			{horizScroll ? (
+				<HorizontalScroll reverseScroll style={childStyle}>
+					{children}
+				</HorizontalScroll>
+			) : (
+				<div ref={childRef} style={childStyle}>
+					{children}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -4,6 +4,7 @@ const React = require('react');
 const { connect } = require('react-redux');
 const { themeStyle } = require('@joplin/lib/theme');
 const ToolbarSpace = require('./ToolbarSpace.min.js');
+const HorizontalScroll = require('react-scroll-horizontal');
 
 interface Props {
 	themeId: number;
@@ -23,6 +24,7 @@ class ToolbarBaseComponent extends React.Component<Props, any> {
 			backgroundColor: theme.backgroundColor3,
 			padding: theme.toolbarPadding,
 			paddingRight: theme.mainPadding,
+			overflow: 'hidden',
 		}, this.props.style);
 
 		const groupStyle: any = {
@@ -71,15 +73,17 @@ class ToolbarBaseComponent extends React.Component<Props, any> {
 
 		return (
 			<div className="editor-toolbar" style={style}>
-				<div style={groupStyle}>
-					{leftItemComps}
-				</div>
-				<div style={groupStyle}>
-					{centerItemComps}
-				</div>
-				<div style={Object.assign({}, groupStyle, { flex: 1, justifyContent: 'flex-end' })}>
-					{rightItemComps}
-				</div>
+				<HorizontalScroll reverseScroll>
+					<div style={groupStyle}>
+						{leftItemComps}
+					</div>
+					<div style={groupStyle}>
+						{centerItemComps}
+					</div>
+					<div style={Object.assign({}, groupStyle, { flex: 1, justifyContent: 'flex-end' })}>
+						{rightItemComps}
+					</div>
+				</HorizontalScroll>
 			</div>
 		);
 	}

--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -25,13 +25,13 @@ function ToolbarBaseComponent(Props: Props) {
 			setHorizScroll(true);
 		}
 		window?.addEventListener('resize', () => {
-			if (
-				childRef.current?.clientWidth > parentRef.current?.clientWidth
-			) {
-				setHorizScroll(true);
-			} else {
-				setHorizScroll(false);
-				if (!childRef.current) {
+			setTimeout(() => {
+				if (
+					childRef.current?.clientWidth > parentRef.current?.clientWidth
+				) {
+					setHorizScroll(true);
+				} else {
+					setHorizScroll(false);
 					setTimeout(() => {
 						if (
 							childRef.current?.clientWidth >
@@ -41,7 +41,7 @@ function ToolbarBaseComponent(Props: Props) {
 						}
 					}, 0);
 				}
-			}
+			}, 0);
 		});
 	}, []);
 

--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -1,8 +1,11 @@
+/* eslint-disable @typescript-eslint/explicit-member-accessibility */
 import ToolbarButton from './ToolbarButton/ToolbarButton';
-import ToggleEditorsButton, { Value } from './ToggleEditorsButton/ToggleEditorsButton';
-const React = require('react');
-const { connect } = require('react-redux');
-const { themeStyle } = require('@joplin/lib/theme');
+import ToggleEditorsButton, {
+	Value,
+} from './ToggleEditorsButton/ToggleEditorsButton';
+import React = require('react');
+import { connect } from 'react-redux';
+import { themeStyle } from '@joplin/lib/theme';
 const ToolbarSpace = require('./ToolbarSpace.min.js');
 const HorizontalScroll = require('react-scroll-horizontal');
 
@@ -12,12 +15,39 @@ interface Props {
 	items: any[];
 }
 
-class ToolbarBaseComponent extends React.Component<Props, any> {
+function ToolbarBaseComponent(Props: Props) {
+	const parentRef = React.useRef<HTMLDivElement>(null);
+	const childRef = React.useRef<HTMLDivElement>(null);
+	const [horizScroll, setHorizScroll] = React.useState(false);
 
-	render() {
-		const theme = themeStyle(this.props.themeId);
+	React.useEffect(() => {
+		if (childRef.current?.clientWidth > parentRef.current?.clientWidth) {
+			setHorizScroll(true);
+		}
+		window?.addEventListener('resize', () => {
+			if (
+				childRef.current?.clientWidth > parentRef.current?.clientWidth
+			) {
+				setHorizScroll(true);
+			} else {
+				setHorizScroll(false);
+				if (!childRef.current) {
+					setTimeout(() => {
+						if (
+							childRef.current?.clientWidth >
+							parentRef.current?.clientWidth
+						) {
+							setHorizScroll(true);
+						}
+					}, 0);
+				}
+			}
+		});
+	}, []);
 
-		const style: any = Object.assign({
+	const theme = themeStyle(Props.themeId);
+	const style: any = Object.assign(
+		{
 			display: 'flex',
 			flexDirection: 'row',
 			boxSizing: 'border-box',
@@ -25,68 +55,75 @@ class ToolbarBaseComponent extends React.Component<Props, any> {
 			padding: theme.toolbarPadding,
 			paddingRight: theme.mainPadding,
 			overflow: 'hidden',
-		}, this.props.style);
-
-		const groupStyle: any = {
-			display: 'flex',
-			flexDirection: 'row',
-			boxSizing: 'border-box',
-		};
-
-		const leftItemComps: any[] = [];
-		const centerItemComps: any[] = [];
-		const rightItemComps: any[] = [];
-
-		if (this.props.items) {
-			for (let i = 0; i < this.props.items.length; i++) {
-				const o = this.props.items[i];
-				let key = o.iconName ? o.iconName : '';
-				key += o.title ? o.title : '';
-				key += o.name ? o.name : '';
-				const itemType = !('type' in o) ? 'button' : o.type;
-
-				if (!key) key = `${o.type}_${i}`;
-
-				const props = Object.assign(
-					{
-						key: key,
-						themeId: this.props.themeId,
-					},
-					o
-				);
-
-				if (o.name === 'toggleEditors') {
-					rightItemComps.push(<ToggleEditorsButton
+		},
+		Props.style
+	);
+	const groupStyle: any = {
+		display: 'flex',
+		flexDirection: 'row',
+		boxSizing: 'border-box',
+	};
+	const leftItemComps: any[] = [];
+	const centerItemComps: any[] = [];
+	const rightItemComps: any[] = [];
+	if (Props.items) {
+		for (let i = 0; i < Props.items.length; i++) {
+			const o = Props.items[i];
+			let key = o.iconName ? o.iconName : '';
+			key += o.title ? o.title : '';
+			key += o.name ? o.name : '';
+			const itemType = !('type' in o) ? 'button' : o.type;
+			if (!key) key = `${o.type}_${i}`;
+			const props = Object.assign(
+				{
+					key: key,
+					themeId: Props.themeId,
+				},
+				o
+			);
+			if (o.name === 'toggleEditors') {
+				rightItemComps.push(
+					<ToggleEditorsButton
 						key={o.name}
 						value={Value.Markdown}
-						themeId={this.props.themeId}
+						themeId={Props.themeId}
 						toolbarButtonInfo={o}
-					/>);
-				} else if (itemType === 'button') {
-					const target = ['historyForward', 'historyBackward', 'toggleExternalEditing'].includes(o.name) ? leftItemComps : centerItemComps;
-					target.push(<ToolbarButton {...props} />);
-				} else if (itemType === 'separator') {
-					centerItemComps.push(<ToolbarSpace {...props} />);
-				}
+					/>
+				);
+			} else if (itemType === 'button') {
+				const target = [
+					'historyForward',
+					'historyBackward',
+					'toggleExternalEditing',
+				].includes(o.name)
+					? leftItemComps
+					: centerItemComps;
+				target.push(<ToolbarButton {...props} />);
+			} else if (itemType === 'separator') {
+				centerItemComps.push(<ToolbarSpace {...props} />);
 			}
 		}
-
-		return (
-			<div className="editor-toolbar" style={style}>
-				<HorizontalScroll reverseScroll>
-					<div style={groupStyle}>
-						{leftItemComps}
-					</div>
-					<div style={groupStyle}>
-						{centerItemComps}
-					</div>
-					<div style={Object.assign({}, groupStyle, { flex: 1, justifyContent: 'flex-end' })}>
-						{rightItemComps}
-					</div>
-				</HorizontalScroll>
-			</div>
-		);
 	}
+	return (
+		<div className="editor-toolbar" ref={parentRef} style={style}>
+			{React.createElement(horizScroll ? HorizontalScroll : 'div', {
+				...(horizScroll ? { reverseScroll: true } : { ref: childRef }),
+				style: { display: 'flex' },
+				children: [
+					<div style={groupStyle}>{leftItemComps}</div>,
+					<div style={groupStyle}>{centerItemComps}</div>,
+					<div
+						style={Object.assign({}, groupStyle, {
+							flex: 1,
+							justifyContent: 'flex-end',
+						})}
+					>
+						{rightItemComps}
+					</div>,
+				],
+			})}
+		</div>
+	);
 }
 
 const mapStateToProps = (state: any) => {

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -69,6 +69,10 @@ a {
 	border: 1px solid rgba(0,160,255,0);
 }
 
+.editor-toolbar > .scroll-horizontal > div {
+	position: initial !important;
+}
+
 .icon-button:hover {
 	background-color: rgba(0,0,0,0.05) !important;
 	border: 1px solid rgba(0,0,0,0.10);

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -165,6 +165,7 @@
     "react-datetime": "^2.14.0",
     "react-dom": "16.9.0",
     "react-redux": "5.0.7",
+    "react-scroll-horizontal": "^1.6.6",
     "react-select": "^2.4.3",
     "react-toggle-button": "^2.2.0",
     "react-tooltip": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3867,6 +3867,7 @@ __metadata:
     react-datetime: ^2.14.0
     react-dom: 16.9.0
     react-redux: 5.0.7
+    react-scroll-horizontal: ^1.6.6
     react-select: ^2.4.3
     react-test-renderer: ^16.14.0
     react-toggle-button: ^2.2.0
@@ -28089,6 +28090,19 @@ __metadata:
   version: 0.4.3
   resolution: "react-refresh@npm:0.4.3"
   checksum: 58d3b899ede4c890b1d06a2d02254a77d1c0dea400be139940e47b1c451ff1c4cbb3ca5d0a9d6ee9574e570075ab6c1bef15e77b7270d4a6f571847d2b26f4fc
+  languageName: node
+  linkType: hard
+
+"react-scroll-horizontal@npm:^1.6.6":
+  version: 1.6.6
+  resolution: "react-scroll-horizontal@npm:1.6.6"
+  dependencies:
+    react-motion: ^0.5.2
+  peerDependencies:
+    prop-types: ^15.5.4
+    react: ^15.0.0 || ^16.0.0
+    react-dom: ^15.0.0 || ^16.0.0
+  checksum: 01bda478587927afc7f9aed25b26ea05e55d06e999ec9fee9f57e88c5ef0656338f1288d6f900eebdb624a2789f6ab80a178df23d29d80516c187e97c70f9c74
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Issue
The toolbar currently overflows if there are too many buttons, and at such situation the buttons hidden would be unusable.

# Reproduce

Zoom in until some buttons are hidden.

# Description
This PR aims to resolve the issue by enabling horizontal scrolling of the toolbar (just mouse, no scrollbar), in a way that allows us to access all of the buttons even if there is overflow.

# Demo
[Screencast 2022-09-24 22:16:58.webm](https://user-images.githubusercontent.com/91375035/192103495-7ee2e93e-f6f3-4925-84b3-cb53cab03dcb.webm)

