### PR TITLE
Desktop: Rich text editor: Disable spellcheck in inline code blocks

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -582,6 +582,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					joplinInsert: { inline: 'ins', remove: 'all' },
 					joplinSub: { inline: 'sub', remove: 'all' },
 					joplinSup: { inline: 'sup', remove: 'all' },
+					code: { inline: 'code', remove: 'all', attributes: { spellcheck: false } },
 				},
 				setup: (editor: Editor) => {
 					editor.addCommand('joplinAttach', () => {
@@ -673,7 +674,17 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						setEditorReady(true);
 					});
 
+					const preprocessContent = () => {
+						// Disable spellcheck for all inline code blocks.
+						const codeElements = editor.dom.doc.querySelectorAll('code.inline-code');
+						for (const code of codeElements) {
+							code.setAttribute('spellcheck', 'false');
+						}
+					};
+
 					editor.on('SetContent', () => {
+						preprocessContent();
+
 						props_onMessage.current({ channel: 'noteRenderComplete' });
 					});
 				},


### PR DESCRIPTION
# Summary

This pull request disables spellcheck in inline code blocks in the rich text editor (matching the behavior of spellcheck in the mobile app).

This should partially resolve https://discourse.joplinapp.org/t/spell-check-in-inline-code/31785

**Note**: This may not be functionality that we want. If so, feel free to close the pull request.

# Testing

1. Open the rich text editor
2. Create an inline codeblock with a misspelling
3. Write text outside of the inline code block without a misspelling
4. Switch to the markdown editor, then back to the rich text editor.
5. Edit the line with the codeblock (preserve the misspelling)
6. Edit the other line with a misspelling (preserve the misspelling).

After steps 5 and 6, only the non-codeblock text should be marked as misspelled. The same should be true after steps 2 and 3.