### PR TITLE
Chore: Make mobile NoteEditor a connected component

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1118,7 +1118,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 
 				bodyComponent = <NoteEditor
 					ref={this.editorRef}
-					themeId={this.props.themeId}
 					initialText={note.body}
 					initialSelection={this.selection}
 					onChange={this.onBodyChange}


### PR DESCRIPTION
**Note**: Feel free to reject this PR! [As mentioned here](https://github.com/laurent22/joplin/pull/7929#discussion_r1137609141), it's possible to do this another way!

[Rationale](https://github.com/laurent22/joplin/pull/7929#discussion_r1137611431)

# Testing plan
1. Enable KaTeX expressions.
2. Set the editor's font size to 20, set the editor's font family to monospace
3. Enable spellcheck
4. Open the editor and verify that settings are applied properly
5. Disable KaTeX expressions,
6. Set the editor's font size to 16 and the font family to the default
7. Disable spellcheck.
8. Open the editor and verify that the settings are applied properly.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
