### PR TITLE
Workspace: improve debugger experience

### DIFF
--- a/joplin.code-workspace
+++ b/joplin.code-workspace
@@ -381,13 +381,14 @@
 					"!**/node_modules/**"
 				],
 				"program": "${workspaceFolder}/packages/server/src/app.ts",
+				"localRoot": "${workspaceFolder}/packages/server",
 				"args": [
 					"--env", "dev"
 				],
 				"env": {
 					"JOPLIN_IS_TESTING": "1",
-					"TERMS_URL": "https://example.com",
-					"PRIVACY_URL": "https://example.com",
+					"APP_BASE_URL": "http://joplincloud.local:22300",
+					"API_BASE_URL": "http://api.joplincloud.local:22300",
 				}
 			}
 		]


### PR DESCRIPTION
I'm adding some improvements to the Server debugger configuration in the workspace.

The `localRoot` value is to fix the problem of the server not being able to load static files that are located in the node_modules, which causes the webpages from the Server to have no style.

`API_BASE_URL` and `APP_BASE_URL` are also set to the default values used in the application development.

I removed `TERMS_URL` and `PRIVACY_URL` since they aren't required anymore