### PR TITLE
Clarified dependency on Arm64 architecture dockerimage builds.

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -6,7 +6,7 @@ FROM node:18-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y \
-    python tini \
+    python-is-python2 tini rsync libcairo2-dev libpango1.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Enables Yarn


### PR DESCRIPTION
Clarified dependency on Arm64 architecture dockerimage builds.


```
Package pangocairo was not found in the pkg-config search path.
Perhaps you should add the directory containing `pangocairo.pc'
to the PKG_CONFIG_PATH environment variable
Package 'pangocairo', required by 'virtual:world', not found
gyp: Call to 'pkg-config pangocairo --libs' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/build/packages/tools/node_modules/node-gyp/lib/configure.js:325:16)
gyp ERR! stack     at ChildProcess.emit (node:events:517:28)
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
gyp ERR! System Linux 5.15.0-1048-oracle
gyp ERR! command "/usr/local/bin/node" "/build/packages/tools/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build" "--update-binary" "--module=/build/packages/pdf-viewer/node_modules/canvas/build/Release/canvas.node" "--module_name=canvas" "--module_path=/build/packages/pdf-viewer/node_modules/canvas/build/Release" "--napi_version=9" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v108"
gyp ERR! cwd /build/packages/pdf-viewer/node_modules/canvas
gyp ERR! node -v v18.19.0
gyp ERR! node-gyp -v v9.4.0
gyp ERR! not ok
```