### PR TITLE
Mobile: Fix #9188: Image editor resets on theme change

### DIFF
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -130,20 +130,31 @@ const ImageEditor = (props: Props) => {
 	}, [onRequestCloseEditor]);
 
 	const css = useCss(editorTheme);
-	const html = useMemo(() => `
-		<!DOCTYPE html>
-		<html>
-			<head>
-				<meta charset="utf-8"/>
-				<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
+	const [html, setHtml] = useState('');
 
-				<style>
-					${css}
-				</style>
-			</head>
-			<body></body>
-		</html>
-	`, [css]);
+	useEffect(() => {
+		setHtml(`
+			<!DOCTYPE html>
+			<html>
+				<head>
+					<meta charset="utf-8"/>
+					<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
+
+					<style id='main-style'>
+						${css}
+					</style>
+				</head>
+				<body></body>
+			</html>
+		`);
+
+		// Only set HTML initially (and don't reset). Changing the HTML reloads
+		// the page.
+		//
+		// We need the HTML to initially have the correct CSS to prevent color
+		// changes on load.
+		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps
+	}, []);
 
 	// A set of localization overrides (Joplin is better localized than js-draw).
 	// All localizable strings (some unused?) can be found at
@@ -235,11 +246,13 @@ const ImageEditor = (props: Props) => {
 
 	useEffect(() => {
 		webviewRef.current?.injectJS(`
+			document.querySelector('#main-style').innerText = ${JSON.stringify(css)};
+
 			if (window.editorControl) {
 				window.editorControl.onThemeUpdate();
 			}
 		`);
-	}, [editorTheme]);
+	}, [css]);
 
 	const onReadyToLoadData = useCallback(async () => {
 		const initialSVGData = await props.loadInitialSVGData?.() ?? '';


### PR DESCRIPTION
# Summary

Previously, when the app theme changed,
1. the image editor CSS updated,
2. which caused the image editor HTML to update,
3. which caused the WebView to reload.

This has been changed such that the editor HTML doesn't change with the app theme. Instead, the new theme CSS is applied with `webviewRef.current?.injectJS`. 

Fixes #9188.

# Testing

This pull request can be manually tested by
1. Enabling "Automatically switch theme to match system theme" in "Configuration > Appearance"
2. Switching the system theme to light mode
3. Opening the image editor
4. Drawing something
5. Switching the system theme to dark mode
6. Switching the system theme back to light mode

This has been manually tested on an iOS 17 simulator and an Android 13 tablet.