### PR TITLE
Desktop: Fixes #8743: Fix escapes breaking linkified URLs

### DIFF
--- a/packages/app-cli/tests/html_to_md/anchor_with_underscores.html
+++ b/packages/app-cli/tests/html_to_md/anchor_with_underscores.html
@@ -1,0 +1,6 @@
+<ul>
+	<li><a href="http://example.com/a_test">http://example.com/a_test</a></li>
+	<li><a href="http://example.com/a_test/___">http://example.com/a_test/___</a></li>
+	<li>Another <i>test</i>: <a href="http://example.com/a_test/*">http://example.com/a_test/*</a></li>
+	<li>And another <b>test</b>: <a href="http://example.com/_test_">Test</a></li>
+</ul>

--- a/packages/app-cli/tests/html_to_md/anchor_with_underscores.md
+++ b/packages/app-cli/tests/html_to_md/anchor_with_underscores.md
@@ -1,0 +1,4 @@
+- http://example.com/a_test
+- http://example.com/a_test/___
+- Another *test*: http://example.com/a_test/*
+- And another **test**: [Test](http://example.com/_test_)

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -316,8 +316,7 @@ rules.inlineLink = {
   escapeContent: function (node, _options) {
     // Disable escaping content (including '_'s) when the link has the same URL and href.
     // This prevents links from being broken by added escapes.
-    const doEscape = node.getAttribute('href') !== node.textContent;
-    return doEscape ? 'auto' : false;
+    return node.getAttribute('href') !== node.textContent;
   },
 
   replacement: function (content, node, options) {

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -313,6 +313,13 @@ rules.inlineLink = {
     )
   },
 
+  escapeContent: function (node, _options) {
+    // Disable escaping content (including '_'s) when the link has the same URL and href.
+    // This prevents links from being broken by added escapes.
+    const doEscape = node.getAttribute('href') !== node.textContent;
+    return doEscape ? 'auto' : false;
+  },
+
   replacement: function (content, node, options) {
     var href = filterLinkHref(node.getAttribute('href'))
 

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -216,7 +216,7 @@ function postProcess (output) {
 
 function replacementForNode (node) {
   var rule = this.rules.forNode(node)
-  var content = process.call(this, node, rule.escapeContent ? rule.escapeContent() : 'auto')
+  var content = process.call(this, node, rule.escapeContent ? rule.escapeContent(node) : 'auto')
   var whitespace = node.flankingWhitespace
   if (whitespace.leading || whitespace.trailing) content = content.trim()
 


### PR DESCRIPTION
# Summary

Changes `turndown` to not escape the content of linkified URLs.

This should fix #8743.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
