### PR TITLE
Android: Resolves #7791: Simplify share logic and close share activity without debounce

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -82,11 +82,10 @@
 		<!-- SHARE EXTENSION -->
 		<activity
 			android:noHistory="true"
-			android:name=".share.ShareActivity"
+			android:name=".ShareActivity"
 			android:configChanges="orientation"
 			android:label="@string/app_name"
 			android:excludeFromRecents="true"
-			android:launchMode="singleTask"
 			android:theme="@style/AppTheme"
 			android:exported="true">
 			<intent-filter>

--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -84,6 +84,7 @@
 			android:noHistory="true"
 			android:name=".ShareActivity"
 			android:configChanges="orientation"
+			android:launchMode="singleTask"
 			android:label="@string/app_name"
 			android:excludeFromRecents="true"
 			android:theme="@style/AppTheme"

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/ShareActivity.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/ShareActivity.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.share;
+package net.cozic.joplin;
 
 import com.facebook.react.ReactActivity;
 

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/share/SharePackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/share/SharePackage.java
@@ -91,6 +91,10 @@ public class SharePackage implements ReactPackage {
                 return null;
             }
 
+            if (intent.getBooleanExtra("is_processed", false)) {
+                return null;
+            }
+
             String type = intent.getType() == null ? "" : intent.getType();
             map.putString("type", type);
             map.putString("title", getTitle(intent));
@@ -112,6 +116,7 @@ public class SharePackage implements ReactPackage {
             }
 
             map.putArray("resources", resources);
+            intent.putExtra("is_processed", true);
             return map;
         }
 

--- a/packages/app-mobile/utils/ShareExtension.ts
+++ b/packages/app-mobile/utils/ShareExtension.ts
@@ -1,5 +1,3 @@
-import debounce from './debounce';
-
 const { NativeModules, Platform } = require('react-native');
 
 export interface SharedData {
@@ -11,9 +9,7 @@ export interface SharedData {
 const ShareExtension = (NativeModules.ShareExtension) ?
 	{
 		data: () => NativeModules.ShareExtension.data(),
-		// we debounce the `close` method, to keep alive permissions of Uris received from the share activity
-		// this is to prevent getting permission denied error while sharing the same file to joplin multiple times in a row
-		close: () => debounce(() => NativeModules.ShareExtension.close(), 3 * 60 * 1000), // close it after 3 minutes
+		close: () => NativeModules.ShareExtension.close(),
 		shareURL: (Platform.OS === 'ios') ? NativeModules.ShareExtension.getConstants().SHARE_EXTENSION_SHARE_URL : '',
 	} :
 	{


### PR DESCRIPTION
Aims to resolve #7791
I could share the same file to joplin multiple times while the note was still open
As I still cannot understand and reproduce the duplication bug properly, it may not solve it completely
the only way I can reproduce is to reload the note in dev mode in this way:
1. select a file and share to joplin
2. reload the app using pressing 'r' in react native bundler

this way I could duplicate the note infinitely

an important note I think may be related:
In my last change I added launchMode, which was not present before my last PR as well
the problem is that share does not work without it
and right now share does not work when app is already open as well
maybe it is the root of our problem afterall ?
