### PR TITLE
Chore: Fixes #9001: Fix error logged to console when a partial link is partially selected in CodeMirror 6

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -503,6 +503,7 @@ packages/editor/CodeMirror/editorCommands/editorCommands.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
+packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
 packages/editor/CodeMirror/markdown/decoratorExtension.js
 packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -489,6 +489,7 @@ packages/editor/CodeMirror/editorCommands/editorCommands.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
+packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
 packages/editor/CodeMirror/markdown/decoratorExtension.js
 packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.js

--- a/packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.ts
+++ b/packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.ts
@@ -1,0 +1,21 @@
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../testUtil/createTestEditor';
+import computeSelectionFormatting from './computeSelectionFormatting';
+
+
+describe('computeSelectionFormatting', () => {
+	// The below tests rely on CodeMirror to correctly parse the document, which
+	// can be buggy (and fail very rarely).
+	jest.retryTimes(2);
+
+	it('should correctly compute formatting for partial links', async () => {
+		// Start with the selection midway through the link
+		const editor = await createTestEditor('A [partial link]', EditorSelection.cursor(4), ['Link']);
+
+		const formatting = computeSelectionFormatting(editor.state, false);
+		expect(formatting.linkData).toMatchObject({
+			linkText: null,
+			linkURL: null,
+		});
+	});
+});

--- a/packages/editor/CodeMirror/markdown/computeSelectionFormatting.ts
+++ b/packages/editor/CodeMirror/markdown/computeSelectionFormatting.ts
@@ -20,7 +20,10 @@ const computeSelectionFormatting = (state: EditorState, globalSpellcheck: boolea
 			};
 		}
 
-		return null;
+		return {
+			linkText: null,
+			linkURL: null,
+		};
 	};
 
 	// Find nodes that overlap/are within the selected region


### PR DESCRIPTION
# Summary

Previously, selecting part of a link in the beta CodeMirror 6 editor on desktop threw an exception because the function for comparing `SelectionFormatting` objects assumed a property was non-`null` (and it could be set to `null` in the case of `[links like this] that don't have URLs`).

This pull request has an associated automated test.

Fixes #9001.

# Manual testing

This pull request has also been tested manually on MacOS by:
1. Launching a copy of the desktop app with this fix (however also with a different work-in-progress fix for a different issue) and a copy without
2. Creating a note in each with the content `Test [test] ...`
3. Moving the mouse cursor to the middle of the partial link on each and inspecting the developer tools log

An exception (`Cannot read properties of null (reading 'linkText')`) was thrown in the copy without this change but not in the copy with this change.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
