### PR TITLE
Desktop: Resolves #6882: Upgrade electron-window-state to 5.0.3

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -147,7 +147,7 @@
     "compare-versions": "^3.2.1",
     "countable": "^3.0.1",
     "debounce": "^1.2.0",
-    "electron-window-state": "^4.1.1",
+    "electron-window-state": "^5.0.3",
     "formatcoords": "^1.1.3",
     "fs-extra": "10.0.0",
     "highlight.js": "^10.2.1",


### PR DESCRIPTION
Resolves #6882
In electron-window-state 5.0.3 version, the author added a new function “windowWithinBounds”. 
This function is used to detect that the app window is in Bounds. If it exceeds bounds, the app window will be displayed on the primary display.

```
function windowWithinBounds(bounds) {
    return (
      state.x >= bounds.x &&
      state.y >= bounds.y &&
      state.x + state.width <= bounds.x + bounds.width &&
      state.y + state.height <= bounds.y + bounds.height
    );
  }

  function ensureWindowVisibleOnSomeDisplay() {
    const visible = screen.getAllDisplays().some(display => {
      return windowWithinBounds(display.bounds);
    });

    if (!visible) {
      // Window is partially or fully not visible now.
      // Reset it to safe defaults.
      return resetStateToDefault();
    }
  }
```
I have tested this version for compatibility. It works perfectly fine.