### PR TITLE
Desktop: Resolves #8380: Always show reencrypt button

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -133,6 +133,7 @@ packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.js

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.js

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -19,6 +19,7 @@ import PluginService from '@joplin/lib/services/plugins/PluginService';
 import { getDefaultPluginsInstallState, updateDefaultPluginsInstallState } from '@joplin/lib/services/plugins/defaultPlugins/defaultPluginsUtils';
 import getDefaultPluginsInfo from '@joplin/lib/services/plugins/defaultPlugins/desktopDefaultPluginsInfo';
 import JoplinCloudConfigScreen from '../JoplinCloudConfigScreen';
+import ToggleAdvancedSettingsButton from './controls/ToggleAdvancedSettingsButton';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 
 const settingKeyToControl: any = {
@@ -208,17 +209,11 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		const advancedSettingsSectionStyle = { display: 'none' };
 
 		if (advancedSettingComps.length) {
-			const iconName = this.state.showAdvancedSettings ? 'fa fa-angle-down' : 'fa fa-angle-right';
-			// const advancedSettingsButtonStyle = { ...theme.buttonStyle,  marginBottom: 10  };
 			advancedSettingsButton = (
-				<div style={{ marginBottom: 10 }}>
-					<Button
-						level={ButtonLevel.Secondary}
-						onClick={() => shared.advancedSettingsButton_click(this)}
-						iconName={iconName}
-						title={_('Show Advanced Settings')}
-					/>
-				</div>
+				<ToggleAdvancedSettingsButton
+					onClick={() => shared.advancedSettingsButton_click(this)}
+					advancedSettingsVisible={this.state.showAdvancedSettings}
+				/>
 			);
 			advancedSettingsSectionStyle.display = this.state.showAdvancedSettings ? 'block' : 'none';
 		}

--- a/packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.tsx
@@ -1,0 +1,24 @@
+
+import * as React from 'react';
+import Button, { ButtonLevel } from '../../Button/Button';
+import { _ } from '@joplin/lib/locale';
+
+interface Props {
+	onClick: ()=> void;
+	advancedSettingsVisible: boolean;
+}
+
+const ToggleAdvancedSettingsButton: React.FunctionComponent<Props> = props => {
+	const iconName = props.advancedSettingsVisible ? 'fa fa-angle-down' : 'fa fa-angle-right';
+	return (
+		<div style={{ marginBottom: 10 }}>
+			<Button
+				level={ButtonLevel.Secondary}
+				onClick={props.onClick}
+				iconName={iconName}
+				title={_('Show Advanced Settings')}
+			/>
+		</div>
+	);
+};
+export default ToggleAdvancedSettingsButton;

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -84,37 +84,6 @@ const EncryptionConfigScreen = (props: Props) => {
 		);
 	};
 
