### PR TITLE
Desktop: Security: Close root electron window before unload: Prevent top-level redirection

### DIFF
--- a/packages/app-desktop/main-html.js
+++ b/packages/app-desktop/main-html.js
@@ -30,6 +30,13 @@ const { FileApiDriverLocal } = require('@joplin/lib/file-api-driver-local');
 const React = require('react');
 const nodeSqlite = require('sqlite3');
 
+// Security: If we attempt to navigate away from the root HTML page, it's likely because
+// of an improperly sanitized link. Prevent this by closing the window before we can
+// navigate away.
+window.onbeforeunload = () => {
+	window.close();
+};
+
 if (bridge().env() === 'dev') {
 	const newConsole = function(oldConsole) {
 		const output = {};


### PR DESCRIPTION
# Summary

This pull request makes it safer to click on links in notes from untrusted sources (which users should still avoid doing!).

Previously, if a malicious link managed to pass the [HTML sanitizer](https://github.com/laurent22/joplin/blob/8d3f60ed1f83ac3440d3955a7f428186f8081f52/packages/renderer/htmlUtils.ts#L170), it could potentially redirect the root electron window to a different URL (which is very bad).
