### PR TITLE
Doc: Clarify that the Play Store does not have the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Operating System | Download | Alt. Download
 Android | <a href='https://play.google.com/store/apps/details?id=net.cozic.joplin&utm_source=GitHub&utm_campaign=README&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' height="40px" src='https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/BadgeAndroid.png'/></a> | or download the APK file: [64-bit](https://github.com/laurent22/joplin-android/releases/download/android-v2.8.1/joplin-v2.8.1.apk) [32-bit](https://github.com/laurent22/joplin-android/releases/download/android-v2.8.1/joplin-v2.8.1-32bit.apk)
 iOS | <a href='https://itunes.apple.com/us/app/joplin/id1315599797'><img alt='Get it on the App Store' height="40px" src='https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/BadgeIOS.png'/></a> | -
 
+Note that due to issues with the Play Store's requirements, only versions up to 2.8.x are available there. Newer versions can be downloaded from [the joplin-android repository](https://github.com/laurent22/joplin-android)). See [The 2.9 release notes](https://discourse.joplinapp.org/t/whats-new-in-joplin-2-9/28661#about-the-android-version-9) for more information about this issue.
+
 ## Terminal application
 
 Operating system | Method


### PR DESCRIPTION
I spent a while wondering why I could only find 2.8.x, while bug reports and source were talking about newer versions. Adding a note to the README here would have saved me some time, so hopefully this will help for others too.