### PR TITLE
Desktop: Resolves #8735: Convert HTML for not-loaded images back into markdown

### DIFF
--- a/packages/app-cli/tests/html_to_md/not_loaded_resource.html
+++ b/packages/app-cli/tests/html_to_md/not_loaded_resource.html
@@ -12,7 +12,7 @@
 	class="not-loaded-resource resource-status-notDownloaded"
 	data-resource-id="someidhere"
 	data-before-html-src="style=&quot;transform: scale(0);&quot;"
-	data-after-html-src="alt=&quot;Test&quot;"
+	data-after-html-src="alt=&quot;Test&quot;/"
 >
 	<img src="some-src-here"/>
 </div>

--- a/packages/app-cli/tests/html_to_md/not_loaded_resource.html
+++ b/packages/app-cli/tests/html_to_md/not_loaded_resource.html
@@ -1,0 +1,10 @@
+<div contenteditable="false" class="not-loaded-resource resource-status-notDownloaded" data-resource-id="198e23d8cf834bb7b65fb2987f2378e3" data-content="Test image" data-mce-selected="1"><img src="blob:file:///bdfb7a28-a49a-45d5-8bf3-11e424db1474"></div>
+<div
+	contenteditable="false"
+	class="not-loaded-resource resource-status-notDownloaded"
+	data-resource-id="someidhere"
+	data-before-html-src="style=&quot;transform: scale(0);&quot;"
+	data-after-html-src="alt=&quot;Test&quot;"
+>
+	<img src="some-src-here"/>
+</div>

--- a/packages/app-cli/tests/html_to_md/not_loaded_resource.html
+++ b/packages/app-cli/tests/html_to_md/not_loaded_resource.html
@@ -1,4 +1,12 @@
-<div contenteditable="false" class="not-loaded-resource resource-status-notDownloaded" data-resource-id="198e23d8cf834bb7b65fb2987f2378e3" data-content="Test image" data-mce-selected="1"><img src="blob:file:///bdfb7a28-a49a-45d5-8bf3-11e424db1474"></div>
+<div
+	contenteditable="false"
+	class="not-loaded-resource resource-status-notDownloaded"
+	data-resource-id="198e23d8cf834bb7b65fb2987f2378e3"
+	data-label="Test image"
+	data-mce-selected="1"
+>
+	<img src="blob:file:///bdfb7a28-a49a-45d5-8bf3-11e424db1474">
+</div>
 <div
 	contenteditable="false"
 	class="not-loaded-resource resource-status-notDownloaded"

--- a/packages/app-cli/tests/html_to_md/not_loaded_resource.md
+++ b/packages/app-cli/tests/html_to_md/not_loaded_resource.md
@@ -1,0 +1,1 @@
+![Test image](:/198e23d8cf834bb7b65fb2987f2378e3)<img style="transform: scale(0);" src=":/someidhere" alt="Test"/>

