### PR TITLE
Desktop: Script: Check libfuse2 dependency

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -115,6 +115,16 @@ elif [[ $ARCHITECTURE =~ .*i386.*|.*i686.* ]] ; then
 fi
 
 #-----------------------------------------------------
+print "Checking dependencies..."
+## Check if libfuse2 is present.
+LIBFUSE=$(ldconfig -p | grep "libfuse.so.2" || echo '')
+if [[ $LIBFUSE == "" ]] ; then
+  print "${COLOR_RED}Error: Can't get libfuse2 on system, please install libfuse2${COLOR_RESET}"
+  print "See https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
+  exit 1
+fi
+
+#-----------------------------------------------------
 # Download Joplin
 #-----------------------------------------------------
 


### PR DESCRIPTION
Check if the libfuse2 is present in the system. If not, present an error.

Avoid a silent error for the users. Previously, it was installed successfully but was never launching it.
To get and see the error, the user has to run it by the command line.