### PR TITLE
Desktop: Resolves #3535: Configure tinymce to handle the first table row as header

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -563,7 +563,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 			// Available table toolbar buttons:
 			// https://www.tiny.cloud/docs/advanced/available-toolbar-buttons/#tableplugin
-			const table_toolbar = [
+			const tableToolbar = [
 				'tabledelete',
 				'tableinsertrowafter tablecopyrow tablepasterowafter tabledeleterow',
 				'tableinsertcolafter tablecopycol tablepastecolafter tabledeletecol',
@@ -588,7 +588,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
-				table_toolbar: table_toolbar.join(' | '),
+				table_toolbar: tableToolbar.join(' | '),
 				table_resize_bars: false,
 				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `${bridge().vendorDir()}/lib/tinymce/langs/${language}`,
 				toolbar: toolbar.join(' '),

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -561,6 +561,14 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				'h1', 'h2', 'h3', 'hr', 'blockquote', 'inserttable', `joplinInsertDateTime${toolbarPluginButtons}`,
 			];
 
+			// Available table toolbar buttons:
+			// https://www.tiny.cloud/docs/advanced/available-toolbar-buttons/#tableplugin
+			const table_toolbar = [
+				'tabledelete',
+				'tableinsertrowafter tablecopyrow tablepasterowafter tabledeleterow',
+				'tableinsertcolafter tablecopycol tablepastecolafter tabledeletecol',
+			];
+
 			const editors = await (window as any).tinymce.init({
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
@@ -580,6 +588,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
+				table_toolbar: table_toolbar.join(' | '),
 				table_resize_bars: false,
 				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `${bridge().vendorDir()}/lib/tinymce/langs/${language}`,
 				toolbar: toolbar.join(' '),

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -557,7 +557,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				'bold', 'italic', 'joplinHighlight', 'joplinStrikethrough', 'formattingExtras', '|',
 				'link', 'joplinInlineCode', 'joplinCodeBlock', 'joplinAttach', '|',
 				'bullist', 'numlist', 'joplinChecklist', '|',
-				'h1', 'h2', 'h3', 'hr', 'blockquote', 'table', `joplinInsertDateTime${toolbarPluginButtons}`,
+				'h1', 'h2', 'h3', 'hr', 'blockquote', 'inserttable', `joplinInsertDateTime${toolbarPluginButtons}`,
 			];
 
 			const editors = await (window as any).tinymce.init({
@@ -576,6 +576,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				branding: false,
 				statusbar: false,
 				target_list: false,
+				// Handle the first table row as table header.
+				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
+				table_header_type: 'sectionCells',
 				table_resize_bars: false,
 				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `${bridge().vendorDir()}/lib/tinymce/langs/${language}`,
 				toolbar: toolbar.join(' '),
@@ -621,6 +624,22 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 							return function() {
 								if (unbind) unbind();
 							};
+						},
+					});
+
+					editor.ui.registry.addMenuButton('inserttable', {
+						icon: 'table',
+						tooltip: 'Table',
+						fetch: (callback: any) => {
+							callback([
+								{
+									type: 'fancymenuitem',
+									fancytype: 'inserttable',
+									onAction: (data: any) => {
+										editor.execCommand('mceInsertTable', false, { rows: data.numRows, columns: data.numColumns, options: { headerRows: 1 } });
+									},
+								},
+							]);
 						},
 					});
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -25,6 +25,7 @@ import { themeStyle } from '@joplin/lib/theme';
 import { loadScript } from '../../../utils/loadScript';
 import bridge from '../../../../services/bridge';
 import { TinyMceEditorEvents } from './utils/types';
+import type { Editor } from 'tinymce';
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 
@@ -592,7 +593,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					joplinSub: { inline: 'sub', remove: 'all' },
 					joplinSup: { inline: 'sup', remove: 'all' },
 				},
-				setup: (editor: any) => {
+				setup: (editor: Editor) => {
 					editor.ui.registry.addButton('joplinAttach', {
 						tooltip: _('Attach file'),
 						icon: 'paperclip',
@@ -617,7 +618,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						onAction: function() {
 							editor.execCommand('mceToggleFormat', false, 'code', { class: 'inline-code' });
 						},
-						onSetup: function(api: any) {
+						onSetup: function(api) {
 							api.setActive(editor.formatter.match('code'));
 							const unbind = editor.formatter.formatChanged('code', api.setActive).unbind;
 
@@ -630,12 +631,12 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.ui.registry.addMenuButton('inserttable', {
 						icon: 'table',
 						tooltip: 'Table',
-						fetch: (callback: any) => {
+						fetch: (callback) => {
 							callback([
 								{
 									type: 'fancymenuitem',
 									fancytype: 'inserttable',
-									onAction: (data: any) => {
+									onAction: (data) => {
 										editor.execCommand('mceInsertTable', false, { rows: data.numRows, columns: data.numColumns, options: { headerRows: 1 } });
 									},
 								},
@@ -666,13 +667,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.addShortcut('Meta+Shift+9', '', () => editor.execCommand('InsertJoplinChecklist'));
 
 					// TODO: remove event on unmount?
-					editor.on('DblClick', (event: any) => {
+					editor.on('DblClick', (event) => {
 						const editable = findEditableContainer(event.target);
 						if (editable) openEditDialog(editor, markupToHtml, dispatchDidUpdate, editable);
 					});
 
 					// This is triggered when an external file is dropped on the editor
-					editor.on('drop', (event: any) => {
+					editor.on('drop', (event) => {
 						// Prevent the message "Dropped file type is not
 						// supported" to show up. It was added in a recent
 						// TinyMCE version and doesn't apply since we do support
@@ -683,7 +684,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						props_onDrop.current(event);
 					});
 
-					editor.on('ObjectResized', (event: any) => {
+					editor.on('ObjectResized', (event) => {
 						if (event.target.nodeName === 'IMG') {
 							editor.fire(TinyMceEditorEvents.JoplinChange);
 							dispatchDidUpdate(editor);


### PR DESCRIPTION
Resolves #3535

Consider the first table row as header in the richtext editor automatically. Switching isn't needed anymore. This is based on https://tinymce.github.io/tinymce-demos/tables/customizing-the-table-toolbar.html.

Open questions:

1. The new menu only contains the table size selection. As far as I see, most of the options are either covered by the table tooltip (insert, delete, properties) or incompatible with markdown (merge and split cells). Only the cut/paste options are missing. I could either try to add the cut/paste options to the tooltip or build the menu manually, as it was before. What would be the preferred way?
2. There are some `any` types. I left them for now, since the surrounding code has them, too. Let me know if I should try to fix them.

Screenshot:

![Screenshot_20230511_155150](https://github.com/laurent22/joplin/assets/33229141/3b2fe2a4-70a8-4570-b229-22609d2c3e9e)