### PR TITLE
Chore: Plugin repo: Prevent plugin authors from marking their own plugins as recommended

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -967,6 +967,8 @@ packages/plugin-repo-cli/lib/types.js
 packages/plugin-repo-cli/lib/updateReadme.test.js
 packages/plugin-repo-cli/lib/updateReadme.js
 packages/plugin-repo-cli/lib/utils.js
+packages/plugin-repo-cli/lib/validateUntrustedManifest.test.js
+packages/plugin-repo-cli/lib/validateUntrustedManifest.js
 packages/plugins/ToggleSidebars/api/index.js
 packages/plugins/ToggleSidebars/api/types.js
 packages/plugins/ToggleSidebars/src/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -949,6 +949,8 @@ packages/plugin-repo-cli/lib/types.js
 packages/plugin-repo-cli/lib/updateReadme.test.js
 packages/plugin-repo-cli/lib/updateReadme.js
 packages/plugin-repo-cli/lib/utils.js
+packages/plugin-repo-cli/lib/validateUntrustedManifest.test.js
+packages/plugin-repo-cli/lib/validateUntrustedManifest.js
 packages/plugins/ToggleSidebars/api/index.js
 packages/plugins/ToggleSidebars/api/types.js
 packages/plugins/ToggleSidebars/src/index.js

--- a/packages/plugin-repo-cli/lib/validateUntrustedManifest.test.ts
+++ b/packages/plugin-repo-cli/lib/validateUntrustedManifest.test.ts
@@ -1,0 +1,96 @@
+
+import validateUntrustedManifest from './validateUntrustedManifest';
+
+const originalManifests = {
+	'joplin-plugin.this.is.a.test': {
+		id: 'joplin-plugin.this.is.a.test',
+		_npm_package_name: 'joplin-plugin-this-is-a-test',
+		version: '0.0.1',
+	},
+};
+
+// Note: Most of the checks below have additional tests in other files.
+// This test suite is primarily to ensure that the checks are present.
+
+describe('validateUntrustedManifest', () => {
+	test('should only allow valid plugin IDs', () => {
+		const badManifest = {
+			id: 'bad',
+			_npm_package_name: 'joplin-plugin-test',
+			version: '1.2.34',
+		};
+
+		expect(
+			() => validateUntrustedManifest(badManifest, originalManifests),
+		).toThrow('ID cannot be shorter than');
+
+
+		const goodManifest = {
+			...badManifest,
+			id: 'this.plugin.has.a.better.id',
+		};
+
+		expect(
+			() => validateUntrustedManifest(goodManifest, originalManifests),
+		).not.toThrow();
+	});
+
+	test('should only allow valid plugin versions', () => {
+		const badManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			_npm_package_name: 'joplin-plugin-this-is-a-test',
+			version: 'bad!',
+		};
+
+		expect(
+			() => validateUntrustedManifest(badManifest, originalManifests),
+		).toThrow();
+
+
+		const goodManifest = {
+			...badManifest,
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(goodManifest, originalManifests),
+		).not.toThrow();
+	});
+
+	test('should not allow plugin authors to mark their own plugins as recommended', () => {
+		const newManifest1 = {
+			id: 'joplin-plugin.this.is.another.test',
+			_recommended: true,
+			_npm_package_name: 'joplin-plugin-another-test',
+			version: '1.2.3',
+		};
+
+		expect(
+			() => validateUntrustedManifest(newManifest1, originalManifests),
+		).toThrow('mark itself as recommended');
+
+		// Should also throw for falsey values
+		const newManifest2 = {
+			id: 'joplin-plugin.yet.another.test',
+			_recommended: '',
+			_npm_package_name: 'another-test',
+			version: '1.2.3',
+		};
+
+		expect(
+			() => validateUntrustedManifest(newManifest2, originalManifests),
+		).toThrow('mark itself as recommended');
+	});
+
+	test('should not allow changing the NPM package for an existing plugin', () => {
+		const newManifest = {
+			id: 'joplin-plugin.this.is.a.test',
+			_npm_package_name: 'joplin-plugin-test',
+			version: '0.0.2',
+		};
+
+		expect(
+			() => validateUntrustedManifest(newManifest, originalManifests),
+		).toThrow();
+	});
+});

