### PR TITLE
Desktop: Fixes #9304: Fix HTML resource links lost when editing notes in the rich text editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -387,6 +387,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js
 packages/app-desktop/integration-tests/util/createStartupArgs.js
 packages/app-desktop/integration-tests/util/firstNonDevToolsWindow.js
+packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js

--- a/.gitignore
+++ b/.gitignore
@@ -369,6 +369,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js
 packages/app-desktop/integration-tests/util/createStartupArgs.js
 packages/app-desktop/integration-tests/util/firstNonDevToolsWindow.js
+packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -28,6 +28,7 @@ import { TinyMceEditorEvents } from './utils/types';
 import type { Editor } from 'tinymce';
 import { joplinCommandToTinyMceCommands, TinyMceCommand } from './utils/joplinCommandToTinyMceCommands';
 import shouldPasteResources from './utils/shouldPasteResources';
+import Setting from '@joplin/lib/models/Setting';
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 
@@ -42,6 +43,7 @@ function markupRenderOptions(override: MarkupToHtmlOptions = null): MarkupToHtml
 			},
 		},
 		replaceResourceInternalToExternalLinks: true,
+		allowedFilePrefixes: [Setting.value('resourceDir')],
 		...override,
 	};
 }

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -28,7 +28,6 @@ import { TinyMceEditorEvents } from './utils/types';
 import type { Editor } from 'tinymce';
 import { joplinCommandToTinyMceCommands, TinyMceCommand } from './utils/joplinCommandToTinyMceCommands';
 import shouldPasteResources from './utils/shouldPasteResources';
-import Setting from '@joplin/lib/models/Setting';
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 
@@ -867,7 +866,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 						// Allow file:// URLs that point to the resource directory.
 						// This prevents HTML-style resource URLs (e.g. <a href="file://path/to/resource/.../"></a>)
 						// from being discarded.
-						allowedFilePrefixes: [Setting.value('resourceDir')],
+						allowedFilePrefixes: [props.resourceDirectory],
 					}),
 				);
 				if (cancelled) return;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -43,7 +43,6 @@ function markupRenderOptions(override: MarkupToHtmlOptions = null): MarkupToHtml
 			},
 		},
 		replaceResourceInternalToExternalLinks: true,
-		allowedFilePrefixes: [Setting.value('resourceDir')],
 		...override,
 	};
 }
