### PR TITLE
Desktop, Linux: Use XDG_DATA_HOME for the .desktop file on linux

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -202,15 +202,15 @@ fi
 if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.*|.*sway.* ]] || [[ `command -v update-desktop-database` ]]
 then
     DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
-    DESKTOP_FILE_LOCATION=$DATA_HOME/applications
+    DESKTOP_FILE_LOCATION="$DATA_HOME/applications"
     # Only delete the desktop file if it will be replaced
-    rm -f $DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop
+    rm -f "$DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop"
 
     # On some systems this directory doesn't exist by default
-    mkdir -p $DESKTOP_FILE_LOCATION
+    mkdir -p "$DESKTOP_FILE_LOCATION"
     
     # Tabs specifically, and not spaces, are needed for indentation with Bash heredocs
-    cat >> $DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop <<-EOF
+    cat >> "$DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop" <<-EOF
 	[Desktop Entry]
 	Encoding=UTF-8
 	Name=Joplin
@@ -226,7 +226,7 @@ then
 	EOF
     
     # Update application icons
-    [[ `command -v update-desktop-database` ]] && update-desktop-database $DESKTOP_FILE_LOCATION && update-desktop-database $DATA_HOME/icons
+    [[ `command -v update-desktop-database` ]] && update-desktop-database "$DESKTOP_FILE_LOCATION" && update-desktop-database "$DATA_HOME/icons"
     print "${COLOR_GREEN}OK${COLOR_RESET}"
 else
     print "${COLOR_RED}NOT DONE, unknown desktop '${DESKTOP}'${COLOR_RESET}"

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -201,14 +201,16 @@ fi
 # If a new environment needs to be supported, then the command check section should be re-thought
 if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.*|.*sway.* ]] || [[ `command -v update-desktop-database` ]]
 then
+    DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
+    DESKTOP_FILE_LOCATION=$DATA_HOME/applications
     # Only delete the desktop file if it will be replaced
-    rm -f ~/.local/share/applications/appimagekit-joplin.desktop
+    rm -f $DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop
 
     # On some systems this directory doesn't exist by default
-    mkdir -p ~/.local/share/applications
+    mkdir -p $DESKTOP_FILE_LOCATION
     
     # Tabs specifically, and not spaces, are needed for indentation with Bash heredocs
-    cat >> ~/.local/share/applications/appimagekit-joplin.desktop <<-EOF
+    cat >> $DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop <<-EOF
 	[Desktop Entry]
 	Encoding=UTF-8
 	Name=Joplin
@@ -224,7 +226,7 @@ then
 	EOF
     
     # Update application icons
-    [[ `command -v update-desktop-database` ]] && update-desktop-database ~/.local/share/applications && update-desktop-database ~/.local/share/icons
+    [[ `command -v update-desktop-database` ]] && update-desktop-database $DESKTOP_FILE_LOCATION && update-desktop-database $DATA_HOME/icons
     print "${COLOR_GREEN}OK${COLOR_RESET}"
 else
     print "${COLOR_RED}NOT DONE, unknown desktop '${DESKTOP}'${COLOR_RESET}"


### PR DESCRIPTION
This is the directory that the DE will look in for .desktop files. By default it is ~/.local/share, which is what Joplin was using. This failed for users that use a different location.

This issue was reported on the [forum](https://discourse.joplinapp.org/t/app-doesnt-show-up-in-app-drawer-or-on-desktop/28602/8?u=calebjohn) and I suspect they aren't the only ones who have experienced it. 

There shouldn't be any risk in this change. If the XDG_DATA_HOME variable doesn't exist, this will fall back on the path Joplin was already using. If it does exist, then the path Joplin was using before wouldn't work anyways.