### PR TITLE
All: Create vscode launch option for debugging lib project

### DIFF
--- a/joplin.code-workspace
+++ b/joplin.code-workspace
@@ -367,6 +367,12 @@
 				"type": "shell",
 				"command": "cd ${workspaceFolder}/packages/server && yarn tsc",
 				"group": "build",
+			},
+			{
+				"label": "transpile-lib",
+				"type": "shell",
+				"command": "cd ${workspaceFolder}/packages/lib && yarn tsc",
+				"group": "build",
 			}
 		]
 	},
@@ -395,6 +401,19 @@
 					"APP_BASE_URL": "http://joplincloud.local:22300",
 					"API_BASE_URL": "http://api.joplincloud.local:22300",
 				}
+			},
+			{
+				"type": "node",
+				"request": "launch",
+				"name": "lib: debug test file",
+				"preLaunchTask": "transpile-lib",
+				"program": "${workspaceFolder}/packages/lib/node_modules/.bin/jest",
+				"args": [
+					"${fileBasenameNoExtension}",
+					"--config", 
+					"packages/lib/jest.config.js",
+				],
+				"console": "integratedTerminal",
 			}
 		]
 	}


### PR DESCRIPTION
This PR creates the launch option to use the vscode debugger when running Jest tests inside the lib project. 

I'm updating the `joplin.code-workspace` file to add a new launch option that allows to use the vscode debugger when running tests in the files inside the lib project.

### How to use:

- Open a test file inside the lib project
- Put a breakpoint inside the test file or inside one of the dependencies used during the test (i.e.: the function that is being tested)
- With the current test file open in vscode, select "lib: debug test file" in the Run and Debug sidebar
- Press F5

The launch option will compile all the lib project and run jest to the file that is currently open inside the editor.

This configuration option is very specific to the lib project, but maybe with some work we could make it work with any file inside the repository, I'm going to take a look if I discover a way to do that.