### PR TITLE
Renderer: Refactor and test long-press and click handlers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -798,6 +798,8 @@ packages/renderer/HtmlToHtml.js
 packages/renderer/InMemoryCache.js
 packages/renderer/MarkupToHtml.js
 packages/renderer/MdToHtml.js
+packages/renderer/MdToHtml/createEventHandlingAttrs.js
+packages/renderer/MdToHtml/createEventHandlingAttrs.test.js
 packages/renderer/MdToHtml/linkReplacement.js
 packages/renderer/MdToHtml/linkReplacement.test.js
 packages/renderer/MdToHtml/renderMedia.js

--- a/.gitignore
+++ b/.gitignore
@@ -786,6 +786,8 @@ packages/renderer/HtmlToHtml.js
 packages/renderer/InMemoryCache.js
 packages/renderer/MarkupToHtml.js
 packages/renderer/MdToHtml.js
+packages/renderer/MdToHtml/createEventHandlingAttrs.js
+packages/renderer/MdToHtml/createEventHandlingAttrs.test.js
 packages/renderer/MdToHtml/linkReplacement.js
 packages/renderer/MdToHtml/linkReplacement.test.js
 packages/renderer/MdToHtml/renderMedia.js

--- a/packages/renderer/MdToHtml/createEventHandlingAttrs.test.ts
+++ b/packages/renderer/MdToHtml/createEventHandlingAttrs.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createEventHandlingListeners, Options } from './createEventHandlingAttrs';
+import { describe, beforeAll, it, jest, expect } from '@jest/globals';
+
+describe('createEventHandlingAttrs', () => {
+	let lastMessage: string|undefined = undefined;
+	const postMessageFn = (message: string) => {
+		lastMessage = message;
+	};
+
+	beforeAll(() => {
+		lastMessage = undefined;
+
+		jest.useFakeTimers();
+	});
+
+	it('should not create listeners to handle long-press when long press is disabled', () => {
+		const options: Options = {
+			enableLongPress: false,
+			postMessageSyntax: 'postMessageFn',
+		};
+		const listeners = createEventHandlingListeners('someresourceid', options, 'postMessage("click")');
+
+		// Should not add touchstart/mouseenter/leave listeners when not long-pressing.
+		expect(listeners.onmouseenter).toBe('');
+		expect(listeners.onmouseleave).toBe('');
+		expect(listeners.ontouchstart).toBe('');
+		expect(listeners.ontouchmove).toBe('');
+		expect(listeners.ontouchend).toBe('');
+		expect(listeners.ontouchcancel).toBe('');
+	});
+
+	it('should create click listener for given click action', () => {
+		const options: Options = {
+			enableLongPress: false,
+			postMessageSyntax: 'postMessageFn',
+		};
+		const clickAction = 'postMessageFn("click")';
+		const listeners = createEventHandlingListeners('someresourceid', options, clickAction);
+		expect(listeners.onclick).toContain(clickAction);
+
+		postMessageFn('test');
+		eval(listeners.onclick);
+		expect(lastMessage).toBe('click');
+	});
+
+	it('should create ontouch listeners for long press', () => {
+		const options: Options = {
+			enableLongPress: true,
+			postMessageSyntax: 'postMessageFn',
+		};
+		const clickAction: null|string = null;
+		const listeners = createEventHandlingListeners('resourceidhere', options, clickAction);
+
+		expect(listeners.onclick).toBe('');
+		expect(listeners.ontouchstart).not.toBe('');
+
+		// Clear lastMessage
+		postMessageFn('test');
+
+		eval(listeners.ontouchstart);
+		jest.advanceTimersByTime(1000 * 4);
+
+		expect(lastMessage).toBe('longclick:resourceidhere');
+	});
+
+	it('motion during a long press should cancel the timeout', () => {
+		const options: Options = {
+			enableLongPress: true,
+			postMessageSyntax: 'postMessageFn',
+		};
+		const listeners = createEventHandlingListeners('id', options, null);
+
+		lastMessage = '';
+		eval(listeners.ontouchstart);
+		jest.advanceTimersByTime(100);
+		eval(listeners.ontouchmove);
+		jest.advanceTimersByTime(1000 * 100);
+
+		// Message handler should not have been called.
+		expect(lastMessage).toBe('');
+	});
+});

