### PR TITLE
Desktop: Fixes #7782: Markdown + Front Matter export fails when tag(s) lost

### DIFF
--- a/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.test.ts
@@ -131,4 +131,15 @@ describe('interop/InteropService_Exporter_Md_frontmatter', function() {
 		expect(content).not.toContain('longitude');
 		expect(content).not.toContain('altitude');
 	}));
+
+	test('should export note without tag keyword if the tag has been deleted', (async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note = await Note.save({ title: 'NoTag', body: '**ma note**', parent_id: folder1.id });
+		const tag = await Tag.save({ title: 'tag' });
+		await Tag.setNoteTagsByIds(note.id, [tag.id]);
+
+		await Tag.delete(tag.id);
+		const content = await exportAndLoad(`${exportDir()}/folder1/NoTag.md`);
+		expect(content).not.toContain('tag');
+	}));
 });

--- a/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Md_frontmatter.ts
@@ -127,8 +127,12 @@ export default class InteropService_Exporter_Md_frontmatter extends InteropServi
 		const context: FrontMatterContext = this.context();
 		if (context.noteTags[note.id]) {
 			const tagIds = context.noteTags[note.id];
-			const tags = tagIds.map((id: string) => context.tagTitles[id]).sort();
-			md['tags'] = tags;
+			// In some cases a NoteTag can still exist, while the Tag does not. In this case, tagTitles
+			// for that tagId will return undefined, which can't be handled by the yaml library (issue #7782)
+			const tags = tagIds.map((id: string) => context.tagTitles[id]).filter(e => !!e).sort();
+			if (tags.length > 0) {
+				md['tags'] = tags;
+			}
 		}
 
 		// This guarentees that fields will always be ordered the same way


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/7782

## Problem:
When the remote Tag that was associated with a Note is deleted and the client tries to synchronize, during the 'delta process' the original Tag is deleted, but the NoteTag records that are associated with it are left untouched.
When we try to export to the Markdown + Front Matter this Note would end up associated with a tag with the value `undefined` (because the only record that still exists is on the NoteTag table, there isn't any tag name to be used on the export) which is not supported by default by the `js-yaml` library.

## Implementation

The best solution here would probably be to fix the synchronization process, but for now, I added a workaround for the export.

## Testing

I added one test, to see the changes, you can run the test over the first commit and see the error being thrown by the third-party library.