### PR TITLE
Desktop: Add a menu option to reset the application layout

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -177,6 +177,7 @@ packages/app-desktop/gui/MainScreen/commands/openTag.js
 packages/app-desktop/gui/MainScreen/commands/print.js
 packages/app-desktop/gui/MainScreen/commands/renameFolder.js
 packages/app-desktop/gui/MainScreen/commands/renameTag.js
+packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.js
 packages/app-desktop/gui/MainScreen/commands/revealResourceFile.js
 packages/app-desktop/gui/MainScreen/commands/search.js
 packages/app-desktop/gui/MainScreen/commands/setTags.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -177,7 +177,7 @@ packages/app-desktop/gui/MainScreen/commands/openTag.js
 packages/app-desktop/gui/MainScreen/commands/print.js
 packages/app-desktop/gui/MainScreen/commands/renameFolder.js
 packages/app-desktop/gui/MainScreen/commands/renameTag.js
-packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.js
+packages/app-desktop/gui/MainScreen/commands/resetLayout.js
 packages/app-desktop/gui/MainScreen/commands/revealResourceFile.js
 packages/app-desktop/gui/MainScreen/commands/search.js
 packages/app-desktop/gui/MainScreen/commands/setTags.js

--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ packages/app-desktop/gui/MainScreen/commands/openTag.js
 packages/app-desktop/gui/MainScreen/commands/print.js
 packages/app-desktop/gui/MainScreen/commands/renameFolder.js
 packages/app-desktop/gui/MainScreen/commands/renameTag.js
-packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.js
+packages/app-desktop/gui/MainScreen/commands/resetLayout.js
 packages/app-desktop/gui/MainScreen/commands/revealResourceFile.js
 packages/app-desktop/gui/MainScreen/commands/search.js
 packages/app-desktop/gui/MainScreen/commands/setTags.js

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ packages/app-desktop/gui/MainScreen/commands/openTag.js
 packages/app-desktop/gui/MainScreen/commands/print.js
 packages/app-desktop/gui/MainScreen/commands/renameFolder.js
 packages/app-desktop/gui/MainScreen/commands/renameTag.js
+packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.js
 packages/app-desktop/gui/MainScreen/commands/revealResourceFile.js
 packages/app-desktop/gui/MainScreen/commands/search.js
 packages/app-desktop/gui/MainScreen/commands/setTags.js

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -38,6 +38,7 @@ export interface AppState extends State {
 	watchedResources: any;
 	mainLayout: LayoutItem;
 	dialogs: AppStateDialog[];
+	isRestoringDefaultLayout: boolean;
 }
 
 export function createAppDefaultState(windowContentSize: any, resourceEditWatcherDefaultState: any): AppState {
@@ -60,6 +61,7 @@ export function createAppDefaultState(windowContentSize: any, resourceEditWatche
 		mainLayout: null,
 		startupPluginsLoaded: false,
 		dialogs: [],
+		isRestoringDefaultLayout: false,
 		...resourceEditWatcherDefaultState,
 	};
 }
@@ -308,7 +310,15 @@ export default function(state: AppState, action: any) {
 			};
 			break;
 
+
+		case 'RESTORE_DEFAULT_LAYOUT':
+			newState = {
+				...state,
+				isRestoringDefaultLayout: action.value,
+			};
+			break;
 		}
