### PR TITLE
Mobile: Fixes #9532: Fix cursor location on opening the editor and attachments inserted in wrong location

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -269,7 +269,7 @@ function NoteEditor(props: Props, ref: any) {
 	const webviewRef = useRef(null);
 
 	const setInitialSelectionJS = props.initialSelection ? `
-		cm.select(${props.initialSelection.from}, ${props.initialSelection.to});
+		cm.select(${props.initialSelection.start}, ${props.initialSelection.end});
 		cm.execCommand('scrollSelectionIntoView');
 	` : '';
 

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -269,7 +269,8 @@ function NoteEditor(props: Props, ref: any) {
 	const webviewRef = useRef(null);
 
 	const setInitialSelectionJS = props.initialSelection ? `
-		cm.select(${props.initialSelection.start}, ${props.initialSelection.end});
+		cm.select(${props.initialSelection.from}, ${props.initialSelection.to});
+		cm.execCommand('scrollSelectionIntoView');
 	` : '';
 
 	const editorSettings: EditorSettings = {
@@ -331,6 +332,7 @@ function NoteEditor(props: Props, ref: any) {
 				const settings = ${JSON.stringify(editorSettings)};
 
 				cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, settings);
+
 				${setInitialSelectionJS}
 
 				window.onresize = () => {

--- a/packages/app-mobile/components/NoteEditor/types.ts
+++ b/packages/app-mobile/components/NoteEditor/types.ts
@@ -48,6 +48,6 @@ export interface EditorSettings extends EditorBodySettings {
 }
 
 export interface SelectionRange {
-	from: number;
-	to: number;
+	start: number;
+	end: number;
 }

--- a/packages/app-mobile/components/NoteEditor/types.ts
+++ b/packages/app-mobile/components/NoteEditor/types.ts
@@ -48,6 +48,6 @@ export interface EditorSettings extends EditorBodySettings {
 }
 
 export interface SelectionRange {
-	start: number;
-	end: number;
+	from: number;
+	to: number;
 }

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -10,6 +10,7 @@ import NoteEditor from '../NoteEditor/NoteEditor';
 const FileViewer = require('react-native-file-viewer').default;
 const React = require('react');
 const { Keyboard, View, TextInput, StyleSheet, Linking, Image, Share } = require('react-native');
+import type { NativeSyntheticEvent } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
 const { connect } = require('react-redux');
 // const { MarkdownEditor } = require('@joplin/lib/../MarkdownEditor/index.js');
@@ -50,7 +51,7 @@ import isEditableResource from '../NoteEditor/ImageEditor/isEditableResource';
 import VoiceTypingDialog from '../voiceTyping/VoiceTypingDialog';
 import { voskEnabled } from '../../services/voiceTyping/vosk';
 import { isSupportedLanguage } from '../../services/voiceTyping/vosk.android';
-import { ChangeEvent as EditorChangeEvent, UndoRedoDepthChangeEvent } from '@joplin/editor/events';
+import { ChangeEvent as EditorChangeEvent, SelectionRangeChangeEvent, UndoRedoDepthChangeEvent } from '@joplin/editor/events';
 import { join } from 'path';
 const urlUtils = require('@joplin/lib/urlUtils');
 
@@ -251,7 +252,6 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.undoRedoService_stackChange = this.undoRedoService_stackChange.bind(this);
 		this.screenHeader_undoButtonPress = this.screenHeader_undoButtonPress.bind(this);
 		this.screenHeader_redoButtonPress = this.screenHeader_redoButtonPress.bind(this);
-		this.body_selectionChange = this.body_selectionChange.bind(this);
 		this.onBodyViewerLoadEnd = this.onBodyViewerLoadEnd.bind(this);
 		this.onBodyViewerCheckboxChange = this.onBodyViewerCheckboxChange.bind(this);
 		this.onBodyChange = this.onBodyChange.bind(this);
@@ -520,13 +520,13 @@ class NoteScreenComponent extends BaseScreenComponent {
 		this.scheduleSave();
 	}
 
-	private body_selectionChange(event: any) {
-		if (this.useEditorBeta()) {
-			this.selection = event.selection;
-		} else {
-			this.selection = event.nativeEvent.selection;
-		}
-	}
+	private onPlainEdtiorSelectionChange = (event: NativeSyntheticEvent<any>) => {
+		this.selection = event.nativeEvent.selection;
+	};
+
+	private onMarkdownEditorSelectionChange = (event: SelectionRangeChangeEvent) => {
+		this.selection = { from: event.from, to: event.to };
+	};
 
 	public makeSaveAction() {
 		return async () => {
@@ -1392,7 +1392,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 						multiline={true}
 						value={note.body}
 						onChangeText={(text: string) => this.body_changeText(text)}
-						onSelectionChange={this.body_selectionChange}
+						onSelectionChange={this.onPlainEdtiorSelectionChange}
 						blurOnSubmit={false}
 						selectionColor={theme.textSelectionColor}
 						keyboardAppearance={theme.keyboardAppearance}
@@ -1413,7 +1413,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 					initialText={note.body}
 					initialSelection={this.selection}
 					onChange={this.onBodyChange}
-					onSelectionChange={this.body_selectionChange}
+					onSelectionChange={this.onMarkdownEditorSelectionChange}
 					onUndoRedoDepthChange={this.onUndoRedoDepthChange}
 					onAttach={() => this.showAttachMenu()}
 					readOnly={this.state.readOnly}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -53,6 +53,7 @@ import { voskEnabled } from '../../services/voiceTyping/vosk';
 import { isSupportedLanguage } from '../../services/voiceTyping/vosk.android';
 import { ChangeEvent as EditorChangeEvent, SelectionRangeChangeEvent, UndoRedoDepthChangeEvent } from '@joplin/editor/events';
 import { join } from 'path';
+import { SelectionRange } from '../NoteEditor/types';
 const urlUtils = require('@joplin/lib/urlUtils');
 
 // import Vosk from 'react-native-vosk';
@@ -65,6 +66,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 	// This isn't in this.state because we don't want changing scroll to trigger
 	// a re-render.
 	private lastBodyScroll: number|undefined = undefined;
+	private selection: SelectionRange;
 
 	public static navigationOptions(): any {
 		return { header: null };
@@ -525,7 +527,7 @@ class NoteScreenComponent extends BaseScreenComponent {
 	};
 
 	private onMarkdownEditorSelectionChange = (event: SelectionRangeChangeEvent) => {
-		this.selection = { from: event.from, to: event.to };
+		this.selection = { start: event.from, end: event.to };
 	};
 
 	public makeSaveAction() {


### PR DESCRIPTION
# Summary

Fixes two regressions:
- The editor cursor location was not preserved when closing/re-opening the editor. (Fixes #9532)
- Attachments were not inserted in the correct location. (Fixes #9509)

The underlying cause was a type-related issue that caused the selection to not actually be saved (saving `undefined` instead).

> [!NOTE]
> 
> This is a version of https://github.com/laurent22/joplin/pull/9533, rebased on `release-2.13`.
>

# Testing

1. Create a new note with a large amount of content
2. Scroll to the middle of the note
3. Attach a drawing
4. Close and re-open the editor

After step 4, the editor should be scrolled to roughly its original location and the drawing should be attached where the cursor was previously.

This has been tested on an Android 7 device.

A previous version of this pull request (based on `dev`) was tested on an iOS 17 device.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
