### PR TITLE
Mobile: Fixes #9207: Fix search highlighting

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -6,8 +6,8 @@ import { defaultSearchState, SearchPanel } from './SearchPanel';
 import ExtendedWebView from '../ExtendedWebView';
 
 import * as React from 'react';
-import { forwardRef, RefObject, useImperativeHandle } from 'react';
-import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
+import { forwardRef, useImperativeHandle } from 'react';
+import { useMemo, useState, useCallback, useRef } from 'react';
 import { LayoutChangeEvent, View, ViewStyle } from 'react-native';
 const { editorFont } = require('../global-style');
 
@@ -126,7 +126,6 @@ type OnSearchStateChangeCallback = (state: SearchState)=> void;
 const useEditorControl = (
 	injectJS: OnInjectJSCallback, setLinkDialogVisible: OnSetVisibleCallback,
 	setSearchState: OnSearchStateChangeCallback,
-	searchStateRef: RefObject<SearchState>,
 ): EditorControl => {
 	return useMemo(() => {
 		const execCommand = (command: EditorCommandType) => {
@@ -252,16 +251,10 @@ const useEditorControl = (
 				},
 
 				showSearch() {
-					setSearchState({
-						...searchStateRef.current,
-						dialogVisible: true,
-					});
+					execCommand(EditorCommandType.ShowSearch);
 				},
 				hideSearch() {
-					setSearchState({
-						...searchStateRef.current,
-						dialogVisible: false,
-					});
+					execCommand(EditorCommandType.HideSearch);
 				},
 
 				setSearchState: setSearchStateCallback,
@@ -269,7 +262,7 @@ const useEditorControl = (
 		};
 
 		return control;
-	}, [injectJS, searchStateRef, setLinkDialogVisible, setSearchState]);
+	}, [injectJS, setLinkDialogVisible, setSearchState]);
 };
 
 function NoteEditor(props: Props, ref: any) {
@@ -356,22 +349,13 @@ function NoteEditor(props: Props, ref: any) {
 	const [linkDialogVisible, setLinkDialogVisible] = useState(false);
 	const [searchState, setSearchState] = useState(defaultSearchState);
 
-	// Having a [searchStateRef] allows [editorControl] to not be re-created
-	// whenever [searchState] changes.
-	const searchStateRef = useRef(defaultSearchState);
-
-	// Keep the reference and the [searchState] in sync
-	useEffect(() => {
-		searchStateRef.current = searchState;
-	}, [searchState]);
-
 	// Runs [js] in the context of the CodeMirror frame.
 	const injectJS = (js: string) => {
 		webviewRef.current.injectJS(js);
 	};
 
 	const editorControl = useEditorControl(
-		injectJS, setLinkDialogVisible, setSearchState, searchStateRef,
+		injectJS, setLinkDialogVisible, setSearchState,
 	);
 
 	useImperativeHandle(ref, () => {


### PR DESCRIPTION
# Summary

This is a follow-up to #9202 that fixes search highlighting. With this pull request, search highlighting should work even with selection highlighting disabled.

# Explanation

Pressing the "search" button previously didn't notify CodeMirror that the search dialog had been shown. This pull request switches from setting the React Native search state directly (changing `dialogVisible` directly) to using the `ShowSearch` and `HideSearch` commands (which notify CodeMirror of the change to the visibility).

# Testing

This pull request can be tested by
1. Disabling `highlightSelectionMatches` (as in #9202)
2. Opening the search dialog in the mobile editor
3. Searching for something present in the editor
4. Verifying that the match is highlighted
5. Closing search
6. Verifying that the match is no longer highlighted

This has been tested manually on an Android 13 tablet.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
