### PR TITLE
Desktop: New design for "New note" and "New todo" buttons

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -23,17 +23,27 @@ const StyledRoot = styled.div`
 	box-sizing: border-box;
 	height: ${(props: any) => props.height}px;
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	padding: ${(props: any) => props.theme.mainPadding}px;
 	background-color: ${(props: any) => props.theme.backgroundColor3};
+	gap: 5px;
 `;
 
-const StyledButton = styled(Button)`
-	margin-left: 8px;
-	width: 26px;
+const StyleNewTodoButton = styled(Button)`
+	width: fit-content;
 	height: 26px;
-	min-width: 26px;
+	min-width: 68px;
 	min-height: 26px;
+	flex: 1 1 auto
+`;
+
+const StyledNewNoteButton = styled(Button)`
+	margin-left: 8px;
+	width: fit-content;
+	height: 26px;
+	min-width: 68px;
+	min-height: 26px;
+	flex: 1 1 auto
 `;
 
 const StyledPairButtonL = styled(Button)`
@@ -51,7 +61,7 @@ const StyledPairButtonR = styled(Button)`
 	width: auto;
 `;
 
-const ButtonContainer = styled.div`
+const RowContainer = styled.div`
 	display: flex;
 	flex-direction: row;
 `;
@@ -116,7 +126,32 @@ function NoteListControls(props: Props) {
 		if (!props.showNewNoteButtons) return null;
 
 		return (
-			<ButtonContainer>
+			<RowContainer>
+				<StyleNewTodoButton
+					className="new-todo-button"
+					tooltip={CommandService.instance().label('newTodo')}
+					title="+ New to do"
+					level={ButtonLevel.Secondary}
+					size={ButtonSize.Small}
+					onClick={onNewTodoButtonClick}
+				/>
+				<StyledNewNoteButton
+					className="new-note-button"
+					tooltip={CommandService.instance().label('newNote')}
+					title="+ New note"
+					level={ButtonLevel.Primary}
+					size={ButtonSize.Small}
+					onClick={onNewNoteButtonClick}
+				/>
+			</RowContainer>
+		);
+	}
+
+	return (
+		<StyledRoot height={props.height}>
+			{renderNewNoteButtons()}
+			<RowContainer>
+				<SearchBar inputRef={searchBarRef}/>
 				{showsSortOrderButtons() &&
 					<StyledPairButtonL
 						className="sort-order-field-button"
@@ -137,30 +172,7 @@ function NoteListControls(props: Props) {
 						onClick={onSortOrderReverseButtonClick}
 					/>
 				}
-				<StyledButton
-					className="new-todo-button"
-					tooltip={CommandService.instance().label('newTodo')}
-					iconName="far fa-check-square"
-					level={ButtonLevel.Primary}
-					size={ButtonSize.Small}
-					onClick={onNewTodoButtonClick}
-				/>
-				<StyledButton
-					className="new-note-button"
-					tooltip={CommandService.instance().label('newNote')}
-					iconName="icon-note"
-					level={ButtonLevel.Primary}
-					size={ButtonSize.Small}
-					onClick={onNewNoteButtonClick}
-				/>
-			</ButtonContainer>
-		);
-	}
-
-	return (
-		<StyledRoot height={props.height}>
-			<SearchBar inputRef={searchBarRef}/>
-			{renderNewNoteButtons()}
+			</RowContainer>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -7,6 +7,7 @@ import CommandService from '@joplin/lib/services/CommandService';
 import { runtime as focusSearchRuntime } from './commands/focusSearch';
 import Note from '@joplin/lib/models/Note';
 import { notesSortOrderNextField } from '../../services/sortOrder/notesSortOrderUtils';
+import { _ } from '@joplin/lib/locale';
 const { connect } = require('react-redux');
 const styled = require('styled-components').default;
 
@@ -30,6 +31,7 @@ const StyledRoot = styled.div`
 `;
 
 const StyleNewTodoButton = styled(Button)`
+	margin-left: 8px;
 	width: fit-content;
 	height: 26px;
 	min-width: 68px;
