### PR TITLE
 Mobile：Add a setting option to control code wrap by add css

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -478,6 +478,7 @@
 		"multimd",
 		"multistatus",
 		"multitable",
+		"coderwrap",
 		"mybucket",
 		"mydir",
 		"myfile",

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -464,6 +464,20 @@ class Application extends BaseApplication {
 			css: cssString,
 		});
 
+		// setting option to control add css for code wrap
+		const codewrap = Setting.value('markdown.plugin.codewrap');
+		this.logger().info(`codewrap: ${codewrap}`);
+		if (codewrap) {
+			const cssString_code = `code {
+				white-space: pre-wrap;
+			}`;
+			this.store().dispatch({
+				type: 'CUSTOM_CSS_APPEND',
+				css: cssString_code,
+			});
+			this.logger().info(`cssString_code: ${cssString_code}`);
+		}
+
 		this.store().dispatch({
 			type: 'NOTE_DEVTOOLS_SET',
 			value: Setting.value('flagOpenDevTools'),

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1161,6 +1161,7 @@ class Setting extends BaseModel {
 			'markdown.plugin.emoji': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable markdown emoji')}${wysiwygNo}` },
 			'markdown.plugin.insert': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable ++insert++ syntax')}${wysiwygYes}` },
 			'markdown.plugin.multitable': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable multimarkdown table extension')}${wysiwygNo}` },
+			'markdown.plugin.codewrap': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable code block wrap, need restart app')}${wysiwygNo}` },
 
 			// Tray icon (called AppIndicator) doesn't work in Ubuntu
 			// http://www.webupd8.org/2017/04/fix-appindicator-not-working-for.html


### PR DESCRIPTION
The display window on the mobile end is very small, and the code block does not Line wrap and word wrap automatically. It is troublesome to move left and right to see the code. Add a switch to control whether the code block displays Line wrap and word wrap. Please give the user a choice to decide whether the code block should wrap.(移动端的显示窗口很小，代码块不自动换行，要左右移动看代码很麻烦。加一个开关控制代码块是否自动换行显示。请给使用者一个决定代码块是否换行的选择。)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
