### PR TITLE
Chore: Desktop: Tests: Reduce duplicate setup logic

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -253,8 +253,8 @@ packages/app-desktop/gui/NoteEditor/utils/clipboardUtils.js
 packages/app-desktop/gui/NoteEditor/utils/contextMenu.js
 packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.js
 packages/app-desktop/gui/NoteEditor/utils/index.js
-packages/app-desktop/gui/NoteEditor/utils/resourceHandling.js
 packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.js
+packages/app-desktop/gui/NoteEditor/utils/resourceHandling.js
 packages/app-desktop/gui/NoteEditor/utils/types.js
 packages/app-desktop/gui/NoteEditor/utils/useDropHandler.js
 packages/app-desktop/gui/NoteEditor/utils/useEffectiveNoteId.js

--- a/.gitignore
+++ b/.gitignore
@@ -238,8 +238,8 @@ packages/app-desktop/gui/NoteEditor/utils/clipboardUtils.js
 packages/app-desktop/gui/NoteEditor/utils/contextMenu.js
 packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.js
 packages/app-desktop/gui/NoteEditor/utils/index.js
-packages/app-desktop/gui/NoteEditor/utils/resourceHandling.js
 packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.js
+packages/app-desktop/gui/NoteEditor/utils/resourceHandling.js
 packages/app-desktop/gui/NoteEditor/utils/types.js
 packages/app-desktop/gui/NoteEditor/utils/useDropHandler.js
 packages/app-desktop/gui/NoteEditor/utils/useEffectiveNoteId.js

--- a/packages/app-desktop/babel.jest-config.js
+++ b/packages/app-desktop/babel.jest-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	// Jest doesn't understand ES6 exports: Babel needs to transform ES6 modules
+	// to CommonJS so that they can be imported successfully.
+	'plugins': ['@babel/plugin-transform-modules-commonjs'],
+
+	// This fixes `this` being `undefined` in ../renderer/MdToHtml/rules/katex_mhchem.js
+	// (and other files) by forcing Babel to treat files as CommonJS unless they include
+	// an `export` statement.
+	//
+	// See https://stackoverflow.com/a/34983495
+	'sourceType': 'unambiguous',
+};

--- a/packages/app-desktop/jest.config.js
+++ b/packages/app-desktop/jest.config.js
@@ -154,7 +154,14 @@ module.exports = {
 	// timers: "real",
 
 	// A map from regular expressions to paths to transformers
-	// transform: undefined,
+	transform: {
+		'\\.js$': ['babel-jest', { configFile: './babel.jest-config.js' }],
+	},
+
+	// So that babel converts ES6 import/exports, override the default transformIgnorePatterns
+	// so that most packages in node_modules **are** transformed.
+	transformIgnorePatterns: ['<rootDir>/node_modules/jest'],
+	testPathIgnorePatterns: ['<rootDir>/node_modules/'],
 
 	// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
 	// unmockedModulePathPatterns: undefined,

--- a/packages/app-desktop/jest.setup.js
+++ b/packages/app-desktop/jest.setup.js
@@ -1,16 +1,18 @@
+/* eslint-disable jest/require-top-level-describe */
 
-const { default: Logger, TargetType } = require('@joplin/lib/Logger');
+const { afterEachCleanUp, afterAllCleanUp } = require('@joplin/lib/testing/test-utils.js');
+const { shimInit } = require('@joplin/lib/shim-init-node.js');
+const sqlite3 = require('sqlite3');
 
-// TODO: Some libraries required by test-utils.js seem to fail to import with the
-// jsdom environment.
-//
-// Thus, require('@joplin/lib/testing/test-utils.js') fails and some setup must be
-// copied.
+shimInit({ nodeSqlite: sqlite3 });
 
-const logger = new Logger();
-logger.addTarget(TargetType.Console);
-logger.setLevel(Logger.LEVEL_WARN);
-Logger.initializeGlobalLogger(logger);
+afterEach(async () => {
+	await afterEachCleanUp();
+});
+
+afterAll(async () => {
+	await afterAllCleanUp();
+});
 
 
 // @electron/remote requires electron to be running. Mock it.

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -107,6 +107,8 @@
   },
   "homepage": "https://github.com/laurent22/joplin#readme",
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "7.22.5",
+    "@babel/runtime": "7.22.5",
     "@electron/rebuild": "3.2.13",
     "@joplin/tools": "~2.12",
     "@testing-library/react-hooks": "8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,7 +4497,6 @@ __metadata:
     styled-system: 5.1.5
     taboverride: 4.0.3
     tinymce: 5.10.6
-    ts-jest: 29.1.1
     typescript: 5.0.2
   dependenciesMeta:
     7zip-bin-linux:
@@ -29834,17 +29833,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.3":
-  version: 7.5.4
-  resolution: "semver@npm:7.5.4"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
-  languageName: node
-  linkType: hard
-
 "send@npm:0.17.1":
   version: 0.17.1
   resolution: "send@npm:0.17.1"
