### PR TITLE
Desktop: Fixes #8978: Rich text editor: Fix repeated <br/>-style linebreaks discarded on save to markdown

### DIFF
--- a/packages/app-cli/tests/html_to_md/linebreaks.md
+++ b/packages/app-cli/tests/html_to_md/linebreaks.md
@@ -15,7 +15,4 @@ however.
 Because it isn't
 
 necessary.  
-  
-  
-  
-...
+<br/><br/><br/>...

--- a/packages/app-cli/tests/html_to_md/repeated_brs.html
+++ b/packages/app-cli/tests/html_to_md/repeated_brs.html
@@ -1,0 +1,4 @@
+A<br/><br/><br/>test.<br/>
+
+A single &lt;br/&gt;<br/>can use two spaces at the end of the line,
+but<br/><br/>the markdown renderer discards these if the line is otherwise empty.

--- a/packages/app-cli/tests/html_to_md/repeated_brs.md
+++ b/packages/app-cli/tests/html_to_md/repeated_brs.md
@@ -1,0 +1,5 @@
+A  
+<br/><br/>test.  
+A single &lt;br/&gt;  
+can use two spaces at the end of the line, but  
+<br/>the markdown renderer discards these if the line is otherwise empty.

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -45,11 +45,18 @@ rules.paragraph = {
 rules.lineBreak = {
   filter: 'br',
 
-  replacement: function (content, node, options) {
+  replacement: function (_content, node, options, previousNode) {
+    let brReplacement = options.br + '\n';
+
     // Code blocks may include <br/>s -- replacing them should not be necessary
     // in code blocks.
-    const brReplacement = node.isCode ? '' : options.br;
-    return brReplacement + '\n'
+    if (node.isCode) {
+      brReplacement = '\n';
+    } else if (previousNode && previousNode.nodeName === 'BR') {
+      brReplacement = '<br/>';
+    }
+
+    return brReplacement;
   }
 }
 


### PR DESCRIPTION
# Summary

Changes `turndown` such that `<br/>`s that follow another `<br/>` do not produce lines that contain only spaces, as such lines were discarded by MarkdownIt.

Fixes #8978

# Testing

This pull request contains an automated test. However, it can be tested manually with the following (markdown) note:
````markdown
a  
test  
<br/>of  
<br/><br/><br/>a.... large number  
of  
<br/><br/>repeated &lt;br/&gt;s  
<br/><br/><br/><br/><br/>                       Should be indented.  
   
<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>A test.

Does

&nbsp;

it work?  
<br/>Probably!

&nbsp;

&nbsp;

&nbsp;   Should be indented
````

Pasting the above note into the markdown editor, editing in the rich text editor, undoing the edit, then switching back to the markdown editor should produce the original markdown. 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
