### PR TITLE
Mobile: Accessibility: Fix sidemenu focusable when closed

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -23,6 +23,7 @@ Icon.loadFont().catch((error: any) => { console.info(error); });
 interface Props {
 	syncStarted: boolean;
 	themeId: number;
+	sideMenuVisible: boolean;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	dispatch: Function;
 	collapsedFolderIds: string[];
@@ -491,15 +492,29 @@ const SideMenuContentComponent = (props: Props) => {
 		items = items.concat(folderItems);
 	}
 
+	const isHidden = !props.sideMenuVisible;
+
 	const style = {
 		flex: 1,
 		borderRightWidth: 1,
 		borderRightColor: theme.dividerColor,
 		backgroundColor: theme.backgroundColor,
+
+		// Have the UI reflect whether the View is hidden to the screen reader.
+		// This way, there will be visual feedback if isHidden is incorrect.
+		opacity: isHidden ? 0.5 : undefined,
 	};
 
+	// Note: iOS uses accessibilityElementsHidden and Android uses importantForAccessibility
+	//       to hide elements from the screenreader.
+
 	return (
-		<View style={style}>
+		<View
+			style={style}
+
+			accessibilityElementsHidden={isHidden}
+			importantForAccessibility={isHidden ? 'no-hide-descendants' : undefined}
+		>
 			<View style={{ flex: 1, opacity: props.opacity }}>
 				<ScrollView scrollsToTop={false} style={styles_.menu}>
 					{items}
@@ -520,6 +535,7 @@ export default connect((state: AppState) => {
 		notesParentType: state.notesParentType,
 		locale: state.settings.locale,
 		themeId: state.settings.theme,
+		sideMenuVisible: state.showSideMenu,
 		// Don't do the opacity animation as it means re-rendering the list multiple times
 		// opacity: state.sideMenuOpenPercent,
 		collapsedFolderIds: state.collapsedFolderIds,

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -22,14 +22,14 @@ import handleShared from './utils/shareHandler';
 import uuid from '@joplin/lib/uuid';
 import { loadKeychainServiceAndSettings } from '@joplin/lib/services/SettingUtils';
 import KeychainServiceDriverMobile from '@joplin/lib/services/keychain/KeychainServiceDriver.mobile';
-import { setLocale } from '@joplin/lib/locale';
+import { _, setLocale } from '@joplin/lib/locale';
 import SyncTargetJoplinServer from '@joplin/lib/SyncTargetJoplinServer';
 import SyncTargetJoplinCloud from '@joplin/lib/SyncTargetJoplinCloud';
 import SyncTargetOneDrive from '@joplin/lib/SyncTargetOneDrive';
 import initProfile from '@joplin/lib/services/profileConfig/initProfile';
 const VersionInfo = require('react-native-version-info').default;
 const { Keyboard, BackHandler, Animated, View, StatusBar, Platform, Dimensions } = require('react-native');
-import { AppState as RNAppState, EmitterSubscription, Linking, NativeEventSubscription, Appearance } from 'react-native';
+import { AppState as RNAppState, EmitterSubscription, Linking, NativeEventSubscription, Appearance, AccessibilityInfo } from 'react-native';
 import getResponsiveValue from './components/getResponsiveValue';
 import NetInfo from '@react-native-community/netinfo';
 const DropdownAlert = require('react-native-dropdownalert').default;
@@ -984,6 +984,9 @@ class AppComponent extends React.Component {
 		this.props.dispatch({
 			type: isOpen ? 'SIDE_MENU_OPEN' : 'SIDE_MENU_CLOSE',
 		});
+		AccessibilityInfo.announceForAccessibility(
+			isOpen ? _('Side menu opened') : _('Side menu closed')
+		);
 	}
 
 	private getSideMenuWidth = () => {


### PR DESCRIPTION
# Summary

Fixes a regression from #8820 — marks the sidebar as hidden to screen readers when the sidebar is not visible on the screen.

# Testing

1. Enable the screen reader
2. Attempt to focus items in the side menu (e.g. by clicking where the items would be or navigating (e.g. with ctrl+option+leftArrow))
3. Open the side menu
4. Attempt to focus items in the side menu
5. Close the side menu

This has been successfully tested on an iOS simulator with VoiceOver and on Android 13 with TalkBack.

Note: This pull request does **not** auto-focus the side menu when opened.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