--- a/packages/renderer/MdToHtml/createEventHandlingAttrs.ts
+++ b/packages/renderer/MdToHtml/createEventHandlingAttrs.ts
@@ -1,0 +1,88 @@
+
+
+import utils from '../utils';
+
+
+export interface Options {
+	enableLongPress: boolean;
+	postMessageSyntax: string;
+}
+
+// longPressTouchStart and clearLongPressTimeout are turned into strings before being called.
+// Thus, they should not reference any other non-builtin functions.
+const longPressTouchStartFnString = `(onLongPress, longPressDelay) => {
+	// if touchTimeout is set when ontouchstart is called it means the user has already touched
+	// the screen once and this is the 2nd touch in this case we assume the user is trying
+	// to zoom and we don't want to show the menu
+	if (!!window.touchTimeout) {
+		clearTimeout(window.touchTimeout);
+		window.touchTimeout = null;
+	} else {
+		window.touchTimeout = setTimeout(() => {
+			window.touchTimeout = null;
+			onLongPress();
+		}, longPressDelay);
+	}
+}`;
+
+const clearLongPressTimeoutFnString = `() => {
+	if (window.touchTimeout) {
+		clearTimeout(window.touchTimeout);
+		window.touchTimeout = null;
+	}
+}`;
+
+// Helper for createEventHandlingAttrs. Exported to facilitate testing.
+export const createEventHandlingListeners = (resourceId: string, options: Options, onClickAction: string|null) => {
+	const eventHandlers = {
+		ontouchstart: '',
+		ontouchmove: '',
+		ontouchend: '',
+		ontouchcancel: '',
+		onmouseenter: '',
+		onmouseleave: '',
+		onclick: '',
+	};
+
+	if (options.enableLongPress) {
+		const longPressHandler = `(() => ${options.postMessageSyntax}('longclick:${resourceId}'))`;
+		const touchStart = `(${longPressTouchStartFnString})(${longPressHandler}, ${utils.longPressDelay}); `;
+
+		const callClearLongPressTimeout = `(${clearLongPressTimeoutFnString})(); `;
+		const touchCancel = callClearLongPressTimeout;
+		const touchEnd = callClearLongPressTimeout;
+
+		eventHandlers.ontouchstart += touchStart;
+		eventHandlers.ontouchcancel += touchCancel;
+		eventHandlers.ontouchmove += touchCancel;
+		eventHandlers.ontouchend += touchEnd;
+	}
+
+	if (onClickAction) {
+		eventHandlers.onclick += onClickAction;
+	}
+
+	return eventHandlers;
+};
+
+// Adds event-handling (e.g. long press) code to images and links.
+// resourceId is the ID of the image resource or link.
+const createEventHandlingAttrs = (resourceId: string, options: Options, onClickAction: string|null) => {
+	const eventHandlers = createEventHandlingListeners(resourceId, options, onClickAction);
+
+	// Build onfoo="listener" strings and add them to the result.
+	let result = '';
+	for (const listenerType in eventHandlers) {
+		const eventHandlersDict = eventHandlers as Record<string, string>;
+
+		// Only create code for non-empty listeners.
+		if (eventHandlersDict[listenerType].length > 0) {
+			const listener = eventHandlersDict[listenerType].replace(/["]/g, '&quot;');
+			result += ` ${listenerType}="${listener}" `;
+		}
+	}
+
+	return result;
+};
+
+export default createEventHandlingAttrs;

--- a/packages/renderer/MdToHtml/linkReplacement.test.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.test.ts
@@ -1,4 +1,5 @@
 import linkReplacement from './linkReplacement';
+import { describe, test, expect } from '@jest/globals';
 
 describe('linkReplacement', () => {
 
@@ -57,4 +58,24 @@ describe('linkReplacement', () => {
 		expect(r.indexOf(expectedPrefix)).toBe(0);
 	});
 
+	test('should create ontouch listeners to handle longpress', () => {
+		const resourceId = 'e6afba55bdf74568ac94f8d1e3578d2c';
+
+		const linkHtml = linkReplacement(`:/${resourceId}`, {
+			ResourceModel: {},
+			resources: {
+				[resourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 2, // FETCH_STATUS_DONE
+					},
+				},
+			},
+			enableLongPress: true,
+		}).html;
+
+		expect(linkHtml).toContain('ontouchstart');
+		expect(linkHtml).toContain('ontouchend');
+		expect(linkHtml).toContain('ontouchcancel');
+	});
 });

--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -1,4 +1,5 @@
 import utils, { ItemIdToUrlHandler } from '../utils';
+import createEventHandlingAttrs from './createEventHandlingAttrs';
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = new Entities().encode;
 const urlUtils = require('../urlUtils.js');
@@ -93,13 +94,10 @@ export default function(href: string, options: Options = null): LinkReplacementR
 	let js = `${options.postMessageSyntax}(${JSON.stringify(href)}, { resourceId: ${JSON.stringify(resourceId)} }); return false;`;
 	if (options.enableLongPress && !!resourceId) {
 		const onClick = `${options.postMessageSyntax}(${JSON.stringify(href)})`;
-		const onLongClick = `${options.postMessageSyntax}("longclick:${resourceId}")`;
-		// if t is set when ontouchstart is called it means the user has already touched the screen once and this is the 2nd touch
-		// in this case we assume the user is trying to zoom and we don't want to show the menu
-		const touchStart = `if (typeof(t) !== "undefined" && !!t) { clearTimeout(t); t = null; } else { t = setTimeout(() => { t = null; ${onLongClick}; }, ${utils.longPressDelay}); }`;
-		const cancel = 'if (!!t) {clearTimeout(t); t=null;';
-		const touchEnd = `${cancel} ${onClick};}`;
-		js = `ontouchstart='${touchStart}' ontouchend='${touchEnd}' ontouchcancel='${cancel} ontouchmove="${cancel}'`;
+		js = createEventHandlingAttrs(resourceId, {
+			enableLongPress: options.enableLongPress ?? false,
+			postMessageSyntax: options.postMessageSyntax ?? 'void',
+		}, onClick);
 	} else {
 		js = `onclick='${js}'`;
 	}

--- a/packages/renderer/MdToHtml/rules/image.ts
+++ b/packages/renderer/MdToHtml/rules/image.ts
@@ -1,6 +1,7 @@
 import { RuleOptions } from '../../MdToHtml';
 import htmlUtils from '../../htmlUtils';
 import utils from '../../utils';
+import createEventHandlingAttrs from '../createEventHandlingAttrs';
 
 function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 	const defaultRender = markdownIt.renderer.rules.image;
@@ -17,19 +18,14 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 		const r = utils.imageReplacement(ruleOptions.ResourceModel, src, ruleOptions.resources, ruleOptions.resourceBaseUrl, ruleOptions.itemIdToUrl);
 		if (typeof r === 'string') return r;
 		if (r) {
-			let js = '';
-			if (ruleOptions.enableLongPress) {
-				const id = r['data-resource-id'];
+			const id = r['data-resource-id'];
 
-				const longPressHandler = `${ruleOptions.postMessageSyntax}('longclick:${id}')`;
-				// if t is set when ontouchstart is called it means the user has already touched the screen once and this is the 2nd touch
-				// in this case we assume the user is trying to zoom and we don't want to show the menu
-				const touchStart = `if (typeof(t) !== 'undefined' && !!t) { clearTimeout(t); t = null; } else { t = setTimeout(() => { t = null; ${longPressHandler}; }, ${utils.longPressDelay}); }`;
-				const cancel = 'if (!!t) clearTimeout(t); t=null';
+			const js = createEventHandlingAttrs(id, {
+				enableLongPress: ruleOptions.enableLongPress ?? false,
+				postMessageSyntax: ruleOptions.postMessageSyntax ?? 'void',
+			}, null);
 
-				js = ` ontouchstart="${touchStart}" ontouchend="${cancel}" ontouchcancel="${cancel}" ontouchmove="${cancel}"`;
-			}
-			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title, alt: token.content }))}${js}/>`;
+			return `<img data-from-md ${htmlUtils.attributesHtml(Object.assign({}, r, { title: title, alt: token.content }))} ${js}/>`;
 		}
 		return defaultRender(tokens, idx, options, env, self);
 	};

--- a/packages/renderer/jest.config.js
+++ b/packages/renderer/jest.config.js
@@ -69,14 +69,11 @@ module.exports = {
 	// ],
 
 	// An array of file extensions your modules use
-	// moduleFileExtensions: [
-	//   "js",
-	//   "json",
-	//   "jsx",
-	//   "ts",
-	//   "tsx",
-	//   "node"
-	// ],
+	moduleFileExtensions: [
+		'ts',
+		'tsx',
+		'js',
+	],
 
 	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
 	// moduleNameMapper: {},
@@ -145,13 +142,13 @@ module.exports = {
 
 	// The glob patterns Jest uses to detect test files
 	testMatch: [
-		'**/*.test.js',
+		'**/*.test.ts',
 	],
 
 	// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-	// testPathIgnorePatterns: [
-	//   "/node_modules/"
-	// ],
+	testPathIgnorePatterns: [
+		'<rootDir>/node_modules/',
+	],
 
 	// The regexp pattern or array of patterns that Jest uses to detect test files
 	// testRegex: [],
@@ -169,7 +166,9 @@ module.exports = {
 	// timers: "real",
 
 	// A map from regular expressions to paths to transformers
-	// transform: undefined,
+	transform: {
+		'\\.(ts|tsx)$': 'ts-jest',
+	},
 
 	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
 	// transformIgnorePatterns: [

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -20,8 +20,8 @@
   "devDependencies": {
     "@types/jest": "29.2.6",
     "@types/node": "18.11.18",
-    "jest": "29.3.1",
-    "jest-environment-jsdom": "29.3.1",
+    "jest": "29.4.1",
+    "jest-environment-jsdom": "29.4.1",
     "ts-jest": "29.0.5",
     "typescript": "4.9.4"
   },

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -20,7 +20,9 @@
   "devDependencies": {
     "@types/jest": "29.2.6",
     "@types/node": "18.11.18",
-    "jest": "29.4.1",
+    "jest": "29.3.1",
+    "jest-environment-jsdom": "29.3.1",
+    "ts-jest": "29.0.5",
     "typescript": "4.9.4"
   },
   "dependencies": {

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -5,6 +5,6 @@
         "**/*.tsx",
 	],
 	"exclude": [
-		"**/node_modules",
+		"**/node_modules"
 	],
 }

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -5,6 +5,6 @@
         "**/*.tsx",
 	],
 	"exclude": [
-		"**/node_modules"
+		"**/node_modules",
 	],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4313,7 +4313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^29.3.1, @jest/core@npm:^29.4.1, @jest/core@npm:^29.4.2":
+"@jest/core@npm:^29.4.1, @jest/core@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/core@npm:29.4.2"
   dependencies:
@@ -4363,7 +4363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^29.3.1, @jest/environment@npm:^29.4.1, @jest/environment@npm:^29.4.2":
+"@jest/environment@npm:^29.4.1, @jest/environment@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/environment@npm:29.4.2"
   dependencies:
@@ -4403,7 +4403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.3.1, @jest/fake-timers@npm:^29.4.1, @jest/fake-timers@npm:^29.4.2":
+"@jest/fake-timers@npm:^29.4.1, @jest/fake-timers@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/fake-timers@npm:29.4.2"
   dependencies:
@@ -5044,8 +5044,8 @@ __metadata:
     fs-extra: 11.1.0
     highlight.js: 11.7.0
     html-entities: 1.4.0
-    jest: 29.3.1
-    jest-environment-jsdom: 29.3.1
+    jest: 29.4.1
+    jest-environment-jsdom: 29.4.1
     json-stringify-safe: 5.0.1
     katex: 0.13.24
     markdown-it: 13.0.1
@@ -19582,7 +19582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^29.3.1, jest-cli@npm:^29.4.1":
+"jest-cli@npm:^29.4.1":
   version: 29.4.2
   resolution: "jest-cli@npm:29.4.2"
   dependencies:
@@ -19702,27 +19702,6 @@ __metadata:
     jest-util: ^29.4.2
     pretty-format: ^29.4.2
   checksum: 51471971032fcd23f659f90f9d821e7b815fe75421cc66a0489fdd4d309f01ad64c14c87e0e819342341d411d633bf02e9eb1657f16ed402271aa5427c8b8fe1
-  languageName: node
-  linkType: hard
-
-"jest-environment-jsdom@npm:29.3.1":
-  version: 29.3.1
-  resolution: "jest-environment-jsdom@npm:29.3.1"
-  dependencies:
-    "@jest/environment": ^29.3.1
-    "@jest/fake-timers": ^29.3.1
-    "@jest/types": ^29.3.1
-    "@types/jsdom": ^20.0.0
-    "@types/node": "*"
-    jest-mock: ^29.3.1
-    jest-util: ^29.3.1
-    jsdom: ^20.0.0
-  peerDependencies:
-    canvas: ^2.5.0
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 91b04ed02b2275c3a47740e20c2691f67c4295e17174c8ccd3a71fe77707239e487506bd157279b4257ce1be0a8c2be377817ee85689966a9e604bb6ef1199f0
   languageName: node
   linkType: hard
 
@@ -19887,7 +19866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^29.3.1, jest-mock@npm:^29.4.1, jest-mock@npm:^29.4.2":
+"jest-mock@npm:^29.4.1, jest-mock@npm:^29.4.2":
   version: 29.4.2
   resolution: "jest-mock@npm:29.4.2"
   dependencies:
@@ -20170,25 +20149,6 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 6fd42900da0047e161fcb7d887f95dcc4aca824decc4a59b019011b9609621902bac71b3d4085ceb4f2d9f266263c547ddc1b29159383b45c04b0ab9944df2f5
-  languageName: node
-  linkType: hard
-
-"jest@npm:29.3.1":
-  version: 29.3.1
-  resolution: "jest@npm:29.3.1"
-  dependencies:
-    "@jest/core": ^29.3.1
-    "@jest/types": ^29.3.1
-    import-local: ^3.0.2
-    jest-cli: ^29.3.1
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    jest: bin/jest.js
-  checksum: 613f4ec657b14dd84c0056b2fef1468502927fd551bef0b19d4a91576a609678fb316c6a5b5fc6120dd30dd4ff4569070ffef3cb507db9bb0260b28ddaa18d7a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4313,7 +4313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^29.4.1, @jest/core@npm:^29.4.2":
+"@jest/core@npm:^29.3.1, @jest/core@npm:^29.4.1, @jest/core@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/core@npm:29.4.2"
   dependencies:
@@ -4363,7 +4363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^29.4.1, @jest/environment@npm:^29.4.2":
+"@jest/environment@npm:^29.3.1, @jest/environment@npm:^29.4.1, @jest/environment@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/environment@npm:29.4.2"
   dependencies:
@@ -4403,7 +4403,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.4.1, @jest/fake-timers@npm:^29.4.2":
+"@jest/fake-timers@npm:^29.3.1, @jest/fake-timers@npm:^29.4.1, @jest/fake-timers@npm:^29.4.2":
   version: 29.4.2
   resolution: "@jest/fake-timers@npm:29.4.2"
   dependencies:
@@ -5044,7 +5044,8 @@ __metadata:
     fs-extra: 11.1.0
     highlight.js: 11.7.0
     html-entities: 1.4.0
-    jest: 29.4.1
+    jest: 29.3.1
+    jest-environment-jsdom: 29.3.1
     json-stringify-safe: 5.0.1
     katex: 0.13.24
     markdown-it: 13.0.1
@@ -5062,6 +5063,7 @@ __metadata:
     markdown-it-toc-done-right: 4.2.0
     md5: 2.3.0
     mermaid: 9.2.2
+    ts-jest: 29.0.5
     typescript: 4.9.4
   languageName: unknown
   linkType: soft
@@ -19580,7 +19582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^29.4.1":
+"jest-cli@npm:^29.3.1, jest-cli@npm:^29.4.1":
   version: 29.4.2
   resolution: "jest-cli@npm:29.4.2"
   dependencies:
@@ -19700,6 +19702,27 @@ __metadata:
     jest-util: ^29.4.2
     pretty-format: ^29.4.2
   checksum: 51471971032fcd23f659f90f9d821e7b815fe75421cc66a0489fdd4d309f01ad64c14c87e0e819342341d411d633bf02e9eb1657f16ed402271aa5427c8b8fe1
+  languageName: node
+  linkType: hard
+
+"jest-environment-jsdom@npm:29.3.1":
+  version: 29.3.1
+  resolution: "jest-environment-jsdom@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/fake-timers": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/jsdom": ^20.0.0
+    "@types/node": "*"
+    jest-mock: ^29.3.1
+    jest-util: ^29.3.1
+    jsdom: ^20.0.0
+  peerDependencies:
+    canvas: ^2.5.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 91b04ed02b2275c3a47740e20c2691f67c4295e17174c8ccd3a71fe77707239e487506bd157279b4257ce1be0a8c2be377817ee85689966a9e604bb6ef1199f0
   languageName: node
   linkType: hard
 
@@ -19864,7 +19887,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^29.4.1, jest-mock@npm:^29.4.2":
+"jest-mock@npm:^29.3.1, jest-mock@npm:^29.4.1, jest-mock@npm:^29.4.2":
   version: 29.4.2
   resolution: "jest-mock@npm:29.4.2"
   dependencies:
@@ -20147,6 +20170,25 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 6fd42900da0047e161fcb7d887f95dcc4aca824decc4a59b019011b9609621902bac71b3d4085ceb4f2d9f266263c547ddc1b29159383b45c04b0ab9944df2f5
+  languageName: node
+  linkType: hard
+
+"jest@npm:29.3.1":
+  version: 29.3.1
+  resolution: "jest@npm:29.3.1"
+  dependencies:
+    "@jest/core": ^29.3.1
+    "@jest/types": ^29.3.1
+    import-local: ^3.0.2
+    jest-cli: ^29.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 613f4ec657b14dd84c0056b2fef1468502927fd551bef0b19d4a91576a609678fb316c6a5b5fc6120dd30dd4ff4569070ffef3cb507db9bb0260b28ddaa18d7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
- #7588 refactors logic for handling resource link long-presses and clicks. This PR includes that refactor.
- `packages/renderer` is migrated to `ts-jest` to allow per-file `jsdom` test environments (required for some of the tests in this PR).
    - Comments that switch test environments (e.g. `/** @jest-environment jsdom */`) seem to need to be at the top of files loaded by `jest`. Transpiled test files have `"use strict";` as the first line (before the comment), causing the environment not to switch.

# Testing plan
1. Create a note
2. Attach an image and a PDF to that note.
3. Create another note and add a link to the first note.
4. Click on the link created in step 3.
5. Long-press on the resource link created in step 2.
6. Dismiss the long-press menu and click on the resource link created in step 2.
7. Repeat steps 5 and 6 for the image added in step 2.

# To-do
- [x] Test on Android.
- [ ] Test on iOS.
- [x] Test on desktop.

# Notes
- This may fix #6592
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
