### PR TITLE
Fixing missing note icon display bug

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/openItem.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/openItem.ts
@@ -3,6 +3,7 @@ import shim from '@joplin/lib/shim';
 import { _ } from '@joplin/lib/locale';
 import bridge from '../../../services/bridge';
 import { openItemById } from '../../NoteEditor/utils/contextMenu';
+import { existsSync } from 'fs';
 const { parseResourceUrl, urlProtocol, fileUriToPath } = require('@joplin/lib/urlUtils');
 const { urlDecode } = require('@joplin/lib/string-utils');
 
@@ -21,7 +22,7 @@ export const runtime = (): CommandRuntime => {
 					const { itemId, hash } = parsedUrl;
 					await openItemById(itemId, context.dispatch, hash);
 				} else {
-					void require('electron').shell.openExternal(link);
+					bridge().showErrorMessageBox(_('Unsupported link or message: %s', link));
 				}
 			} else if (urlProtocol(link)) {
 				if (link.indexOf('file://') === 0) {
@@ -32,6 +33,9 @@ export const runtime = (): CommandRuntime => {
 					// but doesn't on macOS, so we need to convert it to a path
 					// before passing it to openPath.
 					const decodedPath = fileUriToPath(urlDecode(link), shim.platformName());
+					if (!existsSync(decodedPath)) {
+						bridge().showErrorMessageBox(_('File not found', link));
+					}
 					void require('electron').shell.openPath(decodedPath);
 				} else {
 					void require('electron').shell.openExternal(link);

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -34,7 +34,10 @@ export async function openItemById(itemId: string, dispatch: Function, hash: str
 
 	const item = await BaseItem.loadItemById(itemId);
 
-	if (!item) throw new Error(`No item with ID ${itemId}`);
+	if (!item) {
+		bridge().showErrorMessageBox(`No item found with ID ${itemId}`);
+		throw new Error(`No item with ID ${itemId}`);
+	}
 
 	if (item.type_ === BaseModel.TYPE_RESOURCE) {
 		const resource = item as ResourceEntity;

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -149,6 +149,7 @@ export interface RuleOptions {
 	postMessageSyntax: string;
 	ResourceModel: any;
 	resourceBaseUrl: string;
+	linkedNotes: string[];
 	resources: any; // resourceId: Resource
 
 	// Used by checkboxes to specify how it should be rendered
@@ -460,9 +461,13 @@ export default class MdToHtml {
 		const cachedOutput = this.cachedOutputs_[cacheKey];
 		if (cachedOutput) return cachedOutput;
 
+		const linkedNotes = await require('../lib/models/Note').default.linkedNoteIds(body);
+
+
 		const ruleOptions = Object.assign({}, options, {
 			resourceBaseUrl: this.resourceBaseUrl_,
 			ResourceModel: this.ResourceModel_,
+			linkedNotes: linkedNotes,
 		});
 
 		const context: PluginContext = {

--- a/packages/renderer/MdToHtml/linkReplacement.test.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.test.ts
@@ -1,4 +1,5 @@
 import linkReplacement from './linkReplacement';
+const { getClassNameForMimeType } = require('font-awesome-filetypes');
 import { describe, test, expect } from '@jest/globals';
 
 describe('linkReplacement', () => {
@@ -22,12 +23,16 @@ describe('linkReplacement', () => {
 
 	test('should handle resource links - downloaded status', () => {
 		const resourceId = 'f6afba55bdf74568ac94f8d1e3578d2c';
+		const iconType = getClassNameForMimeType('application/pdf');
 
 		const r = linkReplacement(`:/${resourceId}`, {
 			ResourceModel: {},
 			resources: {
 				[resourceId]: {
-					item: {},
+					item: {
+						title: 'Downloaded Resource',
+						mime: 'application/pdf',
+					},
 					localState: {
 						fetch_status: 2, // FETCH_STATUS_DONE
 					},
@@ -35,7 +40,7 @@ describe('linkReplacement', () => {
 			},
 		}).html;
 
-		expect(r).toBe(`<a data-from-md data-resource-id='${resourceId}' href='#' onclick='postMessage("joplin://${resourceId}", { resourceId: "${resourceId}" }); return false;'><span class="resource-icon fa-joplin"></span>`);
+		expect(r).toBe(`<a data-from-md data-resource-id='${resourceId}' title='Downloaded Resource' type='application/pdf' href='#' onclick='postMessage("joplin://${resourceId}", { resourceId: "${resourceId}" }); return false;'><span class="resource-icon ${iconType}"></span>`);
 	});
 
 	test('should handle resource links - idle status', () => {
@@ -56,6 +61,120 @@ describe('linkReplacement', () => {
 		// Since the icon is embedded as SVG, we only check for the prefix
 		const expectedPrefix = `<a class="not-loaded-resource resource-status-notDownloaded" data-resource-id="${resourceId}"><img src="data:image/svg+xml;utf8`;
 		expect(r.indexOf(expectedPrefix)).toBe(0);
+	});
+
+	test('should handle resource links - invalid link format', () => {
+		const validResourceId 	 = 'f6afba55bdf74568ac94f8d1e3578d2c'; // 32 Chars
+
+		const invalidResourceId1 = 'f6afba55bdf74568ac94f8d'; // < 32 Chars
+		const invalidResourceTitle1 = ':/f6afba55bdf74568ac94f8d';
+
+		const invalidResourceId2 = 'f6afba55bdf74568ac94f8d1e35dfs34v'; // > 32 Chars
+		const invalidResourceTitle2 = ':/f6afba55bdf74568ac94f8d1e35dfs34v';
+
+		const r1 = linkReplacement(`:/${invalidResourceId1}`, {
+			title: invalidResourceTitle1,
+			ResourceModel: {},
+			resources: {
+				[validResourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 0, // FETCH_STATUS_IDLE
+					},
+				},
+			},
+			postMessageSyntax: 'ipcProxySendToHost',
+		}).html;
+
+		const r2 = linkReplacement(`:/${invalidResourceId2}`, {
+			title: invalidResourceTitle2,
+			ResourceModel: {},
+			resources: {
+				[validResourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 0, // FETCH_STATUS_IDLE
+					},
+				},
+			},
+			postMessageSyntax: 'ipcProxySendToHost',
+		}).html;
+
+		expect(r1).toBe(`<a data-from-md title='${invalidResourceTitle1}' href='#' onclick='ipcProxySendToHost("${invalidResourceTitle1}", { resourceId: "" }); return false;'><span title="Invlaid resource id" class="resource-icon-error fa-exclamation-circle"></span>`);
+		expect(r2).toBe(`<a data-from-md title='${invalidResourceTitle2}' href='#' onclick='ipcProxySendToHost("${invalidResourceTitle2}", { resourceId: "" }); return false;'><span title="Invlaid resource id" class="resource-icon-error fa-exclamation-circle"></span>`);
+	});
+
+	test('should handle resource links - non-existing resource id', () => {
+		const existingResourceId 	= 'f6afba55bdf74568ac94f8d1e3578d2c'; // 32 Chars
+
+		const nonExistingResourceId = 'f6afba55bdf74568ac94f8d1e3578bad';
+
+		const r = linkReplacement(`:/${nonExistingResourceId}`, {
+			title: '',
+			ResourceModel: {},
+			resources: {
+				[existingResourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 2,
+					},
+				},
+			},
+			postMessageSyntax: 'ipcProxySendToHost',
+			linkedNotes: ['badfba55bdf74568ac94f8d1e3578d2c', 'f6afba5sdef74568ac94f8d1e3578d2c'],
+		}).html;
+
+		expect(r).toBe(`<a data-from-md data-resource-id='${nonExistingResourceId}' href='#' onclick='ipcProxySendToHost("joplin://${nonExistingResourceId}", { resourceId: "${nonExistingResourceId}" }); return false;'><span title="File not found" class="resource-icon-error fa-exclamation-circle"></span>`);
+
+	});
+
+	test('should handle joplin note links', () => {
+		const joplinNoteLink = 'baee37f69fed4417b4f11c50b28a2a42';
+
+		const randomResourceId = 'f6afba55bdf74568ac94f8d1e3578bad';
+
+		const r = linkReplacement(`:/${joplinNoteLink}`, {
+			title: '',
+			ResourceModel: {},
+			resources: {
+				[randomResourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 2,
+					},
+				},
+			},
+			postMessageSyntax: 'ipcProxySendToHost',
+			linkedNotes: ['baee37f69fed4417b4f11c50b28a2a42', 'f6afba5sdef74568ac94f8d1e3578d2c'],
+		}).html;
+
+		expect(r).toBe(`<a data-from-md data-resource-id='${joplinNoteLink}' href='#' onclick='ipcProxySendToHost("joplin://${joplinNoteLink}", { resourceId: "${joplinNoteLink}" }); return false;'><span title="" class="resource-icon fa-joplin"></span>`);
+
+	});
+
+
+	test('should handle "file://" protocol links', () => {
+		const fileURI = 'file://home/home/Desktop/Random.pdf';
+
+		const randomResourceId = 'f6afba55bdf74568ac94f8d1e3578bad';
+
+		const r = linkReplacement(`${fileURI}`, {
+			title: fileURI,
+			ResourceModel: {},
+			resources: {
+				[randomResourceId]: {
+					item: {},
+					localState: {
+						fetch_status: 2,
+					},
+				},
+			},
+			postMessageSyntax: 'ipcProxySendToHost',
+			linkedNotes: ['baee37f69fed4417b4f11c50b28a2a42', 'f6afba5sdef74568ac94f8d1e3578d2c'],
+		}).html;
+
+		expect(r).toBe(`<a data-from-md title='${fileURI}' href='#' onclick='ipcProxySendToHost("${fileURI}", { resourceId: "" }); return false;'><span class="resource-icon fa-file-pdf"></span>`);
+
 	});
 
 	test('should create ontouch listeners to handle longpress', () => {

--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -90,7 +90,7 @@ export default function(href: string, options: Options = null): LinkReplacementR
 				icon = `<span title="File not found" class="resource-icon-error ${iconType}"></span>`;
 			}
 		}
-	} else if (href.startsWith('https://') || href.startsWith('http://')) {
+	} else if (href.startsWith('https://') || href.startsWith('http://') || href.indexOf('#') === 0) {
 		// If the link is a plain URL (as opposed to a resource link), set the href to the actual
 		// link. This allows the link to be exported too when exporting to PDF.
 		hrefAttr = href;

--- a/packages/renderer/MdToHtml/rules/link_open.ts
+++ b/packages/renderer/MdToHtml/rules/link_open.ts
@@ -20,6 +20,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 			plainResourceRendering: ruleOptions.plainResourceRendering,
 			postMessageSyntax: ruleOptions.postMessageSyntax,
 			enableLongPress: ruleOptions.enableLongPress,
+			linkedNotes: ruleOptions.linkedNotes,
 			itemIdToUrl: ruleOptions.itemIdToUrl,
 		});
 

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -167,6 +167,17 @@ export default function(theme: any, options: Options = null) {
 			margin-right: 0.4em;
 			background-color:  ${theme.urlColor};
 		}
+
+		.resource-icon-error {
+			display: inline-block;
+			position: relative;
+			top: 0.3em;
+			text-decoration: none;
+			width: 1.2em;
+			height: 1.4em;
+			margin-right: 0.4em;
+			background-color: red;
+		}
     /* These icons are obtained from the wonderful ForkAwesome project by copying the src svgs 
      * into the css classes below.
      * svgs are obtained from https://github.com/ForkAwesome/Fork-Awesome/tree/master/src/icons/svg
@@ -223,6 +234,10 @@ export default function(theme: any, options: Options = null) {
 		}
 		.fa-file {
 			-webkit-mask: url("data:image/svg+xml;utf8,<svg viewBox='0 0 1536 1792' xmlns='http://www.w3.org/2000/svg'><path d='M1468 380c37 37 68 111 68 164v1152c0 53-43 96-96 96H96c-53 0-96-43-96-96V96C0 43 43 0 96 0h896c53 0 127 31 164 68zm-444-244v376h376c-6-17-15-34-22-41l-313-313c-7-7-24-16-41-22zm384 1528V640H992c-53 0-96-43-96-96V128H128v1536h1280z'/></svg>");
+      -webkit-mask-repeat: no-repeat;
+		}
+		.fa-exclamation-circle {
+			-webkit-mask: url("data:image/svg+xml;utf8,<svg viewBox='0 0 1536 1792' xmlns='http://www.w3.org/2000/svg'><path d='M768 128c424 0 768 344 768 768s-344 768-768 768S0 1320 0 896s344-768 768-768zm128 1247v-190c0-18-14-33-31-33H673c-18 0-33 15-33 33v190c0 18 15 33 33 33h192c17 0 31-15 31-33zm-2-344l18-621c0-7-3-14-10-18-6-5-15-8-24-8H658c-9 0-18 3-24 8-7 4-10 11-10 18l17 621c0 14 15 25 34 25h185c18 0 33-11 34-25z'/></svg>");
       -webkit-mask-repeat: no-repeat;
 		}
 		blockquote {


### PR DESCRIPTION
Fixes #7794 
# On Desktop
## Case 1: Non-Exiting Resource ID

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221254880-3f9726d3-7f11-4844-891b-da6a54943e61.png" width="717" height="201" />
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221255087-9e84532d-d6a1-4a8d-b0ac-8a0bb9f5cde8.png" width="717" height="201" />
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221261106-c35c3924-52ec-4f52-b0b9-ee8180447e7b.png" />
</p>

## Case 2: Non-Exiting Resource ID - Joplin Note

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221257621-60646a44-1621-4fc6-9cb4-19e5fd8161b2.png"/>
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221258020-2851f7c2-d272-401f-a2ed-6d515db42d72.png"/>
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221258666-4626ebd5-f8e0-486f-a6b2-2b5eefd49c56.png" />
</p>


## Case 3: Invalid Resource ID
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221259616-ccea5590-90ec-4493-8503-fb5fd0945787.png"/>
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221258020-2851f7c2-d272-401f-a2ed-6d515db42d72.png"/>
</p>

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221260044-8fb76ef8-626a-4f75-a969-81f347c20281.png" />
</p>

## Case 4: External file (file:// protocol)
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221260253-1537ad06-370c-4784-abd9-d639ce866e35.png"/>
</p>

# On Mobile

## Case 1: Non-Exiting Resource ID

<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221263313-e3a9b341-7918-4db4-a9db-e107a3c65e31.png"/>
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221263101-e7e52d04-97fb-489c-b4c3-897fd95d49cd.png"/>
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221263646-1b862947-ac4a-4ca4-9de3-b2f3e04210d6.png"/>
</p>

## Case 2: Invalid Resource ID
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221275850-c3700473-1cc9-4ee0-9c11-9630c2c5072c.png"/>
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221276144-9df0d02e-f3ab-4853-9d82-63a6e76e8f14.png"/>
</p>

## Case 3: For joplin notes
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221276405-42cd687f-4e45-4c10-8e42-948cf217357d.png"/>
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221276633-5d48654f-933a-4aec-9680-cdfa788304f1.png"/>
</p>
<p align="center">
  <img src="https://user-images.githubusercontent.com/65447610/221276994-001b9d65-9c8f-4f6c-bab7-fde2cf029fde.png"/>
</p>


<!--



Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
