### PR TITLE
Desktop: Fixes #8530: Rich text editor: Use fewer `&nbsp;`s in markdown while still preserving initial paragraph indentation

### DIFF
--- a/packages/app-cli/tests/html_to_md/bold_italic_with_spaces.md
+++ b/packages/app-cli/tests/html_to_md/bold_italic_with_spaces.md
@@ -1,1 +1,1 @@
-   **A test...** Test
+&nbsp;  **A test...** Test

--- a/packages/app-cli/tests/html_to_md/bold_italic_with_spaces.md
+++ b/packages/app-cli/tests/html_to_md/bold_italic_with_spaces.md
@@ -1,1 +1,1 @@
-&nbsp; &nbsp;**A test...**&nbsp;Test
+   **A test...** Test

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp, htmlEscapeLeadingNonbreakingSpace } from './utilities'
+import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp } from './utilities'
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = (new Entities()).encode;
 

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp } from './utilities'
+import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp, htmlEscapeLeadingNonbreakingSpace } from './utilities'
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = (new Entities()).encode;
 
@@ -32,7 +32,7 @@ rules.paragraph = {
     const leadingNonbreakingSpace = /^\u{00A0}/ug;
     content = content.replace(leadingNonbreakingSpace, '&nbsp;');
 
-    return '\n\n' + htmlEscapeLeadingNonbreakingSpace(content) + '\n\n'
+    return '\n\n' + content + '\n\n'
   }
 }
 

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp } from './utilities'
+import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp, htmlEscapeLeadingNonbreakingSpace } from './utilities'
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = (new Entities()).encode;
 
@@ -25,7 +25,14 @@ rules.paragraph = {
   filter: 'p',
 
   replacement: function (content) {
-    return '\n\n' + content + '\n\n'
+    // If the line starts with a nonbreaking space, replace it. By default, the
+    // markdown renderer removes leading non-HTML-escaped nonbreaking spaces. However,
+    // because the space is nonbreaking, we want to keep it.
+    // \u00A0 is a nonbreaking space.
+    const leadingNonbreakingSpace = /^\u{00A0}/ug;
+    content = content.replace(leadingNonbreakingSpace, '&nbsp;');
+
+    return '\n\n' + htmlEscapeLeadingNonbreakingSpace(content) + '\n\n'
   }
 }
 

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -36,10 +36,7 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     anchorNames: [],
     br: '  ',
-
-    // Unicode representation of &nbsp;
-    nonbreakingSpace: '\u00A0',
-    
+    nonbreakingSpace: '\u00A0', // unicode for &nbsp;
     disableEscapeContent: false,
     preformattedCode: false,
     blankReplacement: function (content, node) {

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -36,7 +36,10 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     anchorNames: [],
     br: '  ',
-    nonbreakingSpace: '&nbsp;',
+
+    // Unicode representation of &nbsp;
+    nonbreakingSpace: '\u00A0',
+    
     disableEscapeContent: false,
     preformattedCode: false,
     blankReplacement: function (content, node) {

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -36,7 +36,6 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     anchorNames: [],
     br: '  ',
-    nonbreakingSpace: '\u00A0', // unicode for &nbsp;
     disableEscapeContent: false,
     preformattedCode: false,
     blankReplacement: function (content, node) {
@@ -216,15 +215,10 @@ function replacementForNode (node) {
   var whitespace = node.flankingWhitespace
   if (whitespace.leading || whitespace.trailing) content = content.trim()
 
-  const replaceNonbreakingSpaces = space => {
-    // \u{00A0} is a nonbreaking space
-    return space.replace(/\u{00A0}/ug, this.options.nonbreakingSpace);
-  };
-
   return (
-    replaceNonbreakingSpaces(whitespace.leading) +
-    replaceNonbreakingSpaces(rule.replacement(content, node, this.options)) +
-    replaceNonbreakingSpaces(whitespace.trailing)
+    whitespace.leading +
+    rule.replacement(content, node, this.options) +
+    whitespace.trailing
   )
 }
 

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -36,6 +36,7 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     anchorNames: [],
     br: '  ',
+    nonbreakingSpace: '\u00A0', // unicode for &nbsp;
     disableEscapeContent: false,
     preformattedCode: false,
     blankReplacement: function (content, node) {
@@ -215,10 +216,15 @@ function replacementForNode (node) {
   var whitespace = node.flankingWhitespace
   if (whitespace.leading || whitespace.trailing) content = content.trim()
 
+  const replaceNonbreakingSpaces = space => {
+    // \u{00A0} is a nonbreaking space
+    return space.replace(/\u{00A0}/ug, this.options.nonbreakingSpace);
+  };
+
   return (
-    whitespace.leading +
-    rule.replacement(content, node, this.options) +
-    whitespace.trailing
+    replaceNonbreakingSpaces(whitespace.leading) +
+    replaceNonbreakingSpaces(rule.replacement(content, node, this.options)) +
+    replaceNonbreakingSpaces(whitespace.trailing)
   )
 }
 


### PR DESCRIPTION
# Summary
This partially reverts a change made in https://github.com/laurent22/joplin/pull/8468. This should fix #8530.

Before #8468, `turndown` replaced HTML nonbreaking spaces with their corresponding unicode characters. After, `turndown` replaced nonbreaking spaces with the HTML escape `&nbsp;`.

While this fixes an issue where leading spaces would disappear from paragraph blocks when switching notes, it makes markdown much more difficult to read. For example,
```
&nbsp; &nbsp; This is a test.&nbsp;
```
instead of
```
    This is a test. 
```
(some of the above spaces are nonbreaking).

This pull request mostly reverts this change by only replacing the **first** nonbreaking space with an HTML escape sequence:
```
&nbsp;   This is a test. 
```
When rendered, this preserves the leading indentation while minimizing HTML-escaped `&nbsp;`s.

(A leading HTML-escaped `&nbsp;` seems to be necessary to preserve indentation).

# Testing
This pull request does have an automated test. However, it can be tested manually. To do so,
1. Open the rich text editor.
2. Create a new paragraph with leading spaces (e.g. `    this is a test`).
3. Switch to the markdown editor
4. Switch back to the rich text editor

In step 3, the markdown should only have a single `&nbsp;` ­— the leading space. In step 4, the paragraph should still have leading spaces.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
