### PR TITLE
Desktop: Fixes #8898: Show a gear when a plugin doesn't specify an icon

### DIFF
--- a/packages/lib/services/CommandService.test.ts
+++ b/packages/lib/services/CommandService.test.ts
@@ -262,5 +262,39 @@ describe('services_CommandService', () => {
 		await expectNotThrow(async () => service.isEnabled('test1', { cond1: true, cond2: false }));
 	}));
 
+	it('commands should allow specifying an icon', () => {
+		const service = newService();
 
+		const iconName = 'fas fa-check';
+		registerCommand(service, {
+			declaration: {
+				name: 'test-command-with-icon',
+				label: 'Adding icons to commands',
+				iconName,
+			},
+			runtime: {
+				execute: async () => {},
+			},
+		});
+
+		const command = service.commandByName('test-command-with-icon');
+		expect(command.declaration.iconName).toBe(iconName);
+	});
+
+	it('commands should have a non-empty default icon', () => {
+		const service = newService();
+
+		registerCommand(service, {
+			declaration: {
+				name: 'test1',
+				label: 'Test toolbar icon',
+			},
+			runtime: {
+				execute: async () => {},
+			},
+		});
+
+		const command = service.commandByName('test1');
+		expect(command.declaration.iconName).toBe('fas fa-cog');
+	});
 });

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -182,7 +182,7 @@ export default class CommandService extends BaseService {
 	public registerDeclaration(declaration: CommandDeclaration) {
 		declaration = { ...declaration };
 		if (!declaration.label) declaration.label = '';
-		if (!declaration.iconName) declaration.iconName = '';
+		if (!declaration.iconName) declaration.iconName = 'fas fa-cog';
 
 		this.commands_[declaration.name] = {
 			declaration: declaration,


### PR DESCRIPTION
# Summary

This pull request changes the default icon name from the empty string to the [FontAwesome cog icon](https://fontawesome.com/v5/search?q=cog&o=r).

This should fix #8898.

# Testing

This has been tested manually (Ubuntu 23.04) by
1. cloning a plugin repository (in this case, [joplin-plugin-revealjs-slides](https://github.com/personalizedrefrigerator/joplin-plugin-revealjs-slides)),
2. removing the `iconName: 'some icon name here'` line from a toolbar icon command ([example line](https://github.com/personalizedrefrigerator/joplin-plugin-revealjs-slides/blob/bc29640478ab8a6beba7bc09575f20580ccb6db7/src/index.ts#L66)),
3. adding the plugin as a development plugin,
4. building the plugin,
5. starting Joplin,
6. switching between the rich text and markdown editors, and
7. reverting the change and testing again.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
