### PR TITLE
Desktop: Fixes #8000: Fixed linux tag display issues

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -48,6 +48,15 @@ const StyledFoldersHolder = styled.div`
 	}}
 	}
 `;
+const TagsHolder = styled.div`
+	// linux bug: https://github.com/laurent22/joplin/issues/8000
+	// solution ref: https://github.com/laurent22/joplin/issues/7506#issuecomment-1447101057
+	& a.list-item {
+		${shim.isLinux() && {
+		opacity: 1,
+	}}
+	}
+`;
 
 interface Props {
 	themeId: number;
@@ -738,9 +747,9 @@ const SidebarComponent = (props: Props) => {
 		tagItemsOrder_.current = result.order;
 
 		items.push(
-			<div className="tags" key="tag_items" style={{ display: props.tagHeaderIsExpanded ? 'block' : 'none' }}>
+			<TagsHolder className="tags" key="tag_items" style={{ display: props.tagHeaderIsExpanded ? 'block' : 'none' }}>
 				{tagItems}
-			</div>
+			</TagsHolder>
 		);
 	}
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes #8000 

### Problem Details:

In linux, tags have a weird display with overlapping text.

### Solution:

A similar issue was fixed for linux earlier here - https://github.com/laurent22/joplin/pull/7897. Solution is based on following suggestion - https://github.com/laurent22/joplin/issues/7506#issuecomment-1447101057

A styled component holder is created, and a check is made for linux with `shim.isLinux()` and `opacity: 1` is added for linux platforms

### Testing

Only manual testing is done for this feature. The fix needs to be specifically verified on linux machines.

