### PR TITLE
Desktop: Resolves #8932: Fix pasting images into the CodeMirror 6 editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -389,6 +389,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 					pluginStates={props.plugins}
 					onEvent={onEditorEvent}
 					onLogMessage={logDebug}
+					onEditorPaste={onEditorPaste}
 				/>
 			</div>
 		);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -13,6 +13,8 @@ import setupVim from '../utils/setupVim';
 interface Props extends EditorProps {
 	style: React.CSSProperties;
 	pluginStates: PluginStates;
+
+	onEditorPaste: ()=> void;
 }
 
 const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
@@ -28,6 +30,23 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 		onEventRef.current = props.onEvent;
 		onLogMessageRef.current = props.onLogMessage;
 	}, [props.onEvent, props.onLogMessage]);
+
+	useEffect(() => {
+		if (!editor) {
+			return () => {};
+		}
+
+		const pasteEventHandler = (_editor: any, event: Event) => {
+			event.preventDefault();
+			props.onEditorPaste();
+		};
+
+		editor.on('paste', pasteEventHandler);
+
+		return () => {
+			editor.off('paste', pasteEventHandler);
+		};
+	}, [editor, props.onEditorPaste]);
 
 	useImperativeHandle(ref, () => {
 		return editor;

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -72,6 +72,7 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 			EditorView.domEventHandlers({
 				scroll: () => CodeMirror5Emulation.signal(this, 'scroll'),
 				focus: () => CodeMirror5Emulation.signal(this, 'focus'),
+				paste: event => CodeMirror5Emulation.signal(this, 'paste', event),
 				blur: () => CodeMirror5Emulation.signal(this, 'blur'),
 				mousedown: event => CodeMirror5Emulation.signal(this, 'mousedown', event),
 			}),


### PR DESCRIPTION
# Summary

In the new CodeMirror 6 editor, the custom `onEditorPaste` event handler wasn't connected to the `paste` CodeMirror event. This pull request fires the `onEditorPaste` event when the user pastes text into CodeMirror 6.

Without the `onEditorPaste` event, image resources aren't converted/saved in Joplin.

This should fix #8932.

# Testing

1. Enable the CodeMirror 6 beta editor.
2. Copy an image
3. Paste into Joplin with <kbd>ctrl+v</kbd>
4. Paste into Joplin with Edit > Paste
5. Paste with right click > Paste

This has been tested on Ubuntu 23.04.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
