### PR TITLE
Desktop: Fixes: #8370: Fix note drag-drop into markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -246,6 +246,10 @@ const NoteListComponent = (props: Props) => {
 		event.dataTransfer.setDragImage(new Image(), 1, 1);
 		event.dataTransfer.clearData();
 		event.dataTransfer.setData('text/x-jop-note-ids', JSON.stringify(noteIds));
+		// While setting
+		//   event.dataTransfer.effectAllowed = 'move';
+		// causes the drag cursor to have a "move", rather than an "add", icon,
+		// this breaks note drag and drop into the markdown editor.
 		return true;
 	}, [props.parentFolderIsReadOnly, props.selectedNoteIds]);
 

--- a/packages/app-desktop/gui/NoteList/NoteList.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList.tsx
@@ -246,7 +246,6 @@ const NoteListComponent = (props: Props) => {
 		event.dataTransfer.setDragImage(new Image(), 1, 1);
 		event.dataTransfer.clearData();
 		event.dataTransfer.setData('text/x-jop-note-ids', JSON.stringify(noteIds));
-		event.dataTransfer.effectAllowed = 'move';
 		return true;
 	}, [props.parentFolderIsReadOnly, props.selectedNoteIds]);
 


### PR DESCRIPTION
# Summary
This fixes #8370, but **will regress the fix for #7881**. 

Reverts 89fc5e19d9f4e7eb426974f0750f18b24e1fdcca

# Notes

Setting `event.dataTransfer.effectAllowed` to `"move"` on note list items being dragged may break the CodeMirror drag-and-drop logic:
https://github.com/laurent22/joplin/blob/83cf5eb617d2f8d0cdea17acb9577ac5694ae8b8/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Editor.tsx#L144-L154

However, adding `|| event.dataTransfer.effectAllowed === 'move'` to the end of this `if` statement does not seem to fix the issue. Similarly, changing `effectAllowed` to `linkMove` doesn't seem to fix the issue.

Internal CodeMirror drop events have `effectAllowed=copyMove`. 


