### PR TITLE
Chore: Fix plugin website build

### DIFF
--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -59,10 +59,33 @@ git pull --rebase
 git push
 
 
+# ------------------------------------------------------------------------------
+# Build and deploy the website
+# ------------------------------------------------------------------------------
+
+cd "$JOPLIN_WEBSITE_ROOT_DIR"
+git checkout master
+git pull --rebase
+
+cd "$JOPLIN_ROOT_DIR"
+CROWDIN_PERSONAL_TOKEN="$CROWDIN_PERSONAL_TOKEN" yarn crowdinDownload
+yarn buildWebsite
+
+cd "$JOPLIN_WEBSITE_ROOT_DIR"
+git add -A
+git commit -m "Updated website
+
+Auto-updated using $SCRIPT_NAME" || true
+
+git pull --rebase
+git push
+
 # Copy and update the plugin website.
 # 
 # For security, the plugin website is built in a separate job without access to SSH
 # keys. This file contains the built output of the other job.
+# 
+# We apply this to the existing plugin website to prevent the changes from being overwritten.
 BUILT_PLUGIN_WEBSITE_FILE="$JOPLIN_ROOT_DIR/../plugin-website.tar.gz"
 
 if [ -f "$BUILT_PLUGIN_WEBSITE_FILE" ]; then
@@ -85,24 +108,3 @@ else
 	echo "Not updating plugin website -- release ($BUILT_PLUGIN_WEBSITE_FILE) not present"
 	exit 1
 fi
-
-# ------------------------------------------------------------------------------
-# Build and deploy the website
-# ------------------------------------------------------------------------------
-
-cd "$JOPLIN_WEBSITE_ROOT_DIR"
-git checkout master
-git pull --rebase
-
-cd "$JOPLIN_ROOT_DIR"
-CROWDIN_PERSONAL_TOKEN="$CROWDIN_PERSONAL_TOKEN" yarn crowdinDownload
-yarn buildWebsite
-
-cd "$JOPLIN_WEBSITE_ROOT_DIR"
-git add -A
-git commit -m "Updated website
-
-Auto-updated using $SCRIPT_NAME" || true
-
-git pull --rebase
-git push


### PR DESCRIPTION
# Summary

Prevents the commit that builds the plugin website from being immediately overwritten (extracts the plugin website **after** building the main website).


## Note

Like the [original pull request](https://github.com/laurent22/joplin/pull/9469), this was tested mostly by running **just** the plugin-website specific code (with a copy of the [website repository](https://github.com/joplin/website) cloned for testing).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
