### PR TITLE
Desktop: Resolves #8493: Link to FAQ when encryption password may have been reset by an update

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -133,6 +133,7 @@ packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.js
 packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.js
 packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -21,8 +21,7 @@ import getDefaultPluginsInfo from '@joplin/lib/services/plugins/defaultPlugins/d
 import JoplinCloudConfigScreen from '../JoplinCloudConfigScreen';
 import ToggleAdvancedSettingsButton from './controls/ToggleAdvancedSettingsButton';
 import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/config/shouldShowMissingPasswordWarning';
-import shim from '@joplin/lib/shim';
-import StyledLink from '../style/StyledLink';
+import MissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 
 const settingKeyToControl: any = {
@@ -190,25 +189,11 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			// saved yet).
 			const matchesSavedTarget = settings['sync.target'] === this.props.settings['sync.target'];
 			if (matchesSavedTarget && shouldShowMissingPasswordWarning(settings['sync.target'], settings)) {
-				const openMissingPasswordFAQ = () =>
-					bridge().openExternal('https://joplinapp.org/faq#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin');
-
-				const macInfoLink = (
-					<StyledLink href="#"
-						onClick={openMissingPasswordFAQ}
-						style={theme.linkStyle}
-					>
-						{_('Help')}
-					</StyledLink>
-				);
-
-				// The FAQ section related to missing passwords is specific to MacOS/ARM -- only show it
-				// in that case.
-				const showMacInfoLink = shim.isMac() && process.arch === 'arm64';
-
 				settingComps.push(
 					<p key='missing-password-warning' style={warningStyle}>
-						{_('Warning: Missing password.')}{' '}{showMacInfoLink ? macInfoLink : null}
+						{_('Warning: Missing password.')}
+						{' '}
+						<MissingPasswordHelpLink theme={theme}/>
 					</p>
 				);
 			}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -193,7 +193,10 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					<p key='missing-password-warning' style={warningStyle}>
 						{_('Warning: Missing password.')}
 						{' '}
-						<MissingPasswordHelpLink theme={theme}/>
+						<MissingPasswordHelpLink
+							theme={theme}
+							text={_('Help')}
+						/>
 					</p>
 				);
 			}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -21,7 +21,7 @@ import getDefaultPluginsInfo from '@joplin/lib/services/plugins/defaultPlugins/d
 import JoplinCloudConfigScreen from '../JoplinCloudConfigScreen';
 import ToggleAdvancedSettingsButton from './controls/ToggleAdvancedSettingsButton';
 import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/config/shouldShowMissingPasswordWarning';
-import MissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
+import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 
 const settingKeyToControl: any = {
@@ -193,7 +193,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					<p key='missing-password-warning' style={warningStyle}>
 						{_('Warning: Missing password.')}
 						{' '}
-						<MissingPasswordHelpLink
+						<MacOSMissingPasswordHelpLink
 							theme={theme}
 							text={_('Help')}
 						/>

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -193,10 +193,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					<p key='missing-password-warning' style={warningStyle}>
 						{_('Warning: Missing password.')}
 						{' '}
-						<MacOSMissingPasswordHelpLink
-							theme={theme}
-							text={_('Help')}
-						/>
+						<MacOSMissingPasswordHelpLink theme={theme} />
 					</p>
 				);
 			}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -191,7 +191,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			if (matchesSavedTarget && shouldShowMissingPasswordWarning(settings['sync.target'], settings)) {
 				settingComps.push(
 					<p key='missing-password-warning' style={warningStyle}>
-						{_('Warning: Missing password.')}
+						{_('%s: Missing password.', _('Warning'))}
 						{' '}
 						<MacOSMissingPasswordHelpLink
 							theme={theme}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -193,7 +193,10 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					<p key='missing-password-warning' style={warningStyle}>
 						{_('Warning: Missing password.')}
 						{' '}
-						<MacOSMissingPasswordHelpLink theme={theme} />
+						<MacOSMissingPasswordHelpLink
+							theme={theme}
+							text={_('Help')}
+						/>
 					</p>
 				);
 			}

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import shim from '@joplin/lib/shim';
 import bridge from '../../../services/bridge';
 import StyledLink from '../../style/StyledLink';
+import { _ } from '@joplin/lib/locale';
 
 interface Props {
 	theme: any;
-	text: string;
 }
 
 const openMissingPasswordFAQ = () =>
@@ -20,7 +20,7 @@ const MacOSMissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 			onClick={openMissingPasswordFAQ}
 			style={props.theme.linkStyle}
 		>
