### PR TITLE
Chore: Desktop: Fix NoteEditor unnecessary rerendering

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import TinyMCE from './NoteBody/TinyMCE/TinyMCE';
 import CodeMirror from './NoteBody/CodeMirror/CodeMirror';
 import { connect } from 'react-redux';
@@ -40,7 +40,7 @@ import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
 const bridge = require('@electron/remote').require('./bridge').default;
 import NoteRevisionViewer from '../NoteRevisionViewer';
-import { readFromSettings } from '@joplin/lib/services/share/reducer';
+import { parseShareCache } from '@joplin/lib/services/share/reducer';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import { ModelType } from '@joplin/lib/BaseModel';
 import BaseItem from '@joplin/lib/models/BaseItem';
@@ -286,11 +286,15 @@ function NoteEditor(props: NoteEditorProps) {
 	// 	}
 	// }, [props.dispatch]);
 
+	const shareCache = useMemo(() => {
+		return parseShareCache(props.shareCacheSetting);
+	}, [props.shareCacheSetting]);
+
 	useAsyncEffect(async event => {
 		if (!formNote.id) return;
 
 		try {
-			const result = await itemIsReadOnly(BaseItem, ModelType.Note, ItemChange.SOURCE_UNSPECIFIED, formNote.id, props.syncUserId, props.shareCache);
+			const result = await itemIsReadOnly(BaseItem, ModelType.Note, ItemChange.SOURCE_UNSPECIFIED, formNote.id, props.syncUserId, shareCache);
 			if (event.cancelled) return;
 			setIsReadOnly(result);
 		} catch (error) {
@@ -301,7 +305,7 @@ function NoteEditor(props: NoteEditorProps) {
 				throw error;
 			}
 		}
-	}, [formNote.id, props.syncUserId, props.shareCache]);
+	}, [formNote.id, props.syncUserId, shareCache]);
 
 	const onBodyWillChange = useCallback((event: any) => {
 		handleProvisionalFlag();
@@ -656,7 +660,7 @@ const mapStateToProps = (state: AppState) => {
 		isSafeMode: state.settings.isSafeMode,
 		useCustomPdfViewer: false,
 		syncUserId: state.settings['sync.userId'],
-		shareCache: readFromSettings(state),
+		shareCacheSetting: state.settings['sync.shareCache'],
 	};
 };
 

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -2,7 +2,6 @@
 import AsyncActionQueue from '@joplin/lib/AsyncActionQueue';
 import { ToolbarButtonInfo } from '@joplin/lib/services/commands/ToolbarButtonUtils';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
-import { State as ShareState } from '@joplin/lib/services/share/reducer';
 import { MarkupLanguage } from '@joplin/renderer';
 import { RenderResult, RenderResultPluginAsset } from '@joplin/renderer/MarkupToHtml';
 import { MarkupToHtmlOptions } from './useMarkupToHtml';
@@ -46,7 +45,7 @@ export interface NoteEditorProps {
 	contentMaxWidth: number;
 	isSafeMode: boolean;
 	useCustomPdfViewer: boolean;
-	shareCache: ShareState;
+	shareCacheSetting: string;
 	syncUserId: string;
 }
 

--- a/packages/lib/services/share/reducer.ts
+++ b/packages/lib/services/share/reducer.ts
@@ -82,10 +82,6 @@ export const parseShareCache = (serialized: string): State => {
 	};
 };
 
-export const readFromSettings = (state: RootState): State => {
-	return parseShareCache(state.settings['sync.shareCache']);
-};
-
 export function isSharedFolderOwner(state: RootState, folderId: string): boolean {
 	const userId = state.settings['sync.userId'];
 	const share = state[stateRootKey].shares.find(s => s.folder_id === folderId);


### PR DESCRIPTION
# Summary

This is a follow-up PR to #8654. `NoteEditor.tsx` had a property that (unnecessarily) changed whenever the app state changed. See [comment](https://github.com/laurent22/joplin/pull/8654#issuecomment-1676160246).

This also fixes #8652 (when encryption is disabled), though it does not fix the bugs in `useFormNote`.

# Testing

See the manual testing steps in https://github.com/laurent22/joplin/pull/8654.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
