### PR TITLE
Mobile: Resolves #9377: Don't attach empty drawings when a user exits without saving

### DIFF
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
@@ -156,10 +156,6 @@ export const createJsDrawEditor = (
 			// Load from a template if no initial data
 			if (svgData === '') {
 				await applyTemplateToEditor(editor, templateData);
-
-				// The editor expects to be saved initially (without
-				// unsaved changes). Save now.
-				saveNow();
 			} else {
 				await editor.loadFromSVG(svgData);
 			}


### PR DESCRIPTION
# Summary

Previously, clicking "Draw picture"
1. created a new, empty image resource,
2. attached that resource to the current note, then
3. opened the resource in the image editor.

This pull request changes that behavior to the following:
1. Opens the image editor with no resource
2. On the first save, creates and attaches a new image resource

This prevents empty drawings from being attached to a note when the user clicks "discard changes" or "close" without ever saving the drawing.

> [!NOTE]
>
> This is a **partial fix** that only applies to the note viewer.
> The CodeMirror editor requires a reference to insert text (used for attaching the drawing). This reference is not available while the image editor is visible. This pull request thus only applies the fix in the case where the note viewer is open.
>
> `Note.tsx` will likely require refactoring for a more complete fix. (For example by making the CodeMirror editor watch its `initialText` prop for changes or to send the `insertText` command to the editor by changing a prop).
>

Resolves #9377.

# Testing plan

1. Click "Draw picture" from the note actions menu
2. Click "close"
3. Verify that no new drawing has been attached to the note
4. Click "Draw picture"
5. Draw something and click save
6. Draw something else.
7. Click "close", then "save changes"
8. Verify that the drawing has been attached with changes saved
9. Edit the drawing
10. Make a change
11. Close and save
12. Verify that the changes have been saved
13. **Android only**:
    1. Click "draw picture"
    2. Draw something
    3. Click "save"
    4. Forward a port from the Android device to the computer
    5. Open `chrome://inspect`
    6. Open the developer tools for the WebView
    7. Type `location.reload()` in the console
    8. Verify that the saved drawing is still visible

This has been successfully tested on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
