### PR TITLE
All: Fixes #8706 - Pasting a resource in Rich Text editor breaks the resource link

### DIFF
--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -162,6 +162,7 @@ class HtmlUtils {
 		return url.startsWith('https://') ||
 			url.startsWith('http://') ||
 			url.startsWith('mailto://') ||
+			url.startsWith('file://') ||
 			// We also allow anchors but only with a specific set of a characters.
 			// Fixes https://github.com/laurent22/joplin/issues/8286
 			!!url.match(/^#[a-zA-Z0-9-]+$/);


### PR DESCRIPTION
When pasting some attachment in the RT editor the URLs that starts with file:// was being replaced by '#'. I just added file:// to the list of "valid URLs" to stop of removing it.