### PR TITLE
Server: Resolves #7580: Allowed APP_BASE_URL in CORS

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -118,6 +118,13 @@ async function main() {
 		corsAllowedDomains.push('http://localhost:8077');
 	}
 
+	try {
+		const baseAppOrigin = (new URL(envVariables.APP_BASE_URL)).origin;
+		corsAllowedDomains.push(baseAppOrigin);
+	} catch (e: any) {
+		appLogger().warn(`APP_BASE_URL environment variable: ${envVariables.APP_BASE_URL} is not a valid URL.`);
+	}
+
 	function acceptOrigin(origin: string): boolean {
 		const hostname = (new URL(origin)).hostname;
 		const userContentDomain = envVariables.USER_CONTENT_BASE_URL ? (new URL(envVariables.USER_CONTENT_BASE_URL)).hostname : '';


### PR DESCRIPTION
Resolves #7580 

#### Current Behavior:
If request origin is not equal (or similar) to the following:
- `https://joplinapp.org`
- `http://localhost:8077` (if dev)
- `USER_CONTENT_BASE_URL` environment variable

`https://joplinapp.org` is returned as the Access-Control-Allow-Origin header by default.

```
origin: (ctx: AppContext) => {
	const origin = ctx.request.header.origin;

	if (acceptOrigin(origin)) {
		return origin;
	} else {
		// we can't return void, so let's return one of the valid domains
		return corsAllowedDomains[0];
	}
},
```

This PR attempts to add the APP_BASE_URL environment variable to the allowed domains. 