### PR TITLE
Server: Resolves #5607: Update max item size labels

### DIFF
--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -10,7 +10,7 @@ import config from '../../config';
 import { View } from '../../services/MustacheService';
 import defaultView from '../../utils/defaultView';
 import { AclAction } from '../../models/BaseModel';
-import { AccountType, accountTypeOptions, accountTypeToString } from '../../models/UserModel';
+import { accountByType, AccountType, accountTypeOptions, accountTypeToString } from '../../models/UserModel';
 import uuidgen from '../../utils/uuidgen';
 import { formatMaxItemSize, formatMaxTotalSize, formatTotalSize, formatTotalSizePercent, yesOrNo } from '../../utils/strings';
 import { getCanShareFolder, totalSizeClass } from '../../models/utils/user';
@@ -24,6 +24,7 @@ import { userFlagToString } from '../../models/UserFlagModel';
 import { _ } from '@joplin/lib/locale';
 import { makeTablePagination, makeTableView, Row, Table } from '../../utils/views/table';
 import { PaginationOrderDir } from '../../models/utils/pagination';
+import { formatBytes } from '../../utils/bytes';
 
 export interface CheckRepeatPasswordInput {
 	password: string;
@@ -274,6 +275,10 @@ router.get('admin/users/:id', async (path: SubPath, ctx: AppContext, user: User 
 	view.content.userFlagViews = userFlagViews;
 	view.content.stripePortalUrl = stripePortalUrl();
 	view.content.pageTitle = view.content.buttonTitle;
+
+	const { max_item_size, max_total_item_size } = accountByType(user.account_type ?? AccountType.Default);
+	view.content.accountTypeDefaultMaxItemSize = formatBytes(max_item_size);
+	view.content.accountTypeDefaultMaxTotalSize = formatBytes(max_total_item_size);
 
 	view.jsFiles.push('zxcvbn');
 	view.cssFiles.push('index/user');

--- a/packages/server/src/views/admin/user.mustache
+++ b/packages/server/src/views/admin/user.mustache
@@ -30,22 +30,23 @@
 						{{/accountTypes}}
 					</select>
 				</div>
-				<p class="help">If the below properties are left to their default (empty) values, the account-specific properties will apply.</p>
 			</div>
 		{{/showAccountTypes}}
 
 		<div class="field">
-			<label class="label">Max item size</label>
+			<label class="label">Max item size (in bytes)</label>
 			<div class="control">
 				<input class="input" type="number" placeholder="Default" name="max_item_size" value="{{user.max_item_size}}"/>
 			</div>
+            <p class="help">Leave empty to use the default system limit ({{accountTypeDefaultMaxItemSize}}).</p>
 		</div>
 
 		<div class="field">
-			<label class="label">Max total size</label>
+			<label class="label">Max total size (in bytes)</label>
 			<div class="control">
 				<input class="input" type="number" placeholder="Default" name="max_total_item_size" value="{{user.max_total_item_size}}"/>
 			</div>
+            <p class="help">Leave empty to use the default system limit ({{accountTypeDefaultMaxTotalSize}}).</p>
 		</div>
 
 		<div class="field">


### PR DESCRIPTION
Fixes #5607

- Added (in bytes) postfix in field labels
- Added help text with default max size for user's current account type

**Limitations**
- When user switches between account types (i.e. from Basic to Pro) before saving changes, the default max size in the help text doesn't change. 
- When account types are disabled, default values will be shown as 0B, which may confuse users. 0B is treated as no limits (with exception of hard limit) 

Are any of these limitations a concern?