### PR TITLE
Desktop,Mobile: Resolves #9526: Make backspace delete auto-matching brackets

### DIFF
--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -1,5 +1,5 @@
 import { EditorView, keymap } from '@codemirror/view';
-import { closeBrackets } from '@codemirror/autocomplete';
+import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { EditorKeymap, EditorLanguageType, EditorSettings } from '../types';
 import createTheme from './theme';
 import { EditorState } from '@codemirror/state';
@@ -52,6 +52,7 @@ const configFromSettings = (settings: EditorSettings) => {
 
 	if (settings.automatchBraces) {
 		extensions.push(closeBrackets());
+		extensions.push(keymap.of(closeBracketsKeymap));
 	}
 
 	if (settings.keymap === EditorKeymap.Vim) {


### PR DESCRIPTION
# Summary

Makes the CodeMirror 6 editor's brace matching behavior more similar to the CodeMirror 5 editor's by adding the [`closeBracketsKeymap`](https://codemirror.net/docs/ref/#autocomplete.closeBracketsKeymap) keymap when automatch braces is enabled.

Fixes #9526.

# Testing

1. Enable the beta editor
2. Type `(`
3. Press <kbd>backspace</kbd>

The opening and closing `(`s should both be deleted.

Tested on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
