### PR TITLE
Chore: Fix failing CodeMirror test

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.test.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.test.ts
@@ -17,6 +17,7 @@ const createEditorSettings = (themeId: number) => {
 	const editorSettings: EditorSettings = {
 		katexEnabled: true,
 		spellcheckEnabled: true,
+		readOnly: false,
 		themeId,
 		themeData,
 	};


### PR DESCRIPTION
# Summary
https://github.com/laurent22/joplin/commit/77482a0c956987434a4e1f7d645aeec8d51292eb added a new required property to the mobile CodeMirror settings type, but did not update the corresponding test, causing tests to fail. 