### PR TITLE
Desktop: Add 'Paste as text' to the Context menu of the Rich Text Editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -221,6 +221,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js

--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -24,6 +24,7 @@ import { MarkupToHtmlOptions } from '../../utils/useMarkupToHtml';
 import { themeStyle } from '@joplin/lib/theme';
 import { loadScript } from '../../../utils/loadScript';
 import bridge from '../../../../services/bridge';
+import { TinyMceEditorEvents } from './utils/types';
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 
@@ -84,21 +85,6 @@ function createSyntheticClipboardEventWithoutHTML(): ClipboardEvent {
 		}
 	}
 	return new ClipboardEvent('paste', { clipboardData });
-}
-
-export enum TinyMceEditorEvents {
-	KeyUp = 'keyup',
-	KeyDown = 'keydown',
-	KeyPress = 'keypress',
-	Paste = 'paste',
-	PasteAsText = 'pasteAsText',
-	Copy = 'copy',
-	CompositionEnd = 'compositionend',
-	Cut = 'cut',
-	JoplinChange = 'joplinChange',
-	Undo = 'Undo',
-	Redo = 'Redo',
-	ExecCommand = 'ExecCommand',
 }
 
 interface TinyMceCommand {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -86,6 +86,21 @@ function createSyntheticClipboardEventWithoutHTML(): ClipboardEvent {
 	return new ClipboardEvent('paste', { clipboardData });
 }
 
+export enum TinyMceEditorEvents {
+	KeyUp = 'keyup',
+	KeyDown = 'keydown',
+	KeyPress = 'keypress',
+	Paste = 'paste',
+	PasteAsText = 'pasteAsText',
+	Copy = 'copy',
+	CompositionEnd = 'compositionend',
+	Cut = 'cut',
+	JoplinChange = 'joplinChange',
+	Undo = 'Undo',
+	Redo = 'Redo',
+	ExecCommand = 'ExecCommand',
+}
+
 interface TinyMceCommand {
 	name: string;
 	value?: any;
@@ -169,7 +184,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		const nodeName = event.target ? event.target.nodeName : '';
 
 		if (nodeName === 'INPUT' && event.target.getAttribute('type') === 'checkbox') {
-			editor.fire('joplinChange');
+			editor.fire(TinyMceEditorEvents.JoplinChange);
 			dispatchDidUpdate(editor);
 		}
 
@@ -261,7 +276,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					},
 					replaceSelection: (value: any) => {
 						editor.selection.setContent(value);
-						editor.fire('joplinChange');
+						editor.fire(TinyMceEditorEvents.JoplinChange);
 						dispatchDidUpdate(editor);
 
 						// It doesn't make sense but it seems calling setContent
@@ -270,7 +285,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						// https://github.com/tinymce/tinymce/issues/3745
 						window.requestAnimationFrame(() => editor.undoManager.add());
 					},
-					pasteAsText: () => editor.fire('pasteAsText'),
+					pasteAsText: () => editor.fire(TinyMceEditorEvents.PasteAsText),
 				};
 
 				if (additionalCommands[cmd.name]) {
@@ -674,7 +689,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 					editor.on('ObjectResized', function(event: any) {
 						if (event.target.nodeName === 'IMG') {
-							editor.fire('joplinChange');
+							editor.fire(TinyMceEditorEvents.JoplinChange);
 							dispatchDidUpdate(editor);
 						}
 					});
@@ -1085,35 +1100,35 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			await onPaste(createSyntheticClipboardEventWithoutHTML());
 		}
 
-		editor.on('keyup', onKeyUp);
-		editor.on('keydown', onKeyDown);
-		editor.on('keypress', onKeypress);
-		editor.on('paste', onPaste);
-		editor.on('pasteAsText', onPasteAsText);
-		editor.on('copy', onCopy);
+		editor.on(TinyMceEditorEvents.KeyUp, onKeyUp);
+		editor.on(TinyMceEditorEvents.KeyDown, onKeyDown);
+		editor.on(TinyMceEditorEvents.KeyPress, onKeypress);
+		editor.on(TinyMceEditorEvents.Paste, onPaste);
+		editor.on(TinyMceEditorEvents.PasteAsText, onPasteAsText);
+		editor.on(TinyMceEditorEvents.Copy, onCopy);
 		// `compositionend` means that a user has finished entering a Chinese
 		// (or other languages that require IME) character.
