### PR TITLE
All: Fixes #6838, #6914: Support non-ASCII characters in URL

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -68,8 +68,7 @@
     "stream-browserify": "^3.0.0",
     "string-natural-compare": "^2.0.2",
     "timers": "^0.1.1",
-    "url": "^0.11.0",
-    "valid-url": "^1.0.9"
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -4,7 +4,6 @@ const PoorManIntervals = require('@joplin/lib/PoorManIntervals').default;
 const RNFetchBlob = require('rn-fetch-blob').default;
 const { generateSecureRandom } = require('react-native-securerandom');
 const FsDriverRN = require('./fs-driver-rn').default;
-const urlValidator = require('valid-url');
 const { Buffer } = require('buffer');
 const { Linking, Platform } = require('react-native');
 const mimeUtils = require('@joplin/lib/mime-utils.js').mime;
@@ -88,8 +87,11 @@ function shimInit() {
 		// "http://ocloud. de" so detect if the URL is valid beforehand and
 		// throw a catchable error. Bug:
 		// https://github.com/facebook/react-native/issues/7436
-		const validatedUrl = urlValidator.isUri(url);
-		if (!validatedUrl) throw new Error(`Not a valid URL: ${url}`);
+		try {
+			const validateUrl = new URL(url);
+		} catch (error) {
+			throw new Error(`Not a valid URL: ${url}`);
+		}
 
 		return shim.fetchWithRetry(() => {
 			// If the request has a body and it's not a GET call, and it

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -87,9 +87,9 @@ function shimInit() {
 		// "http://ocloud. de" so detect if the URL is valid beforehand and
 		// throw a catchable error. Bug:
 		// https://github.com/facebook/react-native/issues/7436
-		try {
+		try { // Check if the url is valid
 			const validateUrl = new URL(url);
-		} catch (error) {
+		} catch (error) { // If the url is not valid, a TypeError will be thrown
 			throw new Error(`Not a valid URL: ${url}`);
 		}
 

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -87,8 +87,9 @@ function shimInit() {
 		// "http://ocloud. de" so detect if the URL is valid beforehand and
 		// throw a catchable error. Bug:
 		// https://github.com/facebook/react-native/issues/7436
+		let validatedUrl = '';
 		try { // Check if the url is valid
-			const validateUrl = new URL(url);
+			validatedUrl = new URL(url).href;
 		} catch (error) { // If the url is not valid, a TypeError will be thrown
 			throw new Error(`Not a valid URL: ${url}`);
 		}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -89,7 +89,6 @@
     "uglifycss": "0.0.29",
     "url-parse": "^1.4.7",
     "uuid": "^3.0.1",
-    "valid-url": "^1.0.9",
     "word-wrap": "^1.2.3",
     "xml2js": "^0.4.19"
   },

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -446,7 +446,7 @@ function shimInit(options = null) {
 
 	shim.fetch = async function(url, options = {}) {
 		try { // Check if the url is valid
-			const validateUrl = new URL(url);
+			new URL(url);
 		} catch (error) { // If the url is not valid, a TypeError will be thrown
 			throw new Error(`Not a valid URL: ${url}`);
 		}

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -445,9 +445,9 @@ function shimInit(options = null) {
 	};
 
 	shim.fetch = async function(url, options = {}) {
-		try {
+		try { // Check if the url is valid
 			const validateUrl = new URL(url);
-		} catch (error) {
+		} catch (error) { // If the url is not valid, a TypeError will be thrown
 			throw new Error(`Not a valid URL: ${url}`);
 		}
 		const resolvedProxyUrl = resolveProxyUrl(proxySettings.proxyUrl);

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -9,7 +9,6 @@ const FsDriverNode = require('./fs-driver-node').default;
 const mimeUtils = require('./mime-utils.js').mime;
 const Note = require('./models/Note').default;
 const Resource = require('./models/Resource').default;
-const urlValidator = require('valid-url');
 const { _ } = require('./locale');
 const http = require('http');
 const https = require('https');
@@ -446,8 +445,11 @@ function shimInit(options = null) {
 	};
 
 	shim.fetch = async function(url, options = {}) {
-		const validatedUrl = urlValidator.isUri(url);
-		if (!validatedUrl) throw new Error(`Not a valid URL: ${url}`);
+		try {
+			const validateUrl = new URL(url);
+		} catch (error) {
+			throw new Error(`Not a valid URL: ${url}`);
+		}
 		const resolvedProxyUrl = resolveProxyUrl(proxySettings.proxyUrl);
 		options.agent = (resolvedProxyUrl && proxySettings.proxyEnabled) ? shim.proxyAgent(url, resolvedProxyUrl) : null;
 		return shim.fetchWithRetry(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4193,7 +4193,6 @@ __metadata:
     typescript: ^4.7.4
     uglify-js: ^3.13.10
     url: ^0.11.0
-    valid-url: ^1.0.9
     webpack: ^5.74.0
   languageName: unknown
   linkType: soft
@@ -4327,7 +4326,6 @@ __metadata:
     uglifycss: 0.0.29
     url-parse: ^1.4.7
     uuid: ^3.0.1
-    valid-url: ^1.0.9
     word-wrap: ^1.2.3
     xml2js: ^0.4.19
   languageName: unknown
@@ -34435,13 +34433,6 @@ __metadata:
   dependencies:
     homedir-polyfill: ^1.0.1
   checksum: 193db08aa396d993da04d3d985450784aa0010f51613005d13ef97d7b2b9e1ba5aef04affa585037adece12de5ca532f6f5fc40288495eab55e2eebc201809d2
-  languageName: node
-  linkType: hard
-
-"valid-url@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "valid-url@npm:1.0.9"
-  checksum: 3ecb030559404441c2cf104cbabab8770efb0f36d117db03d1081052ef133015a68806148ce954bb4dd0b5c42c14b709a88783c93d66b0916cb67ba771c98702
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #6838
Fixes #6914
The package `valid-url` doesn't support URL with non-ASCII characters, which leads to issue #6838 and #6914. Not to mention that this package hasn't been updated for years.
This PR removes `isUri()`, then checks the url by trying to create a `URL` object and catching the potential error. 