### PR TITLE
Fixed Scrollbar thumb for light mode

### DIFF
--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -40,17 +40,18 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-	background: rgba(100, 100, 100, 0.3);
+	background: rgba(150, 149, 149, 0.4);
 	border-radius: 5px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+	background: rgba(223, 223, 223, 0.6);
 }
 
 ::-webkit-scrollbar-track:hover {
 	background: rgba(0, 0, 0, 0.1);
 }
 
-::-webkit-scrollbar-thumb:hover {
-	background: rgba(100, 100, 100, 0.7);
-}
 
 .fade_out {
 	-webkit-transition: 0.15s;


### PR DESCRIPTION
- Desktop: Resolves #8817: Added new setting to change font

Scrollbar thumb was hardly visible before in light theme now after changing css it is completely visible as shown below

Scroller -
![image](https://github.com/laurent22/joplin/assets/93479496/88f2e423-3f0e-442b-b50e-76ca944095a3)

Scroller on hover-
![image](https://github.com/laurent22/joplin/assets/93479496/440e6489-977c-488e-809f-edc688de5537)
