### PR TITLE
Mobile, Desktop: Fixes #9201: Disable selection match highlighting

### DIFF
--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -1,8 +1,7 @@
 import { Compartment, EditorState } from '@codemirror/state';
 import { indentOnInput, syntaxHighlighting } from '@codemirror/language';
 import {
-	openSearchPanel, closeSearchPanel, getSearchQuery,
-	highlightSelectionMatches, search,
+	openSearchPanel, closeSearchPanel, getSearchQuery, search,
 } from '@codemirror/search';
 
 import { classHighlighter } from '@lezer/highlight';
@@ -206,7 +205,6 @@ const createEditor = (
 				} : undefined),
 				drawSelection(),
 				highlightSpecialChars(),
-				highlightSelectionMatches(),
 				indentOnInput(),
 
 				EditorView.domEventHandlers({


### PR DESCRIPTION
# Summary

Disables the `highlightSelectionMatches` extension.

Fixes #9201

# Notes

I believe that this was added initially to support highlighting matches while searching with <kbd>ctrl</kbd>+<kbd>f</kbd>. However, at least on desktop, search highlighting seems to work fine without this extension.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
