### PR TITLE
Desktop: S3 settings: enable ignoreTlsErrors and custom certificates

### DIFF
--- a/packages/lib/SyncTargetAmazonS3.js
+++ b/packages/lib/SyncTargetAmazonS3.js
@@ -56,6 +56,7 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			UseArnRegion: true, // override the request region with the region inferred from requested resource's ARN.
 			forcePathStyle: Setting.value('sync.8.forcePathStyle'), // Older implementations may not support more modern access, so we expose this to allow people the option to toggle.
 			endpoint: Setting.value('sync.8.url'),
+			ignoreTlsErrors: Setting.value('net.ignoreTlsErrors'),
 		};
 	}
 
@@ -87,6 +88,7 @@ class SyncTargetAmazonS3 extends BaseSyncTarget {
 			UseArnRegion: true, // override the request region with the region inferred from requested resource's ARN.
 			forcePathStyle: options.forcePathStyle(),
 			endpoint: options.url(),
+			ignoreTlsErrors: options.ignoreTlsErrors(),
 		};
 
 		const api = new S3Client(apiOptions);

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1480,6 +1480,7 @@ class Setting extends BaseModel {
 				advanced: true,
 				show: (settings: any) => {
 					return [
+						SyncTargetRegistry.nameToId('amazon_s3'),
 						SyncTargetRegistry.nameToId('nextcloud'),
 						SyncTargetRegistry.nameToId('webdav'),
 						SyncTargetRegistry.nameToId('joplinServer'),
@@ -1499,6 +1500,7 @@ class Setting extends BaseModel {
 				show: (settings: any) => {
 					return (shim.isNode() || shim.mobilePlatform() === 'android') &&
 						[
+							SyncTargetRegistry.nameToId('amazon_s3'),
 							SyncTargetRegistry.nameToId('nextcloud'),
 							SyncTargetRegistry.nameToId('webdav'),
 							SyncTargetRegistry.nameToId('joplinServer'),


### PR DESCRIPTION
This small modification enables in *Tools / Options / Synchronization* for the target **S3**:
* Custom TLS certificates
* Ignore TLS certificate errors




see: https://discourse.joplinapp.org/t/s3-settings-ignoretlserrors-and-custom-certificates/32924
