### PR TITLE
pt_BR: Use the formal translation of "custom"

### DIFF
--- a/packages/tools/locales/pt_BR.po
+++ b/packages/tools/locales/pt_BR.po
@@ -11,13 +11,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Joplin-CLI 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"Last-Translator: Renato Nunes Bastos <rnbastos@gmail.com>\n"
+"Last-Translator: Douglas Leão <djlsplays@gmail.com>\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 3.0.1\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: packages/app-mobile/components/screens/ConfigScreen.tsx:657
@@ -1089,23 +1089,23 @@ msgstr "A versão atual está atualizada."
 
 #: packages/lib/models/Note.ts:38
 msgid "custom order"
-msgstr "ordem customizada"
+msgstr "ordem personalizada"
 
 #: packages/app-desktop/gui/NoteList/NoteList.tsx:167
 msgid "Custom order"
-msgstr "Ordem customizada"
+msgstr "Ordem personalizada"
 
 #: packages/lib/models/Setting.ts:1298
 msgid "Custom stylesheet for Joplin-wide app styles"
-msgstr "Folha de estilos customizada para estilos do app Joplin"
+msgstr "Folha de estilos personalizada para estilos do app Joplin"
 
 #: packages/lib/models/Setting.ts:1281
 msgid "Custom stylesheet for rendered Markdown"
-msgstr "Folha de estilos customizada para Markdown renderizado"
+msgstr "Folha de estilos personalizada para Markdown renderizado"
 
 #: packages/lib/models/Setting.ts:1440
 msgid "Custom TLS certificates"
-msgstr "Certificados TLS customizados"
+msgstr "Certificados TLS personalizados"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:18
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/CodeMirror.tsx:804
@@ -1921,7 +1921,7 @@ msgstr ""
 
 #: packages/app-cli/app/command-help.js:36
 msgid "For information on how to customise the shortcuts please visit %s"
-msgstr "Para informações sobre como customizar os atalhos, por favor visite %s"
+msgstr "Para informações sobre como personalizar os atalhos, por favor visite %s"
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:291
 msgid ""


### PR DESCRIPTION
While "customizar/customizado" and its variations are considered valid in the pt language dictionary and is widely accepted, it's also considered informal due to its English origin and is used on contexts that don't fit well here.

"Personalizar/personalizado" is a more formal term that fits better.