### PR TITLE
Mobile: Fixes #9502: Fix note editor crash when trying to edit text quickly after opening a note

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1347,7 +1347,9 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		let fieldToFocus = this.state.note.is_todo ? 'title' : 'body';
 		if (this.state.mode === 'view') fieldToFocus = '';
 
-		if (fieldToFocus === 'title' && this.titleTextFieldRef.current) {
+		// Avoid writing `this.titleTextFieldRef.current` -- titleTextFieldRef may
+		// be undefined.
+		if (fieldToFocus === 'title' && this.titleTextFieldRef?.current) {
 			this.titleTextFieldRef.current.focus();
 		}
 		// if (fieldToFocus === 'body' && this.markdownEditorRef.current) {


### PR DESCRIPTION
# Summary

Based on the provided stack trace, this *should* fix #9502.

# Notes

Although I have verified that the note editor can still be opened and used on Android 7, I have not reproduced/tested the crash.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
