### PR TITLE
Desktop: Fixes #9070: Fix external links in PDFs break Joplin

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -4,6 +4,7 @@ import shim from '@joplin/lib/shim';
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 
 import { BrowserWindow, Tray, screen } from 'electron';
+import bridge from './bridge';
 const url = require('url');
 const path = require('path');
 const { dirname } = require('@joplin/lib/path-utils');
@@ -141,6 +142,15 @@ export default class ElectronAppWrapper {
 				}
 			}, 3000);
 		}
+
+		// will-frame-navigate is fired by clicking on a link within the BrowserWindow.
+		this.win_.webContents.on('will-frame-navigate', event => {
+			// If the link changes the URL of the browser window,
+			if (event.isMainFrame) {
+				event.preventDefault();
+				void bridge().openExternal(event.url);
+			}
+		});
 
 		this.win_.on('close', (event: any) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)

--- a/packages/app-desktop/main-html.js
+++ b/packages/app-desktop/main-html.js
@@ -31,12 +31,6 @@ const React = require('react');
 const nodeSqlite = require('sqlite3');
 const initLib = require('@joplin/lib/initLib').default;
 
-// Security: If we attempt to navigate away from the root HTML page, it's likely because
-// of an improperly sanitized link. Prevent this by closing the window before we can
-// navigate away.
-window.onbeforeunload = () => {
-	window.close();
-};
 
 if (bridge().env() === 'dev') {
 	const newConsole = function(oldConsole) {


### PR DESCRIPTION
# Summary

Fixes #9070 by listening for `will-frame-navigate` events.

# Testing

## Automated testing

This pull request contains a related automated test. This end-to-end test clicks on a link that should behave similarly to a link in a PDF and verifies that `shell.openExternal` was called.

## Manual testing

Steps:
1. Attach a PDF with an external link to a note
2. Click on the PDF link in Joplin's note viewer
3. Verify that the link opened in a browser window and that Joplin can still be used

This has been tested manually on Linux (Ubuntu 23.10), MacOS, and Windows 11.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
