### PR TITLE
electron-builder maximum compression

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -27,6 +27,7 @@
   },
   "build": {
     "appId": "net.cozic.joplin-desktop",
+    "compression": "maximum",
     "productName": "Joplin",
     "npmRebuild": false,
     "afterSign": "./tools/notarizeMacApp.js",


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/8028

`dist/Joplin-2.11.1.dmg`

Size is reduced roughly by `20MB`
Before  - `168MB`
After - `149MB`

CI builds are taking slightly longer (roughly `~2-4 minutes` longer)

### Windows:
Before - `22 minutes`
After - `26 minutes`

### Linux:
Before - `14 minutes`
After - `16 minutes`

### Mac:
Before - `28 minutes`
After - `33 minutes`