### PR TITLE
Make contributing to docs easier

### DIFF
--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -155,8 +155,8 @@ const config = {
 					routeBasePath: 'help',
 					sidebarPath: require.resolve('./sidebars.js'),
 					breadcrumbs: false,
-					editUrl: (params) => {
-						return 'https://github.com/laurent22/joplin/tree/dev/readme/' + params.docPath;
+					editUrl: ({ docPath }) => {
+						return `https://holocron.so/github/pr/laurent22/joplin/dev/editor/readme/${docPath}`
 					},
 				},
 				blog: {
@@ -164,8 +164,8 @@ const config = {
 					blogSidebarCount: 'ALL',
 					path: 'news',
 					routeBasePath: 'news',
-					editUrl: (params) => {
-						return 'https://github.com/laurent22/joplin/tree/dev/readme/news/' + params.blogPath;
+					editUrl: ({ docPath }) => {
+						return `https://holocron.so/github/pr/laurent22/joplin/dev/editor/readme/news/${docPath}`
 					},
 				},
 				theme: {


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/laurent22/joplin/dev/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb