### PR TITLE
Mobile: Resolves #9134: Image editor: Allow loading from save when the image editor is reloaded in the background

### DIFF
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -16,11 +16,13 @@ const logger = Logger.create('ImageEditor');
 
 type OnSaveCallback = (svgData: string)=> void;
 type OnCancelCallback = ()=> void;
+
+// Returns the empty string to load from a template.
 type LoadInitialSVGCallback = ()=> Promise<string>;
 
 interface Props {
 	themeId: number;
-	loadInitialSVGData: LoadInitialSVGCallback|null;
+	loadInitialSVGData: LoadInitialSVGCallback;
 	onSave: OnSaveCallback;
 	onExit: OnCancelCallback;
 }

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -814,12 +814,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 	private drawPicture_onPress = async () => {
 		// Create a new empty drawing and attach it now.
 		const resource = await this.attachNewDrawing('');
-
-		this.setState({
-			showImageEditor: true,
-			loadImageEditorData: null,
-			imageEditorResource: resource,
-		});
+		await this.editDrawing(resource);
 	};
 
 	private async updateDrawing(svgData: string) {


### PR DESCRIPTION
# Summary

It seems that iOS sometimes unloads WebViews when an app goes to the background (see #9134).

In this case, the editor should reload from the last save.

Fixes #9134.

# Testing

I tested this by, from this pull request, applying the following patch:
```diff
diff --git a/packages/app-mobile/components/ExtendedWebView.tsx b/packages/app-mobile/components/ExtendedWebView.tsx
index aa9cedd87..40568783f 100644
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -19,6 +19,7 @@ export interface WebViewControl {
 	// Evaluate the given [script] in the context of the page.
 	// Unlike react-native-webview/WebView, this does not need to return true.
 	injectJS(script: string): void;
+	reload(): void;
 }
 
 interface SourceFileUpdateEvent {
@@ -83,6 +84,9 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 
 				true;`);
 			},
+			reload() {
+				webviewRef.current.reload();
+			},
 		};
 	});
 
diff --git a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
index 3742cf9ed..efbb47948 100644
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -272,7 +272,8 @@ const ImageEditor = (props: Props) => {
 		} else if (json.action === 'save-toolbar') {
 			Setting.setValue('imageeditor.jsdrawToolbar', json.data);
 		} else if (json.action === 'close') {
-			onRequestCloseEditor(json.promptIfUnsaved);
+			//onRequestCloseEditor(json.promptIfUnsaved);
+			webviewRef.current.reload();
 		} else if (json.action === 'ready-to-load-data') {
 			void onReadyToLoadData();
 		} else if (json.action === 'set-image-has-changes') {
```

With this patch, clicking "close" reloads the editor. From here, I did the following:
1. Create a new image
2. Draw something
3. Click "save"
4. Click "close"

After step 4, the editor should reload with the saved image.

# Notes

It might make sense to load from the last autosave, if available. I am hesitant to do this because of added complexity that will be difficult to test.

Such a change might look like this:
<details><summary>Diff</summary>

```diff
diff --git a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
index 3742cf9ed..960bda880 100644
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -9,7 +9,7 @@ import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } f
 import { Alert, BackHandler } from 'react-native';
 import { WebViewMessageEvent } from 'react-native-webview';
 import ExtendedWebView, { WebViewControl } from '../../ExtendedWebView';
-import { clearAutosave, writeAutosave } from './autosave';
+import { clearAutosave, readAutosave, writeAutosave } from './autosave';
 import { LocalizedStrings } from './js-draw/types';
 
 const logger = Logger.create('ImageEditor');
@@ -85,6 +85,7 @@ const ImageEditor = (props: Props) => {
 	const editorTheme: Theme = themeStyle(props.themeId);
 	const webviewRef: MutableRefObject<WebViewControl>|null = useRef(null);
 	const [imageChanged, setImageChanged] = useState(false);
+	const [hasAutosaved, setHasAutosaved] = useState(false);
 
 	const onRequestCloseEditor = useCallback((promptIfUnsaved: boolean) => {
 		const discardChangesAndClose = async () => {
@@ -242,7 +243,12 @@ const ImageEditor = (props: Props) => {
 	}, [editorTheme]);
 
 	const onReadyToLoadData = useCallback(async () => {
-		const initialSVGData = await props.loadInitialSVGData?.() ?? '';
+		let initialSVGData = '';
+		if (hasAutosaved) {
+			initialSVGData = await props.loadInitialSVGData();
+		} else {
+			initialSVGData = await readAutosave();
+		}
 
 		// It can take some time for initialSVGData to be transferred to the WebView.
 		// Thus, do so after the main content has been loaded.
@@ -254,7 +260,7 @@ const ImageEditor = (props: Props) => {
 				editorControl.loadImageOrTemplate(initialSVGData, initialTemplateData);
 			}
 		})();`);
-	}, [webviewRef, props.loadInitialSVGData]);
+	}, [webviewRef, props.loadInitialSVGData, hasAutosaved]);
 
 	const onMessage = useCallback(async (event: WebViewMessageEvent) => {
 		const data = event.nativeEvent.data;
@@ -269,6 +275,7 @@ const ImageEditor = (props: Props) => {
 			props.onSave(json.data);
 		} else if (json.action === 'autosave') {
 			await writeAutosave(json.data);
+			setHasAutosaved(true);
 		} else if (json.action === 'save-toolbar') {
 			Setting.setValue('imageeditor.jsdrawToolbar', json.data);
 		} else if (json.action === 'close') {
```

</details>

For example, the line,
```
initialSVGData = await readAutosave();
```

could break in the future. It relies on there only being one image editor (and one instance of Joplin) -- all editors currently use the same autosave file. While this is currently true, this might change in the future.

Without a way to even manually test this behavior (the added `else` branch in the diff above), I'm hesitant to implement this.

One option to allow manual testing could be to add a "debug" widget to the js-draw toolbar that is only visible when Joplin is running in development mode. An option in the dropdown for this widget could be to reload the image editor, allowing this code path to be manually tested.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
