### PR TITLE
Mobile: #9361: Fix to-dos options toggle don't toggle a rerender in 

### DIFF
--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -109,7 +109,7 @@ class NotesScreenComponent extends BaseScreenComponent<any> {
 	}
 
 	public async componentDidUpdate(prevProps: any) {
-		if (prevProps.notesOrder !== this.props.notesOrder || prevProps.selectedFolderId !== this.props.selectedFolderId || prevProps.selectedTagId !== this.props.selectedTagId || prevProps.selectedSmartFilterId !== this.props.selectedSmartFilterId || prevProps.notesParentType !== this.props.notesParentType) {
+		if (prevProps.notesOrder !== this.props.notesOrder || prevProps.selectedFolderId !== this.props.selectedFolderId || prevProps.selectedTagId !== this.props.selectedTagId || prevProps.selectedSmartFilterId !== this.props.selectedSmartFilterId || prevProps.notesParentType !== this.props.notesParentType || prevProps.uncompletedTodosOnTop !== this.props.uncompletedTodosOnTop || prevProps.showCompletedTodos !== this.props.showCompletedTodos) {
 			await this.refreshNotes(this.props);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/9361

The current behavior of the Notes component wouldn't rerender when `showCompletedTodos` or `uncompletedTodosOnTop` prop changed value.

I'm wasn't sure what should be the target for this PR, so I pointed to dev, but the branch was created on `release-v2.13` or `dbb354ad107cbd8c10fee718437f8adabcfdeaeb` commit

### Testing

- Created 3 to-dos notes
- Mark one as complete
- In the sort-by menu select "Uncompleted to-dos on top". The to-do that is complete should drop to the end of the list
- In the sort-by menu select "Showcompleted to-dos". The to-do that is complete should disappear from the list.