@@ -32502,39 +32490,6 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 535dc42ad523cbe1e387701fb2e448518419b515c082f09b25411f0b3dd0b854cf3e8141c316d6f4b99883aeb4a4f94159cbb1edfb06d7f77ea6229fadb2e1bf
-  languageName: node
-  linkType: hard
-
-"ts-jest@npm:29.1.1":
-  version: 29.1.1
-  resolution: "ts-jest@npm:29.1.1"
-  dependencies:
-    bs-logger: 0.x
-    fast-json-stable-stringify: 2.x
-    jest-util: ^29.0.0
-    json5: ^2.2.3
-    lodash.memoize: 4.x
-    make-error: 1.x
-    semver: ^7.5.3
-    yargs-parser: ^21.0.1
-  peerDependencies:
-    "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/types": ^29.0.0
-    babel-jest: ^29.0.0
-    jest: ^29.0.0
-    typescript: ">=4.3 <6"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@jest/types":
-      optional: true
-    babel-jest:
-      optional: true
-    esbuild:
-      optional: true
-  bin:
-    ts-jest: cli.js
-  checksum: a8c9e284ed4f819526749f6e4dc6421ec666f20ab44d31b0f02b4ed979975f7580b18aea4813172d43e39b29464a71899f8893dd29b06b4a351a3af8ba47b402
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,7 +2306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.0.0, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.19.6, @babel/plugin-transform-modules-commonjs@npm:^7.22.5":
+"@babel/plugin-transform-modules-commonjs@npm:7.22.5, @babel/plugin-transform-modules-commonjs@npm:^7.0.0, @babel/plugin-transform-modules-commonjs@npm:^7.13.8, @babel/plugin-transform-modules-commonjs@npm:^7.19.6, @babel/plugin-transform-modules-commonjs@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.22.5"
   dependencies:
@@ -2791,7 +2791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.22.5, @babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -4435,6 +4435,8 @@ __metadata:
     7zip-bin-linux: ^1.0.1
     7zip-bin-mac: ^1.0.1
     7zip-bin-win: ^2.1.1
+    "@babel/plugin-transform-modules-commonjs": 7.22.5
+    "@babel/runtime": 7.22.5
     "@electron/notarize": 1.2.4
     "@electron/rebuild": 3.2.13
     "@electron/remote": 2.0.10
@@ -4495,6 +4497,7 @@ __metadata:
     styled-system: 5.1.5
     taboverride: 4.0.3
     tinymce: 5.10.6
+    ts-jest: 29.1.1
     typescript: 5.0.2
   dependenciesMeta:
     7zip-bin-linux:
@@ -29831,6 +29834,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.5.3":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
 "send@npm:0.17.1":
   version: 0.17.1
   resolution: "send@npm:0.17.1"
@@ -32488,6 +32502,39 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 535dc42ad523cbe1e387701fb2e448518419b515c082f09b25411f0b3dd0b854cf3e8141c316d6f4b99883aeb4a4f94159cbb1edfb06d7f77ea6229fadb2e1bf
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:29.1.1":
+  version: 29.1.1
+  resolution: "ts-jest@npm:29.1.1"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.3
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: ^7.5.3
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: a8c9e284ed4f819526749f6e4dc6421ec666f20ab44d31b0f02b4ed979975f7580b18aea4813172d43e39b29464a71899f8893dd29b06b4a351a3af8ba47b402
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This PR migrates the desktop testing logic to the shared `shimInit` setup function.

This resolves the following `TODO` item:
https://github.com/laurent22/joplin/blob/83cf5eb617d2f8d0cdea17acb9577ac5694ae8b8/packages/app-desktop/jest.setup.js#L4-L8

# Notes

At least one module imported by a dependency uses ES6-style exports, which, without additional preprocessing, breaks `jest` . The mobile app's `babel.config.js` uses a preset that works around this issue. A Babel config has thus been added to the desktop application that transforms ES6 modules into CommonJS modules.

Without this transformation, jest fails with the following message:
<details><summary>Error</summary>

```
   Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /home/builder/Documents/joplin-ghsa-m59c-9rrj-c399/packages/lib/node_modules/@aws-sdk/middleware-retry/node_modules/uuid/dist/esm-browser/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){export { default as v1 } from './v1.js';
                                                                                      ^^^^^^

    SyntaxError: Unexpected token 'export'

      4 | const JoplinError = require('./JoplinError').default;
      5 | const { Buffer } = require('buffer');
    > 6 | const { GetObjectCommand, ListObjectsV2Command, HeadObjectCommand, PutObjectCommand, DeleteObjectCommand, DeleteObjectsCommand, CopyObjectCommand } = require('@aws-sdk/client-s3');
        |                                                                                                                                                       ^
      7 | const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
      8 | const parser = require('fast-xml-parser');
      9 |

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1495:14)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/middleware-retry/dist-cjs/StandardRetryStrategy.js:7:16)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/middleware-retry/dist-cjs/AdaptiveRetryStrategy.js:5:33)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/middleware-retry/dist-cjs/index.js:4:22)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/client-s3/dist-cjs/S3Client.js:12:28)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/client-s3/dist-cjs/S3.js:97:20)
      at Object.<anonymous> (../lib/node_modules/@aws-sdk/client-s3/dist-cjs/index.js:5:22)
      at Object.require (../lib/file-api-driver-amazon-s3.js:6:151)
      at Object.require (../lib/SyncTargetAmazonS3.js:6:35)
      at Object.require (../lib/BaseApplication.ts:38:28)
      at Object.require (../lib/testing/test-utils.ts:2:1)
      at Object.require (jest.setup.js:3:1)
```

</details>