### PR TITLE
Android: Fix the failure of attaching documents

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -677,11 +677,11 @@ class NoteScreenComponent extends BaseScreenComponent {
 					dialogs.error(this, _('Unsupported image type: %s', mimeType));
 					return;
 				} else {
-					await shim.fsDriver().copy(localFilePath, targetPath);
+					await RNFS.copyFile(localFilePath, targetPath);
 
-					const stat = await shim.fsDriver().stat(targetPath);
+					const stat = await RNFS.stat(targetPath);
 					if (stat.size >= 200 * 1024 * 1024) {
-						await shim.fsDriver().remove(targetPath);
+						await RNFS.unlink(targetPath);
 						throw new Error('Resources larger than 200 MB are not currently supported as they may crash the mobile applications. The issue is being investigated and will be fixed at a later time.');
 					}
 				}


### PR DESCRIPTION
In the latest Android pre-release, Joplin cannot attach any types of files except images. The log shows Joplin doesn't have the permission.
```
"Could not attach file:", Error: You don't have read/write permission to access uri: content://com.android.providers.media.documents/documet/documentXXXX
```
In the code, the processes of attaching images and attaching other types of files are different. The former uses `react-native-fs` directly, the latter might use `react-native-saf-x`. To resolve this issue, I replaced some `shim.fsDriver().xx()` with corresponding `RNFS.xx()`
[Related forum topic](https://discourse.joplinapp.org/t/cannot-attaching-documents-not-images-in-v2-9-3-on-android/27709)