### PR TITLE
Chore: Resolves #8697: Rename releases such that MacOS x86_64 releases are selected by old versions of Joplin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -368,6 +368,7 @@ packages/app-desktop/services/sortOrder/notesSortOrderUtils.test.js
 packages/app-desktop/services/sortOrder/notesSortOrderUtils.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/notarizeMacApp.js
+packages/app-desktop/tools/renameReleaseAssets.js
 packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -58,7 +58,7 @@ jobs:
             echo "Building and publishing desktop application..."
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn run dist --mac --arm64
 
-            yarn rename-release-assets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GITHUB_TOKEN"
+            yarn renameReleaseAssets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GITHUB_TOKEN"
           else
             echo "Building but *not* publishing desktop application..."
 

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -58,7 +58,7 @@ jobs:
             echo "Building and publishing desktop application..."
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn run dist --mac --arm64
 
-            yarn rename-releases -- --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GH_TOKEN"
+            yarn rename-release-assets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GH_TOKEN"
           else
             echo "Building but *not* publishing desktop application..."
 

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -42,6 +42,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           IS_CONTINUOUS_INTEGRATION: 1
           BUILD_SEQUENCIAL: 1
         run: |
@@ -56,6 +57,8 @@ jobs:
           if [[ $GIT_TAG_NAME = v* ]]; then
             echo "Building and publishing desktop application..."
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn run dist --mac --arm64
+
+            yarn rename-releases -- --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GH_TOKEN"
           else
             echo "Building but *not* publishing desktop application..."
 

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -41,7 +41,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           IS_CONTINUOUS_INTEGRATION: 1
           BUILD_SEQUENCIAL: 1
@@ -58,7 +58,7 @@ jobs:
             echo "Building and publishing desktop application..."
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn run dist --mac --arm64
 
-            yarn rename-release-assets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GH_TOKEN"
+            yarn rename-release-assets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GITHUB_TOKEN"
           else
             echo "Building but *not* publishing desktop application..."
 

--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,7 @@ packages/app-desktop/services/sortOrder/notesSortOrderUtils.test.js
 packages/app-desktop/services/sortOrder/notesSortOrderUtils.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/notarizeMacApp.js
+packages/app-desktop/tools/renameReleaseAssets.js
 packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -14,7 +14,8 @@
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
     "start": "gulp build && electron . --env dev --log-level debug --open-dev-tools",
     "test": "jest",
