### PR TITLE
Desktop,Mobile: Fixes #9455: Fix KaTeX rendering

### DIFF
--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -291,4 +291,29 @@ describe('MdToHtml', () => {
 			expect(html.html).toContain(opening + trimmedTex + closing);
 		}
 	});
+
+	it('should render inline KaTeX after a numbered equation', async () => {
+		const mdToHtml = newTestMdToHtml();
+
+		// This test is intended to verify that inline KaTeX renders correctly
+		// after creating a numbered equation with \begin{align}...\end{align}.
+		//
+		// See https://github.com/laurent22/joplin/issues/9455 for details.
+
+		const markdown = [
+			'$$',
+			'\\begin{align}\\text{Block}\\end{align}',
+			'$$',
+			'',
+			'$\\text{Inline}$',
+		].join('\n');
+		const { html } = await mdToHtml.render(markdown, null, { bodyOnly: true });
+
+		// Because we don't control the output of KaTeX, this test should be as general as
+		// possible while still verifying that rendering (without an error) occurs.
+
+		// Should have rendered the inline and block content without errors
+		expect(html).toContain('Inline</span>');
+		expect(html).toContain('Block</span>');
+	});
 });

--- a/packages/renderer/MdToHtml/rules/katex.ts
+++ b/packages/renderer/MdToHtml/rules/katex.ts
@@ -43,12 +43,22 @@ function stringifyKatexOptions(options: any) {
 	//     \prob: {tokens: Array(12), numArgs: 1}
 	//     \expval: {tokens: Array(14), numArgs: 2}
 	//     \wf: {tokens: Array(6), numArgs: 0}
+	//     \@eqnsw: "1"
+	//
+	// Additionally, some KaTeX macros don't follow this general format. For example
+	//     \@eqnsw: "1"
+	// is created by \begin{align}...\end{align} environments, and doesn't have a "tokens" property.
 
 	if (options.macros) {
 		const toSerialize: any = {};
 		for (const k of Object.keys(options.macros)) {
-			const macroText: string[] = options.macros[k].tokens.map((t: any) => t.text);
-			toSerialize[k] = `${macroText.join('')}_${options.macros[k].numArgs}`;
+			const macro = options.macros[k];
+			if (typeof macro === 'string') {
+				toSerialize[k] = `${macro}_string`;
+			} else {
+				const macroText: string[] = macro.tokens.map((t: any) => t.text);
+				toSerialize[k] = `${macroText.join('')}_${macro.numArgs}`;
+			}
 		}
 		newOptions.macros = toSerialize;
 	}


### PR DESCRIPTION
# Summary

A macro created by `\begin{align}...\end{align}` was in a format not supported by Joplin's KaTeX macro stringification code.

This pull request fixes #9455 by adding code to handle this case.

**Edit**: Corrected: `\begin{aligned}` should have been `\begin{align}`.

# Testing

Create a note with the following content:
```md
$$
\begin{align}
	Block
\end{align}
$$

$Inline$
```

and verify that it renders.

This has been tested manually on desktop.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
