### PR TITLE
Desktop: Resolves #7662: Fixed ctrl-x behaviour when no text is selected

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx
@@ -276,11 +276,18 @@ function CodeMirror(props: NoteBodyEditorProps, ref: any) {
 	const editorCutText = useCallback(() => {
 		if (editorRef.current) {
 			const selections = editorRef.current.getSelections();
-			if (selections.length > 0) {
+			if (selections.length > 0 && selections[0]) {
 				clipboard.writeText(selections[0]);
 				// Easy way to wipe out just the first selection
 				selections[0] = '';
 				editorRef.current.replaceSelections(selections);
+			} else {
+				//no selection - copy the current line content to the clipboard
+				//and replacing it with an empty line
+				const cursor = editorRef.current.getCursor();
+				const line = editorRef.current.getLine(cursor.line);
+				clipboard.writeText(line);
+				editorRef.current.replaceRange('', { line : cursor.line, ch: 0 }, { line : cursor.line });
 			}
 		}
 	}, []);


### PR DESCRIPTION
Should fix the behaviour of ctrl + x when the cursor is placed at a line and no text is selected.
This would change the clipboard with the content of the line and also removes the line, essentially doing a cut operation like it would be on vscode.  