### PR TITLE
Chore: Desktop: Support uppercase DMG extensions when checking for updates

### DIFF
--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -128,7 +128,7 @@ describe('checkForUpdates', () => {
 		const releaseData = releaseDataWithExtension('-arm64.DMG');
 		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, { });
 
-		// Should match, even with uppercase .DMG.
+		// Should match, with uppercase .DMG
 		expect(releaseInfo).toMatchObject({
 			version: '2.12.4',
 			downloadUrl: 'https://objects.joplinusercontent.com/v2.12.4/Joplin-2.12.4-arm64.DMG',

--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -1,4 +1,4 @@
-import { extractVersionInfo, Release, Platform, Architecture } from './checkForUpdatesUtils';
+import { extractVersionInfo, Release, Platform, Architecture, GitHubRelease } from './checkForUpdatesUtils';
 import { releases1, releases2 } from './checkForUpdatesUtilsTestData';
 
 describe('checkForUpdates', () => {
@@ -102,6 +102,49 @@ describe('checkForUpdates', () => {
 			expect(actual.pageUrl).toBe(expected.pageUrl);
 			expect(actual.version).toBe(expected.version);
 		}
+	});
+
+	it('macOS should match both .DMG and .dmg extensions', () => {
+		// A .DMG may be used to prevent older versions of Joplin from downloading an incompatible
+		// release. Ensure that newer versions of Joplin can download these releases.
+		const releaseDataWithExtension = (extension: string) => {
+			const downloadURL = `https://github.com/laurent22/joplin/releases/download/v2.12.4/Joplin-2.12.4${extension}`;
+			const releaseData: GitHubRelease = {
+				prerelease: false,
+				body: 'this is a test',
+				tag_name: 'v2.12.4',
+				assets: [
+					{
+						name: `Joplin-2.12.4${extension}`,
+						browser_download_url: downloadURL,
+					},
+				],
+				html_url: 'https://github.com/laurent22/joplin/releases/tag/v2.12.4',
+			};
+
+			return releaseData;
+		};
+
+		const releaseData = releaseDataWithExtension('-arm64.DMG');
+		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, { });
+
+		// Should match, even with uppercase .DMG.
+		expect(releaseInfo).toMatchObject({
+			version: '2.12.4',
+			downloadUrl: 'https://objects.joplinusercontent.com/v2.12.4/Joplin-2.12.4-arm64.DMG',
+			pageUrl: releaseData.html_url,
+			prerelease: releaseData.prerelease,
+		});
+
+		// Should not match when the extension is invalid
+		expect(
+			extractVersionInfo([releaseDataWithExtension('-arm64.dmG')], 'darwin', 'arm64', false, { }),
+		).toMatchObject({
+			version: '2.12.4',
+			downloadUrl: null,
+			pageUrl: releaseData.html_url,
+			prerelease: releaseData.prerelease,
+		});
 	});
 
 });

--- a/packages/app-desktop/utils/checkForUpdatesUtils.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.ts
@@ -86,18 +86,18 @@ export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform
 		});
 	}
 
+	const arm64DMGPattern = /arm64\.(dmg|DMG)$/;
 	if (platform === 'darwin' && arch === 'arm64') {
 		foundAsset = release.assets.find(asset => {
-			return asset.name.endsWith('arm64.dmg');
+			return asset.name.match(arm64DMGPattern);
 		});
 	}
 
 	if (!foundAsset && platform === 'darwin') {
 		foundAsset = release.assets.find(asset => {
-			return fileExtension(asset.name) === 'dmg' && !asset.name.endsWith('arm64.dmg');
+			return fileExtension(asset.name) === 'dmg' && !asset.name.match(arm64DMGPattern);
 		});
 	}
-
 	if (platform === 'linux') {
 		foundAsset = release.assets.find(asset => {
 			return fileExtension(asset.name) === 'AppImage';


### PR DESCRIPTION
# Summary

Adds support for downloading releases that use uppercase DMG extensions. See [the discussion associated with this pull request](https://github.com/laurent22/joplin/pull/8713).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
