### PR TITLE
Desktop: Resolves #7848: Made note list controls responsive

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -1,6 +1,6 @@
 import { AppState } from '../../app.reducer';
 import * as React from 'react';
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useState } from 'react';
 import SearchBar from '../SearchBar/SearchBar';
 import Button, { ButtonLevel, ButtonSize, buttonSizePx } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -10,6 +10,13 @@ import { notesSortOrderNextField } from '../../services/sortOrder/notesSortOrder
 import { _ } from '@joplin/lib/locale';
 const { connect } = require('react-redux');
 const styled = require('styled-components').default;
+
+enum BaseBreakpoint {
+	Sm = 120,
+	Md = 174,
+	Lg = 30,
+	Xl = 474,
+}
 
 interface Props {
 	showNewNoteButtons: boolean;
@@ -21,11 +28,11 @@ interface Props {
 	width: number;
 }
 
-enum Breakpoint {
-	Sm = 222,
-	Md = 316,
-	Lg = 470,
-	Xl = 500,
+interface Breakpoints {
+	Sm: number;
+	Md: number;
+	Lg: number;
+	Xl: number;
 }
 
 const StyledRoot = styled.div`
@@ -42,7 +49,6 @@ const StyledButton = styled(Button)`
 	width: auto;
 	height: 26px;
 	min-height: 26px;
-	flex: 1 0 auto;
 	min-width: 0;
 
   .fa, .fas {
@@ -63,7 +69,13 @@ const StyledPairButtonR = styled(Button)`
 	width: auto;
 `;
 
-const RowContainer = styled.div`
+const TopRow = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 8px;
+`;
+
+const BottomRow = styled.div`
 	display: flex;
 	flex-direction: row;
 	flex: 1 1 auto;
@@ -77,73 +89,101 @@ const SortOrderButtonsContainer = styled.div`
 `;
 
 function NoteListControls(props: Props) {
+	const [dynamicBreakpoints, setDynamicBreakpoints] = useState<Breakpoints>({ Sm: BaseBreakpoint.Sm, Md: BaseBreakpoint.Md, Lg: BaseBreakpoint.Lg, Xl: BaseBreakpoint.Xl });
+
 	const searchBarRef = useRef(null);
 	const newNoteRef = useRef(null);
 	const newTodoRef = useRef(null);
 	const noteControlsRef = useRef(null);
 	const searchAndSortRef = useRef(null);
 
-	const breakpoint = useMemo(() => {
-		const breakpoints = [{ sm: Breakpoint.Sm }, { md: Breakpoint.Md }, { l: Breakpoint.Lg }, { xl: Breakpoint.Xl }];
-		// Find largest breakpoint that width is less than
-		const index = breakpoints.map(x => Object.values(x)[0])
-			.findIndex(x => props.width < x);
+	const getTextWidth = (text: string): number => {
+		const canvas = document.createElement('canvas');
+		if (!canvas) throw new Error('Failed to create canvas element');
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('Failed to get context');
+		const fontWeight = getComputedStyle(newNoteRef.current).getPropertyValue('font-weight');
+		const fontSize = getComputedStyle(newNoteRef.current).getPropertyValue('font-size');
+		const fontFamily = getComputedStyle(newNoteRef.current).getPropertyValue('font-family');
+		ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
 
-		return index === -1 ? Object.keys(breakpoints[breakpoints.length - 1])[0] : Object.keys(breakpoints[index])[0];
-	}, [props.width]);
+		return ctx.measureText(text).width;
+	};
+
+	// Initialize language-specific breakpoints
+	useEffect(() => {
+		// Calculate the amount of extra width needed based on the longest string
+		const smAdditional = getTextWidth(_('note')) > getTextWidth(_('to-do')) ? getTextWidth(_('note')) : getTextWidth(_('to-do'));
+		const mdAdditional = getTextWidth(_('New note')) > getTextWidth(_('New to-do')) ? getTextWidth(_('New note')) : getTextWidth(_('New to-do'));
+
+		const Sm = BaseBreakpoint.Sm + smAdditional * 2;
+		const Md = BaseBreakpoint.Md + mdAdditional * 2;
+		const Lg = BaseBreakpoint.Lg + Md;
+		const Xl = BaseBreakpoint.Xl;
+
+		setDynamicBreakpoints({ Sm, Md, Lg, Xl });
+	}, []);
+
+	const breakpoint = useMemo(() => {
+		// Find largest breakpoint that width is less than
+		const index = Object.values(dynamicBreakpoints).findIndex(x => props.width < x);
+
+		return index === -1 ? dynamicBreakpoints.Xl : Object.values(dynamicBreakpoints)[index];
+	}, [props.width, dynamicBreakpoints]);
 
 	const noteButtonText = useMemo(() => {
-		if (breakpoint === 'sm') {
-			return '';
-		} else if (breakpoint === 'md') {
+		if (breakpoint === dynamicBreakpoints.Sm) {
+			return ' ';
+		} else if (breakpoint === dynamicBreakpoints.Md) {
 			return _('note');
 		} else {
 			return _('New note');
 		}
-	}, [breakpoint]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	const todoButtonText = useMemo(() => {
-		if (breakpoint === 'sm') {
-			return '';
-		} else if (breakpoint === 'md') {
+		if (breakpoint === dynamicBreakpoints.Sm) {
+			return ' ';
+		} else if (breakpoint === dynamicBreakpoints.Md) {
 			return _('to-do');
 		} else {
 			return _('New to-do');
 		}
-	}, [breakpoint]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	const noteIcon = useMemo(() => {
-		if (breakpoint === 'sm') {
+		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'icon-note';
 		} else {
 			return 'fas fa-plus';
 		}
-	}, [breakpoint]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	const todoIcon = useMemo(() => {
-		if (breakpoint === 'sm') {
+		if (breakpoint === dynamicBreakpoints.Sm) {
 			return 'far fa-check-square';
 		} else {
 			return 'fas fa-plus';
 		}
-	}, [breakpoint]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	useEffect(() => {
-		if (breakpoint === 'sm') {
-			newNoteRef.current.style.padding = '0px 18px 0px 18px';
-			newTodoRef.current.style.padding = '0px 18px 0px 18px';
+		if (breakpoint === dynamicBreakpoints.Sm) {
+			const paddingLeft = getTextWidth(' ');
+			newNoteRef.current.style.padding = `0px 0px 0px ${paddingLeft}px`;
+			newTodoRef.current.style.padding = `0px 0px 0px ${paddingLeft}px`;
 		} else {
 			newNoteRef.current.style.padding = '0px 4px 0px 4px';
 			newTodoRef.current.style.padding = '0px 4px 0px 4px';
 		}
 
-		if (breakpoint === 'xl') {
+		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
 			searchAndSortRef.current.style.flex = '2 1 auto';
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
 		}
-	}, [breakpoint]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));
@@ -202,7 +242,7 @@ function NoteListControls(props: Props) {
 		if (!props.showNewNoteButtons) return null;
 
 		return (
-			<RowContainer>
+			<TopRow>
 				<StyledButton ref={newNoteRef}
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
@@ -221,38 +261,36 @@ function NoteListControls(props: Props) {
 					size={ButtonSize.Small}
 					onClick={onNewTodoButtonClick}
 				/>
-			</RowContainer>
+			</TopRow>
 		);
 	}
 
 	return (
 		<StyledRoot ref={noteControlsRef}>
 			{renderNewNoteButtons()}
-			<RowContainer ref={searchAndSortRef}>
+			<BottomRow ref={searchAndSortRef}>
 				<SearchBar inputRef={searchBarRef}/>
-				<SortOrderButtonsContainer>
-					{showsSortOrderButtons() &&
-					<StyledPairButtonL
-						className="sort-order-field-button"
-						tooltip={sortOrderFieldTooltip()}
-						iconName={sortOrderFieldIcon()}
-						level={ButtonLevel.Secondary}
-						size={ButtonSize.Small}
-						onClick={onSortOrderFieldButtonClick}
-					/>
-					}
-					{showsSortOrderButtons() &&
-					<StyledPairButtonR
-						className="sort-order-reverse-button"
-						tooltip={CommandService.instance().label('toggleNotesSortOrderReverse')}
-						iconName={sortOrderReverseIcon()}
-						level={ButtonLevel.Secondary}
-						size={ButtonSize.Small}
-						onClick={onSortOrderReverseButtonClick}
-					/>
-					}
-				</SortOrderButtonsContainer>
-			</RowContainer>
+				{showsSortOrderButtons() &&
+					<SortOrderButtonsContainer>
+						<StyledPairButtonL
+							className="sort-order-field-button"
+							tooltip={sortOrderFieldTooltip()}
+							iconName={sortOrderFieldIcon()}
+							level={ButtonLevel.Secondary}
+							size={ButtonSize.Small}
+							onClick={onSortOrderFieldButtonClick}
+						/>
+						<StyledPairButtonR
+							className="sort-order-reverse-button"
+							tooltip={CommandService.instance().label('toggleNotesSortOrderReverse')}
+							iconName={sortOrderReverseIcon()}
+							level={ButtonLevel.Secondary}
+							size={ButtonSize.Small}
+							onClick={onSortOrderReverseButtonClick}
+						/>
+					</SortOrderButtonsContainer>
+				}
+			</BottomRow>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -1,6 +1,6 @@
 import { AppState } from '../../app.reducer';
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import SearchBar from '../SearchBar/SearchBar';
 import Button, { ButtonLevel, ButtonSize, buttonSizePx } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -76,33 +76,48 @@ function NoteListControls(props: Props) {
 	const noteControlsRef = useRef(null);
 	const searchAndSortRef = useRef(null);
 
-	const [noteBtnText, setNoteBtnText] = useState('New note');
-	const [todoBtnText, setTodoBtnText] = useState('New to-do');
-	const [breakpoint, setBreakpoint] = useState('l');
-	const [iconNote, setIconNote] = useState('fas fa-plus');
-	const [iconTodo, setIconTodo] = useState('fas fa-plus');
-
-	useEffect(() => {
+	const breakpoint = useMemo(() => {
 		const breakpoints = [{ s: 135 }, { md: 189 }, { l: 470 }, { xl: 500 }];
 		// Find largest breakpoint that width is less than
 		const index = breakpoints.map(x => Object.values(x)[0])
 			.findIndex(x => props.width < x);
 
-		const bp = index === -1 ? Object.keys(breakpoints[breakpoints.length - 1])[0] : Object.keys(breakpoints[index])[0];
-
-		setBreakpoint(bp);
+		return index === -1 ? Object.keys(breakpoints[breakpoints.length - 1])[0] : Object.keys(breakpoints[index])[0];
 	}, [props.width]);
 
-	useEffect(() => {
+	const noteButtonText = useMemo(() => {
 		if (breakpoint === 's') {
-			setNoteBtnText('');
-			setTodoBtnText('');
+			return '';
 		} else if (breakpoint === 'md') {
-			setNoteBtnText('note');
-			setTodoBtnText('to-do');
+			return _('note');
 		} else {
-			setNoteBtnText('New note');
-			setTodoBtnText('New to-do');
+			return _('New note');
+		}
+	}, [breakpoint]);
+
+	const todoButtonText = useMemo(() => {
+		if (breakpoint === 's') {
+			return '';
+		} else if (breakpoint === 'md') {
+			return _('to-do');
+		} else {
+			return _('New to-do');
+		}
+	}, [breakpoint]);
+
+	const noteIcon = useMemo(() => {
+		if (breakpoint === 's') {
+			return 'icon-note';
+		} else {
+			return 'fas fa-plus';
+		}
+	}, [breakpoint]);
+
+	const todoIcon = useMemo(() => {
+		if (breakpoint === 's') {
+			return 'far fa-check-square';
+		} else {
+			return 'fas fa-plus';
 		}
 	}, [breakpoint]);
 
@@ -120,22 +135,6 @@ function NoteListControls(props: Props) {
 			searchAndSortRef.current.style.flex = '2 1 auto';
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
-		}
-	}, [breakpoint]);
-
-	useEffect(() => {
-		if (breakpoint === 's') {
-			setIconNote('icon-note');
-			setIconTodo('far fa-check-square');
-		} else if (breakpoint === 'md') {
-			setIconNote('fas fa-plus');
-			setIconTodo('fas fa-plus');
-		} else if (breakpoint === 'l') {
-			setIconNote('fas fa-plus');
-			setIconTodo('fas fa-plus');
-		} else {
-			setIconNote('fas fa-plus');
-			setIconTodo('fas fa-plus');
 		}
 	}, [breakpoint]);
 
@@ -200,8 +199,8 @@ function NoteListControls(props: Props) {
 				<StyledButton ref={newNoteRef}
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
-					iconName={iconNote}
-					title={_('%s', noteBtnText)}
+					iconName={noteIcon}
+					title={_('%s', noteButtonText)}
 					level={ButtonLevel.Primary}
 					size={ButtonSize.Small}
 					onClick={onNewNoteButtonClick}
@@ -209,8 +208,8 @@ function NoteListControls(props: Props) {
 				<StyledButton ref={newTodoRef}
 					className="new-todo-button"
 					tooltip={CommandService.instance().label('newTodo')}
-					iconName={iconTodo}
-					title={_('%s', todoBtnText)}
+					iconName={todoIcon}
+					title={_('%s', todoButtonText)}
 					level={ButtonLevel.Secondary}
 					size={ButtonSize.Small}
 					onClick={onNewTodoButtonClick}

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -12,8 +12,8 @@ const { connect } = require('react-redux');
 const styled = require('styled-components').default;
 
 enum BaseBreakpoint {
-	Sm = 120,
-	Md = 174,
+	Sm = 125,
+	Md = 179,
 	Lg = 30,
 	Xl = 474,
 }
@@ -49,7 +49,7 @@ const StyledButton = styled(Button)`
 	width: auto;
 	height: 26px;
 	min-height: 26px;
-	min-width: 0;
+	max-width: none;
 
   .fa, .fas {
     font-size: 11px;
@@ -133,7 +133,7 @@ function NoteListControls(props: Props) {
 
 	const noteButtonText = useMemo(() => {
 		if (breakpoint === dynamicBreakpoints.Sm) {
-			return ' ';
+			return '';
 		} else if (breakpoint === dynamicBreakpoints.Md) {
 			return _('note');
 		} else {
@@ -143,7 +143,7 @@ function NoteListControls(props: Props) {
 
 	const todoButtonText = useMemo(() => {
 		if (breakpoint === dynamicBreakpoints.Sm) {
-			return ' ';
+			return '';
 		} else if (breakpoint === dynamicBreakpoints.Md) {
 			return _('to-do');
 		} else {
@@ -168,22 +168,13 @@ function NoteListControls(props: Props) {
 	}, [breakpoint, dynamicBreakpoints]);
 
 	useEffect(() => {
-		if (breakpoint === dynamicBreakpoints.Sm) {
-			const paddingLeft = getTextWidth(' ');
-			newNoteRef.current.style.padding = `0px 0px 0px ${paddingLeft}px`;
-			newTodoRef.current.style.padding = `0px 0px 0px ${paddingLeft}px`;
-		} else {
-			newNoteRef.current.style.padding = '0px 4px 0px 4px';
-			newTodoRef.current.style.padding = '0px 4px 0px 4px';
-		}
-
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
 			searchAndSortRef.current.style.flex = '2 1 auto';
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
 		}
-	}, [breakpoint, dynamicBreakpoints]);
+	}, [breakpoint, dynamicBreakpoints, props.width]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -21,6 +21,13 @@ interface Props {
 	width: number;
 }
 
+enum Breakpoint {
+	Sm = 222,
+	Md = 316,
+	Lg = 470,
+	Xl = 500,
+}
+
 const StyledRoot = styled.div`
 	box-sizing: border-box;
 	height: ${(props: any) => props.height}px;
@@ -77,7 +84,7 @@ function NoteListControls(props: Props) {
 	const searchAndSortRef = useRef(null);
 
 	const breakpoint = useMemo(() => {
-		const breakpoints = [{ s: 135 }, { md: 189 }, { l: 470 }, { xl: 500 }];
+		const breakpoints = [{ sm: Breakpoint.Sm }, { md: Breakpoint.Md }, { l: Breakpoint.Lg }, { xl: Breakpoint.Xl }];
 		// Find largest breakpoint that width is less than
 		const index = breakpoints.map(x => Object.values(x)[0])
 			.findIndex(x => props.width < x);
@@ -86,7 +93,7 @@ function NoteListControls(props: Props) {
 	}, [props.width]);
 
 	const noteButtonText = useMemo(() => {
-		if (breakpoint === 's') {
+		if (breakpoint === 'sm') {
 			return '';
 		} else if (breakpoint === 'md') {
 			return _('note');
@@ -96,7 +103,7 @@ function NoteListControls(props: Props) {
 	}, [breakpoint]);
 
 	const todoButtonText = useMemo(() => {
-		if (breakpoint === 's') {
+		if (breakpoint === 'sm') {
 			return '';
 		} else if (breakpoint === 'md') {
 			return _('to-do');
@@ -106,7 +113,7 @@ function NoteListControls(props: Props) {
 	}, [breakpoint]);
 
 	const noteIcon = useMemo(() => {
-		if (breakpoint === 's') {
+		if (breakpoint === 'sm') {
 			return 'icon-note';
 		} else {
 			return 'fas fa-plus';
@@ -114,7 +121,7 @@ function NoteListControls(props: Props) {
 	}, [breakpoint]);
 
 	const todoIcon = useMemo(() => {
-		if (breakpoint === 's') {
+		if (breakpoint === 'sm') {
 			return 'far fa-check-square';
 		} else {
 			return 'fas fa-plus';
@@ -122,7 +129,7 @@ function NoteListControls(props: Props) {
 	}, [breakpoint]);
 
 	useEffect(() => {
-		if (breakpoint === 's') {
+		if (breakpoint === 'sm') {
 			newNoteRef.current.style.padding = '0px 18px 0px 18px';
 			newTodoRef.current.style.padding = '0px 18px 0px 18px';
 		} else {

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -112,7 +112,7 @@ function NoteListControls(props: Props) {
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {
-		// Calculate the amount of extra width needed based on the longest string
+		// Use the longest string to Calculate the amount of extra width needed
 		const smAdditional = getTextWidth(_('note')) > getTextWidth(_('to-do')) ? getTextWidth(_('note')) : getTextWidth(_('to-do'));
 		const mdAdditional = getTextWidth(_('New note')) > getTextWidth(_('New to-do')) ? getTextWidth(_('New note')) : getTextWidth(_('New to-do'));
 

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -12,9 +12,9 @@ const { connect } = require('react-redux');
 const styled = require('styled-components').default;
 
 enum BaseBreakpoint {
-	Sm = 125,
-	Md = 179,
-	Lg = 30,
+	Sm = 160,
+	Md = 190,
+	Lg = 40,
 	Xl = 474,
 }
 
@@ -174,7 +174,7 @@ function NoteListControls(props: Props) {
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
 		}
-	}, [breakpoint, dynamicBreakpoints, props.width]);
+	}, [breakpoint, dynamicBreakpoints]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -241,7 +241,7 @@ function NoteListControls(props: Props) {
 		if (!props.showNewNoteButtons) return null;
 
 		return (
-			<TopRow>
+			<TopRow className="new-note-todo-buttons">
 				<StyledButton ref={newNoteRef}
 					className="new-note-button"
 					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }
@@ -267,7 +267,7 @@ function NoteListControls(props: Props) {
 	return (
 		<StyledRoot ref={noteControlsRef}>
 			{renderNewNoteButtons()}
-			<BottomRow ref={searchAndSortRef}>
+			<BottomRow ref={searchAndSortRef} className="search-and-sort">
 				<SearchBar inputRef={searchBarRef}/>
 				{showsSortOrderButtons() &&
 					<SortOrderButtonsContainer>

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -1,6 +1,6 @@
 import { AppState } from '../../app.reducer';
 import * as React from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import SearchBar from '../SearchBar/SearchBar';
 import Button, { ButtonLevel, ButtonSize, buttonSizePx } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -18,6 +18,7 @@ interface Props {
 	sortOrderReverse: boolean;
 	notesParentType: string;
 	height: number;
+	width: number;
 }
 
 const StyledRoot = styled.div`
@@ -35,6 +36,7 @@ const StyledButton = styled(Button)`
 	height: 26px;
 	min-height: 26px;
 	flex: 1 0 auto;
+	min-width: 0;
 
   .fa, .fas {
     font-size: 11px;
@@ -69,6 +71,73 @@ const SortOrderButtonsContainer = styled.div`
 
 function NoteListControls(props: Props) {
 	const searchBarRef = useRef(null);
+	const newNoteRef = useRef(null);
+	const newTodoRef = useRef(null);
+	const noteControlsRef = useRef(null);
+	const searchAndSortRef = useRef(null);
+
+	const [noteBtnText, setNoteBtnText] = useState('New note');
+	const [todoBtnText, setTodoBtnText] = useState('New to-do');
+	const [breakpoint, setBreakpoint] = useState('l');
+	const [iconNote, setIconNote] = useState('fas fa-plus');
+	const [iconTodo, setIconTodo] = useState('fas fa-plus');
+
+	useEffect(() => {
+		const breakpoints = [{ s: 135 }, { md: 189 }, { l: 470 }, { xl: 500 }];
+		// Find largest breakpoint that width is less than
+		const index = breakpoints.map(x => Object.values(x)[0])
+			.findIndex(x => props.width < x);
+
+		const bp = index === -1 ? Object.keys(breakpoints[breakpoints.length - 1])[0] : Object.keys(breakpoints[index])[0];
+
+		setBreakpoint(bp);
+	}, [props.width]);
+
+	useEffect(() => {
+		if (breakpoint === 's') {
+			setNoteBtnText('');
+			setTodoBtnText('');
+		} else if (breakpoint === 'md') {
+			setNoteBtnText('note');
+			setTodoBtnText('to-do');
+		} else {
+			setNoteBtnText('New note');
+			setTodoBtnText('New to-do');
+		}
+	}, [breakpoint]);
+
+	useEffect(() => {
+		if (breakpoint === 's') {
+			newNoteRef.current.style.padding = '0px 18px 0px 18px';
+			newTodoRef.current.style.padding = '0px 18px 0px 18px';
+		} else {
+			newNoteRef.current.style.padding = '0px 4px 0px 4px';
+			newTodoRef.current.style.padding = '0px 4px 0px 4px';
+		}
+
+		if (breakpoint === 'xl') {
+			noteControlsRef.current.style.flexDirection = 'row';
+			searchAndSortRef.current.style.flex = '2 1 auto';
+		} else {
+			noteControlsRef.current.style.flexDirection = 'column';
+		}
+	}, [breakpoint]);
+
+	useEffect(() => {
+		if (breakpoint === 's') {
+			setIconNote('icon-note');
+			setIconTodo('far fa-check-square');
+		} else if (breakpoint === 'md') {
+			setIconNote('fas fa-plus');
+			setIconTodo('fas fa-plus');
+		} else if (breakpoint === 'l') {
+			setIconNote('fas fa-plus');
+			setIconTodo('fas fa-plus');
+		} else {
+			setIconNote('fas fa-plus');
+			setIconTodo('fas fa-plus');
+		}
+	}, [breakpoint]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));
@@ -128,20 +197,20 @@ function NoteListControls(props: Props) {
 
 		return (
 			<RowContainer>
-				<StyledButton
+				<StyledButton ref={newNoteRef}
 					className="new-note-button"
 					tooltip={CommandService.instance().label('newNote')}
-					iconName="fas fa-plus"
-					title={_('%s', 'New note')}
+					iconName={iconNote}
+					title={_('%s', noteBtnText)}
 					level={ButtonLevel.Primary}
 					size={ButtonSize.Small}
 					onClick={onNewNoteButtonClick}
 				/>
-				<StyledButton
+				<StyledButton ref={newTodoRef}
 					className="new-todo-button"
 					tooltip={CommandService.instance().label('newTodo')}
-					iconName="fas fa-plus"
-					title={_('%s', 'New to-do')}
+					iconName={iconTodo}
+					title={_('%s', todoBtnText)}
 					level={ButtonLevel.Secondary}
 					size={ButtonSize.Small}
 					onClick={onNewTodoButtonClick}
@@ -151,9 +220,9 @@ function NoteListControls(props: Props) {
 	}
 
 	return (
-		<StyledRoot>
+		<StyledRoot ref={noteControlsRef}>
 			{renderNewNoteButtons()}
-			<RowContainer>
+			<RowContainer ref={searchAndSortRef}>
 				<SearchBar inputRef={searchBarRef}/>
 				<SortOrderButtonsContainer>
 					{showsSortOrderButtons() &&

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -112,7 +112,7 @@ function NoteListControls(props: Props) {
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {
-		// Use the longest string to Calculate the amount of extra width needed
+		// Use the longest string to calculate the amount of extra width needed
 		const smAdditional = getTextWidth(_('note')) > getTextWidth(_('to-do')) ? getTextWidth(_('note')) : getTextWidth(_('to-do'));
 		const mdAdditional = getTextWidth(_('New note')) > getTextWidth(_('New to-do')) ? getTextWidth(_('New note')) : getTextWidth(_('New to-do'));
 

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -167,6 +167,14 @@ function NoteListControls(props: Props) {
 		}
 	}, [breakpoint, dynamicBreakpoints]);
 
+	const showTooltip = useMemo(() => {
+		if (breakpoint === dynamicBreakpoints.Sm) {
+			return true;
+		} else {
+			return false;
+		}
+	}, [breakpoint, dynamicBreakpoints.Sm]);
+
 	useEffect(() => {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
@@ -236,7 +244,7 @@ function NoteListControls(props: Props) {
 			<TopRow>
 				<StyledButton ref={newNoteRef}
 					className="new-note-button"
-					tooltip={CommandService.instance().label('newNote')}
+					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }
 					iconName={noteIcon}
 					title={_('%s', noteButtonText)}
 					level={ButtonLevel.Primary}
@@ -245,7 +253,7 @@ function NoteListControls(props: Props) {
 				/>
 				<StyledButton ref={newTodoRef}
 					className="new-todo-button"
-					tooltip={CommandService.instance().label('newTodo')}
+					tooltip={ showTooltip ? CommandService.instance().label('newTodo') : '' }
 					iconName={todoIcon}
 					title={_('%s', todoButtonText)}
 					level={ButtonLevel.Secondary}

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -33,7 +33,7 @@ export default function NoteListWrapper(props: Props) {
 
 	return (
 		<StyledRoot>
-			<NoteListControls height={controlHeight}/>
+			<NoteListControls height={controlHeight} width={noteListSize.width}/>
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
This PR makes the note controls responsive by introducing breakpoints at different width of the note list.

The text displayed on the buttons first shortens and then is replaced by icons.

The buttons and the search bar are now on the same line when space allows it. This saves vertical space and is especially suited for a vertical layout.

New behavior.
![responsive-note-list-controls](https://user-images.githubusercontent.com/32807437/223416669-61590526-a192-4f10-896b-bd6784a36f0b.gif)



