### PR TITLE
Fixed Scrollbar thumb for light mode

### DIFF
--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -40,17 +40,18 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-	background: rgba(100, 100, 100, 0.3);
+	background: rgba(150, 149, 149, 0.4);
 	border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: rgba(223, 223, 223, 0.6);
 }
 
 ::-webkit-scrollbar-track:hover {
 	background: rgba(0, 0, 0, 0.1);
 }
 
-::-webkit-scrollbar-thumb:hover {
-	background: rgba(100, 100, 100, 0.7);
-}
 
 .fade_out {
 	-webkit-transition: 0.15s;


### PR DESCRIPTION
- Desktop: Resolves #8817: Changed scrollbar thumb color to make it visible in light theme

Without hover - 
![image](https://github.com/laurent22/joplin/assets/93479496/2e079de3-bbcd-400c-a97a-76c7c6ab0f6b)

With Hover-
![image](https://github.com/laurent22/joplin/assets/93479496/7f0fc9f0-d9c0-44aa-baf3-f5b7f84f5cae)

