### PR TITLE
Mobile/CodeMirror: Increase ensureSyntaxTree timeout in math tests

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
@@ -5,7 +5,7 @@ import { EditorState } from '@codemirror/state';
 import { blockMathTagName, inlineMathContentTagName, inlineMathTagName, MarkdownMathExtension } from './markdownMathParser';
 import { GFM as GithubFlavoredMarkdownExt } from '@lezer/markdown';
 
-const syntaxTreeCreateTimeout = 100; // ms
+const syntaxTreeCreateTimeout = 500; // ms
 
 /** Create an EditorState with markdown extensions */
 const createEditorState = (initialText: string): EditorState => {

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/markdownMathParser.test.ts
@@ -5,8 +5,6 @@ import { EditorState } from '@codemirror/state';
 import { blockMathTagName, inlineMathContentTagName, inlineMathTagName, MarkdownMathExtension } from './markdownMathParser';
 import { GFM as GithubFlavoredMarkdownExt } from '@lezer/markdown';
 
-const syntaxTreeCreateTimeout = 500; // ms
-
 /** Create an EditorState with markdown extensions */
 const createEditorState = (initialText: string): EditorState => {
 	return EditorState.create({
@@ -25,7 +23,9 @@ const createEditorState = (initialText: string): EditorState => {
  */
 const findNodesWithName = (editor: EditorState, nodeName: string) => {
 	const result: SyntaxNode[] = [];
-	ensureSyntaxTree(editor, syntaxTreeCreateTimeout)?.iterate({
+	const syntaxTreeCreateTimeout = 500; // ms
+
+	ensureSyntaxTree(editor, editor.doc.length, syntaxTreeCreateTimeout)?.iterate({
 		enter: (node) => {
 			if (node.name === nodeName) {
 				result.push(node.node);


### PR DESCRIPTION
Addresses https://github.com/laurent22/joplin/pull/7386#issuecomment-1336444703.

Tests related to the syntax tree that were passing locally were observed to fail in CI. This can happen if `ensureSyntaxTree` is unable to finish parsing the syntax tree. Thus, `syntaxTreeCreateTimeout` is increased by several hundred milliseconds.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
