### PR TITLE
Delete ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-👉 Please follow one of these issue templates:
-- https://github.com/laurent22/joplin/issues/new/choose
-
-⚠️
-The GitHub issue tracker is for **bugs** and **security issues** ONLY. For feature requests and support, please use the forum:
-https://discourse.joplinapp.org/
-⚠️
-
-Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.


### PR DESCRIPTION
The old issue template is no longer relevant and is causing confusion. Removing it will streamline the issue creation process and improve user experience.
