### PR TITLE
Mobile: Fix #7323 Tag filter is case sensetive

### DIFF
--- a/packages/app-mobile/components/screens/NoteTagsDialog.js
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.js
@@ -91,7 +91,7 @@ class NoteTagsDialogComponent extends React.Component {
 		};
 
 		this.filterTags = (allTags) => {
-			return allTags.filter((tag) => tag.title.includes(this.state.tagFilter.toLowerCase()), allTags);
+			return allTags.filter((tag) => tag.title.toLowerCase().includes(this.state.tagFilter.toLowerCase()), allTags);
 		};
 	}
 


### PR DESCRIPTION
The tag filter is currently case sensitive as discussed in #7323
Due to an ENEX import, mixed case tags may be present, for which it is then not possible to filter if the exact notation is not known.

<table>
  <tr>
     <th>Befor the change</th>
     <th>After the change</th>
  </tr>
  <tr>
     <td>
<img src="https://user-images.githubusercontent.com/24863925/204325409-daa87afe-b46c-479d-b0e6-2e3199fc1e15.png">
</td>
     <td>
<img src="https://user-images.githubusercontent.com/24863925/204325272-d1347190-d7ad-4250-9db7-93652d838adc.png">
</td>
  </tr>
</table>

Unfortunately I couldn't manage to convert the file to a tsx file. I got too many errors that I can't fix.
If a test is needed, I would need a little or bigger push in the right direction.