### PR TITLE
Chore: Plugins: Allow absolute paths and URLs in screenshot `src`s

### DIFF
--- a/packages/generator-joplin/generators/app/templates/webpack.config.js
+++ b/packages/generator-joplin/generators/app/templates/webpack.config.js
@@ -93,19 +93,28 @@ function validateCategories(categories) {
 
 function validateScreenshots(screenshots) {
 	if (!screenshots) return null;
-	// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-	screenshots.forEach(screenshot => {
+	for (const screenshot of screenshots) {
 		if (!screenshot.src) throw new Error('You must specify a src for each screenshot');
+
+		// Avoid attempting to download and verify URL screenshots.
+		if (screenshot.src.startsWith('https://')) continue;
 
 		const screenshotType = screenshot.src.split('.').pop();
 		if (!allPossibleScreenshotsType.includes(screenshotType)) throw new Error(`${screenshotType} is not a valid screenshot type. Valid types are: \n${allPossibleScreenshotsType}\n`);
 
-		const screenshotPath = path.resolve(srcDir, screenshot.src);
+		let screenshotPath;
+		if (screenshot.src.startsWith('./') || screenshot.src.startsWith('../')) {
+			// If screenshot srcs start with ./ or ../, they're relative to the src directory.
+			screenshotPath = path.resolve(srcDir, screenshot.src);
+		} else {
+			screenshotPath = path.resolve(rootDir, screenshot.src);
+		}
+
 		// Max file size is 1MB
 		const fileMaxSize = 1024;
 		const fileSize = fs.statSync(screenshotPath).size / 1024;
 		if (fileSize > fileMaxSize) throw new Error(`Max screenshot file size is ${fileMaxSize}KB. ${screenshotPath} is ${fileSize}KB`);
-	});
+	}
 }
 
 function readManifest(manifestPath) {

--- a/packages/generator-joplin/generators/app/templates/webpack.config.js
+++ b/packages/generator-joplin/generators/app/templates/webpack.config.js
@@ -97,7 +97,9 @@ function validateScreenshots(screenshots) {
 		if (!screenshot.src) throw new Error('You must specify a src for each screenshot');
 
 		// Avoid attempting to download and verify URL screenshots.
-		if (screenshot.src.startsWith('https://')) continue;
+		if (screenshot.src.startsWith('https://') || screenshot.src.startsWith('http://')) {
+			continue;
+		}
 
 		const screenshotType = screenshot.src.split('.').pop();
 		if (!allPossibleScreenshotsType.includes(screenshotType)) throw new Error(`${screenshotType} is not a valid screenshot type. Valid types are: \n${allPossibleScreenshotsType}\n`);

--- a/packages/generator-joplin/generators/app/templates/webpack.config.js
+++ b/packages/generator-joplin/generators/app/templates/webpack.config.js
@@ -104,13 +104,7 @@ function validateScreenshots(screenshots) {
 		const screenshotType = screenshot.src.split('.').pop();
 		if (!allPossibleScreenshotsType.includes(screenshotType)) throw new Error(`${screenshotType} is not a valid screenshot type. Valid types are: \n${allPossibleScreenshotsType}\n`);
 
-		let screenshotPath;
-		if (screenshot.src.startsWith('./') || screenshot.src.startsWith('../')) {
-			// If screenshot srcs start with ./ or ../, they're relative to the src directory.
-			screenshotPath = path.resolve(srcDir, screenshot.src);
-		} else {
-			screenshotPath = path.resolve(rootDir, screenshot.src);
-		}
+		const screenshotPath = path.resolve(rootDir, screenshot.src);
 
 		// Max file size is 1MB
 		const fileMaxSize = 1024;

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -37,10 +37,10 @@ Name | Type | Required? | Description
 
 | Properties | Description |
 | --- | --- |
-| src | a path or URL to an icon. If a path, `src` should either be relative to the root of the repository (e.g. `screenshots/a.png`) or relative to the `src` directory (e.g. `../screenshots/a.png`). |
+| src | a path or URL to a screenshot. If a path, `src` should either be relative to the root of the repository (e.g. `screenshots/a.png`) or relative to the `src` directory (e.g. `../screenshots/a.png`). |
 | label | description of the image. This label will be used by screen readers or if the image cannot be loaded. |
 
-**Note**: If `src` is a path and not a URL, either `repository_url` or `homepage_url` must point to a GitHub repository for the icon to appear on the Joplin Plugins Website. See [the relevant issue](https://github.com/joplin/website-plugin-discovery/issues/35).
+**Note**: If `src` is a path and not a URL, either `repository_url` or `homepage_url` must point to a GitHub repository for the screenshot to appear on the Joplin Plugins Website. See [the relevant issue](https://github.com/joplin/website-plugin-discovery/issues/35).
 
 ## Icons
 

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -37,8 +37,10 @@ Name | Type | Required? | Description
 
 | Properties | Description |
 | --- | --- |
-| src | a relative path to src dir. |
-| label | description of the image. |
+| src | a path or URL to an icon. If a path, `src` should either be relative to the root of the repository (e.g. `screenshots/a.png`) or relative to the `src` directory (e.g. `../screenshots/a.png`). |
+| label | description of the image. This label will be used by screen readers or if the image cannot be loaded. |
+
+**Note**: If `src` is a path and not a URL, either `repository_url` or `homepage_url` must point to a GitHub repository for the icon to appear on the Joplin Plugins Website. See [the relevant issue](https://github.com/joplin/website-plugin-discovery/issues/35).
 
 ## Icons
 

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -37,7 +37,7 @@ Name | Type | Required? | Description
 
 | Properties | Description |
 | --- | --- |
-| src | a path or URL to a screenshot. If a path, `src` should either be relative to the root of the repository (e.g. `screenshots/a.png`) or relative to the `src` directory (e.g. `../screenshots/a.png`). |
+| src | a path or URL to a screenshot. If a path, `src` should be relative to the root of the repository (e.g. `screenshots/a.png`). |
 | label | description of the image. This label will be used by screen readers or if the image cannot be loaded. |
 
 **Note**: If `src` is a path and not a URL, either `repository_url` or `homepage_url` must point to a GitHub repository for the screenshot to appear on the Joplin Plugins Website. See [the relevant issue](https://github.com/joplin/website-plugin-discovery/issues/35).

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -46,10 +46,10 @@ Name | Type | Required? | Description
 
 | Properties | Description |
 | --- | --- |
-| 16 | a path to a PNG icon. |
-| 32 | a path to a PNG icon. |
-| 48 | a path to a PNG icon. |
-| 128 | a path to a PNG icon. |
+| 16 | a relative path to a PNG icon. |
+| 32 | a relative path to a PNG icon. |
+| 48 | a relative path to a PNG icon. |
+| 128 | a relative path to a PNG icon. |
 
 ## Manifest example
 

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -46,10 +46,10 @@ Name | Type | Required? | Description
 
 | Properties | Description |
 | --- | --- |
-| 16 | a relative path to a PNG icon. |
-| 32 | a relative path to a PNG icon. |
-| 48 | a relative path to a PNG icon. |
-| 128 | a relative path to a PNG icon. |
+| 16 | a path to a PNG icon. |
+| 32 | a path to a PNG icon. |
+| 48 | a path to a PNG icon. |
+| 128 | a path to a PNG icon. |
 
 ## Manifest example
 
@@ -62,10 +62,16 @@ Name | Type | Required? | Description
     "author": "John Smith",
     "app_min_version": "1.4",
     "homepage_url": "https://joplinapp.org",
-    "screenshots": [{
+    "screenshots": [
+      {
         "src": "path/to/image.png",
         "label": "image description"
-    }],
+      },
+      {
+        "src": "https://example.com/path/to/the/screenshot.png",
+        "label": "image description"
+      }
+    ],
     "icons": {
       "16": "path/to/icon16.png",
       "32": "path/to/icon32.png",


### PR DESCRIPTION
# Summary

Allows plugin manifests to specify screenshot `src`s as URLs and paths relative to the root of the repository, rather than the `src` directory.

Currently, if `src` starts with `./` or `../`, it is assumed to be relative to the `src` directory. Otherwise, to be relative to the repository root.

# Testing

The change to the default `webpack.config.js` has been tested with [the custom CodeMirror vimrc plugin](https://joplin.github.io/website-plugin-discovery/plugin/io.github.personalizedrefrigerator.joplin-vimrc/), which now has a manifest that specifies a URL icon and an icon relative to the repository root.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