-		editor.on('compositionend', onChangeHandler);
-		editor.on('cut', onCut);
-		editor.on('joplinChange', onChangeHandler);
-		editor.on('Undo', onChangeHandler);
-		editor.on('Redo', onChangeHandler);
-		editor.on('ExecCommand', onExecCommand);
+		editor.on(TinyMceEditorEvents.CompositionEnd, onChangeHandler);
+		editor.on(TinyMceEditorEvents.Cut, onCut);
+		editor.on(TinyMceEditorEvents.JoplinChange, onChangeHandler);
+		editor.on(TinyMceEditorEvents.Undo, onChangeHandler);
+		editor.on(TinyMceEditorEvents.Redo, onChangeHandler);
+		editor.on(TinyMceEditorEvents.ExecCommand, onExecCommand);
 
 		return () => {
 			try {
-				editor.off('keyup', onKeyUp);
-				editor.off('keydown', onKeyDown);
-				editor.off('keypress', onKeypress);
-				editor.off('paste', onPaste);
-				editor.off('pasteAsText', onPasteAsText);
-				editor.off('copy', onCopy);
-				editor.off('compositionend', onChangeHandler);
-				editor.off('cut', onCut);
-				editor.off('joplinChange', onChangeHandler);
-				editor.off('Undo', onChangeHandler);
-				editor.off('Redo', onChangeHandler);
-				editor.off('ExecCommand', onExecCommand);
+				editor.off(TinyMceEditorEvents.KeyUp, onKeyUp);
+				editor.off(TinyMceEditorEvents.KeyDown, onKeyDown);
+				editor.off(TinyMceEditorEvents.KeyPress, onKeypress);
+				editor.off(TinyMceEditorEvents.Paste, onPaste);
+				editor.off(TinyMceEditorEvents.PasteAsText, onPasteAsText);
+				editor.off(TinyMceEditorEvents.Copy, onCopy);
+				editor.off(TinyMceEditorEvents.CompositionEnd, onChangeHandler);
+				editor.off(TinyMceEditorEvents.Cut, onCut);
+				editor.off(TinyMceEditorEvents.JoplinChange, onChangeHandler);
+				editor.off(TinyMceEditorEvents.Undo, onChangeHandler);
+				editor.off(TinyMceEditorEvents.Redo, onChangeHandler);
+				editor.off(TinyMceEditorEvents.ExecCommand, onExecCommand);
 			} catch (error) {
 				console.warn('Error removing events', error);
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -1,5 +1,6 @@
 import { _ } from '@joplin/lib/locale';
 import { MarkupToHtml } from '@joplin/renderer';
+import { TinyMceEditorEvents } from '../TinyMCE';
 const taboverride = require('taboverride');
 
 interface SourceInfo {
@@ -102,7 +103,7 @@ export default function openEditDialog(editor: any, markupToHtml: any, dispatchD
 			}
 
 			dialogApi.close();
-			editor.fire('joplinChange');
+			editor.fire(TinyMceEditorEvents.JoplinChange);
 			dispatchDidUpdate(editor);
 		},
 		onClose: () => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -1,6 +1,6 @@
 import { _ } from '@joplin/lib/locale';
 import { MarkupToHtml } from '@joplin/renderer';
-import { TinyMceEditorEvents } from '../TinyMCE';
+import { TinyMceEditorEvents } from './types';
 const taboverride = require('taboverride');
 
 interface SourceInfo {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/prefer-default-export
+export enum TinyMceEditorEvents {
+	KeyUp = 'keyup',
+	KeyDown = 'keydown',
+	KeyPress = 'keypress',
+	Paste = 'paste',
+	PasteAsText = 'pasteAsText',
+	Copy = 'copy',
+	CompositionEnd = 'compositionend',
+	Cut = 'cut',
+	JoplinChange = 'joplinChange',
+	Undo = 'Undo',
+	Redo = 'Redo',
+	ExecCommand = 'ExecCommand',
+}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -11,7 +11,7 @@ import convertToScreenCoordinates from '../../../../utils/convertToScreenCoordin
 import Setting from '@joplin/lib/models/Setting';
 
 import Resource from '@joplin/lib/models/Resource';
-import { TinyMceEditorEvents } from '../TinyMCE';
+import { TinyMceEditorEvents } from './types';
 
 const menuUtils = new MenuUtils(CommandService.instance());
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -11,6 +11,7 @@ import convertToScreenCoordinates from '../../../../utils/convertToScreenCoordin
 import Setting from '@joplin/lib/models/Setting';
 
 import Resource from '@joplin/lib/models/Resource';
+import { TinyMceEditorEvents } from '../TinyMCE';
 
 const menuUtils = new MenuUtils(CommandService.instance());
 
@@ -77,6 +78,9 @@ export default function(editor: any, plugins: PluginStates, dispatch: Function) 
 					editor.insertContent(content);
 				},
 				isReadOnly: false,
+				fireEditorEvent: (event: TinyMceEditorEvents) => {
+					editor.fire(event);
+				},
 			};
 
 			let template = [];

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -10,6 +10,7 @@ import BaseItem from '@joplin/lib/models/BaseItem';
 import BaseModel from '@joplin/lib/BaseModel';
 import { processPastedHtml } from './resourceHandling';
 import { NoteEntity, ResourceEntity } from '@joplin/lib/services/database/types';
+import { TinyMceEditorEvents } from '../NoteBody/TinyMCE/TinyMCE';
 const fs = require('fs-extra');
 const { writeFile } = require('fs-extra');
 const { clipboard } = require('electron');
@@ -173,6 +174,13 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 				}
 
 				options.insertContent(content);
