### PR TITLE
Desktop: Fixes #8159: Set minimum search/sort bar width

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -181,7 +181,7 @@ function NoteListControls(props: Props) {
 	useEffect(() => {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
-			searchAndSortRef.current.style.flex = '2 1 60%';
+			searchAndSortRef.current.style.flex = '2 1 Md';
 			props.onContentHeightChange(true);
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -181,7 +181,7 @@ function NoteListControls(props: Props) {
 	useEffect(() => {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
-			searchAndSortRef.current.style.flex = '2 1 Md';
+			searchAndSortRef.current.style.flex = '2 1 50%';
 			props.onContentHeightChange(true);
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -181,7 +181,7 @@ function NoteListControls(props: Props) {
 	useEffect(() => {
 		if (breakpoint === dynamicBreakpoints.Xl) {
 			noteControlsRef.current.style.flexDirection = 'row';
-			searchAndSortRef.current.style.flex = '2 1 auto';
+			searchAndSortRef.current.style.flex = '2 1 60%';
 			props.onContentHeightChange(true);
 		} else {
 			noteControlsRef.current.style.flexDirection = 'column';


### PR DESCRIPTION
### Problem:
When changing the note list panel to a certain width, the search bar becomes so small that it is unusable before flowing to the next line.

### Solution:
Change the flex-basis CSS property of the first-row search and sort bar to 60%, rather than auto. This ensures that the search bar will never become too small.
