### PR TITLE
All: Remove test spy

### DIFF
--- a/packages/lib/versionInfo.test.ts
+++ b/packages/lib/versionInfo.test.ts
@@ -5,8 +5,6 @@ import Plugin from './services/plugins/Plugin';
 
 jest.mock('./registry');
 
-const info = jest.spyOn(console, 'info').mockImplementation(() => {});
-
 const mockedVersion = jest.fn(() => 'test');
 const mockedDb = { version: mockedVersion };
 
@@ -127,6 +125,4 @@ describe('getPluginLists', function() {
 		message.concat('\n...');
 		expect(v.message).toMatch(new RegExp(message));
 	});
-
-	info.mockReset();
 });


### PR DESCRIPTION
Remove a test spy that was added in https://github.com/laurent22/joplin/pull/7711 but that is no longer needed now that eslint rule  `no-console` is enforced.