### PR TITLE
Desktop: Fixes #7831: Skip the resources which haven't been downloaded yet when exporting

### DIFF
--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -75,7 +75,7 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 		for (let i = 0; i < linkedResourceIds.length; i++) {
 			const id = linkedResourceIds[i];
 			// Skip the resources which haven't been downloaded yet
-			if (!resourcePaths.hasOwnProperty(id)) {
+			if (!resourcePaths[id]) {
 				continue;
 			}
 			const resourceContent = `${relativePath ? `${relativePath}/` : ''}_resources/${basename(resourcePaths[id])}`;

--- a/packages/lib/services/interop/InteropService_Exporter_Html.ts
+++ b/packages/lib/services/interop/InteropService_Exporter_Html.ts
@@ -74,6 +74,10 @@ export default class InteropService_Exporter_Html extends InteropService_Exporte
 
 		for (let i = 0; i < linkedResourceIds.length; i++) {
 			const id = linkedResourceIds[i];
+			// Skip the resources which haven't been downloaded yet
+			if (!resourcePaths.hasOwnProperty(id)) {
+				continue;
+			}
 			const resourceContent = `${relativePath ? `${relativePath}/` : ''}_resources/${basename(resourcePaths[id])}`;
 			newBody = newBody.replace(new RegExp(`:/${id}`, 'g'), resourceContent);
 		}


### PR DESCRIPTION
Fixes #7831
https://github.com/laurent22/joplin/blob/9c080ec63172fb09bf2a086ed98e881ed5c00228/packages/lib/services/interop/InteropService_Exporter_Html.ts#L67-L82
If the resources are not downloaded, the `resourcePaths` will not hold the path of it. Then `resourcePaths[id]` will cause a error.
This PR fixes it by checking the existence of `id` in `resourcePaths` and skipping the resource if the `id` doesn't have corresponding path, as @laurent22 suggested in #7831.