### PR TITLE
Mobile: Resolves #8490: Add option to autodetect theme

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -443,6 +443,7 @@ packages/app-mobile/tools/buildInjectedJs.js
 packages/app-mobile/utils/ShareExtension.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
+packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/checkPermissions.js
 packages/app-mobile/utils/createRootStyle.js
 packages/app-mobile/utils/debounce.js

--- a/.gitignore
+++ b/.gitignore
@@ -428,6 +428,7 @@ packages/app-mobile/tools/buildInjectedJs.js
 packages/app-mobile/utils/ShareExtension.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
+packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/checkPermissions.js
 packages/app-mobile/utils/createRootStyle.js
 packages/app-mobile/utils/debounce.js

--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -15,7 +15,7 @@ interface FolderPickerProps {
 	folders: FolderEntity[];
 	placeholder?: string;
 	darkText?: boolean;
-	themeId?: string;
+	themeId?: number;
 }
 
 

--- a/packages/app-mobile/components/ScreenHeader.tsx
+++ b/packages/app-mobile/components/ScreenHeader.tsx
@@ -86,6 +86,7 @@ interface ScreenHeaderProps {
 	shouldUpgradeSyncTarget?: boolean;
 	showShouldUpgradeSyncTargetMessage?: boolean;
 
+	themeId: number;
 }
 
 interface ScreenHeaderState {
@@ -100,7 +101,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 	}
 
 	private styles() {
-		const themeId = Setting.value('theme');
+		const themeId = this.props.themeId;
 		if (this.cachedStyles[themeId]) return this.cachedStyles[themeId];
 		this.cachedStyles = {};
 
@@ -297,7 +298,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 	}
 
 	public render() {
-		const themeId = Setting.value('theme');
+		const themeId = this.props.themeId;
 		function sideMenuButton(styles: any, onPress: OnPressCallback) {
 			return (
 				<TouchableOpacity

--- a/packages/app-mobile/ios/Joplin/Info.plist
+++ b/packages/app-mobile/ios/Joplin/Info.plist
@@ -104,7 +104,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSFaceIDUsageDescription</key>

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -118,7 +118,7 @@ import { getCurrentProfile } from '@joplin/lib/services/profileConfig';
 import { getDatabaseName, getProfilesRootDir, getResourceDir, setDispatch } from './services/profiles';
 import { ReactNode } from 'react';
 import { parseShareCache } from '@joplin/lib/services/share/reducer';
-import autodetectTheme from './utils/autodetectTheme';
+import autodetectTheme, { onSystemColorSchemeChange } from './utils/autodetectTheme';
 
 type SideMenuPosition = 'left' | 'right';
 
@@ -857,8 +857,12 @@ class AppComponent extends React.Component {
 		});
 
 		this.appStateChangeListener_ = RNAppState.addEventListener('change', this.onAppStateChange_);
-		this.themeChangeListener_ = Appearance.addChangeListener(() => autodetectTheme());
 		this.unsubscribeScreenWidthChangeHandler_ = Dimensions.addEventListener('change', this.handleScreenWidthChange_);
+
+		this.themeChangeListener_ = Appearance.addChangeListener(
+			({ colorScheme }) => onSystemColorSchemeChange(colorScheme)
+		);
+		onSystemColorSchemeChange(Appearance.getColorScheme());
 
 		setupQuickActions(this.props.dispatch, this.props.selectedFolderId);
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -190,7 +190,7 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 	if (
 		action.type === 'AUTODETECT_THEME'
 		|| action.type === 'SETTING_UPDATE_ALL'
-		|| (action.type === 'SETTING_UPDATE_ONE' && ['themeAutoDetect', 'theme', 'preferredLightTheme', 'preferredDarkTheme'].includes(action.key))
+		|| (action.type === 'SETTING_UPDATE_ONE' && ['themeAutoDetect', 'preferredLightTheme', 'preferredDarkTheme'].includes(action.key))
 	) {
 		autodetectTheme();
 	}
@@ -686,8 +686,6 @@ async function initialize(dispatch: Function) {
 	// and it cannot collect anything when the app is not active.
 	RevisionService.instance().runInBackground(1000 * 30);
 
-	Appearance.addChangeListener(() => autodetectTheme());
-
 	// ----------------------------------------------------------------------------
 	// Keep this below to test react-native-rsa-native
 	// ----------------------------------------------------------------------------
@@ -723,6 +721,7 @@ class AppComponent extends React.Component {
 
 	private urlOpenListener_: EmitterSubscription|null = null;
 	private appStateChangeListener_: NativeEventSubscription|null = null;
+	private themeChangeListener_: NativeEventSubscription|null = null;
 
 	public constructor() {
 		super();
@@ -858,6 +857,7 @@ class AppComponent extends React.Component {
 		});
 
 		this.appStateChangeListener_ = RNAppState.addEventListener('change', this.onAppStateChange_);
+		this.themeChangeListener_ = Appearance.addChangeListener(() => autodetectTheme());
 		this.unsubscribeScreenWidthChangeHandler_ = Dimensions.addEventListener('change', this.handleScreenWidthChange_);
 
 		setupQuickActions(this.props.dispatch, this.props.selectedFolderId);
@@ -877,6 +877,11 @@ class AppComponent extends React.Component {
 		if (this.urlOpenListener_) {
 			this.urlOpenListener_.remove();
 			this.urlOpenListener_ = null;
+		}
+
+		if (this.themeChangeListener_) {
+			this.themeChangeListener_.remove();
+			this.themeChangeListener_ = null;
 		}
 
 		if (this.unsubscribeScreenWidthChangeHandler_) {

--- a/packages/app-mobile/utils/autodetectTheme.ts
+++ b/packages/app-mobile/utils/autodetectTheme.ts
@@ -1,8 +1,20 @@
 import Logger from '@joplin/lib/Logger';
 import Setting from '@joplin/lib/models/Setting';
-import { Appearance } from 'react-native';
+import { Appearance, ColorSchemeName } from 'react-native';
 
 const logger = Logger.create('autodetectTheme');
+
+let systemColorScheme: ColorSchemeName|null = null;
+
+// We export an `onThemeChange`, rather than using `Appearance.getColorScheme()` directly
+// to work around https://github.com/facebook/react-native/issues/36061. On some devices,
+// `Appearance.getColorScheme()` returns incorrect values.
+export const onSystemColorSchemeChange = (newColorScheme: ColorSchemeName|null) => {
+	if (systemColorScheme !== newColorScheme) {
+		systemColorScheme = newColorScheme;
+		autodetectTheme();
+	}
+};
 
 const autodetectTheme = () => {
 	if (!Setting.value('themeAutoDetect')) {
@@ -10,8 +22,11 @@ const autodetectTheme = () => {
 		return;
 	}
 
-	const colorScheme = Appearance.getColorScheme();
-	logger.info('System colorScheme changed to ', colorScheme);
+	const colorScheme = systemColorScheme;
+	logger.debug(
+		'Autodetecting theme. getColorScheme returns', Appearance.getColorScheme(),
+		'and the expected theme is', systemColorScheme
+	);
 
 	if (colorScheme === 'dark') {
 		Setting.setValue('theme', Setting.value('preferredDarkTheme'));

--- a/packages/app-mobile/utils/autodetectTheme.ts
+++ b/packages/app-mobile/utils/autodetectTheme.ts
@@ -7,6 +7,7 @@ const logger = Logger.create('autodetectTheme');
 const autodetectTheme = () => {
 	if (!Setting.value('themeAutoDetect')) {
 		logger.info('Theme autodetect disabled, not switching theme to match system.');
+		return;
 	}
 
 	const colorScheme = Appearance.getColorScheme();

--- a/packages/app-mobile/utils/autodetectTheme.ts
+++ b/packages/app-mobile/utils/autodetectTheme.ts
@@ -1,0 +1,14 @@
+import Setting from '@joplin/lib/models/Setting';
+import { Appearance } from 'react-native';
+
+const autodetectTheme = () => {
+	if (!Setting.value('themeAutoDetect')) return;
+
+	if (Appearance.getColorScheme() === 'dark') {
+		Setting.setValue('theme', Setting.value('preferredDarkTheme'));
+	} else {
+		Setting.setValue('theme', Setting.value('preferredLightTheme'));
+	}
+};
+
+export default autodetectTheme;

--- a/packages/app-mobile/utils/autodetectTheme.ts
+++ b/packages/app-mobile/utils/autodetectTheme.ts
@@ -1,10 +1,18 @@
+import Logger from '@joplin/lib/Logger';
 import Setting from '@joplin/lib/models/Setting';
 import { Appearance } from 'react-native';
 
-const autodetectTheme = () => {
-	if (!Setting.value('themeAutoDetect')) return;
+const logger = Logger.create('autodetectTheme');
 
-	if (Appearance.getColorScheme() === 'dark') {
+const autodetectTheme = () => {
+	if (!Setting.value('themeAutoDetect')) {
+		logger.info('Theme autodetect disabled, not switching theme to match system.');
+	}
+
+	const colorScheme = Appearance.getColorScheme();
+	logger.info('System colorScheme changed to ', colorScheme);
+
+	if (colorScheme === 'dark') {
 		Setting.setValue('theme', Setting.value('preferredDarkTheme'));
 	} else {
 		Setting.setValue('theme', Setting.value('preferredLightTheme'));

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -6,4 +6,5 @@ export interface AppState extends State {
 	route: any;
 	smartFilterId: string;
 	noteSideMenuOptions: any;
+	themeId: number;
 }

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -840,7 +840,7 @@ class Setting extends BaseModel {
 				value: false,
 				type: SettingItemType.Bool,
 				section: 'appearance',
-				appTypes: [AppType.Desktop],
+				appTypes: [AppType.Mobile, AppType.Desktop],
 				public: true,
 				label: () => _('Automatically switch theme to match system theme'),
 				storage: SettingStorage.File,
@@ -854,7 +854,7 @@ class Setting extends BaseModel {
 				show: (settings) => {
 					return settings['themeAutoDetect'];
 				},
-				appTypes: [AppType.Desktop],
+				appTypes: [AppType.Mobile, AppType.Desktop],
 				isEnum: true,
 				label: () => _('Preferred light theme'),
 				section: 'appearance',
@@ -870,7 +870,7 @@ class Setting extends BaseModel {
 				show: (settings) => {
 					return settings['themeAutoDetect'];
 				},
-				appTypes: [AppType.Desktop],
+				appTypes: [AppType.Mobile, AppType.Desktop],
 				isEnum: true,
 				label: () => _('Preferred dark theme'),
 				section: 'appearance',


### PR DESCRIPTION
# Summary
This shows the "automatically switch theme to match system theme" desktop app setting in the mobile app and makes it functional.

At present, this setting is disabled by default, as it is in the desktop. However, it may make more sense to make this setting enabled by default.

# Screenshots

Setting disabled:
<img src="https://github.com/laurent22/joplin/assets/46334387/c55c1511-0c19-4bc3-9c41-c4f245a9eb48" width="250"/>

Setting enabled:
<img src="https://github.com/laurent22/joplin/assets/46334387/a5ea83de-7bc5-44b2-b65b-fa5a29737eed" width="250"/>

# Testing plan
This pull request needs to be tested manually. So far, it has been tested on
- [x] Android
- [x] iOS

To test:
1. Verify the previous functionality (themeAutoDetect=false) still works
      - Launch the app
      - Close the app
      - Launch the app again
      - Change the system theme (from light to dark or dark to light)
2. Verify that the preferred light and dark themes are switched to
      - Launch the app
      - Open settings
      - Enable "automatically switch theme to match system theme" and save
      - Change the system theme
      - Change the preferred light theme
      - Change the preferred dark theme
      - Restart the app
      - Change the system theme
      - Disable "automatically switch theme to match system theme"

# Notes
The implementation of this feature is modeled on the corresponding implementation in the desktop app and thus, this implementation is also impacted by https://github.com/laurent22/joplin/issues/8500.

Resolves #8490.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
