### PR TITLE
Mobile: Resolves #9260: Fade settings screen icons

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -86,11 +86,12 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 		fontSize: theme.fontSize,
 	};
 
+	const fadedOpacity = 0.75;
 	const sidebarButtonDescriptionText: TextStyle = {
 		...sidebarButtonMainText,
 		fontSize: theme.fontSizeSmaller,
 		color: theme.color,
-		opacity: 0.75,
+		opacity: fadedOpacity,
 	};
 
 
@@ -185,6 +186,7 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 			textAlign: 'center',
 			fontSize: 18,
 			width: sidebarButtonHeight * 0.8,
+			opacity: fadedOpacity,
 		},
 		sidebarSelectedButtonText: {
 			...sidebarButtonMainText,


### PR DESCRIPTION
# Summary

Gives settings screen icons the same opacity as the description text.

Resolves #9260

# Screenshots
![screenshot: Light mode, faded icons](https://github.com/laurent22/joplin/assets/46334387/dd5834de-ccbb-4c50-83a7-ff0dc3e88a86)
![screenshot: Solarized light mode, faded icons](https://github.com/laurent22/joplin/assets/46334387/be558c01-0e36-4a93-b4fa-6e6ebe266c74)
![screenshot: Dark mode, faded icons](https://github.com/laurent22/joplin/assets/46334387/248cc2c0-b09d-490c-bf27-620eeab36490)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
