### PR TITLE
All, Improve error handeling in server response JSON parsing

### DIFF
--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -213,8 +213,11 @@ export default class JoplinServerApi {
 			const loadResponseJson = async () => {
 				if (!responseText) return null;
 				if (responseJson_) return responseJson_;
-				responseJson_ = JSON.parse(responseText);
-				if (!responseJson_) throw newError('Cannot parse JSON response', response.status);
+				try {
+					responseJson_ = JSON.parse(responseText);
+				} catch (error) {
+					throw newError(`Cannot parse JSON response: ${error} Response plain text: ${responseText}`, response.status);
+				}
 				return responseJson_;
 			};
 


### PR DESCRIPTION
Thank you for this great project.

In case the server is not responding with a JSON file type we try to parse the plain text as JSON. If the plain text is not JSON (likely HTML), a generic and hard-to-debug error was generated. This MR adds to the error log the first ~1000 characters or so of the plain text using the project's error format instead of the basic JS exception error. (`JSON.parse` doesn't return an empty string on error but is throwing and it wasn't handled properly)

This was useful for me to debug my issue that was just showing the following error:
```
 unexpected token < in JSON at position 0
```

For me, having the full response showed me that it was an HTML page saying that the reverse proxy was blocking PUT and DELETE methods.

I used this to debug my issue and I successfully ran tests.