### PR TITLE
Desktop: Fixes #7506: Fix Linux folder display issue

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef, useCallback, useMemo } from 'react';
+import styled from 'styled-components';
+import shim from '@joplin/lib/shim';
 import { StyledRoot, StyledAddButton, StyledShareIcon, StyledHeader, StyledHeaderIcon, StyledAllNotesIcon, StyledHeaderLabel, StyledListItem, StyledListItemAnchor, StyledExpandLink, StyledNoteCount, StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton } from './styles';
 import { ButtonLevel } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -37,6 +39,15 @@ const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 const { clipboard } = require('electron');
 
 const logger = Logger.create('Sidebar');
+
+const StyledFoldersHolder = styled.div`
+	// linux bug: https://github.com/laurent22/joplin/issues/7506#issuecomment-1447101057
+	& a.list-item {
+		${shim.isLinux() && {
+		opacity: 1,
+	}}
+	}
+`;
 
 interface Props {
 	themeId: number;
@@ -705,13 +716,13 @@ const SidebarComponent = (props: Props) => {
 		const folderItems = [renderAllNotesItem(theme, allNotesSelected)].concat(result.items);
 		folderItemsOrder_.current = result.order;
 		items.push(
-			<div
+			<StyledFoldersHolder
 				className={`folders ${props.folderHeaderIsExpanded ? 'expanded' : ''}`}
 				key="folder_items"
 				style={foldersStyle}
 			>
 				{folderItems}
-			</div>
+			</StyledFoldersHolder>
 		);
 	}
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes #7506 

### Problem Details:

In linux, notebooks have a weird display with overlapping text. More detailed description - #7506

### Solution:

Solution is based on following suggestion - https://github.com/laurent22/joplin/issues/7506#issuecomment-1447101057

A styled component holder is created, and a check is made for linux with `shim.isLinux()` and `opacity: 1` is added for linux platforms

### Testing

Only manual testing is done for this feature. The fix needs to be specifically verified on linux machines.
