### PR TITLE
Mobile: Warn user when trying to delete a Inbox folder

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -35,6 +35,7 @@ interface Props {
 	folders: FolderEntity[];
 	opacity: number;
 	profileConfig: ProfileConfig;
+	inboxJopId: string;
 }
 
 const syncIconRotationValue = new Animated.Value(0);
@@ -136,6 +137,31 @@ const SideMenuContentComponent = (props: Props) => {
 
 		const folder = folderOrAll as FolderEntity;
 
+		const generateFolderDeletion = () => {
+			const folderDeletion = (message: string) => {
+				Alert.alert('', message, [
+					{
+						text: _('OK'),
+						onPress: () => {
+							void Folder.delete(folder.id);
+						},
+					},
+					{
+						text: _('Cancel'),
+						onPress: () => { },
+						style: 'cancel',
+					},
+				]);
+			};
+
+			if (folder.id === props.inboxJopId) {
+				return folderDeletion(
+					_('Delete the Inbox notebook?\n\nIf you delete the inbox notebook, any email that\'s recently been sent to it may be lost.')
+				);
+			}
+			return folderDeletion(_('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', folder.title));
+		};
+
 		Alert.alert(
 			'',
 			_('Notebook: %s', folder.title),
@@ -154,21 +180,7 @@ const SideMenuContentComponent = (props: Props) => {
 				},
 				{
 					text: _('Delete'),
-					onPress: () => {
-						Alert.alert('', _('Delete notebook "%s"?\n\nAll notes and sub-notebooks within this notebook will also be deleted.', folder.title), [
-							{
-								text: _('OK'),
-								onPress: () => {
-									void Folder.delete(folder.id);
-								},
-							},
-							{
-								text: _('Cancel'),
-								onPress: () => {},
-								style: 'cancel',
-							},
-						]);
-					},
+					onPress: generateFolderDeletion,
 					style: 'destructive',
 				},
 				{
@@ -516,5 +528,6 @@ export default connect((state: AppState) => {
 		isOnMobileData: state.isOnMobileData,
 		syncOnlyOverWifi: state.settings['sync.mobileWifiOnly'],
 		profileConfig: state.profileConfig,
+		inboxJopId: state.settings['emailToNote.inboxJopId'],
 	};
 })(SideMenuContentComponent);

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -117,6 +117,7 @@ import sensorInfo, { SensorInfo } from './components/biometrics/sensorInfo';
 import { getCurrentProfile } from '@joplin/lib/services/profileConfig';
 import { getDatabaseName, getProfilesRootDir, getResourceDir, setDispatch } from './services/profiles';
 import { ReactNode } from 'react';
+import inboxFolderFetcher from '@joplin/lib/utils/inboxFolderFetcher';
 
 type SideMenuPosition = 'left' | 'right';
 
@@ -635,6 +636,9 @@ async function initialize(dispatch: Function) {
 		alert(`Initialization error: ${error.message}`);
 		reg.logger().error('Initialization error:', error);
 	}
+
+	PoorManIntervals.setTimeout(() => { void inboxFolderFetcher(); }, 10000);
+	PoorManIntervals.setInterval(() => { void inboxFolderFetcher(); }, 1000 * 60 * 60);
 
 	reg.setupRecurrentSync();
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -637,7 +637,7 @@ async function initialize(dispatch: Function) {
 		reg.logger().error('Initialization error:', error);
 	}
 
-	PoorManIntervals.setTimeout(() => { void inboxFolderFetcher(); }, 10000);
+	PoorManIntervals.setTimeout(() => { void inboxFolderFetcher(); }, 30000);
 	PoorManIntervals.setInterval(() => { void inboxFolderFetcher(); }, 1000 * 60 * 60);
 
 	reg.setupRecurrentSync();

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1709,6 +1709,8 @@ class Setting extends BaseModel {
 				section: 'note',
 			},
 
+			'emailToNote.inboxJopId': { value: '', type: SettingItemType.String, public: false },
+
 		};
 
 		this.metadata_ = { ...this.buildInMetadata_ };

--- a/packages/lib/utils/inboxFolderFetcher.ts
+++ b/packages/lib/utils/inboxFolderFetcher.ts
@@ -1,0 +1,22 @@
+import SyncTargetRegistry from '../SyncTargetRegistry';
+import Setting from '../models/Setting';
+import { reg } from '../registry';
+
+const inboxFolderFetcher = async () => {
+
+	if (Setting.value('sync.target') !== SyncTargetRegistry.nameToId('joplinCloud')) {
+		return;
+	}
+
+	const syncTarget = reg.syncTarget();
+	const fileApi = await syncTarget.fileApi();
+	const api = fileApi.driver().api();
+
+	const owner = await api.exec('GET', `api/users/${api.userId}`);
+
+	if (owner.inbox) {
+		Setting.setValue('emailToNote.inboxJopId', owner.inbox.jop_id);
+	}
+};
+
+export default inboxFolderFetcher;


### PR DESCRIPTION
Related to feature https://github.com/laurent22/joplin/issues/8459

Changes the warning message when trying to delete a Inbox Folder

![Screenshot from 2023-07-12 19-18-36](https://github.com/laurent22/joplin/assets/5051088/9e38faa5-d39c-4b7e-9a4b-acd475c96b99)


## Functionality:

I'm adding a new function to `lib/utils/inboxFolderFetcher.ts` that will make a request to Joplin Cloud server if the sync target is set to Joplin Cloud.

The function will be called on 30 seconds after initialization and once every 1 hour.

The request will fetch the Inbox folder `jop_id` that will be used when the user tries to delete a folder to check if the folder that is being deleted is the Inbox one. If it is, we change the warning message to make it clear to the user what may happen if the deletion happens.

## Testing:

- Requests should only happen if the Joplin Cloud sync target is selected.
- One request should be sent after 10s of starting the desktop application if Joplin Cloud sync target is selected.
- When trying to delete the Inbox folder the user should see the inbox warning.
- When trying to delete any other type of folder the user should see the generic warning.

Inbox Warning
```
Delete the Inbox notebook?

If you delete the inbox notebook, any email that's recently been sent to it may be lost.
```

Generic Warning
```
Delete notebook "${folder.name}"?

All notes and sub-notebooks within this notebook will also be deleted.
```

