### PR TITLE
Mobile: Fixes #9322: Fix editor scrollbar on iOS

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -129,6 +129,9 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	// to avoid various crashes and errors:
 	// https://github.com/react-native-webview/react-native-webview/issues/2920
 	// https://github.com/react-native-webview/react-native-webview/issues/2995
+	//
+	// decelerationRate='normal' is necessary on iOS for a native-like inertial scroll
+	// (the default deaccelerates too quickly).
 	return (
 		<WebView
 			style={{
@@ -150,6 +153,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 			onMessage={props.onMessage}
 			onError={props.onError}
 			onLoadEnd={props.onLoadEnd}
+			decelerationRate='normal'
 		/>
 	);
 };

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -83,8 +83,10 @@ function useHtml(css: string): string {
 					<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 					<title>${_('Note editor')}</title>
 					<style>
-						.cm-editor {
-							height: 100%;
+						/* For better scrolling on iOS (working scrollbar) we use external, rather than internal,
+						   scrolling. */
+						.cm-scroller {
+							overflow: none;
 						}
 
 						${css}
@@ -456,8 +458,6 @@ function NoteEditor(props: Props, ref: any) {
 		readOnly={props.readOnly}
 	/>;
 
-	// - `scrollEnabled` prevents iOS from scrolling the document (has no effect on Android)
-	//    when an editable region (e.g. a the full-screen NoteEditor) is focused.
 	return (
 		<View
 			testID='note-editor-root'
@@ -482,7 +482,7 @@ function NoteEditor(props: Props, ref: any) {
 				<ExtendedWebView
 					webviewInstanceId='NoteEditor'
 					themeId={props.themeId}
-					scrollEnabled={false}
+					scrollEnabled={true}
 					ref={webviewRef}
 					html={html}
 					injectedJavaScript={injectedJavaScript}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -87,6 +87,10 @@ function useHtml(css: string): string {
 						   scrolling. */
 						.cm-scroller {
 							overflow: none;
+
+							/* Ensure that the editor can be foused by clicking on the lower half of the screen.
+							   Don't use 100vh to prevent a scrollbar being present for empty notes. */
+							min-height: 80vh;
 						}
 
 						${css}


### PR DESCRIPTION
# Summary

Uses the `root` element as the scrolling element, rather than CodeMirror's internal scroller on mobile.

It seems that the scrollbar-related bug does not occur when the root document element is used to scroll.

Fixes #9322.

# Testing

1. Open a very long note
2. Scroll down using the scrollbar
3. Scroll back to the top by clicking on the top of the screen
4. Create a new note
5. Click on the bottom of the body area to edit it

This has been tested on an iOS 17.0 simulator and a physical iOS 17.2 device.

- [ ] This still needs to be tested on Android.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
