### PR TITLE
Desktop: fixes #7932: PDF preview Pane does not show the whole first page.

### DIFF
--- a/packages/renderer/MdToHtml/renderMedia.ts
+++ b/packages/renderer/MdToHtml/renderMedia.ts
@@ -73,7 +73,7 @@ export default function(link: Link, options: Options, linkIndexes: LinkIndexes) 
 		 class="media-player media-pdf"></iframe>`;
 		}
 
-		return `<object data="${escapedResourcePath}" class="media-player media-pdf" type="${escapedMime}"></object>`;
+		return `<object data="${escapedResourcePath}#view=Fit" class="media-player media-pdf" type="${escapedMime}"></object>`;
 	}
 
 	return '';

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -375,8 +375,9 @@ export default function(theme: any, options: Options = null) {
 		}
 
 		.media-player.media-pdf {
-			min-height: 35rem;
 			width: 100%;
+			aspect-ratio: 1/1.414;
+			max-height: 80vh;
 			max-width: 1000px;
 			margin: 0;
 			border: 0;


### PR DESCRIPTION
## Fixes [#7932](https://github.com/laurent22/joplin/issues/7932)

### Problem:
The pdf rendering only assumes the min-height set for it, and wouldn't increase in height even if we have more room for it to grow.

### Solution:
Instead of using javascript to handle resizing as suggested by [TahaNw](https://github.com/laurent22/joplin/issues/7932#issuecomment-1482733220), I used CSS vh set to 80 to ensure a part of the note are still visible, and set A4 aspect ratio to ensure pdf scale accordingly
#### Updated:
`view=fit` has been added to ensure responsiveness, and `min-height=35rem` removed to ensure the preview pane does not contain horizontal blank space when on a small width device.

~Old Loom video: https://www.loom.com/share/52dffc8a33a949558b3cf39da1db6e58~
New Loom video: https://www.loom.com/share/43ea26571c044d1293fe252b810f018a

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
