### PR TITLE
Desktop: Fixes #8726 - Rich Text editor toolbar doesn't show all buttons even when there's enough space

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -444,9 +444,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			
 
 			.tox .tox-tbtn {
-				width: ${theme.toolbarHeight}px;
 				height: ${theme.toolbarHeight}px;
-				min-width: ${theme.toolbarHeight}px;
 				min-height: ${theme.toolbarHeight}px;
 				margin: 0;
 			}


### PR DESCRIPTION
I removed 2 CSS properties that was setting the width and min-width of the toolbar's button and it solved the problem. I'll try to explain what was happening. The default button's width is 35px and it was setting to 26px, I believe that TinyMCE was doing the calculation based on 35px and not 26px, so is like TinyMCE "thought" that the buttons were occupayin more space than they actually were.

To set the width of the toolbar's buttons correctly I think we need to [Create a skin for TinyMCE](https://www.tiny.cloud/docs/advanced/creating-a-skin/). I prefer to finish this PR like this and if we decide to create a skin to change the width of the buttons we can open another PR.