-    "test-ci": "yarn test"
+    "test-ci": "yarn test",
+    "rename-release-assets": "node tools/renameReleaseAssets.js"
   },
   "repository": {
     "type": "git",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -15,7 +15,7 @@
     "start": "gulp build && electron . --env dev --log-level debug --open-dev-tools",
     "test": "jest",
     "test-ci": "yarn test",
-    "rename-release-assets": "node tools/renameReleaseAssets.js"
+    "renameReleaseAssets": "node tools/renameReleaseAssets.js"
   },
   "repository": {
     "type": "git",

--- a/packages/app-desktop/tools/renameReleaseAssets.ts
+++ b/packages/app-desktop/tools/renameReleaseAssets.ts
@@ -3,31 +3,43 @@ import { parseArgs } from 'util';
 interface Context {
 	repo: string; // {owner}/{repo}
 	githubToken: string;
-	tag: string;
 }
 
 const apiBaseUrl = 'https://api.github.com/repos/';
 const defaultApiHeaders = (context: Context) => ({
-	'Authorization': `Bearer ${context.githubToken}`,
+	'Authorization': `token ${context.githubToken}`,
 	'X-GitHub-Api-Version': '2022-11-28',
 	'Accept': 'application/vnd.github+json',
 });
 
-const getTargetRelease = async (context: Context) => {
-	const result = await fetch(`${apiBaseUrl}${context.repo}/releases/tags/${context.tag}`, {
+const getTargetRelease = async (context: Context, targetTag: string) => {
+	console.log('Fetching releases...');
+
+	// Note: We need to fetch all releases, not just /releases/tag/tag-name-here.
+	// The latter doesn't include draft releases.
+
+	const result = await fetch(`${apiBaseUrl}${context.repo}/releases`, {
 		method: 'GET',
 		headers: defaultApiHeaders(context),
 	});
 
-	const json = await result.json();
+	const releases = await result.json();
 	if (!result.ok) {
-		throw new Error(`Error fetching release: ${JSON.stringify(json)}`);
+		throw new Error(`Error fetching release: ${JSON.stringify(releases)}`);
 	}
 
-	return json;
+	for (const release of releases) {
+		if (release.tag_name === targetTag) {
+			return release;
+		}
+	}
+
+	throw new Error(`No release with tag ${targetTag} found!`);
 };
 
 const updateReleaseAsset = async (context: Context, assetUrl: string, newName: string) => {
+	console.log('Updating asset with URL', assetUrl, 'to have name, ', newName);
+
 	// See https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#update-a-release-asset
 	const result = await fetch(assetUrl, {
 		method: 'PATCH',
@@ -61,13 +73,15 @@ const renameReleaseAssets = async () => {
 		].join('\n'));
 	}
 
+
 	const context: Context = {
 		repo: args.values.repo,
 		githubToken: args.values.token,
-		tag: args.values.tag,
 	};
 
-	const release = await getTargetRelease(context);
+	console.log('Renaming release assets for tag', args.values.tag, context.repo);
+
+	const release = await getTargetRelease(context, args.values.tag);
 
 	if (!release.assets) {
 		console.log(release);

--- a/packages/app-desktop/tools/renameReleaseAssets.ts
+++ b/packages/app-desktop/tools/renameReleaseAssets.ts
@@ -1,0 +1,95 @@
+import { parseArgs } from 'util';
+
+interface Context {
+	repo: string; // {owner}/{repo}
+	githubToken: string;
+	tag: string;
+}
+
+const apiBaseUrl = 'https://api.github.com/repos/';
+const defaultApiHeaders = (context: Context) => ({
+	'Authorization': `Bearer ${context.githubToken}`,
+	'X-GitHub-Api-Version': '2022-11-28',
+	'Accept': 'application/vnd.github+json',
+});
+
+const getTargetRelease = async (context: Context) => {
+	const result = await fetch(`${apiBaseUrl}${context.repo}/releases/tags/${context.tag}`, {
+		method: 'GET',
+		headers: defaultApiHeaders(context),
+	});
+
+	const json = await result.json();
+	if (!result.ok) {
+		throw new Error(`Error fetching release: ${JSON.stringify(json)}`);
+	}
+
+	return json;
+};
+
+const updateReleaseAsset = async (context: Context, assetUrl: string, newName: string) => {
+	// See https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#update-a-release-asset
+	const result = await fetch(assetUrl, {
+		method: 'PATCH',
+		headers: defaultApiHeaders(context),
+		body: JSON.stringify({
+			name: newName,
+		}),
+	});
+
+	if (!result.ok) {
+		throw new Error(`Unable to update release asset: ${await result.text()}`);
+	}
+};
+
+// Renames release assets in Joplin Desktop releases
+const renameReleaseAssets = async () => {
+	const args = parseArgs({
+		options: {
+			tag: { type: 'string' },
+			token: { type: 'string' },
+			repo: { type: 'string' },
+		},
+	});
+
+	if (!args.values.tag || !args.values.token || !args.values.repo) {
+		throw new Error([
+			'Required arguments: --tag, --token, --repo',
+			'  --tag should be a git tag with an associated release (e.g. v12.12.12)',
+			'  --token should be a GitHub API token',
+			'  --repo should be a string in the form user/reponame (e.g. laurent22/joplin)',
+		].join('\n'));
+	}
+
+	const context: Context = {
+		repo: args.values.repo,
+		githubToken: args.values.token,
+		tag: args.values.tag,
+	};
+
+	const release = await getTargetRelease(context);
+
+	if (!release.assets) {
+		console.log(release);
+		throw new Error(`Release ${release.name} missing assets!`);
+	}
+
+	// Patterns used to rename releases
+	const renamePatterns = [
+		[/-arm64\.dmg$/, '-arm64.DMG'],
+	];
+
+	for (const asset of release.assets) {
+		for (const [pattern, replacement] of renamePatterns) {
+			if (asset.name.match(pattern)) {
+				const newName = asset.name.replace(pattern, replacement);
+				await updateReleaseAsset(context, asset.url, newName);
+
+				// Only rename a release once.
+				break;
+			}
+		}
+	}
+};
+
+void renameReleaseAssets();


### PR DESCRIPTION
# Summary

This solution uses the GitHub API to rename release assets after they have already been uploaded to GitHub. See https://github.com/laurent22/joplin/pull/8713#issuecomment-1691689188.

Adds a CI step that renames releases with names ending in `-arm64.dmg` to `-arm64.DMG` to prevent older versions of Joplin from downloading them.

# Testing

The new script has been tested locally with a GitHub access token. It has also been [tested in CI](https://github.com/personalizedrefrigerator/joplin/actions/runs/5979573589/job/16223945565) (with a [modified version of the M1 Mac build script](https://github.com/personalizedrefrigerator/joplin/commit/0fe32fb2c000f7a445b8d107896718c562688af4#diff-2879d1565c8f2d5c082226978ee38f28936ef7ea81a6ebf9760a521725dd1238)) with [this release](https://github.com/personalizedrefrigerator/joplin/releases/tag/v0.0.2).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
