### PR TITLE
Desktop: Fixes #7678: Fix openOrCreateFile() with non-ASCII characters in path

### DIFF
--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -637,7 +637,11 @@ function shimInit(options = null) {
 		}
 
 		// Open the file
-		return shim.openUrl(`file://${filepath}`);
+		// Don't use openUrl() there.
+		// The underneath require('electron').shell.openExternal() has a bug
+		// https://github.com/electron/electron/issues/31347
+
+		return shim.electronBridge().openItem(filepath);
 	};
 
 	shim.waitForFrame = () => {};


### PR DESCRIPTION
Fixes #7678
`openOrCreateFile()` eventually calls `require('electron').shell.openExternal()`, which has a [bug](https://github.com/electron/electron/issues/31347) to handle the URL with non-ASCII characters
The `require('electron').shell.openPath()` uses the path directly rather than the URL generated by the path, which prevents this bug.
In this PR, `openOrCreateFile()` calls `shim.electronBridge().openItem(filepath)`, which calls `require('electron').shell.openPath()`.