### PR TITLE
Desktop: Fixes #9543: Fix nested tables not preserved in rich text editor

### DIFF
--- a/packages/app-cli/tests/html_to_md/preserve_nested_tables.html
+++ b/packages/app-cli/tests/html_to_md/preserve_nested_tables.html
@@ -1,10 +1,10 @@
 <body>
-<table border="5px" bordercolor="#8707B0">
+<table>
 <tr>
 <td>Left side of the main table</td>
 <td>
-<table border="5px" bordercolor="#F35557">
-<h4 align="center">Nested Table</h4>
+<table>
+<b>Nested Table</b>
 <tr>
 <td>nested table C1</td>
 <td>nested table C2</td>

--- a/packages/app-cli/tests/html_to_md/preserve_nested_tables.md
+++ b/packages/app-cli/tests/html_to_md/preserve_nested_tables.md
@@ -1,1 +1,1 @@
-<table border="5px" bordercolor="#8707B0"><tbody><tr><td>Left side of the main table</td><td><h4 align="center">Nested Table</h4><table border="5px" bordercolor="#F35557"><tbody><tr><td>nested table C1</td><td>nested table C2</td></tr><tr><td>nested table</td><td>nested table</td></tr></tbody></table></td></tr></tbody></table>
+<table><tbody><tr><td>Left side of the main table</td><td><b>Nested Table</b><table><tbody><tr><td>nested table C1</td><td>nested table C2</td></tr><tr><td>nested table</td><td>nested table</td></tr></tbody></table></td></tr></tbody></table>

--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -74,8 +74,8 @@ rules.tableRow = {
 rules.table = {
   // Only convert tables that can result in valid Markdown
   // Other tables are kept as HTML using `keep` (see below).
-  filter: function (node) {
-    return node.nodeName === 'TABLE' && !tableShouldBeHtml(node);
+  filter: function (node, options) {
+    return node.nodeName === 'TABLE' && !tableShouldBeHtml(node, options);
   },
 
   replacement: function (content, node) {
@@ -174,7 +174,7 @@ const nodeContains = (node, types) => {
   return false;
 }
 
-const tableShouldBeHtml = (tableNode, preserveNestedTables) => {
+const tableShouldBeHtml = (tableNode, options) => {
   const possibleTags = [
     'UL',
     'OL',
@@ -193,7 +193,7 @@ const tableShouldBeHtml = (tableNode, preserveNestedTables) => {
   // that's made of HTML tables. In that case we have this logic of removing the
   // outer table and keeping only the inner ones. For the Rich Text editor
   // however we always want to keep nested tables.
-  if (preserveNestedTables) possibleTags.push('TABLE');
+  if (options.preserveNestedTables) possibleTags.push('TABLE');
 
   return nodeContains(tableNode, 'code') ||
     nodeContains(tableNode, possibleTags);
@@ -249,7 +249,7 @@ export default function tables (turndownService) {
   isCodeBlock_ = turndownService.isCodeBlock;
 
   turndownService.keep(function (node) {
-    if (node.nodeName === 'TABLE' && tableShouldBeHtml(node, turndownService.options.preserveNestedTables)) return true;
+    if (node.nodeName === 'TABLE' && tableShouldBeHtml(node, turndownService.options)) return true;
     return false;
   });
   for (var key in rules) turndownService.addRule(key, rules[key])


### PR DESCRIPTION
# Summary

> [!NOTE]
>
> Because this was a feature advertised in the release notes, this feature targets the `release-2.13` branch.
>

The `turndown.keep` function is only applied **after** all normal rules (added with `.add`) don't match.

As such, `filter` for the `table` rule needed to be modified to return `false` in the cases where we want to preserve tables.

Fixes #9543.

# Testing

1. Create a note in the rich text editor
2. Add a table (2x3)
3. Add a table within that table
4. Add text within the subtable
5. Switch to the markdown editor and verify that both tables are preserved

Tested on Ubuntu 23.10.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
