### PR TITLE
Chore: Mobile: Don't build twice on `postinstall`

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -15,7 +15,7 @@
     "test": "jest",
     "test-ci": "yarn test",
     "watchInjectedJs": "gulp watchInjectedJs",
-    "postinstall": "jetify && yarn run build"
+    "postinstall": "jetify"
   },
   "dependencies": {
     "@bam.tech/react-native-image-resizer": "3.0.7",


### PR DESCRIPTION
`buildSequential`/`buildParallel` is already run by `postinstall` in the root `package.json`. Its inclusion in `postinstall` in `packages/app-mobile` caused the mobile app to be built twice.

As we use the webpack file system cache and these two builds can run at the same time, it's possible that this is the source of [random build failures](https://github.com/laurent22/joplin/pull/9338#issuecomment-1816786231).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
