### PR TITLE
Desktop: Fixes #9528: Fix maximum width setting not respected by CM6 editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useStyles.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useStyles.ts
@@ -7,7 +7,9 @@ import { useMemo } from 'react';
 
 const useStyles = (props: NoteBodyEditorProps) => {
 	return useMemo(() => {
-		return buildStyle(['CodeMirror', props.fontSize], props.themeId, (theme: Theme) => {
+		return buildStyle([
+			'CodeMirror', props.fontSize, props.contentMaxWidth,
+		], props.themeId, (theme: Theme) => {
 			return {
 				root: {
 					position: 'relative',
@@ -70,6 +72,7 @@ const useStyles = (props: NoteBodyEditorProps) => {
 				// CM6 only
 				globalTheme: {
 					...theme,
+					contentMaxWidth: props.contentMaxWidth ? `${props.contentMaxWidth}px` : undefined,
 					fontFamily: 'inherit',
 					fontSize: props.fontSize,
 					fontSizeUnits: 'px',
@@ -77,6 +80,6 @@ const useStyles = (props: NoteBodyEditorProps) => {
 				},
 			};
 		});
-	}, [props.style, props.themeId, props.fontSize]);
+	}, [props.style, props.themeId, props.fontSize, props.contentMaxWidth]);
 };
 export default useStyles;

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -9,6 +9,7 @@ import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
 
 import { inlineMathTag, mathTag } from './markdown/markdownMathParser';
+import { EditorTheme } from '../types';
 
 // For an example on how to customize the theme, see:
 //
@@ -24,7 +25,7 @@ import { inlineMathTag, mathTag } from './markdown/markdownMathParser';
 // use '&.cm-focused' in the theme.
 //
 // [theme] should be a joplin theme (see @joplin/lib/theme)
-const createTheme = (theme: any): Extension[] => {
+const createTheme = (theme: EditorTheme): Extension[] => {
 	// If the theme hasn't loaded yet, return nothing.
 	// (createTheme should be called again after the theme has loaded).
 	if (!theme) {
@@ -160,6 +161,15 @@ const createTheme = (theme: any): Extension[] => {
 
 		'& .cm-tableHeader, & .cm-tableRow, & .cm-tableDelimiter': monospaceStyle,
 		'& .cm-taskMarker': monospaceStyle,
+
+		// Applies maximum width styles to individual lines.
+		'& .cm-line': theme.contentMaxWidth ? {
+			maxWidth: theme.contentMaxWidth,
+
+			// Center
+			marginLeft: 'auto',
+			marginRight: 'auto',
+		} : undefined,
 
 		// Override the default URL style when the URL is within a link
 		'& .tok-url.tok-link, & .tok-link.tok-meta, & .tok-link.tok-string': {

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -108,11 +108,20 @@ export enum EditorKeymap {
 	Emacs = 'emacs',
 }
 
+export interface EditorTheme extends Theme {
+	fontFamily: string;
+	fontSize?: number;
+	fontSizeUnits?: number;
+	isDesktop?: boolean;
+	monospaceFont?: string;
+	contentMaxWidth?: number;
+}
+
 export interface EditorSettings {
 	// EditorSettings objects are deserialized within WebViews, where
 	// [themeStyle(themeId: number)] doesn't work. As such, we need both
 	// a Theme must be provided.
-	themeData: Theme;
+	themeData: EditorTheme;
 
 	// True if the search panel is implemented outside of the editor (e.g. with
 	// React Native).


### PR DESCRIPTION
# Summary

Applies the `contentMaxWidth` setting to the CodeMirror 6 editor on desktop.

Fixes #9528.

# Screenshot

![screenshot: CM6 beta editor renders text with a maximum width](https://github.com/laurent22/joplin/assets/46334387/a37ae5a5-8163-45db-94c2-8c6f8fe36b74)


# Testing

**Desktop**:
1. Enable the "Editor maximum width" setting under "Appearance" and set to 400.
2. Enable the beta editor
3. Hide the note viewer
4. Verify that the beta editor content has a maximum width of 400
7. Disable the beta editor
8. Verify that CodeMirror 5 editor content has a maximum width of 400
9. Enable the beta editor
5. Set "Editor maximum width" to zero
6. Verify that there is no maximum width for the beta editor
7. Set "Editor maximum width" to 600
8. Open a very long note
9. Scroll and edit the note in the middle

Tested successfully on Ubuntu 23.10.

**Mobile**:
Verify that an existing note can be opened and edited.

Tested on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
