### PR TITLE
Mobile: Fixes #8211: Do not log data shared with the app

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -912,8 +912,6 @@ class AppComponent extends React.Component {
 	private async handleShareData() {
 		const sharedData = await ShareExtension.data();
 
-		logger.info('Sharing: handleShareData:', sharedData);
-
 		if (sharedData) {
 			reg.logger().info('Received shared data');
 			if (this.props.selectedFolderId) {
@@ -922,6 +920,8 @@ class AppComponent extends React.Component {
 			} else {
 				reg.logger().info('Cannot handle share - default folder id is not set');
 			}
+		} else {
+			logger.info('Sharing: received empty share data.');
 		}
 	}
 


### PR DESCRIPTION
# Summary
- Removes the `logger.info` call that added data shared with the app to the log.
- This **partially** resolves #8211. To fully resolve the issue, data previously shared with the app needs to be removed from existing logs (or not included in exported log data).