### PR TITLE
Desktop: Fixes #8946: Whitelisted Joplin markdown links for copy pasting in WYSIWYG mode

### DIFF
--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -164,6 +164,7 @@ class HtmlUtils {
 		if (url.startsWith('https://') ||
 			url.startsWith('http://') ||
 			url.startsWith('mailto://') ||
+			url.startsWith('joplin://') ||
 			// We also allow anchors but only with a specific set of a characters.
 			// Fixes https://github.com/laurent22/joplin/issues/8286
 			!!url.match(/^#[a-zA-Z0-9-]+$/)) return true;


### PR DESCRIPTION
When copy and pasting a link to another Joplin note in WYSIWYG mode, the Joplin note would get pasted as a hyperlink to '#' i.e. nowhere (see example). 

Copy and pasting of hyperlink vs Joplin note link
![image](https://github.com/laurent22/joplin/assets/32354598/c1f780a4-7bd2-4c81-b17e-8c0ee3bd294f)

This occurs as Joplin links are treated as anchor tags (`<a></a>`) and the href prefix `joplin://` was not part of the [whitelisted prefixes](https://github.com/CptMeetKat/joplin/blob/0c31da5cbe8787691a8a32b7e803b7d067ce30be/packages/renderer/htmlUtils.ts#L162)
![image](https://github.com/laurent22/joplin/assets/32354598/9499f2d5-2c66-47a5-959c-fe7db39b6a80)
[Relevant code from image](https://github.com/CptMeetKat/joplin/blob/0c31da5cbe8787691a8a32b7e803b7d067ce30be/packages/renderer/htmlUtils.ts#L270)

## To Test
1. Right click note in sidebar
2. Select 'Copy Markdown link'
3. Paste link in WYSIWYM mode
4. Toggle WYSIWYG mode
5. Copy the hyperlinked Joplin note
6. Paste in WYSIWYG mode
7. Toggle WYSIWYM mode to verify
- Verify that the Joplin note now has a link and clicking will direct to the linked note
![image](https://github.com/laurent22/joplin/assets/32354598/fae737a0-6743-4451-9eff-8e113469abc6)

Fixes #8946
