### PR TITLE
Desktop: Fixes #8643: Modified placeholder text on note title input field

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -109,7 +109,7 @@ export default function NoteTitleBar(props: Props) {
 				className="title-input"
 				type="text"
 				ref={props.titleInputRef}
-				placeholder={props.isProvisional ? _('Creating new %s...', props.noteIsTodo ? _('to-do') : _('note')) : ''}
+				placeholder={props.isProvisional ? (props.noteIsTodo ? _('Creating new to-do...') : _('Creating new note...')) : ''}
 				style={styles.titleInput}
 				readOnly={props.disabled}
 				onChange={props.onTitleChange}


### PR DESCRIPTION
The placeholder text "Creating new note..." and "Creating new to-do..." displayed in the note title input field was not translatable in all language contexts. This occurred as the display title was generated using string concatenations. 

To fix this, the note title text is now constructed as a single string. This will allow translators to independently translate "Creating new note..." and "Creating new to-do..." without needing to individually modify either:
- "Creating new %s..." and "note"
- "Creating new %s..." and "to-do"

Previously modifying the translations "note" or "to-do" could not be done as it would affect other areas of the application where a different contextual translation should be used.
- This issue was only raised for the Russian translation

## Test Steps
- Run [build-translations](https://github.com/laurent22/joplin/blob/dev/packages/tools/build-translation.js)
- Open a language file in Poedit ([example](https://github.com/laurent22/joplin/blob/dev/packages/tools/locales/es_ES.po))
- Add a translation for the string "Creating new note..."
- Add a translation for the string "Creating new to-do..."
- Run Joplin
- Create a new note
- See the text in this note title field has been correctly updated to your translation
- Create a new to-do
- See the text in this note title field has been correctly updated to your translations

## Screenshots
After running build-translations.js options to add translations for "Creating new note..." and "Creating new to-do..." become available in Poedit.
- Note Poedit has a suggested fuzzy match for each item, however these fuzzy matches are not pushed into the application.
![Screenshot from 2023-09-12 17-21-56](https://github.com/laurent22/joplin/assets/32354598/b219ef9c-8b46-45bf-a037-beb10cc91d39)
- Joplin will instead use the English translations until translator's improve the language files
![Screenshot from 2023-09-12 17-22-10](https://github.com/laurent22/joplin/assets/32354598/3352edc4-fa88-4eec-b57f-88767460dfd3)
![Screenshot from 2023-09-12 17-22-22](https://github.com/laurent22/joplin/assets/32354598/994c16c7-1dcc-4b81-92fc-5e39eb0ab131)




Fixes #8643