### PR TITLE
Desktop: Fixes #8520: Fix WYSIWYG theme not matching the system theme after several global theme changes

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -694,17 +694,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	const documentScriptElements: Record<string, HTMLScriptElement> = {};
 
 	const loadDocumentAssets = (editor: any, pluginAssets: any[]) => {
-		// Note: The way files are cached is not correct because it assumes there's only one version
-		// of each file. However, when the theme change, a new CSS file, specific to the theme, is
-		// created. That file should not be loaded on top of the previous one, but as a replacement.
-		// Otherwise it would do this:
-		// - Try to load CSS for theme 1 => OK
-		// - Try to load CSS for theme 2 => OK
-		// - Try to load CSS for theme 1 => Skip because the file is in cache. As a result, theme 2
-		//                                  incorrectly stay.
-		// The fix would be to make allAssets() return a name and a version for each asset. Then the loading
-		// code would check this and either append the CSS or replace.
-
 		const theme = themeStyle(props.themeId);
 
 		let docHead_: any = null;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -690,6 +690,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	// Set the initial content and load the plugin CSS and JS files
 	// -----------------------------------------------------------------------------------------
 
+	const documentCssElements: Record<string, HTMLLinkElement> = {};
+	const documentScriptElements: Record<string, HTMLScriptElement> = {};
+
 	const loadDocumentAssets = (editor: any, pluginAssets: any[]) => {
 		// Note: The way files are cached is not correct because it assumes there's only one version
 		// of each file. However, when the theme change, a new CSS file, specific to the theme, is
@@ -712,49 +715,72 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			return docHead_;
 		}
 
-		const cssFiles = [
+		const allCssFiles = [
 			`${bridge().vendorDir()}/lib/@fortawesome/fontawesome-free/css/all.min.css`,
 			`gui/note-viewer/pluginAssets/highlight.js/${theme.codeThemeCss}`,
 		].concat(
 			pluginAssets
 				.filter((a: any) => a.mime === 'text/css')
 				.map((a: any) => a.path)
-		).filter((path: string) => !loadedCssFiles_.includes(path));
+		);
 
-		const jsFiles = [].concat(
+		const allJsFiles = [].concat(
 			pluginAssets
 				.filter((a: any) => a.mime === 'application/javascript')
 				.map((a: any) => a.path)
-		).filter((path: string) => !loadedJsFiles_.includes(path));
+		);
 
-		for (const cssFile of cssFiles) loadedCssFiles_.push(cssFile);
-		for (const jsFile of jsFiles) loadedJsFiles_.push(jsFile);
+
+		// Remove all previously loaded files that aren't in the assets this time.
+		// Note: This is important to ensure that we properly change themes.
+		// See https://github.com/laurent22/joplin/issues/8520
+		for (const cssFile of loadedCssFiles_) {
+			if (!allCssFiles.includes(cssFile)) {
+				documentCssElements[cssFile]?.remove();
+				delete documentCssElements[cssFile];
+			}
+		}
+
+		for (const jsFile of loadedJsFiles_) {
+			if (!allJsFiles.includes(jsFile)) {
+				documentScriptElements[jsFile]?.remove();
+				delete documentScriptElements[jsFile];
+			}
+		}
+
+		const newCssFiles = allCssFiles.filter((path: string) => !loadedCssFiles_.includes(path));
+		const newJsFiles = allJsFiles.filter((path: string) => !loadedJsFiles_.includes(path));
+
+		loadedCssFiles_ = allCssFiles;
+		loadedJsFiles_ = allJsFiles;
 
 		// console.info('loadDocumentAssets: files to load', cssFiles, jsFiles);
 
-		if (cssFiles.length) {
-			for (const cssFile of cssFiles) {
-				const script = editor.dom.create('link', {
+		if (newCssFiles.length) {
+			for (const cssFile of newCssFiles) {
+				const style = editor.dom.create('link', {
 					rel: 'stylesheet',
 					type: 'text/css',
 					href: cssFile,
 					class: 'jop-tinymce-css',
 				});
 
-				docHead().appendChild(script);
+				documentCssElements[cssFile] = style;
+				docHead().appendChild(style);
 			}
 		}
 
-		if (jsFiles.length) {
+		if (newJsFiles.length) {
 			const editorElementId = editor.dom.uniqueId();
 
-			for (const jsFile of jsFiles) {
+			for (const jsFile of newJsFiles) {
 				const script = editor.dom.create('script', {
 					id: editorElementId,
 					type: 'text/javascript',
 					src: jsFile,
 				});
 
+				documentScriptElements[jsFile] = script;
 				docHead().appendChild(script);
 			}
 		}


### PR DESCRIPTION
# Summary
After changing the system theme from light to dark and dark back to light, the TinyMCE theme could previously not match the system theme.

Fixes #8520.

# Testing plan
1. Enable "Automatically switch theme to match system theme"
2. Open the rich text editor
3. Create a note with math and code blocks
4. Toggle system dark mode
5. Toggle system dark mode
6. Toggle system dark mode
7. Add more math and code blocks

After all steps, the rich text editor theme should match the system theme. In step 7, new math blocks should render.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
