### PR TITLE
Mobile: Tests: Markdown math tests: Fix code formatting

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
@@ -5,11 +5,12 @@ import { SelectionRange, EditorSelection, EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view';
 import { MarkdownMathExtension } from './markdownMathParser';
 
-// Creates and returns a minimal editor with markdown extensions
-const createEditor = (initialText: string, initialSelection: SelectionRange): EditorView => {
+// Creates and returns a minimal editor with markdown math and GFM extensions
+const createEditor = (initialText: string, initialSelection?: SelectionRange): EditorView => {
+	const selection = initialSelection ? EditorSelection.create([initialSelection]) : undefined;
 	const editor = new EditorView({
 		doc: initialText,
-		selection: EditorSelection.create([initialSelection]),
+		selection,
 		extensions: [
 			markdown({
 				extensions: [MarkdownMathExtension, GithubFlavoredMarkdownExt],

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/createEditor.ts
@@ -5,12 +5,11 @@ import { SelectionRange, EditorSelection, EditorState } from '@codemirror/state'
 import { EditorView } from '@codemirror/view';
 import { MarkdownMathExtension } from './markdownMathParser';
 
-// Creates and returns a minimal editor with markdown math and GFM extensions
-const createEditor = (initialText: string, initialSelection?: SelectionRange): EditorView => {
-	const selection = initialSelection ? EditorSelection.create([initialSelection]) : undefined;
+// Creates and returns a minimal editor with markdown extensions
+const createEditor = (initialText: string, initialSelection: SelectionRange): EditorView => {
 	const editor = new EditorView({
 		doc: initialText,
-		selection,
+		selection: EditorSelection.create([initialSelection]),
 		extensions: [
 			markdown({
 				extensions: [MarkdownMathExtension, GithubFlavoredMarkdownExt],

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
@@ -7,6 +7,18 @@ import { markdown } from '@codemirror/lang-markdown';
 
 const syntaxTreeCreateTimeout = 100; // ms
 
+// Creates an EditorState with math and markdown extensions
+const createEditorState = (initialText: string): EditorState => {
+	return EditorState.create({
+		doc: initialText,
+		extensions: [
+			markdown({
+				extensions: [MarkdownMathExtension, GithubFlavoredMarkdownExt],
+			}),
+		],
+	});
+};
+
 // Returns a list of all nodes with the given name in the given editor's syntax tree.
 // Attempts to create the syntax tree if it doesn't exist.
 const findNodesWithName = (editor: EditorState, nodeName: string) => {
@@ -20,18 +32,6 @@ const findNodesWithName = (editor: EditorState, nodeName: string) => {
 	});
 
 	return result;
-};
-
-// Creates an EditorState with math and markdown extensions
-const createEditorState = (initialText: string): EditorState => {
-	return EditorState.create({
-		doc: initialText,
-		extensions: [
-			markdown({
-				extensions: [MarkdownMathExtension, GithubFlavoredMarkdownExt],
-			}),
-		],
-	});
 };
 
 describe('markdownMathParser', () => {


### PR DESCRIPTION
# Summary
Refactors markdown math tests to follow the style guide.

# Details
This updates the tests for code that marks text between `$`s and `$$`s as math.

Previously, this file used JSDoc-style comments, nested describes, and didn't use "should ..."-style sentences for test descriptions.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
