### PR TITLE
Desktop: Fixes #7907: Fixed height when controls are on a single row

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -26,6 +26,7 @@ interface Props {
 	notesParentType: string;
 	height: number;
 	width: number;
+	handleControlHeight: (sameRow: boolean)=> void;
 }
 
 interface Breakpoints {
@@ -179,10 +180,12 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
 			searchAndSortRef.current.style.flex = '2 1 auto';
+			props.handleControlHeight(true);
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
+			props.handleControlHeight(false);
 		}
-	}, [breakpoint, dynamicBreakpoints]);
+	}, [breakpoint, dynamicBreakpoints, props.handleControlHeight]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -26,7 +26,7 @@ interface Props {
 	notesParentType: string;
 	height: number;
 	width: number;
-	handleControlHeight: (sameRow: boolean)=> void;
+	onContentHeightChange: (sameRow: boolean)=> void;
 }
 
 interface Breakpoints {
@@ -180,12 +180,12 @@ function NoteListControls(props: Props) {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
 			searchAndSortRef.current.style.flex = '2 1 auto';
-			props.handleControlHeight(true);
+			props.onContentHeightChange(true);
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';
-			props.handleControlHeight(false);
+			props.onContentHeightChange(false);
 		}
-	}, [breakpoint, dynamicBreakpoints, props.handleControlHeight]);
+	}, [breakpoint, dynamicBreakpoints, props.onContentHeightChange]);
 
 	useEffect(() => {
 		CommandService.instance().registerRuntime('focusSearch', focusSearchRuntime(searchBarRef));

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -24,7 +24,7 @@ export default function NoteListWrapper(props: Props) {
 	const theme = themeStyle(props.themeId);
 	const [controlHeight, setControlHeight] = useState(theme.topRowHeight);
 
-	const handleControlHeight = (sameRow: boolean) => {
+	const onContentHeightChange = (sameRow: boolean) => {
 		if (sameRow) {
 			setControlHeight(theme.topRowHeight);
 		} else {
@@ -41,7 +41,7 @@ export default function NoteListWrapper(props: Props) {
 
 	return (
 		<StyledRoot>
-			<NoteListControls height={controlHeight} width={noteListSize.width} handleControlHeight={handleControlHeight}/>
+			<NoteListControls height={controlHeight} width={noteListSize.width} onContentHeightChange={onContentHeightChange}/>
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -1,6 +1,6 @@
 import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import NoteList from '../NoteList/NoteList';
 import NoteListControls from '../NoteListControls/NoteListControls';
 import { Size } from '../ResizableLayout/utils/types';
@@ -22,7 +22,15 @@ const StyledRoot = styled.div`
 
 export default function NoteListWrapper(props: Props) {
 	const theme = themeStyle(props.themeId);
-	const controlHeight = theme.topRowHeight;
+	const [controlHeight, setControlHeight] = useState(theme.topRowHeight);
+
+	const handleControlHeight = (sameRow: boolean) => {
+		if (sameRow) {
+			setControlHeight(theme.topRowHeight);
+		} else {
+			setControlHeight(theme.topRowHeight * 2);
+		}
+	};
 
 	const noteListSize = useMemo(() => {
 		return {
@@ -33,7 +41,7 @@ export default function NoteListWrapper(props: Props) {
 
 	return (
 		<StyledRoot>
-			<NoteListControls height={controlHeight} width={noteListSize.width}/>
+			<NoteListControls height={controlHeight} width={noteListSize.width} handleControlHeight={handleControlHeight}/>
 			<NoteList resizableLayoutEventEmitter={props.resizableLayoutEventEmitter} size={noteListSize} visible={props.visible}/>
 		</StyledRoot>
 	);

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -60,7 +60,7 @@ const globalStyle: any = {
 	toolbarPadding: 6,
 	appearance: 'light',
 	mainPadding: 12,
-	topRowHeight: 81,
+	topRowHeight: 50,
 	editorPaddingLeft: 8,
 };
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes https://github.com/laurent22/joplin/issues/7907. There was unusable space at the bottom of the list.

It is fixed by adjusting the height of the controls container when they're all on the same line.

This can be tested by setting a vertical layout. There is no unusable space at the bottom of the note list anymore.
![fixed](https://user-images.githubusercontent.com/32807437/224692450-bc89429b-d29b-4012-9f91-3f0d56b824c9.png)
