### PR TITLE
Desktop: Fixes #7933: Don't display "obsolete encryption method" message if the key is disabled

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -866,7 +866,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => {
 	const syncInfo = localSyncInfoFromState(state);
-	const showNeedUpgradingEnabledMasterKeyMessage = !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys.filter((K) => !!K.enabled)).length;
+	const showNeedUpgradingEnabledMasterKeyMessage = !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys.filter((k) => !!k.enabled)).length;
 
 	return {
 		themeId: state.settings.theme,

--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -866,6 +866,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => {
 	const syncInfo = localSyncInfoFromState(state);
+	const showNeedUpgradingEnabledMasterKeyMessage = !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys.filter((K) => !!K.enabled)).length;
 
 	return {
 		themeId: state.settings.theme,
@@ -873,7 +874,7 @@ const mapStateToProps = (state: AppState) => {
 		hasDisabledSyncItems: state.hasDisabledSyncItems,
 		hasDisabledEncryptionItems: state.hasDisabledEncryptionItems,
 		showMissingMasterKeyMessage: showMissingMasterKeyMessage(syncInfo, state.notLoadedMasterKeys),
-		showNeedUpgradingMasterKeyMessage: !!EncryptionService.instance().masterKeysThatNeedUpgrading(syncInfo.masterKeys).length,
+		showNeedUpgradingMasterKeyMessage: showNeedUpgradingEnabledMasterKeyMessage,
 		showShouldReencryptMessage: state.settings['encryption.shouldReencrypt'] >= Setting.SHOULD_REENCRYPT_YES,
 		shouldUpgradeSyncTarget: state.settings['sync.upgradeState'] === Setting.SYNC_UPGRADE_STATE_SHOULD_DO,
 		pluginsLegacy: state.pluginsLegacy,


### PR DESCRIPTION
Fixes #7933 

## Details

Reason for the bug: based on [the comment](https://discourse.joplinapp.org/t/remove-old-forgotton-master-key-message/30048/3?u=captweiss) The flag that determines if the "obsolete encryption method" message should pop up considers both enabled and disabled master key.

Solution: Filter has been applied to consider only the enabled keys. Tested locally and it works fine now


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.