### PR TITLE
Mobile: Fix #6175: Enable autocorrect with spellcheck

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -309,6 +309,7 @@ export function initCodeMirror(
 				EditorView.lineWrapping,
 				EditorView.contentAttributes.of({
 					autocapitalize: 'sentence',
+					autocorrect: settings.spellcheckEnabled ? 'true' : 'false',
 					spellcheck: settings.spellcheckEnabled ? 'true' : 'false',
 				}),
 				EditorView.updateListener.of((viewUpdate: ViewUpdate) => {

--- a/packages/app-mobile/components/NoteEditor/CodeMirror/decoratorExtension.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/decoratorExtension.ts
@@ -18,24 +18,26 @@ const regionStopDecoration = Decoration.line({
 	attributes: { class: 'cm-regionLastLine' },
 });
 
+const noSpellCheckAttrs = { spellcheck: 'false', autocorrect: 'false' };
+
 const codeBlockDecoration = Decoration.line({
-	attributes: { class: 'cm-codeBlock', spellcheck: 'false' },
+	attributes: { class: 'cm-codeBlock', ...noSpellCheckAttrs },
 });
 
 const inlineCodeDecoration = Decoration.mark({
-	attributes: { class: 'cm-inlineCode', spellcheck: 'false' },
+	attributes: { class: 'cm-inlineCode', ...noSpellCheckAttrs },
 });
 
 const mathBlockDecoration = Decoration.line({
-	attributes: { class: 'cm-mathBlock', spellcheck: 'false' },
+	attributes: { class: 'cm-mathBlock', ...noSpellCheckAttrs },
 });
 
 const inlineMathDecoration = Decoration.mark({
-	attributes: { class: 'cm-inlineMath', spellcheck: 'false' },
+	attributes: { class: 'cm-inlineMath', ...noSpellCheckAttrs },
 });
 
 const urlDecoration = Decoration.mark({
-	attributes: { class: 'cm-url', spellcheck: 'false' },
+	attributes: { class: 'cm-url', ...noSpellCheckAttrs },
 });
 
 const blockQuoteDecoration = Decoration.line({


### PR DESCRIPTION
# Summary
- On Android, autocorrect needed to be explicitly enabled with `autocorrect=true`. This is now done when the spellcheck setting is enabled. Autocorrect is disabled in code regions.

# Notes
- Autocorrect seems to be different from the manually-configured auto-replace on some keyboards (some keyboards allow users to input a list of words that can be replaced with other words). As such, auto-replace may work even if autocorrect does not.
- This has only been tested on an Android emulator with the GBoard keyboard.

- Resolves #6175.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
