### PR TITLE
Desktop: Fixes #8409: Only attempt to decrypt one time when clicking "retry"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -585,6 +585,7 @@ packages/lib/services/MigrationService.js
 packages/lib/services/NavService.js
 packages/lib/services/PostMessageService.js
 packages/lib/services/ReportService.js
+packages/lib/services/ReportService.test.js
 packages/lib/services/ResourceEditWatcher/index.js
 packages/lib/services/ResourceEditWatcher/reducer.js
 packages/lib/services/ResourceFetcher.js

--- a/.gitignore
+++ b/.gitignore
@@ -570,6 +570,7 @@ packages/lib/services/MigrationService.js
 packages/lib/services/NavService.js
 packages/lib/services/PostMessageService.js
 packages/lib/services/ReportService.js
+packages/lib/services/ReportService.test.js
 packages/lib/services/ResourceEditWatcher/index.js
 packages/lib/services/ResourceEditWatcher/reducer.js
 packages/lib/services/ResourceFetcher.js

--- a/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
+++ b/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
@@ -11,12 +11,14 @@ import Button, { ButtonLevel } from '../Button/Button';
 import bridge from '../../services/bridge';
 const fs = require('fs-extra');
 import styled from 'styled-components';
+import { State } from '@joplin/lib/reducer';
 
 interface Props {
 	themeId: string;
 	style: any;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	dispatch: Function;
+	decryptionWorkerState: string;
 }
 
 const StyledAdvancedToolItem = styled.div`
@@ -47,9 +49,10 @@ function StatusScreen(props: Props) {
 		setReport(r);
 	}
 
+
 	useEffect(() => {
 		void resfreshScreen();
-	}, []);
+	}, [props.decryptionWorkerState]);
 
 	const theme = themeStyle(props.themeId);
 	const style = { ...props.style,
@@ -195,11 +198,12 @@ function StatusScreen(props: Props) {
 	);
 }
 
-const mapStateToProps = (state: any) => {
+const mapStateToProps = (state: State) => {
 	return {
 		themeId: state.settings.theme,
 		settings: state.settings,
 		locale: state.settings.locale,
+		decryptionWorkerState: state.decryptionWorker?.state,
 	};
 };
 

--- a/packages/lib/services/ReportService.test.ts
+++ b/packages/lib/services/ReportService.test.ts
@@ -1,0 +1,200 @@
+import { ModelType } from '../BaseModel';
+import SyncTargetRegistry from '../SyncTargetRegistry';
+import { _ } from '../locale';
+import ReportService, { ReportSection } from './ReportService';
+import { decryptionWorker, encryptionService, loadEncryptionMasterKey, setupDatabaseAndSynchronizer, switchClient, synchronizerStart } from '../testing/test-utils';
+import DecryptionWorker from './DecryptionWorker';
+import Note from '../models/Note';
+import { loadMasterKeysFromSettings, setupAndEnableEncryption } from './e2ee/utils';
+import Setting from '../models/Setting';
+
+
+// Adds corruptedNoteCount corrupted notes to client 2 and returns the IDs
+// The uncorrupted notes are added to client 1.
+const addCorruptedNotes = async (corruptedNoteCount: number) => {
+	await switchClient(1);
+
+	const notes = [];
+	for (let i = 0; i < corruptedNoteCount; i++) {
+		notes.push(await Note.save({ title: `Note ${i}` }));
+	}
+
+	await synchronizerStart();
+
+	await switchClient(2);
+
+	await synchronizerStart();
+
+	// First, simulate a broken note and check that the decryption worker
+	// gives up decrypting after a number of tries. This is mainly relevant
+	// for data that crashes the mobile application - we don't want to keep
+	// decrypting these.
+
+	for (const note of notes) {
+		await Note.save({ id: note.id, encryption_cipher_text: 'bad' });
+	}
+
+	return notes.map(note => note.id);
+};
+
+const addUncorruptedNotes = async (noteCount: number) => {
+	await switchClient(1);
+
+	const notes = [];
+	for (let i = 0; i < noteCount; i++) {
+		notes.push(await Note.save({ title: `Test Note ${i}` }));
+	}
+
+	await synchronizerStart();
+	await switchClient(2);
+
+	return notes.map(note => note.id);
+};
+
+// Disables decryption for all items with the given IDs for the given worker
+const addIdsToUndecryptableList = async (worker: DecryptionWorker, ids: string[]) => {
+	for (const id of ids) {
+		// A value that is more than the maximum number of attempts:
+		const numDecryptionAttempts = 3;
+
+		// Add the failure manually so that the error message is unknown
+		await worker.kvStore().setValue(
+			`decrypt:${ModelType.Note}:${id}`, numDecryptionAttempts
+		);
+	}
+};
+
+const getSectionsWithTitle = (report: ReportSection[], title: string) => {
+	return report.filter(section => section.title === title);
+};
+
+const getDecyptionErrorSection = (report: ReportSection[]): ReportSection|null => {
+	const relevantSections = getSectionsWithTitle(report, _('Items that cannot be decrypted'));
+	return relevantSections.length === 1 ? relevantSections[0] : null;
+};
+
+const sectionBodyToText = (section: ReportSection) => {
+	return section.body.map(item => {
+		if (typeof item === 'string') {
+			return item;
+		}
+
+		return item.text;
+	}).join('\n');
+};
+
+const sectionBodyToContainsAllItemsOf = (section: ReportSection, searchText: string[]) => {
+	const asText = sectionBodyToText(section);
+
+	for (const testText of searchText) {
+		if (asText.indexOf(testText) === -1) {
+			return false;
+		}
+	}
+	return true;
+};
+
+const sectionBodyToContainsAnyItemOf = (section: ReportSection, searchText: string[]) => {
+	const asText = sectionBodyToText(section);
+
+	for (const testText of searchText) {
+		if (asText.indexOf(testText) !== -1) {
+			return true;
+		}
+	}
+	return false;
+};
+
+describe('ReportService', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await setupDatabaseAndSynchronizer(2);
+		await switchClient(1);
+
+		const masterKey = await loadEncryptionMasterKey();
+		await setupAndEnableEncryption(encryptionService(), masterKey, '123456');
+		await synchronizerStart();
+
+		// Give both clients the same master key
+		await switchClient(2);
+		await synchronizerStart();
+
+		Setting.setObjectValue('encryption.passwordCache', masterKey.id, '123456');
+		await loadMasterKeysFromSettings(encryptionService());
+
+		// For compatability with code that calls DecryptionWorker.instance()
+		DecryptionWorker.instance_ = decryptionWorker();
+	});
+
+	it('should not associate decryption failures with error message headers when errors are unknown', async () => {
+		const decryption = decryptionWorker();
+
+		// Create decryption errors:
+		const testIds = ['somenoteidhere1', 'anotherid', 'notarealid'];
+
+		await addIdsToUndecryptableList(decryption, testIds);
+
+		const service = new ReportService();
+		const syncTargetId = SyncTargetRegistry.nameToId('joplinServer');
+		const report = await service.status(syncTargetId);
+
+		// Report should have an "Items that cannot be decrypted" section
+		const undecryptableInfoSections = getSectionsWithTitle(report, _('Items that cannot be decrypted'));
+		expect(undecryptableInfoSections).toHaveLength(1);
+
+		const undecryptableInfoSection = undecryptableInfoSections[0];
+
+		// There should be testIds.length ReportItems with the correct messages:
+		const expectedMessages = testIds.map(id => `Note: ${id}`);
+		expect(sectionBodyToContainsAllItemsOf(undecryptableInfoSection, expectedMessages)).toBe(true);
+	});
+
+	it('retry callback should return failed items to the "cannot be decrypted" list', async () => {
+		const service = new ReportService();
+		const syncTargetId = SyncTargetRegistry.nameToId('filesystem');
+		let report = await service.status(syncTargetId);
+
+		// Initially, should not have a "cannot be decrypted section"
+		expect(getDecyptionErrorSection(report)).toBeNull();
+
+		const corruptedNoteIds = await addCorruptedNotes(4);
+		const uncorruptedNoteIds = await addUncorruptedNotes(4);
+
+		// Manually disable decryption for all notes
+		await addIdsToUndecryptableList(decryptionWorker(), [
+			...corruptedNoteIds, ...uncorruptedNoteIds,
+		]);
+
+		// Because all items are disabled, this should not throw.
+		await decryptionWorker().start({ errorHandler: 'throw' });
+
+		// This should be true even if we call .start several times:
+		await decryptionWorker().start({ errorHandler: 'throw' });
+		await decryptionWorker().start({ errorHandler: 'throw' });
+
+		// The report should have a "cannot be decrypted section"
+		// that can be refreshed.
+		report = await service.status(syncTargetId);
+
+		let undecryptableInfoSection = getDecyptionErrorSection(report);
+		expect(undecryptableInfoSection).not.toBeNull();
+
+		const retryHandlers = undecryptableInfoSection.body.filter(item => {
+			return typeof item !== 'string' && item.canRetryType === 'e2ee';
+		}).map(item => (item as any).retryHandler);
+
+		// Retry all (individually)
+		await Promise.all(retryHandlers.map(handler => handler()));
+
+		// Call .start manually so we don't have to wait (there can be a delay
+		// between calling retry and the effects).
+		await decryptionWorker().start();
+
+		report = await service.status(syncTargetId);
+		undecryptableInfoSection = getDecyptionErrorSection(report);
+		expect(undecryptableInfoSection).not.toBeNull();
+
+		expect(sectionBodyToContainsAllItemsOf(undecryptableInfoSection, corruptedNoteIds)).toBe(true);
+		expect(sectionBodyToContainsAnyItemOf(undecryptableInfoSection, uncorruptedNoteIds)).toBe(false);
+	});
+});

--- a/packages/lib/services/ReportService.ts
+++ b/packages/lib/services/ReportService.ts
@@ -23,7 +23,7 @@ enum ReportItemType {
 
 type RerportItemOrString = ReportItem | string;
 
-interface ReportSection {
+export interface ReportSection {
 	title: string;
 	body: RerportItemOrString[];
 	name?: string;
@@ -221,7 +221,7 @@ export default class ReportService {
 					canRetry: true,
 					canRetryType: CanRetryType.E2EE,
 					retryHandler: async () => {
-						await DecryptionWorker.instance().clearDisabledItem(row.type_, row.id);
+						await DecryptionWorker.instance().retryDisabledItem(row.type_, row.id);
 						void DecryptionWorker.instance().scheduleStart();
 					},
 				});


### PR DESCRIPTION
# Summary
Resolves #8409 

Prior to this commit, clicking "retry" on an item that failed to decrypt in the sync details screen removed the item from the list, regardless of whether the decryption retry failed.

This commit disables decryption for a resource if retrying decryption fails, thus adding it back to the disabled list.

# Notes
- This pull request is a subset of the changes from #8403

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
