### PR TITLE
All: Add SwissDisk sync target (based on WebDAV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A community maintained list of these distributions can be found here: [Unofficia
 - [Web Clipper](https://github.com/laurent22/joplin/blob/dev/readme/clipper.md) for Firefox and Chrome.
 - End To End Encryption (E2EE).
 - Note history (revisions).
-- Synchronisation with various services, including Nextcloud, Dropbox, WebDAV and OneDrive.
+- Synchronisation with various services, including Nextcloud, Dropbox, WebDAV (Such as SwissDisk) and OneDrive.
 - Offline first, so the entire data is always available on the device even without an internet connection.
 - Import Enex files (Evernote export format) and Markdown files.
 - Export JEX files (Joplin Export format) and raw files.

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -80,6 +80,7 @@ import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 const SyncTargetFilesystem = require('@joplin/lib/SyncTargetFilesystem.js');
 const SyncTargetNextcloud = require('@joplin/lib/SyncTargetNextcloud.js');
 const SyncTargetWebDAV = require('@joplin/lib/SyncTargetWebDAV.js');
+const SyncTargetSwissDisk = require('@joplin/lib/SyncTargetSwissDisk.js');
 const SyncTargetDropbox = require('@joplin/lib/SyncTargetDropbox.js');
 const SyncTargetAmazonS3 = require('@joplin/lib/SyncTargetAmazonS3.js');
 
@@ -87,6 +88,7 @@ SyncTargetRegistry.addClass(SyncTargetNone);
 SyncTargetRegistry.addClass(SyncTargetOneDrive);
 SyncTargetRegistry.addClass(SyncTargetNextcloud);
 SyncTargetRegistry.addClass(SyncTargetWebDAV);
+SyncTargetRegistry.addClass(SyncTargetSwissDisk);
 SyncTargetRegistry.addClass(SyncTargetDropbox);
 SyncTargetRegistry.addClass(SyncTargetFilesystem);
 SyncTargetRegistry.addClass(SyncTargetAmazonS3);

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -34,6 +34,7 @@ import SyncTargetRegistry from './SyncTargetRegistry';
 const SyncTargetFilesystem = require('./SyncTargetFilesystem.js');
 const SyncTargetNextcloud = require('./SyncTargetNextcloud.js');
 const SyncTargetWebDAV = require('./SyncTargetWebDAV.js');
+const SyncTargetSwissDisk = require('./SyncTargetSwissDisk.js');
 const SyncTargetDropbox = require('./SyncTargetDropbox.js');
 const SyncTargetAmazonS3 = require('./SyncTargetAmazonS3.js');
 import EncryptionService from './services/e2ee/EncryptionService';
@@ -764,6 +765,7 @@ export default class BaseApplication {
 		SyncTargetRegistry.addClass(SyncTargetOneDrive);
 		SyncTargetRegistry.addClass(SyncTargetNextcloud);
 		SyncTargetRegistry.addClass(SyncTargetWebDAV);
+		SyncTargetRegistry.addClass(SyncTargetSwissDisk);
 		SyncTargetRegistry.addClass(SyncTargetDropbox);
 		SyncTargetRegistry.addClass(SyncTargetAmazonS3);
 		SyncTargetRegistry.addClass(SyncTargetJoplinServer);

--- a/packages/lib/SyncTargetSwissDisk.js
+++ b/packages/lib/SyncTargetSwissDisk.js
@@ -1,0 +1,88 @@
+const BaseSyncTarget = require('./BaseSyncTarget').default;
+const { _ } = require('./locale');
+const Setting = require('./models/Setting').default;
+const { FileApi } = require('./file-api.js');
+const Synchronizer = require('./Synchronizer').default;
+const WebDavApi = require('./WebDavApi');
+const { FileApiDriverWebDav } = require('./file-api-driver-webdav');
+
+class SyncTargetSwissDisk extends BaseSyncTarget {
+	static id() {
+		return 11;
+	}
+
+	static supportsConfigCheck() {
+		return true;
+	}
+
+	static targetName() {
+		return 'swissdisk';
+	}
+
+	static label() {
+		return _('SwissDisk');
+	}
+
+	static description() {
+		return 'A secure encrypted file sync and share service.';
+	}
+
+	async isAuthenticated() {
+		return true;
+	}
+
+	static async newFileApi_(syncTargetId, options) {
+		const apiOptions = {
+			baseUrl: () => `https://disk.swissdisk.com/${options.username()}/${options.path()}`,
+			username: () => options.username(),
+			password: () => options.password(),
+			ignoreTlsErrors: () => options.ignoreTlsErrors(),
+		};
+
+		const api = new WebDavApi(apiOptions);
+		const driver = new FileApiDriverWebDav(api);
+		const fileApi = new FileApi('', driver);
+		fileApi.setSyncTargetId(syncTargetId);
+		return fileApi;
+	}
+
+	static async checkConfig(options) {
+		const fileApi = await SyncTargetSwissDisk.newFileApi_(SyncTargetSwissDisk.id(), options);
+		fileApi.requestRepeatCount_ = 0;
+
+		const output = {
+			ok: false,
+			errorMessage: '',
+		};
+
+		try {
+			const result = await fileApi.stat('');
+			if (!result) throw new Error(`SwissDisk directory not found: ${options.path()}`);
+			output.ok = true;
+		} catch (error) {
+			output.errorMessage = error.message;
+			if (error.code) output.errorMessage += ` (Code ${error.code})`;
+		}
+
+		return output;
+	}
+
+	async initFileApi() {
+		const fileApi = await SyncTargetSwissDisk.newFileApi_(SyncTargetSwissDisk.id(), {
+			path: () => Setting.value('sync.11.path'),
+			username: () => Setting.value('sync.11.username'),
+			password: () => Setting.value('sync.11.password'),
+			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),
+		});
+
+		fileApi.setLogger(this.logger());
+
+		return fileApi;
+	}
+
+	async initSynchronizer() {
+		return new Synchronizer(this.db(), await this.fileApi(), Setting.value('appType'));
+	}
+}
+
+module.exports = SyncTargetSwissDisk;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -712,6 +712,41 @@ class Setting extends BaseModel {
 				secure: true,
 			},
 
+			'sync.11.path': {
+				value: 'Joplin',
+				type: SettingItemType.String,
+				section: 'sync',
+				show: (settings: any) => {
+					return settings['sync.target'] === SyncTargetRegistry.nameToId('swissdisk');
+				},
+				public: true,
+				label: () => _('Directory on SwissDisk for Joplin files'),
+				description: () => emptyDirWarning,
+				storage: SettingStorage.File,
+			},
+			'sync.11.username': {
+				value: '',
+				type: SettingItemType.String,
+				section: 'sync',
+				show: (settings: any) => {
+					return settings['sync.target'] === SyncTargetRegistry.nameToId('swissdisk');
+				},
+				public: true,
+				label: () => _('SwissDisk username'),
+				storage: SettingStorage.File,
+			},
+			'sync.11.password': {
+				value: '',
+				type: SettingItemType.String,
+				section: 'sync',
+				show: (settings: any) => {
+					return settings['sync.target'] === SyncTargetRegistry.nameToId('swissdisk');
+				},
+				public: true,
+				label: () => _('SwissDisk password'),
+				secure: true,
+			},
+
 			'sync.5.syncTargets': { value: {}, type: SettingItemType.Object, public: false },
 
 			'sync.resourceDownloadMode': {
@@ -750,6 +785,7 @@ class Setting extends BaseModel {
 			'sync.8.context': { value: '', type: SettingItemType.String, public: false },
 			'sync.9.context': { value: '', type: SettingItemType.String, public: false },
 			'sync.10.context': { value: '', type: SettingItemType.String, public: false },
+			'sync.11.context': { value: '', type: SettingItemType.String, public: false },
 
 			'sync.maxConcurrentConnections': { value: 5, type: SettingItemType.Int, storage: SettingStorage.File, isGlobal: true, public: true, advanced: true, section: 'sync', label: () => _('Max concurrent connections'), minimum: 1, maximum: 20, step: 1 },
 
@@ -1416,6 +1452,7 @@ class Setting extends BaseModel {
 						[
 							SyncTargetRegistry.nameToId('nextcloud'),
 							SyncTargetRegistry.nameToId('webdav'),
+							SyncTargetRegistry.nameToId('swissdisk'),
 							SyncTargetRegistry.nameToId('joplinServer'),
 							// Needs to be enabled for Joplin Cloud too because
 							// some companies filter all traffic and swap TLS


### PR DESCRIPTION
One of the biggest support requests we get is "what's the WebDAV URL". This change aims to hide and hard code details that will never change so that SwissDisk users can have a simpler sync setup page.

Full disclosure, I own SwissDisk.