### PR TITLE
Mobile: Add setting to enable/disable the markdown toolbar

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -30,6 +30,7 @@ interface Props {
 	initialSelection?: Selection;
 	style: ViewStyle;
 	contentStyle?: ViewStyle;
+	toolbarEnabled: boolean;
 
 	onChange: ChangeEventHandler;
 	onSelectionChange: SelectionChangeEventHandler;
@@ -364,10 +365,6 @@ function NoteEditor(props: Props, ref: any) {
 		console.error('NoteEditor: webview error');
 	}, []);
 
-	const useMarkdownToolbar: boolean = useMemo(() => {
-		return Setting.value('editor.mobile.toolbarEnabled');
-	}, []);
-
 	const toolbar = <MarkdownToolbar
 		style={{
 			// Don't show the markdown toolbar if there isn't enough space
@@ -418,7 +415,7 @@ function NoteEditor(props: Props, ref: any) {
 				searchState={searchState}
 			/>
 
-			{useMarkdownToolbar ? toolbar : null}
+			{props.toolbarEnabled ? toolbar : null}
 		</View>
 	);
 }

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -364,6 +364,23 @@ function NoteEditor(props: Props, ref: any) {
 		console.error('NoteEditor: webview error');
 	}, []);
 
+	const useMarkdownToolbar: boolean = useMemo(() => {
+		return Setting.value('editor.mobile.toolbarEnabled');
+	}, []);
+
+	const toolbar = <MarkdownToolbar
+		style={{
+			// Don't show the markdown toolbar if there isn't enough space
+			// for it:
+			flexShrink: 1,
+		}}
+		editorSettings={editorSettings}
+		editorControl={editorControl}
+		selectionState={selectionState}
+		searchState={searchState}
+		onAttach={props.onAttach}
+	/>;
+
 	// - `scrollEnabled` prevents iOS from scrolling the document (has no effect on Android)
 	//    when an editable region (e.g. a the full-screen NoteEditor) is focused.
 	return (
@@ -401,18 +418,7 @@ function NoteEditor(props: Props, ref: any) {
 				searchState={searchState}
 			/>
 
-			<MarkdownToolbar
-				style={{
-					// Don't show the markdown toolbar if there isn't enough space
-					// for it:
-					flexShrink: 1,
-				}}
-				editorSettings={editorSettings}
-				editorControl={editorControl}
-				selectionState={selectionState}
-				searchState={searchState}
-				onAttach={props.onAttach}
-			/>
+			{useMarkdownToolbar ? toolbar : null}
 		</View>
 	);
 }

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1118,6 +1118,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 				bodyComponent = <NoteEditor
 					ref={this.editorRef}
+					toolbarEnabled={this.props.markdownToolbarEnabled}
 					themeId={this.props.themeId}
 					initialText={note.body}
 					initialSelection={this.selection}
@@ -1231,6 +1232,7 @@ const NoteScreen = connect((state: any) => {
 		themeId: state.settings.theme,
 		editorFont: [state.settings['style.editor.fontFamily']],
 		editorFontSize: state.settings['style.editor.fontSize'],
+		markdownToolbarEnabled: state.settings['editor.mobile.toolbarEnabled'],
 		ftsEnabled: state.settings['db.ftsEnabled'],
 		sharedData: state.sharedData,
 		showSideMenu: state.showSideMenu,

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1118,7 +1118,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 				bodyComponent = <NoteEditor
 					ref={this.editorRef}
-					toolbarEnabled={this.props.markdownToolbarEnabled}
+					toolbarEnabled={this.props.toolbarEnabled}
 					themeId={this.props.themeId}
 					initialText={note.body}
 					initialSelection={this.selection}
@@ -1232,7 +1232,7 @@ const NoteScreen = connect((state: any) => {
 		themeId: state.settings.theme,
 		editorFont: [state.settings['style.editor.fontFamily']],
 		editorFontSize: state.settings['style.editor.fontSize'],
-		markdownToolbarEnabled: state.settings['editor.mobile.toolbarEnabled'],
+		toolbarEnabled: state.settings['editor.mobile.toolbarEnabled'],
 		ftsEnabled: state.settings['db.ftsEnabled'],
 		sharedData: state.sharedData,
 		showSideMenu: state.showSideMenu,

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1050,6 +1050,17 @@ class Setting extends BaseModel {
 				isGlobal: true,
 			},
 
+			'editor.mobile.toolbarEnabled': {
+				value: true,
+				type: SettingItemType.Bool,
+				section: 'note',
+				public: true,
+				appTypes: [AppType.Mobile],
+				label: () => _('Enable the markdown toolbar'),
+				storage: SettingStorage.File,
+				isGlobal: true,
+			},
+
 			// Works around a bug in which additional space is visible beneath the toolbar on some devices.
 			// See https://github.com/laurent22/joplin/pull/6823
 			'editor.mobile.removeSpaceBelowToolbar': {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1056,7 +1056,7 @@ class Setting extends BaseModel {
 				section: 'note',
 				public: true,
 				appTypes: [AppType.Mobile],
-				label: () => _('Enable the markdown toolbar'),
+				label: () => _('Enable the Markdown toolbar'),
 				storage: SettingStorage.File,
 				isGlobal: true,
 			},


### PR DESCRIPTION
# Summary
- [It has been requested](https://discourse.joplinapp.org/t/mobile-new-text-editor-hide-bar-option/29977/4) that the markdown toolbar be disableable in settings. This PR adds this option.

# Testing plan
- Disable the markdown toolbar
- Edit a note
- Rotate the device's screen while the note editor is open
- Enable the markdown toolbar
- Edit a note
- Rotate the device's screen while the note editor is open.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
