### PR TITLE
Desktop: Warn user when trying to delete a Inbox folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -781,6 +781,7 @@ packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
 packages/lib/utils/credentialFiles.js
+packages/lib/utils/inboxFolderFetcher.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/webDAVUtils.js
 packages/lib/utils/webDAVUtils.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -766,6 +766,7 @@ packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
 packages/lib/utils/credentialFiles.js
+packages/lib/utils/inboxFolderFetcher.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/webDAVUtils.js
 packages/lib/utils/webDAVUtils.test.js

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -46,6 +46,7 @@ import { homedir } from 'os';
 import getDefaultPluginsInfo from '@joplin/lib/services/plugins/defaultPlugins/desktopDefaultPluginsInfo';
 const electronContextMenu = require('./services/electron-context-menu');
 // import  populateDatabase from '@joplin/lib/services/debug/populateDatabase';
+import inboxFolderFetcher from '@joplin/lib/utils/inboxFolderFetcher';
 
 const commands = mainScreenCommands
 	.concat(noteEditorCommands)
@@ -486,6 +487,9 @@ class Application extends BaseApplication {
 			// Then every x hours
 			shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
 		}
+
+		shim.setTimeout(() => { void inboxFolderFetcher(); }, 10000);
+		shim.setInterval(() => { void inboxFolderFetcher(); }, 1000 * 60 * 60);
 
 		this.updateTray();
 

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -299,7 +299,11 @@ const SidebarComponent = (props: Props) => {
 		let deleteButtonLabel = _('Remove');
 		if (itemType === BaseModel.TYPE_FOLDER) {
 			const folder = await Folder.load(itemId);
-			deleteMessage = _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', substrWithEllipsis(folder.title, 0, 32));
+			if (itemId === state.settings['emailToNote.inboxJopId']) {
+				deleteMessage = _('Delete the Inbox notebook?\n\nIf you delete the inbox notebook, any email that\'s recently been sent to it may be lost.');
+			} else {
+				deleteMessage = _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', substrWithEllipsis(folder.title, 0, 32));
+			}
 			deleteButtonLabel = _('Delete');
 		} else if (itemType === BaseModel.TYPE_TAG) {
 			const tag = await Tag.load(itemId);

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1709,6 +1709,8 @@ class Setting extends BaseModel {
 				section: 'note',
 			},
 
+			'emailToNote.inboxJopId': { value: '', type: SettingItemType.String, public: false },
+
 		};
 
 		this.metadata_ = { ...this.buildInMetadata_ };

--- a/packages/lib/utils/inboxFolderFetcher.ts
+++ b/packages/lib/utils/inboxFolderFetcher.ts
@@ -1,0 +1,22 @@
+import SyncTargetRegistry from '../SyncTargetRegistry';
+import Setting from '../models/Setting';
+import { reg } from '../registry';
+
+const inboxFolderFetcher = async () => {
+
+	if (Setting.value('sync.target') !== SyncTargetRegistry.nameToId('joplinCloud')) {
+		return;
+	}
+
+	const syncTarget = reg.syncTarget();
+	const fileApi = await syncTarget.fileApi();
+	const api = fileApi.driver().api();
+
+	const owner = await api.exec('GET', `api/users/${api.userId}`);
+
+	if (owner.inbox) {
+		Setting.setValue('emailToNote.inboxJopId', owner.inbox.jop_id);
+	}
+};
+
+export default inboxFolderFetcher;


### PR DESCRIPTION
Related to feature https://github.com/laurent22/joplin/issues/8459

Changes the warning message when trying to delete a Inbox Folder
![Screenshot from 2023-07-12 15-51-11](https://github.com/laurent22/joplin/assets/5051088/1eb0e29f-c935-48aa-8eee-087c5f63762b)

## Functionality:

I'm adding a new function to `lib/utils/inboxFolderFetcher.ts` that will make a request to Joplin Cloud server if the sync target is set to Joplin Cloud.

The function will be called in the desktop 30 seconds after initialization and once every one hour.

The request will fetch the Inbox folder `jop_id` that will be used when the user tries to delete a folder to check if the folder that is being deleted is the Inbox one. If it is, we change the warning message to make it clear to the user what may happen if the deletion happens.

## Testing:

- Requests should only happen if the Joplin Cloud sync target is selected.
- One request should be sent after 10s of starting the desktop application if Joplin Cloud sync target is selected.
- When trying to delete the Inbox folder the user should see the inbox warning.
- When trying to delete any other type of folder the user should see the generic warning.


Inbox warning:
```
Delete the Inbox notebook?\n\nIf you delete the inbox notebook, any email that\'s recently been sent to it may be lost.
```


Generic warning:
```
Delete notebook "${folder.name}"?

All notes and sub-notebooks within this notebook will also be deleted.
```