### PR TITLE
All: Fixes #7851: Encode the non-ASCII characters in OneDrive URI

### DIFF
--- a/packages/lib/SyncTargetOneDrive.ts
+++ b/packages/lib/SyncTargetOneDrive.ts
@@ -103,7 +103,9 @@ export default class SyncTargetOneDrive extends BaseSyncTarget {
 		}
 		this.api_.setAccountProperties(accountProperties);
 		const appDir = await this.api().appDirectory();
-		const fileApi = new FileApi(appDir, new FileApiDriverOneDrive(this.api()));
+		// the appDir might contain non-ASCII characters
+		// baseDir = encodeURI(appDir)
+		const fileApi = new FileApi(encodeURI(appDir), new FileApiDriverOneDrive(this.api()));
 		fileApi.setSyncTargetId(this.syncTargetId());
 		fileApi.setLogger(this.logger());
 		return fileApi;

--- a/packages/lib/SyncTargetOneDrive.ts
+++ b/packages/lib/SyncTargetOneDrive.ts
@@ -106,7 +106,7 @@ export default class SyncTargetOneDrive extends BaseSyncTarget {
 		// the appDir might contain non-ASCII characters
 		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
 		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
-		const baseDir = RegExp(/[^\u0021-\u00ff]/).exec() !== null ? encodeURI(appDir) : appDir
+		const baseDir = RegExp(/[^\u0021-\u00ff]/).exec(appDir) !== null ? encodeURI(appDir) : appDir
 		const fileApi = new FileApi(baseDir, new FileApiDriverOneDrive(this.api()));
 		fileApi.setSyncTargetId(this.syncTargetId());
 		fileApi.setLogger(this.logger());

--- a/packages/lib/SyncTargetOneDrive.ts
+++ b/packages/lib/SyncTargetOneDrive.ts
@@ -106,7 +106,7 @@ export default class SyncTargetOneDrive extends BaseSyncTarget {
 		// the appDir might contain non-ASCII characters
 		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
 		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
-		const baseDir = RegExp(/[^\u0021-\u00ff]/).exec(appDir) !== null ? encodeURI(appDir) : appDir
+		const baseDir = RegExp(/[^\u0021-\u00ff]/).exec(appDir) !== null ? encodeURI(appDir) : appDir;
 		const fileApi = new FileApi(baseDir, new FileApiDriverOneDrive(this.api()));
 		fileApi.setSyncTargetId(this.syncTargetId());
 		fileApi.setLogger(this.logger());

--- a/packages/lib/SyncTargetOneDrive.ts
+++ b/packages/lib/SyncTargetOneDrive.ts
@@ -104,8 +104,10 @@ export default class SyncTargetOneDrive extends BaseSyncTarget {
 		this.api_.setAccountProperties(accountProperties);
 		const appDir = await this.api().appDirectory();
 		// the appDir might contain non-ASCII characters
-		// baseDir = encodeURI(appDir)
-		const fileApi = new FileApi(encodeURI(appDir), new FileApiDriverOneDrive(this.api()));
+		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
+		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
+		const baseDir = RegExp(/[^\u0021-\u00ff]/).exec() !== null ? encodeURI(appDir) : appDir
+		const fileApi = new FileApi(baseDir, new FileApiDriverOneDrive(this.api()));
 		fileApi.setSyncTargetId(this.syncTargetId());
 		fileApi.setLogger(this.logger());
 		return fileApi;


### PR DESCRIPTION
This fixes #7851

The `appDir` might contain non-ASCII characters in OneDrive, like
```
/drive/root:/应用應用程式/Joplin
```
I use the same regular expression for detecting unescaped characters in Node.js to check this, then call `encodeURI()` for it.

Here is a small demo
URI with unescaped characters
![图片](https://user-images.githubusercontent.com/62299611/222751121-44680574-9d2c-44cd-8fe6-c627394b4d83.png)

URI without unescaped characters
![图片](https://user-images.githubusercontent.com/62299611/222751422-596bc39c-7fdc-45b4-9ed0-d0a91b95c3b2.png)
