### PR TITLE
Desktop: Ensure codemirror plugin options are loaded on notebook change

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useExternalPlugins.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useExternalPlugins.ts
@@ -19,9 +19,6 @@ export default function useExternalPlugins(CodeMirror: any, plugins: PluginState
 
 		for (const contentScript of contentScripts) {
 			try {
-				if (loadedPluginIdSet.has(contentScript.id)) {
-					continue;
-				}
 
 				const mod = contentScript.module;
 
@@ -38,6 +35,10 @@ export default function useExternalPlugins(CodeMirror: any, plugins: PluginState
 
 				if (mod.codeMirrorOptions) {
 					newOptions = Object.assign({}, newOptions, mod.codeMirrorOptions);
+				}
+
+				if (loadedPluginIdSet.has(contentScript.id)) {
+					continue;
 				}
 
 				if (mod.assets) {


### PR DESCRIPTION
There is an early stopping condition that prevents plugins from reloading css and from re-initializing, but it was also preventing the plugin options from being set. Some plugins (e.g. rich-markdown) rely on specific codemirror options always being set. The fix is to shift the early stopping condition further down so that the plugins options are loaded, but the plugin is not re-initialized and the css is not re-added.

The broader failure here is that the editor gets reset when switching notebooks causing codemirror to re-initialize without any of it's options set. The fix for that issue is in https://github.com/laurent22/joplin/pull/6430. I would recommend merging both these PRs to prevent issues like this one from cropping up again.

This is a followup to https://github.com/laurent22/joplin/pull/6742.

