### PR TITLE
Desktop: Removing Markdown when using 'Paste as Text'

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1106,7 +1106,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		}
 
 		function onPasteAsText() {
-			pasteAsPlainText(null);
+			const clipboardWithoutMarkdown = stripMarkup(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, clipboard.readText());
+			pasteAsPlainText(clipboardWithoutMarkdown);
 		}
 
 		editor.on(TinyMceEditorEvents.KeyUp, onKeyUp);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1106,6 +1106,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		}
 
 		function onPasteAsText() {
+			// clipboard.readText returns Markdown instead of text when copying content from
+			// the Rich Text Editor. When the user "Paste as text" he does not expect to see
+			// anything besides text, that is why we are stripping here before pasting
+			// https://github.com/laurent22/joplin/pull/8351
 			const clipboardWithoutMarkdown = stripMarkup(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, clipboard.readText());
 			pasteAsPlainText(clipboardWithoutMarkdown);
 		}


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/8317

For usability reasons, when we copy content from the Rich Text Editor the "text" part of the clipboard is populated with the markdown equivalent of the HTML that was copied. 

While this is useful, when the user tries to "Paste as Text" with this content in the clipboard, it gets text with Markdown, which is not what the user usually expect.

On this PR, we add a call to `stripMarkdown` before calling `pasteAsPlainText` to remove all the Markdown from the content before pasting it.

## How to test:

- Open the Rich Text editor
- Copy some content which has bold, italic, bullet points, headers, etc.
- When using 'Paste as Text' the content should be plain text, without any Markdown symbols.