### PR TITLE
Mobile: Fixes #8510 - Android: The voice typing box covers the texts in the editor

### DIFF
--- a/packages/app-mobile/components/voiceTyping/VoiceTypingDialog.tsx
+++ b/packages/app-mobile/components/voiceTyping/VoiceTypingDialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState, useEffect, useCallback } from 'react';
-import { Banner, ActivityIndicator, Modal } from 'react-native-paper';
+import { Banner, ActivityIndicator } from 'react-native-paper';
 import { _, languageName } from '@joplin/lib/locale';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import { getVosk, Recorder, startRecording, Vosk } from '../../services/voiceTyping/vosk';
@@ -107,18 +107,16 @@ export default (props: Props) => {
 	};
 
 	return (
-		<Modal visible={true} style={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
-			<Banner
-				visible={true}
-				icon={renderIcon()}
-				actions={[
-					{
-						label: _('Done'),
-						onPress: onDismiss,
-					},
-				]}>
-				{`${_('Voice typing...')}\n${renderContent()}`}
-			</Banner>
-		</Modal>
+		<Banner
+			visible={true}
+			icon={renderIcon()}
+			actions={[
+				{
+					label: _('Done'),
+					onPress: onDismiss,
+				},
+			]}>
+			{`${_('Voice typing...')}\n${renderContent()}`}
+		</Banner>
 	);
 };


### PR DESCRIPTION
To solve the problem I've removed the Voice Typing from within the modal.

Voice typing closed:
![close](https://github.com/laurent22/joplin/assets/19213902/7f25479e-07a9-4988-bb92-a62b9551257b)

Voice typing opened:
![open](https://github.com/laurent22/joplin/assets/19213902/fc13155e-8662-4e40-a069-ee97d481532b)

Voice typing opened with the keyboard opened:
![open-with-the-keyboard](https://github.com/laurent22/joplin/assets/19213902/5839d6f8-852f-4c88-9c10-b58a59bcea9a)

This last screenshot shows what seems to be a problem, but as we talked in the dev-channel, maybe is better to solve this in another issue.
