### PR TITLE
Mobile,Desktop: Fix #9200: Fix list renumbering and enable multiple selections

### DIFF
--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -204,6 +204,7 @@ const createEditor = (
 					},
 				} : undefined),
 				drawSelection(),
+				EditorState.allowMultipleSelections.of(true),
 				highlightSpecialChars(),
 				indentOnInput(),
 

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -7,7 +7,7 @@ import {
 import { classHighlighter } from '@lezer/highlight';
 
 import {
-	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command,
+	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command, rectangularSelection,
 } from '@codemirror/view';
 import { history, undoDepth, redoDepth, standardKeymap } from '@codemirror/commands';
 
@@ -203,8 +203,13 @@ const createEditor = (
 						};
 					},
 				} : undefined),
-				drawSelection(),
+
+				// Allows multiple selections and allows selecting a rectangle
+				// with ctrl (as in CodeMirror 5)
 				EditorState.allowMultipleSelections.of(true),
+				rectangularSelection(),
+				drawSelection(),
+
 				highlightSpecialChars(),
 				indentOnInput(),
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -354,9 +354,7 @@ export const toggleList = (listType: ListType): Command => {
 		doc = state.doc;
 
 		// Renumber the list
-		view.dispatch(state.changeByRange((sel: SelectionRange) => {
-			return renumberList(state, sel);
-		}));
+		view.dispatch(renumberList(state, state.selection.ranges));
 
 		return true;
 	};
@@ -417,9 +415,7 @@ export const increaseIndent: Command = (view: EditorView): boolean => {
 	view.dispatch(changes);
 
 	// Fix any lists
-	view.dispatch(view.state.changeByRange((sel: SelectionRange) => {
-		return renumberList(view.state, sel);
-	}));
+	view.dispatch(renumberList(view.state, view.state.selection.ranges));
 
 	return true;
 };
@@ -468,9 +464,7 @@ export const decreaseIndent: Command = (view: EditorView): boolean => {
 	view.dispatch(changes);
 
 	// Fix any lists
-	view.dispatch(view.state.changeByRange((sel: SelectionRange) => {
-		return renumberList(view.state, sel);
-	}));
+	view.dispatch(renumberList(view.state, view.state.selection.ranges));
 
 	return true;
 };

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -8,7 +8,7 @@ import {
 } from '@codemirror/state';
 import { getIndentUnit, indentString, syntaxTree } from '@codemirror/language';
 import {
-	RegionSpec, growSelectionToNode, renumberList,
+	RegionSpec, growSelectionToNode, renumberSelectedLists,
 	toggleInlineFormatGlobally, toggleRegionFormatGlobally, toggleSelectedLinesStartWith,
 	isIndentationEquivalent, stripBlockquote, tabsToSpaces,
 } from './markdownReformatter';
@@ -354,7 +354,7 @@ export const toggleList = (listType: ListType): Command => {
 		doc = state.doc;
 
 		// Renumber the list
-		view.dispatch(renumberList(state, state.selection.ranges));
+		view.dispatch(renumberSelectedLists(state));
 
 		return true;
 	};
@@ -415,7 +415,7 @@ export const increaseIndent: Command = (view: EditorView): boolean => {
 	view.dispatch(changes);
 
 	// Fix any lists
-	view.dispatch(renumberList(view.state, view.state.selection.ranges));
+	view.dispatch(renumberSelectedLists(view.state));
 
 	return true;
 };
@@ -464,7 +464,7 @@ export const decreaseIndent: Command = (view: EditorView): boolean => {
 	view.dispatch(changes);
 
 	// Fix any lists
-	view.dispatch(renumberList(view.state, view.state.selection.ranges));
+	view.dispatch(renumberSelectedLists(view.state));
 
 	return true;
 };

--- a/packages/editor/CodeMirror/markdown/markdownReformatter.ts
+++ b/packages/editor/CodeMirror/markdown/markdownReformatter.ts
@@ -712,21 +712,23 @@ export const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 		}
 	}
 
-	// Use EditorSelection.create to merge overlapping lists
-	const listsToHandle = EditorSelection.create(selectedListRanges).ranges;
-
 	const changes: ChangeSpec[] = [];
-	for (const listSelection of listsToHandle) {
-		const lines = [];
+	if (selectedListRanges.length > 0) {
+		// Use EditorSelection.create to merge overlapping lists
+		const listsToHandle = EditorSelection.create(selectedListRanges).ranges;
 
-		const startLine = doc.lineAt(listSelection.from);
-		const endLine = doc.lineAt(listSelection.to);
+		for (const listSelection of listsToHandle) {
+			const lines = [];
 
-		for (let i = startLine.number; i <= endLine.number; i++) {
-			lines.push(doc.line(i));
+			const startLine = doc.lineAt(listSelection.from);
+			const endLine = doc.lineAt(listSelection.to);
+
+			for (let i = startLine.number; i <= endLine.number; i++) {
+				lines.push(doc.line(i));
+			}
+
+			changes.push(...handleLines(lines));
 		}
-
-		changes.push(...handleLines(lines));
 	}
 
 	return {


### PR DESCRIPTION
# Summary

This pull request does two things:
- Fixes a list renumbering issue when there are multiple selections (fixes #9200)
- Enables multiple selections (fixes #9196) to allow testing the above manually,
    - On request, enabling multiple selections can be moved to a separate pull request.


# Testing plan

This pull request has an automated test. However, it can be tested manually by:
1. Creating a numbered list:
```
1. this
2. is
3. a
4. test
5. of
6. lists
```
2. Adding cursors to lines 2, 3, and 4:
3. Pressing <kbd>tab</kbd>
4. Removing all cursors, then adding cursors to lines 3 and 4
5. Pressing <kbd>tab</kbd>
6. Adding a cursor to just line 4 (remove the cursor from line 3)
7. Pressing <kbd>tab</kbd>
8. Adding a cursor to line 5
9. Pressing <kbd>shift</kbd>-<kbd>tab</kbd> twice

After each step, each list should have the same numbering as it does in the viewer.

This has been successfully tested on Ubuntu 23.10.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
