### PR TITLE
Mobile: Fixes #9259: Config screen: Fix section list scroll

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Setting, { AppType, SettingMetadataSection } from '@joplin/lib/models/Setting';
 import { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { ConfigScreenStyles } from './configScreenStyles';
-import { FlatList, Text, Pressable, View } from 'react-native';
+import { FlatList, Text, Pressable, View, ViewStyle } from 'react-native';
 import { settingsSections } from '@joplin/lib/components/shared/config/config-shared';
 import Icon from '../../Icon';
 
@@ -82,8 +82,15 @@ const SectionSelector: FunctionComponent<Props> = props => {
 		}
 	}, [props.selectedSectionName, flatListRef, sections]);
 
+	const containerStyle: ViewStyle = useMemo(() => ({
+		width: props.width,
+		maxWidth: props.width,
+		minWidth: props.width,
+		flex: 1,
+	}), [props.width]);
+
 	return (
-		<View style={{ width: props.width, flexDirection: 'column' }}>
+		<View style={containerStyle}>
 			<FlatList
 				role='tablist'
 				ref={setFlatListRef}


### PR DESCRIPTION
# Summary

The section list was not shrinking with the parent container in some cases, breaking scroll:

[Screen recording: Red border shown around scrollable region. The red border goes offscreen when the window is too small.](https://github.com/laurent22/joplin/assets/46334387/8ebc885d-d934-491b-a492-fb9c0afb4a6e)

Fixes #9259.

# Testing

1. Open the config screen with a screen/window size that requires scroll to access all categories, and only shows categories
2. Scroll to the end
3. Open the config screen with a screen/window size that requires scroll and shows the categories as a sidebar
4. Scroll to the top
5. Scroll to the end

This has been tested on an Android 14 emulator.

[Screencast from 2023-11-10 07-32-32.webm](https://github.com/laurent22/joplin/assets/46334387/2cfc2359-2178-4c76-a7e5-7cca72d2e52e)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