@@ -38,7 +40,6 @@ const StyleNewTodoButton = styled(Button)`
 `;
 
 const StyledNewNoteButton = styled(Button)`
-	margin-left: 8px;
 	width: fit-content;
 	height: 26px;
 	min-width: 68px;
@@ -64,6 +65,7 @@ const StyledPairButtonR = styled(Button)`
 const RowContainer = styled.div`
 	display: flex;
 	flex-direction: row;
+	flex: 1 1 auto
 `;
 
 function NoteListControls(props: Props) {
@@ -127,21 +129,21 @@ function NoteListControls(props: Props) {
 
 		return (
 			<RowContainer>
-				<StyleNewTodoButton
-					className="new-todo-button"
-					tooltip={CommandService.instance().label('newTodo')}
-					title="+ New to do"
-					level={ButtonLevel.Secondary}
-					size={ButtonSize.Small}
-					onClick={onNewTodoButtonClick}
-				/>
 				<StyledNewNoteButton
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
-					title="+ New note"
+					title={_('+ %s', 'New note')}
 					level={ButtonLevel.Primary}
 					size={ButtonSize.Small}
 					onClick={onNewNoteButtonClick}
+				/>
+				<StyleNewTodoButton
+					className="new-todo-button"
+					tooltip={CommandService.instance().label('newTodo')}
+					title={_('+ %s', 'New to-do')}
+					level={ButtonLevel.Secondary}
+					size={ButtonSize.Small}
+					onClick={onNewTodoButtonClick}
 				/>
 			</RowContainer>
 		);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -29,20 +29,7 @@ const StyledRoot = styled.div`
 	gap: 5px;
 `;
 
-const StyleNewTodoButton = styled(Button)`
-	margin-left: 8px;
-	width: fit-content;
-	height: 26px;
-	min-width: 68px;
-	min-height: 26px;
-	flex: 1 1 auto;
-
-  .fa, .fas {
-    font-size: 11px;
-  }
-`;
-
-const StyledNewNoteButton = styled(Button)`
+const StyledButton = styled(Button)`
 	width: fit-content;
 	height: 26px;
 	min-width: 68px;
@@ -55,7 +42,6 @@ const StyledNewNoteButton = styled(Button)`
 `;
 
 const StyledPairButtonL = styled(Button)`
-	margin-left: 8px;
 	border-radius: 3px 0 0 3px;
 	min-width: ${(props: any) => buttonSizePx(props)}px;
 	max-width: ${(props: any) => buttonSizePx(props)}px;
@@ -63,7 +49,6 @@ const StyledPairButtonL = styled(Button)`
 
 const StyledPairButtonR = styled(Button)`
 	min-width: 8px;
-	margin-left: 0px;
 	border-radius: 0 3px 3px 0;
 	border-width: 1px 1px 1px 0;
 	width: auto;
@@ -72,7 +57,14 @@ const StyledPairButtonR = styled(Button)`
 const RowContainer = styled.div`
 	display: flex;
 	flex-direction: row;
-	flex: 1 1 auto
+	flex: 1 1 auto;
+	gap: 8px;
+`;
+
+const SortOrderButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
 `;
 
 function NoteListControls(props: Props) {
@@ -136,7 +128,7 @@ function NoteListControls(props: Props) {
 
 		return (
 			<RowContainer>
-				<StyledNewNoteButton
+				<StyledButton
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
 					iconName="fas fa-plus"
@@ -145,7 +137,7 @@ function NoteListControls(props: Props) {
 					size={ButtonSize.Small}
 					onClick={onNewNoteButtonClick}
 				/>
-				<StyleNewTodoButton
+				<StyledButton
 					className="new-todo-button"
 					tooltip={CommandService.instance().label('newTodo')}
 					iconName="fas fa-plus"
@@ -163,7 +155,8 @@ function NoteListControls(props: Props) {
 			{renderNewNoteButtons()}
 			<RowContainer>
 				<SearchBar inputRef={searchBarRef}/>
-				{showsSortOrderButtons() &&
+				<SortOrderButtonsContainer>
+					{showsSortOrderButtons() &&
 					<StyledPairButtonL
 						className="sort-order-field-button"
 						tooltip={sortOrderFieldTooltip()}
@@ -172,8 +165,8 @@ function NoteListControls(props: Props) {
 						size={ButtonSize.Small}
 						onClick={onSortOrderFieldButtonClick}
 					/>
-				}
-				{showsSortOrderButtons() &&
+					}
+					{showsSortOrderButtons() &&
 					<StyledPairButtonR
 						className="sort-order-reverse-button"
 						tooltip={CommandService.instance().label('toggleNotesSortOrderReverse')}
@@ -182,7 +175,8 @@ function NoteListControls(props: Props) {
 						size={ButtonSize.Small}
 						onClick={onSortOrderReverseButtonClick}
 					/>
-				}
+					}
+				</SortOrderButtonsContainer>
 			</RowContainer>
 		</StyledRoot>
 	);

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -30,11 +30,10 @@ const StyledRoot = styled.div`
 `;
 
 const StyledButton = styled(Button)`
-	width: fit-content;
+	width: auto;
 	height: 26px;
-	min-width: 68px;
 	min-height: 26px;
-	flex: 1 1 auto;
+	flex: 1 0 auto;
 
   .fa, .fas {
     font-size: 11px;

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -35,7 +35,11 @@ const StyleNewTodoButton = styled(Button)`
 	height: 26px;
 	min-width: 68px;
 	min-height: 26px;
-	flex: 1 1 auto
+	flex: 1 1 auto;
+
+  .fa, .fas {
+    font-size: 11px;
+  }
 `;
 
 const StyledNewNoteButton = styled(Button)`
@@ -43,7 +47,11 @@ const StyledNewNoteButton = styled(Button)`
 	height: 26px;
 	min-width: 68px;
 	min-height: 26px;
-	flex: 1 1 auto
+	flex: 1 1 auto;
+
+  .fa, .fas {
+    font-size: 11px;
+  }
 `;
 
 const StyledPairButtonL = styled(Button)`
@@ -131,7 +139,8 @@ function NoteListControls(props: Props) {
 				<StyledNewNoteButton
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
-					title={_('+ %s', 'New note')}
+					iconName="fas fa-plus"
+					title={_('%s', 'New note')}
 					level={ButtonLevel.Primary}
 					size={ButtonSize.Small}
 					onClick={onNewNoteButtonClick}
@@ -139,7 +148,8 @@ function NoteListControls(props: Props) {
 				<StyleNewTodoButton
 					className="new-todo-button"
 					tooltip={CommandService.instance().label('newTodo')}
-					title={_('+ %s', 'New to-do')}
+					iconName="fas fa-plus"
+					title={_('%s', 'New to-do')}
 					level={ButtonLevel.Secondary}
 					size={ButtonSize.Small}
 					onClick={onNewTodoButtonClick}

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -17,13 +17,12 @@ interface Props {
 	sortOrderField: string;
 	sortOrderReverse: boolean;
 	notesParentType: string;
-	height: number;
 }
 
 const StyledRoot = styled.div`
 	box-sizing: border-box;
-	height: ${(props: any) => props.height}px;
 	display: flex;
+	height: auto;
 	flex-direction: column;
 	padding: ${(props: any) => props.theme.mainPadding}px;
 	background-color: ${(props: any) => props.theme.backgroundColor3};
@@ -150,7 +149,7 @@ function NoteListControls(props: Props) {
 	}
 
 	return (
-		<StyledRoot height={props.height}>
+		<StyledRoot>
 			{renderNewNoteButtons()}
 			<RowContainer>
 				<SearchBar inputRef={searchBarRef}/>

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -1,4 +1,3 @@
-import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
 import { useMemo } from 'react';
 import NoteList from '../NoteList/NoteList';
@@ -21,19 +20,16 @@ const StyledRoot = styled.div`
 `;
 
 export default function NoteListWrapper(props: Props) {
-	const theme = themeStyle(props.themeId);
-	const controlHeight = theme.topRowHeight;
-
 	const noteListSize = useMemo(() => {
 		return {
 			width: props.size.width,
-			height: props.size.height - controlHeight,
+			height: props.size.height,
 		};
-	}, [props.size, controlHeight]);
+	}, [props.size]);
 
 	return (
 		<StyledRoot>
-			<NoteListControls height={controlHeight} />
+			<NoteListControls />
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -60,7 +60,7 @@ const globalStyle: any = {
 	toolbarPadding: 6,
 	appearance: 'light',
 	mainPadding: 12,
-	topRowHeight: 100,
+	topRowHeight: 50,
 	editorPaddingLeft: 8,
 };
 

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -60,7 +60,7 @@ const globalStyle: any = {
 	toolbarPadding: 6,
 	appearance: 'light',
 	mainPadding: 12,
-	topRowHeight: 50,
+	topRowHeight: 100,
 	editorPaddingLeft: 8,
 };
 


### PR DESCRIPTION
This PR implements a new design to create new todos and new notes in an attempt to make these two actions unambiguous and make these two buttons stand out more among other buttons.

This new design is based on a new UI proposal that was once considered: https://global.discourse-cdn.com/standard14/uploads/cozic/original/2X/2/26c255d41e5a128eb8a5579474e9627768b518db.png

See below screenshots of the result (with light and dark themes) followed by a possible alternative design.

#### New design
![1](https://user-images.githubusercontent.com/32807437/219040212-139ce5e6-1785-4951-9d4a-636d546fd0e7.png)
![1-dark](https://user-images.githubusercontent.com/32807437/219040222-43ddb2ee-285e-4654-9e0a-aa5cb95299ed.png)
#### Possible alternative
![2](https://user-images.githubusercontent.com/32807437/219040227-14c9eea9-a251-4d53-a543-42bf6d4220b9.png)