@@ -859,7 +858,18 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			const resourcesEqual = resourceInfosEqual(lastOnChangeEventInfo.current.resourceInfos, props.resourceInfos);
 
 			if (lastOnChangeEventInfo.current.content !== props.content || !resourcesEqual) {
-				const result = await props.markupToHtml(props.contentMarkupLanguage, props.content, markupRenderOptions({ resourceInfos: props.resourceInfos }));
+				const result = await props.markupToHtml(
+					props.contentMarkupLanguage,
+					props.content,
+					markupRenderOptions({
+						resourceInfos: props.resourceInfos,
+
+						// Allow file:// URLs that point to the resource directory.
+						// This prevents HTML-style resource URLs (e.g. <a href="file://path/to/resource/.../"></a>)
+						// from being discarded.
+						allowedFilePrefixes: [Setting.value('resourceDir')],
+					}),
+				);
 				if (cancelled) return;
 
 				editor.setContent(awfulBrHack(result.html));

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -439,6 +439,7 @@ function NoteEditor(props: NoteEditorProps) {
 		contentMarkupLanguage: formNote.markup_language,
 		contentOriginalCss: formNote.originalCss,
 		resourceInfos: resourceInfos,
+		resourceDirectory: Setting.value('resourceDir'),
 		htmlToMarkdown: htmlToMarkdown,
 		markupToHtml: markupToHtml,
 		allAssets: allAssets,

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -82,6 +82,7 @@ export interface NoteBodyEditorProps {
 	visiblePanes: string[];
 	keyboardMode: string;
 	resourceInfos: ResourceInfos;
+	resourceDirectory: string;
 	locale: string;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onDrop: Function;

--- a/packages/app-desktop/gui/NoteEditor/utils/useMarkupToHtml.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMarkupToHtml.ts
@@ -26,6 +26,7 @@ export interface MarkupToHtmlOptions {
 	noteId?: string;
 	vendorDir?: string;
 	platformName?: string;
+	allowedFilePrefixes?: string[];
 }
 
 export default function useMarkupToHtml(deps: HookDependencies) {

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -81,8 +81,7 @@ test.describe('main', () => {
 
 		// Note should still contain the resource ID and note title
 		const finalCodeMirrorContent = await editor.codeMirrorEditor.innerText();
-		expect(finalCodeMirrorContent).toContain(resourceId);
-		expect(finalCodeMirrorContent).toContain('HTML Link');
+		expect(finalCodeMirrorContent).toContain(`:/${resourceId}`);
 	});
 
 	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -6,7 +6,7 @@ export default class MainScreen {
 	public readonly noteListContainer: Locator;
 	public readonly noteEditor: NoteEditorScreen;
 
-	public constructor(page: Page) {
+	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
 		this.noteListContainer = page.locator('.rli-noteList');
 		this.noteEditor = new NoteEditorScreen(page);
@@ -16,5 +16,21 @@ export default class MainScreen {
 		await this.newNoteButton.waitFor();
 		await this.noteEditor.waitFor();
 		await this.noteListContainer.waitFor();
+	}
+
+	// Follows the steps a user would use to create a new note.
+	public async createNewNote(title: string) {
+		await this.waitFor();
+		await this.newNoteButton.click();
+		await this.noteEditor.waitFor();
+
+		// Wait for the title input to have the correct placeholder
+		await this.page.locator('input[placeholder^="Creating new note"]').waitFor();
+
+		// Fill the title
+		await this.noteEditor.noteTitleInput.click();
+		await this.noteEditor.noteTitleInput.fill(title);
+
+		return this.noteEditor;
 	}
 }

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -3,13 +3,19 @@ import { Locator, Page } from '@playwright/test';
 
 export default class NoteEditorPage {
 	public readonly codeMirrorEditor: Locator;
+	public readonly richTextEditor: Locator;
 	public readonly noteTitleInput: Locator;
+	public readonly attachFileButton: Locator;
+	public readonly toggleEditorsButton: Locator;
 	private readonly containerLocator: Locator;
 
 	public constructor(private readonly page: Page) {
 		this.containerLocator = page.locator('.rli-editor');
 		this.codeMirrorEditor = this.containerLocator.locator('.codeMirrorEditor');
+		this.richTextEditor = this.containerLocator.locator('iframe[title="Rich Text Area"]');
 		this.noteTitleInput = this.containerLocator.locator('.title-input');
+		this.attachFileButton = this.containerLocator.locator('[title^="Attach file"]');
+		this.toggleEditorsButton = this.containerLocator.locator('[title^="Toggle editors"]');
 	}
 
 	public getNoteViewerIframe() {
@@ -19,8 +25,12 @@ export default class NoteEditorPage {
 		return this.page.frame({ url: /.*note-viewer[/\\]index.html.*/ });
 	}
 
+	public getTinyMCEFrameLocator() {
+		return this.richTextEditor.frameLocator(':scope');
+	}
+
 	public async waitFor() {
-		await this.codeMirrorEditor.waitFor();
 		await this.noteTitleInput.waitFor();
+		await this.toggleEditorsButton.waitFor();
 	}
 }

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -26,6 +26,9 @@ export default class NoteEditorPage {
 	}
 
 	public getTinyMCEFrameLocator() {
+		// We use frameLocator(':scope') to convert the richTextEditor Locator into
+		// a FrameLocator. (:scope selects the locator itself).
+		// https://playwright.dev/docs/api/class-framelocator
 		return this.richTextEditor.frameLocator(':scope');
 	}
 

--- a/packages/app-desktop/integration-tests/util/setFilePickerResponse.ts
+++ b/packages/app-desktop/integration-tests/util/setFilePickerResponse.ts
@@ -1,0 +1,13 @@
+import { ElectronApplication } from '@playwright/test';
+
+const setFilePickerResponse = (electronApp: ElectronApplication, response: string[]) => {
+	return electronApp.evaluate(async ({ dialog }, response) => {
+		dialog.showOpenDialog = async () => ({
+			canceled: false,
+			filePaths: response,
+		});
+		dialog.showOpenDialogSync = () => response;
+	}, response);
+};
+
+export default setFilePickerResponse;

--- a/packages/renderer/HtmlToHtml.ts
+++ b/packages/renderer/HtmlToHtml.ts
@@ -38,6 +38,7 @@ interface RenderOptions {
 	postMessageSyntax: string;
 	enableLongPress: boolean;
 	itemIdToUrl?: ItemIdToUrlHandler;
+	allowedFilePrefixes?: string[];
 }
 
 // https://github.com/es-shims/String.prototype.trimStart/blob/main/implementation.js
@@ -99,7 +100,9 @@ export default class HtmlToHtml {
 		let html = this.cache_.value(cacheKey);
 
 		if (!html) {
-			html = htmlUtils.sanitizeHtml(markup);
+			html = htmlUtils.sanitizeHtml(markup, {
+				allowedFilePrefixes: options.allowedFilePrefixes,
+			});
 
 			html = htmlUtils.processImageTags(html, (data: any) => {
 				if (!data.src) return null;

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -192,6 +192,10 @@ export interface RuleOptions {
 	vendorDir?: string;
 	itemIdToUrl?: ItemIdToUrlHandler;
 
+	// Passed to the HTML sanitizer: Allows file:// URLs with
+	// paths with the included prefixes.
+	allowedFilePrefixes?: string[];
+
 	platformName?: string;
 }
 

--- a/packages/renderer/MdToHtml/rules/sanitize_html.ts
+++ b/packages/renderer/MdToHtml/rules/sanitize_html.ts
@@ -34,7 +34,13 @@ export default {
 					// So the sanitizeHtml function must handle this kind of non-valid HTML.
 
 					if (!sanitizedContent) {
-						sanitizedContent = htmlUtils.sanitizeHtml(token.content, { addNoMdConvClass: true });
+						sanitizedContent = htmlUtils.sanitizeHtml(
+							token.content,
+							{
+								addNoMdConvClass: true,
+								allowedFilePrefixes: ruleOptions.allowedFilePrefixes,
+							},
+						);
 					}
 
 					token.content = sanitizedContent;

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -189,9 +189,11 @@ class HtmlUtils {
 			// If true, adds a "jop-noMdConv" class to all the tags.
 			// It can be used afterwards to restore HTML tags in Markdown.
 			addNoMdConvClass: false,
-			allowedFilePrefixes: [],
 			...options,
 		};
+
+		// If options.allowedFilePrefixes is `undefined`, default to [].
+		options.allowedFilePrefixes ??= [];
 
 		const output: string[] = [];
 


### PR DESCRIPTION
# Summary

Fixes links to resources written in HTML would be discarded when editing a note in the rich text editor.

Fixes #9304.

# Testing

This pull request's Playwright test only covers the case where a resource link is added to a markdown note. As such, the HTML case must be tested manually. To do this,
1. Export a note as HTML
2. Import that note as HTML
3. Delete the content of the note
4. Attach a resource
5. Switch to the WYSIWYG editor
6. Switch back to the markdown editor

This has been successfully tested on Ubuntu 23.10.

# Notes

**HTML note only**: The resource link, after editing in the WYSIWYG editor, looks similar to this:
```
<p><a data-from-md="" href=":/fed66f2f1c214d8dbf0a6180b6788448" onclick="ipcProxySendToHost(&quot;:/fed66f2f1c214d8dbf0a6180b6788448&quot;, { resourceId: &quot;&quot; }); return false;">index.html</a>. This is a test...</p>
```

The `onclick` attribute is added by `HtmlToHtml` [here](https://github.com/laurent22/joplin/blob/aaa1dc853dd28d3f4796e95cc176f126d8646996/packages/renderer/MdToHtml/linkReplacement.ts#L103) (called [here](https://github.com/laurent22/joplin/blob/aaa1dc853dd28d3f4796e95cc176f126d8646996/packages/renderer/HtmlToHtml.ts#L126)).

When rendering in a way that will be saved in the database (and not directly shown in the note viewer), we should not add `onclick` handlers.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
