### PR TITLE
Chore: Tests: Fix vscode doesn't recognize Jest types in some test files

### DIFF
--- a/packages/app-mobile/tsconfig.json
+++ b/packages/app-mobile/tsconfig.json
@@ -7,8 +7,6 @@
 	"exclude": [
 		//Files that don't need transpilation
 		"**/node_modules",
-		"**/*.test.ts",
-		"**/*.test.tsx",
 		"gulpfile.ts",
 		"tools/*.ts",
 	],

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -5,7 +5,6 @@
         "**/*.tsx",
 	],
 	"exclude": [
-		"**/node_modules",
-		"**/*.test.ts",
+		"**/node_modules"
 	],
 }


### PR DESCRIPTION
# Summary

Removes the exclusion of `.test.ts` files from `tsconfig.json`.

Excluding `.test.ts` files from compilation in `tsconfig.json` may slightly improve build time, but it also means that VSCode (and perhaps other editors) don't load the `describe`/`expect`/`jest` types.

This pull request removes these files from the ignore list.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
