### PR TITLE
Desktop: Resolves #8203: Don't fail install if dependencies could not be checked

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -121,8 +121,8 @@ set +e
 trap - ERR
 LIBFUSE=$(ldconfig -p 2>/dev/null | grep "libfuse.so.2")
 if [[ $? -ne 0 ]]; then
-  print "${COLOR_RED}Could not check dependencies. Continuing anyway.${COLOR_RESET}"
-  print "If starting Joplin fails you might want to check https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
+  print "${COLOR_YELLOW}Warning: Could not check dependencies. Continuing anyway.${COLOR_RESET}"
+  print "If starting Joplin fails you might want to check if libfuse2 is installed. See https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
 elif [[ $LIBFUSE == "" ]] ; then
   print "${COLOR_RED}Error: Can't get libfuse2 on system, please install libfuse2${COLOR_RESET}"
   print "See https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -117,12 +117,19 @@ fi
 #-----------------------------------------------------
 print "Checking dependencies..."
 ## Check if libfuse2 is present.
-LIBFUSE=$(ldconfig -p | grep "libfuse.so.2" || echo '')
-if [[ $LIBFUSE == "" ]] ; then
+set +e
+trap - ERR
+LIBFUSE=$(ldconfig -p 2>/dev/null | grep "libfuse.so.2")
+if [[ $? -ne 0 ]]; then
+  print "${COLOR_RED}Could not check dependencies. Continuing anyway.${COLOR_RESET}"
+  print "If starting Joplin fails you might want to check https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
+elif [[ $LIBFUSE == "" ]] ; then
   print "${COLOR_RED}Error: Can't get libfuse2 on system, please install libfuse2${COLOR_RESET}"
   print "See https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
   exit 1
 fi
+set -e
+trap 'handleError' ERR
 
 #-----------------------------------------------------
 # Download Joplin


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #8203: Don't fail install if dependencies could not be checked

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

This is quick and dirty. I am not really proficient with bash but it works until someone comes up with a better alternative for the the `LIBFUSE=$(ldconfig -p 2>/dev/null | grep "libfuse.so.2")` line.
