### PR TITLE
Desktop: Fixes #8504: Support FontAwesome icons in the WYSIWYG toolbar

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -479,6 +479,21 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox-tinymce {
 				border-top: none !important;
 			}
+			
+			/* Re-override Font Awesome styles that are otherwise overridden by TinyMCE: */
+			.plugin-icon.fa, .plugin-icon.far, .plugin-icon.fas {
+				font-family: "Font Awesome 5 Free";
+				font-size: 20px;
+			}
+			
+			.plugin-icon.fa, .plugin-icon.fas {
+				font-weight: 900;
+			}
+
+			.plugin-icon.fab, .plugin-icon.far {
+				font-weight: 400;
+			}
+
 
 			.joplin-tinymce .tox-toolbar__group {
 				background-color: ${theme.backgroundColor3};
@@ -631,9 +646,16 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					});
 
 					for (const pluginCommandName of pluginCommandNames) {
+						const iconClassName = CommandService.instance().iconName(pluginCommandName);
+
+						// Only allow characters that appear in Font Awesome class names: letters, spaces, and dashes.
+						const safeIconClassName = iconClassName.replace(/[^a-z0-9 -]/g, '');
+
+						editor.ui.registry.addIcon(pluginCommandName, `<i class="plugin-icon ${safeIconClassName}"></i>`);
+
 						editor.ui.registry.addButton(pluginCommandName, {
 							tooltip: CommandService.instance().label(pluginCommandName),
-							icon: CommandService.instance().iconName(pluginCommandName, 'tinymce'),
+							icon: pluginCommandName,
 							onAction: function() {
 								void CommandService.instance().execute(pluginCommandName);
 							},

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -479,8 +479,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			.tox-tinymce {
 				border-top: none !important;
 			}
-			
-			/* Re-override Font Awesome styles that are otherwise overridden by TinyMCE: */
+
+			/* Override the TinyMCE font styles with more specific CSS selectors.
+			   Without this, the built-in FontAwesome styles are not applied because
+			   they are overridden by TinyMCE. */
 			.plugin-icon.fa, .plugin-icon.far, .plugin-icon.fas {
 				font-family: "Font Awesome 5 Free";
 				font-size: 20px;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -485,7 +485,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			   they are overridden by TinyMCE. */
 			.plugin-icon.fa, .plugin-icon.far, .plugin-icon.fas {
 				font-family: "Font Awesome 5 Free";
-				font-size: 20px;
+				font-size: ${theme.toolbarHeight - theme.toolbarPadding}px;
 			}
 			
 			.plugin-icon.fa, .plugin-icon.fas {

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -43,11 +43,6 @@ export interface CommandDeclaration {
 	// All free Font Awesome icons are available: https://fontawesome.com/icons?d=gallery&m=free
 	iconName?: string;
 
-	// Will be used by TinyMCE (which doesn't support Font Awesome icons).
-	// Defaults to the "preferences" icon (a cog) if not specified.
-	// https://www.tiny.cloud/docs/advanced/editor-icon-identifiers/
-	tinymceIconName?: string;
-
 	// Same as `role` key in Electron MenuItem:
 	// https://www.electronjs.org/docs/api/menu-item#new-menuitemoptions
 	// Note that due to a bug in Electron, menu items with a role cannot
@@ -296,10 +291,10 @@ export default class CommandService extends BaseService {
 		}
 	}
 
-	public iconName(commandName: string, variant: string = null): string {
+	public iconName(commandName: string): string {
 		const command = this.commandByName(commandName);
 		if (!command) throw new Error(`No such command: ${commandName}`);
-		if (variant === 'tinymce') return command.declaration.tinymceIconName ? command.declaration.tinymceIconName : 'preferences';
+
 		return command.declaration.iconName;
 	}
 


### PR DESCRIPTION
# Summary

Allows plugins to use FontAwesome icons in the TinyMCE toolbar.

Fixes #8504.

# Notes
- This pull request passes HTML data as the second argument to `editor.ui.registry.addIcon`, rather than SVG data. While this seems to work in both TinyMCE 5 and 6, `editor.ui.registry.addIcon` is documented to accept **SVG, not HTML data**.
- If the TinyMCE editor is open on application startup, #8518 is still an issue.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