+			},
+			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !options.isReadOnly && (!!clipboard.readText() || !!clipboard.readHTML()),
+		},
+		pasteAsText: {
+			label: _('Paste as text'),
+			onAction: async (options: ContextMenuOptions) => {
+				options.fireEditorEvent(TinyMceEditorEvents.PasteAsText);
 			},
 			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !options.isReadOnly && (!!clipboard.readText() || !!clipboard.readHTML()),
 		},

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -10,7 +10,7 @@ import BaseItem from '@joplin/lib/models/BaseItem';
 import BaseModel from '@joplin/lib/BaseModel';
 import { processPastedHtml } from './resourceHandling';
 import { NoteEntity, ResourceEntity } from '@joplin/lib/services/database/types';
-import { TinyMceEditorEvents } from '../NoteBody/TinyMCE/TinyMCE';
+import { TinyMceEditorEvents } from '../NoteBody/TinyMCE/utils/types';
 const fs = require('fs-extra');
 const { writeFile } = require('fs-extra');
 const { clipboard } = require('electron');

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
@@ -19,6 +19,7 @@ export interface ContextMenuOptions {
 	htmlToCopy: string;
 	insertContent: Function;
 	isReadOnly?: boolean;
+	fireEditorEvent: Function;
 }
 
 export interface ContextMenuItem {

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -41,6 +41,7 @@ export default function useMessageHandler(scrollWhenReady: any, setScrollWhenRea
 				linkToCopy: arg0.linkToCopy || null,
 				htmlToCopy: '',
 				insertContent: () => { console.warn('insertContent() not implemented'); },
+				fireEditorEvent: () => { console.warn('fireEditorEvent() not implemented'); },
 			}, dispatch);
 
 			menu.popup(bridge().window());

--- a/packages/app-desktop/gui/PdfViewer.tsx
+++ b/packages/app-desktop/gui/PdfViewer.tsx
@@ -59,6 +59,7 @@ export default function PdfViewer(props: Props) {
 			linkToCopy: null,
 			htmlToCopy: '',
 			insertContent: () => { console.warn('insertContent() not implemented'); },
+			fireEditorEvent: () => { console.warn('fireEditorEvent() not implemented'); },
 		} as ContextMenuOptions, props.dispatch);
 
 		menu.popup(bridge().window());


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/pull/7751

## Functionality
Add a new option to the Context Menu of the Rich Text Editor that pastes the content of the clipboard as text.

The context menu can be accessed by right-clicking inside the text editor. 
![image](https://user-images.githubusercontent.com/5051088/218756585-4101d5b2-0f8e-42c7-b4ae-f40a90bf0846.png)

## Implementation

I end up following the implementation of the Paste option from the context menu to decide when to show or not the option, I think it is a pretty safe choice. 

https://github.com/laurent22/joplin/blob/62ddfb0a88261c9d66894c662f1f93df5c17bc57/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts#L185

I also made some refactoring in TinyMCE component to create an enum and make it easier to follow each part of the code is calling what.

https://github.com/laurent22/joplin/blob/62ddfb0a88261c9d66894c662f1f93df5c17bc57/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx#L89-L102

https://github.com/laurent22/joplin/blob/62ddfb0a88261c9d66894c662f1f93df5c17bc57/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx#L1103-L1116

I also made changes to other calls to `editor.fire` to use the enum instead of string values. E.g.:
https://github.com/laurent22/joplin/blob/62ddfb0a88261c9d66894c662f1f93df5c17bc57/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts#L106




## Testing

Inside the Rich Text Editor, anywhere you right-click, it should appear an option called Paste as text and it should behave exactly equal to the Paste as text option in the Edit menu

