### PR TITLE
fixes broken faq links

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -124,7 +124,7 @@ else
 fi
 if [[ $LIBFUSE == "" ]] ; then
   print "${COLOR_RED}Error: Can't get libfuse2 on system, please install libfuse2${COLOR_RESET}"
-  print "See https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
+  print "See https://joplinapp.org/help/faq/#desktop-application-will-not-launch-on-linux and https://github.com/AppImage/AppImageKit/wiki/FUSE for more information"
   exit 1
 fi
 

--- a/readme/apps/terminal.md
+++ b/readme/apps/terminal.md
@@ -325,7 +325,7 @@ Possible keys/values:
 									make sure you copy all your content to it
 									before syncing, otherwise all files will be
 									removed! See the FAQ for more details:
-									https://joplinapp.org/help/faq/
+									https://joplinapp.org/faq/
 									Type: string.
 
 	sync.5.path                    Nextcloud WebDAV URL.
@@ -333,7 +333,7 @@ Possible keys/values:
 									make sure you copy all your content to it
 									before syncing, otherwise all files will be
 									removed! See the FAQ for more details:
-									https://joplinapp.org/help/faq/
+									https://joplinapp.org/faq/
 									Type: string.
 
 	sync.5.username                Nextcloud username.

--- a/readme/apps/terminal.md
+++ b/readme/apps/terminal.md
@@ -325,7 +325,7 @@ Possible keys/values:
 									make sure you copy all your content to it
 									before syncing, otherwise all files will be
 									removed! See the FAQ for more details:
-									https://joplinapp.org/faq/
+									https://joplinapp.org/help/faq/
 									Type: string.
 
 	sync.5.path                    Nextcloud WebDAV URL.
@@ -333,7 +333,7 @@ Possible keys/values:
 									make sure you copy all your content to it
 									before syncing, otherwise all files will be
 									removed! See the FAQ for more details:
-									https://joplinapp.org/faq/
+									https://joplinapp.org/help/faq/
 									Type: string.
 
 	sync.5.username                Nextcloud username.


### PR DESCRIPTION
I hope its ok to directly present these small changes in a PR instead of creating an issue first :pray: 

## Before

Links lead to 404 (btw same as https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md from the PR description template :stuck_out_tongue_winking_eye: )

https://joplinapp.org/faq/
https://joplinapp.org/faq/#desktop-application-will-not-launch-on-linux

## After

https://joplinapp.org/help/faq/
https://joplinapp.org/help/faq/#desktop-application-will-not-launch-on-linux

Feel free to close, if these places are wrong in any way :see_no_evil: 
