### PR TITLE
Mobile: Fixes #9477: Fix inline code at beginning of line in table breaks formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -542,6 +542,7 @@ packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
+packages/editor/CodeMirror/markdown/decoratorExtension.test.js
 packages/editor/CodeMirror/markdown/decoratorExtension.js
 packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.js
 packages/editor/CodeMirror/markdown/markdownCommands.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -524,6 +524,7 @@ packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
+packages/editor/CodeMirror/markdown/decoratorExtension.test.js
 packages/editor/CodeMirror/markdown/decoratorExtension.js
 packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.js
 packages/editor/CodeMirror/markdown/markdownCommands.test.js

--- a/packages/editor/CodeMirror/markdown/decoratorExtension.test.ts
+++ b/packages/editor/CodeMirror/markdown/decoratorExtension.test.ts
@@ -1,0 +1,30 @@
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../testUtil/createTestEditor';
+import decoratorExtension from './decoratorExtension';
+
+jest.retryTimes(2);
+
+describe('decoratorExtension', () => {
+	it('should highlight code blocks within tables', async () => {
+		// Regression test for https://github.com/laurent22/joplin/issues/9477
+		const editorText = `
+left    | right
+--------|-------
+\`foo\` | bar  
+		`;
+		const editor = await createTestEditor(
+			editorText,
+
+			// Put the initial cursor at the start of "foo"
+			EditorSelection.cursor(editorText.indexOf('foo')),
+
+			['TableRow', 'InlineCode'],
+			[decoratorExtension],
+		);
+
+		const codeBlock = editor.contentDOM.querySelector('.cm-inlineCode');
+
+		expect(codeBlock.textContent).toBe('`foo`');
+		expect(codeBlock.parentElement.classList.contains('.cm-tableRow'));
+	});
+});

--- a/packages/editor/CodeMirror/testUtil/createTestEditor.ts
+++ b/packages/editor/CodeMirror/testUtil/createTestEditor.ts
@@ -1,7 +1,7 @@
 import { markdown } from '@codemirror/lang-markdown';
 import { GFM as GithubFlavoredMarkdownExt } from '@lezer/markdown';
 import { indentUnit, syntaxTree } from '@codemirror/language';
-import { SelectionRange, EditorSelection, EditorState } from '@codemirror/state';
+import { SelectionRange, EditorSelection, EditorState, Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { MarkdownMathExtension } from '../markdown/markdownMathParser';
 import forceFullParse from './forceFullParse';
@@ -10,7 +10,10 @@ import loadLangauges from './loadLanguages';
 // Creates and returns a minimal editor with markdown extensions. Waits to return the editor
 // until all syntax tree tags in `expectedSyntaxTreeTags` exist.
 const createTestEditor = async (
-	initialText: string, initialSelection: SelectionRange, expectedSyntaxTreeTags: string[],
+	initialText: string,
+	initialSelection: SelectionRange,
+	expectedSyntaxTreeTags: string[],
+	extraExtensions: Extension[] = [],
 ): Promise<EditorView> => {
 	await loadLangauges();
 
@@ -23,6 +26,7 @@ const createTestEditor = async (
 			}),
 			indentUnit.of('\t'),
 			EditorState.tabSize.of(4),
+			extraExtensions,
 		],
 	});
 


### PR DESCRIPTION
# Summary

CodeMirror 6 requires decorations to be added in sorted order. First by the start position of a decoration, next by length.

Joplin's decorator extension was only sorting by start position. As such, in some cases, it could add decorations in an incorrect order.

This pull request fixes #9477 by sorting by length if start positions are equal.

# Notes

The example given in #9477 is a regression from the previous version of the mobile app (2.12.3):
```md
Some text with an `inline code block`.

x     | y
------|-----
`foo` | bar
```
Previously, the mobile editor didn't render tables in a monospace font. As such, it didn't attempt to add a decoration to table rows.

Full-line decorations have length `0`. For the above table, Joplin adds the decorations to <code>\`foo\`</code> and to the table row in the wrong order. This throws an exception, causing no decorations to be added.

# Testing

This pull request contains an automated test, but has been tested manually with the following steps:
1. Enable the beta editor
2. Paste the example from #9477 (see above)
3. Verify that code blocks have borders.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
