### PR TITLE
All: Improve isNode to be more inclusive

### DIFF
--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -42,6 +42,7 @@ const shim = {
 	isNode: () => {
 		if (typeof process === 'undefined') return false;
 		if (shim.isElectron()) return true;
+		if (!shim.mobilePlatform()) return true;
 		return process.title === 'node' || (process.title && process.title.indexOf('gulp') === 0);
 	},
 

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -42,8 +42,7 @@ const shim = {
 	isNode: () => {
 		if (typeof process === 'undefined') return false;
 		if (shim.isElectron()) return true;
-		if (!shim.mobilePlatform()) return true;
-		return process.title === 'node' || (process.title && process.title.indexOf('gulp') === 0);
+		return !shim.mobilePlatform();
 	},
 
 	isReactNative: () => {


### PR DESCRIPTION
Not sure exactly what is the best solution here, but right now the `isNode` logic end up falling short.

From this logic, it seems to me that if the application isn't running in Electron or is in React Native, it will be a Node application, but maybe I'm missing something.

*This change might impact the `lib/models/Settings.ts` `metadata` static function, which seems very crucial. Would be nice some ideas on how to test this change.*