--- a/packages/renderer/HtmlToHtml.ts
+++ b/packages/renderer/HtmlToHtml.ts
@@ -106,11 +106,10 @@ export default class HtmlToHtml {
 
 				const r = imageReplacement(
 					this.ResourceModel_,
-					data.src,
+					{ src: data.src, beforeSrc: '', afterSrc: '' },
 					options.resources,
 					this.resourceBaseUrl_,
 					options.itemIdToUrl,
-					{ htmlBefore: '', htmlAfter: '' },
 				);
 				if (!r) return null;
 

--- a/packages/renderer/HtmlToHtml.ts
+++ b/packages/renderer/HtmlToHtml.ts
@@ -1,6 +1,6 @@
 import htmlUtils from './htmlUtils';
 import linkReplacement from './MdToHtml/linkReplacement';
-import utils, { ItemIdToUrlHandler } from './utils';
+import { imageReplacement, ItemIdToUrlHandler } from './utils';
 import InMemoryCache from './InMemoryCache';
 import { RenderResult } from './MarkupToHtml';
 const md5 = require('md5');
@@ -104,7 +104,14 @@ export default class HtmlToHtml {
 			html = htmlUtils.processImageTags(html, (data: any) => {
 				if (!data.src) return null;
 
-				const r = utils.imageReplacement(this.ResourceModel_, data.src, options.resources, this.resourceBaseUrl_, options.itemIdToUrl);
+				const r = imageReplacement(
+					this.ResourceModel_,
+					data.src,
+					options.resources,
+					this.resourceBaseUrl_,
+					options.itemIdToUrl,
+					{ htmlBefore: '', htmlAfter: '' },
+				);
 				if (!r) return null;
 
 				if (typeof r === 'string') {

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -32,6 +32,7 @@ export interface RenderOptions {
 	useCustomPdfViewer?: boolean;
 	noteId?: string;
 	vendorDir?: string;
+	resources?: Record<string, any>;
 }
 
 interface RendererRule {

--- a/packages/renderer/MdToHtml/createEventHandlingAttrs.ts
+++ b/packages/renderer/MdToHtml/createEventHandlingAttrs.ts
@@ -1,6 +1,6 @@
 
 
-import utils from '../utils';
+import { longPressDelay } from '../utils';
 
 
 export interface Options {
@@ -46,7 +46,7 @@ export const createEventHandlingListeners = (resourceId: string, options: Option
 
 	if (options.enableLongPress) {
 		const longPressHandler = `(() => ${options.postMessageSyntax}('longclick:${resourceId}'))`;
-		const touchStart = `(${longPressTouchStartFnString})(${longPressHandler}, ${utils.longPressDelay}); `;
+		const touchStart = `(${longPressTouchStartFnString})(${longPressHandler}, ${longPressDelay}); `;
 
 		const callClearLongPressTimeout = `(${clearLongPressTimeoutFnString})(); `;
 		const touchCancel = callClearLongPressTimeout;

--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -62,11 +62,7 @@ export default function(href: string, options: Options = null): LinkReplacementR
 
 			return {
 				resourceReady: false,
-				html: `<a
-					class="not-loaded-resource resource-status-${status}"
-					contenteditable="false"
-					data-resource-type="resource"
-					data-resource-id="${resourceId}">` + `<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>`,
+				html: `<a class="not-loaded-resource resource-status-${status}" data-resource-id="${resourceId}">` + `<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>`,
 				resource,
 				resourceFullPath: null,
 			};

--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -1,4 +1,4 @@
-import utils, { ItemIdToUrlHandler } from '../utils';
+import { ItemIdToUrlHandler, resourceStatus, resourceStatusFile } from '../utils';
 import createEventHandlingAttrs from './createEventHandlingAttrs';
 const Entities = require('html-entities').AllHtmlEntities;
 const htmlentities = new Entities().encode;
@@ -49,7 +49,7 @@ export default function(href: string, options: Options = null): LinkReplacementR
 		resourceId = resourceHrefInfo.itemId;
 
 		const result = options.resources[resourceId];
-		const resourceStatus = utils.resourceStatus(options.ResourceModel, result);
+		const status = resourceStatus(options.ResourceModel, result);
 
 		if (result && result.item) {
 			if (!title) title = result.item.title;
@@ -57,12 +57,16 @@ export default function(href: string, options: Options = null): LinkReplacementR
 			resource = result.item;
 		}
 
-		if (result && resourceStatus !== 'ready' && !options.plainResourceRendering) {
-			const icon = utils.resourceStatusFile(resourceStatus);
+		if (result && status !== 'ready' && !options.plainResourceRendering) {
+			const icon = resourceStatusFile(status);
 
 			return {
 				resourceReady: false,
-				html: `<a class="not-loaded-resource resource-status-${resourceStatus}" data-resource-id="${resourceId}">` + `<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>`,
+				html: `<a
+					class="not-loaded-resource resource-status-${status}"
+					contenteditable="false"
+					data-resource-type="resource"
+					data-resource-id="${resourceId}">` + `<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>`,
 				resource,
 				resourceFullPath: null,
 			};

--- a/packages/renderer/MdToHtml/rules/html_image.ts
+++ b/packages/renderer/MdToHtml/rules/html_image.ts
@@ -1,9 +1,16 @@
 import { RuleOptions } from '../../MdToHtml';
 import { attributesHtml } from '../../htmlUtils';
-import utils from '../../utils';
+import { imageReplacement } from '../../utils';
 
 function renderImageHtml(before: string, src: string, after: string, ruleOptions: RuleOptions) {
-	const r = utils.imageReplacement(ruleOptions.ResourceModel, src, ruleOptions.resources, ruleOptions.resourceBaseUrl, ruleOptions.itemIdToUrl);
+	const r = imageReplacement(
+		ruleOptions.ResourceModel,
+		src,
+		ruleOptions.resources,
+		ruleOptions.resourceBaseUrl,
+		ruleOptions.itemIdToUrl,
+		{ htmlBefore: before, htmlAfter: after },
+	);
 	if (typeof r === 'string') return r;
 	if (r) return `<img ${before} ${attributesHtml(r)} ${after}/>`;
 	return `[Image: ${src}]`;

--- a/packages/renderer/MdToHtml/rules/html_image.ts
+++ b/packages/renderer/MdToHtml/rules/html_image.ts
@@ -30,7 +30,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 			return self.renderToken(tokens, idx, options);
 		};
 
-	const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)[/]?>/gi;
+	const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)>/gi;
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	const handleImageTags = function(defaultRender: Function) {

--- a/packages/renderer/MdToHtml/rules/html_image.ts
+++ b/packages/renderer/MdToHtml/rules/html_image.ts
@@ -5,11 +5,10 @@ import { imageReplacement } from '../../utils';
 function renderImageHtml(before: string, src: string, after: string, ruleOptions: RuleOptions) {
 	const r = imageReplacement(
 		ruleOptions.ResourceModel,
-		src,
+		{ src, beforeSrc: before, afterSrc: after },
 		ruleOptions.resources,
 		ruleOptions.resourceBaseUrl,
 		ruleOptions.itemIdToUrl,
-		{ htmlBefore: before, htmlAfter: after },
 	);
 	if (typeof r === 'string') return r;
 	if (r) return `<img ${before} ${attributesHtml(r)} ${after}/>`;
@@ -31,7 +30,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 			return self.renderToken(tokens, idx, options);
 		};
 
-	const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)>/gi;
+	const imageRegex = /<img(.*?)src=["'](.*?)["'](.*?)[/]?>/gi;
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	const handleImageTags = function(defaultRender: Function) {

--- a/packages/renderer/MdToHtml/rules/image.ts
+++ b/packages/renderer/MdToHtml/rules/image.ts
@@ -1,6 +1,6 @@
 import { RuleOptions } from '../../MdToHtml';
 import { attributesHtml } from '../../htmlUtils';
-import utils from '../../utils';
+import { imageReplacement, getAttr } from '../../utils';
 import createEventHandlingAttrs from '../createEventHandlingAttrs';
 
 function plugin(markdownIt: any, ruleOptions: RuleOptions) {
@@ -10,12 +10,21 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 		const Resource = ruleOptions.ResourceModel;
 
 		const token = tokens[idx];
-		const src = utils.getAttr(token.attrs, 'src');
-		const title = utils.getAttr(token.attrs, 'title');
+		const src = getAttr(token.attrs, 'src');
+		const title = getAttr(token.attrs, 'title');
 
 		if (!Resource.isResourceUrl(src) || ruleOptions.plainResourceRendering) return defaultRender(tokens, idx, options, env, self);
 
-		const r = utils.imageReplacement(ruleOptions.ResourceModel, src, ruleOptions.resources, ruleOptions.resourceBaseUrl, ruleOptions.itemIdToUrl);
+		const content = token.content;
+
+		const r = imageReplacement(
+			ruleOptions.ResourceModel,
+			src,
+			ruleOptions.resources,
+			ruleOptions.resourceBaseUrl,
+			ruleOptions.itemIdToUrl,
+			{ content },
+		);
 		if (typeof r === 'string') return r;
 		if (r) {
 			const id = r['data-resource-id'];
@@ -25,7 +34,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 				postMessageSyntax: ruleOptions.postMessageSyntax ?? 'void',
 			}, null);
 
-			return `<img data-from-md ${attributesHtml({ ...r, title: title, alt: token.content })} ${js}/>`;
+			return `<img data-from-md ${attributesHtml({ ...r, title: title, alt: content })} ${js}/>`;
 		}
 		return defaultRender(tokens, idx, options, env, self);
 	};

--- a/packages/renderer/MdToHtml/rules/image.ts
+++ b/packages/renderer/MdToHtml/rules/image.ts
@@ -19,11 +19,10 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 
 		const r = imageReplacement(
 			ruleOptions.ResourceModel,
-			src,
+			{ src, label: content },
 			ruleOptions.resources,
 			ruleOptions.resourceBaseUrl,
 			ruleOptions.itemIdToUrl,
-			{ content },
 		);
 		if (typeof r === 'string') return r;
 		if (r) {

--- a/packages/renderer/MdToHtml/rules/link_open.ts
+++ b/packages/renderer/MdToHtml/rules/link_open.ts
@@ -1,6 +1,6 @@
 import { RuleOptions } from '../../MdToHtml';
 import linkReplacement from '../linkReplacement';
-import utils from '../../utils';
+import * as utils from '../../utils';
 
 const urlUtils = require('../../urlUtils.js');
 

--- a/packages/renderer/index.ts
+++ b/packages/renderer/index.ts
@@ -1,7 +1,7 @@
 import MarkupToHtml, { MarkupLanguage } from './MarkupToHtml';
 import MdToHtml from './MdToHtml';
 import HtmlToHtml from './HtmlToHtml';
-import utils from './utils';
+import * as utils from './utils';
 import setupLinkify from './MdToHtml/setupLinkify';
 import validateLinks from './MdToHtml/validateLinks';
 import headerAnchor from './headerAnchor';

--- a/packages/renderer/utils.ts
+++ b/packages/renderer/utils.ts
@@ -9,16 +9,14 @@ const FetchStatuses = {
 	FETCH_STATUS_ERROR: 3,
 };
 
-const utils: any = {};
-
-utils.getAttr = function(attrs: string[], name: string, defaultValue: string = null) {
+export const getAttr = function(attrs: string[], name: string, defaultValue: string = null) {
 	for (let i = 0; i < attrs.length; i++) {
 		if (attrs[i][0] === name) return attrs[i].length > 1 ? attrs[i][1] : null;
 	}
 	return defaultValue;
 };
 
-utils.notDownloadedResource = function() {
+export const notDownloadedResource = function() {
 	return `
 		<svg width="1700" height="1536" xmlns="http://www.w3.org/2000/svg">
 		    <path d="M1280 1344c0-35-29-64-64-64s-64 29-64 64 29 64 64 64 64-29 64-64zm256 0c0-35-29-64-64-64s-64 29-64 64 29 64 64 64 64-29 64-64zm128-224v320c0 53-43 96-96 96H96c-53 0-96-43-96-96v-320c0-53 43-96 96-96h465l135 136c37 36 85 56 136 56s99-20 136-56l136-136h464c53 0 96 43 96 96zm-325-569c10 24 5 52-14 70l-448 448c-12 13-29 19-45 19s-33-6-45-19L339 621c-19-18-24-46-14-70 10-23 33-39 59-39h256V64c0-35 29-64 64-64h256c35 0 64 29 64 64v448h256c26 0 49 16 59 39z"/>
@@ -26,7 +24,7 @@ utils.notDownloadedResource = function() {
 	`;
 };
 
-utils.notDownloadedImage = function() {
+export const notDownloadedImage = function() {
 	// https://github.com/ForkAwesome/Fork-Awesome/blob/master/src/icons/svg/file-image-o.svg
 	// Height changed to 1795
 	return `
@@ -36,7 +34,7 @@ utils.notDownloadedImage = function() {
 	`;
 };
 
-utils.notDownloadedFile = function() {
+export const notDownloadedFile = function() {
 	// https://github.com/ForkAwesome/Fork-Awesome/blob/master/src/icons/svg/file-o.svg
 	return `
 		<svg width="1925" height="1792" xmlns="http://www.w3.org/2000/svg">
@@ -45,7 +43,7 @@ utils.notDownloadedFile = function() {
 	`;
 };
 
-utils.errorImage = function() {
+export const errorImage = function() {
 	// https://github.com/ForkAwesome/Fork-Awesome/blob/master/src/icons/svg/times-circle.svg
 	return `
 		<svg width="1795" height="1795" xmlns="http://www.w3.org/2000/svg">
@@ -54,7 +52,7 @@ utils.errorImage = function() {
 	`;
 };
 
-utils.loaderImage = function() {
+export const loaderImage = function() {
 	// https://github.com/ForkAwesome/Fork-Awesome/blob/master/src/icons/svg/hourglass-half.svg
 	return `
 		<svg width="1536" height="1790" xmlns="http://www.w3.org/2000/svg">
@@ -63,21 +61,21 @@ utils.loaderImage = function() {
 	`;
 };
 
-utils.resourceStatusImage = function(status: string) {
-	if (status === 'notDownloaded') return utils.notDownloadedResource();
-	return utils.resourceStatusFile(status);
+export const resourceStatusImage = function(status: string) {
+	if (status === 'notDownloaded') return notDownloadedResource();
+	return resourceStatusFile(status);
 };
 
-utils.resourceStatusFile = function(status: string) {
-	if (status === 'notDownloaded') return utils.notDownloadedResource();
-	if (status === 'downloading') return utils.loaderImage();
-	if (status === 'encrypted') return utils.loaderImage();
-	if (status === 'error') return utils.errorImage();
+export const resourceStatusFile = function(status: string) {
+	if (status === 'notDownloaded') return notDownloadedResource();
+	if (status === 'downloading') return loaderImage();
+	if (status === 'encrypted') return loaderImage();
+	if (status === 'error') return errorImage();
 
 	throw new Error(`Unknown status: ${status}`);
 };
 
-utils.resourceStatusIndex = function(status: string) {
+export const resourceStatusIndex = function(status: string) {
 	if (status === 'error') return -1;
 	if (status === 'notDownloaded') return 0;
 	if (status === 'downloading') return 1;
@@ -87,7 +85,7 @@ utils.resourceStatusIndex = function(status: string) {
 	throw new Error(`Unknown status: ${status}`);
 };
 
-utils.resourceStatusName = function(index: number) {
+export const resourceStatusName = function(index: number) {
 	if (index === -1) return 'error';
 	if (index === 0) return 'notDownloaded';
 	if (index === 1) return 'downloading';
@@ -97,7 +95,7 @@ utils.resourceStatusName = function(index: number) {
 	throw new Error(`Unknown index: ${index}`);
 };
 
-utils.resourceStatus = function(ResourceModel: any, resourceInfo: any) {
+export const resourceStatus = function(ResourceModel: any, resourceInfo: any) {
 	if (!ResourceModel) return 'ready';
 
 	let resourceStatus = 'ready';
@@ -124,7 +122,14 @@ utils.resourceStatus = function(ResourceModel: any, resourceInfo: any) {
 
 export type ItemIdToUrlHandler = (resource: any)=> string;
 
-utils.imageReplacement = function(ResourceModel: any, src: string, resources: any, resourceBaseUrl: string, itemIdToUrl: ItemIdToUrlHandler = null) {
+export const imageReplacement = (
+	ResourceModel: any,
+	src: string,
+	resources: any,
+	resourceBaseUrl: string,
+	itemIdToUrl: ItemIdToUrlHandler = null,
+	context: { content: string } | { htmlBefore: string; htmlAfter: string },
+) => {
 	if (!ResourceModel || !resources) return null;
 
 	if (!ResourceModel.isResourceUrl(src)) return null;
@@ -132,11 +137,29 @@ utils.imageReplacement = function(ResourceModel: any, src: string, resources: an
 	const resourceId = ResourceModel.urlToId(src);
 	const result = resources[resourceId];
 	const resource = result ? result.item : null;
-	const resourceStatus = utils.resourceStatus(ResourceModel, result);
+	const status = resourceStatus(ResourceModel, result);
 
-	if (resourceStatus !== 'ready') {
-		const icon = utils.resourceStatusImage(resourceStatus);
-		return `<div class="not-loaded-resource resource-status-${resourceStatus}" data-resource-id="${resourceId}">` + `<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>` + '</div>';
+	if (status !== 'ready') {
+		const icon = resourceStatusImage(status).replace(/\s+/g, ' ');
+
+		// contenteditable=false prevents users from editing the status image when
+		// displayed in TinyMCE.
+		return `
+			<div
+				contenteditable="false"
+				class="not-loaded-resource resource-status-${status}"
+				data-resource-id="${resourceId}"
+				${
+	'content' in context
+		? `data-content="${htmlentities(context.content)}"`
+		: `
+							data-before-html-src="${htmlentities(context.htmlBefore)}"
+							data-after-html-src="${htmlentities(context.htmlAfter)}"`
+}
+			>
+				<img src="data:image/svg+xml;utf8,${htmlentities(icon)}"/>
+			</div>
+		`.replace(/[\n]\s+/g, '\n');
 	}
 	const mime = resource.mime ? resource.mime.toLowerCase() : '';
 	if (ResourceModel.isSupportedImageMimeType(mime)) {
@@ -172,6 +195,5 @@ utils.imageReplacement = function(ResourceModel: any, src: string, resources: an
 
 // Used in mobile app when enableLongPress = true. Tells for how long
 // the resource should be pressed before the menu is shown.
-utils.longPressDelay = 500;
+export const longPressDelay = 500;
 
-export default utils;

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -541,7 +541,8 @@ rules.joplinNotLoadedResource = {
     if (label) {
       return `![${label}](:/${resourceId})`;
     } else {
-      return `<img ${before} src=":/${resourceId}" ${after}/>`;
+      // after already contains the "/"
+      return `<img ${before} src=":/${resourceId}" ${after}>`;
     }
   }
 }

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -533,7 +533,7 @@ rules.joplinNotLoadedResource = {
   },
 
   replacement: function (content, node, options) {
-    const label = node.getAttribute('data-content');
+    const label = node.getAttribute('data-label');
     const before = node.getAttribute('data-before-html-src');
     const after = node.getAttribute('data-after-html-src');
     const resourceId = node.getAttribute('data-resource-id');

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -520,6 +520,32 @@ rules.picture = {
   }
 }
 
+rules.joplinNotLoadedResource = {
+  filter: (node) => {
+
+    // TODO: Check that the node has exactly one IMG tag child.
+    // This depends on https://github.com/laurent22/joplin/issues/8736.
+
+    return node.nodeName === 'DIV'
+      && node.classList.contains('not-loaded-resource')
+      && node.getAttribute('data-resource-id')
+      && node.getAttribute('contenteditable') === 'false';
+  },
+
+  replacement: function (content, node, options) {
+    const label = node.getAttribute('data-content');
+    const before = node.getAttribute('data-before-html-src');
+    const after = node.getAttribute('data-after-html-src');
+    const resourceId = node.getAttribute('data-resource-id');
+
+    if (label) {
+      return `![${label}](:/${resourceId})`;
+    } else {
+      return `<img ${before} src=":/${resourceId}" ${after}/>`;
+    }
+  }
+}
+
 function findFirstDescendant(node, byType, name) {
   for (const childNode of node.childNodes) {
     if (byType === 'class' && childNode.classList.contains(name)) return childNode;


### PR DESCRIPTION
# Summary

This is a partial fix for #8735. It converts HTML for not-yet-loaded images back into markdown.

This **partially** resolves #8735.

This is only a partial fix because:
- This fix is only for Markdown resources (not HTML)
- This fix is only for image resources.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
