### PR TITLE
Desktop: Fixes #6055: Preserve empty newlines created by pressing Enter repeatedly in the rich text editor

### DIFF
--- a/packages/app-cli/tests/html_to_md/paragraph_with_nonbreaking_space.html
+++ b/packages/app-cli/tests/html_to_md/paragraph_with_nonbreaking_space.html
@@ -1,0 +1,3 @@
+<p>Paragraphs with a single nonbreaking space should be preserved:</p>
+<p>&nbsp;</p>
+<p>&nbsp;</p>

--- a/packages/app-cli/tests/html_to_md/paragraph_with_nonbreaking_space.md
+++ b/packages/app-cli/tests/html_to_md/paragraph_with_nonbreaking_space.md
@@ -1,0 +1,5 @@
+Paragraphs with a single nonbreaking space should be preserved:
+
+&nbsp;
+
+&nbsp;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -578,8 +578,12 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
 				plugins: 'noneditable link joplinLists hr searchreplace codesample table',
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
-				// Note: Replacing valid_elements breaks empty paragraph elements.
-				extended_valid_elements: '*[*]', // We already filter in sanitize_html
+
+				// #p: Pad empty paragraphs with &nbsp; to prevent them from being removed.
+				// *[*]: Allow all elements and attributes -- we already filter in sanitize_html
+				// See https://www.tiny.cloud/docs/configure/content-filtering/#controlcharacters
+				valid_elements: '#p,*[*]',
+
 				menubar: false,
 				relative_urls: false,
 				branding: false,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -91,7 +91,7 @@ let dispatchDidUpdateIID_: any = null;
 let changeId_ = 1;
 
 const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
-	const [editor, setEditor] = useState(null);
+	const [editor, setEditor] = useState<Editor|null>(null);
 	const [scriptLoaded, setScriptLoaded] = useState(false);
 	const [editorReady, setEditorReady] = useState(false);
 	const [draggingStarted, setDraggingStarted] = useState(false);
@@ -578,7 +578,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
 				plugins: 'noneditable link joplinLists hr searchreplace codesample table',
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
-				valid_elements: '*[*]', // We already filter in sanitize_html
+				// Note: Replacing valid_elements breaks empty paragraph elements.
+				extended_valid_elements: '*[*]', // We already filter in sanitize_html
 				menubar: false,
 				relative_urls: false,
 				branding: false,

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp, htmlEscapeLeadingNonbreakingSpace } from './utilities'
+import { repeat, isCodeBlockSpecialCase1, isCodeBlockSpecialCase2, isCodeBlock, getStyleProp } from './utilities'
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = (new Entities()).encode;
 

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -32,6 +32,12 @@ rules.paragraph = {
     const leadingNonbreakingSpace = /^\u{00A0}/ug;
     content = content.replace(leadingNonbreakingSpace, '&nbsp;');
 
+    // Paragraphs that are truly empty (not even containing nonbreaking spaces)
+    // take up by default no space. Output nothing.
+    if (content === '') {
+      return '';
+    }
+
     return '\n\n' + content + '\n\n'
   }
 }

--- a/packages/turndown/src/utilities.js
+++ b/packages/turndown/src/utilities.js
@@ -53,7 +53,7 @@ export function hasVoid (node) {
 
 var meaningfulWhenBlankElements = [
   'A', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TH', 'TD', 'IFRAME', 'SCRIPT',
-  'AUDIO', 'VIDEO'
+  'AUDIO', 'VIDEO', 'P'
 ]
 
 export function isMeaningfulWhenBlank (node) {


### PR DESCRIPTION
# Summary
Fixes #6055.

TinyMCE was outputting `<p></p>` for empty newlines, which is both ignored by `turndown` and renders to an element with zero height.

Using `extended_valid_elements` rather than `valid_elements` to allow additional HTML elements, however, causes TinyMCE to output `<p>&nbsp;</p>` instead. This can be handled by TinyMCE without breaking existing tests that rely on TinyMCE ignoring empty `<p>` elements.

**Note**: This does *not* fix the issue where repeated newlines created by shift+enter are lost.

# Testing

1. Open the rich text editor
2. Create a new note with several empty **paragraphs**
    - Note: In an empty new note, TinyMCE creates empty `<div>`s instead of empty paragraphs. It may be necessary to add a non-empty line to the note and switch to another note before pressing enter adds paragraphs.
4. Switch to the markdown editor
5. Switch back to the rich text editor

In step 4, the same number of empty paragraphs should be present as in step 2.

Additionally, to verify that custom elements are still supported,
1. Open the markdown editor in a new note
2. Add a custom element (e.g. `<x-custom-element>test</x-custom-element>`)
3. Switch to the rich text editor
4. Update the content of the custom element
6. Switch back to the markdown editor.


To verify that KaTeX rendering still works:
1. Create a new math block with the following KaTeX: `$$ \int_0^1 x^2 dx $$`
2. Switch to the rich text editor