### PR TITLE
Desktop: Fixes #9003: Fix pasting text into CodeMirror 6 with Cmd+V/Ctrl+V

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -14,7 +14,7 @@ interface Props extends EditorProps {
 	style: React.CSSProperties;
 	pluginStates: PluginStates;
 
-	onEditorPaste: ()=> void;
+	onEditorPaste: (event: Event)=> void;
 }
 
 const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
@@ -37,8 +37,7 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 		}
 
 		const pasteEventHandler = (_editor: any, event: Event) => {
-			event.preventDefault();
-			props.onEditorPaste();
+			props.onEditorPaste(event);
 		};
 
 		editor.on('paste', pasteEventHandler);


### PR DESCRIPTION
# Summary

The paste event sent by CodeMirror 6 was incorrectly connected to the paste event handler (using the same logic as for CodeMirror 5).

The handler expected the default behavior (pasting text) of the event to run if `.preventDefault` was not called. However, the CodeMirror 6 logic prevented this default behavior.

Fixes #9003 by allowing the `onPaste` handler cancel the event with `.preventDefault`, rather than canceling it automatically.

# Testing plan

This commit has been tested **manually** on MacOS by:
1. Enable the CodeMirror 6 beta.
2. Create a new, empty note.
3. Type "This is a test..."
4. Copy "This is a test..."
5. Paste
6. Take a screenshot and copy it to the clipboard
7. Paste the screenshot into the editor

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
