### PR TITLE
Desktop:  Resolves #7763: Add link to Twitter

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -789,6 +789,9 @@ function useMenu(props: Props) {
 						label: _('Joplin Forum'),
 						click() { void bridge().openExternal('https://discourse.joplinapp.org'); },
 					}, {
+						label: _('Join us on Twitter'),
+						click() { void bridge().openExternal('https://twitter.com/joplinapp'); },
+					}, {
 						label: _('Make a donation'),
 						click() { void bridge().openExternal('https://joplinapp.org/donate/'); },
 					}, {


### PR DESCRIPTION
Original issue: https://github.com/laurent22/joplin/issues/7763

I'm adding a new option inside the Help menu to make it easier for users to discover Joplin's Twitter account.