### PR TITLE
Mobile: Fixes #8017: Patch for android sync crash 

### DIFF
--- a/.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch
+++ b/.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch
@@ -1,0 +1,30 @@
+diff --git a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+index a8abd71833879201e3438b2fa51d712a311c4551..ffe9c2c6dfa5c703ba76b65d94d5dd6784102c19 100644
+--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
++++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+@@ -591,7 +591,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
+ //                    ignored.printStackTrace();
+                 }
+ 
+-                RNFetchBlobFileResp rnFetchBlobFileResp = (RNFetchBlobFileResp) responseBody;
++                RNFetchBlobFileResp rnFetchBlobFileResp = new RNFetchBlobFileResp(responseBody);
+ 
+                 if(rnFetchBlobFileResp != null && !rnFetchBlobFileResp.isDownloadComplete()){
+                     callback.invoke("Download interrupted.", null);
+diff --git a/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java b/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
+index 2470eef612308c15a89dfea5a1f16937469be29f..965f8becc195965907699182c764ec9e51811450 100644
+--- a/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
++++ b/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
+@@ -35,6 +35,12 @@ public class RNFetchBlobFileResp extends ResponseBody {
+     FileOutputStream ofStream;
+     boolean isEndMarkerReceived;
+ 
++    // ref: https://github.com/joltup/rn-fetch-blob/issues/490#issuecomment-990899440
++    public RNFetchBlobFileResp(ResponseBody body) {
++        super();
++        this.originalBody = body;
++    }
++
+     public RNFetchBlobFileResp(ReactApplicationContext ctx, String taskId, ResponseBody body, String path, boolean overwrite) throws IOException {
+         super();
+         this.rctContext = ctx;

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   },
   "packageManager": "yarn@3.3.1",
   "resolutions": {
-    "react-native-camera@4.2.1": "patch:react-native-camera@npm%3A4.2.1#./.yarn/patches/react-native-camera-npm-4.2.1-24b2600a7e.patch"
+    "react-native-camera@4.2.1": "patch:react-native-camera@npm%3A4.2.1#./.yarn/patches/react-native-camera-npm-4.2.1-24b2600a7e.patch",
+    "rn-fetch-blob@0.12.0": "patch:rn-fetch-blob@npm%3A0.12.0#./.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28790,6 +28790,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rn-fetch-blob@patch:rn-fetch-blob@npm%3A0.12.0#./.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch::locator=root%40workspace%3A.":
+  version: 0.12.0
+  resolution: "rn-fetch-blob@patch:rn-fetch-blob@npm%3A0.12.0#./.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch::version=0.12.0&hash=9431c2&locator=root%40workspace%3A."
+  dependencies:
+    base-64: 0.1.0
+    glob: 7.0.6
+  checksum: 6535ee347b3e76733a10c3873c14622b35613caa86242536b68f130b75a3379d9bb060ad5c8832d78e639c88869e321c288e5c8e89373cdb0c14f23253c31c50
+  languageName: node
+  linkType: hard
+
 "roarr@npm:^2.15.3":
   version: 2.15.4
   resolution: "roarr@npm:2.15.4"


### PR DESCRIPTION
Fixes #8017 

### Problem

Android app randomly crashes during sync.

### Solution

Ref: https://github.com/joltup/rn-fetch-blob/issues/490#issuecomment-990899440

### Testing

Basic syncing testing was done in local android app and local joplin server setup. Was able to sync items locally (checked with fetching the synced items from desktop).

I was not able to reproduce this issue in my local android app setup and local server setup. I have just applied the changes via `yarn patch` as per the solution.

