### PR TITLE
Desktop: Fixes #8256: Don't start window minimized in GNOME

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -100,7 +100,10 @@ export default class ElectronAppWrapper {
 			webviewTag: true,
 			// We start with a hidden window, which is then made visible depending on the showTrayIcon setting
 			// https://github.com/laurent22/joplin/issues/2031
-			show: debugEarlyBugs,
+			//
+			// On Linux/GNOME, however, the window doesn't show correctly if show is false initially:
+			// https://github.com/laurent22/joplin/issues/8256
+			show: debugEarlyBugs || shim.isGNOME(),
 		};
 
 		// Linux icon workaround for bug https://github.com/electron-userland/electron-builder/issues/2098

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -494,7 +494,7 @@ class Application extends BaseApplication {
 		}, 1000 * 60 * 60);
 
 		if (Setting.value('startMinimized') && Setting.value('showTrayIcon')) {
-			// Keep it hidden
+			bridge().window().hide();
 		} else {
 			bridge().window().show();
 		}

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -58,8 +58,10 @@ const shim = {
 	},
 
 	isGNOME: () => {
+		// XDG_CURRENT_DESKTOP may be something like "ubuntu:GNOME" and not just "GNOME".
+		// Thus, we use .includes and not ===.
 		return (shim.isLinux() || shim.isFreeBSD())
-			&& (process.env['XDG_CURRENT_DESKTOP'] ?? '').includes('GNOME');
+			&& process && (process.env['XDG_CURRENT_DESKTOP'] ?? '').includes('GNOME');
 	},
 
 	isFreeBSD: () => {

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -57,6 +57,11 @@ const shim = {
 		return process && process.platform === 'linux';
 	},
 
+	isGNOME: () => {
+		return (shim.isLinux() || shim.isFreeBSD())
+			&& (process.env['XDG_CURRENT_DESKTOP'] ?? '').includes('GNOME');
+	},
+
 	isFreeBSD: () => {
 		return process && process.platform === 'freebsd';
 	},


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

# Summary

This pull request prevents Joplin from starting minimized on GNOME.

This should fix #8256.

# Explanation

At present, Joplin always starts minimized (unless running in dev mode), and is then shown or remains hidden based on the `startMinimized` setting.

However, the GNOME desktop environment seems to not always show a minimized window when requested. As such, this pull request should fix Joplin windows sometimes not appearing (#8256).

# Testing plan
This pull request changes some logic related to the "start minimized" feature. Thus, this feature needs to be manually tested.

- Launch Joplin (**not** in dev mode, so use `npx electron .`, not `yarn start`)
- Enable start minimized
- Re-launch Joplin
- Verify that Joplin starts minimized and can be opened.
