### PR TITLE
Mobile: Resolves #1044: Add functionality to create sub-notebooks 

### DIFF
--- a/packages/app-mobile/components/screens/folder.js
+++ b/packages/app-mobile/components/screens/folder.js
@@ -63,6 +63,10 @@ class FolderScreenComponent extends BaseScreenComponent {
 	async saveFolderButton_press() {
 		let folder = Object.assign({}, this.state.folder);
 
+		if (this.props.navigation.state.parentFolderId) {
+			folder.parent_id = this.props.navigation.state.parentFolderId;
+		}
+
 		try {
 			folder = await Folder.save(folder, { userSideValidation: true });
 		} catch (error) {

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -139,6 +139,19 @@ const SideMenuContentComponent = (props: Props) => {
 			_('Notebook: %s', folder.title),
 			[
 				{
+					text: _('New sub-notebook'),
+					onPress: () => {
+						props.dispatch({ type: 'SIDE_MENU_CLOSE' });
+
+						props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'Folder',
+							folderId: null,
+							parentFolderId: folder.id,
+						});
+					},
+				},
+				{
 					text: _('Rename'),
 					onPress: () => {
 						if (folder.encryption_applied) {


### PR DESCRIPTION
Resolves #1044

#7719, but uses context menu (upon tap-and-holding folder name in the sidebar) instead of FAB menu. 

Couldn't follow up with your comment @laurent22 in the mentioned PR, but what do we mean by spec? Do we mean tests or feature specifications?

**Limitations:**

- Previously, the menu action buttons for Android were laid out horizontally; now they're laid out vertically.

**New context menu**

![new-context-menu](https://user-images.githubusercontent.com/36130773/216822245-cc03da44-6bdc-44f0-8389-435a9e54b872.png)
