### PR TITLE
Mobile: Skip the network check if sync target is filesystem

### DIFF
--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -116,16 +116,16 @@ class Registry {
 					this.scheduleSyncId_ = null;
 					this.logger().info('Preparing scheduled sync');
 
-					if (doWifiConnectionCheck && Setting.value('sync.mobileWifiOnly') && this.isOnMobileData_) {
-						this.logger().info('Sync cancelled because we\'re on mobile data');
-						promiseResolve();
-						return;
-					}
-
 					const syncTargetId = Setting.value('sync.target');
 
 					if (!syncTargetId) {
 						this.logger().info('Sync cancelled - no sync target is selected.');
+						promiseResolve();
+						return;
+					}
+
+					if (syncTargetId != SyncTargetRegistry.nameToId('filesystem') && doWifiConnectionCheck && Setting.value('sync.mobileWifiOnly') && this.isOnMobileData_) {
+						this.logger().info('Sync cancelled because we\'re on mobile data');
 						promiseResolve();
 						return;
 					}

--- a/packages/lib/registry.ts
+++ b/packages/lib/registry.ts
@@ -124,7 +124,7 @@ class Registry {
 						return;
 					}
 
-					if (syncTargetId != SyncTargetRegistry.nameToId('filesystem') && doWifiConnectionCheck && Setting.value('sync.mobileWifiOnly') && this.isOnMobileData_) {
+					if (syncTargetId !== SyncTargetRegistry.nameToId('filesystem') && doWifiConnectionCheck && Setting.value('sync.mobileWifiOnly') && this.isOnMobileData_) {
 						this.logger().info('Sync cancelled because we\'re on mobile data');
 						promiseResolve();
 						return;


### PR DESCRIPTION
As mentioned in this [post](https://discourse.joplinapp.org/t/slow-first-time-sync-on-android/27651), if the sync target is filesystem, there is no need to check the network. This PR will fix this.
