### PR TITLE
Mobile/iOS: Fixes #7469: Scroll NoteViewer markdown container instead of body/root

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
@@ -145,6 +145,16 @@ export default function useSource(noteBody: string, noteMarkupLanguage: number, 
 						font: -apple-system-body;
 					}
 				}
+
+				/*
+				 iOS seems to increase inertial scrolling friction when the WebView body/root elements
+				 scroll. Scroll the main container instead.
+				*/
+				#rendered-md {
+					width: 100vw;
+					height: 100vh;
+					overflow: auto;
+				}
 			`;
 
 			html =

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
@@ -150,7 +150,7 @@ export default function useSource(noteBody: string, noteMarkupLanguage: number, 
 				 iOS seems to increase inertial scrolling friction when the WebView body/root elements
 				 scroll. Scroll the main container instead.
 				*/
-				#rendered-md {
+				body > #rendered-md {
 					width: 100vw;
 					height: 100vh;
 					overflow: auto;


### PR DESCRIPTION
# Summary
When the `body` or `html` elements scroll, inertial/momentum scroll behavior is different from such scrolling in other apps. With this PR, a `div` that contains the rendered note content scrolls instead.

Should fix #7469.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
