### PR TITLE
Desktop: Fixes #8084: Rich Text Editor: The "Stop" and "Bold text" buttons overlap with each other when toggling external editing.

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -110,6 +110,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	const [scriptLoaded, setScriptLoaded] = useState(false);
 	const [editorReady, setEditorReady] = useState(false);
 	const [draggingStarted, setDraggingStarted] = useState(false);
+	const [externalClicked, setExternalClicked] = useState(false);
 
 	const props_onMessage = useRef(null);
 	props_onMessage.current = props.onMessage;
@@ -368,7 +369,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		document.head.appendChild(element);
 		element.appendChild(document.createTextNode(`
 			.joplin-tinymce .tox-editor-header {
-				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
+				padding-left: ${(styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * (externalClicked ? 6.5 : 2))}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
 			
@@ -517,7 +518,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		//
 		// tl;dr: editorReady is used here because the css needs to be re-applied after TinyMCE init
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
-	}, [editorReady, props.themeId]);
+	}, [editorReady, props.themeId, externalClicked]);
 
 	// -----------------------------------------------------------------------------------------
 	// Enable or disable the editor
@@ -1150,11 +1151,15 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		const buttons = [];
 		for (const info of props.noteToolbarButtonInfos) {
 			if (!leftButtonCommandNames.includes(info.name)) continue;
+			if (info.name === 'toggleExternalEditing') {
+				info.externalClickedState = externalClicked;
+				info.updateExternalClicked = setExternalClicked;
+			}
 			buttons.push(renderExtraToolbarButton(info.name, info));
 		}
 
 		return (
-			<div style={styles.leftExtraToolbarContainer}>
+			<div style={externalClicked ? styles.leftExtraToolbarContainerClicked : styles.leftExtraToolbarContainer}>
 				{buttons}
 			</div>
 		);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
@@ -41,6 +41,11 @@ export default function styles(props: NoteBodyEditorProps) {
 				width: 80,
 				left: 0,
 			},
+			leftExtraToolbarContainerClicked: {
+				...extraToolbarContainer,
+				width: 120,
+				left: 0,
+			},
 			rightExtraToolbarContainer: {
 				...extraToolbarContainer,
 				alignItems: 'center',

--- a/packages/app-desktop/gui/ToolbarButton/ToolbarButton.tsx
+++ b/packages/app-desktop/gui/ToolbarButton/ToolbarButton.tsx
@@ -44,6 +44,14 @@ export default function ToolbarButton(props: Props) {
 
 	const onClick = getProp(props, 'onClick');
 
+	const updateExternal = () => {
+		const updateExternalClicked = getProp(props, 'updateExternalClicked');
+		const externalClickedState = getProp(props, 'externalClickedState');
+		if (typeof updateExternalClicked === 'function') {
+			updateExternalClicked(!externalClickedState);
+		}
+	};
+
 	return (
 		<StyledRoot
 			className={classes.join(' ')}
@@ -53,6 +61,7 @@ export default function ToolbarButton(props: Props) {
 			hasTitle={!!title}
 			onClick={() => {
 				if (isEnabled && onClick) onClick();
+				if (tooltip === 'Toggle external editing') updateExternal();
 			}}
 		>
 			{icon}
@@ -60,4 +69,3 @@ export default function ToolbarButton(props: Props) {
 		</StyledRoot>
 	);
 }
-

--- a/packages/lib/services/commands/ToolbarButtonUtils.ts
+++ b/packages/lib/services/commands/ToolbarButtonUtils.ts
@@ -11,6 +11,8 @@ export interface ToolbarButtonInfo {
 	enabled: boolean;
 	onClick(): void;
 	title: string;
+	updateExternalClicked?: (value: boolean)=> void;
+	externalClickedState?: boolean;
 }
 
 interface ToolbarButtonCacheItem {


### PR DESCRIPTION
Here is the GitStart Ticket for this pull request: [JP-OSS-18](https://developers.gitstart.com/client/joplin-oss/ticket/JP-OSS-18)

Problem:
The problem happens basically because of the clicking of the ''toggling external editing'' button, which when clicked adds the word ''stop'' to the button, but the toolbar's CSS is not configured to handle the button's increase when clicked.

Solution:
As it is commented in the issue related to this problem, just increasing the size of the elements generates another problem, a large distance between the buttons changing the default configuration of the toolbar.

To solve this I created a state that stores the event of the button being clicked or not. This state is monitored by the component that creates the toolbar CSS.
If it is clicked, the width of the component rendering the ''lefttoolbar'' (which contains the external editing button) and the padding of the default toolbar (the middle buttons) are changed to fit the increase of the button with the word ''stop''. 
When not clicked, the elements have their default settings.

![243459164-7da224e5-b888-46ca-8897-78e9ebaffb1c](https://github.com/GitStartHQ/client-joplin/assets/102544529/3b60f4b1-ee1d-4556-84e1-f681725e7685)

https://www.loom.com/share/c86d341e799c4c638c20b66e1d2c5a0c



---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
