### PR TITLE
Chore: Mobile: Fix "MenuContext is deprecated" warning

### DIFF
--- a/packages/app-mobile/index.js
+++ b/packages/app-mobile/index.js
@@ -45,9 +45,6 @@ LogBox.ignoreLogs([
 	// Apparently it can be safely ignored:
 	// https://github.com/react-native-webview/react-native-webview/issues/124
 	'Did not receive response to shouldStartLoad in time, defaulting to YES',
-
-	// Emitted by react-native-popup-menu
-	'MenuContext is deprecated and it might be removed in future releases, use MenuProvider instead.',
 ]);
 
 AppRegistry.registerComponent('Joplin', () => Root);

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -66,7 +66,7 @@ const { SearchScreen } = require('./components/screens/search.js');
 const { OneDriveLoginScreen } = require('./components/screens/onedrive-login.js');
 import EncryptionConfigScreen from './components/screens/encryption-config';
 const { DropboxLoginScreen } = require('./components/screens/dropbox-login.js');
-const { MenuContext } = require('react-native-popup-menu');
+import { MenuProvider } from 'react-native-popup-menu';
 import SideMenu from './components/SideMenu';
 import SideMenuContent from './components/side-menu-content';
 const { SideMenuContentNote } = require('./components/side-menu-content-note.js');
@@ -1088,7 +1088,7 @@ class AppComponent extends React.Component {
 					}}
 				>
 					<StatusBar barStyle={statusBarStyle} />
-					<MenuContext style={{ flex: 1 }}>
+					<MenuProvider style={{ flex: 1 }}>
 						<SafeAreaView style={{ flex: 0, backgroundColor: theme.backgroundColor2 }}/>
 						<SafeAreaView style={{ flex: 1 }}>
 							<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
@@ -1101,7 +1101,7 @@ class AppComponent extends React.Component {
 								sensorInfo={this.state.sensorInfo}
 							/> }
 						</SafeAreaView>
-					</MenuContext>
+					</MenuProvider>
 				</SideMenu>
 			</View>
 		);


### PR DESCRIPTION
# Summary

According to [the documentation](https://github.com/instea/react-native-popup-menu/blob/master/doc/api.md), `MenuContext` was renamed to `MenuProvider`.

# Testing

1. Launch the app
2. Long-press on the search button
    - Should show a tooltip popup
3. Open a note
4. Open the note properties menu

The "MenuContext is deprecated" warning should no longer be shown on startup.

This has been successfully tested on Android 13.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