--- a/packages/plugin-repo-cli/lib/validateUntrustedManifest.ts
+++ b/packages/plugin-repo-cli/lib/validateUntrustedManifest.ts
@@ -1,0 +1,29 @@
+import validatePluginId from '@joplin/lib/services/plugins/utils/validatePluginId';
+import validatePluginVersion from '@joplin/lib/services/plugins/utils/validatePluginVersion';
+import checkIfPluginCanBeAdded from './checkIfPluginCanBeAdded';
+
+// Assumes that
+// 1. manifest._npm_package_name is correct,
+// 2. other fields were set by the plugin author and are thus untrusted.
+const validateUntrustedManifest = (manifest: any, existingManifests: any) => {
+	// At this point, we need to check the manifest ID as it's used in various
+	// places including as directory name and object key in manifests.json, so
+	// it needs to be correct. It's mostly for security reasons. The other
+	// manifest properties are checked when the plugin is loaded into the app.
+	validatePluginId(manifest.id);
+	validatePluginVersion(manifest.version);
+
+	// This prevents a plugin author from marking their own plugin as _recommended
+	// or _built_in.
+	if (typeof manifest._recommended !== 'undefined') {
+		throw new Error(`Plugin ${manifest.id} cannot mark itself as recommended.`);
+	}
+
+	if (typeof manifest._built_in !== 'undefined') {
+		throw new Error(`Plugin ${manifest.id} cannot mark itself as built-in.`);
+	}
+
+	checkIfPluginCanBeAdded(existingManifests, manifest);
+};
+
+export default validateUntrustedManifest;


### PR DESCRIPTION
# Summary

Adds a check to the plugin CI script that verifies that `_recommended` and `_built_in` are not set in the manifest uploaded to NPM.

# Testing

In addition to the automated tests added in this pull request, I have run the plugin repository script locally.

It had the following terminal output:
<details>

