### PR TITLE
Desktop: Fixes #8777: Fix AppImage fails to launch on Linux distros with older versions of GLIBC

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -108,7 +108,7 @@
   },
   "homepage": "https://github.com/laurent22/joplin#readme",
   "devDependencies": {
-    "@electron/rebuild": "3.2.13",
+    "@electron/rebuild": "3.3.0",
     "@joplin/tools": "~2.12",
     "@testing-library/react-hooks": "8.0.1",
     "@types/jest": "29.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3524,7 +3524,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/rebuild@npm:3.2.13, @electron/rebuild@npm:^3.2.13":
+"@electron/rebuild@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@electron/rebuild@npm:3.3.0"
+  dependencies:
+    "@malept/cross-spawn-promise": ^2.0.0
+    chalk: ^4.0.0
+    debug: ^4.1.1
+    detect-libc: ^2.0.1
+    fs-extra: ^10.0.0
+    got: ^11.7.0
+    node-abi: ^3.45.0
+    node-api-version: ^0.1.4
+    node-gyp: ^9.0.0
+    ora: ^5.1.0
+    semver: ^7.3.5
+    tar: ^6.0.5
+    yargs: ^17.0.1
+  bin:
+    electron-rebuild: lib/cli.js
+  checksum: 95d2fdc392d30c3fde7f87a2dfa4bdd4663b77685497329eb21622cdb4c46dc3eb504636647e0df93a1d8c2319282d1f0dd0212626a1f23755b0990c3f0d135d
+  languageName: node
+  linkType: hard
+
+"@electron/rebuild@npm:^3.2.13":
   version: 3.2.13
   resolution: "@electron/rebuild@npm:3.2.13"
   dependencies:
@@ -4425,7 +4448,7 @@ __metadata:
     7zip-bin-mac: ^1.0.1
     7zip-bin-win: ^2.1.1
     "@electron/notarize": 1.2.4
-    "@electron/rebuild": 3.2.13
+    "@electron/rebuild": 3.3.0
     "@electron/remote": 2.0.10
     "@fortawesome/fontawesome-free": 5.15.4
     "@joeattardi/emoji-button": 4.6.4
@@ -24544,6 +24567,15 @@ __metadata:
   dependencies:
     semver: ^7.3.5
   checksum: ed8db5e58fc9e1400a3f74d8815b6981208a4fca2031e2c5f5986f58f7e3a1f4161dae82c655f9114892b3f46c21c02feec10fbac0f8ffcfd26a3d57447093d1
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.45.0":
+  version: 3.47.0
+  resolution: "node-abi@npm:3.47.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: ff8498dcd4a805ebf0af27162023bb17e56cb973c955d6c411ebce0938b0827e34323ede846b635daff516d5cd2ea8d64f9d99f2d63f61d1d7469415323fa9a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
Upgrades to @electron/rebuild 3.3.0.

Resolves https://github.com/laurent22/joplin/issues/8777

# Notes

Although it has been verified that this upgrade produces AppImages that launch on Ubuntu 18.04 and 23.04, this upgrade still needs to be tested on
- [x] MacOS
- [x] Windows  11



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
