### PR TITLE
Desktop: Fixes #4124: Fix note list blank space display problems

### DIFF
--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+import Logger from '@joplin/lib/Logger';
+
+const logger = Logger.create('ItemList');
 
 interface Props {
 	style: any;
@@ -51,6 +54,7 @@ class ItemList extends React.Component<Props, State> {
 		// ref: https://github.com/laurent22/joplin/issues/4124
 		// when the note list is hidden, visibleItemCount is negative, and scroll top is positive when a note is selected
 		if (visibleItemCount < 0 && this.scrollTop_ > 0) {
+			logger.warn('Resetting scrollTop to 0. visibleItemCount is negative, scrollTop is positive.');
 			// we will reset the scroll top so that there is no blank space at the top of note list
 			this.scrollTop_ = 0;
 		}
@@ -82,6 +86,7 @@ class ItemList extends React.Component<Props, State> {
 		// scroll top is not updated when item list visibility is toggled
 		// if the user was at the bottom of the item list before hiding, blank spaces are added at the bottom of the item list
 		if (this.offsetScroll() !== this.listRef.current?.scrollTop) {
+			logger.warn(`scrollTop mismatch. Updating scrollTop with current listRef scrollTop(${this.listRef.current.scrollTop})`);
 			// update scroll postion once if there is a mismatch in scroll position after showing item list
 			this.onScroll({
 				target: {

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -77,6 +77,21 @@ class ItemList extends React.Component<Props, State> {
 		this.updateStateItemIndexes(newProps);
 	}
 
+	public componentDidUpdate(): void {
+		// EDGE CASE
+		// scroll top is not updated when note list visibility is toggled
+		// as a result, blank spaces are added at the bottom of the note list
+		// if the user was at the bottom of the note list before hiding
+		if (this.offsetScroll() !== this.listRef.current?.scrollTop) {
+			// update scroll postion once if there is a mismatch in scroll position after showing note list
+			this.onScroll({
+				target: {
+					scrollTop: this.listRef.current.scrollTop,
+				},
+			});
+		}
+	}
+
 	public onScroll(event: any) {
 		this.scrollTop_ = event.target.scrollTop;
 		this.updateStateItemIndexes();

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -47,6 +47,14 @@ class ItemList extends React.Component<Props, State> {
 		let bottomItemIndex = topItemIndex + (visibleItemCount - 1);
 		if (bottomItemIndex >= props.items.length) bottomItemIndex = props.items.length - 1;
 
+		// EDGE CASE:
+		// ref: https://github.com/laurent22/joplin/issues/4124
+		// when the note list is hidden, visibleItemCount is negative, and scroll top is positive when a note is selected
+		if (visibleItemCount < 0 && this.scrollTop_ > 0) {
+			// we will reset the scroll top so that there is no blank space at the top of note list
+			this.scrollTop_ = 0;
+		}
+
 		this.setState({
 			topItemIndex: topItemIndex,
 			bottomItemIndex: bottomItemIndex,

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -80,8 +80,7 @@ class ItemList extends React.Component<Props, State> {
 	public componentDidUpdate(): void {
 		// EDGE CASE
 		// scroll top is not updated when note list visibility is toggled
-		// as a result, blank spaces are added at the bottom of the note list
-		// if the user was at the bottom of the note list before hiding
+		// if the user was at the bottom of the note list before hiding, blank spaces are added at the bottom of the note list
 		if (this.offsetScroll() !== this.listRef.current?.scrollTop) {
 			// update scroll postion once if there is a mismatch in scroll position after showing note list
 			this.onScroll({

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -79,10 +79,10 @@ class ItemList extends React.Component<Props, State> {
 
 	public componentDidUpdate(): void {
 		// EDGE CASE
-		// scroll top is not updated when note list visibility is toggled
-		// if the user was at the bottom of the note list before hiding, blank spaces are added at the bottom of the note list
+		// scroll top is not updated when item list visibility is toggled
+		// if the user was at the bottom of the item list before hiding, blank spaces are added at the bottom of the item list
 		if (this.offsetScroll() !== this.listRef.current?.scrollTop) {
-			// update scroll postion once if there is a mismatch in scroll position after showing note list
+			// update scroll postion once if there is a mismatch in scroll position after showing item list
 			this.onScroll({
 				target: {
 					scrollTop: this.listRef.current.scrollTop,


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes - https://github.com/laurent22/joplin/issues/4124

### Problem Details:

**Problem 1**: 

When the note list is hidden, and user searches for a note in goto anything/global search, and then reveals the note list again, there is a big blank space on top of the note list. It does not go away, till the user scrolls on the note list. This issue is described in detail in https://github.com/laurent22/joplin/issues/4124

**Problem 2**:

When the user is at the bottom of the note list screen (scroll bar at the end of the note list), and hides and reopens the note list, there is a blank space at the bottom of the screen. This does not go away till the user scrolls on the note list.

### Solution

For problem 1, when the note list is hidden `visibleItemCount` is negative, and `scrollTop` becomes positive when a note is selected. This is the reason for the empty blank space at the top of the screen. For this specific scenario, we are resetting `scrollTop` to `0`.

For problem 2, when the user is at the bottom of the screen, the actual `scrollTop` is some positive integer, say 150. When the user hides and reveals the note list, the browser maintains the scrollTop (150), but the `ItemList` component starts with `scrollTop: 0`. In this case, if there is a mismatch in scrollTop, we are triggering a `onScroll` call in `componentDidUpdate`.

### Testing

For this fix, only manual testing is done. Following are some of the scenarios for which this feature is tested.

##### Case 1 (problem 1):
- Note list is open normally. 
- Note list is hidden (with shortcut or otherwise).
- A note is searched
- Note list is open again. No blank space was seen at the top.

##### Case 2 (problem 2):
- Note list is scrolled to the bottom till the end
- Note list is hidden
- Note is opened again. No blank space was seen at the bottom.

##### Case 3:
When note list is always open, normal search works fine. There is no blank space in the opened note list.







