### PR TITLE
Desktop: Fixes 7434: Encode file path uri in addPluginAssets

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -347,7 +347,6 @@
 				setPercentScroll(event.options.percent);
 			}
 
-			console.log(event.options)
 			addPluginAssets(event.options.pluginAssets);
 
 			if (event.options.downloadResources === 'manual') {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -158,18 +158,11 @@
 
 			for (let i = 0; i < assets.length; i++) {
 				const asset = assets[i];
-				// encode everything that encodeURIComponent does, except forward slash
-				// since these chars might be used in file paths, and shouldn't be treated as special characters
-				const encodedPath = encodeURI(asset.path)
+				// # and ? can be used in valid paths and shouldn't be treated as the start of a query or fragment
+				const encodedPath = asset.path
 						.replaceAll('#','%23')
-						.replaceAll('$','%24')
-						.replaceAll('+','%2B')
-						.replaceAll(',','%2C')
-						.replaceAll(':','%3A')
-						.replaceAll(';','%3B')
-						.replaceAll('=','%3D')
 						.replaceAll('?','%3F')
-						.replaceAll('@','%40')
+
 				const assetId = asset.name ? asset.name : encodedPath;
 				if (pluginAssetsAdded_[assetId]) continue;
 				pluginAssetsAdded_[assetId] = true;

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -158,19 +158,30 @@
 
 			for (let i = 0; i < assets.length; i++) {
 				const asset = assets[i];
-
-				const assetId = asset.name ? asset.name : asset.path;
+				// encode everything that encodeURIComponent does, except forward slash
+				// since these chars might be used in file paths, and shouldn't be treated as special characters
+				const encodedPath = encodeURI(asset.path)
+						.replaceAll('#','%23')
+						.replaceAll('$','%24')
+						.replaceAll('+','%2B')
+						.replaceAll(',','%2C')
+						.replaceAll(':','%3A')
+						.replaceAll(';','%3B')
+						.replaceAll('=','%3D')
+						.replaceAll('?','%3F')
+						.replaceAll('@','%40')
+				const assetId = asset.name ? asset.name : encodedPath;
 				if (pluginAssetsAdded_[assetId]) continue;
 				pluginAssetsAdded_[assetId] = true;
 
 				if (asset.mime === 'application/javascript') {
 					const script = document.createElement('script');
-					script.src = asset.path;
+					script.src = encodedPath;
 					pluginAssetsContainer.appendChild(script);
 				} else if (asset.mime === 'text/css') {
 					const link = document.createElement('link');
 					link.rel = 'stylesheet';
-					link.href = asset.path;
+					link.href = encodedPath
 					pluginAssetsContainer.appendChild(link);
 				}
 			}
@@ -343,6 +354,7 @@
 				setPercentScroll(event.options.percent);
 			}
 
+			console.log(event.options)
 			addPluginAssets(event.options.pluginAssets);
 
 			if (event.options.downloadResources === 'manual') {


### PR DESCRIPTION
Encoded all off the special characters, except for `/`,  of the file paths in `addPluginAssets` so they don't' get a special treatment  (e.g. removing everything after a `#` when loading the stylesheet, like happened in https://github.com/laurent22/joplin/issues/7434)

I'm not sure how to add tests for this, but I've tested this manually in Linux by changing the id of the current profile so it contains these characters.