### PR TITLE
Mobile: Fixes #7360: Fix build error

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -61,7 +61,7 @@
     "react-native-vector-icons": "9.2.0",
     "react-native-version-info": "1.1.1",
     "react-native-webview": "11.25.0",
-    "react-redux": "8.0.5",
+    "react-redux": "7.2.8",
     "redux": "4.2.0",
     "rn-fetch-blob": "0.12.0",
     "stream": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,6 +2655,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.15.4":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.0.0, @babel/template@npm:^7.16.0, @babel/template@npm:^7.3.3":
   version: 7.16.0
   resolution: "@babel/template@npm:7.16.0"
@@ -4330,7 +4339,7 @@ __metadata:
     react-native-vector-icons: 9.2.0
     react-native-version-info: 1.1.1
     react-native-webview: 11.25.0
-    react-redux: 8.0.5
+    react-redux: 7.2.8
     redux: 4.2.0
     rn-fetch-blob: 0.12.0
     stream: 0.0.2
@@ -7231,7 +7240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-redux@npm:7.1.24":
+"@types/react-redux@npm:7.1.24, @types/react-redux@npm:^7.1.20":
   version: 7.1.24
   resolution: "@types/react-redux@npm:7.1.24"
   dependencies:
@@ -26251,7 +26260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.1":
+"react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
@@ -26615,6 +26624,27 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
   checksum: 2ebceace56f547f51eaf142becefef9cca980eae4f42d90ee5a966f54a375f5082d78b71b00c40bbd9bca69e0e0f698c7d4e81cc7373437caa19831fddc1d01b
+  languageName: node
+  linkType: hard
+
+"react-redux@npm:7.2.8":
+  version: 7.2.8
+  resolution: "react-redux@npm:7.2.8"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    "@types/react-redux": ^7.1.20
+    hoist-non-react-statics: ^3.3.2
+    loose-envify: ^1.4.0
+    prop-types: ^15.7.2
+    react-is: ^17.0.2
+  peerDependencies:
+    react: ^16.8.3 || ^17 || ^18
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: ecf1933e91013f2d41bfc781515b536bf81eb1f70ff228607841094c8330fe77d522372b359687e51c0b52b9888dba73db9ac0486aace1896ab9eb9daec102d5
   languageName: node
   linkType: hard
 
@@ -27127,6 +27157,13 @@ __metadata:
   version: 0.13.10
   resolution: "regenerator-runtime@npm:0.13.10"
   checksum: 09893f5a9e82932642d9a999716b6c626dc53ef2a01307c952ebbf8e011802360163a37c304c18a6c358548be5a72b448e37209954a18696f21e438c81cbb4b9
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
There's an issue with React 18 and redux support that's causing an error when you try to run both android and ios builds.

<details>
<summary>Error</summary>

```
 TypeError: dispatcher.useSyncExternalStore is not a function. (In 'dispatcher.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)', 'dispatcher.useSyncExternalStore' is undefined)

This error is located at:
    in Connect(AppComponent) (created by Root)
    in Provider (created by Root)
    in Root (at renderApplication.js:50)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:92)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:119)
    in AppContainer (at renderApplication.js:43)
    in Joplin(RootComponent) (at renderApplication.js:60)
 ERROR  TypeError: dispatcher.useSyncExternalStore is not a function. (In 'dispatcher.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)', 'dispatcher.useSyncExternalStore' is undefined)

This error is located at:
    in Connect(AppComponent) (created by Root)
    in Provider (created by Root)
    in Root (at renderApplication.js:50)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:92)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:119)
    in AppContainer (at renderApplication.js:43)
    in Joplin(RootComponent) (at renderApplication.js:60)
```

</details>

I fixed this by downgrading `react-redux` to version `7.2.8`

Reference: [Stack Overflow Solution](https://stackoverflow.com/a/72112470/10840670)