### PR TITLE
Desktop: Fixes #7602:   fix copy text with no selection

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -287,8 +287,12 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	const editorCopyText = useCallback(() => {
 		if (editorRef.current) {
 			const selections = editorRef.current.getSelections();
-			if (selections.length > 0) {
+			if (selections.length > 0 && selections[0]) {
 				clipboard.writeText(selections[0]);
+			} else {
+				const cursor = editorRef.current.getCursor();
+				const line = editorRef.current.getLine(cursor.line);
+				clipboard.writeText(line);
 			}
 		}
 	}, []);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -287,9 +287,15 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	const editorCopyText = useCallback(() => {
 		if (editorRef.current) {
 			const selections = editorRef.current.getSelections();
+
+			/**
+       * Handle the case when there is a selection - copy the selection to the clipboard
+	   * When there is no selection, the selection array contains an empty string.
+       */
 			if (selections.length > 0 && selections[0]) {
 				clipboard.writeText(selections[0]);
 			} else {
+				// This is the case when there is no selection - copy the current line to the clipboard
 				const cursor = editorRef.current.getCursor();
 				const line = editorRef.current.getLine(cursor.line);
 				clipboard.writeText(line);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -288,10 +288,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		if (editorRef.current) {
 			const selections = editorRef.current.getSelections();
 
-			/**
-       * Handle the case when there is a selection - copy the selection to the clipboard
-	   * When there is no selection, the selection array contains an empty string.
-       */
+
+			// Handle the case when there is a selection - copy the selection to the clipboard
+			// When there is no selection, the selection array contains an empty string.
 			if (selections.length > 0 && selections[0]) {
 				clipboard.writeText(selections[0]);
 			} else {


### PR DESCRIPTION
I did some research around why the Codemirror option `lineWiseCopyCut` does not work, but couldn't get anywhere trying to make it work.

So I proceeded to trying to implement this manually. 

The challenge here is, when a line is copied, since the lines are wrapped, it copies the entire line (which might be made of 3 wrapped lines) as shown in the video below
 
I would love to get some comments on what the actual expected behaviour is, and hopefully some guidance on how to achieve it.

cc @semyl


https://user-images.githubusercontent.com/94234459/213701290-68a98946-5fd5-41ba-b201-dd8bed40956b.mp4

