### PR TITLE
Desktop: Fixes #8541: Fix toggle external editing button always disabled in rich text editor

### DIFF
--- a/packages/app-desktop/commands/toggleExternalEditing.ts
+++ b/packages/app-desktop/commands/toggleExternalEditing.ts
@@ -22,7 +22,7 @@ export const runtime = (): CommandRuntime => {
 				void CommandService.instance().execute('startExternalEditing', noteId);
 			}
 		},
-		enabledCondition: 'oneNoteSelected && !noteIsReadOnly',
+		enabledCondition: 'oneNoteSelected && !noteIsReadOnly && (!modalDialogVisible || gotoAnythingVisible)',
 		mapStateToTitle: (state: any) => {
 			const noteId = stateUtils.selectedNoteId(state);
 			return state.watchedNoteFiles.includes(noteId) ? _('Stop') : '';

--- a/packages/app-desktop/commands/toggleExternalEditing.ts
+++ b/packages/app-desktop/commands/toggleExternalEditing.ts
@@ -2,7 +2,6 @@ import CommandService, { CommandRuntime, CommandDeclaration } from '@joplin/lib/
 import { _ } from '@joplin/lib/locale';
 import { stateUtils } from '@joplin/lib/reducer';
 import { DesktopCommandContext } from '../services/commands/types';
-import { enabledCondition } from '../gui/NoteEditor/editorCommandDeclarations';
 
 export const declaration: CommandDeclaration = {
 	name: 'toggleExternalEditing',
@@ -23,7 +22,7 @@ export const runtime = (): CommandRuntime => {
 				void CommandService.instance().execute('startExternalEditing', noteId);
 			}
 		},
-		enabledCondition: enabledCondition(declaration.name),
+		enabledCondition: 'oneNoteSelected && !noteIsReadOnly',
 		mapStateToTitle: (state: any) => {
 			const noteId = stateUtils.selectedNoteId(state);
 			return state.watchedNoteFiles.includes(noteId) ? _('Stop') : '';


### PR DESCRIPTION
# Summary

Fixes #8541.

# Testing plan

1. Open a markdown note in the rich text editor
2. Click "toggle external editing"
5. Open the markdown note in the markdown editor
6. Click "toggle external editing"
7. Open an HTML note
8. Click "toggle external editing"

This has been manually tested on Ubuntu 23.04.

# Notes

External editing was updated to use the shared `enabledCondition` function 77482a0c956987434a4e1f7d645aeec8d51292eb.

This, however, disabled external editing when the markdown editor was not visible (and also when the note was not a markdown note).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