-			{props.text}
+			{_('Help')}
 		</StyledLink>
 	);
 

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import shim from '@joplin/lib/shim';
 import bridge from '../../../services/bridge';
 import StyledLink from '../../style/StyledLink';
-import { _ } from '@joplin/lib/locale';
 
 interface Props {
 	theme: any;
+	text: string;
 }
 
 const openMissingPasswordFAQ = () =>
@@ -20,7 +20,7 @@ const MacOSMissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 			onClick={openMissingPasswordFAQ}
 			style={props.theme.linkStyle}
 		>
-			{_('Help')}
+			{props.text}
 		</StyledLink>
 	);
 

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -26,7 +26,8 @@ const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 
 	// The FAQ section related to missing passwords is specific to MacOS/ARM -- only show it
 	// in that case.
-	const showMacInfoLink = shim.isMac() && process.arch === 'arm64';
+	const newArchitectureReleasedRecently = Date.now() <= Date.UTC(2023, 10); // 10 = November
+	const showMacInfoLink = shim.isMac() && process.arch === 'arm64' && newArchitectureReleasedRecently;
 
 	return showMacInfoLink ? macInfoLink : null;
 };

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import shim from '@joplin/lib/shim';
-import bridge from '../../../bridge';
+import bridge from '../../../services/bridge';
 import StyledLink from '../../style/StyledLink';
 import { _ } from '@joplin/lib/locale';
 
@@ -9,10 +9,12 @@ interface Props {
 	theme: any;
 }
 
-const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
-	const openMissingPasswordFAQ = () =>
-		bridge().openExternal('https://joplinapp.org/faq#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin');
+const openMissingPasswordFAQ = () =>
+	bridge().openExternal('https://joplinapp.org/faq#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin');
 
+// A link to a specific part of the FAQ related to passwords being cleared when upgrading
+// to a MacOS/ARM release.
+const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 	const macInfoLink = (
 		<StyledLink href="#"
 			onClick={openMissingPasswordFAQ}

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -14,7 +14,7 @@ const openMissingPasswordFAQ = () =>
 
 // A link to a specific part of the FAQ related to passwords being cleared when upgrading
 // to a MacOS/ARM release.
-const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
+const MacOSMissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 	const macInfoLink = (
 		<StyledLink href="#"
 			onClick={openMissingPasswordFAQ}
@@ -32,4 +32,4 @@ const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 	return showMacInfoLink ? macInfoLink : null;
 };
 
-export default MissingPasswordHelpLink;
+export default MacOSMissingPasswordHelpLink;

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import shim from '@joplin/lib/shim';
+import bridge from '../../../bridge';
+import StyledLink from '../../style/StyledLink';
+import { _ } from '@joplin/lib/locale';
+
+interface Props {
+	theme: any;
+}
+
+const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
+	const openMissingPasswordFAQ = () =>
+		bridge().openExternal('https://joplinapp.org/faq#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin');
+
+	const macInfoLink = (
+		<StyledLink href="#"
+			onClick={openMissingPasswordFAQ}
+			style={props.theme.linkStyle}
+		>
+			{_('Help')}
+		</StyledLink>
+	);
+
+	// The FAQ section related to missing passwords is specific to MacOS/ARM -- only show it
+	// in that case.
+	const showMacInfoLink = shim.isMac() && process.arch === 'arm64';
+
+	return showMacInfoLink ? macInfoLink : null;
+};
+
+export default MissingPasswordHelpLink;

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import shim from '@joplin/lib/shim';
 import bridge from '../../../services/bridge';
 import StyledLink from '../../style/StyledLink';
-import { _ } from '@joplin/lib/locale';
 
 interface Props {
 	theme: any;
+	text: string;
 }
 
 const openMissingPasswordFAQ = () =>
@@ -20,7 +20,7 @@ const MissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 			onClick={openMissingPasswordFAQ}
 			style={props.theme.linkStyle}
 		>
-			{_('Help')}
+			{props.text}
 		</StyledLink>
 	);
 