```
testuser@vbox-pop-os:~/Documents/joplin/packages/plugin-repo-cli$ yarn start build ~/Documents/test-plugin-repo/
2023-12-01T16:39:40.878Z Building repository...
Skipping git pull because no tracking information on current branch
> npm search joplin-plugin --searchlimit 5000 --json
> npm install joplin-plugin-attache --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-templates --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-apollo --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-conflict-resolution --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-pastespecial --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-dddot --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-knowledge-graph --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-freehand-drawing --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-combine-notes --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-remoods-theme --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-athena --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-cmoptions --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-better-code-blocks --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-journal --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-inline-todo --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-custom-codemirror-vimrc --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-excalidraw --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bibtex --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-app-lock --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-victor --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-multimd-table-tools --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-disable-pdf --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-history-panel --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-timetagger --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-macos-theme --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-markmap --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-calibre-import --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-evernote-links-replacer --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-remark-slides --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-reset-checkboxes --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-paginator --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-typograms --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-wavedrom --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-kanban --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-enhancement --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-abc-sheet-music --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-advanced-tagging --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-turn-to-chart --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-remote-note-pull --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-outline --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-better-markdown-viewer --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-slash-commands --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-timelinerender --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-search-and-replace --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-note-email --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-email --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-drawio --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-hotfolder --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-textcolorize --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-hackmd --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-csv-import --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-selectedtext-to-googlesearch --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-white-theme --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-encrypt --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-cjk-breaks --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-todoist --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-auto-alarm --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-kity-minder --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-plantuml2 --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-whitespacer --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin-hotkey --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-jtab --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-rename --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-export-as-md --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-publish --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-code-clipboard --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-home-note --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-jarvis --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-quick-links --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-copy-code-blocks --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-life-calendar --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-link-graph-ui --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-rich-markdown --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-vextab --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-export-to-noteson --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-event-calendar --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-markdown-table-sortable --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bidirectional-links --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-suitcase --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-code-section --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-agenda --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-revealjs-slides --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-eztable --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-jsheets --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-discord-rich-presence --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-backup --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-math-mode --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-markdown-table-colorize --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-spoiler-cards --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-untagged --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-hackmd --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-hypothesis --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-auto-tag --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-readcube-papers --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-joplin2jira --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-copy-anchor-link --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bytefield-svg --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-function-plot --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-simple-highlighter --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-auto-show-active-note-in-sidebar --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-remove-images --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-font-size-shortcut --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bible-quote --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-emoji --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-wakatime --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-jira-issue --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-highlight-matching --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-container-with-classes --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-send-snippet-to-different-note --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bulk-note-creator --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-variables --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-email-note --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-autolinker --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-inline-tags --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-day-review --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-automate-notes --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-random-note --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-complete-link --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-copytags --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-metis --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-notes-station-import --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-quick-move --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-menu-shortcut-toolbar --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-persistent-editor-layout --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-table-formatter --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-testing-new-plugin --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-user-link --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-fold-cm --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-nlr --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-export-to-ssg --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-insert-date --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-copy-note-link --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-embedded-tags --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-space-indenter --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-make-all-links --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-get-notebook-id --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-rubi-and-furigana --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-tabs --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-create-from-text --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-tag-and-notebook-links --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-benji-favorites --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-pages-publisher --save --ignore-scripts
Nothing to commit
> npm install @joplin/joplin-plugin-toggle-sidebars --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-bundle --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-personalizedrefrigerator-favorites --save --ignore-scripts
Error: Plugin "joplin.plugin.benji.favorites" from npm package "joplin-plugin-personalizedrefri
gerator-favorites" has already been published under npm package "joplin-plugin-benji-favorites"
. Plugin from package "joplin-plugin-benji-favorites" will not be imported.
    at default_1 (/home/testuser/Documents/joplin/packages/plugin-repo-cli/lib/checkIfPluginCan
BeAdded.ts:19:9)
    at validateUntrustedManifest (/home/testuser/Documents/joplin/packages/plugin-repo-cli/lib/
validateUntrustedManifest.ts:26:25)
    at /home/testuser/Documents/joplin/packages/plugin-repo-cli/index.ts:69:27
    at Generator.next (<anonymous>)
    at fulfilled (/home/testuser/Documents/joplin/packages/plugin-repo-cli/index.js:7:58)
Nothing to commit
> npm install joplin-plugin-backstage --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-dependency-graph --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-overview --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-resource-search --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-embed-search --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-toggle-editor --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-tag-links --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-calendar --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-link-system --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-rohan --save --ignore-scripts
Error: ID cannot be shorter than 16 characters
    at default_1 (/home/testuser/Documents/joplin/packages/lib/services/plugins/utils/validateP
luginId.ts:4:80)
    at validateUntrustedManifest (/home/testuser/Documents/joplin/packages/plugin-repo-cli/lib/
validateUntrustedManifest.ts:13:18)
    at /home/testuser/Documents/joplin/packages/plugin-repo-cli/index.ts:69:27
    at Generator.next (<anonymous>)
    at fulfilled (/home/testuser/Documents/joplin/packages/plugin-repo-cli/index.js:7:58)
Nothing to commit
> npm install joplin-plugin-quick-goto --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-note-stats --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-headings-4-to-6 --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-enhanced-editing --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-pseudocode-support --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-zotero-link --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-repeating-to-dos --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-codemirror-line-numbers --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-backlinks --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-markdown-prettier --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-semantically-similar-notes --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-quick-html-tags --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-plantuml --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-ianylink --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-github-theme --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-ocr --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-markdown-calc --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-admonition --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-tags-generator --save --ignore-scripts
Nothing to commit
> npm install joplin-plugin-biblenotes --save --ignore-scripts
Nothing to commit
Got release with 182 assets from https://github.com/joplin/plugins/releases/tag/plugins
Updating stats file...
Fatal error
Error: Cannot get Oauth token. Neither github_oauth_token.txt nor the env variable JOPLIN_GITHU
B_OAUTH_TOKEN are present
    at githubOauthToken (/home/testuser/Documents/joplin/packages/tools/tool-utils.ts:328:8)
    at /home/testuser/Documents/joplin/packages/plugin-repo-cli/commands/updateRelease.ts:162:4
3
    at Generator.next (<anonymous>)
    at fulfilled (/home/testuser/Documents/joplin/packages/plugin-repo-cli/commands/updateRelea
se.js:6:58)

```

</details>

This output contains the same two error messages as the output from before this pull request was applied.

## Notes

This error message is included in the output:
```
> npm install joplin-plugin-personalizedrefrigerator-favorites --save --ignore-scripts
Error: Plugin "joplin.plugin.benji.favorites" from npm package "joplin-plugin-personalizedrefri
gerator-favorites" has already been published under npm package "joplin-plugin-benji-favorites"
. Plugin from package "joplin-plugin-benji-favorites" will not be imported.
```

This is expected (`joplin-plugin-personalizedrefrigerator-favorites` was created for testing purposes). However, it shoould read
```
Plugin from package "joplin-plugin-personalizedrefrigerator-favorites" will not be imported.
```
and not
```
Plugin from package "joplin-plugin-benji-favorites" will not be imported.
```


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
