### PR TITLE
Chore: Desktop: Increase Playwright test timeout by 20s in CI

### DIFF
--- a/packages/app-desktop/playwright.config.ts
+++ b/packages/app-desktop/playwright.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
 	// Reporter to use. See https://playwright.dev/docs/test-reporters
 	reporter: process.env.CI ? 'line' : 'html',
 
+	// The CI machines can sometimes be very slow. Increase timeout in CI.
+	globalTimeout: process.env.CI ? 50_000 : 30_000, // milliseconds
+
 	// Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
 	use: {
 		// Base URL to use in actions like `await page.goto('/')`.

--- a/packages/app-desktop/playwright.config.ts
+++ b/packages/app-desktop/playwright.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
 	// Reporter to use. See https://playwright.dev/docs/test-reporters
 	reporter: process.env.CI ? 'line' : 'html',
 
-	// The CI machines can sometimes be very slow. Increase timeout in CI.
-	globalTimeout: process.env.CI ? 50_000 : 30_000, // milliseconds
+	// The CI machines can sometimes be very slow. Increase per-test timeout in CI.
+	timeout: process.env.CI ? 50_000 : 30_000, // milliseconds
 
 	// Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
 	use: {


### PR DESCRIPTION
# Summary

Increases the Playwright global test timeout in CI from 30s to 50s.

This does not change the timeout per call to `expect` (see [the documentation](https://playwright.dev/docs/test-timeouts)).

Relevant failing CI: https://github.com/laurent22/joplin/actions/runs/7169144443/job/19518878104?pr=9492#step:13:945 , https://github.com/laurent22/joplin/actions/runs/7188267590/job/19577606727?pr=9506#step:13:845

# Notes

- It seems that the CI is failing mostly (only?) on the MacOS runner.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
