### PR TITLE
Chore: Fix plugin website build

### DIFF
--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -66,7 +66,7 @@ git push
 BUILT_PLUGIN_WEBSITE_FILE="$JOPLIN_ROOT_DIR/../plugin-website.tar.gz"
 
 if [ -f "$BUILT_PLUGIN_WEBSITE_FILE" ]; then
-	cd "$JOPLIN_WEBSITE_ROOT_DIR"
+	cd "$JOPLIN_WEBSITE_ROOT_DIR/docs"
 
 	mkdir -p plugins
 	cd plugins


### PR DESCRIPTION
# Summary

Corrects the output directory for the plugin website build script.

Output should have gone to `website/docs/plugins` but was instead sent to `website/plugins`.

A separate pull request will need to be opened to remove the incorrectly placed `/plugins` directory.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
