### PR TITLE
Chore: Refactor Note.tsx and note-screen-shared.tsx to improve type safety 

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -18,7 +18,6 @@ export interface BaseNoteScreenComponent {
 	setState: (newState: any)=> void;
 
 	scheduleFocusUpdate(): void;
-	scheduleSave(): void;
 	attachFile(asset: any, fileType: any): void;
 	lastLoadedNoteId_?: string;
 }

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -12,17 +12,28 @@ import { itemIsReadOnlySync, ItemSlice } from '../../models/utils/readOnly';
 import ItemChange from '../../models/ItemChange';
 import BaseItem from '../../models/BaseItem';
 
+export interface BaseNoteScreenComponent {
+	props: any;
+	state: any;
+	setState: (newState: any)=> void;
+
+	scheduleFocusUpdate(): void;
+	scheduleSave(): void;
+	attachFile(asset: any, fileType: any): void;
+	lastLoadedNoteId_?: string;
+}
+
 interface Shared {
 	noteExists?: (noteId: string)=> Promise<boolean>;
 	handleNoteDeletedWhileEditing_?: (note: NoteEntity)=> Promise<NoteEntity>;
-	saveNoteButton_press?: (comp: any, folderId: string, options: any)=> Promise<void>;
-	saveOneProperty?: (comp: any, name: string, value: any)=> void;
-	noteComponent_change?: (comp: any, propName: string, propValue: any)=> void;
+	saveNoteButton_press?: (comp: BaseNoteScreenComponent, folderId: string, options: any)=> Promise<void>;
+	saveOneProperty?: (comp: BaseNoteScreenComponent, name: string, value: any)=> void;
+	noteComponent_change?: (comp: BaseNoteScreenComponent, propName: string, propValue: any)=> void;
 	clearResourceCache?: ()=> void;
 	attachedResources?: (noteBody: string)=> Promise<any>;
-	isModified?: (comp: any)=> boolean;
-	initState?: (comp: any)=> void;
-	toggleIsTodo_onPress?: (comp: any)=> void;
+	isModified?: (comp: BaseNoteScreenComponent)=> boolean;
+	initState?: (comp: BaseNoteScreenComponent)=> Promise<void>;
+	toggleIsTodo_onPress?: (comp: BaseNoteScreenComponent)=> void;
 	toggleCheckboxRange?: (ipcMessage: string, noteBody: string)=> any;
 	toggleCheckbox?: (ipcMessage: string, noteBody: string)=> string;
 	installResourceHandling?: (refreshResourceHandler: any)=> void;
@@ -54,7 +65,7 @@ shared.handleNoteDeletedWhileEditing_ = async (note: NoteEntity) => {
 	return Note.load(newNote.id);
 };
 
-shared.saveNoteButton_press = async function(comp: any, folderId: string = null, options: any = null) {
+shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, folderId: string = null, options: any = null) {
 	options = { autoTitle: true, ...options };
 
 	const releaseMutex = await saveNoteMutex_.acquire();
@@ -150,7 +161,7 @@ shared.saveNoteButton_press = async function(comp: any, folderId: string = null,
 	releaseMutex();
 };
 
-shared.saveOneProperty = async function(comp: any, name: string, value: any) {
+shared.saveOneProperty = async function(comp: BaseNoteScreenComponent, name: string, value: any) {
 	let note = { ...comp.state.note };
 
 	const recreatedNote = await shared.handleNoteDeletedWhileEditing_(note);
@@ -167,7 +178,7 @@ shared.saveOneProperty = async function(comp: any, name: string, value: any) {
 	});
 };
 
-shared.noteComponent_change = function(comp: any, propName: string, propValue: any) {
+shared.noteComponent_change = function(comp: BaseNoteScreenComponent, propName: string, propValue: any) {
 	const newState: any = {};
 
 	const note = { ...comp.state.note };
@@ -211,14 +222,14 @@ shared.attachedResources = async function(noteBody: string) {
 	return output;
 };
 
-shared.isModified = function(comp: any) {
+shared.isModified = function(comp: BaseNoteScreenComponent) {
 	if (!comp.state.note || !comp.state.lastSavedNote) return false;
 	const diff = BaseModel.diffObjects(comp.state.lastSavedNote, comp.state.note);
 	delete diff.type_;
 	return !!Object.getOwnPropertyNames(diff).length;
 };
 
-shared.initState = async function(comp: any) {
+shared.initState = async function(comp: BaseNoteScreenComponent) {
 	const isProvisionalNote = comp.props.provisionalNoteIds.includes(comp.props.noteId);
 
 	const note = await Note.load(comp.props.noteId);
@@ -268,7 +279,7 @@ shared.initState = async function(comp: any) {
 	comp.lastLoadedNoteId_ = note.id;
 };
 
-shared.toggleIsTodo_onPress = function(comp: any) {
+shared.toggleIsTodo_onPress = function(comp: BaseNoteScreenComponent) {
 	const newNote = Note.toggleIsTodo(comp.state.note);
 	const newState = { note: newNote };
 	comp.setState(newState);

--- a/packages/lib/services/NavService.ts
+++ b/packages/lib/services/NavService.ts
@@ -1,9 +1,10 @@
+export type OnNavigateCallback = ()=> Promise<boolean>;
+
 export default class NavService {
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	public static dispatch: Function = () => {};
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	private static handlers_: Function[] = [];
+	private static handlers_: OnNavigateCallback[] = [];
 
 	public static async go(routeName: string) {
 		if (this.handlers_.length) {
@@ -15,10 +16,11 @@ export default class NavService {
 			type: 'NAV_GO',
 			routeName: routeName,
 		});
+		return false;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public static addHandler(handler: Function) {
+	public static addHandler(handler: OnNavigateCallback) {
 		for (let i = this.handlers_.length - 1; i >= 0; i--) {
 			const h = this.handlers_[i];
 			if (h === handler) return;
@@ -28,7 +30,7 @@ export default class NavService {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public static removeHandler(hanlder: Function) {
+	public static removeHandler(hanlder: OnNavigateCallback) {
 		for (let i = this.handlers_.length - 1; i >= 0; i--) {
 			const h = this.handlers_[i];
 			if (h === hanlder) this.handlers_.splice(i, 1);


### PR DESCRIPTION
# Summary

- Creates types for `Props`, `State`, and properties in `Note.tsx`
- Adds a `BaseNoteScreenComponent` interface so component arguments don't have type `any` in `note-screen-shared.tsx`.

# Testing

Mobile:
1. Create a new note
2. Edit its title
3. Edit its body
4. Close and re-open the note (verify that it saved)
5. Attach a very tall drawing
6. Scroll to the end of the note
7. Edit the note
8. Return to the note viewer and verify that the note is still scrolled to the end
9. Attach a photo
10. Move the note to a new notebook using the dropdown at the top of the screen
11. Share a website link with Joplin from a different app.

Tested on Android 13.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