-	const renderReencryptData = (isAdvanced: boolean) => {
-		if (!shim.isElectron()) return null;
-
-		// If props.shouldReencrypt, show this setting in the main section, rather
-		// than the advanced section.
-		if (isAdvanced === props.shouldReencrypt) return null;
-
-		const theme = themeStyle(props.themeId);
-		const buttonLabel = _('Re-encrypt data');
-
-		const intro = props.shouldReencrypt ? _('The default encryption method has been changed to a more secure one and it is recommended that you apply it to your data.') : _('You may use the tool below to re-encrypt your data, for example if you know that some of your notes are encrypted with an obsolete encryption method.');
-
-		let t = `${intro}\n\n${_('In order to do so, your entire data set will have to be encrypted and synchronised, so it is best to run it overnight.\n\nTo start, please follow these instructions:\n\n1. Synchronise all your devices.\n2. Click "%s".\n3. Let it run to completion. While it runs, avoid changing any note on your other devices, to avoid conflicts.\n4. Once sync is done on this device, sync all your other devices and let it run to completion.\n\nImportant: you only need to run this ONCE on one device.', buttonLabel)}`;
-
-		t = t.replace(/\n\n/g, '</p><p>');
-		t = t.replace(/\n/g, '<br>');
-		t = `<p>${t}</p>`;
-
-		return (
-			<div>
-				<h2>{_('Re-encryption')}</h2>
-				<p style={theme.textStyle} dangerouslySetInnerHTML={{ __html: t }}></p>
-				<span style={{ marginRight: 10 }}>
-					<button onClick={() => void reencryptData()} style={theme.buttonStyle}>{buttonLabel}</button>
-				</span>
-
-				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }
-			</div>
-		);
-	};
-
 	const renderMasterKey = (mk: MasterKeyEntity) => {
 		const theme = themeStyle(props.themeId);
 
@@ -243,7 +212,6 @@ const EncryptionConfigScreen = (props: Props) => {
 			/>
 		);
 		const needUpgradeSection = renderNeedUpgradeSection();
-		const reencryptDataSection = renderReencryptData(false);
 
 		return (
 			<div className="section">
@@ -258,7 +226,6 @@ const EncryptionConfigScreen = (props: Props) => {
 					{decryptedItemsInfo}
 					{toggleButton}
 					{needUpgradeSection}
-					{reencryptDataSection}
 				</div>
 			</div>
 		);
@@ -342,13 +309,42 @@ const EncryptionConfigScreen = (props: Props) => {
 		return nonExistingMasterKeySection;
 	};
 
-	const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
+	const renderReencryptData = () => {
+		if (!shim.isElectron()) return null;
+		if (!props.encryptionEnabled) return null;
+
+		const theme = themeStyle(props.themeId);
+		const buttonLabel = _('Re-encrypt data');
+
+		const intro = props.shouldReencrypt ? _('The default encryption method has been changed to a more secure one and it is recommended that you apply it to your data.') : _('You may use the tool below to re-encrypt your data, for example if you know that some of your notes are encrypted with an obsolete encryption method.');
+
+		let t = `${intro}\n\n${_('In order to do so, your entire data set will have to be encrypted and synchronised, so it is best to run it overnight.\n\nTo start, please follow these instructions:\n\n1. Synchronise all your devices.\n2. Click "%s".\n3. Let it run to completion. While it runs, avoid changing any note on your other devices, to avoid conflicts.\n4. Once sync is done on this device, sync all your other devices and let it run to completion.\n\nImportant: you only need to run this ONCE on one device.', buttonLabel)}`;
+
+		t = t.replace(/\n\n/g, '</p><p>');
+		t = t.replace(/\n/g, '<br>');
+		t = `<p>${t}</p>`;
+
+		return (
+			<div>
+				<h2>{_('Re-encryption')}</h2>
+				<p style={theme.textStyle} dangerouslySetInnerHTML={{ __html: t }}></p>
+				<span style={{ marginRight: 10 }}>
+					<button onClick={() => void reencryptData()} style={theme.buttonStyle}>{buttonLabel}</button>
+				</span>
+
+				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }
+			</div>
+		);
+	};
+
+	// If the user should re-encrypt, ensure that the section is visible initially.
+	const [showAdvanced, setShowAdvanced] = useState<boolean>(props.shouldReencrypt);
 	const toggleAdvanced = useCallback(() => {
 		setShowAdvanced(!showAdvanced);
 	}, [showAdvanced]);
 
 	const renderAdvancedSection = () => {
-		const reEncryptSection = renderReencryptData(true);
+		const reEncryptSection = renderReencryptData();
 
 		if (!reEncryptSection) return null;
 


### PR DESCRIPTION
# Summary

Shows the re-encryption button under "Encryption" settings always, not just when the `encryption.shouldReencrypt` setting has value `Setting.SHOULD_REENCRYPT_YES`.

The re-encryption button is now shown under "Advanced".

Fixes #8380.

# To-do

While this pull request could be merged as is, it may be helpful to have the following:
- [ ] ~~Wait for sync to finish before allowing users to press "reencrypt all"~~
    - I am no longer convinced that this is necessary. Because `reencryptAll` works by calling `BaseItem.forceSyncAll();`, then `reg.waitForSyncFinishedThenSync();`, any unsynchronized items should remain queued to be synchronized.

# Testing

0. Ensure Joplin has several notes/folders.
1. Ensure Joplin is connected to a sync target and can sync successfully.
2. Do a full sync.
3. Close Joplin
4. Add a new encryption method to `EncryptionService.ts`

<details><summary>Example Diff</summary>

```diff
diff --git a/packages/lib/services/e2ee/EncryptionService.ts b/packages/lib/services/e2ee/EncryptionService.ts
index 3e835a753..b4ce6d41d 100644
--- a/packages/lib/services/e2ee/EncryptionService.ts
+++ b/packages/lib/services/e2ee/EncryptionService.ts
@@ -39,6 +39,7 @@ export enum EncryptionMethod {
 	SJCL1a = 5,
 	Custom = 6,
 	SJCL1b = 7,
+	SJCL1c = 8,
 }
 
 export interface EncryptOptions {
@@ -70,7 +71,7 @@ export default class EncryptionService {
 	// changed easily since the chunk size is incorporated into the encrypted data.
 	private chunkSize_ = 5000;
 	private decryptedMasterKeys_: Record<string, DecryptedMasterKey> = {};
-	public defaultEncryptionMethod_ = EncryptionMethod.SJCL1b; // public because used in tests
+	public defaultEncryptionMethod_ = EncryptionMethod.SJCL1c; // public because used in tests
 	private defaultMasterKeyEncryptionMethod_ = EncryptionMethod.SJCL4;
 
 	private headerTemplates_ = {
@@ -332,6 +333,26 @@ export default class EncryptionService {
 				}
 			},
 
+			// Test: DO NOT COMMIT
+			[EncryptionMethod.SJCL1c]: () => {
+				try {
+					// We need to escape the data because SJCL uses encodeURIComponent to process the data and it only
+					// accepts UTF-8 data, or else it throws an error. And the notes might occasionally contain
+					// invalid UTF-8 data. Fixes https://github.com/laurent22/joplin/issues/2591
+					return sjcl.json.encrypt(key, escape(plainText), {
+						v: 1, // version
+						iter: 2000, // Since the master key already uses key derivations and is secure, additional iteration here aren't necessary, which will make decryption faster. SJCL enforces an iter strictly greater than 100
+						ks: 512, // Key size - "256-bit is the golden standard that we should follow."
+						ts: 64, // ???
+						mode: 'ccm', //  The cipher mode is a standard for how to use AES and other algorithms to encrypt and authenticate your message. OCB2 mode is slightly faster and has more features, but CCM mode has wider support because it is not patented.
+						// "adata":"", // Associated Data - not needed?
+						cipher: 'aes',
+					});
+				} catch (error) {
+					throw this.wrapSjclError(error);
+				}
+			},
+
 			// 2020-01-23: Deprecated - see above.
 			// Was used to encrypt master keys
 			[EncryptionMethod.SJCL2]: () => {
@@ -404,7 +425,7 @@ export default class EncryptionService {
 		try {
 			const output = sjcl.json.decrypt(key, cipherText);
 
-			if (method === EncryptionMethod.SJCL1a || method === EncryptionMethod.SJCL1b) {
+			if (method === EncryptionMethod.SJCL1a || method === EncryptionMethod.SJCL1b || method === EncryptionMethod.SJCL1c) {
 				return unescape(output);
 			} else {
 				return output;
@@ -655,7 +676,7 @@ export default class EncryptionService {
 	}
 
 	public isValidEncryptionMethod(method: EncryptionMethod) {
-		return [EncryptionMethod.SJCL, EncryptionMethod.SJCL1a, EncryptionMethod.SJCL1b, EncryptionMethod.SJCL2, EncryptionMethod.SJCL3, EncryptionMethod.SJCL4].indexOf(method) >= 0;
+		return [EncryptionMethod.SJCL, EncryptionMethod.SJCL1a, EncryptionMethod.SJCL1b, EncryptionMethod.SJCL1c, EncryptionMethod.SJCL2, EncryptionMethod.SJCL3, EncryptionMethod.SJCL4].indexOf(method) >= 0;
 	}
 
 	public async itemIsEncrypted(item: any) {

```

</details>

5. Re-build and re-launch Joplin
6. Open settings > encryption > advanced
7. Click "Re-encrypt data"
8. Wait for sync to finish
9. Quit Joplin
10. Reset `EncryptionService.ts` to what it was before step 4
11. Open Joplin and click "delete local data and re-downlad from sync target"
12. Verify that none of the downloaded notes can be decrypted.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
