### PR TITLE
Chore: Fix search filter tests in non UTC+0 timezones

### DIFF
--- a/packages/lib/services/searchengine/SearchFilter.test.ts
+++ b/packages/lib/services/searchengine/SearchFilter.test.ts
@@ -15,6 +15,14 @@ let engine: any = null;
 
 const ids = (array: NoteEntity[]) => array.map(a => a.id);
 
+const dateStringToTimestamp = (dateString: string) => {
+	const localTimestamp = new Date(dateString);
+
+	// Without getTimezoneOffset(), .getTime() doesn't account for the timezone offset.
+	const minutesToMilliseconds = 1000 * 60;
+	return localTimestamp.getTime() + localTimestamp.getTimezoneOffset() * minutesToMilliseconds;
+};
+
 describe('services_SearchFilter', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
@@ -437,9 +445,9 @@ describe('services_SearchFilter', () => {
 
 			it('should support filtering by created date', (async () => {
 				let rows;
-				const n1 = await Note.save({ title: 'I made this on', body: 'May 20 2020', user_created_time: Date.parse('2020-05-20') });
-				const n2 = await Note.save({ title: 'I made this on', body: 'May 19 2020', user_created_time: Date.parse('2020-05-19') });
-				const n3 = await Note.save({ title: 'I made this on', body: 'May 18 2020', user_created_time: Date.parse('2020-05-18') });
+				const n1 = await Note.save({ title: 'I made this on', body: 'May 20 2020', user_created_time: dateStringToTimestamp('2020-05-20') });
+				const n2 = await Note.save({ title: 'I made this on', body: 'May 19 2020', user_created_time: dateStringToTimestamp('2020-05-19') });
+				const n3 = await Note.save({ title: 'I made this on', body: 'May 18 2020', user_created_time: dateStringToTimestamp('2020-05-18') });
 
 				await engine.syncTables();
 
@@ -460,26 +468,26 @@ describe('services_SearchFilter', () => {
 
 			it('should support filtering by between two dates', (async () => {
 				let rows;
-				const n1 = await Note.save({ title: 'January 01 2020', body: 'January 01 2020', user_created_time: Date.parse('2020-01-01') });
-				const n2 = await Note.save({ title: 'February 15 2020', body: 'February 15 2020', user_created_time: Date.parse('2020-02-15') });
-				const n3 = await Note.save({ title: 'March 25 2019', body: 'March 25 2019', user_created_time: Date.parse('2019-03-25') });
-				const n4 = await Note.save({ title: 'March 01 2018', body: 'March 01 2018', user_created_time: Date.parse('2018-03-01') });
+				const n1 = await Note.save({ title: 'January 01 2020', body: 'January 01 2020', user_created_time: dateStringToTimestamp('2020-01-01') });
+				const n2 = await Note.save({ title: 'February 15 2020', body: 'February 15 2020', user_created_time: dateStringToTimestamp('2020-02-15') });
+				const n3 = await Note.save({ title: 'March 25 2019', body: 'March 25 2019', user_created_time: dateStringToTimestamp('2019-03-25') });
+				const n4 = await Note.save({ title: 'March 01 2018', body: 'March 01 2018', user_created_time: dateStringToTimestamp('2018-03-01') });
 
 				await engine.syncTables();
 
-				rows = await engine.search('created:20200101 -created:20200220', { searchType });
-				expect(rows.length).toBe(2);
-				expect(ids(rows)).toContain(n1.id);
-				expect(ids(rows)).toContain(n2.id);
+				rows = await engine.search('created:2018 -created:2019', { searchType });
+				expect(rows.length).toBe(1);
+				expect(ids(rows)).toContain(n4.id);
 
 				rows = await engine.search('created:201901 -created:202002', { searchType });
 				expect(rows.length).toBe(2);
 				expect(ids(rows)).toContain(n3.id);
 				expect(ids(rows)).toContain(n1.id);
 
-				rows = await engine.search('created:2018 -created:2019', { searchType });
-				expect(rows.length).toBe(1);
-				expect(ids(rows)).toContain(n4.id);
+				rows = await engine.search('created:20200101 -created:20200220', { searchType });
+				expect(rows.length).toBe(2);
+				expect(ids(rows)).toContain(n1.id);
+				expect(ids(rows)).toContain(n2.id);
 			}));
 
 			it('should support filtering by created with smart value: day', (async () => {
@@ -580,8 +588,8 @@ describe('services_SearchFilter', () => {
 
 			it('should support filtering by updated date', (async () => {
 				let rows;
-				const n1 = await Note.save({ title: 'I updated this on', body: 'May 20 2020', updated_time: Date.parse('2020-05-20'), user_updated_time: Date.parse('2020-05-20') }, { autoTimestamp: false });
-				const n2 = await Note.save({ title: 'I updated this on', body: 'May 19 2020', updated_time: Date.parse('2020-05-19'), user_updated_time: Date.parse('2020-05-19') }, { autoTimestamp: false });
+				const n1 = await Note.save({ title: 'I updated this on', body: 'May 20 2020', updated_time: dateStringToTimestamp('2020-05-20'), user_updated_time: dateStringToTimestamp('2020-05-20') }, { autoTimestamp: false });
+				const n2 = await Note.save({ title: 'I updated this on', body: 'May 19 2020', updated_time: dateStringToTimestamp('2020-05-19'), user_updated_time: dateStringToTimestamp('2020-05-19') }, { autoTimestamp: false });
 
 				await engine.syncTables();
 
@@ -668,8 +676,8 @@ describe('services_SearchFilter', () => {
 
 			it('should support filtering by due date', (async () => {
 				let rows;
-				const toDo1 = await Note.save({ title: 'ToDo 1', body: 'todo', is_todo: 1, todo_due: Date.parse('2021-04-27') });
-				const toDo2 = await Note.save({ title: 'ToDo 2', body: 'todo', is_todo: 1, todo_due: Date.parse('2021-03-17') });
+				const toDo1 = await Note.save({ title: 'ToDo 1', body: 'todo', is_todo: 1, todo_due: dateStringToTimestamp('2021-04-27') });
+				const toDo2 = await Note.save({ title: 'ToDo 2', body: 'todo', is_todo: 1, todo_due: dateStringToTimestamp('2021-03-17') });
 				await Note.save({ title: 'Note 1', body: 'Note' });
 
 				await engine.syncTables();


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
# Summary

`SearchFilter` tests are currently failing if run in an environment configured to use a non-UTC timezones. This is because [`Date.parse` assumes its argument is in UTC time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#using_date.parse). Thus, an adjustment must be made if the argument is in local time.
