### PR TITLE
Mobile: Fixes #9066: Improve list toggle logic

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -63,6 +63,35 @@ describe('markdownCommands.toggleList', () => {
 		);
 	});
 
+	it('should not toggle a the full list when the cursor is on a blank line', async () => {
+		const checklistStartText = [
+			'# Test',
+			'',
+			'- [ ] This',
+			'- [ ] is',
+			'',
+		].join('\n');
+
+		const checklistEndText = [
+			'- [ ] a',
+			'- [ ] test',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			`${checklistStartText}\n${checklistEndText}`,
+
+			// Place the cursor on the blank line between the checklist
+			// regions
+			EditorSelection.cursor(unorderedListText.length + 1),
+			['BulletList', 'ATXHeading1'],
+		);
+
+		// Should create a checkbox on the blank line
+		toggleList(ListType.CheckList)(editor);
+		expect(editor.state.doc.toString()).toBe(
+			`${checklistStartText}- [ ] \n${checklistEndText}`,
+		);
+	});
 
 	// it('should correctly replace an unordered list with a checklist', async () => {
 	// 	const editor = await createEditor(

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -184,7 +184,7 @@ export const toggleList = (listType: ListType): Command => {
 			const origContainerType = containerType;
 
 			// Grow [sel] to the smallest containing list
-			if (sel.empty) {
+			if (sel.empty && fromLine.text.trim() !== '') {
 				sel = growSelectionToNode(state, sel, [orderedListTag, unorderedListTag]);
 				computeSelectionProps();
 			}

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -183,7 +183,10 @@ export const toggleList = (listType: ListType): Command => {
 			const origFirstLineIndentation = firstLineIndentation;
 			const origContainerType = containerType;
 
-			// Grow [sel] to the smallest containing list
+			// Grow `sel` to the smallest containing list, unless the
+			// cursor is on an empty line, in which case, the user
+			// probably wants to add a list item (and not select the entire
+			// list).
 			if (sel.empty && fromLine.text.trim() !== '') {
 				sel = growSelectionToNode(state, sel, [orderedListTag, unorderedListTag]);
 				computeSelectionProps();


### PR DESCRIPTION
# Summary

This PR adds a case to the list toggling logic that continues a list if the cursor is on a blank line. This applies to all list types.

For example, where the cursor is represented by `❚`,
```
1. A test
2. of
❚
3. list
4. toggling
```
pressing "toggle numbered list" now produces
```
1. A test
2. of
3. ❚
4. list
5. toggling
```
rather than selecting and removing the entire list.

This should fix #9066.

# Testing

This pull request has an automated test. However, it can be tested manually using the steps above in either the desktop beta editor or the mobile editor.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
