### PR TITLE
All: Add property to Setting to control if file storage is used to save the configuration

### DIFF
--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -303,6 +303,7 @@ class Setting extends BaseModel {
 	};
 
 	public static autoSaveEnabled = true;
+	public static allowFileStorage = true;
 
 	private static metadata_: SettingItems = null;
 	private static keychainService_: any = null;
@@ -2055,7 +2056,7 @@ class Setting extends BaseModel {
 	}
 
 	private static canUseFileStorage(): boolean {
-		return !shim.mobilePlatform();
+		return this.allowFileStorage && !shim.mobilePlatform();
 	}
 
 	private static keyStorage(key: string): SettingStorage {


### PR DESCRIPTION
Adding a new static property to the Setting class controls if the client tries to save settings in the file system, allowing platforms besides mobile to store everything in the database.