### PR TITLE
Server: Fixes #9367: Redirect user from login to home if already logged

### DIFF
--- a/packages/server/src/routes/index/login.test.ts
+++ b/packages/server/src/routes/index/login.test.ts
@@ -72,4 +72,38 @@ describe('index_login', () => {
 		}
 	});
 
+	test('should redirect if already logged in', async () => {
+		const user = await createUser(1);
+
+		const context = await doLogin(user.email, '123456');
+		const sessionId = cookieGet(context, 'sessionId');
+
+		const getContext = await koaAppContext({
+			sessionId: sessionId,
+			request: {
+				method: 'GET',
+				url: '/login',
+			},
+		});
+
+		await routeHandler(getContext);
+
+		expect(getContext.response.status).toBe(302);
+	});
+
+	test('should not redirect if sessionId is not valid', async () => {
+
+		const getContext = await koaAppContext({
+			sessionId: 'no-sense',
+			request: {
+				method: 'GET',
+				url: '/login',
+			},
+		});
+
+		await routeHandler(getContext);
+
+		expect(getContext.response.status).toBe(200);
+	});
+
 });

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -22,7 +22,10 @@ const router: Router = new Router(RouteType.Web);
 
 router.public = true;
 
-router.get('login', async (_path: SubPath, _ctx: AppContext) => {
+router.get('login', async (_path: SubPath, ctx: AppContext) => {
+	if (ctx.joplin.owner) {
+		return redirect(ctx, `${config().baseUrl}/home`);
+	}
 	return makeView();
 });
 

--- a/packages/server/src/routes/index/login.ts
+++ b/packages/server/src/routes/index/login.ts
@@ -8,6 +8,7 @@ import defaultView from '../../utils/defaultView';
 import { View } from '../../services/MustacheService';
 import limiterLoginBruteForce from '../../utils/request/limiterLoginBruteForce';
 import { cookieSet } from '../../utils/cookies';
+import { homeUrl } from '../../utils/urlUtils';
 
 function makeView(error: any = null): View {
 	const view = defaultView('login', 'Login');
@@ -24,7 +25,7 @@ router.public = true;
 
 router.get('login', async (_path: SubPath, ctx: AppContext) => {
 	if (ctx.joplin.owner) {
-		return redirect(ctx, `${config().baseUrl}/home`);
+		return redirect(ctx, homeUrl());
 	}
 	return makeView();
 });


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/9367

Currently, the Joplin Server will allow the user to make login again if the user accesses the `/login` endpoint, this PR add a redirect to fix this unexpected behavior.

### Testing

I added two automated tests, one has a valid sessionId and the other does not. Ideally we would also check to where the user was being redirected, but I'm not sure if it is possible, so I'm just checking if the response status is 302.