--- a/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.tsx
@@ -26,7 +26,7 @@ const MacOSMissingPasswordHelpLink: React.FunctionComponent<Props> = props => {
 
 	// The FAQ section related to missing passwords is specific to MacOS/ARM -- only show it
 	// in that case.
-	const newArchitectureReleasedRecently = Date.now() <= Date.UTC(2023, 10); // 10 = November
+	const newArchitectureReleasedRecently = Date.now() <= Date.UTC(2023, 11); // 11 = December
 	const showMacInfoLink = shim.isMac() && process.arch === 'arm64' && newArchitectureReleasedRecently;
 
 	return showMacInfoLink ? macInfoLink : null;

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -260,7 +260,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				<MissingPasswordHelpLink
 					theme={theme}
-					text={_('Help: Missing password')}
+					text={_('Help')}
 				/>
 			</p>
 		);

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -17,6 +17,7 @@ import Setting from '@joplin/lib/models/Setting';
 import CommandService from '@joplin/lib/services/CommandService';
 import { PublicPrivateKeyPair } from '@joplin/lib/services/e2ee/ppk';
 import ToggleAdvancedSettingsButton from '../ConfigScreen/controls/ToggleAdvancedSettingsButton';
+import MissingPasswordHelpLink from '../ConfigScreen/controls/MissingPasswordHelpLink';
 
 interface Props {
 	themeId: any;
@@ -252,7 +253,13 @@ const EncryptionConfigScreen = (props: Props) => {
 		const buttonTitle = CommandService.instance().label('openMasterPasswordDialog');
 
 		const needPasswordMessage = !needMasterPassword ? null : (
-			<p className="needpassword">{_('Your password is needed to decrypt some of your data.')}<br/>{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}</p>
+			<p className="needpassword">
+				{_('Your password is needed to decrypt some of your data.')}
+				<br/>
+				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
+				<br/>
+				<MissingPasswordHelpLink theme={theme} />
+			</p>
 		);
 
 		return (

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -258,7 +258,10 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
 				<br/>
-				<MacOSMissingPasswordHelpLink theme={theme} />
+				<MacOSMissingPasswordHelpLink
+					theme={theme}
+					text={_('Help')}
+				/>
 			</p>
 		);
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -258,10 +258,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
 				<br/>
-				<MacOSMissingPasswordHelpLink
-					theme={theme}
-					text={_('Help')}
-				/>
+				<MacOSMissingPasswordHelpLink theme={theme} />
 			</p>
 		);
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -258,7 +258,10 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
 				<br/>
-				<MissingPasswordHelpLink theme={theme} />
+				<MissingPasswordHelpLink
+					theme={theme}
+					text={_('Help: Missing password')}
+				/>
 			</p>
 		);
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -17,7 +17,7 @@ import Setting from '@joplin/lib/models/Setting';
 import CommandService from '@joplin/lib/services/CommandService';
 import { PublicPrivateKeyPair } from '@joplin/lib/services/e2ee/ppk';
 import ToggleAdvancedSettingsButton from '../ConfigScreen/controls/ToggleAdvancedSettingsButton';
-import MissingPasswordHelpLink from '../ConfigScreen/controls/MissingPasswordHelpLink';
+import MacOSMissingPasswordHelpLink from '../ConfigScreen/controls/MissingPasswordHelpLink';
 
 interface Props {
 	themeId: any;
@@ -258,7 +258,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
 				<br/>
-				<MissingPasswordHelpLink
+				<MacOSMissingPasswordHelpLink
 					theme={theme}
 					text={_('Help')}
 				/>

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -260,7 +260,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				<br/>
 				<MacOSMissingPasswordHelpLink
 					theme={theme}
-					text={_('Help')}
+					text={_('%s: Missing password', _('Help'))}
 				/>
 			</p>
 		);


### PR DESCRIPTION
# Summary

This pull request adds a link to [the relevant section of the FAQ](https://joplinapp.org/faq/#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin) when the user is on an ARM64 Mac with a missing master key password.

Resolves #8493.

# Testing
1. Modify `MissingPasswordHelpLink.tsx` such that the help link displays on the current system (e.g. comment out `process.arch === 'arm64'` if on an x86_64 Mac).
2. Launch Joplin and clear the encryption password.
3. Click on the help link.

# Screenshot
<img width="1019" alt="Screenshot: Help: Missing password link in encryption settings" src="https://github.com/laurent22/joplin/assets/46334387/6512262a-1625-4fc7-a133-12d2f2f7df33">

# Notes
**There may be a better solution** -- the link is currently shown on *any* MacOS/ARM64 system with an empty encryption password. Additionally, it adds to an already large amount of text. An alternative might be to
1. make the link appear on all systems and link to the [encryption setup documentation](https://joplinapp.org/e2ee/), and,
4. link the encryption setup documentation to [the relevant portion of the FAQ](https://joplinapp.org/faq/#why-did-my-sync-and-encryption-passwords-disappear-after-updating-joplin).

