### PR TITLE
All: Fixes #6956: set updated_time when a note's custom sort order is updated, so it syncs 

### DIFF
--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -828,6 +828,7 @@ export default class Note extends BaseItem {
 		return Note.save(Object.assign({}, note, {
 			order: order,
 			user_updated_time: note.user_updated_time,
+			updated_time: time.unixMs(),
 		}), { autoTimestamp: false, dispatchUpdateAction: false });
 	}
 


### PR DESCRIPTION
As detailed in issue #6956, when you reorder notes according to a custom sort, and don't make any further updates to those notes, the sort order does not propagate to other synchronized clients.

This commit fixes this, by ensuring the update_time, used for synchronization,
*is* updated even though the update is made with "autoTimestamp: false".
