### PR TITLE
Desktop: Fixes #8114: Emojis are the wrong size until restart

### DIFF
--- a/packages/app-desktop/gui/EmojiBox.tsx
+++ b/packages/app-desktop/gui/EmojiBox.tsx
@@ -38,6 +38,12 @@ export default (props: Props) => {
 			rect = span.getBoundingClientRect();
 		}
 
+		if (rect.height <= props.height) {
+			spanFontSize = 15;
+			span.style.fontSize = `${spanFontSize}px`;
+			rect = span.getBoundingClientRect();
+		}
+
 		span.remove();
 
 		fontSizeCache_[cacheKey] = spanFontSize;


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/8114
Problem: 

Emojis are the wrong size until restart:
the problem happens because the fontsize of the emoji is relative to the ''DomRect'', using a repetition to decrease the fontsize until the size of the rect is equal to the one defined in the code
It happens that, because the notebook was created in a different component, the element size values were also different and the logic used for the creation did not go through the repeat structure.

Solution:
To solve the problem, I analyzed the default size in the props and also the default fontsize that the emojis were after rendering in restart.
So, I created an exception for when the rect size is already equal to the prop size and the fontsize of the emoji is bigger than the default, making the fontsize become the default size, without changing the existing logic.

![Emoji Issue](https://github.com/GitStartHQ/client-joplin/assets/102544529/656c36d1-6772-47b2-aef7-335a579dabd4)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
