### PR TITLE
Mobile: Fixes #9321: Restore scroll position when returning to the note viewer from the editor or camera

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -44,6 +44,7 @@ export default function NoteBodyViewer(props: Props) {
 		props.noteResources,
 		props.paddingBottom,
 		props.noteHash,
+		props.initialScroll,
 	);
 
 	const onResourceLongPress = useOnResourceLongPress(
@@ -68,13 +69,7 @@ export default function NoteBodyViewer(props: Props) {
 
 	const onLoadEnd = useCallback(() => {
 		if (props.onLoadEnd) props.onLoadEnd();
-
-		if (props.initialScroll) {
-			webviewRef.current.injectJS(`
-				window.scrollContentToPosition(${JSON.stringify(props.initialScroll)});
-			`);
-		}
-	}, [props.onLoadEnd, props.initialScroll]);
+	}, [props.onLoadEnd]);
 
 	function onError() {
 		reg.logger().error('WebView error');

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
@@ -3,6 +3,7 @@ import shared from '@joplin/lib/components/shared/note-screen-shared';
 
 export type HandleMessageCallback = (message: string)=> void;
 export type OnMarkForDownloadCallback = (resource: { resourceId: string })=> void;
+export type HandleScrollCallback = (scrollTop: number)=> void;
 
 interface MessageCallbacks {
 	onMarkForDownload?: OnMarkForDownloadCallback;
@@ -10,6 +11,7 @@ interface MessageCallbacks {
 	onResourceLongPress: HandleMessageCallback;
 	onRequestEditResource?: HandleMessageCallback;
 	onCheckboxChange: HandleMessageCallback;
+	onMainContainerScroll: HandleScrollCallback;
 }
 
 export default function useOnMessage(
@@ -24,6 +26,7 @@ export default function useOnMessage(
 	// Thus, useCallback should depend on each callback individually.
 	const {
 		onMarkForDownload, onResourceLongPress, onCheckboxChange, onRequestEditResource, onJoplinLinkClick,
+		onMainContainerScroll,
 	} = callbacks;
 
 	return useCallback((event: any) => {
@@ -49,6 +52,14 @@ export default function useOnMessage(
 			onResourceLongPress(msg);
 		} else if (msg.startsWith('edit:')) {
 			onRequestEditResource?.(msg);
+		} else if (msg.startsWith('onscroll:')) {
+			const eventData = JSON.parse(msg.substring(msg.indexOf(':') + 1));
+
+			if (typeof eventData.scrollTop !== 'number') {
+				throw new Error(`Invalid scroll message, ${msg}`);
+			}
+
+			onMainContainerScroll?.(eventData.scrollTop);
 		} else if (msg.startsWith('joplin:')) {
 			onJoplinLinkClick(msg);
 		} else if (msg.startsWith('error:')) {
@@ -63,5 +74,6 @@ export default function useOnMessage(
 		onJoplinLinkClick,
 		onResourceLongPress,
 		onRequestEditResource,
+		onMainContainerScroll,
 	]);
 }

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
@@ -40,8 +40,7 @@ export default function useOnMessage(
 
 		const isScrollMessage = msg.startsWith('onscroll:');
 
-		// Scroll messages are very frequent. If we log each, it's much harder to find
-		// non-scroll messages.
+		// Scroll messages are very frequent so we avoid logging them.
 		if (!isScrollMessage) {
 			// eslint-disable-next-line no-console
 			console.info('Got IPC message: ', msg);

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
@@ -175,8 +175,14 @@ export default function useSource(
 						window.ReactNativeWebView.postMessage('onscroll:' + JSON.stringify(eventData));
 					}
 				};
-				window.addEventListener('scroll', onMainContentScroll);
+
+				// Listen for events on both scrollingElement and window
+				// - On Android, scrollingElement.addEventListener('scroll', callback) doesn't call callback on
+				// scroll. However, window.addEventListener('scroll', callback) does.
+				// - iOS needs a listener to be added to scrollingElement -- events aren't received when
+				//   the listener is added to window with window.addEventListener('scroll', ...).
 				scrollingElement.addEventListener('scroll', onMainContentScroll);
+				window.addEventListener('scroll', onMainContentScroll);
 
 				const scrollContentToPosition = (position) => {
 					scrollingElement.scrollTop = position;
@@ -231,7 +237,7 @@ export default function useSource(
 					padding: 0;
 				}
 			`;
-			const scrollRenderedMdCss = `
+			const scrollRenderedMdContainerCss = `
 				body > #rendered-md {
 					width: 100vw;
 					overflow: auto;
@@ -257,7 +263,7 @@ export default function useSource(
 						<style>
 							${defaultCss}
 							${shim.mobilePlatform() === 'ios' ? iOSSpecificCss : ''}
-							${scrollRenderedMdContainer ? scrollRenderedMdCss : ''}
+							${scrollRenderedMdContainer ? scrollRenderedMdContainerCss : ''}
 							${editPopupCss}
 						</style>
 						${assetsToHeaders(result.pluginAssets, { asHtml: true })}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -61,6 +61,9 @@ const emptyArray: any[] = [];
 const logger = Logger.create('screens/Note');
 
 class NoteScreenComponent extends BaseScreenComponent {
+	// This isn't in this.state because we don't want changing scroll to trigger
+	// a re-render.
+	private lastBodyScroll: number|undefined = undefined;
 
 	public static navigationOptions(): any {
 		return { header: null };
@@ -1257,6 +1260,10 @@ class NoteScreenComponent extends BaseScreenComponent {
 		}, 5);
 	}
 
+	private onBodyViewerScroll = (scrollTop: number) => {
+		this.lastBodyScroll = scrollTop;
+	};
+
 	public onBodyViewerCheckboxChange(newBody: string) {
 		void this.saveOneProperty('body', newBody);
 	}
@@ -1331,6 +1338,8 @@ class NoteScreenComponent extends BaseScreenComponent {
 						onMarkForDownload={this.onMarkForDownload}
 						onRequestEditResource={this.onEditResource}
 						onLoadEnd={this.onBodyViewerLoadEnd}
+						onScroll={this.onBodyViewerScroll}
+						initialScroll={this.lastBodyScroll}
 					/>
 				);
 		} else {


### PR DESCRIPTION
# Summary

Saves the note viewer's scroll and restores it when closing the image editor/note editor/camera.

Fixes #9321.

# Testing

1. Open a note with a large amount of content
2. Scroll to the end
3. Attach a drawing
4. Draw something and close the editor
    - The editor should still be scrolled to the end.
5. Click to edit the drawing
6. Close the image editor
    - The editor should still be scrolled to the end.
7. Open the note editor
8. Add a heading near the end (e.g. `Some memorable heading`)
9. Add a link to that heading at the top of the note (e.g. `[link](#some-memorable-heading)`)
10. Open the note viewer
    - Should be scrolled to the position from before the editor was opened
11. Click the heading link
    - Should jump to the heading

This has been tested on an Android 12 emulator and an iOS 17 simulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
