### PR TITLE
Desktop: Fixes #6257: Fixed the missing format when pasting text by Ctrl+V in TinyMCE

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1008,7 +1008,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);
 				} else { // Paste regular text
-					// event.clipboardData.getData('text/html') wraps the content with <html><body></body></html>, 
+					// event.clipboardData.getData('text/html') wraps the content with <html><body></body></html>,
 					// which seems to be not supported in editor.insertContent().
 					const pastedHtml = clipboard.readHTML();
 					if (pastedHtml) { // Handles HTML

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1008,7 +1008,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);
 				} else { // Paste regular text
-					const pastedHtml = event.clipboardData.getData('text/html');
+					// event.clipboardData.getData('text/html') will wrap the content with <html><body></body></html>, 
+					// which seems to be not supported in editor.insertContent().
+					const pastedHtml = clipboard.readHTML();
 					if (pastedHtml) { // Handles HTML
 						const modifiedHtml = await processPastedHtml(pastedHtml);
 						editor.insertContent(modifiedHtml);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1008,7 +1008,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);
 				} else { // Paste regular text
-					// event.clipboardData.getData('text/html') will wrap the content with <html><body></body></html>, 
+					// event.clipboardData.getData('text/html') wraps the content with <html><body></body></html>, 
 					// which seems to be not supported in editor.insertContent().
 					const pastedHtml = clipboard.readHTML();
 					if (pastedHtml) { // Handles HTML


### PR DESCRIPTION
This PR fixes #6257 by using `clipboard.readHTML()` instead of `event.clipboardData.getData('text/html')`


`event.clipboardData.getData('text/html')` wraps the content with `<html><body></body></html>`,  which seems to be not supported in `editor.insertContent()`. 
By contrast, the `clipboard.readHTML()` works fine.
This function is also used in https://github.com/laurent22/joplin/blob/ce02d4c94f6a35b436aac6a474e5c24443ce838c/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts#L166

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
