### PR TITLE
Desktop: Fixes #7881: Fixed icon when note is dragged across notebooks

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -241,7 +241,6 @@ const NoteListComponent = (props: Props) => {
 		event.dataTransfer.setDragImage(new Image(), 1, 1);
 		event.dataTransfer.clearData();
 		event.dataTransfer.setData('text/x-jop-note-ids', JSON.stringify(noteIds));
-		// ref: https://github.com/laurent22/joplin/issues/7881
 		event.dataTransfer.effectAllowed = 'move';
 	};
 

--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -241,6 +241,8 @@ const NoteListComponent = (props: Props) => {
 		event.dataTransfer.setDragImage(new Image(), 1, 1);
 		event.dataTransfer.clearData();
 		event.dataTransfer.setData('text/x-jop-note-ids', JSON.stringify(noteIds));
+		// ref: https://github.com/laurent22/joplin/issues/7881
+		event.dataTransfer.effectAllowed = 'move';
 	};
 
 	const renderItem = useCallback((item: any, index: number) => {


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes #7881 

### Problem:

When notes are dragged across notebooks, cursor is shown with `Copy +` icon. Since notes are moved to the destination, and not copied, copy cursor icon is misleading. 

### Solution

Copy cursor icon is not shown by setting `dataTransfer.effectAllowed: "move"`. Now, the icon is plain cursor without copy icon. More details - https://github.com/laurent22/joplin/issues/7881#issuecomment-1469492895

### Testing

Manual testing is done by dragging notes across notebooks. No Copy plus icon is seen when dragging notebooks.

![effectAllowed-move-cursor](https://user-images.githubusercontent.com/4299398/225236200-66364ce6-125d-47bd-a97b-93bb2b10cd34.gif)




