### PR TITLE
Revert "Linux: Fix AppImage icon when installing using Joplin_install…

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -216,7 +216,7 @@ then
 	Name=Joplin
 	Comment=Joplin for Desktop
 	Exec=${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
-	Icon=@joplinapp-desktop
+	Icon=joplin
 	StartupWMClass=Joplin
 	Type=Application
 	Categories=Office;

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -95,7 +95,7 @@
       "icon": "../../Assets/LinuxIcons",
       "category": "Office",
       "desktop": {
-        "Icon": "@joplinapp-desktop",
+        "Icon": "joplin",
         "MimeType": "x-scheme-handler/joplin;"
       },
       "target": "AppImage"


### PR DESCRIPTION
This reverts https://github.com/laurent22/joplin/pull/7346
The above change broke the icon when installing Joplin using the script so reverting the change.