### PR TITLE
Chore: Change the return type of `shim.fsDriver()` from `any` to `FsDriverBase`

### DIFF
--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -50,7 +50,7 @@ export default class InteropServiceHelper {
 
 		const cleanup = () => {
 			if (win) win.destroy();
-			if (htmlFile) shim.fsDriver().remove(htmlFile);
+			if (htmlFile) void shim.fsDriver().remove(htmlFile);
 		};
 
 		try {
@@ -67,7 +67,7 @@ export default class InteropServiceHelper {
 
 			win = bridge().newBrowserWindow(windowOptions);
 
-			return new Promise((resolve, reject) => {
+			return new Promise<any>((resolve, reject) => {
 				win.webContents.on('did-finish-load', () => {
 
 					// did-finish-load will trigger when most assets are done loading, probably

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.ts
@@ -301,12 +301,8 @@ export default class FsDriverRN extends FsDriverBase {
 		return output ? output : null;
 	}
 
-	public resolve(path: string) {
-		throw new Error(`Not implemented: resolve(): ${path}`);
-	}
-
-	public resolveRelativePathWithinDir(_baseDir: string, relativePath: string) {
-		throw new Error(`Not implemented: resolveRelativePathWithinDir(): ${relativePath}`);
+	public resolve(...paths: string[]): string {
+		throw new Error(`Not implemented: resolve(): ${JSON.stringify(paths)}`);
 	}
 
 	public async md5File(path: string): Promise<string> {

--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -4,8 +4,8 @@ import { filename, fileExtension } from './path-utils';
 const md5 = require('md5');
 
 export interface Stat {
-	birthtime: number;
-	mtime: number;
+	birthtime: Date;
+	mtime: Date;
 	isDirectory(): boolean;
 	path: string;
 	size: number;
@@ -49,6 +49,10 @@ export default class FsDriverBase {
 		throw new Error('Not implemented');
 	}
 
+	public async rename(source: string, dest: string) {
+		return this.move(source, dest);
+	}
+
 	public async readFileChunk(_handle: any, _length: number, _encoding = 'base64'): Promise<string> {
 		throw new Error('Not implemented');
 	}
@@ -80,6 +84,26 @@ export default class FsDriverBase {
 
 	public async writeFile(_path: string, _content: string, _encoding = 'base64'): Promise<void> {
 		throw new Error('Not implemented');
+	}
+
+	public async md5File(_path: string): Promise<string> {
+		throw new Error('Not implemented: md5File');
+	}
+
+	public resolve(..._paths: string[]): string {
+		throw new Error('Not implemented: resolve');
+	}
+
+	public resolveRelativePathWithinDir(_baseDir: string, relativePath: string): string {
+		throw new Error(`Not implemented: resolveRelativePathWithinDir(): ${relativePath}`);
+	}
+
+	public getExternalDirectoryPath(): Promise<string | undefined> {
+		throw new Error('Not implemented: getExternalDirectoryPath');
+	}
+
+	public isUsingAndroidSAF() {
+		return false;
 	}
 
 	protected async readDirStatsHandleRecursion_(basePath: string, stat: Stat, output: Stat[], options: ReadDirStatsOptions): Promise<Stat[]> {

--- a/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
+++ b/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
@@ -31,8 +31,8 @@ export async function installDefaultPlugins(service: PluginService, defaultPlugi
 
 	const installedPlugins = Setting.value('installedDefaultPlugins');
 
-	for (let pluginId of defaultPluginsPaths) {
-		pluginId = pluginId.path;
+	for (const pluginStat of defaultPluginsPaths) {
+		const pluginId = pluginStat.path;
 
 		// if pluginId is present in 'installedDefaultPlugins' array or it doesn't have default plugin ID, then we won't install it again as default plugin
 		if (installedPlugins.includes(pluginId) || !defaultPluginsId.includes(pluginId)) continue;

--- a/packages/lib/services/rest/routes/notes.test.ts
+++ b/packages/lib/services/rest/routes/notes.test.ts
@@ -38,7 +38,7 @@ describe('routes/notes', () => {
 		jest.spyOn(shim, 'fsDriver').mockImplementation(() => {
 			return {
 				copy: fsDriverCopySpy,
-			};
+			} as any;
 		});
 		jest.spyOn(uuid, 'create').mockReturnValue('mocked_uuid_value');
 

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { NoteEntity, ResourceEntity } from './services/database/types';
+import type FsDriverBase from './fs-driver-base';
 
 let isTestingEnv_ = false;
 
@@ -203,7 +204,7 @@ const shim = {
 
 	FormData: typeof FormData !== 'undefined' ? FormData : null,
 
-	fsDriver: (): any => {
+	fsDriver: (): FsDriverBase => {
 		throw new Error('Not implemented');
 	},
 


### PR DESCRIPTION
# Summary

To improve type safety, this pull request changes the return type of `shim.fsDriver()` from `any` to `FsDriverBase`.

Most of the changes in this pull request are required to fix compilation errors resulting from the change.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
