### PR TITLE
[Desktop, Linux] Fix AppImage icon when installing using Joplin_install_and_update.sh

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -214,7 +214,7 @@ then
 	Name=Joplin
 	Comment=Joplin for Desktop
 	Exec=${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
-	Icon=joplin
+	Icon=@joplinapp-desktop
 	StartupWMClass=Joplin
 	Type=Application
 	Categories=Office;

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -95,7 +95,7 @@
       "icon": "../../Assets/LinuxIcons",
       "category": "Office",
       "desktop": {
-        "Icon": "joplin",
+        "Icon": "@joplinapp-desktop",
         "MimeType": "x-scheme-handler/joplin;"
       },
       "target": "AppImage"


### PR DESCRIPTION
See https://github.com/laurent22/joplin/issues/6596#issuecomment-1306370723

It does not help when the AppImage is integrated using AppImageLauncher (see my next comment on the above issue) but it should fix the icon when installed via the script.