### PR TITLE
Desktop: Resolves #9250: Make settings tabs focusable by keyboard

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/Sidebar.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/Sidebar.tsx
@@ -92,7 +92,15 @@ export default function Sidebar(props: Props) {
 	function renderButton(section: any) {
 		const selected = props.selection === section.name;
 		return (
-			<StyledListItem key={section.name} isSubSection={Setting.isSubSection(section.name)} selected={selected} onClick={() => { props.onSelectionChange({ section: section }); }}>
+			<StyledListItem
+				key={section.name}
+				href='#'
+				aria-role='tab'
+				aria-selected={selected}
+				isSubSection={Setting.isSubSection(section.name)}
+				selected={selected}
+				onClick={() => { props.onSelectionChange({ section: section }); }}
+			>
 				<StyledListItemIcon
 					className={Setting.sectionNameToIcon(section.name, AppType.Desktop)}
 				/>
@@ -123,7 +131,7 @@ export default function Sidebar(props: Props) {
 	}
 
 	return (
-		<StyledRoot>
+		<StyledRoot aria-role='tablist'>
 			{buttons}
 		</StyledRoot>
 	);


### PR DESCRIPTION
# Summary

- Makes the tab items in the settings sidebar focusable and openable with the keyboard.
- Partially applies the [`tab`/`tablist`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role) ARIA roles.

Resolves #9250.

# Notes

To make the tabs properly accessible, we may also need to [use `aria-controls` and `aria-labelledby` attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role) (which may require adding additional `id` attributes/changing how settings tabs are shown/hidden). 

# Testing

1. Add `*:focus-visible { outline: 1px solid red; }` to the custom application-wide CSS
    - This allows the keyboard focus to be visible while navigating.
2. Open settings
3. Select and open a tab by pressing <kbd>Tab</kbd> repeatedly (then <kbd>Enter</kbd> after the tab is selected).

This has been tested on Ubuntu 23.10 with and without the screen reader enabled. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
