### PR TITLE
Mobile: Fixes #9159: Fix fast search

### DIFF
--- a/packages/app-mobile/components/screens/search.tsx
+++ b/packages/app-mobile/components/screens/search.tsx
@@ -98,7 +98,7 @@ class SearchScreenComponent extends BaseScreenComponent {
 
 		if (query) {
 			if (this.props.settings['db.ftsEnabled']) {
-				notes = await SearchEngineUtils.notesForQuery(query, true);
+				notes = await SearchEngineUtils.notesForQuery(query, true, { appendWildCards: true });
 			} else {
 				const p = query.split(' ');
 				const temp = [];


### PR DESCRIPTION
# Summary

When the `db.ftsEnabled` is `1`, `SearchEngineUtils.notesForQuery` is used to search for text in notes, which defaults to not appending wildcards (fast search).

This pull request enables appending wild cards on mobile, which fixes fast search.

The `appendWildCards` option was [added in this commit](https://github.com/laurent22/joplin/commit/9f14e61aff76fff5db92d6c3a4b3983d1d6f45ea).

Fixes #9159.

# Testing

This pull request can be manually tested by:
1. Create two notes both containing the word "Joplin" (and perhaps other text)
2. Open settings and verify that "FTS" is enabled
3. Search for `Jop` from the search screen
    - There should be two results.
5. **Unapply** the pull request's change and rebuild
6. Search for `Jop` from the search screen
    - There should be no results.

This pull request has been manually tested on Android 13.