### PR TITLE
Mobile: Fixes #9500: Fix font for the inbox email address not using the theme color

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -438,7 +438,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				<View key="joplinCloud">
 					<View style={this.styles().styleSheet.settingContainerNoBottomBorder}>
 						<Text style={this.styles().styleSheet.settingText}>{label}</Text>
-						<Text style={{ fontWeight: 'bold' }}>{this.props.settings['sync.10.inboxEmail']}</Text>
+						<Text style={this.styles().styleSheet.settingTextEmphasis}>{this.props.settings['sync.10.inboxEmail']}</Text>
 					</View>
 					{
 						this.renderButton(

--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -12,6 +12,7 @@ export interface ConfigScreenStyleSheet {
 
 	headerTextStyle: TextStyle;
 	settingText: TextStyle;
+	settingTextEmphasis: TextStyle;
 	linkText: TextStyle;
 	descriptionText: TextStyle;
 	warningText: TextStyle;
@@ -109,6 +110,10 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 			paddingBottom: theme.marginBottom / 2,
 		},
 		settingText: settingTextStyle,
+		settingTextEmphasis: {
+			fontWeight: 'bold',
+			color: theme.color,
+		},
 		descriptionText: {
 			color: theme.colorFaded,
 			fontSize: theme.fontSizeSmaller,


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/9500

### Testing

- Connect to Joplin Cloud
- Change themes
- Access Joplin Cloud settings screen
- Inbox email/Email to Note value should change color according to theme scheme

![Screenshot from 2023-12-12 10-44-11](https://github.com/laurent22/joplin/assets/5051088/9d3884fa-594b-4869-ac0e-c990e13fe895)
![Screenshot from 2023-12-12 10-44-36](https://github.com/laurent22/joplin/assets/5051088/9a467eeb-af2a-4c21-935e-47275b1f78a4)
![Screenshot from 2023-12-12 10-45-02](https://github.com/laurent22/joplin/assets/5051088/d0e18745-b6d0-4f5c-af56-6566b67a0391)
![Screenshot from 2023-12-12 10-45-44](https://github.com/laurent22/joplin/assets/5051088/80a8517f-d4ff-4440-8d3c-d0bb498309df)
