### PR TITLE
Desktop: Handles #7634: Handling errors when searched term is too long

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearch.ts
@@ -128,8 +128,18 @@ export default function useEditorSearch(CodeMirror: any) {
 			// We only want to scroll the first keyword into view in the case of a multi keyword search
 			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex || options.searchTimestamp !== previousSearchTimestamp);
 
-			const match = highlightSearch(this, searchTerm, options.selectedIndex, scrollTo, !!options.withSelection);
-			if (match) marks.push(match);
+			try {
+				const match = highlightSearch(this, searchTerm, options.selectedIndex, scrollTo, !!options.withSelection);
+				if (match) marks.push(match);
+			} catch (error) {
+				if (error.name !== 'SyntaxError') {
+					throw error;
+				}
+				// An error of 'Regular expression too large' might occour in the markJs library
+				// when the input is really big, this catch is here to avoid the application crashing
+				// https://github.com/laurent22/joplin/issues/7634
+				console.error('Error while trying to highlight words from search: ', error);
+			}
 		}
 
 		setMarkers(marks);

--- a/packages/app-desktop/gui/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem.tsx
@@ -127,13 +127,21 @@ function NoteListItem(props: NoteListItemProps, ref: any) {
 
 		mark.unmark();
 
-		for (let i = 0; i < props.highlightedWords.length; i++) {
-			const w = props.highlightedWords[i];
-
-			markJsUtils.markKeyword(mark, w, {
-				pregQuote: pregQuote,
-				replaceRegexDiacritics: replaceRegexDiacritics,
-			});
+		try {
+			for (const wordToBeHighlighted of props.highlightedWords) {
+				markJsUtils.markKeyword(mark, wordToBeHighlighted, {
+					pregQuote: pregQuote,
+					replaceRegexDiacritics: replaceRegexDiacritics,
+				});
+			}
+		} catch (error) {
+			if (error.name !== 'SyntaxError') {
+				throw error;
+			}
+			// An error of 'Regular expression too large' might occour in the markJs library
+			// when the input is really big, this catch is here to avoid the application crashing
+			// https://github.com/laurent22/joplin/issues/7634
+			console.error('Error while trying to highlight words from search: ', error);
 		}
 
 		// Note: in this case it is safe to use dangerouslySetInnerHTML because titleElement

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -423,13 +423,21 @@
 
 			if ('separateWordSearch' in options) markKeywordOptions.separateWordSearch = options.separateWordSearch;
 
-			for (let i = 0; i < keywords.length; i++) {
-				let keyword = keywords[i];
-
-				markJsUtils.markKeyword(mark_, keyword, {
-					pregQuote: pregQuote,
-					replaceRegexDiacritics: replaceRegexDiacritics,
-				}, markKeywordOptions);
+			try {
+				for (const keyword of keywords) {
+					markJsUtils.markKeyword(mark_, keyword, {
+						pregQuote: pregQuote,
+						replaceRegexDiacritics: replaceRegexDiacritics,
+					}, markKeywordOptions);
+				}
+			} catch (error) {
+				if (error.name !== 'SyntaxError') {
+					throw error;
+				}
+				// An error of 'Regular expression too large' might occour in the markJs library
+				// when the input is really big, this catch is here to avoid the application crashing
+				// https://github.com/laurent22/joplin/issues/7634
+				console.error('Error while trying to highlight words from search: ', error);
 			}
 		}
 


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/7634

I created a branch wrapping every error occurrence of the error "Regular expression too large" that seems to happen when a very large text is used as search input.

In the issue discussion, I highlight that I found references about the error in the chrome/v8 bug tracker, but, as far as I know, they should be resolved in the version of Electon we are using (maybe it is just a related bug).
https://github.com/laurent22/joplin/issues/7634#issuecomment-1426160458

**Also, I open the PR to discuss the best way to handle the error in cases like this**. From what I understand that are different ways of logging in the application, and I wasn't sure which was the best approach for this case, so I went with the simplest which is just using `console.error`.

## Testing:

Using the input from this file (I was just copying the three lines and using them as a single input):

### Behavior before this PR:

**If the users do not try to create a New to-do or a New note with the searched term still active in the status bar the bug does not appear to occur.**

In the image, the search term is still in the search bar, if I try to create a new to-do or a new note from the File menu or from the buttons beside the search input the application will crash
![image](https://user-images.githubusercontent.com/5051088/218579234-4b9c3754-e564-4564-a7ab-1da35bfb589b.png)

- With any text editor active
- Use the provided input as a search term
- Click anywhere on the screen to make the New to-do and New note buttons available or use the File menu options
- Try to create a new note or a new to-do
- The application crashes


### Behavior after this PR:

- With any text editor active
- Use the provided input as a search term
- Click anywhere on the screen to make the New to-do and New note buttons available or use the File menu options
- Try to create a new note or a new to-do
- The application should still be usable, but a momentary freeze still happens


## The error message that is generated
```
SyntaxError: Invalid regular expression: <expression used in the search> 
(?=$|\s|:|;|\.|,|\-|–|—|‒|_|\(|\)|\{|\}|\[|\]|!|'|"|\+|=)/: Regular expression too large
```

