### PR TITLE
Desktop: Resolves #6167 Fixed Move to notebook's name ambiguity

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -17,15 +17,19 @@ export const runtime = (comp: any): CommandRuntime => {
 			const startFolders: any[] = [];
 			const maxDepth = 15;
 
-			const addOptions = (folders: any[], depth: number) => {
+			const addOptions = (folders: any[], depth: number, parentPath: String) => {
 				for (let i = 0; i < folders.length; i++) {
 					const folder = folders[i];
-					startFolders.push({ key: folder.id, value: folder.id, label: folder.title, indentDepth: depth });
-					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth);
+					startFolders.push({ key: folder.id, value: folder.id, label: (parentPath === '' ? folder.title : (parentPath + folder.title)), indentDepth: depth });
+					if (folder.children) {
+						parentPath = `${parentPath + folder.title} > `;
+						addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth, parentPath);
+						parentPath = '';
+					}
 				}
 			};
 
-			addOptions(folders, 0);
+			addOptions(folders, 0,'');
 
 			comp.setState({
 				promptOptions: {


### PR DESCRIPTION
Fixes/Resolves #6167 , Issue was that while using the `Move to notebook` the notebooks with same name were ambiguous as shown in the issue.

Fix now shows the entire path of notebook in the format specified in the issue so that notebooks with same name can be distinguished by their parent notebooks.

Before:
![154341192-8c86316e-9d00-46f9-aedd-e43779e14929](https://user-images.githubusercontent.com/61308264/197357034-68f3628d-9ad7-4c7f-ae7d-d062783bb476.png)

After:
![Screenshot 2022-10-22 235822](https://user-images.githubusercontent.com/61308264/197357046-51b2bad2-0c28-4b0f-978e-b0fba7d3dba8.png)

![Screenshot 2022-10-22 235728](https://user-images.githubusercontent.com/61308264/197357041-79ec3dbd-24b0-447a-8e84-1ead8d58a045.png)

It was fixed by using an extra parameter `parentPath` that stores the Parent's path of the current notebook. The fix follows the coding style mentioned in guidelines.

Tested with single notebook as well as multiple notebooks nested structure. Will add the bold/highlight **feature** in another PR.