### PR TITLE
Desktop: Fixes an error when importing a shortcut map and canceling the dialog

### DIFF
--- a/packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx
+++ b/packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx
@@ -56,7 +56,7 @@ export const KeymapConfigScreen = ({ themeId }: KeymapConfigScreenProps) => {
 			filters: [{ name: 'Joplin Keymaps (keymap-desktop.json)', extensions: ['json'] }],
 		});
 
-		if (filePath) {
+		if (filePath&&filePath.length!==0) {
 			const actualFilePath = filePath[0];
 			try {
 				const keymapFile = await shim.fsDriver().readFile(actualFilePath, 'utf-8');

--- a/packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx
+++ b/packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx
@@ -56,7 +56,7 @@ export const KeymapConfigScreen = ({ themeId }: KeymapConfigScreenProps) => {
 			filters: [{ name: 'Joplin Keymaps (keymap-desktop.json)', extensions: ['json'] }],
 		});
 
-		if (filePath&&filePath.length!==0) {
+		if (filePath && filePath.length !== 0) {
 			const actualFilePath = filePath[0];
 			try {
 				const keymapFile = await shim.fsDriver().readFile(actualFilePath, 'utf-8');


### PR DESCRIPTION
Fixed a bug where it showes an error dialog when clicking cancel on importing shortcuts
### Enviornment 
Platform: Win 10 x64

### Steps to reproduce
1-Go to options
2-Go to Shortcuts
3-Click import
4-Click Cancel

![err](https://user-images.githubusercontent.com/61756360/198724966-b617ed6d-24e3-4a71-bb1f-8f6171af0083.jpg)

### The fix
The fix is a one liner if the paths array is empty don't do anything
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
