### PR TITLE
Desktop: Fixes #7345: Fix translation in zh_CN.po

### DIFF
--- a/packages/tools/locales/zh_CN.po
+++ b/packages/tools/locales/zh_CN.po
@@ -2714,7 +2714,7 @@ msgstr "注意：笔记分享后，便不再在服务器上加密。"
 
 #: packages/app-desktop/gui/MenuBar.tsx:757
 msgid "Note&book"
-msgstr "笔记&笔记本"
+msgstr "笔记本 (&B)"
 
 #: packages/lib/models/Setting.ts:2402
 msgid "Notebook"


### PR DESCRIPTION
Fixes #7345
Change `笔记&笔记本` to `笔记本 (&B)`. The original translator might misunderstand the `&` there.