### PR TITLE
Mobile: Fixes #8687: Hide markdown toolbar completely when low on vertical space

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -410,6 +410,7 @@ packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/ToolbarButton.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/ToolbarOverflowRows.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/types.js
+packages/app-mobile/components/NoteEditor/NoteEditor.test.js
 packages/app-mobile/components/NoteEditor/NoteEditor.js
 packages/app-mobile/components/NoteEditor/SearchPanel.js
 packages/app-mobile/components/NoteEditor/SelectionFormatting.js

--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/ToolbarButton.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/ToolbarOverflowRows.js
 packages/app-mobile/components/NoteEditor/MarkdownToolbar/types.js
+packages/app-mobile/components/NoteEditor/NoteEditor.test.js
 packages/app-mobile/components/NoteEditor/NoteEditor.js
 packages/app-mobile/components/NoteEditor/SearchPanel.js
 packages/app-mobile/components/NoteEditor/SelectionFormatting.js

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import '@testing-library/jest-native';
+
+import NoteEditor from './NoteEditor';
+import Setting from '@joplin/lib/models/Setting';
+import { _ } from '@joplin/lib/locale';
+import { MenuProvider } from 'react-native-popup-menu';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+
+describe('NoteEditor', () => {
+	beforeEach(async () => {
+		// Required to use ExtendedWebView
+		await setupDatabaseAndSynchronizer(0);
+		await switchClient(0);
+	});
+
+	it('should hide the markdown toolbar when the window is small', async () => {
+		const wrappedNoteEditor = render(
+			<MenuProvider>
+				<NoteEditor
+					themeId={Setting.THEME_ARITIM_DARK}
+					initialText='Testing...'
+					style={{}}
+					toolbarEnabled={true}
+					readOnly={false}
+					onChange={()=>{}}
+					onSelectionChange={()=>{}}
+					onUndoRedoDepthChange={()=>{}}
+					onAttach={()=>{}}
+				/>
+			</MenuProvider>
+		);
+
+		// Maps from screen height to whether the markdown toolbar should be visible.
+		const testCases: [number, boolean][] = [
+			[10, false],
+			[1000, true],
+			[100, false],
+			[80, false],
+			[600, true],
+		];
+
+		const noteEditorRoot = await wrappedNoteEditor.findByTestId('note-editor-root');
+
+		const setRootHeight = (height: number) => {
+			act(() => {
+				// See https://stackoverflow.com/a/61774123
+				fireEvent(noteEditorRoot, 'layout', {
+					nativeEvent: {
+						layout: { height },
+					},
+				});
+			});
+		};
+
+		for (const [height, visible] of testCases) {
+			setRootHeight(height);
+
+			await waitFor(async () => {
+				const showMoreButton = await screen.queryByLabelText(_('Show more actions'));
+				if (visible) {
+					expect(showMoreButton).not.toBeNull();
+				} else {
+					expect(showMoreButton).toBeNull();
+				}
+			});
+		}
+	});
+});

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -215,7 +215,7 @@ const useEditorControl = (
 	}, [injectJS, searchStateRef, setLinkDialogVisible, setSearchState]);
 };
 
-const NoteEditor = (props: Props, ref: any) => {
+function NoteEditor(props: Props, ref: any) {
 	const webviewRef = useRef(null);
 
 	const setInitialSelectionJS = props.initialSelection ? `
@@ -439,6 +439,6 @@ const NoteEditor = (props: Props, ref: any) => {
 			{toolbarEnabled ? toolbar : null}
 		</View>
 	);
-};
+}
 
 export default forwardRef(NoteEditor);

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -18,7 +18,6 @@ import {
 } from './types';
 import { _ } from '@joplin/lib/locale';
 import MarkdownToolbar from './MarkdownToolbar/MarkdownToolbar';
-import { buttonSize } from './MarkdownToolbar/ToolbarButton';
 
 type ChangeEventHandler = (event: ChangeEvent)=> void;
 type UndoRedoDepthChangeHandler = (event: UndoRedoDepthChangeEvent)=> void;
@@ -372,18 +371,15 @@ const NoteEditor = (props: Props, ref: any) => {
 	const [hasSpaceForToolbar, setHasSpaceForToolbar] = useState(true);
 	const toolbarEnabled = props.toolbarEnabled && hasSpaceForToolbar;
 
-	// Listens for changes to the container's height, not the editor's height, because
-	// this callback changes the height of the editor.
 	const onContainerLayout = useCallback((event: LayoutChangeEvent) => {
-		const toolbarHeight = toolbarEnabled ? buttonSize : 0;
-		const editorHeight = event.nativeEvent.layout.height - toolbarHeight;
+		const containerHeight = event.nativeEvent.layout.height;
 
-		if (editorHeight < 140) {
+		if (containerHeight < 140) {
 			setHasSpaceForToolbar(false);
 		} else {
 			setHasSpaceForToolbar(true);
 		}
-	}, [toolbarEnabled]);
+	}, []);
 
 	const toolbar = <MarkdownToolbar
 		style={{
@@ -416,14 +412,12 @@ const NoteEditor = (props: Props, ref: any) => {
 				editorControl={editorControl}
 				selectionState={selectionState}
 			/>
-			<View
-				style={{
-					flexGrow: 1,
-					flexShrink: 0,
-					minHeight: '30%',
-					...props.contentStyle,
-				}}
-			>
+			<View style={{
+				flexGrow: 1,
+				flexShrink: 0,
+				minHeight: '30%',
+				...props.contentStyle,
+			}}>
 				<ExtendedWebView
 					webviewInstanceId='NoteEditor'
 					themeId={props.themeId}

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -33,6 +33,21 @@ document.createRange = () => {
 
 shimInit({ nodeSqlite: sqlite3 });
 
+// This library has the following error when running within Jest:
+//   Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.
+jest.mock('react-native-device-info', () => {
+	return {
+		hasNotch: () => false,
+	};
+});
+
+// react-native-webview expects native iOS/Android code so needs to be mocked.
+jest.mock('react-native-webview', () => {
+	const { View } = require('react-native');
+	return {
+		WebView: View,
+	};
+});
 
 // react-native-fs's CachesDirectoryPath export doesn't work in a testing environment.
 // Use a temporary folder instead.


### PR DESCRIPTION
# Summary

This pull request hides the markdown toolbar completely when the editor  is low on vertical space, rather than clipping the edge of buttons.

This should fix #8687.