### PR TITLE
Chore: Add function exports to lib/uuid module

### DIFF
--- a/packages/lib/uuid.ts
+++ b/packages/lib/uuid.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { customAlphabet } from 'nanoid/non-secure';
-import { nanoid as nanoidSecure } from 'nanoid';
+import { nanoid as nanoidSecure, customAlphabet as customAlphabetSecure } from 'nanoid';
 
 // https://zelark.github.io/nano-id-cc/
 // https://security.stackexchange.com/a/41749/1873
@@ -44,3 +44,4 @@ export const createNanoForInboxEmail = (): string => {
 	return customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 8)();
 };
 
+export { customAlphabetSecure };

--- a/packages/lib/uuid.ts
+++ b/packages/lib/uuid.ts
@@ -17,9 +17,6 @@ export default {
 	createNano: function(): string {
 		return nanoid();
 	},
-	createNanoForInboxEmail: (): string => {
-		return customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 8)();
-	},
 };
 
 export const createSecureRandom = (size = 32) => {
@@ -42,3 +39,8 @@ export const uuidgen = (length = 22) => {
 	const cachedUuidgen = getCachedUuidgen(length);
 	return cachedUuidgen();
 };
+
+export const createNanoForInboxEmail = (): string => {
+	return customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 8)();
+};
+


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/pull/9501

I'm exporting two new functions from `lib/uuid`, one is the `createNanoForInboxEmail` that moved out of the default object. The other export is `customAlphabetSecure` which is just the customAlphabet imported from the more secure nanoid implementation.