### PR TITLE
Add enums for ApplicationPlatform and ApplicationSource 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -925,6 +925,7 @@ packages/lib/themes/solarizedDark.js
 packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
+packages/lib/types.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/processStartFlags.js

--- a/.gitignore
+++ b/.gitignore
@@ -907,6 +907,7 @@ packages/lib/themes/solarizedDark.js
 packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
+packages/lib/types.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/processStartFlags.js

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -6,7 +6,7 @@ export enum ApplicationPlatform {
 	Android = 4,
 }
 
-export enum ApplicationSource {
+export enum ApplicationType {
 	Unknown = 0,
 	Desktop = 1,
 	Mobile = 2,

--- a/packages/lib/types.ts
+++ b/packages/lib/types.ts
@@ -1,0 +1,14 @@
+export enum ApplicationPlatform {
+	Unknown = 0,
+	Windows = 1,
+	Linux = 2,
+	MacOs = 3,
+	Android = 4,
+}
+
+export enum ApplicationSource {
+	Unknown = 0,
+	Desktop = 1,
+	Mobile = 2,
+	Cli = 3,
+}


### PR DESCRIPTION
Creating a new module in `packages/lib/types.ts` to export types that can be used in the clients and in the server.