### PR TITLE
Mobile: Resolves #9258: Add more space between settings title and description

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
@@ -53,7 +53,7 @@ const SectionSelector: FunctionComponent<Props> = props => {
 					</Text>
 					<Text
 						style={styles.sidebarButtonDescriptionText}
-						numberOfLines={2}
+						numberOfLines={1}
 						ellipsizeMode='tail'
 					>
 						{shortDescription ?? ''}

--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -92,6 +92,7 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 		color: theme.color,
 		opacity: 0.75,
 		paddingTop: 3,
+		paddingBottom: 3,
 	};
 
 

--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -92,7 +92,6 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 		color: theme.color,
 		opacity: 0.75,
 		paddingTop: 3,
-		paddingBottom: 3,
 	};
 
 

--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -91,6 +91,7 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 		fontSize: theme.fontSizeSmaller,
 		color: theme.color,
 		opacity: 0.75,
+		paddingTop: 3,
 	};
 
 


### PR DESCRIPTION
# Summary

Adds additional space between the section headers and descriptions in the mobile settings screen.

Resolves #9258.

# Screenshots

![screenshot: Before and after. Shows section list, with more space between titles and descriptions after than before](https://github.com/laurent22/joplin/assets/46334387/2ddab1e2-9040-409a-92d9-65cb6496fbec)

# Notes

With this change, the description text seems a bit too close to the next heading in some cases.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
