### PR TITLE
Mobile: Resolves #1044: Add functionality to create sub-notebooks

### DIFF
--- a/packages/app-mobile/components/screens/folder.js
+++ b/packages/app-mobile/components/screens/folder.js
@@ -63,6 +63,10 @@ class FolderScreenComponent extends BaseScreenComponent {
 	async saveFolderButton_press() {
 		let folder = Object.assign({}, this.state.folder);
 
+		if (this.props.navigation.state.parentFolderId) {
+			folder.parent_id = this.props.navigation.state.parentFolderId;
+		}
+
 		try {
 			folder = await Folder.save(folder, { userSideValidation: true });
 		} catch (error) {

--- a/packages/app-mobile/components/screens/notes.js
+++ b/packages/app-mobile/components/screens/notes.js
@@ -179,6 +179,15 @@ class NotesScreenComponent extends BaseScreenComponent {
 		});
 	}
 
+	newSubNotebook(folderId) {
+		this.props.dispatch({
+			type: 'NAV_GO',
+			routeName: 'Folder',
+			folderId: null,
+			parentFolderId: folderId,
+		});
+	}
+
 	newNoteNavigate = async (folderId, isTodo) => {
 		const newNote = await Note.save({
 			parent_id: folderId,
@@ -255,6 +264,15 @@ class NotesScreenComponent extends BaseScreenComponent {
 		const makeActionButtonComp = () => {
 			if (addFolderNoteButtons && this.props.folders.length > 0) {
 				const buttons = [];
+				buttons.push({
+					label: _('New sub-notebook'),
+					onPress: () => {
+						this.newSubNotebook(buttonFolderId);
+					},
+					color: '#9b59b6',
+					icon: 'md-folder',
+				});
+
 				buttons.push({
 					label: _('New to-do'),
 					onPress: () => {


### PR DESCRIPTION
Resolves #1044

This PR builds on top of #5308; it implements the same logic as in the desktop app:

```
if (props.parentId) folder.parent_id = props.parentId;
try {
	const savedFolder = await Folder.save(folder, { userSideValidation: true });
        // truncated lines
}
```

wherein folder parent ID is set to the current folder ID.