### PR TITLE
Chore: Desktop: Tests: Reduce duplicate setup logic

### DIFF
--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -34,7 +34,6 @@ const { FileApiDriverLocal } = require('../file-api-driver-local');
 const { FileApiDriverWebDav } = require('../file-api-driver-webdav.js');
 const { FileApiDriverDropbox } = require('../file-api-driver-dropbox.js');
 const { FileApiDriverOneDrive } = require('../file-api-driver-onedrive.js');
-const { FileApiDriverAmazonS3 } = require('../file-api-driver-amazon-s3.js');
 import SyncTargetRegistry from '../SyncTargetRegistry';
 const SyncTargetMemory = require('../SyncTargetMemory.js');
 const SyncTargetFilesystem = require('../SyncTargetFilesystem.js');
@@ -59,7 +58,6 @@ import Synchronizer from '../Synchronizer';
 import SyncTargetNone from '../SyncTargetNone';
 import { setRSA } from '../services/e2ee/ppk';
 const md5 = require('md5');
-const { S3Client } = require('@aws-sdk/client-s3');
 const { Dirnames } = require('../services/synchronizer/utils/types');
 import RSA from '../services/e2ee/RSA.node';
 import { State as ShareState } from '../services/share/reducer';
@@ -625,6 +623,13 @@ async function initFileApi() {
 		const appDir = await api.appDirectory();
 		fileApi = new FileApi(appDir, new FileApiDriverOneDrive(api));
 	} else if (syncTargetId_ === SyncTargetRegistry.nameToId('amazon_s3')) {
+		// (Most of?) the @aws-sdk libraries depend on an old version of uuid
+		// that doesn't work with jest (without converting ES6 exports to CommonJS).
+		//
+		// Require it dynamically so that this doesn't break test environments that
+		// aren't configured to do this conversion.
+		const { FileApiDriverAmazonS3 } = require('../file-api-driver-amazon-s3.js');
+		const { S3Client } = require('@aws-sdk/client-s3');
 
 		// We make sure for S3 tests run in band because tests
 		// share the same directory which will cause locking errors.


### PR DESCRIPTION
# Summary

This PR migrates the desktop testing logic to the shared `shimInit` setup function.

This allows additional functions in `lib` to be used during testing and resolves the following `TODO` item:
https://github.com/laurent22/joplin/blob/83cf5eb617d2f8d0cdea17acb9577ac5694ae8b8/packages/app-desktop/jest.setup.js#L4-L8

# Notes

The `@aws-sdk` libraries used by `lib/testing/test-utils.ts` import an old version of `uuid` that doesn't support CommonJS exports. This pull request 
- mocks `@joplin/lib/SyncTargetAmazonS3`, replacing it with `SyncTargetNone` in the desktop app setup, and
- defers imports of `@aws-sdk/*` in `test-utils.ts` until these imports would be used.

Things that do not seem to fix the issue:
- Upgrading to the latest version of the `@aws-sdk` libraries
- Using a `jest.mock('uuid', ...)` (the old version of `uuid` still seems to be imported — possibly because it's in `lib/node_modules/@smithy/middleware-retry/node_modules/uuid` and not just in `node_modules`). 