### PR TITLE
Desktop: Fixes #7618: Fixed Web Clipper popup display cutoff due to browser's display scale

### DIFF
--- a/packages/app-clipper/popup/src/index.js
+++ b/packages/app-clipper/popup/src/index.js
@@ -114,7 +114,13 @@ async function main() {
 
 	console.info('Popup: Creating React app...');
 
-	ReactDOM.render(<Provider store={store}><App /></Provider>, document.getElementById('root'));
+	ReactDOM.render(
+		<div style = {{ maxHeight: screen.height * 0.65, overflowY: 'scroll' }}>
+			<Provider store={store}>
+				<App />
+			</Provider>
+		</div>,
+		document.getElementById('root'));
 }
 
 main().catch((error) => {


### PR DESCRIPTION
 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
**Before:**
Browser: Firefox 109.0.1 (64-bit)
layout.css.devPixelsPerPx (in about:config - refers to scale): 3.0 
![before](https://user-images.githubusercontent.com/107347429/218310752-57c611dc-5fe9-4185-8899-7668c13870f5.jpg)

The popup gets cut off due to the scale and the option to scroll is unavailable



**After:**
Browser: Firefox 109.0.1 (64-bit)
layout.css.devPixelsPerPx (in about:config - refers to scale): 3.0
![3 0_after](https://user-images.githubusercontent.com/107347429/218310808-9544d0d4-55d5-463a-a87c-73aa821c04ec.jpg)


The user can scroll and view the entire content.

Browser: Firefox 109.0.1 (64-bit)
layout.css.devPixelsPerPx (in about:config - refers to scale): 2.0
![2 0_after](https://user-images.githubusercontent.com/107347429/218310843-52356c97-e638-45fe-87e7-dbb1fb2164d6.jpg)

Browser: Firefox 109.0.1 (64-bit)
layout.css.devPixelsPerPx (in about:config - refers to scale): -1.0 (default)
![default_after](https://user-images.githubusercontent.com/107347429/218311064-9ef853fb-44e5-4178-8319-ea138e2c2655.jpg)





