### PR TITLE
Mobile: Fixes #7762: Hide main content while biometric is enabled and not authenticated

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -954,6 +954,9 @@ class AppComponent extends React.Component {
 		// const statusBarStyle = theme.appearance === 'light-content';
 		const statusBarStyle = 'light-content';
 
+		const biometricIsEnabled = !!this.state.sensorInfo && this.state.sensorInfo.enabled;
+		const shouldShowMainContent = !biometricIsEnabled || this.props.biometricsDone;
+
 		const mainContent = (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
 				<SideMenu
@@ -974,7 +977,7 @@ class AppComponent extends React.Component {
 						<SafeAreaView style={{ flex: 0, backgroundColor: theme.backgroundColor2 }}/>
 						<SafeAreaView style={{ flex: 1 }}>
 							<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
-								<AppNav screens={appNavInit} dispatch={this.props.dispatch} />
+								{ shouldShowMainContent && <AppNav screens={appNavInit} dispatch={this.props.dispatch} /> }
 							</View>
 							<DropdownAlert ref={(ref: any) => this.dropdownAlert_ = ref} tapToCloseEnabled={true} />
 							<Animated.View pointerEvents='none' style={{ position: 'absolute', backgroundColor: 'black', opacity: this.state.sideMenuContentOpacity, width: '100%', height: '120%' }}/>


### PR DESCRIPTION
Issue: https://github.com/laurent22/joplin/issues/7762

Problem: The FAB from the `NotesScreen` was becoming visible while the Biometrics setting was enabled but the user hadn't authenticated yet.

## Implementation 
To fix this I created a conditional render to the main content of the app, that checks if the setting is enabled and if the biometric is done. I noticed that there is flickering that happens when the app opens, but this also happens in the version before my modification (I can look into it if necessary)

## Testing

In Android:
- Register a fingerprint in the mobile configurations options
- Enable biometrics inside de app
- Close the app
- Opening the app again should show a prompt for the biometrics 
- Ignoring the prompt should **NOT** show the FAB in the right bottom corner, but the button at the top of the app "Try Again" should be visible
- Being authorized by the biometrics prompt should take the user to the app