### PR TITLE
Desktop: Fixes #6822: Fix extra lines added to KaTeX source when toggling the rich text editor

### DIFF
--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -252,4 +252,41 @@ describe('MdToHtml', () => {
 			);
 		}
 	}));
+
+	it('should attach source blocks to block KaTeX', async () => {
+		const mdToHtml = newTestMdToHtml();
+
+		const katex = [
+			'3 + 3',
+			'\n\\int_0^1 x dx\n\n',
+			'\n\\int_0^1 x dx\n3 + 3\n',
+			'\n\t2^{3^4}\n\t3 + 3\n',
+			'3\n4',
+		];
+		const surroundingTextChoices = [
+			['', ''],
+			['Test', ''],
+			['Test', 'Test!'],
+			['Test\n\n', '\n\nTest!'],
+		];
+
+		const tests = [];
+		for (const texSource of katex) {
+			for (const [start, end] of surroundingTextChoices) {
+				tests.push([texSource, `${start}\n$$${texSource}$$\n${end}`]);
+			}
+		}
+
+		for (const [tex, input] of tests) {
+			const html = await mdToHtml.render(input, null, { bodyOnly: true });
+
+			const opening = '<pre class="joplin-source" data-joplin-language="katex" data-joplin-source-open="$$&#10;" data-joplin-source-close="&#10;$$&#10;">';
+			const closing = '</pre>';
+
+			// Remove any single leading and trailing newlines, those are included in data-joplin-source-open
+			// and data-joplin-source-close.
+			const trimmedTex = tex.replace(/^[\n]/, '').replace(/[\n]$/, '');
+			expect(html.html).toContain(opening + trimmedTex + closing);
+		}
+	});
 });

--- a/packages/renderer/MdToHtml/rules/katex.ts
+++ b/packages/renderer/MdToHtml/rules/katex.ts
@@ -246,9 +246,24 @@ function math_block(state: any, start: number, end: number, silent: boolean) {
 
 	state.line = next + 1;
 
+	const contentLines = [];
+	if (firstLine && firstLine.trim()) {
+		contentLines.push(firstLine);
+	}
+
+	const includeTrailingNewline = false;
+	const interiorLines = state.getLines(start + 1, next, state.tShift[start], includeTrailingNewline);
+	if (interiorLines.length > 0) {
+		contentLines.push(interiorLines);
+	}
+
+	if (lastLine && lastLine.trim()) {
+		contentLines.push(lastLine);
+	}
+
 	const token = state.push('math_block', 'math', 0);
 	token.block = true;
-	token.content = (firstLine && firstLine.trim() ? `${firstLine}\n` : '') + state.getLines(start + 1, next, state.tShift[start], true) + (lastLine && lastLine.trim() ? lastLine : '');
+	token.content = contentLines.join('\n');
 	token.map = [start, state.line];
 	token.markup = '$$';
 	return true;
@@ -312,6 +327,7 @@ export default {
 			} catch (error) {
 				outputHtml = renderKatexError(latex, error);
 			}
+
 			return `<div class="joplin-editable"><pre class="joplin-source" data-joplin-language="katex" data-joplin-source-open="$$&#10;" data-joplin-source-close="&#10;$$&#10;">${markdownIt.utils.escapeHtml(latex)}</pre>${outputHtml}</div>`;
 		};
 


### PR DESCRIPTION
# Summary

Updates the markdown-it KaTeX plugin such that it does not add an extra newline to the end of block math.

As I am no longer able to reproduce the code block portion of #6822, this should fix #6822.

# Testing

Automated tests are included, however, to test this manually:
1. Create a note with block math. For example,

       Test:
       $$ 3 + 3 $$
       
       More math:
       $$
           \int_0^1 \cos^2 x dx
       $$
       End test.

2. Switch to the rich text editor, make a small change
3. Switch back to the markdown editor
4. Switch back to the rich text editor, make a small change
5. Switch back to the markdown editor

Even if the math content changes between steps 1 and 3, it should remain the same between steps 3 and 5.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
