### PR TITLE
Server: throwing an error if the password being saved already seems to be hashed

### DIFF
--- a/packages/server/src/models/UserModel.ts
+++ b/packages/server/src/models/UserModel.ts
@@ -6,7 +6,7 @@ import { ModelType } from '@joplin/lib/BaseModel';
 import { _ } from '@joplin/lib/locale';
 import { formatBytes, GB, MB } from '../utils/bytes';
 import { itemIsEncrypted } from '../utils/joplinUtils';
-import { getMaxItemSize, getMaxTotalItemSize } from './utils/user';
+import { getMaxItemSize, getMaxTotalItemSize, isHashedPassword } from './utils/user';
 import * as zxcvbn from 'zxcvbn';
 import { confirmUrl, resetPasswordUrl } from '../utils/urlUtils';
 import { checkRepeatPassword, CheckRepeatPasswordInput } from '../routes/index/users';
@@ -636,6 +636,9 @@ export default class UserModel extends BaseModel<User> {
 		const user = this.formatValues(object);
 
 		if (user.password) {
+			if (isHashedPassword(user.password)) {
+				throw new ErrorBadRequest(`Unable to save user because password already seems to be hashed. User id: ${user.id}`);
+			}
 			if (!options.skipValidation) this.validatePassword(user.password);
 			user.password = auth.hashPassword(user.password);
 		}

--- a/packages/server/src/models/utils/user.test.ts
+++ b/packages/server/src/models/utils/user.test.ts
@@ -1,0 +1,19 @@
+import { isHashedPassword } from './user';
+
+describe('isHashedPassword', () => {
+
+	it('should be true if password starts with $2a$10', () => {
+		expect(isHashedPassword('$2a$10$LMKVPiNOWDZhtw9NizNIEuNGLsjOxQAcrwQJ0lnKuiaOtyFgZEnwO')).toBe(true);
+	});
+
+	it.each(
+		[
+			'password',
+			'123456',
+			'simple-password-that-takes-is-long',
+			'nuXUhqecx!RzK3wv6^xYaVEP%9fc$T%$E2k%9Q&TKvtDhR#2PUw3kA8KX3w2baAD8m#N9@52!DvfYn*X6hP#uAvpGF57*H9avcoePbR&4Q2XzckJnSW*EVm4G@a#YvnR',
+		]
+	)('should be false if password starts with $2a$10: %', (password) => {
+		expect(isHashedPassword(password)).toBe(false);
+	});
+});

--- a/packages/server/src/models/utils/user.ts
+++ b/packages/server/src/models/utils/user.ts
@@ -37,3 +37,7 @@ export function totalSizeClass(user: User) {
 	if (d >= .7) return 'is-warning';
 	return '';
 }
+
+export const isHashedPassword = (password: string) => {
+	return password.startsWith('$2a$10');
+};

--- a/packages/server/src/utils/auth.test.ts
+++ b/packages/server/src/utils/auth.test.ts
@@ -1,0 +1,18 @@
+import { hashPassword } from './auth';
+
+describe('hashPassword', () => {
+
+	it.each(
+		[
+			'password',
+			'123456',
+			'simple-password-that-takes-is-long',
+			'nuXUhqecx!RzK3wv6^xYaVEP%9fc$T%$E2k%9Q&TKvtDhR#2PUw3kA8KX3w2baAD8m#N9@52!DvfYn*X6hP#uAvpGF57*H9avcoePbR&4Q2XzckJnSW*EVm4G@a#YvnR',
+			'$2a$10',
+			'$2a$10$LMKVPiNOWDZhtw9NizNIEuNGLsjOxQAcrwQJ0lnKuiaOtyFgZEnwO',
+		]
+	)('should return a string that starts with $2a$10 for the password: %', async (plainText) => {
+		expect(hashPassword(plainText).startsWith('$2a$10')).toBe(true);
+	});
+
+});


### PR DESCRIPTION
To avoid problems where we might rehash the password, we are going to check the password format before saving the user record.

We can't really be sure if the password sent to the function is already hashed or not, but we can check the start of the string to see if it matches the hash algorithm identifier for bcrypt and the rounds applied (`$2a$10`).

In this case, if we find the password field starts with these 5 characters, we are throwing a BadRequest error and logging the `user.id` that caused the error.