### PR TITLE
Desktop: Resolves #9136: Install script: Work around unprivlidged user namespace restrictions by adding the --no-sandbox flag to the launcher

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -213,6 +213,7 @@ if command -v lsb_release &> /dev/null; then
   if [[ $DISTVER = "Ubuntu23.10" || $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]
   then
     SANDBOXPARAM="--no-sandbox"
+    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled. Avoid loading untrusted notes/PDFs/audio/video files."
   fi
 fi
 

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -277,4 +277,3 @@ fi
 print "Cleaning up..."
 rm -rf "$TEMP_DIR"
 print "${COLOR_GREEN}OK${COLOR_RESET}"
-

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -214,7 +214,7 @@ if command -v lsb_release &> /dev/null; then
   then
     SANDBOXPARAM="--no-sandbox"
     print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled."
-	print "    See https://discourse.joplinapp.org/t/32160/5 for details."
+    print "    See https://discourse.joplinapp.org/t/32160/5 for details."
   fi
 fi
 

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -213,7 +213,7 @@ if command -v lsb_release &> /dev/null; then
   if [[ $DISTVER = "Ubuntu23.10" || $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]
   then
     SANDBOXPARAM="--no-sandbox"
-    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled. Avoid loading untrusted notes/PDFs/audio/video files."
+    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled. See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/32160/5 for details"
   fi
 fi
 

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -205,7 +205,12 @@ if command -v lsb_release &> /dev/null; then
   # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
   # It is present in Debian 1X. A (temporary) patch will be applied at .desktop file
   # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
-  if [[ $DISTVER =~ Debian1. ]] || [ "$DISTVER" = "Linuxmint4" ] && [ "$DISTCODENAME" = "debbie" ] || [ "$DISTVER" = "CentOS" ] && [[ "$DISTMAJOR" =~ 6|7 ]]
+  #
+  # This also works around Ubuntu 23.10+'s restrictions on unprivileged user namespaces. Electron
+  # uses these to sandbox processes. Unfortunately, it doesn't look like we can get around this
+  # without writing the AppImage to a non-user-writable location (without invalidating other security
+  # controls). See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/.
+  if [[ $DISTVER = "Ubuntu23.10" || $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]
   then
     SANDBOXPARAM="--no-sandbox"
   fi
@@ -272,3 +277,4 @@ fi
 print "Cleaning up..."
 rm -rf "$TEMP_DIR"
 print "${COLOR_GREEN}OK${COLOR_RESET}"
+

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -213,7 +213,8 @@ if command -v lsb_release &> /dev/null; then
   if [[ $DISTVER = "Ubuntu23.10" || $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]
   then
     SANDBOXPARAM="--no-sandbox"
-    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled. See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/32160/5 for details"
+    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled."
+	print "    See https://discourse.joplinapp.org/t/32160/5 for details."
   fi
 fi
 


### PR DESCRIPTION
# Summary

Updates the Linux install script to add the `--no-sandbox` flag on Ubuntu 23.10. See [the discussion on the forum](https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/32160).

[According to this article on Chromium's sandbox on Linux,](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/linux/sandboxing.md#The-sandbox-1) there are legacy sandboxes that don't use the unprivileged user namespace capabilities of the kernel. However, I don't see a way to disable *just* the unprivileged user namespace restriction and enable one of the legacy sandboxing approaches (or any notes about whether this is a bad idea).

# Testing

Using this, I have manually tested the script on Ubuntu 23.10 by running
```console
$ echo 1 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
```
then
```console
$ bash Joplin_install_and_update.sh --force
```
(`--force` because I already have Joplin 2.12.19 from previous runs of the script), then attempting to launch Joplin.

# Notes 

This pull request is a draft mostly intended for discussion. Note that the [Electron docs state](https://www.electronjs.org/docs/latest/tutorial/sandbox#disabling-chromiums-sandbox-testing-only),

> **Disabling Chromium's sandbox (testing only)**
>
> You can also disable Chromium's sandbox entirely with the [--no-sandbox](https://www.electronjs.org/docs/latest/api/command-line-switches#--no-sandbox) CLI flag, which will disable the sandbox for all processes (including utility processes). *We highly recommend that you only use this flag for testing purposes, and never in production*.
>
> Note that the sandbox: true option will still disable the renderer's Node.js environment.
>
> [[ emphasis added ]]

An alternative would be distributing a custom `.deb`, but it seems that [Electron Builder doesn't support this](https://www.electron.build/configuration/linux) (we would likely have to switch to Electron Forge).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
