### PR TITLE
Chore: Fixes #9284: Desktop: Fix warning on opening settings screen

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/Sidebar.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/Sidebar.tsx
@@ -95,7 +95,7 @@ export default function Sidebar(props: Props) {
 			<StyledListItem
 				key={section.name}
 				href='#'
-				aria-role='tab'
+				role='tab'
 				aria-selected={selected}
 				isSubSection={Setting.isSubSection(section.name)}
 				selected={selected}
@@ -131,7 +131,7 @@ export default function Sidebar(props: Props) {
 	}
 
 	return (
-		<StyledRoot aria-role='tablist'>
+		<StyledRoot role='tablist'>
 			{buttons}
 		</StyledRoot>
 	);


### PR DESCRIPTION
# Summary

Changes `aria-role` to `role`. See [the documentation for the warning](https://react.dev/warnings/invalid-aria-prop).

Fixes #9284.

# Testing

This pull request can be manually tested with the following tests:
1. Open settings
2. Check the developer tools for warnings related to `aria-role`.

It has been successfully tested on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
