### PR TITLE
Desktop: Fixes #9104: Beta editor: Allow tab key to insert tabs at cursor rather than indent in some cases

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -533,6 +533,7 @@ packages/editor/CodeMirror/testUtil/createTestEditor.js
 packages/editor/CodeMirror/testUtil/forceFullParse.js
 packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/util/isInSyntaxNode.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js
 packages/editor/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -515,6 +515,7 @@ packages/editor/CodeMirror/testUtil/createTestEditor.js
 packages/editor/CodeMirror/testUtil/forceFullParse.js
 packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/util/isInSyntaxNode.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js
 packages/editor/types.js

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -20,6 +20,7 @@ import { SearchState, EditorProps, EditorSettings } from '../types';
 import { EditorEventType, SelectionRangeChangeEvent } from '../events';
 import {
 	decreaseIndent, increaseIndent,
+	insertOrIncreaseIndent,
 	toggleBolded, toggleCode,
 	toggleItalicized, toggleMath,
 } from './markdown/markdownCommands';
@@ -254,7 +255,7 @@ const createEditor = (
 						notifyLinkEditRequest();
 						return true;
 					}),
-					keyCommand('Tab', increaseIndent, true),
+					keyCommand('Tab', insertOrIncreaseIndent, true),
 					keyCommand('Shift-Tab', decreaseIndent, true),
 
 					...standardKeymap, ...historyKeymap, ...searchKeymap,

--- a/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
@@ -1,5 +1,6 @@
 import { EditorSelection } from '@codemirror/state';
 import {
+	insertOrIncreaseIndent,
 	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleMath, updateLink,
 } from './markdownCommands';
 import createTestEditor from '../testUtil/createTestEditor';
@@ -237,6 +238,42 @@ describe('markdownCommands', () => {
 		const sel = editor.state.selection.main;
 		expect(sel.from).toBe('> Testing...> \n> \n'.length);
 		expect(sel.to).toBe(editor.state.doc.length);
+	});
+
+	it('insertOrIncreaseIndent should indent when text is selected', async () => {
+		const initialText = '> Testing...\n> Test.';
+		const editor = await createTestEditor(
+			initialText,
+			EditorSelection.range(0, initialText.length),
+			['Blockquote'],
+		);
+
+		insertOrIncreaseIndent(editor);
+
+		expect(editor.state.doc.toString()).toBe('> \tTesting...\n> \tTest.');
+	});
+
+	it('insertOrIncreaseIndent should insert tabs when selection is empty, in a paragraph', async () => {
+		const initialText = 'This is a test\nof indentation.';
+		const editor = await createTestEditor(
+			initialText,
+			EditorSelection.cursor(initialText.length),
+			[],
+		);
+
+		insertOrIncreaseIndent(editor);
+
+		const finalText = editor.state.doc.toString();
+
+		// Should add tab character at the cursor
+		expect(finalText).toBe('This is a test\nof indentation.\t');
+
+		// Should move the selection after the tab
+		expect(editor.state.selection.ranges).toHaveLength(1);
+		expect(editor.state.selection.main).toMatchObject({
+			from: finalText.length,
+			to: finalText.length,
+		});
 	});
 });
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -421,7 +421,8 @@ export const increaseIndent: Command = (view: EditorView): boolean => {
 	return true;
 };
 
-// Like `increaseIndent`, but may insert tabs in some instances.
+// Like `increaseIndent`, but may insert tabs, rather than
+// indenting, in some instances.
 export const insertOrIncreaseIndent: Command = (view: EditorView): boolean => {
 	const selection = view.state.selection;
 	const mainSelection = selection.main;
@@ -435,12 +436,16 @@ export const insertOrIncreaseIndent: Command = (view: EditorView): boolean => {
 	}
 
 	const indentUnit = indentString(view.state, getIndentUnit(view.state));
-	view.dispatch({
-		changes: {
-			from: mainSelection.from,
-			insert: indentUnit,
-		},
-	});
+	view.dispatch(view.state.changeByRange(selection => {
+		return {
+			// Move the selection to after the inserted text
+			range: EditorSelection.cursor(selection.from + indentUnit.length),
+			changes: {
+				from: selection.from,
+				insert: indentUnit,
+			},
+		};
+	}));
 
 	return true;
 };

--- a/packages/editor/CodeMirror/util/isInSyntaxNode.ts
+++ b/packages/editor/CodeMirror/util/isInSyntaxNode.ts
@@ -1,0 +1,32 @@
+import { syntaxTree } from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+
+interface Range {
+	from: number;
+	to: number;
+}
+
+const intersectsSyntaxNode = (state: EditorState, range: Range, nodeName: string) => {
+	let foundNode = false;
+
+	syntaxTree(state).iterate({
+		from: range.from,
+		to: range.to,
+		enter: node => {
+			if (node.name === nodeName) {
+				foundNode = true;
+
+				// Skip children
+				return false;
+			}
+
+			// Search children if we haven't found a matching node yet.
+			return !foundNode;
+		},
+	});
+
+	return foundNode;
+};
+
+export default intersectsSyntaxNode;
+


### PR DESCRIPTION
# Summary

Previously, the CodeMirror 6 editor always indented when <kbd>tab</kbd> was pressed. This pull request changes the behavior to insert tab characters at the cursor if:
1. The cursor isn't within a list, and
2. There is only one cursor and nothing is selected.

Fixes #9104.

# Testing

This pull request has automated tests. However, it can be tested manually with the following steps:
1. Create a new note with an ordered list and several paragraphs
2. Enable the beta editor
3. Move the cursor to the middle one of the paragraphs
4. Press <kbd>tab</kbd> several times
    - Tab characters should be inserted
5. Move the cursor to one of the list items
6. Press <kbd>tab</kbd> several times
    - The list item should be indented and the other items should be re-numbered

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
