### PR TITLE
Mobile: Resolves #8796: Add screen reader labels to search/note actions buttons

### DIFF
--- a/packages/app-mobile/components/ScreenHeader.tsx
+++ b/packages/app-mobile/components/ScreenHeader.tsx
@@ -601,7 +601,9 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 			!menuOptionComponents.length || !showContextMenuButton ? null : (
 				<Menu onSelect={value => this.menu_select(value)} style={this.styles().contextMenu}>
 					<MenuTrigger style={contextMenuStyle}>
-						<Icon name="md-ellipsis-vertical" style={this.styles().contextMenuTrigger} />
+						<View accessibilityLabel={_('Actions')}>
+							<Icon name="md-ellipsis-vertical" style={this.styles().contextMenuTrigger} />
+						</View>
 					</MenuTrigger>
 					<MenuOptions>
 						<ScrollView style={{ maxHeight: windowHeight }}>{menuOptionComponents}</ScrollView>

--- a/packages/app-mobile/components/screens/search.tsx
+++ b/packages/app-mobile/components/screens/search.tsx
@@ -188,8 +188,6 @@ class SearchScreenComponent extends BaseScreenComponent {
 							value={this.state.query}
 							selectionColor={theme.textSelectionColor}
 							keyboardAppearance={theme.keyboardAppearance}
-							accessibilityHint={_('Search for...')}
-							returnKeyType='search'
 						/>
 						<TouchableHighlight
 							onPress={() => this.clearButton_press()}

--- a/packages/app-mobile/components/screens/search.tsx
+++ b/packages/app-mobile/components/screens/search.tsx
@@ -188,8 +188,13 @@ class SearchScreenComponent extends BaseScreenComponent {
 							value={this.state.query}
 							selectionColor={theme.textSelectionColor}
 							keyboardAppearance={theme.keyboardAppearance}
+							accessibilityHint={_('Search for...')}
+							returnKeyType='search'
 						/>
-						<TouchableHighlight onPress={() => this.clearButton_press()}>
+						<TouchableHighlight
+							onPress={() => this.clearButton_press()}
+							accessibilityLabel={_('Reset search input')}
+						>
 							<Icon name="md-close-circle" style={this.styles().clearIcon} />
 						</TouchableHighlight>
 					</View>

--- a/packages/app-mobile/components/screens/search.tsx
+++ b/packages/app-mobile/components/screens/search.tsx
@@ -193,7 +193,7 @@ class SearchScreenComponent extends BaseScreenComponent {
 						/>
 						<TouchableHighlight
 							onPress={() => this.clearButton_press()}
-							accessibilityLabel={_('Reset search input')}
+							accessibilityLabel={_('Clear')}
 						>
 							<Icon name="md-close-circle" style={this.styles().clearIcon} />
 						</TouchableHighlight>


### PR DESCRIPTION
# Summary

The note action menu button and the button for clearing search were missing accessibility labels.

This resolves #8796 and partially resolves #8794.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