+
 	} catch (error) {
 		error.message = `In reducer: ${error.message} Action: ${JSON.stringify(action)}`;
 		throw error;

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -38,7 +38,7 @@ export interface AppState extends State {
 	watchedResources: any;
 	mainLayout: LayoutItem;
 	dialogs: AppStateDialog[];
-	isRestoringDefaultLayout: boolean;
+	isResettingLayout: boolean;
 }
 
 export function createAppDefaultState(windowContentSize: any, resourceEditWatcherDefaultState: any): AppState {
@@ -61,7 +61,7 @@ export function createAppDefaultState(windowContentSize: any, resourceEditWatche
 		mainLayout: null,
 		startupPluginsLoaded: false,
 		dialogs: [],
-		isRestoringDefaultLayout: false,
+		isResettingLayout: false,
 		...resourceEditWatcherDefaultState,
 	};
 }
@@ -311,10 +311,10 @@ export default function(state: AppState, action: any) {
 			break;
 
 
-		case 'RESTORE_DEFAULT_LAYOUT':
+		case 'RESET_LAYOUT':
 			newState = {
 				...state,
-				isRestoringDefaultLayout: action.value,
+				isResettingLayout: action.value,
 			};
 			break;
 		}

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -78,6 +78,7 @@ interface Props {
 	isSafeMode: boolean;
 	needApiAuth: boolean;
 	processingShareInvitationResponse: boolean;
+	isRestoringDefaultLayout: boolean;
 }
 
 interface ShareFolderDialogOptions {
@@ -370,6 +371,15 @@ class MainScreenComponent extends React.Component<Props, State> {
 			this.props.dispatch({
 				type: !prevState.promptOptions ? 'VISIBLE_DIALOGS_ADD' : 'VISIBLE_DIALOGS_REMOVE',
 				name: 'promptDialog',
+			});
+		}
+
+		if (this.props.isRestoringDefaultLayout) {
+			Setting.setValue('ui.layout', null);
+			this.updateMainLayout(this.buildLayout(this.props.plugins));
+			this.props.dispatch({
+				type: 'RESTORE_DEFAULT_LAYOUT',
+				value: false,
 			});
 		}
 	}
@@ -879,6 +889,7 @@ const mapStateToProps = (state: AppState) => {
 		isSafeMode: state.settings.isSafeMode,
 		needApiAuth: state.needApiAuth,
 		showInstallTemplatesPlugin: state.hasLegacyTemplates && !state.pluginService.plugins['joplin.plugin.templates'],
+		isRestoringDefaultLayout: state.isRestoringDefaultLayout,
 	};
 };
 

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -78,7 +78,7 @@ interface Props {
 	isSafeMode: boolean;
 	needApiAuth: boolean;
 	processingShareInvitationResponse: boolean;
-	isRestoringDefaultLayout: boolean;
+	isResettingLayout: boolean;
 }
 
 interface ShareFolderDialogOptions {
@@ -374,11 +374,11 @@ class MainScreenComponent extends React.Component<Props, State> {
 			});
 		}
 
-		if (this.props.isRestoringDefaultLayout) {
+		if (this.props.isResettingLayout) {
 			Setting.setValue('ui.layout', null);
 			this.updateMainLayout(this.buildLayout(this.props.plugins));
 			this.props.dispatch({
-				type: 'RESTORE_DEFAULT_LAYOUT',
+				type: 'RESET_LAYOUT',
 				value: false,
 			});
 		}
@@ -889,7 +889,7 @@ const mapStateToProps = (state: AppState) => {
 		isSafeMode: state.settings.isSafeMode,
 		needApiAuth: state.needApiAuth,
 		showInstallTemplatesPlugin: state.hasLegacyTemplates && !state.pluginService.plugins['joplin.plugin.templates'],
-		isRestoringDefaultLayout: state.isRestoringDefaultLayout,
+		isResettingLayout: state.isResettingLayout,
 	};
 };
 

--- a/packages/app-desktop/gui/MainScreen/commands/index.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/index.ts
@@ -20,7 +20,7 @@ import * as openTag from './openTag';
 import * as print from './print';
 import * as renameFolder from './renameFolder';
 import * as renameTag from './renameTag';
-import * as restoreDefaultLayout from './restoreDefaultLayout';
+import * as resetLayout from './resetLayout';
 import * as revealResourceFile from './revealResourceFile';
 import * as search from './search';
 import * as setTags from './setTags';
