### PR TITLE
Desktop: Fixes #8535: Upgrade to electron 25.3.1

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -115,7 +115,7 @@
     "@types/react": "16.14.41",
     "@types/react-redux": "7.1.25",
     "@types/styled-components": "5.1.26",
-    "electron": "25.2.0",
+    "electron": "25.3.1",
     "electron-builder": "24.4.0",
     "glob": "10.2.7",
     "gulp": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,7 +4455,7 @@ __metadata:
     compare-versions: 3.6.0
     countable: 3.0.1
     debounce: 1.2.1
-    electron: 25.2.0
+    electron: 25.3.1
     electron-builder: 24.4.0
     electron-window-state: 5.0.3
     formatcoords: 1.1.3
@@ -14983,16 +14983,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:25.2.0":
-  version: 25.2.0
-  resolution: "electron@npm:25.2.0"
+"electron@npm:25.3.1":
+  version: 25.3.1
+  resolution: "electron@npm:25.3.1"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^18.11.18
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 264b19af3077da70fc137a244cec24a7674b0938695fcbf8b22a48164d43efe58c597e189501ee48d02bb52ff26e6952a8c69e4c50bb42686f117d6e10a33aa4
+  checksum: c8e6c18722f4d142e3f80c973db9e9c60039fe9f4a32ecdb17ff14834bc6ed26891cb573b7f922eebace1a946c0b6ada18e858080246c52b3b6ce5d383605da0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Upgrades Electron to v25.3.1.

This, combined with #8543, resolves #8535.

# Notes

As most of the tests below have not been done, this pull request is still a draft.

* * *

# Testing Summary

Many of the below checkboxes are unchecked not because the tests failed, but because the tests still need to be done.

## Windows:

- [x] Dropdown menus are in the correct location
- [x] Check resource attachment
    - [x] PDF
        - [x] Viewer shows
        - [x] Can open print/save dialogs
    - [x] Image
    - [x] Text file
        - [x] Can be edited
- [x] Check external editing (only from markdown editor, see [issue](https://github.com/laurent22/joplin/issues/8541#issuecomment-1647278043))
- [x] Check export/import
    - [x] PDF (export only)
    - [x] Markdown
        - Possible issue: resources folder is imported as a notebook
    - [x] JEX
- [x] Check sync
    - [x] DropBox
- [x] Check print
    - [x] Print dialog shows up when clicking "File > Print"
- [x] Portable version launches

## MacOS

- [x] App starts
- [x] Print dialog is shown when clicking "Print"
- [x] Sync
    - [x] OneDrive
- [x] Files can be attached to notes


## Linux (Fedora 38)

- [x] App starts
- [x] Can attach PDFs to notes

