### PR TITLE
Desktop: Fixes #9036: Fix note list scroll

### DIFF
--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -145,6 +145,7 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		tabIndex={0}
 		className={className}
 		data-id={noteId}
+		style={{ height: props.itemSize.height }}
 		onContextMenu={props.onContextMenu}
 		onDragStart={props.onDragStart}
 		onDragOver={props.onDragOver}


### PR DESCRIPTION
# Summary

Forces items in the note list to have the correct height. Initially incorrect heights lead to scrolling issues on some systems.

Fixes #9036.

# Notes

It seems that, soon after loading, note list items could have an incorrect height, which could cause scrolling to not work correctly.

# Testing

1. Open a notebook with a large number of notes
2. Scroll down
3. Move the mouse cursor over one of the notes near the center
4. Slowly scroll up (see video attached to #9036)
5. Scroll up slightly faster

This has been tested on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
