### PR TITLE
API: Fixes #6862 set todo related fields when adding or changing a todo

### DIFF
--- a/packages/lib/services/rest/Api.test.ts
+++ b/packages/lib/services/rest/Api.test.ts
@@ -299,7 +299,21 @@ describe('services_rest_Api', function() {
 			title: 'testing 4',
 			parent_id: f.id,
 			is_todo: '1',
+			todo_due: '2',
+			todo_completed: '3',
 		}));
+		expect(response.todo_due).toBe(2);
+		expect(response.todo_completed).toBe(3);
+
+		response = await api.route(RequestMethod.POST, 'notes', null, JSON.stringify({
+			title: 'testing 5',
+			parent_id: f.id,
+			is_todo: '0',
+			todo_due: '2',
+			todo_completed: '3',
+		}));
+		expect(response.todo_due).toBeUndefined();
+		expect(response.todo_completed).toBeUndefined();
 	}));
 
 	it('should create folders with supplied ID', (async () => {

--- a/packages/lib/services/rest/Api.test.ts
+++ b/packages/lib/services/rest/Api.test.ts
@@ -316,6 +316,22 @@ describe('services_rest_Api', function() {
 		expect(response.todo_completed).toBeUndefined();
 	}));
 
+	it('should not have todo properties when not a todo', (async () => {
+		let response = null;
+		const note = await Note.save({ title: 'some todo', is_todo: 1, todo_due: 2, todo_completed: 3 });
+		response = await api.route(RequestMethod.PUT, `notes/${note.id}`, null, JSON.stringify({
+			title: 'still a todo',
+		}));
+		expect(response.todo_due).toBe(2);
+		expect(response.todo_completed).toBe(3);
+
+		response = await api.route(RequestMethod.PUT, `notes/${note.id}`, null, JSON.stringify({
+			is_todo: 0,
+		}));
+		expect(response.todo_completed).toBe(0);
+		expect(response.todo_due).toBe(0);
+	}));
+
 	it('should create folders with supplied ID', (async () => {
 		const response = await api.route(RequestMethod.POST, 'folders', null, JSON.stringify({
 			id: '12345678123456781234567812345678',

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -414,6 +414,10 @@ export default async function(request: Request, id: string = null, link: string 
 
 		const newProps = request.bodyJson(readonlyProperties('PUT'));
 		if (!('user_updated_time' in newProps)) newProps.user_updated_time = timestamp;
+		if (newProps.is_todo === 0) {
+			newProps.todo_due = 0;
+			newProps.todo_completed = 0;
+		}
 
 		let newNote = {
 			...note,

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -103,11 +103,18 @@ async function requestNoteToNote(requestNote: any) {
 		output.parent_id = folder.id;
 	}
 
+	if ('is_todo' in requestNote) {
+		output.is_todo = Database.formatValue(Database.TYPE_INT, requestNote.is_todo);
+		if (output.is_todo === 1) {
+			if ('todo_due' in requestNote) output.todo_due = Database.formatValue(Database.TYPE_INT, requestNote.todo_due);
+			if ('todo_completed' in requestNote) output.todo_completed = Database.formatValue(Database.TYPE_INT, requestNote.todo_completed);
+		}
+	}
+
 	if ('source_url' in requestNote) output.source_url = requestNote.source_url;
 	if ('author' in requestNote) output.author = requestNote.author;
 	if ('user_updated_time' in requestNote) output.user_updated_time = Database.formatValue(Database.TYPE_INT, requestNote.user_updated_time);
 	if ('user_created_time' in requestNote) output.user_created_time = Database.formatValue(Database.TYPE_INT, requestNote.user_created_time);
-	if ('is_todo' in requestNote) output.is_todo = Database.formatValue(Database.TYPE_INT, requestNote.is_todo);
 	if ('markup_language' in requestNote) output.markup_language = Database.formatValue(Database.TYPE_INT, requestNote.markup_language);
 	if ('longitude' in requestNote) output.longitude = requestNote.longitude;
 	if ('latitude' in requestNote) output.latitude = requestNote.latitude;

--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -166,8 +166,8 @@ command | 16
 | author | text  |       |
 | source_url | text  | The full URL where the note comes from. |
 | is_todo | int   | Tells whether this note is a todo or not. |
-| todo_due | int   | When the todo is due. An alarm will be triggered on that date. |
-| todo_completed | int   | Tells whether todo is completed or not. This is a timestamp in milliseconds. |
+| todo_due | int   | When the todo is due. An alarm will be triggered on that date. Can only be used when `is_todo` is set to 1. |
+| todo_completed | int   | Tells whether todo is completed or not. This is a timestamp in milliseconds. Can only be used when `is_todo` is set to 1. |
 | source | text  |       |
 | source_application | text  |       |
 | application_data | text  |       |


### PR DESCRIPTION
- Set `todo_due` and `todo_completed` when adding a todo via the API. This fixes https://github.com/laurent22/joplin/issues/6862
- Set  `todo_due` and `todo_completed` when changing `is_todo`, to stay consistent with the behavior when adding a todo, and because those fields are only meant to be used in todos .
- Update the api docs to reflect these changes.


I don't know if it makes sense to only be able to set `todo_completed` if `todo_due` is set. So I haven't added checks for that. 