### PR TITLE
Add prefer-arrow-callbacks to ESlint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,17 +50,6 @@ module.exports = {
 		},
 		'sourceType': 'module',
 	},
-	'plugins': [
-		'react',
-		'@typescript-eslint',
-		// Need to use a fork of the official rules of hooks because of this bug:
-		// https://github.com/facebook/react/issues/16265
-		'@seiyab/eslint-plugin-react-hooks',
-		// 'react-hooks',
-		'import',
-		'promise',
-		'prefer-arrow-functions',
-	],
 	'rules': {
 		// -------------------------------
 		// Code correctness
@@ -154,16 +143,18 @@ module.exports = {
 		// - notebook: In code, it should always be "folder" (not "notebook").
 		//   In user-facing text, it should be "notebook".
 		'id-denylist': ['error', 'err', 'notebook', 'notebooks'],
-		'prefer-arrow-functions/prefer-arrow-functions': [
-			'warn',
-			{
-				'classPropertiesAllowed': true,
-				'disallowPrototype': true,
-				'returnStyle': 'unchanged',
-				'singleReturnOnly': false,
-			},
-		],
+		'prefer-arrow-callback': ['error'],
 	},
+	'plugins': [
+		'react',
+		'@typescript-eslint',
+		// Need to use a fork of the official rules of hooks because of this bug:
+		// https://github.com/facebook/react/issues/16265
+		'@seiyab/eslint-plugin-react-hooks',
+		// 'react-hooks',
+		'import',
+		'promise',
+	],
 	'overrides': [
 		{
 			'files': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,17 @@ module.exports = {
 		},
 		'sourceType': 'module',
 	},
+	'plugins': [
+		'react',
+		'@typescript-eslint',
+		// Need to use a fork of the official rules of hooks because of this bug:
+		// https://github.com/facebook/react/issues/16265
+		'@seiyab/eslint-plugin-react-hooks',
+		// 'react-hooks',
+		'import',
+		'promise',
+		'prefer-arrow-functions',
+	],
 	'rules': {
 		// -------------------------------
 		// Code correctness
@@ -143,17 +154,16 @@ module.exports = {
 		// - notebook: In code, it should always be "folder" (not "notebook").
 		//   In user-facing text, it should be "notebook".
 		'id-denylist': ['error', 'err', 'notebook', 'notebooks'],
+		'prefer-arrow-functions/prefer-arrow-functions': [
+			'warn',
+			{
+				'classPropertiesAllowed': true,
+				'disallowPrototype': true,
+				'returnStyle': 'unchanged',
+				'singleReturnOnly': false,
+			},
+		],
 	},
-	'plugins': [
-		'react',
-		'@typescript-eslint',
-		// Need to use a fork of the official rules of hooks because of this bug:
-		// https://github.com/facebook/react/issues/16265
-		'@seiyab/eslint-plugin-react-hooks',
-		// 'react-hooks',
-		'import',
-		'promise',
-	],
 	'overrides': [
 		{
 			'files': [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint": "8.31.0",
     "eslint-interactive": "10.3.0",
     "eslint-plugin-import": "2.27.4",
-    "eslint-plugin-prefer-arrow-functions": "^3.1.4",
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.32.0",
     "fs-extra": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint": "8.31.0",
     "eslint-interactive": "10.3.0",
     "eslint-plugin-import": "2.27.4",
+    "eslint-plugin-prefer-arrow-functions": "^3.1.4",
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.32.0",
     "fs-extra": "11.1.0",

--- a/packages/app-cli/app/autocompletion.js
+++ b/packages/app-cli/app/autocompletion.js
@@ -125,14 +125,14 @@ async function handleAutocompletionPromise(line) {
 }
 function handleAutocompletion(str, callback) {
 // eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
-	handleAutocompletionPromise(str).then(function(res) {
+	handleAutocompletionPromise(str).then((res) => {
 		callback(undefined, res);
 	});
 }
 function toCommandLine(args) {
 	if (Array.isArray(args)) {
 		return args
-			.map(function(a) {
+			.map((a) => {
 				if (a.indexOf('"') !== -1 || a.indexOf(' ') !== -1) {
 					return `'${a}'`;
 				} else if (a.indexOf('\'') !== -1) {

--- a/packages/app-cli/app/main.js
+++ b/packages/app-cli/app/main.js
@@ -75,12 +75,12 @@ if (process.platform === 'win32') {
 		output: process.stdout,
 	});
 
-	rl.on('SIGINT', function() {
+	rl.on('SIGINT', () => {
 		process.emit('SIGINT');
 	});
 }
 
-process.stdout.on('error', function(error) {
+process.stdout.on('error', (error) => {
 	// https://stackoverflow.com/questions/12329816/error-write-epipe-when-piping-node-output-to-head#15884508
 	if (error.code === 'EPIPE') {
 		process.exit(0);

--- a/packages/app-cli/tests/HtmlToHtml.js
+++ b/packages/app-cli/tests/HtmlToHtml.js
@@ -12,7 +12,7 @@ const shim = require('@joplin/lib/shim').default;
 const HtmlToHtml = require('@joplin/renderer/HtmlToHtml').default;
 const { enexXmlToMd } = require('@joplin/lib/import-enex-md-gen.js');
 
-describe('HtmlToHtml', function() {
+describe('HtmlToHtml', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/app-cli/tests/HtmlToMd.ts
+++ b/packages/app-cli/tests/HtmlToMd.ts
@@ -3,7 +3,7 @@ const os = require('os');
 const { filename } = require('@joplin/lib/path-utils');
 import HtmlToMd from '@joplin/lib/HtmlToMd';
 
-describe('HtmlToMd', function() {
+describe('HtmlToMd', () => {
 
 	it('should convert from Html to Markdown', (async () => {
 		const basePath = `${__dirname}/html_to_md`;

--- a/packages/app-cli/tests/MarkupToHtml.js
+++ b/packages/app-cli/tests/MarkupToHtml.js
@@ -1,7 +1,7 @@
 
 const MarkupToHtml = require('@joplin/renderer/MarkupToHtml').default;
 
-describe('MarkupToHtml', function() {
+describe('MarkupToHtml', () => {
 
 	it('should strip markup', (async () => {
 		const service = new MarkupToHtml();

--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -16,7 +16,7 @@ function newTestMdToHtml(options: any = null) {
 	return new MdToHtml(options);
 }
 
-describe('MdToHtml', function() {
+describe('MdToHtml', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/app-cli/tests/feature_NoteHistory.js
+++ b/packages/app-cli/tests/feature_NoteHistory.js
@@ -22,7 +22,7 @@ const goToNote = (testApp, note) => {
 	testApp.dispatch({ type: 'NOTE_SELECT', id: note.id });
 };
 
-describe('feature_NoteHistory', function() {
+describe('feature_NoteHistory', () => {
 	beforeEach(async () => {
 		testApp = new TestApp();
 		await testApp.start(['--no-welcome']);

--- a/packages/app-cli/tests/feature_NoteList.js
+++ b/packages/app-cli/tests/feature_NoteList.js
@@ -8,7 +8,7 @@ const time = require('@joplin/lib/time').default;
 
 let testApp = null;
 
-describe('integration_NoteList', function() {
+describe('integration_NoteList', () => {
 
 	beforeEach(async () => {
 		testApp = new TestApp();

--- a/packages/app-cli/tests/feature_ShowAllNotes.js
+++ b/packages/app-cli/tests/feature_ShowAllNotes.js
@@ -22,7 +22,7 @@ const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids.js');
 
 let testApp = null;
 
-describe('integration_ShowAllNotes', function() {
+describe('integration_ShowAllNotes', () => {
 
 	beforeEach(async () => {
 		testApp = new TestApp();

--- a/packages/app-cli/tests/feature_TagList.js
+++ b/packages/app-cli/tests/feature_TagList.js
@@ -8,7 +8,7 @@ const time = require('@joplin/lib/time').default;
 
 let testApp = null;
 
-describe('integration_TagList', function() {
+describe('integration_TagList', () => {
 
 	beforeEach(async () => {
 		testApp = new TestApp();

--- a/packages/app-cli/tests/services/keychain/KeychainService.ts
+++ b/packages/app-cli/tests/services/keychain/KeychainService.ts
@@ -11,7 +11,7 @@ function describeIfCompatible(name: string, fn: any, elseFn: any) {
 	}
 }
 
-describeIfCompatible('services_KeychainService', function() {
+describeIfCompatible('services_KeychainService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1, { keychainEnabled: true });

--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -29,7 +29,7 @@ function newPluginService(appVersion: string = '1.4') {
 	return service;
 }
 
-describe('services_PluginService', function() {
+describe('services_PluginService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/app-cli/tests/services/plugins/RepositoryApi.ts
+++ b/packages/app-cli/tests/services/plugins/RepositoryApi.ts
@@ -8,7 +8,7 @@ async function newRepoApi(): Promise<RepositoryApi> {
 	return repo;
 }
 
-describe('services_plugins_RepositoryApi', function() {
+describe('services_plugins_RepositoryApi', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
+++ b/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
@@ -24,7 +24,7 @@ function newPluginService(appVersion: string = '1.4') {
 	return service;
 }
 
-describe('defaultPluginsUtils', function() {
+describe('defaultPluginsUtils', () => {
 
 	const pluginsId = ['joplin.plugin.ambrt.backlinksToNote', 'org.joplinapp.plugins.ToggleSidebars'];
 

--- a/packages/app-cli/tests/services/plugins/sandboxProxy.ts
+++ b/packages/app-cli/tests/services/plugins/sandboxProxy.ts
@@ -1,7 +1,7 @@
 const sandboxProxy = require('@joplin/lib/services/plugins/sandboxProxy');
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 
-describe('services_plugins_sandboxProxy', function() {
+describe('services_plugins_sandboxProxy', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/app-clipper/background.js
+++ b/packages/app-clipper/background.js
@@ -50,7 +50,7 @@ async function browserGetZoom(tabId) {
 	});
 }
 
-browser_.runtime.onInstalled.addListener(function() {
+browser_.runtime.onInstalled.addListener(() => {
 	if (window.joplinEnv() === 'dev') {
 		browser_.browserAction.setIcon({
 			path: 'icons/32-dev.png',
@@ -165,7 +165,7 @@ async function sendClipMessage(clipType) {
 	}
 }
 
-browser_.commands.onCommand.addListener(function(command) {
+browser_.commands.onCommand.addListener((command) => {
 	// We could enumerate these twice, but since we're in here first,
 	// why not save ourselves the trouble with this convention
 	if (command.startsWith('clip')) {

--- a/packages/app-clipper/popup/scripts/start.js
+++ b/packages/app-clipper/popup/scripts/start.js
@@ -130,8 +130,8 @@ checkBrowsers(paths.appPath, isInteractive)
 			openBrowser(urls.localUrlForBrowser);
 		});
 
-		['SIGINT', 'SIGTERM'].forEach(function(sig) {
-			process.on(sig, function() {
+		['SIGINT', 'SIGTERM'].forEach((sig) => {
+			process.on(sig, () => {
 				devServer.close();
 				process.exit();
 			});

--- a/packages/app-desktop/app.reducer.test.ts
+++ b/packages/app-desktop/app.reducer.test.ts
@@ -1,7 +1,7 @@
 import { AppState } from './app.reducer';
 import appReducer, { createAppDefaultState } from './app.reducer';
 
-describe('app.reducer', function() {
+describe('app.reducer', () => {
 
 	it('DIALOG_OPEN', async () => {
 		const state: AppState = createAppDefaultState({}, {});

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useJoplinCommands.ts
@@ -1,7 +1,7 @@
 // Helper commands added to the the CodeMirror instance
 export default function useJoplinCommands(CodeMirror: any) {
 
-	CodeMirror.defineExtension('commandExists', function(name: string) {
+	CodeMirror.defineExtension('commandExists', (name: string) => {
 		return !!CodeMirror.commands[name];
 	});
 }

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
@@ -93,7 +93,7 @@ export default function useKeymap(CodeMirror: any) {
 	}
 
 
-	CodeMirror.defineExtension('supportsCommand', function(cmd: EditorCommand) {
+	CodeMirror.defineExtension('supportsCommand', (cmd: EditorCommand) => {
 		return isEditorCommand(cmd.name) && editorCommandToCodeMirror(cmd.name) in CodeMirror.commands;
 	});
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -674,7 +674,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						props_onDrop.current(event);
 					});
 
-					editor.on('ObjectResized', function(event: any) {
+					editor.on('ObjectResized', (event: any) => {
 						if (event.target.nodeName === 'IMG') {
 							editor.fire(TinyMceEditorEvents.JoplinChange);
 							dispatchDidUpdate(editor);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
@@ -51,7 +51,7 @@ export default function(editor: any) {
 				editor.execCommand('mceToggleFormat', false, def.name);
 			},
 			onSetup: function(api: any) {
-				editor.formatter.formatChanged(def.name, function(state: boolean) {
+				editor.formatter.formatChanged(def.name, (state: boolean) => {
 					api.setActive(state);
 				});
 			},

--- a/packages/app-desktop/gui/NoteEditor/utils/useFolder.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFolder.ts
@@ -9,7 +9,7 @@ export default function(dependencies: HookDependencies) {
 	const { folderId } = dependencies;
 	const [folder, setFolder] = useState(null);
 
-	useEffect(function() {
+	useEffect(() => {
 		let cancelled = false;
 
 		async function loadFolder() {

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -192,7 +192,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [noteId, isProvisional, formNote]);
 
-	const onResourceChange = useCallback(async function(event: any = null) {
+	const onResourceChange = useCallback(async (event: any = null) => {
 		const resourceIds = await Note.linkedResourceIds(formNote.body);
 		if (!event || resourceIds.indexOf(event.id) >= 0) {
 			clearResourceCache();

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -69,7 +69,7 @@ const SortOrderButtonsContainer = styled.div`
 function NoteListControls(props: Props) {
 	const searchBarRef = useRef(null);
 
-	useEffect(function() {
+	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));
 
 		return function() {

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -98,7 +98,7 @@ const GlobalStyle = createGlobalStyle`
 let wcsTimeoutId_: any = null;
 
 async function initialize() {
-	bridge().window().on('resize', function() {
+	bridge().window().on('resize', () => {
 		if (wcsTimeoutId_) shim.clearTimeout(wcsTimeoutId_);
 
 		wcsTimeoutId_ = shim.setTimeout(() => {

--- a/packages/app-desktop/gui/Root_UpgradeSyncTarget.tsx
+++ b/packages/app-desktop/gui/Root_UpgradeSyncTarget.tsx
@@ -8,7 +8,7 @@ import Setting from '@joplin/lib/models/Setting';
 import restart from '../services/restart';
 
 function useAppCloseHandler(upgradeResult: SyncTargetUpgradeResult) {
-	useEffect(function() {
+	useEffect(() => {
 		async function onAppClose() {
 			let canClose = true;
 
@@ -38,7 +38,7 @@ function useAppCloseHandler(upgradeResult: SyncTargetUpgradeResult) {
 }
 
 function useStyle() {
-	useEffect(function() {
+	useEffect(() => {
 		const element = document.createElement('style');
 		element.appendChild(document.createTextNode(`
 			body {
@@ -62,7 +62,7 @@ function useStyle() {
 }
 
 function useRestartOnDone(upgradeResult: SyncTargetUpgradeResult) {
-	useEffect(function() {
+	useEffect(() => {
 		if (upgradeResult.done && !upgradeResult.error) {
 			void restart();
 		}

--- a/packages/app-desktop/gui/note-viewer/lib.js
+++ b/packages/app-desktop/gui/note-viewer/lib.js
@@ -188,7 +188,7 @@ webviewLib.initialize = function(options) {
 	webviewLib.options_ = options;
 };
 
-document.addEventListener('click', function(event) {
+document.addEventListener('click', (event) => {
 	const anchor = webviewLib.getParentAnchorElement(event.target);
 	if (!anchor) return;
 

--- a/packages/app-mobile/tools/encodeAssets.js
+++ b/packages/app-mobile/tools/encodeAssets.js
@@ -8,7 +8,7 @@ const outputDir = `${rootDir}/pluginAssets`;
 const walk = function(dir) {
 	let results = [];
 	const list = fs.readdirSync(dir);
-	list.forEach(function(file) {
+	list.forEach((file) => {
 		file = `${dir}/${file}`;
 		const stat = fs.statSync(file);
 		if (stat && stat.isDirectory()) {

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -215,8 +215,8 @@ function shimInit() {
 	};
 
 	shim.waitForFrame = () => {
-		return new Promise(function(resolve) {
-			requestAnimationFrame(function() {
+		return new Promise((resolve) => {
+			requestAnimationFrame(() => {
 				resolve();
 			});
 		});

--- a/packages/generator-joplin/generators/app/utils.js
+++ b/packages/generator-joplin/generators/app/utils.js
@@ -43,7 +43,7 @@ function mergePackageKey(parentKey, source, dest) {
 function mergeIgnoreFile(source, dest) {
 	const output = dest.trim().split(/\r?\n/).concat(source.trim().split(/\r?\n/));
 
-	return `${output.filter(function(item, pos) {
+	return `${output.filter((item, pos) => {
 		if (!item) return true; // Leave blank lines
 		return output.indexOf(item) === pos;
 	}).join('\n').trim()}\n`;

--- a/packages/lib/ArrayUtils.test.js
+++ b/packages/lib/ArrayUtils.test.js
@@ -1,6 +1,6 @@
 const ArrayUtils = require('./ArrayUtils');
 
-describe('ArrayUtils', function() {
+describe('ArrayUtils', () => {
 
 
 

--- a/packages/lib/ArrayUtils.ts
+++ b/packages/lib/ArrayUtils.ts
@@ -1,5 +1,5 @@
 export const unique = function(array: any[]) {
-	return array.filter(function(elem, index, self) {
+	return array.filter((elem, index, self) => {
 		return index === self.indexOf(elem);
 	});
 };

--- a/packages/lib/ClipperServer.ts
+++ b/packages/lib/ClipperServer.ts
@@ -198,7 +198,7 @@ export default class ClipperServer {
 				if (contentType.indexOf('multipart/form-data') === 0) {
 					const form = new multiparty.Form();
 
-					form.parse(request, function(error: any, fields: any, files: any) {
+					form.parse(request, (error: any, fields: any, files: any) => {
 						if (error) {
 							writeResponse(error.httpCode ? error.httpCode : 500, error.message);
 							return;

--- a/packages/lib/InMemoryCache.test.ts
+++ b/packages/lib/InMemoryCache.test.ts
@@ -1,7 +1,7 @@
 import InMemoryCache from './InMemoryCache';
 import time from './time';
 
-describe('InMemoryCache', function() {
+describe('InMemoryCache', () => {
 
 	it('should get and set values', () => {
 		const cache = new InMemoryCache();

--- a/packages/lib/ObjectUtils.ts
+++ b/packages/lib/ObjectUtils.ts
@@ -8,7 +8,7 @@ export function sortByValue(object: any) {
 		});
 	}
 
-	temp.sort(function(a, b) {
+	temp.sort((a, b) => {
 		let v1 = a.value;
 		let v2 = b.value;
 		if (typeof v1 === 'string') v1 = v1.toLowerCase();

--- a/packages/lib/StringUtils.test.js
+++ b/packages/lib/StringUtils.test.js
@@ -3,7 +3,7 @@
 const { splitCommandBatch } = require('./string-utils');
 const StringUtils = require('./string-utils');
 
-describe('StringUtils', function() {
+describe('StringUtils', () => {
 
 
 

--- a/packages/lib/TaskQueue.test.js
+++ b/packages/lib/TaskQueue.test.js
@@ -1,7 +1,7 @@
 const { setupDatabaseAndSynchronizer, sleep, switchClient } = require('./testing/test-utils.js');
 const TaskQueue = require('./TaskQueue').default;
 
-describe('TaskQueue', function() {
+describe('TaskQueue', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/array.ts
+++ b/packages/lib/array.ts
@@ -10,7 +10,7 @@ export function shuffle<T>(array: T[]): T[] {
 }
 
 export function unique<T>(array: T[]): T[] {
-	return array.filter(function(elem, index, self) {
+	return array.filter((elem, index, self) => {
 		return index === self.indexOf(elem);
 	});
 }

--- a/packages/lib/callbackUrlUtils.test.ts
+++ b/packages/lib/callbackUrlUtils.test.ts
@@ -1,6 +1,6 @@
 import * as callbackUrlUtils from './callbackUrlUtils';
 
-describe('callbackUrlUtils', function() {
+describe('callbackUrlUtils', () => {
 
 	it('should identify valid callback urls', () => {
 		const url = 'joplin://x-callback-url/123?a=b';

--- a/packages/lib/database.test.js
+++ b/packages/lib/database.test.js
@@ -1,7 +1,7 @@
 const { setupDatabaseAndSynchronizer, switchClient } = require('./testing/test-utils.js');
 const BaseModel = require('./BaseModel').default;
 
-describe('database', function() {
+describe('database', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);

--- a/packages/lib/database.ts
+++ b/packages/lib/database.ts
@@ -68,14 +68,14 @@ export default class Database {
 		this.logger().info('Database was open successfully');
 	}
 
-	escapeField = (field: string) => {
+	public escapeField(field: string) {
 		if (field === '*') return '*';
 		const p = field.split('.');
 		if (p.length === 1) return `\`${field}\``;
 		if (p.length === 2) return `${p[0]}.\`${p[1]}\``;
 
 		throw new Error(`Invalid field format: ${field}`);
-	};
+	}
 
 	public escapeFields(fields: string[] | string): string[] | string {
 		if (fields === '*') return '*';
@@ -161,7 +161,17 @@ export default class Database {
 		return this.tryCall('selectOne', sql, params);
 	}
 
-	loadExtension = async () => undefined;
+	async loadExtension(/* path */) {
+		return; // Disabled for now as fuzzy search extension is not in use
+
+		// let result =  null;
+		// try {
+		// 	result = await this.driver().loadExtension(path);
+		// 	return result;
+		// } catch (e) {
+		// 	throw new Error(`Could not load extension ${path}`);
+		// }
+	}
 
 	async selectAll(sql: string, params: SqlParams = null): Promise<Row[]> {
 		return this.tryCall('selectAll', sql, params);
@@ -230,7 +240,7 @@ export default class Database {
 		throw new Error(`Unknown enum type or value: ${type}, ${s}`);
 	}
 
-	enumName = (type: string, id: number) => {
+	static enumName(type: string, id: number) {
 		if (type === 'fieldType') {
 			if (id === Database.TYPE_UNKNOWN) return 'unknown';
 			if (id === Database.TYPE_INT) return 'int';
@@ -241,7 +251,7 @@ export default class Database {
 
 		// Or maybe an error should be thrown
 		return undefined;
-	};
+	}
 
 	static formatValue(type: number, value: any) {
 		if (value === null || value === undefined) return null;
@@ -251,7 +261,7 @@ export default class Database {
 		throw new Error(`Unknown type: ${type}`);
 	}
 
-	sqlStringToLines = (sql: string) => {
+	sqlStringToLines(sql: string) {
 		const output = [];
 		const lines = sql.split('\n');
 		let statement = '';
@@ -267,7 +277,7 @@ export default class Database {
 			}
 		}
 		return output;
-	};
+	}
 
 	logQuery(sql: string, params: SqlParams = null) {
 		if (!this.sqlQueryLogEnabled_) return;
@@ -283,7 +293,7 @@ export default class Database {
 		if (params !== null && params.length) this.logger().debug(JSON.stringify(params));
 	}
 
-	insertQuery = (tableName: string, data: Record<string, any>) => {
+	static insertQuery(tableName: string, data: Record<string, any>) {
 		if (!data || !Object.keys(data).length) throw new Error('Data is empty');
 
 		let keySql = '';
@@ -302,9 +312,9 @@ export default class Database {
 			sql: `INSERT INTO \`${tableName}\` (${keySql}) VALUES (${valueSql})`,
 			params: params,
 		};
-	};
+	}
 
-	updateQuery = (tableName: string, data: Record<string, any>, where: string | Record<string, any>) => {
+	static updateQuery(tableName: string, data: Record<string, any>, where: string | Record<string, any>) {
 		if (!data || !Object.keys(data).length) throw new Error('Data is empty');
 
 		let sql = '';
@@ -331,7 +341,7 @@ export default class Database {
 			sql: `UPDATE \`${tableName}\` SET ${sql} WHERE ${where}`,
 			params: params,
 		};
-	};
+	}
 
 	alterColumnQueries(tableName: string, fields: Record<string, string>) {
 		const fieldsNoType = [];
@@ -371,7 +381,7 @@ export default class Database {
 		return output;
 	}
 
-	wrapQuery = (sql: any, params: SqlParams = null): SqlQuery => {
+	wrapQuery(sql: any, params: SqlParams = null): SqlQuery {
 		if (!sql) throw new Error(`Cannot wrap empty string: ${sql}`);
 
 		if (Array.isArray(sql)) {
@@ -384,5 +394,5 @@ export default class Database {
 		} else {
 			return sql; // Already wrapped
 		}
-	};
+	}
 }

--- a/packages/lib/database.ts
+++ b/packages/lib/database.ts
@@ -68,14 +68,14 @@ export default class Database {
 		this.logger().info('Database was open successfully');
 	}
 
-	public escapeField(field: string) {
+	escapeField = (field: string) => {
 		if (field === '*') return '*';
 		const p = field.split('.');
 		if (p.length === 1) return `\`${field}\``;
 		if (p.length === 2) return `${p[0]}.\`${p[1]}\``;
 
 		throw new Error(`Invalid field format: ${field}`);
-	}
+	};
 
 	public escapeFields(fields: string[] | string): string[] | string {
 		if (fields === '*') return '*';
@@ -161,17 +161,7 @@ export default class Database {
 		return this.tryCall('selectOne', sql, params);
 	}
 
-	async loadExtension(/* path */) {
-		return; // Disabled for now as fuzzy search extension is not in use
-
-		// let result =  null;
-		// try {
-		// 	result = await this.driver().loadExtension(path);
-		// 	return result;
-		// } catch (e) {
-		// 	throw new Error(`Could not load extension ${path}`);
-		// }
-	}
+	loadExtension = async () => undefined;
 
 	async selectAll(sql: string, params: SqlParams = null): Promise<Row[]> {
 		return this.tryCall('selectAll', sql, params);
@@ -240,7 +230,7 @@ export default class Database {
 		throw new Error(`Unknown enum type or value: ${type}, ${s}`);
 	}
 
-	static enumName(type: string, id: number) {
+	enumName = (type: string, id: number) => {
 		if (type === 'fieldType') {
 			if (id === Database.TYPE_UNKNOWN) return 'unknown';
 			if (id === Database.TYPE_INT) return 'int';
@@ -251,7 +241,7 @@ export default class Database {
 
 		// Or maybe an error should be thrown
 		return undefined;
-	}
+	};
 
 	static formatValue(type: number, value: any) {
 		if (value === null || value === undefined) return null;
@@ -261,7 +251,7 @@ export default class Database {
 		throw new Error(`Unknown type: ${type}`);
 	}
 
-	sqlStringToLines(sql: string) {
+	sqlStringToLines = (sql: string) => {
 		const output = [];
 		const lines = sql.split('\n');
 		let statement = '';
@@ -277,7 +267,7 @@ export default class Database {
 			}
 		}
 		return output;
-	}
+	};
 
 	logQuery(sql: string, params: SqlParams = null) {
 		if (!this.sqlQueryLogEnabled_) return;
@@ -293,7 +283,7 @@ export default class Database {
 		if (params !== null && params.length) this.logger().debug(JSON.stringify(params));
 	}
 
-	static insertQuery(tableName: string, data: Record<string, any>) {
+	insertQuery = (tableName: string, data: Record<string, any>) => {
 		if (!data || !Object.keys(data).length) throw new Error('Data is empty');
 
 		let keySql = '';
@@ -312,9 +302,9 @@ export default class Database {
 			sql: `INSERT INTO \`${tableName}\` (${keySql}) VALUES (${valueSql})`,
 			params: params,
 		};
-	}
+	};
 
-	static updateQuery(tableName: string, data: Record<string, any>, where: string | Record<string, any>) {
+	updateQuery = (tableName: string, data: Record<string, any>, where: string | Record<string, any>) => {
 		if (!data || !Object.keys(data).length) throw new Error('Data is empty');
 
 		let sql = '';
@@ -341,7 +331,7 @@ export default class Database {
 			sql: `UPDATE \`${tableName}\` SET ${sql} WHERE ${where}`,
 			params: params,
 		};
-	}
+	};
 
 	alterColumnQueries(tableName: string, fields: Record<string, string>) {
 		const fieldsNoType = [];
@@ -381,7 +371,7 @@ export default class Database {
 		return output;
 	}
 
-	wrapQuery(sql: any, params: SqlParams = null): SqlQuery {
+	wrapQuery = (sql: any, params: SqlParams = null): SqlQuery => {
 		if (!sql) throw new Error(`Cannot wrap empty string: ${sql}`);
 
 		if (Array.isArray(sql)) {
@@ -394,5 +384,5 @@ export default class Database {
 		} else {
 			return sql; // Already wrapped
 		}
-	}
+	};
 }

--- a/packages/lib/eventManager.test.js
+++ b/packages/lib/eventManager.test.js
@@ -4,7 +4,7 @@
 const { checkThrow } = require('./testing/test-utils.js');
 const eventManager = require('./eventManager').default;
 
-describe('eventManager', function() {
+describe('eventManager', () => {
 
 	beforeEach(async () => {
 		eventManager.reset();

--- a/packages/lib/file-api-driver.test.ts
+++ b/packages/lib/file-api-driver.test.ts
@@ -1,6 +1,6 @@
 import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient, fileApi } from './testing/test-utils';
 
-describe('file-api-driver', function() {
+describe('file-api-driver', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -422,7 +422,7 @@ async function basicDelta(path: string, getDirStatFn: Function, options: any) {
 	// Stats are cached until all items have been processed (until hasMore is false)
 	if (newContext.statsCache === null) {
 		newContext.statsCache = await getDirStatFn(path);
-		newContext.statsCache.sort(function(a: any, b: any) {
+		newContext.statsCache.sort((a: any, b: any) => {
 			return a.updated_time - b.updated_time;
 		});
 		newContext.statIdsCache = newContext.statsCache.filter((item: any) => BaseItem.isSystemPath(item.path)).map((item: any) => BaseItem.pathToId(item.path));

--- a/packages/lib/fsDriver.test.ts
+++ b/packages/lib/fsDriver.test.ts
@@ -12,7 +12,7 @@ function platformPath(path: string) {
 	}
 }
 
-describe('fsDriver', function() {
+describe('fsDriver', () => {
 
 	it('should resolveRelativePathWithinDir', async () => {
 		const fsDriver = new FsDriverNode();

--- a/packages/lib/htmlUtils2.test.ts
+++ b/packages/lib/htmlUtils2.test.ts
@@ -1,6 +1,6 @@
 import htmlUtils from './htmlUtils';
 
-describe('htmlUtils', function() {
+describe('htmlUtils', () => {
 
 
 

--- a/packages/lib/import-enex-html-gen.js
+++ b/packages/lib/import-enex-html-gen.js
@@ -69,12 +69,12 @@ function enexXmlToHtml_(stream, resources) {
 			parent: null,
 		};
 
-		saxStream.on('error', function(e) {
+		saxStream.on('error', (e) => {
 			console.warn(e);
 		});
 
 
-		saxStream.on('text', function(text) {
+		saxStream.on('text', (text) => {
 			section.lines.push(htmlentities(text));
 		});
 
@@ -135,14 +135,14 @@ function enexXmlToHtml_(stream, resources) {
 			}
 		});
 
-		saxStream.on('closetag', function(node) {
+		saxStream.on('closetag', (node) => {
 			const tagName = node ? node.toLowerCase() : node;
 			if (!htmlUtils.isSelfClosingTag(tagName)) section.lines.push(`</${tagName}>`);
 		});
 
-		saxStream.on('attribute', function() {});
+		saxStream.on('attribute', () => {});
 
-		saxStream.on('end', function() {
+		saxStream.on('end', () => {
 			resolve({
 				content: section,
 				resources: remainingResources,

--- a/packages/lib/import-enex-html-gen.test.js
+++ b/packages/lib/import-enex-html-gen.test.js
@@ -58,7 +58,7 @@ const compareOutputToExpected = (options) => {
 	}));
 };
 
-describe('EnexToHtml', function() {
+describe('EnexToHtml', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);

--- a/packages/lib/import-enex-md-gen.test.ts
+++ b/packages/lib/import-enex-md-gen.test.ts
@@ -13,7 +13,7 @@ import Resource from './models/Resource';
 
 const enexSampleBaseDir = `${supportDir}/../enex_to_md`;
 
-describe('import-enex-md-gen', function() {
+describe('import-enex-md-gen', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/import-enex-md-gen.ts
+++ b/packages/lib/import-enex-md-gen.ts
@@ -587,7 +587,7 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[]): Promise<Ene
 			parent: null,
 		};
 
-		saxStream.on('error', function(e: any) {
+		saxStream.on('error', (e: any) => {
 			console.warn(e);
 		});
 
@@ -615,7 +615,7 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[]): Promise<Ene
 			return output;
 		};
 
-		saxStream.on('text', function(text: string) {
+		saxStream.on('text', (text: string) => {
 			if (['table', 'tr', 'tbody'].indexOf(section.type) >= 0) return;
 
 			text = !state.inPre ? unwrapInnerText(text) : text;
@@ -923,7 +923,7 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[]): Promise<Ene
 			}
 		});
 
-		saxStream.on('closetag', function(n: string) {
+		saxStream.on('closetag', (n: string) => {
 			n = n ? n.toLowerCase() : n;
 
 			const poppedTag = state.tags.pop();
@@ -1121,9 +1121,9 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[]): Promise<Ene
 			}
 		});
 
-		saxStream.on('attribute', function() {});
+		saxStream.on('attribute', () => {});
 
-		saxStream.on('end', function() {
+		saxStream.on('end', () => {
 			resolve({
 				content: section,
 				resources: remainingResources,

--- a/packages/lib/import-enex.ts
+++ b/packages/lib/import-enex.ts
@@ -53,7 +53,7 @@ async function decodeBase64File(sourceFilePath: string, destFilePath: string) {
 	// would be ignored. I don't think it's happening anymore, but something to keep in mind
 	// anyway.
 
-	return new Promise(function(resolve, reject) {
+	return new Promise((resolve, reject) => {
 		// Note: we manually handle closing the file so that we can
 		// force flusing it before close. This is needed because
 		// "end" might be called before the file has been flushed
@@ -528,7 +528,7 @@ export default async function importEnex(parentFolderId: string, filePath: strin
 			}
 		}));
 
-		saxStream.on('opentag', handleSaxStreamEvent(function(node: Node) {
+		saxStream.on('opentag', handleSaxStreamEvent((node: Node) => {
 			const n = node.name.toLowerCase();
 			nodes.push(node);
 
@@ -551,7 +551,7 @@ export default async function importEnex(parentFolderId: string, filePath: strin
 			}
 		}));
 
-		saxStream.on('cdata', handleSaxStreamEvent(function(data: any) {
+		saxStream.on('cdata', handleSaxStreamEvent((data: any) => {
 			const n = currentNodeName();
 
 			if (noteResourceRecognition) {
@@ -633,7 +633,7 @@ export default async function importEnex(parentFolderId: string, filePath: strin
 			}
 		}));
 
-		saxStream.on('end', handleSaxStreamEvent(function() {
+		saxStream.on('end', handleSaxStreamEvent(() => {
 			// Wait till there is no more notes to process.
 			const iid = shim.setInterval(() => {
 				// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied

--- a/packages/lib/markdownUtils2.test.ts
+++ b/packages/lib/markdownUtils2.test.ts
@@ -2,7 +2,7 @@
 
 import markdownUtils from './markdownUtils';
 
-describe('markdownUtils', function() {
+describe('markdownUtils', () => {
 
 
 

--- a/packages/lib/mimeUtils.test.js
+++ b/packages/lib/mimeUtils.test.js
@@ -1,6 +1,6 @@
 const mimeUtils = require('./mime-utils.js').mime;
 
-describe('mimeUils', function() {
+describe('mimeUils', () => {
 
 
 

--- a/packages/lib/models/BaseItem.test.js
+++ b/packages/lib/models/BaseItem.test.js
@@ -2,7 +2,7 @@ const { setupDatabaseAndSynchronizer, switchClient } = require('../testing/test-
 const Folder = require('../models/Folder').default;
 const Note = require('../models/Note').default;
 
-describe('models/BaseItem', function() {
+describe('models/BaseItem', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Folder.sharing.test.ts
+++ b/packages/lib/models/Folder.sharing.test.ts
@@ -9,7 +9,7 @@ import ResourceService from '../services/ResourceService';
 
 const testImagePath = `${supportDir}/photo.jpg`;
 
-describe('models/Folder.sharing', function() {
+describe('models/Folder.sharing', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Folder.test.ts
+++ b/packages/lib/models/Folder.test.ts
@@ -9,7 +9,7 @@ async function allItems() {
 	return folders.concat(notes);
 }
 
-describe('models/Folder', function() {
+describe('models/Folder', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/ItemChange.test.ts
+++ b/packages/lib/models/ItemChange.test.ts
@@ -7,7 +7,7 @@ import ItemChange from '../models/ItemChange';
 
 let searchEngine: SearchEngine = null;
 
-describe('models/ItemChange', function() {
+describe('models/ItemChange', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/MasterKey.test.ts
+++ b/packages/lib/models/MasterKey.test.ts
@@ -1,7 +1,7 @@
 import { encryptionService, msleep, setupDatabaseAndSynchronizer, switchClient } from '../testing/test-utils';
 import MasterKey from './MasterKey';
 
-describe('models/MasterKey', function() {
+describe('models/MasterKey', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -18,7 +18,7 @@ async function allItems() {
 	return folders.concat(notes);
 }
 
-describe('models/Note', function() {
+describe('models/Note', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
@@ -411,7 +411,7 @@ describe('models/Note', function() {
 
 });
 
-describe('models/Note_replacePaths', function() {
+describe('models/Note_replacePaths', () => {
 
 	function testResourceReplacment(body: string, pathsToTry: string[], expected: string) {
 		expect(Note['replaceResourceExternalToInternalLinks_'](pathsToTry, body)).toBe(expected);

--- a/packages/lib/models/Note_CustomSortOrder.test.js
+++ b/packages/lib/models/Note_CustomSortOrder.test.js
@@ -3,7 +3,7 @@ const { setupDatabaseAndSynchronizer, switchClient } = require('../testing/test-
 const Folder = require('../models/Folder').default;
 const Note = require('../models/Note').default;
 
-describe('models/Note_CustomSortOrder', function() {
+describe('models/Note_CustomSortOrder', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);

--- a/packages/lib/models/Resource.test.ts
+++ b/packages/lib/models/Resource.test.ts
@@ -6,7 +6,7 @@ import shim from '../shim';
 
 const testImagePath = `${supportDir}/photo.jpg`;
 
-describe('models/Resource', function() {
+describe('models/Resource', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Revision.test.ts
+++ b/packages/lib/models/Revision.test.ts
@@ -2,7 +2,7 @@ import { expectNotThrow, naughtyStrings, setupDatabaseAndSynchronizer, switchCli
 import Note from '../models/Note';
 import Revision, { ObjectPatch } from '../models/Revision';
 
-describe('models/Revision', function() {
+describe('models/Revision', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -24,7 +24,7 @@ const switchToSubProfileSettings = async () => {
 	await Setting.load();
 };
 
-describe('models/Setting', function() {
+describe('models/Setting', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/Tag.test.js
+++ b/packages/lib/models/Tag.test.js
@@ -3,7 +3,7 @@ const Folder = require('../models/Folder').default;
 const Note = require('../models/Note').default;
 const Tag = require('../models/Tag').default;
 
-describe('models/Tag', function() {
+describe('models/Tag', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/models/dateTimeFormats.test.ts
+++ b/packages/lib/models/dateTimeFormats.test.ts
@@ -1,7 +1,7 @@
 import Setting from '../models/Setting';
 import time from '../time';
 
-describe('dateFormats', function() {
+describe('dateFormats', () => {
 
 
 

--- a/packages/lib/ntp.ts
+++ b/packages/lib/ntp.ts
@@ -13,8 +13,8 @@ function ntpClient() {
 }
 
 export async function getNetworkTime(): Promise<Date> {
-	return new Promise(function(resolve: Function, reject: Function) {
-		ntpClient().getNetworkTime(server.domain, server.port, function(error: any, date: Date) {
+	return new Promise((resolve: Function, reject: Function) => {
+		ntpClient().getNetworkTime(server.domain, server.port, (error: any, date: Date) => {
 			if (error) {
 				reject(error);
 				return;

--- a/packages/lib/parseUri.js
+++ b/packages/lib/parseUri.js
@@ -14,7 +14,7 @@ function parseUri(str) {
 	while (i--) uri[o.key[i]] = m[i] || '';
 
 	uri[o.q.name] = {};
-	uri[o.key[12]].replace(o.q.parser, function($0, $1, $2) {
+	uri[o.key[12]].replace(o.q.parser, ($0, $1, $2) => {
 		if ($1) uri[o.q.name][$1] = $2;
 	});
 

--- a/packages/lib/pathUtils.test.js
+++ b/packages/lib/pathUtils.test.js
@@ -1,6 +1,6 @@
 const { extractExecutablePath, quotePath, unquotePath, friendlySafeFilename, toFileProtocolPath } = require('./path-utils');
 
-describe('pathUtils', function() {
+describe('pathUtils', () => {
 
 
 

--- a/packages/lib/reducer.test.js
+++ b/packages/lib/reducer.test.js
@@ -81,7 +81,7 @@ function getIds(items, indexes = null) {
 	return ids;
 }
 
-describe('reducer', function() {
+describe('reducer', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/registry.test.ts
+++ b/packages/lib/registry.test.ts
@@ -5,7 +5,7 @@ const sync = {
 	start: jest.fn().mockReturnValue({}),
 };
 
-describe('Registry', function() {
+describe('Registry', () => {
 	let originalSyncTarget: typeof reg.syncTarget;
 
 	beforeAll(() => {

--- a/packages/lib/renderers/webviewLib.js
+++ b/packages/lib/renderers/webviewLib.js
@@ -90,7 +90,7 @@ webviewLib.initialize = function(options) {
 	webviewLib.options_ = options;
 };
 
-document.addEventListener('click', function(event) {
+document.addEventListener('click', (event) => {
 	const anchor = webviewLib.getParentAnchorElement(event.target);
 	if (!anchor) return;
 

--- a/packages/lib/services/CommandService.test.ts
+++ b/packages/lib/services/CommandService.test.ts
@@ -40,7 +40,7 @@ function registerCommand(service: CommandService, cmd: TestCommand) {
 	service.registerRuntime(cmd.declaration.name, cmd.runtime);
 }
 
-describe('services_CommandService', function() {
+describe('services_CommandService', () => {
 
 	beforeEach(async () => {
 		KeymapService.destroyInstance();

--- a/packages/lib/services/KvStore.test.js
+++ b/packages/lib/services/KvStore.test.js
@@ -7,7 +7,7 @@ function setupStore() {
 	return store;
 }
 
-describe('services_KvStore', function() {
+describe('services_KvStore', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/ResourceService.test.ts
+++ b/packages/lib/services/ResourceService.test.ts
@@ -9,7 +9,7 @@ import Resource from '../models/Resource';
 import SearchEngine from '../services/searchengine/SearchEngine';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from './e2ee/utils';
 
-describe('services/ResourceService', function() {
+describe('services/ResourceService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -8,7 +8,7 @@ import BaseModel, { ModelType } from '../BaseModel';
 import RevisionService from '../services/RevisionService';
 import { MarkupLanguage } from '../../renderer';
 
-describe('services/RevisionService', function() {
+describe('services/RevisionService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/WhenClause.test.ts
+++ b/packages/lib/services/WhenClause.test.ts
@@ -1,8 +1,8 @@
 import WhenClause from './WhenClause';
 
-describe('WhenClause', function() {
+describe('WhenClause', () => {
 
-	test('should work with simple condition', async function() {
+	test('should work with simple condition', async () => {
 		const wc = new WhenClause('test1 && test2');
 
 		expect(wc.evaluate({
@@ -16,7 +16,7 @@ describe('WhenClause', function() {
 		})).toBe(false);
 	});
 
-	test('should work with parenthesis', async function() {
+	test('should work with parenthesis', async () => {
 		const wc = new WhenClause('(test1 && test2) || test3 && (test4 && !test5)');
 
 		expect(wc.evaluate({

--- a/packages/lib/services/e2ee/EncryptionService.test.ts
+++ b/packages/lib/services/e2ee/EncryptionService.test.ts
@@ -9,7 +9,7 @@ import { setEncryptionEnabled } from '../synchronizer/syncInfoUtils';
 
 let service: EncryptionService = null;
 
-describe('services_EncryptionService', function() {
+describe('services_EncryptionService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/e2ee/ppk.test.ts
+++ b/packages/lib/services/e2ee/ppk.test.ts
@@ -2,7 +2,7 @@ import { afterAllCleanUp, encryptionService, expectNotThrow, expectThrow, setupD
 import { decryptPrivateKey, generateKeyPair, ppkDecryptMasterKeyContent, ppkGenerateMasterKey, ppkPasswordIsValid, mkReencryptFromPasswordToPublicKey, mkReencryptFromPublicKeyToPassword } from './ppk';
 import { runIntegrationTests } from './ppkTestUtils';
 
-describe('e2ee/ppk', function() {
+describe('e2ee/ppk', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/e2ee/utils.test.ts
+++ b/packages/lib/services/e2ee/utils.test.ts
@@ -5,7 +5,7 @@ import { localSyncInfo, masterKeyById, masterKeyEnabled, setActiveMasterKeyId, s
 import Setting from '../../models/Setting';
 import { generateKeyPair, ppkPasswordIsValid } from './ppk';
 
-describe('e2ee/utils', function() {
+describe('e2ee/utils', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/interop/InteropService.test.ts
+++ b/packages/lib/services/interop/InteropService.test.ts
@@ -80,7 +80,7 @@ function memoryExportModule() {
 	return { result, module };
 }
 
-describe('services_InteropService', function() {
+describe('services_InteropService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/interop/InteropService_Exporter_Html.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.test.ts
@@ -14,7 +14,7 @@ async function recreateExportDir() {
 	await fs.mkdirp(dir);
 }
 
-describe('interop/InteropService_Exporter_Html', function() {
+describe('interop/InteropService_Exporter_Html', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.test.ts
@@ -11,7 +11,7 @@ import { NoteEntity, ResourceEntity } from '../database/types.js';
 import InteropService from './InteropService.js';
 import { fileExtension } from '../../path-utils.js';
 
-describe('interop/InteropService_Exporter_Md', function() {
+describe('interop/InteropService_Exporter_Md', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/interop/InteropService_Exporter_Md.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md.ts
@@ -102,7 +102,7 @@ export default class InteropService_Exporter_Md extends InteropService_Exporter_
 
 			// Strip the absolute path to export dir and keep only the relative paths
 			const destDir = this.destDir_;
-			Object.keys(context.notePaths).map(function(id) {
+			Object.keys(context.notePaths).map((id) => {
 				context.notePaths[id] = context.notePaths[id].substr(destDir.length + 1);
 			});
 

--- a/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.test.ts
@@ -13,7 +13,7 @@ async function recreateExportDir() {
 	await fs.mkdirp(dir);
 }
 
-describe('interop/InteropService_Exporter_Md_frontmatter', function() {
+describe('interop/InteropService_Exporter_Md_frontmatter', () => {
 	async function exportAndLoad(path: string): Promise<string> {
 		const service = InteropService.instance();
 

--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -7,7 +7,7 @@ import { MarkupToHtml } from '@joplin/renderer';
 import { FolderEntity } from '../database/types';
 
 
-describe('InteropService_Importer_Md', function() {
+describe('InteropService_Importer_Md', () => {
 	let tempDir: string;
 	async function importNote(path: string) {
 		const importer = new InteropService_Importer_Md();
@@ -27,7 +27,7 @@ describe('InteropService_Importer_Md', function() {
 	afterEach(async () => {
 		await fs.remove(tempDir);
 	});
-	it('should import linked files and modify tags appropriately', async function() {
+	it('should import linked files and modify tags appropriately', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample.md`);
 
 		const tagNonExistentFile = '![does not exist](does_not_exist.png)';
@@ -36,7 +36,7 @@ describe('InteropService_Importer_Md', function() {
 		const inexistentLinkUnchanged = note.body.includes(tagNonExistentFile);
 		expect(inexistentLinkUnchanged).toBe(true);
 	});
-	it('should only create 1 resource for duplicate links, all tags should be updated', async function() {
+	it('should only create 1 resource for duplicate links, all tags should be updated', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-duplicate-links.md`);
 
 		const items = await Note.linkedItems(note.body);
@@ -45,20 +45,20 @@ describe('InteropService_Importer_Md', function() {
 		const matched = note.body.match(reg);
 		expect(matched.length).toBe(2);
 	});
-	it('should import linked files and modify tags appropriately when link is also in alt text', async function() {
+	it('should import linked files and modify tags appropriately when link is also in alt text', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-link-in-alt-text.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
-	it('should passthrough unchanged if no links present', async function() {
+	it('should passthrough unchanged if no links present', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-no-links.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
 		expect(note.body).toContain('Unidentified vessel travelling at sub warp speed, bearing 235.7. Fluctuations in energy readings from it, Captain. All transporters off.');
 	});
-	it('should import linked image with special characters in name', async function() {
+	it('should import linked image with special characters in name', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-special-chars.md`);
 
 		const items = await Note.linkedItems(note.body);
@@ -68,7 +68,7 @@ describe('InteropService_Importer_Md', function() {
 		const spaceSyntaxLeft = note.body.includes('<../../photo sample.jpg>');
 		expect(spaceSyntaxLeft).toBe(false);
 	});
-	it('should import resources and notes for files', async function() {
+	it('should import resources and notes for files', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-files.md`);
 
 		const items = await Note.linkedItems(note.body);
@@ -76,7 +76,7 @@ describe('InteropService_Importer_Md', function() {
 		const noteIds = await Note.linkedNoteIds(note.body);
 		expect(noteIds.length).toBe(1);
 	});
-	it('should gracefully handle reference cycles in notes', async function() {
+	it('should gracefully handle reference cycles in notes', async () => {
 		const importer = new InteropService_Importer_Md();
 		importer.setMetadata({ fileExtensions: ['md'] });
 		const noteA = await importer.importFile(`${supportDir}/test_notes/md/sample-cycles-a.md`, 'notebook');
@@ -89,27 +89,27 @@ describe('InteropService_Importer_Md', function() {
 		expect(noteAIds[0]).toEqual(noteB.id);
 		expect(noteBIds[0]).toEqual(noteA.id);
 	});
-	it('should not import resources from file:// links', async function() {
+	it('should not import resources from file:// links', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-file-links.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
 		expect(note.body).toContain('![sample](file://../../photo.jpg)');
 	});
-	it('should attach resources that are missing the file extension', async function() {
+	it('should attach resources that are missing the file extension', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-no-extension.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
-	it('should attach resources that include anchor links', async function() {
+	it('should attach resources that include anchor links', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-anchor-link.md`);
 
 		const itemIds = await Note.linkedItemIds(note.body);
 		expect(itemIds.length).toBe(1);
 		expect(note.body).toContain(`[Section 1](:/${itemIds[0]}#markdown)`);
 	});
-	it('should attach resources that include a title', async function() {
+	it('should attach resources that include a title', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample-link-title.md`);
 
 		const items = await Note.linkedItems(note.body);
@@ -117,7 +117,7 @@ describe('InteropService_Importer_Md', function() {
 		const noteIds = await Note.linkedNoteIds(note.body);
 		expect(noteIds.length).toBe(1);
 	});
-	it('should import notes with html file extension as html', async function() {
+	it('should import notes with html file extension as html', async () => {
 		const note = await importNote(`${supportDir}/test_notes/md/sample.html`);
 
 		const items = await Note.linkedItems(note.body);
@@ -128,7 +128,7 @@ describe('InteropService_Importer_Md', function() {
 		const preservedAlt = note.body.includes('alt="../../photo.jpg"');
 		expect(preservedAlt).toBe(true);
 	});
-	it('should import non-empty directory', async function() {
+	it('should import non-empty directory', async () => {
 		await fs.mkdirp(`${tempDir}/non-empty/non-empty`);
 		await fs.writeFile(`${tempDir}/non-empty/non-empty/sample.md`, '# Sample');
 
@@ -136,14 +136,14 @@ describe('InteropService_Importer_Md', function() {
 		const allFolders = await Folder.all();
 		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty')).toBeGreaterThanOrEqual(0);
 	});
-	it('should not import empty directory', async function() {
+	it('should not import empty directory', async () => {
 		await fs.mkdirp(`${tempDir}/empty/empty`);
 
 		await importNoteDirectory(`${tempDir}/empty`);
 		const allFolders = await Folder.all();
 		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty')).toBe(-1);
 	});
-	it('should import directory with non-empty subdirectory', async function() {
+	it('should import directory with non-empty subdirectory', async () => {
 		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-empty`);
 		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty`);
 		await fs.writeFile(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty/sample.md`, '# Sample');

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -5,7 +5,7 @@ import time from '../../time';
 import { setupDatabaseAndSynchronizer, supportDir, switchClient } from '../../testing/test-utils';
 
 
-describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
+describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 	async function importNote(path: string) {
 		const importer = new InteropService_Importer_Md_frontmatter();
 		importer.setMetadata({ fileExtensions: ['md', 'html'] });
@@ -16,7 +16,7 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 	});
-	it('should import file and set all metadata correctly', async function() {
+	it('should import file and set all metadata correctly', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/full.md`);
 		const format = 'DD/MM/YYYY HH:mm';
 
@@ -41,14 +41,14 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		expect(tagTitles).toContain('note');
 		expect(tagTitles).toContain('pencil');
 	});
-	it('should only import data from the first yaml block', async function() {
+	it('should only import data from the first yaml block', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/split.md`);
 
 		expect(note.title).toBe('xxx');
 		expect(note.author).not.toBe('xxx');
 		expect(note.body).toBe('---\nauthor: xxx\n---\n\nnote body\n');
 	});
-	it('should only import, duplicate notes and tags are not created', async function() {
+	it('should only import, duplicate notes and tags are not created', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/duplicates.md`);
 
 		expect(note.title).toBe('ddd');
@@ -58,13 +58,13 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		const tags = await Tag.tagsByNoteId(note.id);
 		expect(tags.length).toBe(1);
 	});
-	it('should not import items as numbers', async function() {
+	it('should not import items as numbers', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/numbers.md`);
 
 		expect(note.title).toBe('001');
 		expect(note.body).toBe('note body\n');
 	});
-	it('should normalize whitespace and load correctly', async function() {
+	it('should normalize whitespace and load correctly', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/normalize.md`);
 
 		expect(note.title).toBe('norm');
@@ -73,7 +73,7 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		const tags = await Tag.tagsByNoteId(note.id);
 		expect(tags.length).toBe(3);
 	});
-	it('should load unquoted special forms correctly', async function() {
+	it('should load unquoted special forms correctly', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/unquoted.md`);
 
 		expect(note.title).toBe('Unquoted');
@@ -83,19 +83,19 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		expect(note.is_todo).toBe(1);
 		expect(note.todo_completed).toBeUndefined();
 	});
-	it('should load notes with newline in the title', async function() {
+	it('should load notes with newline in the title', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/title_newline.md`);
 
 		expect(note.title).toBe('First\nSecond');
 	});
-	it('should import dates (without time) correctly', async function() {
+	it('should import dates (without time) correctly', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/short_date.md`);
 		const format = 'YYYY-MM-DD HH:mm';
 
 		expect(time.formatMsToLocal(note.user_updated_time, format)).toBe('2021-01-01 00:00');
 		expect(time.formatMsToLocal(note.user_created_time, format)).toBe('2017-01-01 00:00');
 	});
-	it('should load tags even with the inline syntax', async function() {
+	it('should load tags even with the inline syntax', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/inline_tags.md`);
 
 		expect(note.title).toBe('Inline Tags');
@@ -103,7 +103,7 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		const tags = await Tag.tagsByNoteId(note.id);
 		expect(tags.length).toBe(2);
 	});
-	it('should import r-markdown files correctly and set what metadata it can', async function() {
+	it('should import r-markdown files correctly and set what metadata it can', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/r-markdown.md`);
 		const format = 'YYYY-MM-DD HH:mm';
 
@@ -119,13 +119,13 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', function() {
 		expect(tagTitles).toContain('yaml');
 		expect(tagTitles).toContain('rmd');
 	});
-	it('should import r-markdown files with alternative author syntax', async function() {
+	it('should import r-markdown files with alternative author syntax', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/r-markdown_author.md`);
 
 		expect(note.title).toBe('Distill for R Markdown');
 		expect(note.author).toBe('JJ Allaire');
 	});
-	it('should handle date formats with timezone information', async function() {
+	it('should handle date formats with timezone information', async () => {
 		const note = await importNote(`${supportDir}/test_notes/yaml/utc.md`);
 
 		expect(note.user_updated_time).toBe(1556729640000);

--- a/packages/lib/services/interop/InteropService_Importer_Raw.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Raw.test.ts
@@ -119,7 +119,7 @@ const createFiles = async () => {
 	await writeFile(makeFilePath(tempDir, rawNote2), rawNote2);
 };
 
-describe('InteropService_Importer_Raw', function() {
+describe('InteropService_Importer_Raw', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
@@ -131,7 +131,7 @@ describe('InteropService_Importer_Raw', function() {
 		await remove(tempDir);
 	});
 
-	it('should import raw files', async function() {
+	it('should import raw files', async () => {
 		await createFiles();
 
 		const importOptions: ImportOptions = {
@@ -163,7 +163,7 @@ describe('InteropService_Importer_Raw', function() {
 		expect(note2.parent_id).toBe(folder2.id);
 	});
 
-	it('should handle duplicate names', async function() {
+	it('should handle duplicate names', async () => {
 		await createFiles();
 
 		const importOptions: ImportOptions = {

--- a/packages/lib/services/rest/Api.test.ts
+++ b/packages/lib/services/rest/Api.test.ts
@@ -35,7 +35,7 @@ const createNoteForPagination = async (numOrTitle: number | string, time: number
 
 let api: Api = null;
 
-describe('services_rest_Api', function() {
+describe('services_rest_Api', () => {
 
 	beforeEach(async () => {
 		api = new Api();

--- a/packages/lib/services/rest/routes/events.test.ts
+++ b/packages/lib/services/rest/routes/events.test.ts
@@ -7,7 +7,7 @@ import Api, { RequestMethod } from '../Api';
 
 let api: Api = null;
 
-describe('routes/events', function() {
+describe('routes/events', () => {
 
 	beforeEach(async () => {
 		api = new Api();

--- a/packages/lib/services/searchengine/SearchEngine.test.js
+++ b/packages/lib/services/searchengine/SearchEngine.test.js
@@ -57,7 +57,7 @@ const calculateScore = (searchString, notes) => {
 	return scores;
 };
 
-describe('services_SearchEngine', function() {
+describe('services_SearchEngine', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/searchengine/SearchEngineUtils.test.ts
+++ b/packages/lib/services/searchengine/SearchEngineUtils.test.ts
@@ -7,7 +7,7 @@ const Note = require('../../models/Note').default;
 
 let searchEngine: any = null;
 
-describe('services_SearchEngineUtils', function() {
+describe('services_SearchEngineUtils', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
@@ -15,7 +15,7 @@ describe('services_SearchEngineUtils', function() {
 		searchEngine.setDb(db());
 	});
 
-	describe('filter todos based on showCompletedTodos', function() {
+	describe('filter todos based on showCompletedTodos', () => {
 		it('show completed', (async () => {
 			const note1 = await Note.save({ title: 'abcd', body: 'body 1' });
 			const todo1 = await Note.save({ title: 'abcd', body: 'todo 1', is_todo: 1 });

--- a/packages/lib/services/searchengine/SearchFilter.test.ts
+++ b/packages/lib/services/searchengine/SearchFilter.test.ts
@@ -15,7 +15,7 @@ let engine: any = null;
 
 const ids = (array: NoteEntity[]) => array.map(a => a.id);
 
-describe('services_SearchFilter', function() {
+describe('services_SearchFilter', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);

--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -33,7 +33,7 @@ function mockService(api: any) {
 	return service;
 }
 
-describe('ShareService', function() {
+describe('ShareService', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/style/cssToTheme.test.ts
+++ b/packages/lib/services/style/cssToTheme.test.ts
@@ -1,6 +1,6 @@
 import cssToTheme from './cssToTheme';
 
-describe('cssToTheme', function() {
+describe('cssToTheme', () => {
 
 	it('should convert a CSS string to a theme', async () => {
 		const input = `

--- a/packages/lib/services/style/themeToCss.test.ts
+++ b/packages/lib/services/style/themeToCss.test.ts
@@ -97,7 +97,7 @@ const expected = `
 	--joplin-code-theme-css: atom-one-light.css;
 }`;
 
-describe('themeToCss', function() {
+describe('themeToCss', () => {
 
 	it('should a theme to a CSS string', async () => {
 		const actual = themeToCss(input);

--- a/packages/lib/services/synchronizer/ItemUploader.test.ts
+++ b/packages/lib/services/synchronizer/ItemUploader.test.ts
@@ -41,7 +41,7 @@ function newFakeApiCall(callRecorder: ApiCall[], itemBodyCallback: Function = nu
 	return apiCall;
 }
 
-describe('synchronizer/ItemUploader', function() {
+describe('synchronizer/ItemUploader', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
@@ -6,7 +6,7 @@ import Note from '../../models/Note';
 import BaseItem from '../../models/BaseItem';
 const WelcomeUtils = require('../../WelcomeUtils');
 
-describe('Synchronizer.basics', function() {
+describe('Synchronizer.basics', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.conflicts.test.ts
@@ -6,7 +6,7 @@ import Note from '../../models/Note';
 import BaseItem from '../../models/BaseItem';
 import { setEncryptionEnabled } from '../synchronizer/syncInfoUtils';
 
-describe('Synchronizer.conflicts', function() {
+describe('Synchronizer.conflicts', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
@@ -18,7 +18,7 @@ function newResourceFetcher(synchronizer: Synchronizer) {
 	return new ResourceFetcher(() => { return synchronizer.api(); });
 }
 
-describe('Synchronizer.e2ee', function() {
+describe('Synchronizer.e2ee', () => {
 
 	beforeEach(async () => {
 		insideBeforeEach = true;

--- a/packages/lib/services/synchronizer/Synchronizer.ppk.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.ppk.test.ts
@@ -4,7 +4,7 @@ import { fetchSyncInfo, localSyncInfo, setEncryptionEnabled } from '../synchroni
 import { EncryptionMethod } from '../e2ee/EncryptionService';
 import { updateMasterPassword } from '../e2ee/utils';
 
-describe('Synchronizer.ppk', function() {
+describe('Synchronizer.ppk', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.resources.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.resources.test.ts
@@ -15,7 +15,7 @@ import { loadMasterKeysFromSettings } from '../e2ee/utils';
 
 let insideBeforeEach = false;
 
-describe('Synchronizer.resources', function() {
+describe('Synchronizer.resources', () => {
 
 	beforeEach(async () => {
 		insideBeforeEach = true;

--- a/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
@@ -5,7 +5,7 @@ import Note from '../../models/Note';
 import Revision from '../../models/Revision';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from '../e2ee/utils';
 
-describe('Synchronizer.revisions', function() {
+describe('Synchronizer.revisions', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.sharing.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.sharing.test.ts
@@ -1,4 +1,4 @@
-describe('Synchronizer.sharing', function() {
+describe('Synchronizer.sharing', () => {
 
 	it('should skip', (async () => {
 		expect(true).toBe(true);

--- a/packages/lib/services/synchronizer/Synchronizer.tags.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.tags.test.ts
@@ -5,7 +5,7 @@ import Tag from '../../models/Tag';
 import MasterKey from '../../models/MasterKey';
 import { setEncryptionEnabled } from '../synchronizer/syncInfoUtils';
 
-describe('Synchronizer.tags', function() {
+describe('Synchronizer.tags', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/Synchronizer.tools.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.tools.test.ts
@@ -4,7 +4,7 @@ import Folder from '../../models/Folder';
 import Note from '../../models/Note';
 import { clearLocalDataForRedownload, clearLocalSyncStateForReupload } from '../../services/synchronizer/tools';
 
-describe('Synchronizer.tools', function() {
+describe('Synchronizer.tools', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.ts
+++ b/packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.ts
@@ -52,7 +52,7 @@ export default function useSyncTargetUpgrade(): SyncTargetUpgradeResult {
 		});
 	}
 
-	useEffect(function() {
+	useEffect(() => {
 		void upgradeSyncTarget();
 	}, []);
 

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -2,7 +2,7 @@ import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient, encryption
 import MasterKey from '../../models/MasterKey';
 import { masterKeyEnabled, mergeSyncInfos, setMasterKeyEnabled, SyncInfo, syncInfoEquals } from './syncInfoUtils';
 
-describe('syncInfoUtils', function() {
+describe('syncInfoUtils', () => {
 
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);

--- a/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
+++ b/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
@@ -20,7 +20,7 @@ function lockHandler(): LockHandler {
 	return lockHandler_;
 }
 
-describe('synchronizer_LockHandler', function() {
+describe('synchronizer_LockHandler', () => {
 
 	beforeEach(async () => {
 		// logger.setLevel(Logger.LEVEL_WARN);

--- a/packages/lib/services/synchronizer/synchronizer_MigrationHandler.test.ts
+++ b/packages/lib/services/synchronizer/synchronizer_MigrationHandler.test.ts
@@ -143,7 +143,7 @@ async function testMigrationE2EE(migrationVersion: number, maxSyncVersion: numbe
 
 let previousSyncTargetName = '';
 
-describe('MigrationHandler', function() {
+describe('MigrationHandler', () => {
 
 	beforeEach(async () => {
 		// Note that, for undocumented reasons, the timeout argument passed

--- a/packages/lib/shim-init-node.js
+++ b/packages/lib/shim-init-node.js
@@ -66,7 +66,7 @@ const gunzipFile = function(source, destination) {
 		src.pipe(zlib.createGunzip()).pipe(dest);
 
 		// callback on extract completion
-		dest.on('close', function() {
+		dest.on('close', () => {
 			resolve();
 		});
 
@@ -523,16 +523,16 @@ function shimInit(options = null) {
 					// Note: relative paths aren't supported
 					file = fs.createWriteStream(filePath);
 
-					file.on('error', function(error) {
+					file.on('error', (error) => {
 						cleanUpOnError(error);
 					});
 
-					const request = http.request(requestOptions, function(response) {
+					const request = http.request(requestOptions, (response) => {
 						response.pipe(file);
 
 						const isGzipped = response.headers['content-encoding'] === 'gzip';
 
-						file.on('finish', function() {
+						file.on('finish', () => {
 							file.close(async () => {
 								if (isGzipped) {
 									const gzipFilePath = `${filePath}.gzip`;
@@ -553,7 +553,7 @@ function shimInit(options = null) {
 						});
 					});
 
-					request.on('error', function(error) {
+					request.on('error', (error) => {
 						cleanUpOnError(error);
 					});
 

--- a/packages/lib/timeUtils.test.js
+++ b/packages/lib/timeUtils.test.js
@@ -1,6 +1,6 @@
 const time = require('./time').default;
 
-describe('timeUtils', function() {
+describe('timeUtils', () => {
 
 
 

--- a/packages/lib/urlUtils.test.js
+++ b/packages/lib/urlUtils.test.js
@@ -1,7 +1,7 @@
 
 const urlUtils = require('./urlUtils.js');
 
-describe('urlUtils', function() {
+describe('urlUtils', () => {
 
 	it('should prepend a base URL', (async () => {
 		expect(urlUtils.prependBaseUrl('testing.html', 'http://example.com')).toBe('http://example.com/testing.html');

--- a/packages/lib/versionInfo.test.ts
+++ b/packages/lib/versionInfo.test.ts
@@ -31,7 +31,7 @@ const packageInfo = {
 	},
 };
 
-describe('getPluginLists', function() {
+describe('getPluginLists', () => {
 
 	beforeAll(() => {
 		(reg.db as jest.Mock).mockReturnValue(mockedDb);

--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -6,7 +6,7 @@ async function dbSchemaSnapshot(db: DbConnection): Promise<any> {
 	return sqlts.toTypeScript({}, db as any);
 }
 
-describe('db', function() {
+describe('db', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('db', { autoMigrate: false });
@@ -20,7 +20,7 @@ describe('db', function() {
 		await beforeEachDb();
 	});
 
-	it('should allow upgrading and downgrading schema', async function() {
+	it('should allow upgrading and downgrading schema', async () => {
 		// Migrations before that didn't have a down() step.
 		const ignoreAllBefore = '20210819165350_user_flags';
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -11,7 +11,7 @@ import { databaseSchema } from './services/database/types';
 //
 // In our case, all bigInteger are timestamps, which JavaScript can handle
 // fine as numbers.
-require('pg').types.setTypeParser(20, function(val: any) {
+require('pg').types.setTypeParser(20, (val: any) => {
 	return parseInt(val, 10);
 });
 

--- a/packages/server/src/env.test.ts
+++ b/packages/server/src/env.test.ts
@@ -1,7 +1,7 @@
 import { afterAllTests, beforeAllDb, beforeEachDb, expectThrow } from './utils/testing/testUtils';
 import { parseEnv } from './env';
 
-describe('env', function() {
+describe('env', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('env');
@@ -15,7 +15,7 @@ describe('env', function() {
 		await beforeEachDb();
 	});
 
-	it('should parse env values', async function() {
+	it('should parse env values', async () => {
 		const result = parseEnv({
 			DB_CLIENT: 'pg',
 			POSTGRES_PORT: '123',
@@ -33,12 +33,12 @@ describe('env', function() {
 		expect(result.ACCOUNT_TYPES_ENABLED).toBe(true);
 	});
 
-	it('should overrides default values', async function() {
+	it('should overrides default values', async () => {
 		expect(parseEnv({}).POSTGRES_USER).toBe('joplin');
 		expect(parseEnv({}, { POSTGRES_USER: 'other' }).POSTGRES_USER).toBe('other');
 	});
 
-	it('should validate values', async function() {
+	it('should validate values', async () => {
 		await expectThrow(async () => parseEnv({ POSTGRES_PORT: 'notanumber' }));
 		await expectThrow(async () => parseEnv({ MAILER_ENABLED: 'TRUE' }));
 	});

--- a/packages/server/src/middleware/apiVersionHandler.test.ts
+++ b/packages/server/src/middleware/apiVersionHandler.test.ts
@@ -3,7 +3,7 @@ import { ErrorPreconditionFailed } from '../utils/errors';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, koaNext, expectNotThrow, expectHttpError } from '../utils/testing/testUtils';
 import apiVersionHandler from './apiVersionHandler';
 
-describe('apiVersionHandler', function() {
+describe('apiVersionHandler', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('apiVersionHandler');
@@ -17,12 +17,12 @@ describe('apiVersionHandler', function() {
 		await beforeEachDb();
 	});
 
-	test('should work if no version header is provided', async function() {
+	test('should work if no version header is provided', async () => {
 		const context = await koaAppContext({});
 		await expectNotThrow(async () => apiVersionHandler(context, koaNext));
 	});
 
-	test('should work if the header version number is lower than the server version', async function() {
+	test('should work if the header version number is lower than the server version', async () => {
 		config().appVersion = '2.1.0';
 
 		const context = await koaAppContext({
@@ -38,7 +38,7 @@ describe('apiVersionHandler', function() {
 		await expectNotThrow(async () => apiVersionHandler(context, koaNext));
 	});
 
-	test('should not work if the header version number is greater than the server version', async function() {
+	test('should not work if the header version number is greater than the server version', async () => {
 		config().appVersion = '2.1.0';
 
 		const context = await koaAppContext({

--- a/packages/server/src/middleware/checkAdminHandler.test.ts
+++ b/packages/server/src/middleware/checkAdminHandler.test.ts
@@ -2,7 +2,7 @@ import { ErrorForbidden } from '../utils/errors';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, koaNext, expectNotThrow, expectHttpError, createUserAndSession } from '../utils/testing/testUtils';
 import checkAdminHandler from './checkAdminHandler';
 
-describe('checkAdminHandler', function() {
+describe('checkAdminHandler', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('checkAdminHandler');
@@ -16,7 +16,7 @@ describe('checkAdminHandler', function() {
 		await beforeEachDb();
 	});
 
-	test('should access /admin if the user is admin', async function() {
+	test('should access /admin if the user is admin', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const context = await koaAppContext({
@@ -30,7 +30,7 @@ describe('checkAdminHandler', function() {
 		await expectNotThrow(async () => checkAdminHandler(context, koaNext));
 	});
 
-	test('should not access /admin if the user is not admin', async function() {
+	test('should not access /admin if the user is not admin', async () => {
 		const { session } = await createUserAndSession(1);
 
 		const context = await koaAppContext({
@@ -44,7 +44,7 @@ describe('checkAdminHandler', function() {
 		await expectHttpError(async () => checkAdminHandler(context, koaNext), ErrorForbidden.httpCode);
 	});
 
-	test('should not access /admin if the user is not logged in', async function() {
+	test('should not access /admin if the user is not logged in', async () => {
 		const context = await koaAppContext({
 			request: {
 				method: 'GET',

--- a/packages/server/src/middleware/notificationHandler.test.ts
+++ b/packages/server/src/middleware/notificationHandler.test.ts
@@ -10,7 +10,7 @@ const runNotificationHandler = async (sessionId: string): Promise<AppContext> =>
 	return context;
 };
 
-describe('notificationHandler', function() {
+describe('notificationHandler', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('notificationHandler');
@@ -24,7 +24,7 @@ describe('notificationHandler', function() {
 		await beforeEachDb();
 	});
 
-	test('should check admin password', async function() {
+	test('should check admin password', async () => {
 		const r = await createUserAndSession(1, true);
 		const session = r.session;
 		let admin = r.user;
@@ -70,7 +70,7 @@ describe('notificationHandler', function() {
 		}
 	});
 
-	test('should not check admin password for non-admin', async function() {
+	test('should not check admin password for non-admin', async () => {
 		const { session } = await createUserAndSession(1, false);
 
 		await createUserAndSession(2, true, {
@@ -84,7 +84,7 @@ describe('notificationHandler', function() {
 		expect(notifications.length).toBe(0);
 	});
 
-	test('should display a banner if the account is disabled', async function() {
+	test('should display a banner if the account is disabled', async () => {
 		const { session, user } = await createUserAndSession(1);
 
 		await models().userFlag().add(user.id, UserFlagType.FailedPaymentFinal);
@@ -94,7 +94,7 @@ describe('notificationHandler', function() {
 		expect(ctx.joplin.notifications.find(v => v.id === 'accountDisabled')).toBeTruthy();
 	});
 
-	test('should display a banner if the email is not confirmed', async function() {
+	test('should display a banner if the email is not confirmed', async () => {
 		const { session, user } = await createUserAndSession(1);
 
 		{

--- a/packages/server/src/middleware/ownerHandler.test.ts
+++ b/packages/server/src/middleware/ownerHandler.test.ts
@@ -1,7 +1,7 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, koaNext } from '../utils/testing/testUtils';
 import ownerHandler from './ownerHandler';
 
-describe('ownerHandler', function() {
+describe('ownerHandler', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ownerHandler');
@@ -15,7 +15,7 @@ describe('ownerHandler', function() {
 		await beforeEachDb();
 	});
 
-	test('should login user with valid session ID', async function() {
+	test('should login user with valid session ID', async () => {
 		const { user, session } = await createUserAndSession(1, false);
 
 		const context = await koaAppContext({
@@ -30,7 +30,7 @@ describe('ownerHandler', function() {
 		expect(context.joplin.owner.id).toBe(user.id);
 	});
 
-	test('should not login user with invalid session ID', async function() {
+	test('should not login user with invalid session ID', async () => {
 		await createUserAndSession(1, false);
 
 		const context = await koaAppContext({

--- a/packages/server/src/migrations/20190913171451_create.ts
+++ b/packages/server/src/migrations/20190913171451_create.ts
@@ -4,7 +4,7 @@ import { hashPassword } from '../utils/auth';
 import uuidgen from '../utils/uuidgen';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('users', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.text('email', 'mediumtext').unique().notNullable();
 		table.text('password', 'mediumtext').notNullable();
@@ -14,11 +14,11 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.index(['email']);
 	});
 
-	await db.schema.createTable('sessions', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('sessions', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('user_id', 32).notNullable();
 		table.string('auth_code', 32).defaultTo('').notNullable();
@@ -26,7 +26,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.createTable('permissions', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('permissions', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('user_id', 32).notNullable();
 		table.integer('item_type').notNullable();
@@ -37,13 +37,13 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('permissions', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('permissions', (table: Knex.CreateTableBuilder) => {
 		table.unique(['user_id', 'item_type', 'item_id']);
 		table.index(['item_id']);
 		table.index(['item_type', 'item_id']);
 	});
 
-	await db.schema.createTable('files', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('files', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('owner_id', 32).notNullable();
 		table.text('name').notNullable();
@@ -57,12 +57,12 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('files', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('files', (table: Knex.CreateTableBuilder) => {
 		table.unique(['parent_id', 'name']);
 		table.index(['parent_id']);
 	});
 
-	await db.schema.createTable('changes', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('changes', (table: Knex.CreateTableBuilder) => {
 		// Note that in this table, the counter is the primary key, since
 		// we want it to be automatically incremented. There's also a
 		// column ID to publicly identify a change.
@@ -78,12 +78,12 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('changes', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('changes', (table: Knex.CreateTableBuilder) => {
 		table.index(['id']);
 		table.index(['parent_id']);
 	});
 
-	await db.schema.createTable('api_clients', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('api_clients', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('name', 32).notNullable();
 		table.string('secret', 32).notNullable();

--- a/packages/server/src/migrations/20203012152842_notifications.ts
+++ b/packages/server/src/migrations/20203012152842_notifications.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('notifications', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('notifications', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('owner_id', 32).notNullable();
 		table.integer('level').notNullable();
@@ -14,7 +14,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('notifications', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('notifications', (table: Knex.CreateTableBuilder) => {
 		table.unique(['owner_id', 'key']);
 	});
 }

--- a/packages/server/src/migrations/20203012152842_shares.ts
+++ b/packages/server/src/migrations/20203012152842_shares.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('shares', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('shares', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('owner_id', 32).notNullable();
 		table.string('file_id', 32).notNullable();

--- a/packages/server/src/migrations/20210201143859_app_share.ts
+++ b/packages/server/src/migrations/20210201143859_app_share.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('share_users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('share_users', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('share_id', 32).notNullable();
 		table.string('user_id', 32).notNullable();
@@ -11,26 +11,26 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('share_users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('share_users', (table: Knex.CreateTableBuilder) => {
 		table.unique(['share_id', 'user_id']);
 	});
 
-	await db.schema.alterTable('files', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('files', (table: Knex.CreateTableBuilder) => {
 		table.string('source_file_id', 32).defaultTo('').notNullable();
 	});
 
-	await db.schema.alterTable('files', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('files', (table: Knex.CreateTableBuilder) => {
 		table.index(['owner_id']);
 		table.index(['source_file_id']);
 	});
 
-	await db.schema.alterTable('changes', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('changes', (table: Knex.CreateTableBuilder) => {
 		table.index(['item_id']);
 	});
 
 	await db.schema.dropTable('shares');
 
-	await db.schema.createTable('shares', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('shares', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('owner_id', 32).notNullable();
 		table.string('item_id', 32).notNullable();

--- a/packages/server/src/migrations/20210321112923_joplin_items.ts
+++ b/packages/server/src/migrations/20210321112923_joplin_items.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('joplin_file_contents', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('joplin_file_contents', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.string('owner_id', 32).notNullable();
 		table.string('item_id', 32).notNullable();
@@ -14,7 +14,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.binary('content').defaultTo('').notNullable();
 	});
 
-	await db.schema.alterTable('files', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('files', (table: Knex.CreateTableBuilder) => {
 		table.integer('content_type', 2).defaultTo(1).notNullable();
 		table.string('content_id', 32).defaultTo('').notNullable();
 	});

--- a/packages/server/src/migrations/20210328114529_share_folder.ts
+++ b/packages/server/src/migrations/20210328114529_share_folder.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('shares', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('shares', (table: Knex.CreateTableBuilder) => {
 		table.string('folder_id', 32).defaultTo('').notNullable();
 		table.integer('is_auto', 1).defaultTo(0).notNullable();
 	});

--- a/packages/server/src/migrations/20210412110640_item_refactor.ts
+++ b/packages/server/src/migrations/20210412110640_item_refactor.ts
@@ -26,7 +26,7 @@ import { DbConnection } from '../db';
 // type_: 1`;
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('items', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('items', (table: Knex.CreateTableBuilder) => {
 		table.string('id', 32).unique().primary().notNullable();
 		table.text('name').notNullable();
 		table.string('mime_type', 128).defaultTo('application/octet-stream').notNullable();
@@ -41,7 +41,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.integer('jop_encryption_applied', 1).defaultTo(0).notNullable();
 	});
 
-	await db.schema.alterTable('items', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('items', (table: Knex.CreateTableBuilder) => {
 		table.index('name');
 		table.index('jop_id');
 		table.index('jop_parent_id');
@@ -49,7 +49,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.index('jop_share_id');
 	});
 
-	await db.schema.createTable('user_items', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('user_items', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.string('user_id', 32).notNullable();
 		table.string('item_id', 32).notNullable();
@@ -57,35 +57,35 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('user_items', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('user_items', (table: Knex.CreateTableBuilder) => {
 		table.unique(['user_id', 'item_id']);
 		table.index('user_id');
 		table.index('item_id');
 	});
 
-	await db.schema.createTable('item_resources', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('item_resources', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.string('item_id', 32).notNullable();
 		table.string('resource_id', 32).notNullable();
 	});
 
-	await db.schema.alterTable('item_resources', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('item_resources', (table: Knex.CreateTableBuilder) => {
 		table.unique(['item_id', 'resource_id']);
 		table.index(['item_id', 'resource_id']);
 	});
 
-	await db.schema.createTable('key_values', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('key_values', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.text('key').notNullable();
 		table.integer('type').notNullable();
 		table.text('value').notNullable();
 	});
 
-	await db.schema.alterTable('key_values', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('key_values', (table: Knex.CreateTableBuilder) => {
 		table.index(['key']);
 	});
 
-	await db.schema.alterTable('shares', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('shares', (table: Knex.CreateTableBuilder) => {
 		table.dropColumn('is_auto');
 		table.string('note_id', 32).defaultTo('').notNullable();
 		table.index(['note_id']);
@@ -93,7 +93,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.index(['item_id']);
 	});
 
-	await db.schema.alterTable('changes', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('changes', (table: Knex.CreateTableBuilder) => {
 		table.text('previous_item').defaultTo('').notNullable();
 		table.string('user_id', 32).defaultTo('').notNullable();
 

--- a/packages/server/src/migrations/20210517173042_user_item_size_limit.ts
+++ b/packages/server/src/migrations/20210517173042_user_item_size_limit.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('max_item_size').defaultTo(0).notNullable();
 	});
 }

--- a/packages/server/src/migrations/20210518150551_can_share.ts
+++ b/packages/server/src/migrations/20210518150551_can_share.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('can_share').defaultTo(1).notNullable();
 	});
 }

--- a/packages/server/src/migrations/20210518172311_mailer.ts
+++ b/packages/server/src/migrations/20210518172311_mailer.ts
@@ -2,12 +2,12 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('email_confirmed').defaultTo(0).notNullable();
 		table.integer('must_set_password').defaultTo(0).notNullable();
 	});
 
-	await db.schema.createTable('emails', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('emails', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.text('recipient_name', 'mediumtext').defaultTo('').notNullable();
 		table.text('recipient_email', 'mediumtext').defaultTo('').notNullable();
@@ -22,7 +22,7 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.createTable('tokens', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('tokens', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.string('value', 32).notNullable();
 		table.string('user_id', 32).defaultTo('').notNullable();
@@ -30,14 +30,14 @@ export async function up(db: DbConnection): Promise<any> {
 		table.bigInteger('created_time').notNullable();
 	});
 
-	await db.schema.alterTable('emails', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('emails', (table: Knex.CreateTableBuilder) => {
 		table.index(['sent_time']);
 		table.index(['sent_success']);
 	});
 
 	await db('users').update({ email_confirmed: 1 });
 
-	await db.schema.alterTable('tokens', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('tokens', (table: Knex.CreateTableBuilder) => {
 		table.index(['value', 'user_id']);
 	});
 }

--- a/packages/server/src/migrations/20210526180359_account_type.ts
+++ b/packages/server/src/migrations/20210526180359_account_type.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('account_type').defaultTo(0).notNullable();
 	});
 }

--- a/packages/server/src/migrations/20210527161932_can_upload.ts
+++ b/packages/server/src/migrations/20210527161932_can_upload.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('can_upload').defaultTo(1).notNullable();
 	});
 

--- a/packages/server/src/migrations/20210531150817_stripe.ts
+++ b/packages/server/src/migrations/20210531150817_stripe.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.createTable('subscriptions', function(table: Knex.CreateTableBuilder) {
+	await db.schema.createTable('subscriptions', (table: Knex.CreateTableBuilder) => {
 		table.increments('id').unique().primary().notNullable();
 		table.string('user_id', 32).notNullable();
 		table.string('stripe_user_id', 64).notNullable();

--- a/packages/server/src/migrations/20210618192423_jop_updated_time.ts
+++ b/packages/server/src/migrations/20210618192423_jop_updated_time.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('items', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('items', (table: Knex.CreateTableBuilder) => {
 		table.bigInteger('jop_updated_time').defaultTo(0).notNullable();
 	});
 

--- a/packages/server/src/migrations/20210621185454_share_permissions.ts
+++ b/packages/server/src/migrations/20210621185454_share_permissions.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.renameColumn('can_share', 'can_share_folder');
 		table.integer('can_share_note').defaultTo(1).notNullable();
 	});

--- a/packages/server/src/migrations/20210702182439_account_max_total_size.ts
+++ b/packages/server/src/migrations/20210702182439_account_max_total_size.ts
@@ -6,7 +6,7 @@ import { DbConnection } from '../db';
 // https://github.com/knex/knex/issues/2581
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.dropColumn('max_item_size');
 		table.dropColumn('can_share_folder');
 		table.dropColumn('can_share_note');

--- a/packages/server/src/migrations/20210702182440_account_max_total_size_2.ts
+++ b/packages/server/src/migrations/20210702182440_account_max_total_size_2.ts
@@ -2,14 +2,14 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('max_item_size').defaultTo(null).nullable();
 		table.specificType('can_share_folder', 'smallint').defaultTo(null).nullable();
 		table.specificType('can_share_note', 'smallint').defaultTo(null).nullable();
 		table.bigInteger('max_total_item_size').defaultTo(null).nullable();
 	});
 
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.integer('total_item_size').defaultTo(0).notNullable();
 	});
 }

--- a/packages/server/src/migrations/20210703202852_account_total_size_int_fix.ts
+++ b/packages/server/src/migrations/20210703202852_account_total_size_int_fix.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.dropColumn('total_item_size');
 	});
 }

--- a/packages/server/src/migrations/20210703202853_account_total_size_int_fix_2.ts
+++ b/packages/server/src/migrations/20210703202853_account_total_size_int_fix_2.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.bigInteger('total_item_size').defaultTo(0).notNullable();
 	});
 }

--- a/packages/server/src/migrations/20210721161355_user_is_deleted.ts
+++ b/packages/server/src/migrations/20210721161355_user_is_deleted.ts
@@ -2,11 +2,11 @@ import { Knex } from 'knex';
 import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
-	await db.schema.alterTable('users', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('users', (table: Knex.CreateTableBuilder) => {
 		table.specificType('enabled', 'smallint').defaultTo(1).nullable();
 	});
 
-	await db.schema.alterTable('subscriptions', function(table: Knex.CreateTableBuilder) {
+	await db.schema.alterTable('subscriptions', (table: Knex.CreateTableBuilder) => {
 		table.specificType('is_deleted', 'smallint').defaultTo(0).nullable();
 	});
 }

--- a/packages/server/src/migrations/20210809163307_email_key.ts
+++ b/packages/server/src/migrations/20210809163307_email_key.ts
@@ -3,7 +3,7 @@ import { DbConnection } from '../db';
 
 export async function up(db: DbConnection): Promise<any> {
 	try {
-		await db.schema.alterTable('emails', function(table: Knex.CreateTableBuilder) {
+		await db.schema.alterTable('emails', (table: Knex.CreateTableBuilder) => {
 			table.text('key', 'mediumtext').defaultTo('').notNullable();
 		});
 	} catch (error) {

--- a/packages/server/src/migrations/tests/20220131185922_account_disabled_timestamp.test.ts
+++ b/packages/server/src/migrations/tests/20220131185922_account_disabled_timestamp.test.ts
@@ -2,7 +2,7 @@ import { UserFlagType } from '../../services/database/types';
 import { beforeAllDb, afterAllTests, beforeEachDb, createUser, models, db } from '../../utils/testing/testUtils';
 import { disabledUserIds, setUserAccountDisabledTimes } from '../20220131185922_account_disabled_timestamp';
 
-describe('20220131185922_account_disabled_timestamp', function() {
+describe('20220131185922_account_disabled_timestamp', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('20220131185922_account_disabled_timestamp');
@@ -16,7 +16,7 @@ describe('20220131185922_account_disabled_timestamp', function() {
 		await beforeEachDb();
 	});
 
-	test('should set the user account disabled time', async function() {
+	test('should set the user account disabled time', async () => {
 		const user1 = await createUser(1);
 		const user2 = await createUser(2);
 		const user3 = await createUser(3);

--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -4,7 +4,7 @@ import { Day, msleep } from '../utils/time';
 import { ChangePagination } from './ChangeModel';
 import { SqliteMaxVariableNum } from '../db';
 
-describe('ChangeModel', function() {
+describe('ChangeModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ChangeModel');
@@ -18,7 +18,7 @@ describe('ChangeModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should track changes - create only', async function() {
+	test('should track changes - create only', async () => {
 		const { session, user } = await createUserAndSession(1, true);
 		const changeModel = models().change();
 
@@ -32,7 +32,7 @@ describe('ChangeModel', function() {
 		}
 	});
 
-	test('should track changes - create, then update', async function() {
+	test('should track changes - create, then update', async () => {
 		const { user } = await createUserAndSession(1, true);
 		const itemModel = models().item();
 		const changeModel = models().change();
@@ -113,7 +113,7 @@ describe('ChangeModel', function() {
 		}
 	});
 
-	test('should throw an error if cursor is invalid', async function() {
+	test('should throw an error if cursor is invalid', async () => {
 		const { user } = await createUserAndSession(1, true);
 		const itemModel = models().item();
 		const changeModel = models().change();
@@ -125,7 +125,7 @@ describe('ChangeModel', function() {
 		await expectThrow(async () => changeModel.delta(user.id, { limit: 1, cursor: 'invalid' }), 'resyncRequired');
 	});
 
-	test('should tell that there are more changes even when current page is empty', async function() {
+	test('should tell that there are more changes even when current page is empty', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		const changeCount = 10;
@@ -159,7 +159,7 @@ describe('ChangeModel', function() {
 		expect(allFromIds3.has_more).toBe(false);
 	});
 
-	test('should not fail when retrieving many changes', async function() {
+	test('should not fail when retrieving many changes', async () => {
 		// Create many changes and verify that, by default, the SQL query that
 		// returns change doesn't fail. Before the max number of items was set
 		// to 1000 and it would fail with "SQLITE_ERROR: too many SQL variables"
@@ -178,7 +178,7 @@ describe('ChangeModel', function() {
 		expect(changeCount).toBe(SqliteMaxVariableNum);
 	});
 
-	test('should delete old changes', async function() {
+	test('should delete old changes', async () => {
 		// Create the following events:
 		//
 		// T1   2020-01-01    U1 Create

--- a/packages/server/src/models/EmailModel.test.ts
+++ b/packages/server/src/models/EmailModel.test.ts
@@ -2,7 +2,7 @@ import { EmailSender } from '../services/database/types';
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession } from '../utils/testing/testUtils';
 import paymentFailedTemplate from '../views/emails/paymentFailedTemplate';
 
-describe('EmailModel', function() {
+describe('EmailModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('EmailModel');
@@ -16,7 +16,7 @@ describe('EmailModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should not send the same keyed email twice', async function() {
+	test('should not send the same keyed email twice', async () => {
 		const { user } = await createUserAndSession();
 
 		const sendEmail = async (key: string) => {

--- a/packages/server/src/models/EventModel.test.ts
+++ b/packages/server/src/models/EventModel.test.ts
@@ -2,7 +2,7 @@ import { EventType } from '../services/database/types';
 import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 import { msleep } from '../utils/time';
 
-describe('EventModel', function() {
+describe('EventModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('EventModel');
@@ -16,7 +16,7 @@ describe('EventModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should create an event', async function() {
+	test('should create an event', async () => {
 		await models().event().create(EventType.TaskStarted, 'deleteExpiredTokens');
 
 		const events = await models().event().all();
@@ -25,7 +25,7 @@ describe('EventModel', function() {
 		expect(events[0].name).toBe('deleteExpiredTokens');
 	});
 
-	test('should get the latest event', async function() {
+	test('should get the latest event', async () => {
 		await models().event().create(EventType.TaskStarted, 'deleteExpiredTokens');
 		await msleep(1);
 		await models().event().create(EventType.TaskStarted, 'deleteExpiredTokens');

--- a/packages/server/src/models/ItemModel.test.ts
+++ b/packages/server/src/models/ItemModel.test.ts
@@ -9,7 +9,7 @@ import loadStorageDriver from './items/storage/loadStorageDriver';
 import { ErrorPayloadTooLarge } from '../utils/errors';
 import { isSqlite } from '../db';
 
-describe('ItemModel', function() {
+describe('ItemModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ItemModel');
@@ -82,7 +82,7 @@ describe('ItemModel', function() {
 	// 	}
 	// });
 
-	test('should find all items within a shared folder', async function() {
+	test('should find all items within a shared folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -137,7 +137,7 @@ describe('ItemModel', function() {
 		}
 	});
 
-	test('should count items', async function() {
+	test('should count items', async () => {
 		const { user: user1 } = await createUserAndSession(1, true);
 
 		await createItemTree(user1.id, '', {
@@ -149,7 +149,7 @@ describe('ItemModel', function() {
 		expect(await models().item().childrenCount(user1.id)).toBe(2);
 	});
 
-	test('should calculate the total size', async function() {
+	test('should calculate the total size', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);
@@ -203,7 +203,7 @@ describe('ItemModel', function() {
 		expect((await models().user().load(user3.id)).total_item_size).toBe(totalSize3);
 	});
 
-	test('should update total size when an item is deleted', async function() {
+	test('should update total size when an item is deleted', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		await createItemTree3(user1.id, '', '', [
@@ -231,7 +231,7 @@ describe('ItemModel', function() {
 		expect((await models().user().load(user1.id)).total_item_size).toBe(folder1.content_size);
 	});
 
-	test('should include shared items in total size calculation', async function() {
+	test('should include shared items in total size calculation', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);
@@ -272,7 +272,7 @@ describe('ItemModel', function() {
 		expect((await models().user().load(user3.id)).total_item_size).toBe(expected3);
 	});
 
-	test('should respect the hard item size limit', async function() {
+	test('should respect the hard item size limit', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		let models = newModelFactory(db(), config());
@@ -339,7 +339,7 @@ describe('ItemModel', function() {
 		};
 	};
 
-	test('should allow importing content to item storage', async function() {
+	test('should allow importing content to item storage', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		const {
@@ -393,7 +393,7 @@ describe('ItemModel', function() {
 		expect(toContent.toString()).toBe(fromContent.toString());
 	});
 
-	test('should skip large items when importing content to item storage', async function() {
+	test('should skip large items when importing content to item storage', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		const {
@@ -425,7 +425,7 @@ describe('ItemModel', function() {
 		expect(await toDriver.exists(itemId, { models: fromModels })).toBe(true);
 	});
 
-	test('should delete the database item content', async function() {
+	test('should delete the database item content', async () => {
 		if (isSqlite(db())) {
 			expect(1).toBe(1);
 			return;
@@ -462,7 +462,7 @@ describe('ItemModel', function() {
 		expect(await models().item().dbContent(note1.id)).toEqual(Buffer.from(''));
 	});
 
-	test('should delete the database item content - maxProcessedItems handling', async function() {
+	test('should delete the database item content - maxProcessedItems handling', async () => {
 		if (isSqlite(db())) {
 			expect(1).toBe(1);
 			return;

--- a/packages/server/src/models/ItemResourceModel.test.ts
+++ b/packages/server/src/models/ItemResourceModel.test.ts
@@ -1,6 +1,6 @@
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession, createNote, createResource } from '../utils/testing/testUtils';
 
-describe('ItemResourceModel', function() {
+describe('ItemResourceModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ItemResourceModel');

--- a/packages/server/src/models/KeyValueModel.test.ts
+++ b/packages/server/src/models/KeyValueModel.test.ts
@@ -1,6 +1,6 @@
 import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 
-describe('KeyValueModel', function() {
+describe('KeyValueModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('KeyValueModel');
@@ -14,7 +14,7 @@ describe('KeyValueModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should set and get value', async function() {
+	test('should set and get value', async () => {
 		const m = models().keyValue();
 
 		await m.setValue('testing1', 'something');
@@ -27,7 +27,7 @@ describe('KeyValueModel', function() {
 		expect(await m.value('testing1')).toBe(456);
 	});
 
-	test('should delete value', async function() {
+	test('should delete value', async () => {
 		const m = models().keyValue();
 
 		await m.setValue('testing1', 'something');

--- a/packages/server/src/models/LockModel.test.ts
+++ b/packages/server/src/models/LockModel.test.ts
@@ -6,7 +6,7 @@ import { ErrorConflict, ErrorUnprocessableEntity } from '../utils/errors';
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession, expectHttpError } from '../utils/testing/testUtils';
 import { LockType, LockClientType, defaultLockTtl } from '@joplin/lib/services/synchronizer/LockHandler';
 
-describe('LockModel', function() {
+describe('LockModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('LockModel');
@@ -20,7 +20,7 @@ describe('LockModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should allow exclusive lock if the sync locks have expired', async function() {
+	test('should allow exclusive lock if the sync locks have expired', async () => {
 		jest.useFakeTimers();
 
 		const { user } = await createUserAndSession(1);
@@ -45,7 +45,7 @@ describe('LockModel', function() {
 		jest.useRealTimers();
 	});
 
-	test('should keep user locks separated', async function() {
+	test('should keep user locks separated', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 
@@ -59,7 +59,7 @@ describe('LockModel', function() {
 		expect(exclusiveLock).toBeTruthy();
 	});
 
-	test('should validate locks', async function() {
+	test('should validate locks', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		await expectHttpError(async () => models().lock().acquireLock(user1.id, 'wrongtype' as any, LockClientType.Desktop, '1111'), ErrorUnprocessableEntity.httpCode);
@@ -67,7 +67,7 @@ describe('LockModel', function() {
 		await expectHttpError(async () => models().lock().acquireLock(user1.id, LockType.Exclusive, LockClientType.Desktop, 'veryverylongclientidveryverylongclientidveryverylongclientidveryverylongclientid'), ErrorUnprocessableEntity.httpCode);
 	});
 
-	test('should expire locks', async function() {
+	test('should expire locks', async () => {
 		const { user } = await createUserAndSession(1);
 
 		jest.useFakeTimers();

--- a/packages/server/src/models/NotificationModel.test.ts
+++ b/packages/server/src/models/NotificationModel.test.ts
@@ -2,7 +2,7 @@ import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models,
 import { Notification, NotificationLevel } from '../services/database/types';
 import { NotificationKey } from './NotificationModel';
 
-describe('NotificationModel', function() {
+describe('NotificationModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('NotificationModel');
@@ -16,11 +16,11 @@ describe('NotificationModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should require a user to create the notification', async function() {
+	test('should require a user to create the notification', async () => {
 		await expectThrow(async () => models().notification().add('', NotificationKey.EmailConfirmed, NotificationLevel.Normal, NotificationKey.EmailConfirmed));
 	});
 
-	test('should create a notification', async function() {
+	test('should create a notification', async () => {
 		const { user } = await createUserAndSession(1, true);
 		const model = models().notification();
 		await model.add(user.id, NotificationKey.EmailConfirmed, NotificationLevel.Important, 'testing');
@@ -30,7 +30,7 @@ describe('NotificationModel', function() {
 		expect(n.level).toBe(NotificationLevel.Important);
 	});
 
-	test('should create only one notification per key', async function() {
+	test('should create only one notification per key', async () => {
 		const { user } = await createUserAndSession(1, true);
 		const model = models().notification();
 		await model.add(user.id, NotificationKey.EmailConfirmed, NotificationLevel.Important, 'testing');
@@ -38,7 +38,7 @@ describe('NotificationModel', function() {
 		expect((await model.all()).length).toBe(1);
 	});
 
-	test('should mark a notification as read', async function() {
+	test('should mark a notification as read', async () => {
 		const { user } = await createUserAndSession(1, true);
 		const model = models().notification();
 		await model.add(user.id, NotificationKey.EmailConfirmed, NotificationLevel.Important, 'testing');

--- a/packages/server/src/models/SessionModel.test.ts
+++ b/packages/server/src/models/SessionModel.test.ts
@@ -1,7 +1,7 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 import { defaultSessionTtl } from './SessionModel';
 
-describe('SessionModel', function() {
+describe('SessionModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('SessionModel');
@@ -15,7 +15,7 @@ describe('SessionModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should delete expired sessions', async function() {
+	test('should delete expired sessions', async () => {
 		jest.useFakeTimers();
 
 		const t0 = new Date('2020-01-01T00:00:00').getTime();

--- a/packages/server/src/models/ShareModel.test.ts
+++ b/packages/server/src/models/ShareModel.test.ts
@@ -3,7 +3,7 @@ import { ErrorBadRequest, ErrorNotFound } from '../utils/errors';
 import { ShareType } from '../services/database/types';
 import { inviteUserToShare, shareFolderWithUser, shareWithUserAndAccept } from '../utils/testing/shareApiUtils';
 
-describe('ShareModel', function() {
+describe('ShareModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ShareModel');
@@ -17,7 +17,7 @@ describe('ShareModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should validate share objects', async function() {
+	test('should validate share objects', async () => {
 		const { user, session } = await createUserAndSession(1, true);
 
 		const item = await createItem(session.id, 'root:/test.txt:', 'testing');
@@ -31,7 +31,7 @@ describe('ShareModel', function() {
 		expect(error instanceof ErrorNotFound).toBe(true);
 	});
 
-	test('should get all shares of a user', async function() {
+	test('should get all shares of a user', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		const { user: user3, session: session3 } = await createUserAndSession(3);
@@ -83,7 +83,7 @@ describe('ShareModel', function() {
 		expect(participatedShares3[0].folder_id).toBe('000000000000000000000000000000F1');
 	});
 
-	test('should generate only one link per shared note', async function() {
+	test('should generate only one link per shared note', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		await createItemTree(user1.id, '', {
@@ -98,7 +98,7 @@ describe('ShareModel', function() {
 		expect(share1.id).toBe(share2.id);
 	});
 
-	test('should delete a note that has been shared', async function() {
+	test('should delete a note that has been shared', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		await createItemTree(user1.id, '', {
@@ -113,7 +113,7 @@ describe('ShareModel', function() {
 		expect(await models().item().load(noteItem.id)).toBeFalsy();
 	});
 
-	test('should count number of items in share', async function() {
+	test('should count number of items in share', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -131,7 +131,7 @@ describe('ShareModel', function() {
 		expect(await models().share().itemCountByShareId(share.id)).toBe(0);
 	});
 
-	test('should count number of items in share per recipient', async function() {
+	test('should count number of items in share per recipient', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);
@@ -153,7 +153,7 @@ describe('ShareModel', function() {
 		expect(rows.find(r => r.user_id === user3.id).item_count).toBe(2);
 	});
 
-	test('should create user items for shared folder', async function() {
+	test('should create user items for shared folder', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);

--- a/packages/server/src/models/SubscriptionModel.test.ts
+++ b/packages/server/src/models/SubscriptionModel.test.ts
@@ -3,7 +3,7 @@ import { AccountType } from './UserModel';
 import { MB } from '../utils/bytes';
 import { getCanShareFolder, getMaxItemSize } from './utils/user';
 
-describe('SubscriptionModel', function() {
+describe('SubscriptionModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('SubscriptionModel');
@@ -17,7 +17,7 @@ describe('SubscriptionModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should create a user and subscription', async function() {
+	test('should create a user and subscription', async () => {
 		await models().subscription().saveUserAndSubscription(
 			'toto@example.com',
 			'Toto',
@@ -40,7 +40,7 @@ describe('SubscriptionModel', function() {
 		expect(sub.user_id).toBe(user.id);
 	});
 
-	test('should enable and allow the user to upload if a payment is successful', async function() {
+	test('should enable and allow the user to upload if a payment is successful', async () => {
 		let { user } = await models().subscription().saveUserAndSubscription(
 			'toto@example.com',
 			'Toto',

--- a/packages/server/src/models/TokenModel.test.ts
+++ b/packages/server/src/models/TokenModel.test.ts
@@ -1,6 +1,6 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 
-describe('TokenModel', function() {
+describe('TokenModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('TokenModel');
@@ -14,7 +14,7 @@ describe('TokenModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should delete old tokens', async function() {
+	test('should delete old tokens', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		await models().token().generate(user1.id);
 

--- a/packages/server/src/models/UserDeletionModel.test.ts
+++ b/packages/server/src/models/UserDeletionModel.test.ts
@@ -1,7 +1,7 @@
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUser, expectThrow } from '../utils/testing/testUtils';
 import { Day } from '../utils/time';
 
-describe('UserDeletionModel', function() {
+describe('UserDeletionModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('UserDeletionModel');
@@ -15,7 +15,7 @@ describe('UserDeletionModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should add a deletion operation', async function() {
+	test('should add a deletion operation', async () => {
 		{
 			const user = await createUser(1);
 
@@ -53,7 +53,7 @@ describe('UserDeletionModel', function() {
 		}
 	});
 
-	test('should provide the next deletion operation', async function() {
+	test('should provide the next deletion operation', async () => {
 		expect(await models().userDeletion().next()).toBeFalsy();
 
 		jest.useFakeTimers();
@@ -91,7 +91,7 @@ describe('UserDeletionModel', function() {
 		jest.useRealTimers();
 	});
 
-	test('should start and stop deletion jobs', async function() {
+	test('should start and stop deletion jobs', async () => {
 		jest.useFakeTimers();
 
 		const t0 = new Date('2021-12-14').getTime();
@@ -144,7 +144,7 @@ describe('UserDeletionModel', function() {
 		jest.useRealTimers();
 	});
 
-	test('should auto-add users for deletion', async function() {
+	test('should auto-add users for deletion', async () => {
 		jest.useFakeTimers();
 
 		const t0 = new Date('2022-02-22').getTime();

--- a/packages/server/src/models/UserFlagModel.test.ts
+++ b/packages/server/src/models/UserFlagModel.test.ts
@@ -1,7 +1,7 @@
 import { UserFlagType } from '../services/database/types';
 import { beforeAllDb, afterAllTests, beforeEachDb, models, createUserAndSession } from '../utils/testing/testUtils';
 
-describe('UserFlagModel', function() {
+describe('UserFlagModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('UserFlagModel');
@@ -15,7 +15,7 @@ describe('UserFlagModel', function() {
 		await beforeEachDb();
 	});
 
-	test('should create no more than one flag per type', async function() {
+	test('should create no more than one flag per type', async () => {
 		const { user } = await createUserAndSession(1);
 
 		const beforeTime = Date.now();
@@ -39,7 +39,7 @@ describe('UserFlagModel', function() {
 		expect(flag.id).not.toBe(differentFlag.id);
 	});
 
-	test('should set the timestamp when disabling an account', async function() {
+	test('should set the timestamp when disabling an account', async () => {
 		const { user } = await createUserAndSession(1);
 
 		const beforeTime = Date.now();

--- a/packages/server/src/models/UserModel.test.ts
+++ b/packages/server/src/models/UserModel.test.ts
@@ -7,7 +7,7 @@ import { failedPaymentFinalAccount, failedPaymentWarningInterval } from './Subsc
 import { stripePortalUrl } from '../utils/urlUtils';
 import { Day } from '../utils/time';
 
-describe('UserModel', function() {
+describe('UserModel', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('UserModel');
@@ -331,7 +331,7 @@ describe('UserModel', function() {
 		}
 	});
 
-	test('should get the user public key', async function() {
+	test('should get the user public key', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);

--- a/packages/server/src/models/items/storage/StorageDriverDatabase.test.ts
+++ b/packages/server/src/models/items/storage/StorageDriverDatabase.test.ts
@@ -16,7 +16,7 @@ const newConfig = (): StorageDriverConfig => {
 	};
 };
 
-describe('StorageDriverDatabase', function() {
+describe('StorageDriverDatabase', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('StorageDriverDatabase');
@@ -39,12 +39,12 @@ describe('StorageDriverDatabase', function() {
 	shouldUpdateContentStorageIdAfterSwitchingDriver(newConfig(), { type: StorageDriverType.Memory });
 	shouldThrowNotFoundIfNotExist(newConfig());
 
-	test('should fail if the item row does not exist', async function() {
+	test('should fail if the item row does not exist', async () => {
 		const driver = newDriver();
 		await expectThrow(async () => driver.read('oops', { models: models() }));
 	});
 
-	test('should do nothing if deleting non-existing row', async function() {
+	test('should do nothing if deleting non-existing row', async () => {
 		const driver = newDriver();
 		await expectNotThrow(async () => driver.delete('oops', { models: models() }));
 	});

--- a/packages/server/src/models/items/storage/StorageDriverFs.test.ts
+++ b/packages/server/src/models/items/storage/StorageDriverFs.test.ts
@@ -17,7 +17,7 @@ const newConfig = (path: string = null): StorageDriverConfig => {
 	};
 };
 
-describe('StorageDriverFs', function() {
+describe('StorageDriverFs', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('StorageDriverFs');
@@ -45,14 +45,14 @@ describe('StorageDriverFs', function() {
 	shouldUpdateContentStorageIdAfterSwitchingDriver(newConfig(), { type: StorageDriverType.Memory });
 	shouldThrowNotFoundIfNotExist(newConfig());
 
-	test('should write to a file and read it back', async function() {
+	test('should write to a file and read it back', async () => {
 		const driver = newDriver();
 		await driver.write('testing', Buffer.from('testing'));
 		const content = await driver.read('testing');
 		expect(content.toString()).toBe('testing');
 	});
 
-	test('should automatically create the base path', async function() {
+	test('should automatically create the base path', async () => {
 		const tmp = `${tempDirPath()}/testcreate`;
 		expect(await pathExists(tmp)).toBe(false);
 		const driver = newDriver(tmp);
@@ -60,7 +60,7 @@ describe('StorageDriverFs', function() {
 		expect(await pathExists(tmp)).toBe(true);
 	});
 
-	test('should not throw if deleting a file that does not exist', async function() {
+	test('should not throw if deleting a file that does not exist', async () => {
 		const driver = newDriver();
 		await expectNotThrow(async () => driver.delete('notthere'));
 	});

--- a/packages/server/src/models/items/storage/StorageDriverMemory.test.ts
+++ b/packages/server/src/models/items/storage/StorageDriverMemory.test.ts
@@ -11,7 +11,7 @@ const newConfig = (): StorageDriverConfig => {
 	};
 };
 
-describe('StorageDriverMemory', function() {
+describe('StorageDriverMemory', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('StorageDriverMemory');

--- a/packages/server/src/models/items/storage/StorageDriverS3.test.ts
+++ b/packages/server/src/models/items/storage/StorageDriverS3.test.ts
@@ -29,7 +29,7 @@ const configIsSet = () => {
 	return !!s3config_;
 };
 
-describe('StorageDriverS3', function() {
+describe('StorageDriverS3', () => {
 
 	beforeAll(async () => {
 		if (!(configIsSet())) {

--- a/packages/server/src/models/items/storage/loadStorageDriver.test.ts
+++ b/packages/server/src/models/items/storage/loadStorageDriver.test.ts
@@ -2,7 +2,7 @@ import { afterAllTests, beforeAllDb, beforeEachDb, db, expectThrow, models } fro
 import { StorageDriverType } from '../../../utils/types';
 import loadStorageDriver from './loadStorageDriver';
 
-describe('loadStorageDriver', function() {
+describe('loadStorageDriver', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('loadStorageDriver');
@@ -16,7 +16,7 @@ describe('loadStorageDriver', function() {
 		await beforeEachDb();
 	});
 
-	test('should load a driver and assign an ID to it', async function() {
+	test('should load a driver and assign an ID to it', async () => {
 		{
 			const newDriver = await loadStorageDriver({ type: StorageDriverType.Memory }, db());
 			expect(newDriver.storageId).toBe(1);
@@ -30,7 +30,7 @@ describe('loadStorageDriver', function() {
 		}
 	});
 
-	test('should not record the same storage connection twice', async function() {
+	test('should not record the same storage connection twice', async () => {
 		await db()('storages').insert({
 			connection_string: 'Type=Database',
 			updated_time: Date.now(),

--- a/packages/server/src/models/items/storage/parseStorageConnectionString.test.ts
+++ b/packages/server/src/models/items/storage/parseStorageConnectionString.test.ts
@@ -1,9 +1,9 @@
 import { StorageDriverConfig, StorageDriverType } from '../../../utils/types';
 import parseStorageConnectionString from './parseStorageConnectionString';
 
-describe('parseStorageConnectionString', function() {
+describe('parseStorageConnectionString', () => {
 
-	test('should parse a connection string', async function() {
+	test('should parse a connection string', async () => {
 		const testCases: Record<string, StorageDriverConfig> = {
 			'Type=Database': {
 				type: StorageDriverType.Database,
@@ -31,7 +31,7 @@ describe('parseStorageConnectionString', function() {
 		}
 	});
 
-	test('should detect errors', async function() {
+	test('should detect errors', async () => {
 		expect(() => parseStorageConnectionString('Path=/path/to/dir')).toThrow(); // Type is missing
 		expect(() => parseStorageConnectionString('Type=')).toThrow();
 		expect(() => parseStorageConnectionString('Type;')).toThrow();

--- a/packages/server/src/models/items/storage/testUtils.ts
+++ b/packages/server/src/models/items/storage/testUtils.ts
@@ -17,7 +17,7 @@ const newTestModels = (driverConfig: StorageDriverConfig, driverConfigFallback: 
 };
 
 export function shouldWriteToContentAndReadItBack(driverConfig: StorageDriverConfig) {
-	test('should write to content and read it back', async function() {
+	test('should write to content and read it back', async () => {
 		const { user } = await createUserAndSession(1);
 		const noteBody = makeNoteSerializedBody({
 			id: '00000000000000000000000000000001',
@@ -49,7 +49,7 @@ export function shouldWriteToContentAndReadItBack(driverConfig: StorageDriverCon
 }
 
 export function shouldDeleteContent(driverConfig: StorageDriverConfig) {
-	test('should delete the content', async function() {
+	test('should delete the content', async () => {
 		const { user } = await createUserAndSession(1);
 		const noteBody = makeNoteSerializedBody({
 			id: '00000000000000000000000000000001',
@@ -72,7 +72,7 @@ export function shouldDeleteContent(driverConfig: StorageDriverConfig) {
 }
 
 export function shouldNotCreateItemIfContentNotSaved(driverConfig: StorageDriverConfig) {
-	test('should not create the item if the content cannot be saved', async function() {
+	test('should not create the item if the content cannot be saved', async () => {
 		const testModels = newTestModels(driverConfig);
 		const driver = await testModels.item().storageDriver();
 
@@ -100,7 +100,7 @@ export function shouldNotCreateItemIfContentNotSaved(driverConfig: StorageDriver
 }
 
 export function shouldNotUpdateItemIfContentNotSaved(driverConfig: StorageDriverConfig) {
-	test('should not update the item if the content cannot be saved', async function() {
+	test('should not update the item if the content cannot be saved', async () => {
 		const { user } = await createUserAndSession(1);
 		const noteBody = makeNoteSerializedBody({
 			id: '00000000000000000000000000000001',
@@ -152,7 +152,7 @@ export function shouldNotUpdateItemIfContentNotSaved(driverConfig: StorageDriver
 }
 
 export function shouldSupportFallbackDriver(driverConfig: StorageDriverConfig, fallbackDriverConfig: StorageDriverConfig) {
-	test('should support fallback content drivers', async function() {
+	test('should support fallback content drivers', async () => {
 		const { user } = await createUserAndSession(1);
 
 		const testModels = newTestModels(driverConfig);
@@ -209,7 +209,7 @@ export function shouldSupportFallbackDriver(driverConfig: StorageDriverConfig, f
 }
 
 export function shouldSupportFallbackDriverInReadWriteMode(driverConfig: StorageDriverConfig, fallbackDriverConfig: StorageDriverConfig) {
-	test('should support fallback content drivers in rw mode', async function() {
+	test('should support fallback content drivers in rw mode', async () => {
 		if (fallbackDriverConfig.mode !== StorageDriverMode.ReadAndWrite) throw new Error('Content driver must be configured in RW mode for this test');
 
 		const { user } = await createUserAndSession(1);
@@ -242,7 +242,7 @@ export function shouldSupportFallbackDriverInReadWriteMode(driverConfig: Storage
 }
 
 export function shouldUpdateContentStorageIdAfterSwitchingDriver(oldDriverConfig: StorageDriverConfig, newDriverConfig: StorageDriverConfig) {
-	test('should update content storage ID after switching driver', async function() {
+	test('should update content storage ID after switching driver', async () => {
 		if (oldDriverConfig.type === newDriverConfig.type) throw new Error('Drivers must be different for this test');
 
 		const { user } = await createUserAndSession(1);
@@ -278,7 +278,7 @@ export function shouldUpdateContentStorageIdAfterSwitchingDriver(oldDriverConfig
 }
 
 export function shouldThrowNotFoundIfNotExist(driverConfig: StorageDriverConfig) {
-	test('should throw not found if item does not exist', async function() {
+	test('should throw not found if item does not exist', async () => {
 		const driver = await loadStorageDriver(driverConfig, db());
 
 		let error: any = null;

--- a/packages/server/src/models/utils/pagination.test.ts
+++ b/packages/server/src/models/utils/pagination.test.ts
@@ -1,9 +1,9 @@
 import { expectThrow } from '../../utils/testing/testUtils';
 import { defaultPagination, Pagination, createPaginationLinks, requestPagination } from './pagination';
 
-describe('pagination', function() {
+describe('pagination', () => {
 
-	test('should create options from request query parameters', async function() {
+	test('should create options from request query parameters', async () => {
 		const d = defaultPagination();
 
 		const testCases: any = [
@@ -69,7 +69,7 @@ describe('pagination', function() {
 		await expectThrow(async () => requestPagination({ page: 0 }));
 	});
 
-	test('should create page link logic', async function() {
+	test('should create page link logic', async () => {
 		expect(createPaginationLinks(1, 5)).toEqual([
 			{ page: 1, isCurrent: true },
 			{ page: 2 },

--- a/packages/server/src/routes/admin/users.test.ts
+++ b/packages/server/src/routes/admin/users.test.ts
@@ -46,7 +46,7 @@ async function patchUser(sessionId: string, user: any, url: string = ''): Promis
 	return context.response.body;
 }
 
-describe('admin/users', function() {
+describe('admin/users', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('admin/users');
@@ -60,7 +60,7 @@ describe('admin/users', function() {
 		await beforeEachDb();
 	});
 
-	test('should create a new user', async function() {
+	test('should create a new user', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const password = uuidgen();
@@ -83,7 +83,7 @@ describe('admin/users', function() {
 		expect(userFromModel.password === password).toBe(false); // Password has been hashed
 	});
 
-	test('should create a user with null properties if they are not explicitly set', async function() {
+	test('should create a user with null properties if they are not explicitly set', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		await postUser(session.id, 'test@example.com');
@@ -95,7 +95,7 @@ describe('admin/users', function() {
 		expect(newUser.max_total_item_size).toBe(null);
 	});
 
-	test('should ask user to set password if not set on creation', async function() {
+	test('should ask user to set password if not set on creation', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		await postUser(session.id, 'test@example.com', '', {
@@ -107,7 +107,7 @@ describe('admin/users', function() {
 		expect(!!newUser.password).toBe(true);
 	});
 
-	test('should format the email when saving it', async function() {
+	test('should format the email when saving it', async () => {
 		const email = 'ILikeUppercaseAndSpaces@Example.COM   ';
 
 		const { session } = await createUserAndSession(1, true);
@@ -119,7 +119,7 @@ describe('admin/users', function() {
 		expect(loggedInUser.email).toBe('ilikeuppercaseandspaces@example.com');
 	});
 
-	test('should not create anything if user creation fail', async function() {
+	test('should not create anything if user creation fail', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const userModel = models().user();
@@ -140,7 +140,7 @@ describe('admin/users', function() {
 		expect(beforeUserCount).toBe(afterUserCount);
 	});
 
-	test('should list users', async function() {
+	test('should list users', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1, true);
 		const { user: user2 } = await createUserAndSession(2, false);
 
@@ -149,7 +149,7 @@ describe('admin/users', function() {
 		expect(result).toContain(user2.email);
 	});
 
-	test('should delete sessions when changing password', async function() {
+	test('should delete sessions when changing password', async () => {
 		const { user, session, password } = await createUserAndSession(1);
 
 		await models().session().authenticate(user.email, password);
@@ -170,7 +170,7 @@ describe('admin/users', function() {
 		expect(sessions[0].id).toBe(session.id);
 	});
 
-	test('should apply ACL', async function() {
+	test('should apply ACL', async () => {
 		const { user: admin, session: adminSession } = await createUserAndSession(1, true);
 
 		// admin user cannot make themselves a non-admin

--- a/packages/server/src/routes/admin/utils/users/impersonate.test.ts
+++ b/packages/server/src/routes/admin/utils/users/impersonate.test.ts
@@ -2,7 +2,7 @@ import { afterAllTests, beforeAllDb, beforeEachDb, createUserAndSession, expectT
 import { cookieGet, cookieSet } from '../../../../utils/cookies';
 import { startImpersonating, stopImpersonating } from './impersonate';
 
-describe('users/impersonate', function() {
+describe('users/impersonate', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('users/impersonate');
@@ -16,7 +16,7 @@ describe('users/impersonate', function() {
 		await beforeEachDb();
 	});
 
-	test('should impersonate a user', async function() {
+	test('should impersonate a user', async () => {
 		const ctx = await koaAppContext();
 
 		const { user: adminUser, session: adminSession } = await createUserAndSession(1, true);
@@ -41,7 +41,7 @@ describe('users/impersonate', function() {
 		}
 	});
 
-	test('should not impersonate if not admin', async function() {
+	test('should not impersonate if not admin', async () => {
 		const ctx = await koaAppContext();
 
 		const { user: adminUser } = await createUserAndSession(1, true);

--- a/packages/server/src/routes/api/items.test.ts
+++ b/packages/server/src/routes/api/items.test.ts
@@ -9,7 +9,7 @@ import { resourceBlobPath } from '../../utils/joplinUtils';
 import { ErrorForbidden, ErrorPayloadTooLarge } from '../../utils/errors';
 import { PaginatedResults } from '../../models/utils/pagination';
 
-describe('api_items', function() {
+describe('api_items', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('api_items');
@@ -23,7 +23,7 @@ describe('api_items', function() {
 		await beforeEachDb();
 	});
 
-	test('should create an item', async function() {
+	test('should create an item', async () => {
 		const { user, session } = await createUserAndSession(1, true);
 
 		const noteId = '00000000000000000000000000000001';
@@ -58,7 +58,7 @@ describe('api_items', function() {
 		}
 	});
 
-	test('should modify an item', async function() {
+	test('should modify an item', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const noteId = '00000000000000000000000000000001';
@@ -80,7 +80,7 @@ describe('api_items', function() {
 		expect(note.title).toBe('new title');
 	});
 
-	test('should delete an item', async function() {
+	test('should delete an item', async () => {
 		const { user, session } = await createUserAndSession(1, true);
 
 		const tree: any = {
@@ -99,7 +99,7 @@ describe('api_items', function() {
 		expect((await itemModel.all())[0].jop_id).toBe('000000000000000000000000000000F1');
 	});
 
-	test('should delete all items', async function() {
+	test('should delete all items', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1, true);
 		const { user: user2 } = await createUserAndSession(2, true);
 
@@ -125,7 +125,7 @@ describe('api_items', function() {
 		expect(ids.sort()).toEqual(['000000000000000000000000000000F2', '00000000000000000000000000000002'].sort());
 	});
 
-	test('should get back the serialized note', async function() {
+	test('should get back the serialized note', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const noteId = '00000000000000000000000000000001';
@@ -139,7 +139,7 @@ describe('api_items', function() {
 		expect(result).toBe(serializedNote);
 	});
 
-	test('should get back the item metadata', async function() {
+	test('should get back the item metadata', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const noteId = '00000000000000000000000000000001';
@@ -151,7 +151,7 @@ describe('api_items', function() {
 		expect(result.name).toBe(`${noteId}.md`);
 	});
 
-	test('should batch upload items', async function() {
+	test('should batch upload items', async () => {
 		const { session: session1 } = await createUserAndSession(1, false);
 
 		const result: PaginatedResults<any> = await putApi(session1.id, 'batch_items', {
@@ -171,7 +171,7 @@ describe('api_items', function() {
 		expect(Object.keys(result.items).sort()).toEqual(['00000000000000000000000000000001.md', '00000000000000000000000000000002.md']);
 	});
 
-	test('should report errors when batch uploading', async function() {
+	test('should report errors when batch uploading', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1, false);
 
 		const note1 = makeNoteSerializedBody({ id: '00000000000000000000000000000001' });
@@ -201,7 +201,7 @@ describe('api_items', function() {
 		expect(items['00000000000000000000000000000002.md'].error.httpCode).toBe(ErrorPayloadTooLarge.httpCode);
 	});
 
-	test('should list children', async function() {
+	test('should list children', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const itemNames = [
@@ -256,7 +256,7 @@ describe('api_items', function() {
 		}
 	});
 
-	test('should associate a resource blob with a share', async function() {
+	test('should associate a resource blob with a share', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -273,7 +273,7 @@ describe('api_items', function() {
 		expect(item.jop_share_id).toBe(share.id);
 	});
 
-	test('should not upload or download items if the account is disabled', async function() {
+	test('should not upload or download items if the account is disabled', async () => {
 		const { session, user } = await createUserAndSession(1);
 
 		// Should work
@@ -286,7 +286,7 @@ describe('api_items', function() {
 		await expectHttpError(async () => getItem(session.id, 'root:/test1.txt:'), ErrorForbidden.httpCode);
 	});
 
-	test('should check permissions - only share participants can associate an item with a share', async function() {
+	test('should check permissions - only share participants can associate an item with a share', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 		const { session: session3 } = await createUserAndSession(3);
@@ -304,7 +304,7 @@ describe('api_items', function() {
 		);
 	});
 
-	test('should check permissions - uploaded item should be below the allowed limit', async function() {
+	test('should check permissions - uploaded item should be below the allowed limit', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 
 		{
@@ -341,7 +341,7 @@ describe('api_items', function() {
 		}
 	});
 
-	test('should check permissions - uploaded item should not make the account go over the allowed max limit', async function() {
+	test('should check permissions - uploaded item should not make the account go over the allowed max limit', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 
 		{
@@ -379,7 +379,7 @@ describe('api_items', function() {
 		}
 	});
 
-	test('should check permissions - should not allow uploading items if disabled', async function() {
+	test('should check permissions - should not allow uploading items if disabled', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 
 		await models().user().save({ id: user1.id, can_upload: 0 });

--- a/packages/server/src/routes/api/ping.test.ts
+++ b/packages/server/src/routes/api/ping.test.ts
@@ -1,7 +1,7 @@
 import routeHandler from '../../middleware/routeHandler';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext } from '../../utils/testing/testUtils';
 
-describe('api_ping', function() {
+describe('api_ping', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('api_ping');
@@ -15,7 +15,7 @@ describe('api_ping', function() {
 		await beforeEachDb();
 	});
 
-	test('should ping', async function() {
+	test('should ping', async () => {
 		const context = await koaAppContext({
 			request: {
 				url: '/api/ping',

--- a/packages/server/src/routes/api/sessions.test.ts
+++ b/packages/server/src/routes/api/sessions.test.ts
@@ -20,7 +20,7 @@ async function postSession(email: string, password: string): Promise<AppContext>
 	return context;
 }
 
-describe('api/sessions', function() {
+describe('api/sessions', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('api/sessions');
@@ -34,7 +34,7 @@ describe('api/sessions', function() {
 		await beforeEachDb();
 	});
 
-	test('should login user', async function() {
+	test('should login user', async () => {
 		const { user, password } = await createUserAndSession(1, false);
 
 		const context = await postSession(user.email, password);
@@ -45,7 +45,7 @@ describe('api/sessions', function() {
 		expect(session.user_id).toBe(user.id);
 	});
 
-	test('should not login user with wrong password', async function() {
+	test('should not login user with wrong password', async () => {
 		const { user } = await createUserAndSession(1, false);
 
 		{

--- a/packages/server/src/routes/api/share_users.test.ts
+++ b/packages/server/src/routes/api/share_users.test.ts
@@ -5,7 +5,7 @@ import { shareFolderWithUser, shareWithUserAndAccept } from '../../utils/testing
 import { ErrorBadRequest, ErrorForbidden } from '../../utils/errors';
 import { PaginatedResults } from '../../models/utils/pagination';
 
-describe('share_users', function() {
+describe('share_users', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('share_users');
@@ -19,7 +19,7 @@ describe('share_users', function() {
 		await beforeEachDb();
 	});
 
-	test('should list user invitations', async function() {
+	test('should list user invitations', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -38,7 +38,7 @@ describe('share_users', function() {
 		expect(shareUsers.items.find(su => su.share.id === share2.id)).toBeTruthy();
 	});
 
-	test('should not change someone else shareUser object', async function() {
+	test('should not change someone else shareUser object', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -53,7 +53,7 @@ describe('share_users', function() {
 		await expectHttpError(async () => patchApi(session1.id, `share_users/${shareUser.id}`, { status: ShareUserStatus.Accepted }), ErrorForbidden.httpCode);
 	});
 
-	test('should not allow accepting a share twice or more', async function() {
+	test('should not allow accepting a share twice or more', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 

--- a/packages/server/src/routes/api/shares.folder.test.ts
+++ b/packages/server/src/routes/api/shares.folder.test.ts
@@ -9,7 +9,7 @@ import { resourceBlobPath, serializeJoplinItem, unserializeJoplinItem } from '..
 import { PaginatedItems } from '../../models/ItemModel';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
-describe('shares.folder', function() {
+describe('shares.folder', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('shares.folder');
@@ -23,7 +23,7 @@ describe('shares.folder', function() {
 		await beforeEachDb();
 	});
 
-	test('should share a folder with another user', async function() {
+	test('should share a folder with another user', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		const folderItem = await createFolder(session1.id, { title: 'created by sharer' });
@@ -97,7 +97,7 @@ describe('shares.folder', function() {
 		}
 	});
 
-	test('should share a folder and all its children', async function() {
+	test('should share a folder and all its children', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -152,7 +152,7 @@ describe('shares.folder', function() {
 		expect(children2.items.map(i => i.name).sort().join(',')).toBe(expectedNames.sort().join(','));
 	});
 
-	test('should received shared items only once invitation accepted', async function() {
+	test('should received shared items only once invitation accepted', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -185,7 +185,7 @@ describe('shares.folder', function() {
 		}
 	});
 
-	test('should share when a note is added to a shared folder', async function() {
+	test('should share when a note is added to a shared folder', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -213,7 +213,7 @@ describe('shares.folder', function() {
 		expect(!!newChildren.items.find(i => i.name === '00000000000000000000000000000002.md')).toBe(true);
 	});
 
-	test('should update share status when note parent changes', async function() {
+	test('should update share status when note parent changes', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -329,7 +329,7 @@ describe('shares.folder', function() {
 		}
 	});
 
-	test('should update share status when note parent changes more than once between updates', async function() {
+	test('should update share status when note parent changes more than once between updates', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -367,7 +367,7 @@ describe('shares.folder', function() {
 		expect(newChildren.items[0].id).toBe(folderItem1.id);
 	});
 
-	test('should not throw an error if an item is associated with a share that no longer exists', async function() {
+	test('should not throw an error if an item is associated with a share that no longer exists', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -385,7 +385,7 @@ describe('shares.folder', function() {
 		await expectNotThrow(async () => await models().share().updateSharedItems3());
 	});
 
-	test('should not throw an error if a change is associated with an item that no longer exists', async function() {
+	test('should not throw an error if a change is associated with an item that no longer exists', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -414,7 +414,7 @@ describe('shares.folder', function() {
 		await expectNotThrow(async () => await models().share().updateSharedItems3());
 	});
 
-	test('should not throw an error if a user no longer has a user item, and the target share changes', async function() {
+	test('should not throw an error if a user no longer has a user item, and the target share changes', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -451,7 +451,7 @@ describe('shares.folder', function() {
 		await expectNotThrow(async () => await models().share().updateSharedItems3());
 	});
 
-	test('should unshare a deleted item', async function() {
+	test('should unshare a deleted item', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -470,7 +470,7 @@ describe('shares.folder', function() {
 		expect((await models().item().children(user2.id)).items.length).toBe(1);
 	});
 
-	test('should unshare a deleted shared root folder', async function() {
+	test('should unshare a deleted shared root folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -502,7 +502,7 @@ describe('shares.folder', function() {
 		// Test deleting the share, but not the root folder
 	});
 
-	test('should unshare when the share object is deleted', async function() {
+	test('should unshare when the share object is deleted', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -545,7 +545,7 @@ describe('shares.folder', function() {
 	// 	expect(error.httpCode).toBe(ErrorBadRequest.httpCode);
 	// });
 
-	test('should see delta changes for linked items', async function() {
+	test('should see delta changes for linked items', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -622,7 +622,7 @@ describe('shares.folder', function() {
 		}
 	});
 
-	test('should get delta changes - user 2 sync, user 1 share and sync, user 2 sync', async function() {
+	test('should get delta changes - user 2 sync, user 1 share and sync, user 2 sync', async () => {
 		// - User 1 sync
 		// - User 2 sync - and keep delta2
 		// - User 1 share a folder with user 2
@@ -653,7 +653,7 @@ describe('shares.folder', function() {
 		expect(latestChanges2.items.length).toBe(2);
 	});
 
-	test('should get delta changes - user 1 and 2 are in sync, user 2 adds a note to shared folder', async function() {
+	test('should get delta changes - user 1 and 2 are in sync, user 2 adds a note to shared folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -682,7 +682,7 @@ describe('shares.folder', function() {
 		expect(latestChanges1.items[0].item_name).toBe('00000000000000000000000000000002.md');
 	});
 
-	test('should get delta changes - user 1 and 2 are in sync, user 2 moves a note out of shared folder', async function() {
+	test('should get delta changes - user 1 and 2 are in sync, user 2 moves a note out of shared folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -708,7 +708,7 @@ describe('shares.folder', function() {
 		expect(latestChanges1.items[0].item_id).toBe(noteItem.id);
 	});
 
-	test('should get delta changes - user 1 and 2 are in sync, user 1 deletes invitation', async function() {
+	test('should get delta changes - user 1 and 2 are in sync, user 1 deletes invitation', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -748,7 +748,7 @@ describe('shares.folder', function() {
 		expect((await models().userItem().byUserId(user2.id)).length).toBe(0);
 	});
 
-	test('should share an empty folder', async function() {
+	test('should share an empty folder', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -760,7 +760,7 @@ describe('shares.folder', function() {
 		]);
 	});
 
-	test('should unshare from a non-owner user who has deleted the root folder', async function() {
+	test('should unshare from a non-owner user who has deleted the root folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -785,7 +785,7 @@ describe('shares.folder', function() {
 		expect((await models().userItem().byUserId(user2.id)).length).toBe(0);
 	});
 
-	test('should unshare a folder', async function() {
+	test('should unshare a folder', async () => {
 		// The process to unshare a folder is as follow:
 		//
 		// - Client call DELETE /api/share/:id
@@ -847,7 +847,7 @@ describe('shares.folder', function() {
 	// 	expect(children.items.find(c => c.id === noteItem1.id)).toBeTruthy();
 	// });
 
-	test('should check permissions - cannot share a folder with yourself', async function() {
+	test('should check permissions - cannot share a folder with yourself', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 
 		await createItemTree(user1.id, '', { '000000000000000000000000000000F1': {} });
@@ -855,7 +855,7 @@ describe('shares.folder', function() {
 		await expectHttpError(async () => postApi(session1.id, `shares/${share.id}/users`, { email: user1.email }), ErrorForbidden.httpCode);
 	});
 
-	test('should check permissions - cannot share a folder twice with a user', async function() {
+	test('should check permissions - cannot share a folder twice with a user', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 
@@ -865,7 +865,7 @@ describe('shares.folder', function() {
 		await expectHttpError(async () => postApi(session1.id, `shares/${share.id}/users`, { email: user2.email }), ErrorForbidden.httpCode);
 	});
 
-	test('should check permissions - cannot share a non-root folder', async function() {
+	test('should check permissions - cannot share a non-root folder', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 
 		await createItemTree(user1.id, '', {
@@ -877,7 +877,7 @@ describe('shares.folder', function() {
 		await expectHttpError(async () => postApi<Share>(session1.id, 'shares', { folder_id: '000000000000000000000000000000F2' }), ErrorForbidden.httpCode);
 	});
 
-	test('should check permissions - cannot share if share feature not enabled', async function() {
+	test('should check permissions - cannot share if share feature not enabled', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 		await models().user().save({ id: user1.id, can_share_folder: 0 });
@@ -893,7 +893,7 @@ describe('shares.folder', function() {
 		);
 	});
 
-	test('should check permissions - cannot share if share feature not enabled for recipient', async function() {
+	test('should check permissions - cannot share if share feature not enabled for recipient', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		await models().user().save({ id: user2.id, can_share_folder: 0 });
@@ -909,7 +909,7 @@ describe('shares.folder', function() {
 		);
 	});
 
-	test('should check permissions - by default sharing by note is always possible', async function() {
+	test('should check permissions - by default sharing by note is always possible', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 
 		const noteItem = await createNote(session1.id, {
@@ -925,7 +925,7 @@ describe('shares.folder', function() {
 		expect(share).toBeTruthy();
 	});
 
-	test('should check permissions - cannot share with a disabled account', async function() {
+	test('should check permissions - cannot share with a disabled account', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		await models().user().save({
@@ -944,7 +944,7 @@ describe('shares.folder', function() {
 		);
 	});
 
-	test('should allow sharing, unsharing and sharing again', async function() {
+	test('should allow sharing, unsharing and sharing again', async () => {
 		// - U1 share a folder that contains a note
 		// - U2 accept
 		// - U2 syncs

--- a/packages/server/src/routes/api/shares.resource.test.ts
+++ b/packages/server/src/routes/api/shares.resource.test.ts
@@ -3,7 +3,7 @@ import { afterAllTests, beforeAllDb, beforeEachDb } from '../../utils/testing/te
 // What resources should be shared is now handled on the client so these tests
 // probably aren't necessary anymore.
 
-describe('shares.resource', function() {
+describe('shares.resource', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('shares.resource');
@@ -17,7 +17,7 @@ describe('shares.resource', function() {
 		await beforeEachDb();
 	});
 
-	test('should pass', async function() {
+	test('should pass', async () => {
 		expect(true).toBe(true);
 	});
 

--- a/packages/server/src/routes/api/shares.test.ts
+++ b/packages/server/src/routes/api/shares.test.ts
@@ -4,7 +4,7 @@ import { postApi, getApi } from '../../utils/testing/apiUtils';
 import { shareWithUserAndAccept } from '../../utils/testing/shareApiUtils';
 import { PaginatedResults } from '../../models/utils/pagination';
 
-describe('shares', function() {
+describe('shares', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('shares');
@@ -18,7 +18,7 @@ describe('shares', function() {
 		await beforeEachDb();
 	});
 
-	test('should retrieve share info', async function() {
+	test('should retrieve share info', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		const { user: user3 } = await createUserAndSession(3);

--- a/packages/server/src/routes/api/users.test.ts
+++ b/packages/server/src/routes/api/users.test.ts
@@ -2,7 +2,7 @@ import { User } from '../../services/database/types';
 import { deleteApi, getApi, patchApi, postApi } from '../../utils/testing/apiUtils';
 import { beforeAllDb, afterAllTests, beforeEachDb, createUserAndSession, models } from '../../utils/testing/testUtils';
 
-describe('api_users', function() {
+describe('api_users', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('api_users');
@@ -16,7 +16,7 @@ describe('api_users', function() {
 		await beforeEachDb();
 	});
 
-	test('should create a user', async function() {
+	test('should create a user', async () => {
 		const { session: adminSession } = await createUserAndSession(1, true);
 
 		const userToSave: User = {
@@ -37,7 +37,7 @@ describe('api_users', function() {
 		expect(savedUser.must_set_password).toBe(1);
 	});
 
-	test('should patch a user', async function() {
+	test('should patch a user', async () => {
 		const { session: adminSession } = await createUserAndSession(1, true);
 		const { user } = await createUserAndSession(2);
 
@@ -49,7 +49,7 @@ describe('api_users', function() {
 		expect(savedUser.max_item_size).toBe(1000);
 	});
 
-	test('should get a user', async function() {
+	test('should get a user', async () => {
 		const { session: adminSession } = await createUserAndSession(1, true);
 		const { user } = await createUserAndSession(2);
 
@@ -59,7 +59,7 @@ describe('api_users', function() {
 		expect(fetchedUser.email).toBe(user.email);
 	});
 
-	test('should delete a user', async function() {
+	test('should delete a user', async () => {
 		const { session: adminSession } = await createUserAndSession(1, true);
 		const { user } = await createUserAndSession(2);
 
@@ -69,7 +69,7 @@ describe('api_users', function() {
 		expect(loadedUser).toBeFalsy();
 	});
 
-	test('should list users', async function() {
+	test('should list users', async () => {
 		const { session: adminSession } = await createUserAndSession(1, true);
 		await createUserAndSession(2);
 		await createUserAndSession(3);

--- a/packages/server/src/routes/index/changes.test.ts
+++ b/packages/server/src/routes/index/changes.test.ts
@@ -1,7 +1,7 @@
 import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml } from '../../utils/testing/testUtils';
 import { execRequest } from '../../utils/testing/apiUtils';
 
-describe('index_changes', function() {
+describe('index_changes', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_changes');
@@ -15,7 +15,7 @@ describe('index_changes', function() {
 		await beforeEachDb();
 	});
 
-	test('should list changes', async function() {
+	test('should list changes', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1, true);
 
 		const items: any = {};

--- a/packages/server/src/routes/index/home.test.ts
+++ b/packages/server/src/routes/index/home.test.ts
@@ -1,7 +1,7 @@
 import routeHandler from '../../middleware/routeHandler';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, createUserAndSession } from '../../utils/testing/testUtils';
 
-describe('index/home', function() {
+describe('index/home', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index/home');
@@ -15,7 +15,7 @@ describe('index/home', function() {
 		await beforeEachDb();
 	});
 
-	test('should show the home page', async function() {
+	test('should show the home page', async () => {
 		const { user, session } = await createUserAndSession();
 
 		const context = await koaAppContext({

--- a/packages/server/src/routes/index/items.test.ts
+++ b/packages/server/src/routes/index/items.test.ts
@@ -1,7 +1,7 @@
 import { beforeAllDb, afterAllTests, beforeEachDb, createItemTree, createUserAndSession, parseHtml } from '../../utils/testing/testUtils';
 import { execRequest } from '../../utils/testing/apiUtils';
 
-describe('index_items', function() {
+describe('index_items', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_items');
@@ -15,7 +15,7 @@ describe('index_items', function() {
 		await beforeEachDb();
 	});
 
-	test('should list the user items', async function() {
+	test('should list the user items', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1, true);
 
 		const items: any = {};

--- a/packages/server/src/routes/index/login.test.ts
+++ b/packages/server/src/routes/index/login.test.ts
@@ -20,7 +20,7 @@ async function doLogin(email: string, password: string): Promise<AppContext> {
 	return context;
 }
 
-describe('index_login', function() {
+describe('index_login', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_login');
@@ -34,7 +34,7 @@ describe('index_login', function() {
 		await beforeEachDb();
 	});
 
-	test('should show the login page', async function() {
+	test('should show the login page', async () => {
 		const context = await koaAppContext({
 			request: {
 				method: 'GET',
@@ -49,7 +49,7 @@ describe('index_login', function() {
 		expect(!!doc.querySelector('input[name=password]')).toBe(true);
 	});
 
-	test('should login', async function() {
+	test('should login', async () => {
 		const user = await createUser(1);
 
 		const context = await doLogin(user.email, '123456');
@@ -58,7 +58,7 @@ describe('index_login', function() {
 		expect(session.user_id).toBe(user.id);
 	});
 
-	test('should not login with invalid credentials', async function() {
+	test('should not login with invalid credentials', async () => {
 		const user = await createUser(1);
 
 		{

--- a/packages/server/src/routes/index/logout.test.ts
+++ b/packages/server/src/routes/index/logout.test.ts
@@ -2,7 +2,7 @@ import routeHandler from '../../middleware/routeHandler';
 import { cookieGet } from '../../utils/cookies';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, models, createUserAndSession } from '../../utils/testing/testUtils';
 
-describe('index_logout', function() {
+describe('index_logout', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_logout');
@@ -16,7 +16,7 @@ describe('index_logout', function() {
 		await beforeEachDb();
 	});
 
-	test('should logout', async function() {
+	test('should logout', async () => {
 		const { session } = await createUserAndSession();
 
 		const context = await koaAppContext({

--- a/packages/server/src/routes/index/notifications.test.ts
+++ b/packages/server/src/routes/index/notifications.test.ts
@@ -3,7 +3,7 @@ import routeHandler from '../../middleware/routeHandler';
 import { NotificationKey } from '../../models/NotificationModel';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, models, createUserAndSession } from '../../utils/testing/testUtils';
 
-describe('index_notification', function() {
+describe('index_notification', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_notification');
@@ -17,7 +17,7 @@ describe('index_notification', function() {
 		await beforeEachDb();
 	});
 
-	test('should update notification', async function() {
+	test('should update notification', async () => {
 		const { user, session } = await createUserAndSession();
 
 		const model = models().notification();

--- a/packages/server/src/routes/index/password.test.ts
+++ b/packages/server/src/routes/index/password.test.ts
@@ -3,7 +3,7 @@ import { execRequest } from '../../utils/testing/apiUtils';
 import uuidgen from '../../utils/uuidgen';
 import { ErrorNotFound } from '../../utils/errors';
 
-describe('index/password', function() {
+describe('index/password', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index/password');
@@ -17,7 +17,7 @@ describe('index/password', function() {
 		await beforeEachDb();
 	});
 
-	test('should queue an email to reset password', async function() {
+	test('should queue an email to reset password', async () => {
 		const { user, password } = await createUserAndSession(1);
 
 		// Create a few sessions, to verify that they are all deleted when the
@@ -47,14 +47,14 @@ describe('index/password', function() {
 		expect(await models().session().count()).toBe(0);
 	});
 
-	test('should not queue an email for non-existing emails', async function() {
+	test('should not queue an email for non-existing emails', async () => {
 		await createUserAndSession(1);
 		await models().email().deleteAll();
 		await execRequest('', 'POST', 'password/forgot', { email: 'justtryingtohackdontmindme@example.com' });
 		expect((await models().email().all()).length).toBe(0);
 	});
 
-	test('should not reset the password if the token is invalid', async function() {
+	test('should not reset the password if the token is invalid', async () => {
 		const { user } = await createUserAndSession(1);
 		await models().email().deleteAll();
 

--- a/packages/server/src/routes/index/shares.link.test.ts
+++ b/packages/server/src/routes/index/shares.link.test.ts
@@ -40,7 +40,7 @@ async function getShareContent(shareId: string, query: any = {}): Promise<string
 	return context.response.body as any;
 }
 
-describe('shares.link', function() {
+describe('shares.link', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('shares.link');
@@ -54,7 +54,7 @@ describe('shares.link', function() {
 		await beforeEachDb();
 	});
 
-	test('should display a simple note', async function() {
+	test('should display a simple note', async () => {
 		const { session } = await createUserAndSession();
 
 		const noteItem = await createNote(session.id, {
@@ -76,7 +76,7 @@ describe('shares.link', function() {
 		expect(bodyHtml).toContain('<title>Testing title'); // Means the page title is set to the note title
 	});
 
-	test('should load plugins', async function() {
+	test('should load plugins', async () => {
 		const { session } = await createUserAndSession();
 
 		const noteItem = await createNote(session.id, {
@@ -93,7 +93,7 @@ describe('shares.link', function() {
 		expect(bodyHtml).toContain('class="katex-mathml"');
 	});
 
-	test('should render attached images', async function() {
+	test('should render attached images', async () => {
 		const { session } = await createUserAndSession();
 
 		const noteItem = await createNote(session.id, {
@@ -129,7 +129,7 @@ describe('shares.link', function() {
 		expect(resourceContent.byteLength).toBe(resourceSize);
 	});
 
-	test('should share a linked note', async function() {
+	test('should share a linked note', async () => {
 		const { session } = await createUserAndSession();
 
 		const linkedNote1 = await createNote(session.id, {
@@ -165,7 +165,7 @@ describe('shares.link', function() {
 		expect(resourceContent.toString()).toBe('test');
 	});
 
-	test('should not share items that are not linked to a shared note', async function() {
+	test('should not share items that are not linked to a shared note', async () => {
 		const { session } = await createUserAndSession();
 
 		const notSharedResource = await createResource(session.id, {
@@ -192,7 +192,7 @@ describe('shares.link', function() {
 		await expectHttpError(async () => getShareContent(share.id, { note_id: '000000000000000000000000000000E2' }), ErrorNotFound.httpCode);
 	});
 
-	test('should not share linked notes if the "recursive" field is not set', async function() {
+	test('should not share linked notes if the "recursive" field is not set', async () => {
 		const { session } = await createUserAndSession();
 
 		const linkedNote1 = await createNote(session.id, {
@@ -212,7 +212,7 @@ describe('shares.link', function() {
 		await expectHttpError(async () => getShareContent(share.id, { note_id: '000000000000000000000000000000C1' }), ErrorForbidden.httpCode);
 	});
 
-	test('should not throw an error if the note contains links to non-existing items', async function() {
+	test('should not throw an error if the note contains links to non-existing items', async () => {
 		const { session } = await createUserAndSession();
 
 		{
@@ -244,7 +244,7 @@ describe('shares.link', function() {
 		}
 	});
 
-	test('should throw an error if owner of share is disabled', async function() {
+	test('should throw an error if owner of share is disabled', async () => {
 		const { user, session } = await createUserAndSession();
 
 		const noteItem = await createNote(session.id, {

--- a/packages/server/src/routes/index/signup.test.ts
+++ b/packages/server/src/routes/index/signup.test.ts
@@ -8,7 +8,7 @@ import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../../utils/te
 import uuidgen from '../../utils/uuidgen';
 import { FormUser } from './signup';
 
-describe('index_signup', function() {
+describe('index_signup', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_signup');
@@ -22,7 +22,7 @@ describe('index_signup', function() {
 		await beforeEachDb();
 	});
 
-	test('should create a new account', async function() {
+	test('should create a new account', async () => {
 		const password = uuidgen();
 		const formUser: FormUser = {
 			full_name: 'Toto',

--- a/packages/server/src/routes/index/stripe.test.ts
+++ b/packages/server/src/routes/index/stripe.test.ts
@@ -81,7 +81,7 @@ async function createUserViaSubscription(ctx: AppContext, options: WebhookOption
 	}, options);
 }
 
-describe('index/stripe', function() {
+describe('index/stripe', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index/stripe');
@@ -96,7 +96,7 @@ describe('index/stripe', function() {
 		await beforeEachDb();
 	});
 
-	test('should handle the checkout.session.completed event', async function() {
+	test('should handle the checkout.session.completed event', async () => {
 		const startTime = Date.now();
 
 		const ctx = await koaAppContext();
@@ -113,7 +113,7 @@ describe('index/stripe', function() {
 		expect(sub.last_payment_failed_time).toBe(0);
 	});
 
-	test('should not process the same event twice', async function() {
+	test('should not process the same event twice', async () => {
 		const ctx = await koaAppContext();
 		await createUserViaSubscription(ctx, { userEmail: 'toto@example.com', eventId: 'evt_1' });
 		const v = await models().keyValue().value('stripeEventDone::evt_1');
@@ -122,7 +122,7 @@ describe('index/stripe', function() {
 		await expectNotThrow(async () => createUserViaSubscription(ctx, { userEmail: 'toto@example.com', eventId: 'evt_1' }));
 	});
 
-	test('should check if it is a beta user', async function() {
+	test('should check if it is a beta user', async () => {
 		const user1 = await models().user().save({ email: 'toto@example.com', password: uuidgen() });
 		const user2 = await models().user().save({ email: 'tutu@example.com', password: uuidgen() });
 		await models().user().save({ id: user2.id, created_time: 1624441295775 });
@@ -140,13 +140,13 @@ describe('index/stripe', function() {
 		expect(await isBetaUser(models(), user2.id)).toBe(false);
 	});
 
-	test('should find out beta user trial end date', async function() {
+	test('should find out beta user trial end date', async () => {
 		const fromDateTime = 1627901594842; // Mon Aug 02 2021 10:53:14 GMT+0000
 		expect(betaUserTrialPeriodDays(1624441295775, fromDateTime)).toBe(50); // Wed Jun 23 2021 09:41:35 GMT+0000
 		expect(betaUserTrialPeriodDays(1614682158000, fromDateTime)).toBe(7); // Tue Mar 02 2021 10:49:18 GMT+0000
 	});
 
-	test('should setup subscription for an existing user', async function() {
+	test('should setup subscription for an existing user', async () => {
 		// This is for example if a user has been manually added to the system,
 		// and then later they setup their subscription. Applies to beta users
 		// for instance.
@@ -160,7 +160,7 @@ describe('index/stripe', function() {
 		expect(sub.stripe_subscription_id).toBe('sub_123');
 	});
 
-	test('should cancel duplicate subscriptions', async function() {
+	test('should cancel duplicate subscriptions', async () => {
 		const stripe = mockStripe();
 		const ctx = await koaAppContext();
 
@@ -178,7 +178,7 @@ describe('index/stripe', function() {
 		expect(subBefore.stripe_subscription_id).toBe(subAfter.stripe_subscription_id);
 	});
 
-	test('should disable an account if the sub is cancelled', async function() {
+	test('should disable an account if the sub is cancelled', async () => {
 		const stripe = mockStripe();
 		const ctx = await koaAppContext();
 
@@ -191,7 +191,7 @@ describe('index/stripe', function() {
 		expect(sub.is_deleted).toBe(1);
 	});
 
-	test('should re-enable account if sub was cancelled and new sub created', async function() {
+	test('should re-enable account if sub was cancelled and new sub created', async () => {
 		const stripe = mockStripe();
 		const ctx = await koaAppContext();
 
@@ -213,7 +213,7 @@ describe('index/stripe', function() {
 		}
 	});
 
-	test('should re-enable account if successful payment is made', async function() {
+	test('should re-enable account if successful payment is made', async () => {
 		const stripe = mockStripe();
 		const ctx = await koaAppContext();
 
@@ -235,7 +235,7 @@ describe('index/stripe', function() {
 		expect(user.can_upload).toBe(1);
 	});
 
-	test('should attach new sub to existing user', async function() {
+	test('should attach new sub to existing user', async () => {
 		// Simulates:
 		// - User subscribes
 		// - Later the subscription is cancelled, either automatically by Stripe or manually
@@ -269,7 +269,7 @@ describe('index/stripe', function() {
 		expect(sub.stripe_subscription_id).toBe('sub_new');
 	});
 
-	test('should not cancel a subscription as duplicate if it is already associated with a user', async function() {
+	test('should not cancel a subscription as duplicate if it is already associated with a user', async () => {
 		// When user goes through a Stripe checkout, we get the following
 		// events:
 		//

--- a/packages/server/src/routes/index/users.test.ts
+++ b/packages/server/src/routes/index/users.test.ts
@@ -62,7 +62,7 @@ async function getUserHtml(sessionId: string, userId: string): Promise<string> {
 	return context.response.body as string;
 }
 
-describe('index/users', function() {
+describe('index/users', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('index_users');
@@ -76,7 +76,7 @@ describe('index/users', function() {
 		await beforeEachDb();
 	});
 
-	test('new user should be able to login', async function() {
+	test('new user should be able to login', async () => {
 		const { session } = await createUserAndSession(1, true);
 
 		const password = uuidgen();
@@ -86,7 +86,7 @@ describe('index/users', function() {
 		expect(loggedInUser.email).toBe('test@example.com');
 	});
 
-	test('should change user properties', async function() {
+	test('should change user properties', async () => {
 		const { user, session } = await createUserAndSession(1, false);
 
 		const userModel = models().user();
@@ -96,7 +96,7 @@ describe('index/users', function() {
 		expect(modUser.full_name).toBe('new name');
 	});
 
-	test('should change the password', async function() {
+	test('should change the password', async () => {
 		const { user, session } = await createUserAndSession(1, true);
 
 		const userModel = models().user();
@@ -108,7 +108,7 @@ describe('index/users', function() {
 		expect(modUser.id).toBe(user.id);
 	});
 
-	test('should get a user', async function() {
+	test('should get a user', async () => {
 		const { user, session } = await createUserAndSession();
 
 		const userHtml = await getUserHtml(session.id, user.id);
@@ -118,7 +118,7 @@ describe('index/users', function() {
 		expect((doc.querySelector('input[name=email]') as any).value).toBe('user1@localhost');
 	});
 
-	test('should allow user to set a password for new accounts', async function() {
+	test('should allow user to set a password for new accounts', async () => {
 		let user1 = await models().user().save({
 			email: 'user1@localhost',
 			must_set_password: 1,
@@ -197,7 +197,7 @@ describe('index/users', function() {
 		expect(notification.key).toBe('passwordSet');
 	});
 
-	test('should not confirm email if not requested', async function() {
+	test('should not confirm email if not requested', async () => {
 		let user1 = await models().user().save({
 			email: 'user1@localhost',
 			must_set_password: 1,
@@ -218,7 +218,7 @@ describe('index/users', function() {
 		expect(user1.email_confirmed).toBe(0);
 	});
 
-	test('should allow user to verify their email', async function() {
+	test('should allow user to verify their email', async () => {
 		let user1 = await models().user().save({
 			email: 'user1@localhost',
 			must_set_password: 0,
@@ -250,7 +250,7 @@ describe('index/users', function() {
 		expect(notification.key).toBe(NotificationKey.EmailConfirmed);
 	});
 
-	test('should allow changing an email', async function() {
+	test('should allow changing an email', async () => {
 		const { user, session } = await createUserAndSession();
 
 		await patchUser(session.id, {
@@ -296,7 +296,7 @@ describe('index/users', function() {
 		expect(reloadedUser1.can_upload).toBe(1);
 	});
 
-	test('should apply ACL', async function() {
+	test('should apply ACL', async () => {
 		const { user: admin } = await createUserAndSession(1, true);
 		const { session: session1 } = await createUserAndSession(2, false);
 

--- a/packages/server/src/services/ShareService.test.ts
+++ b/packages/server/src/services/ShareService.test.ts
@@ -4,7 +4,7 @@ import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models,
 import { Env } from '../utils/types';
 import ShareService from './ShareService';
 
-describe('ShareService', function() {
+describe('ShareService', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('ShareService');
@@ -18,7 +18,7 @@ describe('ShareService', function() {
 		await beforeEachDb();
 	});
 
-	test('should run maintenance when an item is changed', async function() {
+	test('should run maintenance when an item is changed', async () => {
 		jest.useFakeTimers();
 
 		const { user: user1, session: session1 } = await createUserAndSession(1);

--- a/packages/server/src/services/TaskService.test.ts
+++ b/packages/server/src/services/TaskService.test.ts
@@ -14,7 +14,7 @@ const newService = () => {
 	});
 };
 
-describe('TaskService', function() {
+describe('TaskService', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('TaskService');
@@ -28,7 +28,7 @@ describe('TaskService', function() {
 		await beforeEachDb();
 	});
 
-	test('should register a task', async function() {
+	test('should register a task', async () => {
 		const service = newService();
 
 		const task: Task = {
@@ -98,7 +98,7 @@ describe('TaskService', function() {
 	// 	expect(events.taskCompleted.created_time).toBeGreaterThan(startTime.getTime());
 	// });
 
-	test('should not run if task is disabled', async function() {
+	test('should not run if task is disabled', async () => {
 		const service = newService();
 
 		let taskHasRan = false;

--- a/packages/server/src/services/UserDeletionService.test.ts
+++ b/packages/server/src/services/UserDeletionService.test.ts
@@ -9,7 +9,7 @@ const newService = () => {
 	return new UserDeletionService(Env.Dev, models(), config());
 };
 
-describe('UserDeletionService', function() {
+describe('UserDeletionService', () => {
 
 	beforeAll(async () => {
 		await beforeAllDb('UserDeletionService');
@@ -23,7 +23,7 @@ describe('UserDeletionService', function() {
 		await beforeEachDb();
 	});
 
-	test('should delete user data', async function() {
+	test('should delete user data', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 		await createNote(session1.id, { title: 'testing1' });
@@ -58,7 +58,7 @@ describe('UserDeletionService', function() {
 		expect(await models().session().count()).toBe(2);
 	});
 
-	test('should delete user account', async function() {
+	test('should delete user account', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 		const { user: user2 } = await createUserAndSession(2);
 
@@ -99,7 +99,7 @@ describe('UserDeletionService', function() {
 		expect(content.flags.length).toBe(1);
 	});
 
-	test('should not delete notebooks that are not owned', async function() {
+	test('should not delete notebooks that are not owned', async () => {
 		const { session: session1 } = await createUserAndSession(1);
 		const { user: user2, session: session2 } = await createUserAndSession(2);
 
@@ -128,7 +128,7 @@ describe('UserDeletionService', function() {
 		expect(await models().item().count()).toBe(2);
 	});
 
-	test('should not delete notebooks that are owned', async function() {
+	test('should not delete notebooks that are owned', async () => {
 		const { user: user1, session: session1 } = await createUserAndSession(1);
 		const { session: session2 } = await createUserAndSession(2);
 
@@ -157,7 +157,7 @@ describe('UserDeletionService', function() {
 		expect(await models().item().count()).toBe(0);
 	});
 
-	test('should not do anything if the user is still enabled', async function() {
+	test('should not do anything if the user is still enabled', async () => {
 		const { user: user1 } = await createUserAndSession(1);
 
 		const t0 = new Date('2021-12-14').getTime();

--- a/packages/server/src/services/email/utils.test.ts
+++ b/packages/server/src/services/email/utils.test.ts
@@ -1,8 +1,8 @@
 import { markdownBodyToHtml, markdownBodyToPlainText } from './utils';
 
-describe('services/email/utils', function() {
+describe('services/email/utils', () => {
 
-	test('markdownBodyToHtml should convert URLs to clickable links', async function() {
+	test('markdownBodyToHtml should convert URLs to clickable links', async () => {
 		const testCases = [
 			['Click this: [link](https://joplinapp.org)', '<p>Click this: <a href="https://joplinapp.org">link</a></p>'],
 			['Click this: https://joplinapp.org', '<p>Click this: <a href="https://joplinapp.org">https://joplinapp.org</a></p>'],
@@ -15,7 +15,7 @@ describe('services/email/utils', function() {
 		}
 	});
 
-	test('markdownBodyToPlainText should convert links to plain URLs', async function() {
+	test('markdownBodyToPlainText should convert links to plain URLs', async () => {
 		const testCases = [
 			['Click this: [link](https://joplinapp.org)', 'Click this: https://joplinapp.org'],
 			['Click this: https://joplinapp.org', 'Click this: https://joplinapp.org'],

--- a/packages/server/src/utils/array.ts
+++ b/packages/server/src/utils/array.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 export function unique(array: any[]): any[] {
-	return array.filter(function(elem, index, self) {
+	return array.filter((elem, index, self) => {
 		return index === self.indexOf(elem);
 	});
 }

--- a/packages/server/src/utils/bytes.test.ts
+++ b/packages/server/src/utils/bytes.test.ts
@@ -1,14 +1,14 @@
 import { GB, KB, MB, formatBytes } from './bytes';
 
-describe('bytes', function() {
+describe('bytes', () => {
 
-	it('should convert bytes', async function() {
+	it('should convert bytes', async () => {
 		expect(1 * KB).toBe(1024);
 		expect(1 * MB).toBe(1048576);
 		expect(1 * GB).toBe(1073741824);
 	});
 
-	it('should display pretty bytes', async function() {
+	it('should display pretty bytes', async () => {
 		expect(formatBytes(100 * KB)).toBe('100 kB');
 		expect(formatBytes(200 * MB)).toBe('200 MB');
 		expect(formatBytes(3 * GB)).toBe('3 GB');

--- a/packages/server/src/utils/joplinUtils.test.ts
+++ b/packages/server/src/utils/joplinUtils.test.ts
@@ -2,9 +2,9 @@ import { Item } from '../services/database/types';
 import { itemIsEncrypted } from './joplinUtils';
 import { expectThrow } from './testing/testUtils';
 
-describe('joplinUtils', function() {
+describe('joplinUtils', () => {
 
-	it('should check if an item is encrypted', async function() {
+	it('should check if an item is encrypted', async () => {
 		type TestCase = [boolean, Item];
 
 		const testCases: TestCase[] = [

--- a/packages/server/src/utils/prettycron.ts
+++ b/packages/server/src/utils/prettycron.ts
@@ -90,7 +90,7 @@ const later = require('later');
 		if (numbers.length === 2) return expectedStep;
 
 		// Check that every number is the previous number + the first number
-		return numbers.slice(1).every(function(n, i, a) {
+		return numbers.slice(1).every((n, i, a) => {
 			return (i === 0 ? n : n - a[i - 1]) === expectedStep;
 		}) ? expectedStep : 0;
 	};
@@ -330,7 +330,7 @@ const later = require('later');
 			}
 		}
 
-		return textParts.filter(function(p) { return p; }).join(' ');
+		return textParts.filter((p) => { return p; }).join(' ');
 	};
 
 	// ----------------

--- a/packages/server/src/utils/routeUtils.test.ts
+++ b/packages/server/src/utils/routeUtils.test.ts
@@ -3,9 +3,9 @@ import { ItemAddressingType } from '../services/database/types';
 import { RouteType } from './types';
 import { expectThrow } from './testing/testUtils';
 
-describe('routeUtils', function() {
+describe('routeUtils', () => {
 
-	it('should parse a route path', async function() {
+	it('should parse a route path', async () => {
 		const testCases: any[] = [
 			['123456/content', '123456', 'content', ItemAddressingType.Id],
 			['123456', '123456', '', ItemAddressingType.Id],
@@ -27,7 +27,7 @@ describe('routeUtils', function() {
 		}
 	});
 
-	it('should find a matching route', async function() {
+	it('should find a matching route', async () => {
 		const testCases: any[] = [
 			['/admin/organizations', {
 				route: 1,
@@ -82,7 +82,7 @@ describe('routeUtils', function() {
 		await expectThrow(async () => findMatchingRoute('api/users/123', routes));
 	});
 
-	it('should split an item path', async function() {
+	it('should split an item path', async () => {
 		const testCases: any[] = [
 			['root:/Documents/MyFile.md:', ['root', 'Documents', 'MyFile.md']],
 			['documents:/CV.doc:', ['documents', 'CV.doc']],
@@ -98,7 +98,7 @@ describe('routeUtils', function() {
 		}
 	});
 
-	it('should check the request origin for API URLs', async function() {
+	it('should check the request origin for API URLs', async () => {
 		const testCases: [string, string, boolean][] = [
 			[
 				'https://example.com', // Request origin
@@ -140,7 +140,7 @@ describe('routeUtils', function() {
 		}
 	});
 
-	it('should check the request origin for User Content URLs', async function() {
+	it('should check the request origin for User Content URLs', async () => {
 		const testCases: [string, string, boolean][] = [
 			[
 				'https://usercontent.local', // Request origin
@@ -170,7 +170,7 @@ describe('routeUtils', function() {
 		}
 	});
 
-	it('should check if a URL matches a schema', async function() {
+	it('should check if a URL matches a schema', async () => {
 		const testCases: [string, string, boolean][] = [
 			[
 				'https://test.com/items/123/children',

--- a/packages/server/src/utils/testing/testRouters.ts
+++ b/packages/server/src/utils/testing/testRouters.ts
@@ -132,7 +132,7 @@ async function main() {
 		serverProcess.kill();
 	};
 
-	process.on('SIGINT', function() {
+	process.on('SIGINT', () => {
 		console.info('Received SIGINT signal - killing server');
 		cleanUp();
 		process.exit();

--- a/packages/server/src/utils/time.test.ts
+++ b/packages/server/src/utils/time.test.ts
@@ -1,8 +1,8 @@
 import { Day, Month, Second } from './time';
 
-describe('time', function() {
+describe('time', () => {
 
-	it('should have correct interval durations', async function() {
+	it('should have correct interval durations', async () => {
 		expect(Second).toBe(1000);
 		expect(Day).toBe(86400000);
 		expect(Month).toBe(2592000000);

--- a/packages/tools/buildServerDocker.test.ts
+++ b/packages/tools/buildServerDocker.test.ts
@@ -1,6 +1,6 @@
 import { getIsPreRelease, getVersionFromTag } from './buildServerDocker';
 
-describe('buildServerDocker', function() {
+describe('buildServerDocker', () => {
 
 	test('should get the tag version', async () => {
 		type TestCase = [string, boolean, string];

--- a/packages/tools/bundleDefaultPlugins.test.ts
+++ b/packages/tools/bundleDefaultPlugins.test.ts
@@ -108,7 +108,7 @@ async function mockPluginData() {
 	return tgzData;
 }
 
-describe('bundleDefaultPlugins', function() {
+describe('bundleDefaultPlugins', () => {
 
 	const testDefaultPluginsInfo = {
 		'plugin.calebjohn.rich-markdown': {

--- a/packages/tools/checkLibPaths.test.ts
+++ b/packages/tools/checkLibPaths.test.ts
@@ -1,6 +1,6 @@
 import { findInvalidImportPaths } from './checkLibPaths';
 
-describe('checkLibPaths', function() {
+describe('checkLibPaths', () => {
 
 	test('should detect invalid lib paths', async () => {
 		const testCases: [number, string][] = [

--- a/packages/tools/release-android.ts
+++ b/packages/tools/release-android.ts
@@ -16,7 +16,7 @@ interface Release {
 }
 
 function increaseGradleVersionCode(content: string) {
-	const newContent = content.replace(/versionCode\s+(\d+)/, function(_a, versionCode: string) {
+	const newContent = content.replace(/versionCode\s+(\d+)/, (_a, versionCode: string) => {
 		const n = Number(versionCode);
 		if (isNaN(n) || !n) throw new Error(`Invalid version code: ${versionCode}`);
 		return `versionCode ${n + 1}`;
@@ -28,7 +28,7 @@ function increaseGradleVersionCode(content: string) {
 }
 
 function increaseGradleVersionName(content: string) {
-	const newContent = content.replace(/(versionName\s+"\d+?\.\d+?\.)(\d+)"/, function(_match, prefix: string, buildNum: string) {
+	const newContent = content.replace(/(versionName\s+"\d+?\.\d+?\.)(\d+)"/, (_match, prefix: string, buildNum: string) => {
 		const n = Number(buildNum);
 		if (isNaN(n)) throw new Error(`Invalid version code: ${buildNum}`);
 		return `${prefix + (n + 1)}"`;

--- a/packages/tools/release-ios.ts
+++ b/packages/tools/release-ios.ts
@@ -15,7 +15,7 @@ async function updateCodeProjVersions(filePath: string) {
 	let newVersionId = 0;
 
 	// MARKETING_VERSION = 10.1.0;
-	newContent = newContent.replace(/(MARKETING_VERSION = )(\d+\.\d+)\.(\d+)(.*)/g, function(_match, prefix, majorMinorVersion, buildNum, suffix) {
+	newContent = newContent.replace(/(MARKETING_VERSION = )(\d+\.\d+)\.(\d+)(.*)/g, (_match, prefix, majorMinorVersion, buildNum, suffix) => {
 		const n = Number(buildNum);
 		if (isNaN(n)) throw new Error(`Invalid version code: ${buildNum}`);
 		newVersion = `${majorMinorVersion}.${n + 1}`;
@@ -23,7 +23,7 @@ async function updateCodeProjVersions(filePath: string) {
 	});
 
 	// CURRENT_PROJECT_VERSION = 58;
-	newContent = newContent.replace(/(CURRENT_PROJECT_VERSION = )(\d+)(.*)/g, function(_match, prefix, projectVersion, suffix) {
+	newContent = newContent.replace(/(CURRENT_PROJECT_VERSION = )(\d+)(.*)/g, (_match, prefix, projectVersion, suffix) => {
 		const n = Number(projectVersion);
 		if (isNaN(n)) throw new Error(`Invalid version code: ${projectVersion}`);
 		newVersionId = n + 1;

--- a/packages/tools/setupNewRelease.ts
+++ b/packages/tools/setupNewRelease.ts
@@ -56,7 +56,7 @@ async function updatePackageVersion(packageFilePath: string, majorMinorVersion: 
 async function updateGradleVersion(filePath: string, majorMinorVersion: string) {
 	const contentText = await fs.readFile(filePath, 'utf8');
 
-	const newContent = contentText.replace(/(versionName\s+")(\d+?\.\d+?)(\.\d+")/, function(_match, prefix, version, suffix) {
+	const newContent = contentText.replace(/(versionName\s+")(\d+?\.\d+?)(\.\d+")/, (_match, prefix, version, suffix) => {
 		if (version === majorMinorVersion) return prefix + version + suffix;
 		return `${prefix + majorMinorVersion}.0"`;
 	});
@@ -70,7 +70,7 @@ async function updateCodeProjVersion(filePath: string, majorMinorVersion: string
 	const contentText = await fs.readFile(filePath, 'utf8');
 
 	// MARKETING_VERSION = 10.1.0;
-	const newContent = contentText.replace(/(MARKETING_VERSION = )(\d+\.\d+)(\.\d+;)/g, function(_match, prefix, version, suffix) {
+	const newContent = contentText.replace(/(MARKETING_VERSION = )(\d+\.\d+)(\.\d+;)/g, (_match, prefix, version, suffix) => {
 		if (version === majorMinorVersion) return prefix + version + suffix;
 		return `${prefix + majorMinorVersion}.0;`;
 	});

--- a/packages/tools/tool-utils.ts
+++ b/packages/tools/tool-utils.ts
@@ -252,10 +252,10 @@ export async function downloadFile(url: string, targetPath: string) {
 
 	return new Promise((resolve, reject) => {
 		const file = fs.createWriteStream(targetPath);
-		https.get(url, function(response: any) {
+		https.get(url, (response: any) => {
 			if (response.statusCode !== 200) reject(new Error(`HTTP error ${response.statusCode}`));
 			response.pipe(file);
-			file.on('finish', function() {
+			file.on('finish', () => {
 				// file.close();
 				resolve(null);
 			});
@@ -273,12 +273,12 @@ export function fileSha256(filePath: string) {
 		const shasum = crypto.createHash(algo);
 
 		const s = fs.ReadStream(filePath);
-		s.on('data', function(d: any) { shasum.update(d); });
-		s.on('end', function() {
+		s.on('data', (d: any) => { shasum.update(d); });
+		s.on('end', () => {
 			const d = shasum.digest('hex');
 			resolve(d);
 		});
-		s.on('error', function(error: any) {
+		s.on('error', (error: any) => {
 			reject(error);
 		});
 	});
@@ -299,7 +299,7 @@ export function fileExists(filePath: string) {
 	const fs = require('fs-extra');
 
 	return new Promise((resolve, reject) => {
-		fs.stat(filePath, function(error: any) {
+		fs.stat(filePath, (error: any) => {
 			if (!error) {
 				resolve(true);
 			} else if (error.code === 'ENOENT') {

--- a/packages/tools/website/utils/openGraph.test.ts
+++ b/packages/tools/website/utils/openGraph.test.ts
@@ -2,9 +2,9 @@ import { extractOpenGraphTags, OpenGraphTags } from './openGraph';
 import { tempFilePath } from '@joplin/lib/testing/test-utils';
 import { writeFile } from 'fs-extra';
 
-describe('openGraph', function() {
+describe('openGraph', () => {
 
-	it('should extract the Open Graph tags', async function() {
+	it('should extract the Open Graph tags', async () => {
 		const tests: [string, OpenGraphTags][] = [
 
 			['# My title\n\nMy note description **with bold text**', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15078,6 +15078,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prefer-arrow-functions@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "eslint-plugin-prefer-arrow-functions@npm:3.1.4"
+  peerDependencies:
+    eslint: ">=5.0.0"
+  checksum: 581f1be4ea056d70aad1866ee16a0def7ecece050e03ff3bc2a6695b8bdca3751d6360fcd0e4efccd0068a0e0557b7ab36586a301afa38957acc8c58d293560c
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-promise@npm:6.1.1, eslint-plugin-promise@npm:^6.0.0":
   version: 6.1.1
   resolution: "eslint-plugin-promise@npm:6.1.1"
@@ -27824,6 +27833,7 @@ __metadata:
     eslint: 8.31.0
     eslint-interactive: 10.3.0
     eslint-plugin-import: 2.27.4
+    eslint-plugin-prefer-arrow-functions: ^3.1.4
     eslint-plugin-promise: 6.1.1
     eslint-plugin-react: 7.32.0
     fs-extra: 11.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -15078,15 +15078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prefer-arrow-functions@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "eslint-plugin-prefer-arrow-functions@npm:3.1.4"
-  peerDependencies:
-    eslint: ">=5.0.0"
-  checksum: 581f1be4ea056d70aad1866ee16a0def7ecece050e03ff3bc2a6695b8bdca3751d6360fcd0e4efccd0068a0e0557b7ab36586a301afa38957acc8c58d293560c
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-promise@npm:6.1.1, eslint-plugin-promise@npm:^6.0.0":
   version: 6.1.1
   resolution: "eslint-plugin-promise@npm:6.1.1"
@@ -27833,7 +27824,6 @@ __metadata:
     eslint: 8.31.0
     eslint-interactive: 10.3.0
     eslint-plugin-import: 2.27.4
-    eslint-plugin-prefer-arrow-functions: ^3.1.4
     eslint-plugin-promise: 6.1.1
     eslint-plugin-react: 7.32.0
     fs-extra: 11.1.0


### PR DESCRIPTION
Relates to https://github.com/laurent22/joplin/issues/7771

Initially Laurent had the idea of using a third-party ESLint plugin to enforce the usage of arrow functions whenever possible. The original library that was considered was `eslint-plugin-prefer-arrow-functions` https://www.npmjs.com/package/eslint-plugin-prefer-arrow-functions 

After some tests trying to run the auto-fix and see how the library behaves we learned that it doesn't seem consistent in enforcing arrow functions, it looks like it has the propensity of enforcing arrow functions on simpler/smaller functions. One example is documented in the issue https://github.com/laurent22/joplin/issues/7771#issuecomment-1435407538

When I learned that the library was a bit funky I started looking for alternatives and I found an ESLint rule to enforce arrow functions in callbacks: `prefer-arrow-callback` https://eslint.org/docs/latest/rules/prefer-arrow-callback 

While this rule doesn't solve the problem that was presented, it is a good step forward in enforcing consistency.