### PR TITLE
 Modified the existing docker-compose.server-dev.yml file to add more features to the docker-compose file.server-dev file

### DIFF
--- a/docker-compose.server-dev.yml
+++ b/docker-compose.server-dev.yml
@@ -18,9 +18,9 @@ services:
       - POSTGRES_HOST=localhost
     depends_on:
       - db
-    command: <command to run when the container starts>
+    command: npm run start
     healthcheck:
-      test: <command to use to check the health of the service>
+      test: curl -f http://localhost:22300 || exit 1
       interval: 30s
       timeout: 10s
       retries: 3
@@ -29,12 +29,11 @@ services:
   db:
     image: postgres:15
     ports:
-        - "5432:5432"
+      - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=joplin
       - POSTGRES_USER=joplin
       - POSTGRES_DB=joplin
     volumes:
-      - <local path>:<container path>:<mode>
+      - /path/on/host:/path/in/container:rw
     restart: always
-

--- a/docker-compose.server-dev.yml
+++ b/docker-compose.server-dev.yml
@@ -1,27 +1,40 @@
 # This compose file can be used in development to run both the database and app
 # within Docker.
-
 version: '3'
 
 services:
-    app:
-        build:
-            context: .
-            dockerfile: Dockerfile.server
-        ports:
-            - "22300:22300"
-        environment:
-            - DB_CLIENT=pg
-            - POSTGRES_PASSWORD=joplin
-            - POSTGRES_DATABASE=joplin
-            - POSTGRES_USER=joplin
-            - POSTGRES_PORT=5432
-            - POSTGRES_HOST=localhost
-    db:
-        image: postgres:15
-        ports:
-            - "5432:5432"
-        environment:
-            - POSTGRES_PASSWORD=joplin
-            - POSTGRES_USER=joplin
-            - POSTGRES_DB=joplin
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    ports:
+      - "22300:22300"
+    environment:
+      - DB_CLIENT=pg
+      - POSTGRES_PASSWORD=joplin
+      - POSTGRES_DATABASE=joplin
+      - POSTGRES_USER=joplin
+      - POSTGRES_PORT=5432
+      - POSTGRES_HOST=localhost
+    depends_on:
+      - db
+    command: <command to run when the container starts>
+    healthcheck:
+      test: <command to use to check the health of the service>
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: always
+  db:
+    image: postgres:15
+    ports:
+        - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=joplin
+      - POSTGRES_USER=joplin
+      - POSTGRES_DB=joplin
+    volumes:
+      - <local path>:<container path>:<mode>
+    restart: always
+


### PR DESCRIPTION
Added a `restart` policy to the `app` and `db` services. This will ensure that the containers are restarted if they stop or crash for any reason.

Added a `depends_on` directive to the app service. This will ensure that the db service is started before the app service, as the app service depends on the database to function.

Added a `volumes` section to the db service. This will allow you to persist the data in the database even if the container is stopped or deleted.

Added a `command` to the app service. This will allow you to specify the command that is run when the container is started.

Added a `health-check` to the app service. This will allow you to specify a command that is used to check the health of the service, and if it fails, the container will be restarted.

Please review the yaml file, updating the commands suitable.