### PR TITLE
Desktop: Resolves #6882: Upgrade electron-window-state to 5.0.3

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -147,7 +147,7 @@
     "compare-versions": "^3.2.1",
     "countable": "^3.0.1",
     "debounce": "^1.2.0",
-    "electron-window-state": "^4.1.1",
+    "electron-window-state": "^5.0.3",
     "formatcoords": "^1.1.3",
     "fs-extra": "10.0.0",
     "highlight.js": "^10.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,7 +4055,7 @@ __metadata:
     electron-builder: ^23.0.3
     electron-notarize: ^1.2.1
     electron-rebuild: ^3.2.7
-    electron-window-state: ^4.1.1
+    electron-window-state: ^5.0.3
     formatcoords: ^1.1.3
     fs-extra: 10.0.0
     glob: ^7.1.6
@@ -13430,7 +13430,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-equal@npm:^1.0.1, deep-equal@npm:~1.1.1":
+"deep-equal@npm:~1.0.1":
+  version: 1.0.1
+  resolution: "deep-equal@npm:1.0.1"
+  checksum: 5af8cbfcebf190491878a498caccc7dc9592f8ebd1685b976eacc3825619d222b5e929923163b92c4f414494e2b884f7ebf00c022e8198e8292deb70dd9785f4
+  languageName: node
+  linkType: hard
+
+"deep-equal@npm:~1.1.1":
   version: 1.1.1
   resolution: "deep-equal@npm:1.1.1"
   dependencies:
@@ -13441,13 +13448,6 @@ __metadata:
     object-keys: ^1.1.1
     regexp.prototype.flags: ^1.2.0
   checksum: f92686f2c5bcdf714a75a5fa7a9e47cb374a8ec9307e717b8d1ce61f56a75aaebf5619c2a12b8087a705b5a2f60d0292c35f8b58cb1f72e3268a3a15cab9f78d
-  languageName: node
-  linkType: hard
-
-"deep-equal@npm:~1.0.1":
-  version: 1.0.1
-  resolution: "deep-equal@npm:1.0.1"
-  checksum: 5af8cbfcebf190491878a498caccc7dc9592f8ebd1685b976eacc3825619d222b5e929923163b92c4f414494e2b884f7ebf00c022e8198e8292deb70dd9785f4
   languageName: node
   linkType: hard
 
@@ -14518,14 +14518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-window-state@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "electron-window-state@npm:4.1.1"
+"electron-window-state@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "electron-window-state@npm:5.0.3"
   dependencies:
-    deep-equal: ^1.0.1
-    jsonfile: ^2.2.3
+    jsonfile: ^4.0.0
     mkdirp: ^0.5.1
-  checksum: 442f71f798b61d3738bbe9273ee7db2e55ea1d9c6d6c15e44392f7966fadc41e2e3f8fe4ad88ea0f5df2580a0256c4d29b5e245dc1b3852cecffd8addd3bfe23
+  checksum: 955868c1db598cfb5111612c9df93f61b8999b339fb56cb37ba884a9141478feaef9e9b4d9e777079cdad80fb0bb64b61ae706c85f1f91ba5904f8596d30d7e9
   languageName: node
   linkType: hard
 
@@ -22431,7 +22430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^2.1.0, jsonfile@npm:^2.2.3":
+"jsonfile@npm:^2.1.0":
   version: 2.4.0
   resolution: "jsonfile@npm:2.4.0"
   dependencies:


### PR DESCRIPTION
Resolves #6882
In electron-window-state 5.0.3, the author added a new function “windowWithinBounds”.
This function is used to detect that the app window is in Bounds. If it exceeds bounds, the app window will be displayed on the primary display.

```
  function windowWithinBounds(bounds) {
    return (
      state.x >= bounds.x &&
      state.y >= bounds.y &&
      state.x + state.width <= bounds.x + bounds.width &&
      state.y + state.height <= bounds.y + bounds.height
    );
  }

  function ensureWindowVisibleOnSomeDisplay() {
    const visible = screen.getAllDisplays().some(display => {
      return windowWithinBounds(display.bounds);
    });

    if (!visible) {
      // Window is partially or fully not visible now.
      // Reset it to safe defaults.
      return resetStateToDefault();
    }
  }
```

I have tested this version for compatibility. It works perfectly fine.