### PR TITLE
Mobile：code block  default  line wrap

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/theme.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/theme.ts
@@ -101,6 +101,7 @@ const createTheme = (theme: any): Extension[] => {
 			borderStyle: 'solid',
 			borderColor: theme.colorFaded,
 			backgroundColor: 'rgba(155, 155, 155, 0.1)',
+			whiteSpace: 'pre-wrap',
 		},
 
 		// CodeMirror wraps the existing inline span in an additional element.


### PR DESCRIPTION
The display window on the mobile end is very small, and the code block does not Line wrap and word wrap automatically. It is troublesome to move left and right to see the code. Add a switch to control whether the code block displays Line wrap and word wrap. Please give the user a choice to decide whether the code block should wrap.(移动端的显示窗口很小，代码块不自动换行，要左右移动看代码很麻烦。加一个开关控制代码块是否自动换行显示。请给使用者一个决定代码块是否换行的选择。)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
