### PR TITLE
Chore: Mobile: Fix build

### DIFF
--- a/packages/app-mobile/metro.config.js
+++ b/packages/app-mobile/metro.config.js
@@ -14,6 +14,7 @@ const path = require('path');
 
 const localPackages = {
 	'@joplin/lib': path.resolve(__dirname, '../lib/'),
+	'@joplin/utils': path.resolve(__dirname, '../utils/'),
 	'@joplin/renderer': path.resolve(__dirname, '../renderer/'),
 	'@joplin/tools': path.resolve(__dirname, '../tools/'),
 	'@joplin/fork-htmlparser2': path.resolve(__dirname, '../fork-htmlparser2/'),


### PR DESCRIPTION
# Summary
`yarn start` is currently failing because the mobile app can't access the `utils` package (and thus can't access the logger).

This pull request updates `metro.config.js` to allow Metro to access `utils`.