### PR TITLE
Chore: Website: Include plugin discovery website on joplinapp.org (method 2)

### DIFF
--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -72,7 +72,6 @@ const config = {
 							'mobile',
 							'note_history',
 							'notifications',
-							'plugins',
 							'profiles',
 							'publish_note',
 							'rich_text_editor',
@@ -80,6 +79,10 @@ const config = {
 							'share_notebook',
 							'subnotebooks',
 							'terminal',
+
+							// Redirect disabled: This URL is now used for the plugin discovery
+							// website. 
+							// 'plugins',
 						];
 
 						for (const p of oldAppsPages) {

--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -59,6 +59,33 @@ git pull --rebase
 git push
 
 # ------------------------------------------------------------------------------
+# Build the plugin discovery website
+# ------------------------------------------------------------------------------
+
+PLUGIN_DISCOVERY_WEBSITE_PATH="$JOPLIN_ROOT_DIR/../website-plugin-discovery"
+if [ -d "$PLUGIN_DISCOVERY_WEBSITE_PATH" ]; then
+	cd "$PLUGIN_DISCOVERY_WEBSITE_PATH"
+	yarn install
+
+	# /plugins specifies the base URL for the website.
+	# Change this if moving the plugin discovery website from joplinapp.org/plugins
+	# to some other URL.
+	yarn build-production /plugins
+
+	rm -rf "$JOPLIN_WEBSITE_ROOT_DIR/plugins/"
+	cp -r "./site/" "$JOPLIN_WEBSITE_ROOT_DIR/plugins"
+
+	cd "$JOPLIN_WEBSITE_ROOT_DIR"
+
+	git add -A
+	git commit -m "Updated plugin discovery website
+Auto-updated using $SCRIPT_NAME" || true
+
+	git pull --rebase
+	git push
+fi
+
+# ------------------------------------------------------------------------------
 # Build and deploy the website
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Summary

This pull request is an alternative to #9469 and https://github.com/joplin/website/pull/5.

# Notes

Unlike https://github.com/joplin/website/pull/5, this builds the plugin discovery website in Joplin's main CI. This has the advantage of being simpler, but the disadvantage of happening while the build script has access to SSH keys and other secrets.

This must be merged with https://github.com/joplin/website/pull/5.

# Testing


To (partially) test this,
1. `mkdir /tmp/test/`
2. `cd /tmp/test/`
3. Create a new file: `/tmp/test/test/test.sh` with the content
```sh
JOPLIN_ROOT_DIR="$(pwd)"
JOPLIN_WEBSITE_ROOT_DIR="$(pwd)"
SCRIPT_NAME="Test"
```
followed by the lines added to `release-website.sh` by this pull request.

4. Comment out the `git pull --rebase` and `git push` lines
5. In `/tmp/test`, run
```
zsh$ git clone https://github.com/joplin/website-plugin-discovery.git
zsh$ cd /tmp/test/test
zsh$ git init .
zsh$ bash test.sh
```


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
