### PR TITLE
Desktop: Fixes #9108: Added Note Properties to Note menu bar items

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -817,6 +817,7 @@ function useMenu(props: Props) {
 						menuItemDic.setTags,
 						menuItemDic.showShareNoteDialog,
 						separator(),
+						menuItemDic.showNoteProperties,
 						menuItemDic.showNoteContentProperties,
 					],
 				},

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -67,5 +67,6 @@ export default function() {
 		'switchProfile2',
 		'switchProfile3',
 		'pasteAsText',
+		'showNoteProperties',
 	];
 }


### PR DESCRIPTION
Added the 'Note Properties' option to the 'Note' dropdown on the menu bar.

This was already accessible from within the editor; this PR simply introduces an alternative route to access it.

## Tests

**The 'Note Properties' menu item when a note is selected**

![image](https://github.com/laurent22/joplin/assets/32354598/5c4bae11-5fd3-405c-915e-73ee54520a3a)

![image](https://github.com/laurent22/joplin/assets/32354598/874f111a-151c-4853-8036-11df6357ec8f)

**The 'Note Properties' menu item when a note is not selected**

![image](https://github.com/laurent22/joplin/assets/32354598/bbfb7e24-a869-4b91-986e-f99668b5395a)


Fixes #9108