### PR TITLE
Desktop: Replace Sidebar note count opacity with colorFaded2

### DIFF
--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -100,9 +100,8 @@ export const StyledExpandLink = styled.a`
 `;
 
 export const StyledNoteCount = styled.div`
-	color: ${(props: any) => props.theme.color2};
+	color: ${(props: any) => props.theme.colorFaded2};
 	padding-left: 8px;
-	opacity: 0.5;
 	user-select: none;
 `;
 


### PR DESCRIPTION
Linux users still reporting corrupted text in sidebar. This is a result
of applying a new workaround in 03424f76ea462d67af0e2181d458089250665167. However it seems that testing
with particular folder structure and icons was overlooked.

The new issue is still a Chrome Intel GPU bug but because note count also
sets opacity this is another factor requiring fixed. Perhaps the note
count opacity was also the reason for the tag text corruption.

Fixed by removing opacity from note count and using the more correct text
styling of colorFaded2 which has 0.5 alpha channel, as used by AllNotes.

Related: https://github.com/laurent22/joplin/issues/7506
Fixes: https://github.com/laurent22/joplin/issues/8297

Before

![Screenshot from 2023-06-09 14-59-26](https://github.com/laurent22/joplin/assets/606038/74091277-e91e-470c-9ce3-99e9b993545e)

After

![Screenshot from 2023-06-09 15-03-07](https://github.com/laurent22/joplin/assets/606038/7a2a84be-3d80-465f-80fc-96ccc32ce2e6)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
