### PR TITLE
Desktop: Resolves #3870: Vim mode: Allow copy/paste with ctrl+C/ctrl+V in insert mode

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
@@ -24,6 +24,10 @@ export default function useKeymap(CodeMirror: any) {
 		CodeMirror.Vim.mapCommand('<A-k>', 'action', 'swapLineUp', {}, { context: 'normal', isEdit: true });
 		CodeMirror.Vim.defineAction('insertListElement', CodeMirror.commands.vimInsertListElement);
 		CodeMirror.Vim.mapCommand('o', 'action', 'insertListElement', { after: true }, { context: 'normal', isEdit: true, interlaceInsertRepeat: true });
+
+		// Allow copy-paste in insert mode
+		CodeMirror.Vim.unmap('<C-c>', 'insert');
+		CodeMirror.Vim.unmap('<C-v>', 'insert');
 	}
 	function isEditorCommand(command: string) {
 		return command.startsWith('editor.');


### PR DESCRIPTION
# Summary

This unmaps `<C-c>` and `<C-v>` in insert mode, allowing them to be used for copy/paste.

This should fix #3870.

# Testing

1. Enable Vim keybindings
2. Open a note
3. Select a block with <kbd>Ctrl</kbd>-<kbd>v</kbd>
4. Deselect the block
5. Enter insert mode
6. Select and copy text with <kbd>Ctrl</kbd>-<kbd>c</kbd>
7. Paste text with <kbd>Ctrl</kbd>-<kbd>v</kbd>

**Note**: This still needs to be tested on MacOS.

# Notes
- This breaks using <kbd>Ctrl</kbd>-<kbd>c</kbd> as a shortcut to exit insert mode. An alternative might be to remap <kbd>Ctrl</kbd>-<kbd>c</kbd> to <kbd>Escape</kbd> only when no text is selected.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