@@ -62,7 +62,7 @@ const index:any[] = [
 	print,
 	renameFolder,
 	renameTag,
-	restoreDefaultLayout,
+	resetLayout,
 	revealResourceFile,
 	search,
 	setTags,

--- a/packages/app-desktop/gui/MainScreen/commands/index.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/index.ts
@@ -20,6 +20,7 @@ import * as openTag from './openTag';
 import * as print from './print';
 import * as renameFolder from './renameFolder';
 import * as renameTag from './renameTag';
+import * as restoreDefaultLayout from './restoreDefaultLayout';
 import * as revealResourceFile from './revealResourceFile';
 import * as search from './search';
 import * as setTags from './setTags';
@@ -61,6 +62,7 @@ const index:any[] = [
 	print,
 	renameFolder,
 	renameTag,
+	restoreDefaultLayout,
 	revealResourceFile,
 	search,
 	setTags,

--- a/packages/app-desktop/gui/MainScreen/commands/resetLayout.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/resetLayout.ts
@@ -3,8 +3,8 @@ import { _ } from '@joplin/lib/locale';
 import dialogs from '../../dialogs';
 
 export const declaration: CommandDeclaration = {
-	name: 'restoreDefaultLayout',
-	label: () => _('Restore the default layout'),
+	name: 'resetLayout',
+	label: () => _('Reset application layout'),
 };
 
 export const runtime = (): CommandRuntime => {
@@ -17,7 +17,7 @@ export const runtime = (): CommandRuntime => {
 			if (!isConfirmed) return;
 
 			context.dispatch({
-				type: 'RESTORE_DEFAULT_LAYOUT',
+				type: 'RESET_LAYOUT',
 				value: true,
 			});
 		},

--- a/packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.ts
@@ -1,24 +1,25 @@
-import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import dialogs from '../../dialogs';
-// import Setting from '@joplin/lib/models/Setting';
 
 export const declaration: CommandDeclaration = {
 	name: 'restoreDefaultLayout',
-	label: () => _('Restore default layout'),
+	label: () => _('Restore the default layout'),
 };
 
 export const runtime = (): CommandRuntime => {
 	return {
-		execute: async () => {
+		execute: async (context: CommandContext) => {
+
 			const message = _('Are you sure you want to return to the default layout? The current layout configuration will be lost.');
-			const confirmed = await dialogs.confirm(message);
+			const isConfirmed = await dialogs.confirm(message);
 
-			if (!confirmed) return;
+			if (!isConfirmed) return;
 
-			// load the default values
-			// set as the new active ones
-			// log a event??
+			context.dispatch({
+				type: 'RESTORE_DEFAULT_LAYOUT',
+				value: true,
+			});
 		},
 	};
 };

--- a/packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/restoreDefaultLayout.ts
@@ -1,0 +1,24 @@
+import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import dialogs from '../../dialogs';
+// import Setting from '@joplin/lib/models/Setting';
+
+export const declaration: CommandDeclaration = {
+	name: 'restoreDefaultLayout',
+	label: () => _('Restore default layout'),
+};
+
+export const runtime = (): CommandRuntime => {
+	return {
+		execute: async () => {
+			const message = _('Are you sure you want to return to the default layout? The current layout configuration will be lost.');
+			const confirmed = await dialogs.confirm(message);
+
+			if (!confirmed) return;
+
+			// load the default values
+			// set as the new active ones
+			// log a event??
+		},
+	};
+};

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -674,7 +674,7 @@ function useMenu(props: Props) {
 					label: _('&View'),
 					submenu: [
 						menuItemDic.toggleLayoutMoveMode,
-						menuItemDic.restoreDefaultLayout,
+						menuItemDic.resetLayout,
 						separator(),
 						menuItemDic.toggleSideBar,
 						menuItemDic.toggleNoteList,

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -674,6 +674,7 @@ function useMenu(props: Props) {
 					label: _('&View'),
 					submenu: [
 						menuItemDic.toggleLayoutMoveMode,
+						menuItemDic.restoreDefaultLayout,
 						separator(),
 						menuItemDic.toggleSideBar,
 						menuItemDic.toggleNoteList,

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -32,7 +32,7 @@ export default function() {
 		'textBulletedList',
 		'toggleExternalEditing',
 		'toggleLayoutMoveMode',
-		'restoreDefaultLayout',
+		'resetLayout',
 		'toggleNoteList',
 		'toggleNotesSortOrderField',
 		'toggleNotesSortOrderReverse',

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -32,6 +32,7 @@ export default function() {
 		'textBulletedList',
 		'toggleExternalEditing',
 		'toggleLayoutMoveMode',
+		'restoreDefaultLayout',
 		'toggleNoteList',
 		'toggleNotesSortOrderField',
 		'toggleNotesSortOrderReverse',


### PR DESCRIPTION
## Motivation/Functionality 

Change application layout is a nice feature but not that easy to use imo. At some point, the user may simply want to switch back to Joplin's standard layout, but for that the user 1) needs to remind what it was 2) know how to do it.

To do that, under the "View" menu, please add an item "Reset application layout" below "Change application layout". Ask for confirmation before doing so since the user will lose their custom layout

## Implementation:

The implementation, to avoid duplication of code and some kind of refactoring of the `MainScreen` component (the component that has the majority of the layout control logic), I created a new reducer event that changes a value called `isResettingLayout`. This value will be tracked inside the `MainScreen` that will be responsible to reset the layout and set `isResettingLayout` to `false` again.


## Testing

- Make some modifications to the layout: hide an element, drag some edges, or use the Change application layout option
- When pressing Reset application layout should return to the original layout