### PR TITLE
Desktop: Security: Disallow map and area tags

### DIFF
--- a/packages/app-cli/tests/md_to_html/sanitize_16.html
+++ b/packages/app-cli/tests/md_to_html/sanitize_16.html
@@ -1,1 +1,1 @@
-<map name="test" class="jop-noMdConv"><area coords="0,0,1000,1000" href="#" class="jop-noMdConv"/></map><img usemap="#test" src="https://github.com/Ry0taK.png" class="jop-noMdConv"/>
+<img usemap="#test" src="https://github.com/Ry0taK.png" class="jop-noMdConv"/>

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -308,7 +308,7 @@ class HtmlUtils {
 				// The Markdown sanitization code can result in calls like this:
 				//     sanitizeHtml('<invlaid>')
 				//     sanitizeHtml('</invalid>')
-				// Thus, we need ot be able to remove '</invalid>'), even if there is no
+				// Thus, we need to be able to remove '</invalid>', even if there is no
 				// corresponding opening tag.
 				if (disallowedTags.includes(current) || disallowedTags.includes(name)) {
 					if (disallowedTagDepth > 0) {


### PR DESCRIPTION
# Summary

Disallows `<map/>` and `<area/>` tags in rendered markdown.

Note: Moved to the public repository at request.
<!-- Moved to the public repository at the request of @ laurent22 -->