### PR TITLE
Chore: Plugin website build: Decrease commit size

### DIFF
--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -71,7 +71,13 @@ cd "$JOPLIN_ROOT_DIR"
 CROWDIN_PERSONAL_TOKEN="$CROWDIN_PERSONAL_TOKEN" yarn crowdinDownload
 yarn buildWebsite
 
+
 cd "$JOPLIN_WEBSITE_ROOT_DIR"
+
+# yarn buildWebsite removes docs/plugins. Restoring the original version
+# significantly decreases the size of commits.
+git restore docs/plugins || true
+
 git add -A
 git commit -m "Updated website
 


### PR DESCRIPTION
# Summary

- Restores the deletion of `docs/plugins` in the Joplin Website CI before committing. As `docs/plugins` will be created just after the `Auto-updated` commit, this should significantly decrease the size of commits.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
