### PR TITLE
Mobile: Fixes #8381: Show warning if some items could not be decrypted

### DIFF
--- a/packages/app-mobile/components/ScreenHeader.tsx
+++ b/packages/app-mobile/components/ScreenHeader.tsx
@@ -81,6 +81,7 @@ interface ScreenHeaderProps {
 	historyCanGoBack?: boolean;
 	showMissingMasterKeyMessage?: boolean;
 	hasDisabledSyncItems?: boolean;
+	hasDisabledEncryptionItems?: boolean;
 	shouldUpgradeSyncTarget?: boolean;
 	showShouldUpgradeSyncTargetMessage?: boolean;
 
@@ -543,6 +544,10 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		if (this.props.hasDisabledSyncItems) warningComps.push(this.renderWarningBox('Status', _('Some items cannot be synchronised. Press for more info.')));
 		if (this.props.shouldUpgradeSyncTarget && this.props.showShouldUpgradeSyncTargetMessage !== false) warningComps.push(this.renderWarningBox('UpgradeSyncTarget', _('The sync target needs to be upgraded. Press this banner to proceed.')));
 
+		if (this.props.hasDisabledEncryptionItems) {
+			warningComps.push(this.renderWarningBox('Status', _('Some items cannot be decrypted.')));
+		}
+
 		const showSideMenuButton = !!this.props.showSideMenuButton && !this.props.noteSelectionEnabled;
 		const showSelectAllButton = this.props.noteSelectionEnabled;
 		const showSearchButton = !!this.props.showSearchButton && !this.props.noteSelectionEnabled;
@@ -629,6 +634,7 @@ const ScreenHeader = connect((state: State) => {
 		locale: state.settings.locale,
 		folders: state.folders,
 		themeId: state.settings.theme,
+		hasDisabledEncryptionItems: state.hasDisabledEncryptionItems,
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		selectedNoteIds: state.selectedNoteIds,
 		showMissingMasterKeyMessage: showMissingMasterKeyMessage(syncInfo, state.notLoadedMasterKeys),


### PR DESCRIPTION
# Summary
This pull request shows a "Some items could not be decrypted" warning that, when clicked, opens the sync status page.

# Screenshot
!["some items could not be decrypted" banner at the top of the screen](https://github.com/laurent22/joplin/assets/46334387/18cbde39-050b-45a3-8a91-99c4d141dbc6)

This should partially resolve #8381.

# Testing
This pull request has been manually tested on Android.

The steps for testing it are
1. Set up sync on a mobile device and enable encryption (in dev mode)
2. Add another device ("device 2") to the sync target and enable encryption (also in dev mode)
3. Temporarily remove `EncryptionMethod.SJCL1b` from the [valid decryption methods list](https://github.com/laurent22/joplin/blob/8d3f60ed1f83ac3440d3955a7f428186f8081f52/packages/lib/services/e2ee/EncryptionService.ts#L658), rebuild, and rerun.
4. Create a new note on device 2 and sync it to device 1.

After step 4 (and possibly retrying sync a few times), the "some items could not be decrypted" banner should be visible on the device.