### PR TITLE
Chore: Resolves #8697: MacOS build: Name releases such that x86_64 releases are selected by old versions of Joplin

### DIFF
--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -49,7 +49,7 @@ jobs:
           export npm_config_target_arch=arm64
           yarn install
           cd packages/app-desktop
-          npm pkg set 'build.mac.artifactName'='${productName}-${version}-${arch}.${ext}'
+          npm pkg set 'build.mac.artifactName'='${productName}-${version}.${arch}.${ext}'
           npm pkg set 'build.mac.target.target'='dmg'
           npm pkg set 'build.mac.target.arch[0]'='arm64'
 

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -90,7 +90,8 @@
             "CFBundleURLName": "org.joplinapp.x-callback-url"
           }
         ]
-      }
+      },
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "linux": {
       "icon": "../../Assets/LinuxIcons",


### PR DESCRIPTION
# Summary

This pull request names new builds of Joplin such that older versions of Joplin select x86_64 builds for upgrade, rather than ARM builds.

This is done by observing that the GitHub API returns release artifacts in alphabetic order such that `Joplin-x.x.x-x64.dmg` is returned before `Joplin-x.x.x.arm64.dmg`. This seems to be both the case in the UI and in the ordering of objects processed in `checkForUpdates.ts`.

# Notes
Changing the ARM64 build's extension to `.DMG` may require patching `electron-builder`. `electron-builder` currently handles uploading built artifacts to GitHub and seems to change the file extension to lowercase even if an uppercase file extension is specified. For example, 
```
npm pkg set 'build.mac.artifactName'='${productName}-${version}.${arch}.DMG'
```
produces an artifact with the extension `.dmg`.

This has been tested with the following test release https://github.com/personalizedrefrigerator/joplin/releases/tag/v0.0.1 and a fork of Joplin v2.11.11 modified to fetch release data from https://github.com/personalizedrefrigerator/joplin/releases and to ignore the version number associated with the release.
