### PR TITLE
Desktop: Fixes #7848: Fixed note list controls alignment when sort order buttons are disabled

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -155,28 +155,26 @@ function NoteListControls(props: Props) {
 			{renderNewNoteButtons()}
 			<RowContainer>
 				<SearchBar inputRef={searchBarRef}/>
-				<SortOrderButtonsContainer>
-					{showsSortOrderButtons() &&
-					<StyledPairButtonL
-						className="sort-order-field-button"
-						tooltip={sortOrderFieldTooltip()}
-						iconName={sortOrderFieldIcon()}
-						level={ButtonLevel.Secondary}
-						size={ButtonSize.Small}
-						onClick={onSortOrderFieldButtonClick}
-					/>
-					}
-					{showsSortOrderButtons() &&
-					<StyledPairButtonR
-						className="sort-order-reverse-button"
-						tooltip={CommandService.instance().label('toggleNotesSortOrderReverse')}
-						iconName={sortOrderReverseIcon()}
-						level={ButtonLevel.Secondary}
-						size={ButtonSize.Small}
-						onClick={onSortOrderReverseButtonClick}
-					/>
-					}
-				</SortOrderButtonsContainer>
+				{showsSortOrderButtons() &&
+					<SortOrderButtonsContainer>
+						<StyledPairButtonL
+							className="sort-order-field-button"
+							tooltip={sortOrderFieldTooltip()}
+							iconName={sortOrderFieldIcon()}
+							level={ButtonLevel.Secondary}
+							size={ButtonSize.Small}
+							onClick={onSortOrderFieldButtonClick}
+						/>
+						<StyledPairButtonR
+							className="sort-order-reverse-button"
+							tooltip={CommandService.instance().label('toggleNotesSortOrderReverse')}
+							iconName={sortOrderReverseIcon()}
+							level={ButtonLevel.Secondary}
+							size={ButtonSize.Small}
+							onClick={onSortOrderReverseButtonClick}
+						/>
+					</SortOrderButtonsContainer>
+				}
 			</RowContainer>
 		</StyledRoot>
 	);


### PR DESCRIPTION
This PR addresses a bug mentionned in https://github.com/laurent22/joplin/issues/7848 introduced by the new design of the note list controls that caused the two rows to be misaligned when sort buttons were disabled.

Before.
![bug-controls-alignment-sort-buttons-before](https://user-images.githubusercontent.com/32807437/221631725-53711a2a-b706-44f1-9585-af3542e187c7.png)

Now with the correct alignment in both cases.
![bug-controls-alignment-sort-buttons-after-2](https://user-images.githubusercontent.com/32807437/221631827-85a95219-2281-4432-aad1-8a25aee0c907.png)
![bug-controls-alignment-sort-buttons-after](https://user-images.githubusercontent.com/32807437/221631962-6f8d392c-a29e-4250-9c08-beb2847150a6.png)
