### PR TITLE
Desktop: Fixes #8598 - Recent logs appear to be deleted

### DIFF
--- a/packages/lib/RotatingLogs.test.ts
+++ b/packages/lib/RotatingLogs.test.ts
@@ -12,7 +12,7 @@ describe('RotatingLogs', () => {
 		try {
 			dir = await createTempDir();
 			await createTestLogFile(dir);
-			let files: string[] = await readdir(dir);
+			let files = await readdir(dir);
 			expect(files.find(file => file.match(/^log.txt$/gi))).toBeTruthy();
 			expect(files.length).toBe(1);
 			const rotatingLogs: RotatingLogs = new RotatingLogs(dir, 1, 1);
@@ -35,7 +35,7 @@ describe('RotatingLogs', () => {
 			await rotatingLogs.cleanActiveLogFile();
 			await msleep(1);
 			await rotatingLogs.deleteNonActiveLogFiles();
-			const files: string[] = await readdir(dir);
+			const files = await readdir(dir);
 			expect(files.find(file => file.match(/^log-[0-9]+.txt$/gi))).toBeFalsy();
 			expect(files.length).toBe(0);
 		} finally {
@@ -52,7 +52,7 @@ describe('RotatingLogs', () => {
 			const rotatingLogs: RotatingLogs = new RotatingLogs(dir, 1, 100);
 			await rotatingLogs.cleanActiveLogFile();
 			await rotatingLogs.deleteNonActiveLogFiles();
-			const files: string[] = await readdir(dir);
+			const files = await readdir(dir);
 			expect(files.find(file => file.match(/^log-[0-9]+.txt$/gi))).toBeTruthy();
 			expect(files.length).toBe(1);
 		} finally {

--- a/packages/lib/RotatingLogs.test.ts
+++ b/packages/lib/RotatingLogs.test.ts
@@ -26,7 +26,7 @@ describe('RotatingLogs', () => {
 		}
 	});
 
-	test('should delete inative log file after 1ms', async () => {
+	test('should delete inactive log file after 1ms', async () => {
 		let dir: string;
 		try {
 			dir = await createTempDir();
@@ -35,9 +35,26 @@ describe('RotatingLogs', () => {
 			await rotatingLogs.cleanActiveLogFile();
 			await msleep(1);
 			await rotatingLogs.deleteNonActiveLogFiles();
-			const files = await readdir(dir);
+			const files: string[] = await readdir(dir);
 			expect(files.find(file => file.match(/^log-[0-9]+.txt$/gi))).toBeFalsy();
 			expect(files.length).toBe(0);
+		} finally {
+			await remove(dir);
+		}
+	});
+
+	test('should not delete the log-timestamp.txt right after its be created', async () => {
+		let dir: string;
+		try {
+			dir = await createTempDir();
+			await createTestLogFile(dir);
+			await msleep(1000);
+			const rotatingLogs: RotatingLogs = new RotatingLogs(dir, 1, 1000);
+			await rotatingLogs.cleanActiveLogFile();
+			await rotatingLogs.deleteNonActiveLogFiles();
+			const files: string[] = await readdir(dir);
+			expect(files.find(file => file.match(/^log-[0-9]+.txt$/gi))).toBeTruthy();
+			expect(files.length).toBe(1);
 		} finally {
 			await remove(dir);
 		}

--- a/packages/lib/RotatingLogs.test.ts
+++ b/packages/lib/RotatingLogs.test.ts
@@ -48,8 +48,8 @@ describe('RotatingLogs', () => {
 		try {
 			dir = await createTempDir();
 			await createTestLogFile(dir);
-			await msleep(1000);
-			const rotatingLogs: RotatingLogs = new RotatingLogs(dir, 1, 1000);
+			await msleep(100);
+			const rotatingLogs: RotatingLogs = new RotatingLogs(dir, 1, 100);
 			await rotatingLogs.cleanActiveLogFile();
 			await rotatingLogs.deleteNonActiveLogFiles();
 			const files: string[] = await readdir(dir);

--- a/packages/lib/RotatingLogs.ts
+++ b/packages/lib/RotatingLogs.ts
@@ -29,7 +29,8 @@ export default class RotatingLogs {
 		const files: Stat[] = await this.fsDriver().readDirStats(this.logFilesDir);
 		for (const file of files) {
 			if (!file.path.match(/^log-[0-9]+.txt$/gi)) continue;
-			const ageOfTheFile: number = Date.now() - file.mtime;
+			const timestamp: string = file.path.match(/[0-9]+/g)[0];
+			const ageOfTheFile: number = Date.now() - timestamp;
 			if (ageOfTheFile >= this.inactiveMaxAge) {
 				await this.fsDriver().remove(this.logFileFullpath(file.path));
 			}

--- a/packages/lib/RotatingLogs.ts
+++ b/packages/lib/RotatingLogs.ts
@@ -29,7 +29,7 @@ export default class RotatingLogs {
 		const files: Stat[] = await this.fsDriver().readDirStats(this.logFilesDir);
 		for (const file of files) {
 			if (!file.path.match(/^log-[0-9]+.txt$/gi)) continue;
-			const timestamp: string = file.path.match(/[0-9]+/g)[0];
+			const timestamp: number = parseInt(file.path.match(/[0-9]+/g)[0], 10);
 			const ageOfTheFile: number = Date.now() - timestamp;
 			if (ageOfTheFile >= this.inactiveMaxAge) {
 				await this.fsDriver().remove(this.logFileFullpath(file.path));

--- a/packages/lib/RotatingLogs.ts
+++ b/packages/lib/RotatingLogs.ts
@@ -29,7 +29,7 @@ export default class RotatingLogs {
 		const files: Stat[] = await this.fsDriver().readDirStats(this.logFilesDir);
 		for (const file of files) {
 			if (!file.path.match(/^log-[0-9]+.txt$/gi)) continue;
-			const ageOfTheFile: number = Date.now() - file.birthtime;
+			const ageOfTheFile: number = Date.now() - file.mtime;
 			if (ageOfTheFile >= this.inactiveMaxAge) {
 				await this.fsDriver().remove(this.logFileFullpath(file.path));
 			}


### PR DESCRIPTION
The log-timestamp.txt is being delete because the function is just renaming log.txt to log-timestamp.txt, therefore the log-timestamp.txt has the birthdate of log.txt and not the birthdate since when this was renamed.

To solve the problem I just stop using the creation time to check the age of the file, and instead of that I'm using the modification time, since it's update when the file is renamed.