### PR TITLE
Chore: Fix packageJsonLint on some systems

### DIFF
--- a/packages/tools/packageJsonLint.ts
+++ b/packages/tools/packageJsonLint.ts
@@ -2,6 +2,10 @@ import { execCommand, getRootDir } from '@joplin/utils';
 import { chdir } from 'process';
 
 const main = async () => {
+	// Having no output seems to cause lint-staged to fail on some systems.
+	// Add a console.log statement to work around this issue.
+	console.log('Linting package.json files...');
+
 	const rootDir = await getRootDir();
 	chdir(rootDir);
 	await execCommand('yarn run npmPkgJsonLint --configFile .npmpackagejsonlintrc.json --quiet .');


### PR DESCRIPTION
# Summary

`git commit` was failing on my Ubuntu 23.04 system while running `packageJsonLint`. Adding output to this script seems to fix the issue.

Strangely, `yarn run lint-staged` works, but `git commit` (which runs `yarn run lint-staged` internally) doesn't.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
