### PR TITLE
Chore: Website: Use only one commit per website update

### DIFF
--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -72,13 +72,6 @@ CROWDIN_PERSONAL_TOKEN="$CROWDIN_PERSONAL_TOKEN" yarn crowdinDownload
 yarn buildWebsite
 
 cd "$JOPLIN_WEBSITE_ROOT_DIR"
-git add -A
-git commit -m "Updated website
-
-Auto-updated using $SCRIPT_NAME" || true
-
-git pull --rebase
-git push
 
 # Copy and update the plugin website.
 # 
@@ -95,16 +88,17 @@ if [ -f "$BUILT_PLUGIN_WEBSITE_FILE" ]; then
 	cd plugins
 
 	tar -xzvf "$BUILT_PLUGIN_WEBSITE_FILE"
-	cd "$JOPLIN_WEBSITE_ROOT_DIR"
-
-	git add -A
-	git commit -m "Updated plugin discovery website
-
-Auto-updated using $SCRIPT_NAME" || true
-
-	git pull --rebase
-	git push
 else
 	echo "Not updating plugin website -- release ($BUILT_PLUGIN_WEBSITE_FILE) not present"
 	exit 1
 fi
+
+
+cd "$JOPLIN_WEBSITE_ROOT_DIR"
+git add -A
+git commit -m "Updated website
+
+Auto-updated using $SCRIPT_NAME" || true
+
+git pull --rebase
+git push


### PR DESCRIPTION
# Summary

This pull request should reduce the size and number of commits needed to update the Joplin website.

Previously, website updates were split into two commits:
- One commit to update the main website
- One commit to update the plugin website

The main website commit, however, also deletes the plugin website, which leads to a large number of insertions and deletions.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
