### PR TITLE
Mobile: Show client ID in log

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -500,7 +500,7 @@ async function initialize(dispatch: Function) {
 		await migrateMasterPassword();
 
 		if (!Setting.value('clientId')) Setting.setValue('clientId', uuid.create());
-		reg.logger.info(`Client ID: ${Setting.value('clientId')}`);
+		reg.logger().info(`Client ID: ${Setting.value('clientId')}`);
 
 		if (Setting.value('firstStart')) {
 			let locale = NativeModules.I18nManager.localeIdentifier;

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -500,6 +500,7 @@ async function initialize(dispatch: Function) {
 		await migrateMasterPassword();
 
 		if (!Setting.value('clientId')) Setting.setValue('clientId', uuid.create());
+		reg.logger.info(`Client ID: ${Setting.value('clientId')}`);
 
 		if (Setting.value('firstStart')) {
 			let locale = NativeModules.I18nManager.localeIdentifier;


### PR DESCRIPTION
The client ID is useful when debugging Synchronizer. 
[In the current code](https://github.com/laurent22/joplin/blob/afc34b44c84d18d3c7ff67b135a6f31b844f7037/packages/lib/BaseApplication.ts#L830), the desktop app shows client ID in log, but the mobile app doesn't. This PR will fix it.
