### PR TITLE
Desktop: Fixes #4801: Do not allow update for plugins incompatible with current version

### DIFF
--- a/packages/app-cli/tests/services/plugins/RepositoryApi.ts
+++ b/packages/app-cli/tests/services/plugins/RepositoryApi.ts
@@ -47,9 +47,11 @@ describe('services_plugins_RepositoryApi', () => {
 
 	it('should tell if a plugin can be updated', (async () => {
 		const api = await newRepoApi();
-		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0')).toBe(true);
-		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.2')).toBe(false);
-		expect(await api.pluginCanBeUpdated('does.not.exist', '1.0.0')).toBe(false);
+
+		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0', '3.0.0')).toBe(true);
+		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.0', '1.0.0')).toBe(false);
+		expect(await api.pluginCanBeUpdated('org.joplinapp.plugins.ToggleSidebars', '1.0.2', '3.0.0')).toBe(false);
+		expect(await api.pluginCanBeUpdated('does.not.exist', '1.0.0', '3.0.0')).toBe(false);
 	}));
 
 });

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -143,7 +143,7 @@ export default function(props: Props) {
 		let cancelled = false;
 
 		async function fetchPluginIds() {
-			const pluginIds = await repoApi().canBeUpdatedPlugins(pluginItems.map(p => p.manifest));
+			const pluginIds = await repoApi().canBeUpdatedPlugins(pluginItems.map(p => p.manifest), pluginService.appVersion);
 			if (cancelled) return;
 			const conv: Record<string, boolean> = {};
 			pluginIds.forEach(id => conv[id] = true);
@@ -155,7 +155,7 @@ export default function(props: Props) {
 		return () => {
 			cancelled = true;
 		};
-	}, [manifestsLoaded, pluginItems]);
+	}, [manifestsLoaded, pluginItems, pluginService.appVersion]);
 
 	const onDelete = useCallback(async (event: ItemEvent) => {
 		const item = event.item;

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -108,6 +108,10 @@ export default class PluginService extends BaseService {
 		return this.isSafeMode_;
 	}
 
+	public get appVersion(): string {
+		return this.appVersion_;
+	}
+
 	public set isSafeMode(v: boolean) {
 		this.isSafeMode_ = v;
 	}

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -215,21 +215,21 @@ export default class RepositoryApi {
 		return this.manifests_;
 	}
 
-	public async canBeUpdatedPlugins(installedManifests: PluginManifest[]): Promise<string[]> {
+	public async canBeUpdatedPlugins(installedManifests: PluginManifest[], appVersion: string): Promise<string[]> {
 		const output = [];
 
 		for (const manifest of installedManifests) {
-			const canBe = await this.pluginCanBeUpdated(manifest.id, manifest.version);
+			const canBe = await this.pluginCanBeUpdated(manifest.id, manifest.version, appVersion);
 			if (canBe) output.push(manifest.id);
 		}
 
 		return output;
 	}
 
-	public async pluginCanBeUpdated(pluginId: string, installedVersion: string): Promise<boolean> {
+	public async pluginCanBeUpdated(pluginId: string, installedVersion: string, appVersion: string): Promise<boolean> {
 		const manifest = (await this.manifests()).find(m => m.id === pluginId);
 		if (!manifest) return false;
-		return compareVersions(installedVersion, manifest.version) < 0;
+		return compareVersions(installedVersion, manifest.version) < 0 && compareVersions(appVersion, manifest.app_min_version) >= 0;
 	}
 
 }


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Fixes https://github.com/laurent22/joplin/issues/4801

Previously updates were suggested even for plugins that were not compatible with the current version of the application.
This PR fixes this issue by checking the `app_min_version` of a plugin's manifest against the current version of the application.
