### PR TITLE
Desktop: Fixes #7814: Revert changes made to note list's height

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -17,12 +17,13 @@ interface Props {
 	sortOrderField: string;
 	sortOrderReverse: boolean;
 	notesParentType: string;
+	height: number;
 }
 
 const StyledRoot = styled.div`
 	box-sizing: border-box;
+	height: ${(props: any) => props.height}px;
 	display: flex;
-	height: auto;
 	flex-direction: column;
 	padding: ${(props: any) => props.theme.mainPadding}px;
 	background-color: ${(props: any) => props.theme.backgroundColor3};

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -1,3 +1,4 @@
+import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
 import { useMemo } from 'react';
 import NoteList from '../NoteList/NoteList';
@@ -20,16 +21,19 @@ const StyledRoot = styled.div`
 `;
 
 export default function NoteListWrapper(props: Props) {
+	const theme = themeStyle(props.themeId);
+	const controlHeight = theme.topRowHeight;
+
 	const noteListSize = useMemo(() => {
 		return {
 			width: props.size.width,
-			height: props.size.height,
+			height: props.size.height - controlHeight,
 		};
-	}, [props.size]);
+	}, [props.size, controlHeight]);
 
 	return (
 		<StyledRoot>
-			<NoteListControls />
+			<NoteListControls height={controlHeight}/>
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -60,7 +60,7 @@ const globalStyle: any = {
 	toolbarPadding: 6,
 	appearance: 'light',
 	mainPadding: 12,
-	topRowHeight: 50,
+	topRowHeight: 81,
 	editorPaddingLeft: 8,
 };
 


### PR DESCRIPTION
The note list does not fit in its container after a change made in https://github.com/laurent22/joplin/pull/7780.

This PR reverts to the original code and increases `topRowHeight` to account for the new layout.

Fixes https://github.com/laurent22/joplin/issues/7814.