### PR TITLE
Desktop: Fixes text wrap on new buttons

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -51,6 +51,7 @@ const StyledButton = styled(Button)`
 	height: 26px;
 	min-height: 26px;
 	max-width: none;
+	white-space: nowrap;
 
   .fa, .fas {
     font-size: 11px;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
Under some circumstances (e.g custom css with extra padding) the text displayed on the buttons `New note` and `New to-do` can wrap.
In order to avoid that we simply set `white-space: nowrap` to these buttons.
