### PR TITLE
Chore: iOS: Remove now-unnecessary scrolling non-root element

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useSource.ts
@@ -151,12 +151,6 @@ export default function useSource(
 
 			const resourceDownloadMode = Setting.value('sync.resourceDownloadMode');
 
-			// On iOS, the root container has slow inertial scroll, which feels very different from
-			// the native scroll in other apps. This is not the case, however, when a child (e.g. a div)
-			// scrolls the content instead.
-			// Use a div to scroll on iOS instead of the main container:
-			const scrollRenderedMdContainer = shim.mobilePlatform() === 'ios';
-
 			const js = [];
 			js.push('try {');
 			js.push(shim.injectedJs('webviewLib'));
@@ -165,8 +159,7 @@ export default function useSource(
 			js.push('window.joplinPostMessage_ = (msg, args) => { return window.ReactNativeWebView.postMessage(msg); };');
 			js.push('webviewLib.initialize({ postMessage: msg => { return window.ReactNativeWebView.postMessage(msg); } });');
 			js.push(`
-				const scrollingElement =
-					${scrollRenderedMdContainer ? 'document.querySelector("#rendered-md")' : 'document.scrollingElement'};
+				const scrollingElement = document.scrollingElement;
 				let lastScrollTop;
 				const onMainContentScroll = () => {
 					const newScrollTop = scrollingElement.scrollTop;
@@ -232,19 +225,6 @@ export default function useSource(
 						font: -apple-system-body;
 					}
 				}
-
-				:root > body {
-					padding: 0;
-				}
-			`;
-			const scrollRenderedMdContainerCss = `
-				body > #rendered-md {
-					width: 100vw;
-					overflow: auto;
-					height: calc(100vh - ${paddingBottom}px - ${paddingTop});
-					padding-bottom: ${paddingBottom}px;
-					padding-top: ${paddingTop};
-				}
 			`;
 			const defaultCss = `
 				code {
@@ -263,7 +243,6 @@ export default function useSource(
 						<style>
 							${defaultCss}
 							${shim.mobilePlatform() === 'ios' ? iOSSpecificCss : ''}
-							${scrollRenderedMdContainer ? scrollRenderedMdContainerCss : ''}
 							${editPopupCss}
 						</style>
 						${assetsToHeaders(result.pluginAssets, { asHtml: true })}


### PR DESCRIPTION
# Summary

With https://github.com/laurent22/joplin/commit/b237a92e02271640fad0aafaaca07c468ef5a02f, the note viewer in iOS can have more of the same CSS as Android.

Before b237a92e02271640fad0aafaaca07c468ef5a02f, the note viewer webview had very fast inertial scroll deceleration, while scrolling regions within the note viewer had normal inertial scroll. The note viewer webview now has the expected inertial scroll behavior and, as such, the root webview can scroll.

# Testing

1. Open a long note
2. Scroll down
3. Open the editor
4. Close the editor
5. Verify that the note viewer scroll is roughly the same as before opening the editor.
6. Zoom in
7. Zoom out

This has been successfully tested on an iOS 17 simulator and an Android 7 device.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
