### PR TITLE
Mobile: Add Email to note to new Joplin Cloud section on Settings screen

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen.tsx
@@ -391,7 +391,9 @@ class ConfigScreenComponent extends BaseScreenComponent {
 
 		const owner = await api.exec('GET', `api/users/${api.userId}`);
 
-		Setting.setValue('emailToNote.inboxEmail', owner.inbox_email);
+		if (owner.inbox_email) {
+			Setting.setValue('emailToNote.inboxEmail', owner.inbox_email);
+		}
 	}
 
 	public renderHeader(key: string, title: string) {

--- a/packages/lib/components/shared/config-shared.js
+++ b/packages/lib/components/shared/config-shared.js
@@ -186,6 +186,17 @@ shared.settingsSections = createSelector(
 			isScreen: true,
 		});
 
+		// Ideallly we would also check if the user was able to synchronize
+		// but we don't have a way of doing that besides making a request to Joplin Cloud
+		const syncTargetIsJoplinCloud = settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud');
+		if (syncTargetIsJoplinCloud) {
+			output.push({
+				name: 'joplinCloud',
+				metadatas: [],
+				isScreen: true,
+			});
+		}
+
 		return output;
 	}
 );

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1709,6 +1709,8 @@ class Setting extends BaseModel {
 				section: 'note',
 			},
 
+			'emailToNote.inboxEmail': { value: '', type: SettingItemType.String, public: false },
+
 		};
 
 		this.metadata_ = { ...this.buildInMetadata_ };
@@ -2523,6 +2525,7 @@ class Setting extends BaseModel {
 		if (name === 'encryption') return _('Encryption');
 		if (name === 'server') return _('Web Clipper');
 		if (name === 'keymap') return _('Keyboard Shortcuts');
+		if (name === 'joplinCloud') return _('Joplin Cloud');
 
 		if (this.customSections_[name] && this.customSections_[name].label) return this.customSections_[name].label;
 
@@ -2551,6 +2554,7 @@ class Setting extends BaseModel {
 		if (name === 'encryption') return 'icon-encryption';
 		if (name === 'server') return 'far fa-hand-scissors';
 		if (name === 'keymap') return 'fa fa-keyboard';
+		if (name === 'joplinCloud') return 'fa fa-cloud';
 
 		if (this.customSections_[name] && this.customSections_[name].iconName) return this.customSections_[name].iconName;
 


### PR DESCRIPTION
Related to feature https://github.com/laurent22/joplin/issues/8459

We are adding a Joplin Cloud section to the Settings screens to show the inbox email address to Joplin Cloud users.

![Screenshot from 2023-07-12 18-20-07](https://github.com/laurent22/joplin/assets/5051088/bbd994d5-d4f6-40c2-848d-c9b9beeb2151)

## Functionality:

When the Joplin Cloud target is selected for synchronization we will show a new section in the settings screen that will reference any settings that may involve Joplin Cloud.

For now, we will have only one section called Email to Note where the Joplin Cloud user will be able to copy the inbox email.

Every time the users open the Settings screen and the Joplin Cloud tab is visible we will check if the `emailToNote.inboxEmail` property was set in the application state, if it was not we will make a request to the server to try to get this information.

## Testing:

- Should only show the Joplin Cloud section when Joplin Cloud is selected as a synchronization target.
- Should only make a request if Joplin Cloud tab is visible and the property `emailToNote.inboxEmail` still is an empty string (default value).
- The button `Copy to clipboard` should copy the inbox email to the clipboard.
- If the user is not able to connect to Joplin Cloud the email field will be empty.