### PR TITLE
Android: Fixed #8533, #8870: Fix sharing image to Joplin

### DIFF
--- a/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
+++ b/packages/react-native-saf-x/android/src/main/java/com/reactnativesafx/utils/EfficientDocumentHelper.java
@@ -791,7 +791,7 @@ public class EfficientDocumentHelper {
           try {
             destUri = getDocumentUri(unknownDestUri, false, true);
             if (!replaceIfDestExists) {
-              if (!checkIfExists(destUri)) {
+              if (checkIfExists(destUri)) {
                 throw new IOExceptionFast("a document with the same name already exists in destination");
               } else {
                 throw new FileNotFoundExceptionFast();


### PR DESCRIPTION
Fixes #8533
Fixes #8870

I did some tests and found that some apps don't implement their ContentProvider with the required columns of DocumentsContract (like DocumentsContract.Document.COLUMN_DOCUMENT_ID). And the `react-native-saf-x` cannot handle this edge case properly.
According to #8533 and #8870, the gallery app of MIUI and the screenshot app of OneUI will trigger this bug.

In this PR, I made these changes:
+ Added `checkIfExists(@NonNull Uri uri)` to test if the file/document pointed by a uri exists. This was checked by `getStat()` in the old code, but `getStat()` cannot handle the edge case I mentioned above. To keep the function of `getStat()` unchanged, I added `checkIfExists()` with some fallback code.
+ Replaced `getStat()` with `checkIfExists()` where the stat is only used for checking existence.
+ Changed the code of `transferFile()` to handle the edge case. It's possible that the source file does exist but `getStat()` doesn't work. For such uris I use `null` as the default destination file mimetype, which will be treated as `"*/*"` in the `createFile()`