### PR TITLE
Server: Fixes #8307 - Searching for user should be case insensitive

### DIFF
--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -100,7 +100,7 @@ router.get('admin/users', async (_path: SubPath, ctx: AppContext) => {
 	await userModel.checkIfAllowed(ctx.joplin.owner, AclAction.List);
 
 	const showDisabled = ctx.query.show_disabled === '1';
-	const searchQuery = (ctx.query.query && ctx.query.query.trim()) || '';
+	const searchQuery = ctx.query.query || '';
 
 	const pagination = makeTablePagination(ctx.query, 'full_name', PaginationOrderDir.ASC);
 	pagination.limit = 1000;

--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -100,7 +100,7 @@ router.get('admin/users', async (_path: SubPath, ctx: AppContext) => {
 	await userModel.checkIfAllowed(ctx.joplin.owner, AclAction.List);
 
 	const showDisabled = ctx.query.show_disabled === '1';
-	const searchQuery = ctx.query.query || '';
+	const searchQuery = (ctx.query.query && ctx.query.query.trim()) || '';
 
 	const pagination = makeTablePagination(ctx.query, 'full_name', PaginationOrderDir.ASC);
 	pagination.limit = 1000;

--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -100,7 +100,7 @@ router.get('admin/users', async (_path: SubPath, ctx: AppContext) => {
 	await userModel.checkIfAllowed(ctx.joplin.owner, AclAction.List);
 
 	const showDisabled = ctx.query.show_disabled === '1';
-	const searchQuery = (ctx.query.query && ctx.query.query.toLowerCase()) || '';
+	const searchQuery = (ctx.query.query && ctx.query.query.toString().toLowerCase()) || '';
 
 	const pagination = makeTablePagination(ctx.query, 'full_name', PaginationOrderDir.ASC);
 	pagination.limit = 1000;

--- a/packages/server/src/routes/admin/users.ts
+++ b/packages/server/src/routes/admin/users.ts
@@ -100,7 +100,7 @@ router.get('admin/users', async (_path: SubPath, ctx: AppContext) => {
 	await userModel.checkIfAllowed(ctx.joplin.owner, AclAction.List);
 
 	const showDisabled = ctx.query.show_disabled === '1';
-	const searchQuery = ctx.query.query || '';
+	const searchQuery = (ctx.query.query && ctx.query.query.toLowerCase()) || '';
 
 	const pagination = makeTablePagination(ctx.query, 'full_name', PaginationOrderDir.ASC);
 	pagination.limit = 1000;
@@ -112,7 +112,9 @@ router.get('admin/users', async (_path: SubPath, ctx: AppContext) => {
 
 			if (searchQuery) {
 				void query.where(qb => {
-					void qb.whereRaw('full_name like ?', [`%${searchQuery}%`]).orWhereRaw('email like ?', [`%${searchQuery}%`]);
+					void qb
+						.whereRaw('lower(full_name) like ?', [`%${searchQuery}%`])
+						.orWhereRaw('lower(email) like ?', [`%${searchQuery}%`]);
 				});
 			}
 


### PR DESCRIPTION
As I've explained in the issue description:

I believe that the problem is when using PostgreSQL in the production enviroment.
Maybe in the SQLite the LIKE operator is case-insentive, but in the PostgreSQL doesn't. In PostgreSQL the case-insentive operator for LIKE searches is ILIKE (as far as I remember).

To solve the problem I'm transforming everything to lowercase.