### PR TITLE
Desktop: Fixes #8723: Update CSS variables in user iframes on theme change

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -381,6 +381,7 @@ packages/app-desktop/services/plugins/hooks/useContentSize.js
 packages/app-desktop/services/plugins/hooks/useHtmlLoader.js
 packages/app-desktop/services/plugins/hooks/useScriptLoader.js
 packages/app-desktop/services/plugins/hooks/useSubmitHandler.js
+packages/app-desktop/services/plugins/hooks/useThemeCss.test.js
 packages/app-desktop/services/plugins/hooks/useThemeCss.js
 packages/app-desktop/services/plugins/hooks/useViewIsReady.js
 packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js

--- a/.gitignore
+++ b/.gitignore
@@ -367,6 +367,7 @@ packages/app-desktop/services/plugins/hooks/useContentSize.js
 packages/app-desktop/services/plugins/hooks/useHtmlLoader.js
 packages/app-desktop/services/plugins/hooks/useScriptLoader.js
 packages/app-desktop/services/plugins/hooks/useSubmitHandler.js
+packages/app-desktop/services/plugins/hooks/useThemeCss.test.js
 packages/app-desktop/services/plugins/hooks/useThemeCss.js
 packages/app-desktop/services/plugins/hooks/useViewIsReady.js
 packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js

--- a/packages/app-desktop/services/plugins/hooks/useThemeCss.test.ts
+++ b/packages/app-desktop/services/plugins/hooks/useThemeCss.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useThemeCss from './useThemeCss';
+import Setting from '@joplin/lib/models/Setting';
+
+describe('useThemeCss', () => {
+	it('should return a different path when the theme changes', async () => {
+		const hookResult = renderHook(useThemeCss, {
+			initialProps: { pluginId: 'testid', themeId: Setting.THEME_DARK },
+		});
+
+		await hookResult.waitFor(() => {
+			expect(hookResult.result.current).toContain(`plugin_testid_theme_${Setting.THEME_DARK}.css`);
+		});
+
+		hookResult.rerender({ pluginId: 'testid', themeId: Setting.THEME_LIGHT });
+
+		await hookResult.waitFor(() => {
+			expect(hookResult.result.current).toContain(`plugin_testid_theme_${Setting.THEME_LIGHT}.css`);
+		});
+	});
+});

--- a/packages/app-desktop/services/plugins/hooks/useThemeCss.ts
+++ b/packages/app-desktop/services/plugins/hooks/useThemeCss.ts
@@ -36,16 +36,18 @@ export default function useThemeCss(dep: HookDependencies) {
 	const [cssFilePath, setCssFilePath] = useState('');
 
 	useEffect(() => {
-		if (cssFilePath) return () => {};
-
 		let cancelled = false;
 
 		async function createThemeStyleSheet() {
 			const theme = themeStyle(themeId);
 			const css = themeToCssVariables(theme);
 			const filePath = `${Setting.value('tempDir')}/plugin_${pluginId}_theme_${themeId}.css`;
-			await shim.fsDriver().writeFile(filePath, css, 'utf8');
-			if (cancelled) return;
+
+			if (!(await shim.fsDriver().exists(filePath))) {
+				await shim.fsDriver().writeFile(filePath, css, 'utf8');
+				if (cancelled) return;
+			}
+
 			setCssFilePath(filePath);
 		}
 
@@ -54,7 +56,7 @@ export default function useThemeCss(dep: HookDependencies) {
 		return () => {
 			cancelled = true;
 		};
-	}, [pluginId, themeId, cssFilePath]);
+	}, [pluginId, themeId]);
 
 	return cssFilePath;
 }


### PR DESCRIPTION
# Summary

This PR causes the `useThemeCss` hook to generate a new CSS file, if necessary, when Joplin's theme changes, updating theme-related CSS variables in plugin-related iframes.

Fixes #8723.


# Testing


 1. Install a plugin that creates a dialog or a sidebar (e.g. note tabs)
 2. Enable automatically switching Joplin's theme to match the system
 3. Show the sidebar/dialog
 4. Toggle dark theme

This has been manually tested on Ubuntu.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
