### PR TITLE
Desktop: Resolves #7612 : Fixing Note Viewer theme reset issue on switching HTML to Md note or between 2 HTML notes.

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -671,6 +671,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 		if (!webviewReady) return;
 
 		const options: any = {
+			noteId: props.noteId,
 			pluginAssets: renderedBody.pluginAssets,
 			downloadResources: Setting.value('sync.resourceDownloadMode'),
 			markupLineCount: editorRef.current?.lineCount() || 0,

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -78,6 +78,7 @@
 	}
 
 	let pluginAssetsAdded_ = {};
+	let currentNoteId = ''
 
 	try {
 		const contentElement = document.getElementById('joplin-container-content');
@@ -154,15 +155,25 @@
 			setPercentScroll(percentScroll_);
 		}
 
-		// Note that this function keeps track of what's been added so as not to
-		// add the same CSS files multiple times.
-		function addPluginAssets(assets) {
+		// This function now keeps a track of the css or javascript files loaded as well switching of notes. 
+		// Recreating of div#joplin-container-pluginAssetsContainer on loading a new note ensures that plugin
+		// assets belonging to current note are only loaded into view to avoid css styling conflict issue.
+		function addPluginAssets(noteId, assets) {
 			if (!assets) return;
 
-			const pluginAssetsContainer = document.getElementById('joplin-container-pluginAssetsContainer');
-
-			const processedAssetIds = [];
-
+			let pluginAssetsContainer = document.getElementById('joplin-container-pluginAssetsContainer');
+			
+			if (currentNoteId !== noteId) {
+				pluginAssetsContainer.remove();
+				currentNoteId = noteId;
+				pluginAssetsAdded_ = {};
+				const joplinContainerBody = document.getElementById('joplin-container-body');
+				const newPluginAssetsContainer = document.createElement('div');
+				newPluginAssetsContainer.id = 'joplin-container-pluginAssetsContainer';
+				joplinContainerBody.insertBefore(newPluginAssetsContainer, joplinContainerBody.firstChild);
+				pluginAssetsContainer = newPluginAssetsContainer;
+			}
+			
 			for (let i = 0; i < assets.length; i++) {
 				const asset = assets[i];
 				
@@ -385,7 +396,9 @@
 				setPercentScroll(event.options.percent);
 			}
 
-			addPluginAssets(event.options.pluginAssets);
+			if (currentNoteId === '') currentNoteId = event.options.noteId
+
+			addPluginAssets(event.options.noteId, event.options.pluginAssets);
 
 			if (event.options.downloadResources === 'manual') {
 				webviewLib.setupResourceManualDownload();

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -378,12 +378,13 @@ export default class MdToHtml {
 	}
 
 	private async outputAssetsToExternalAssets_(output: any) {
-		for (const cssString of output.cssStrings) {
+		const newOutput = { ...output, pluginAssets: output.pluginAssets.slice() };
+		for (const cssString of newOutput.cssStrings) {
 			const filePath = await this.fsDriver().cacheCssToFile(cssString);
-			output.pluginAssets.push(filePath);
+			newOutput.pluginAssets.push(filePath);
 		}
-		delete output.cssStrings;
-		return output;
+		delete newOutput.cssStrings;
+		return newOutput;
 	}
 
 	// The string we are looking for is: <p></p>\n
@@ -582,7 +583,6 @@ export default class MdToHtml {
 		let cssStrings = noteStyle(options.theme, {
 			contentMaxWidth: options.contentMaxWidth,
 		});
-
 		let output = { ...this.allProcessedAssets(allRules, options.theme, options.codeTheme) };
 		cssStrings = cssStrings.concat(output.cssStrings);
 


### PR DESCRIPTION
Fixes #7612 
The issue was caused due to the function `addPluginAssets(assets)` in `./packages/app-desktop/gui/note-viewer/index.html` file. One of task of this function was to check loading multiple duplicate css/javascript files while switching between two notes. It works well when two notes share the same css styling (file) but it doesn't removes those css/javascript file links from the DOM tree which was loaded by some other notes and which shouldn't be applied to the current note being viewed. End result => the last appended link node for a css file overwrites the any previously loaded css file belonging to the current note being viewed.

![image](https://user-images.githubusercontent.com/65447610/216077490-0cbac470-9097-4010-b8ec-0420674a85e3.png)
