### PR TITLE
Desktop: Fixed About Joplin's list of plugins

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -487,7 +487,7 @@ function useMenu(props: Props) {
 			}
 
 			function _showAbout() {
-				const v = versionInfo(packageInfo, PluginService.instance().plugins);
+				const v = versionInfo(packageInfo, PluginService.instance().pluginsEnabled);
 
 				const copyToClipboard = bridge().showMessageBox(v.message, {
 					icon: `${bridge().electronApp().buildDir()}/icons/128x128.png`,

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -100,6 +100,12 @@ export default class PluginService extends BaseService {
 		return this.plugins_;
 	}
 
+	public get pluginsEnabled(): Plugins {
+		const pluginSettings = this.unserializePluginSettings(Setting.value('plugins.states'));
+		const enabledPlugins = Object.fromEntries(Object.entries(this.plugins_).filter((p) => this.pluginEnabled(pluginSettings, p[0])));
+		return enabledPlugins;
+	}
+
 	public get pluginIds(): string[] {
 		return Object.keys(this.plugins_);
 	}

--- a/packages/lib/versionInfo.test.ts
+++ b/packages/lib/versionInfo.test.ts
@@ -2,8 +2,6 @@ import versionInfo from './versionInfo';
 import { reg } from './registry';
 import { Plugins } from './services/plugins/PluginService';
 import Plugin from './services/plugins/Plugin';
-import Setting from './models/Setting';
-import { PluginSettings } from './services/plugins/PluginService';
 
 jest.mock('./registry');
 
@@ -66,10 +64,6 @@ describe('getPluginLists', () => {
 		const plugins: Plugins = {};
 		plugins[plugin.manifest.id] = plugin;
 
-		const pluginSettings: PluginSettings = {};
-		pluginSettings[plugin.id] = { enabled: true, deleted: false, hasBeenUpdated: false };
-		Setting.setValue('plugins.states', pluginSettings);
-
 		const v = versionInfo(packageInfo, plugins);
 		expect(v.body).toMatch(/\n\nPlugin1: 1/);
 		expect(v.message).toMatch(/\n\nPlugin1: 1/);
@@ -92,12 +86,6 @@ describe('getPluginLists', () => {
 			);
 			plugins[plugin.manifest.id] = plugin;
 		}
-
-		const pluginSettings: PluginSettings = {};
-		for (const key of Object.keys(plugins)) {
-			pluginSettings[key] = { enabled: true, deleted: false, hasBeenUpdated: false };
-		}
-		Setting.setValue('plugins.states', pluginSettings);
 
 		const v = versionInfo(packageInfo, plugins);
 
@@ -123,12 +111,6 @@ describe('getPluginLists', () => {
 
 			plugins[plugin.manifest.id] = plugin;
 		}
-
-		const pluginSettings: PluginSettings = {};
-		for (const key of Object.keys(plugins)) {
-			pluginSettings[key] = { enabled: true, deleted: false, hasBeenUpdated: false };
-		}
-		Setting.setValue('plugins.states', pluginSettings);
 
 		const v = versionInfo(packageInfo, plugins);
 

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -2,7 +2,6 @@ import { _ } from './locale';
 import Setting from './models/Setting';
 import { reg } from './registry';
 import { Plugins } from './services/plugins/PluginService';
-import PluginService from './services/plugins/PluginService';
 
 interface PluginList {
   completeList: string;
@@ -11,12 +10,9 @@ interface PluginList {
 
 function getPluginLists(plugins: Plugins): PluginList {
 	const pluginList = [];
-	const pluginSettings = PluginService.instance().unserializePluginSettings(Setting.value('plugins.states'));
-	const enabledPlugins = Object.fromEntries(Object.entries(plugins).filter((p) => pluginSettings[p[0]] && pluginSettings[p[0]].enabled === true));
-
-	if (Object.keys(enabledPlugins).length > 0) {
-		for (const pluginId in enabledPlugins) {
-			pluginList.push(`${enabledPlugins[pluginId].manifest.name}: ${enabledPlugins[pluginId].manifest.version}`);
+	if (Object.keys(plugins).length > 0) {
+		for (const pluginId in plugins) {
+			pluginList.push(`${plugins[pluginId].manifest.name}: ${plugins[pluginId].manifest.version}`);
 		}
 	}
 

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -16,7 +16,7 @@ function getPluginLists(plugins: Plugins): PluginList {
 		}
 	}
 
-	pluginList.sort();
+	pluginList.sort(Intl.Collator().compare);
 
 	let completeList = '';
 	let summary = '';


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
This PR fixes an issue in the existing implementation of the About Joplin plugin list, which does not consistently display all installed plugins.

## Tests
Test with 0, 1, 2, 20, 21, 94 plugins:
![zero-plugin](https://user-images.githubusercontent.com/32807437/227958691-a8220e25-069c-428f-8354-a0dc4cd67029.png)
![one-plugin](https://user-images.githubusercontent.com/32807437/227959088-ba24c5d5-d862-4ecb-a271-1a2b91e2b6b5.png)
![two-plugins](https://user-images.githubusercontent.com/32807437/227959154-17c024b5-824c-4721-8f06-c26723dd2580.png)
![twenty-plugins](https://user-images.githubusercontent.com/32807437/227959326-ab446ef1-4cb3-4bc0-ae88-0d1d30432936.png)
![twenty-one](https://user-images.githubusercontent.com/32807437/227959367-0831903b-ad6b-4c05-a90f-963b135d96a6.png)
![ninety-four-plugins](https://user-images.githubusercontent.com/32807437/227959438-ef70c25d-832c-46ab-be70-e2aad93ac523.png)

Test that 94 plugins are shown with an ellipsis after 20 plugins but that the whole list is copied when clicking on `Copy`.
![ninety-four-plugins-copied](https://user-images.githubusercontent.com/32807437/227960285-e4f518c3-f20f-4149-8e4b-3abcca19921f.png)

Test with 21 plugins installed and two disabled
![disable-one-plugins-2](https://user-images.githubusercontent.com/32807437/227960949-755b9732-b3cc-4f9b-9eba-88601e4a4cba.png)
![disable-one-plugins](https://user-images.githubusercontent.com/32807437/227960943-7c55fd09-ea61-4911-a530-337a421a39d8.png)

Test with 21 plugins installed and all disabled:
![disable-every-plugin](https://user-images.githubusercontent.com/32807437/227961290-3ea32063-da53-4550-b3d1-d5c029f9ded2.png)
![disable-every-plugin-2](https://user-images.githubusercontent.com/32807437/227961313-c14aab17-7dde-427c-8a7b-dd046ec29bf6.png)

Test in `app-cli` that the related command is working:
![app-cli](https://user-images.githubusercontent.com/32807437/227961597-5ed14247-a4ff-461a-b097-323e519af3a5.png)
