### PR TITLE
Desktop: Adjusted New Note and New to-do buttons' breakpoints to happen earlier

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -12,9 +12,9 @@ const { connect } = require('react-redux');
 const styled = require('styled-components').default;
 
 enum BaseBreakpoint {
-	Sm = 160,
-	Md = 190,
-	Lg = 40,
+	Sm = 75,
+	Md = 80,
+	Lg = 120,
 	Xl = 474,
 }
 
@@ -50,6 +50,7 @@ const StyledButton = styled(Button)`
 	width: auto;
 	height: 26px;
 	min-height: 26px;
+	min-width: 37px;
 	max-width: none;
 	white-space: nowrap;
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
It is important to display the full text of "New Note" and "New To-do" for as long as possible, particularly when the application is launched for the first time. The short versions of the buttons, "note" and "to-do", should be used only when there is very limited space available.

This PR changes the breakpoints accordingly.
![adjust-breakpoints](https://user-images.githubusercontent.com/32807437/227186145-113b7d37-3558-469a-92a9-5fdfe3990416.gif)