### PR TITLE
Desktop: Fixes #9586: Fix code blocks with blank lines break tables in the rich text editor

### DIFF
--- a/packages/app-cli/tests/html_to_md/table_with_code_3.html
+++ b/packages/app-cli/tests/html_to_md/table_with_code_3.html
@@ -1,0 +1,31 @@
+<div id="rendered-md">
+    <table class="jop-noMdConv">
+        <thead class="jop-noMdConv">
+            <tr class="jop-noMdConv">
+                <th class="jop-noMdConv">Code</th>
+                <th class="jop-noMdConv">Description</th>
+            </tr>
+            <tr class="jop-noMdConv">
+                <td class="jop-noMdConv">
+                    <pre class="jop-noMdConv"><code class="jop-noMdConv">const test = "hello";
+
+// Another line
+console.log('Test...');
+
+// Blank lines
+
+
+
+// Should not break things.</code></pre>
+                </td>
+                <td class="jop-noMdConv">abcda</td>
+            </tr>
+            <tr class="jop-noMdConv">
+                <td class="jop-noMdConv">
+                    <pre class="jop-noMdConv"><code class="jop-noMdConv">const test = "hello";</code></pre>
+                </td>
+                <td class="jop-noMdConv">abcd</td>
+            </tr>
+        </thead>
+    </table>
+</div>

--- a/packages/app-cli/tests/html_to_md/table_with_code_3.md
+++ b/packages/app-cli/tests/html_to_md/table_with_code_3.md
@@ -1,0 +1,10 @@
+<table class="jop-noMdConv"><thead class="jop-noMdConv"><tr class="jop-noMdConv"><th class="jop-noMdConv">Code</th><th class="jop-noMdConv">Description</th></tr><tr class="jop-noMdConv"><td class="jop-noMdConv"><pre class="jop-noMdConv"><code class="">const test = "hello";
+<!-- -->
+// Another line
+console.log('Test...');
+<!-- -->
+// Blank lines
+<!-- -->
+<!-- -->
+<!-- -->
+// Should not break things.</code></pre></td><td class="jop-noMdConv">abcda</td></tr><tr class="jop-noMdConv"><td class="jop-noMdConv"><pre class="jop-noMdConv"><code class="">const test = "hello";</code></pre></td><td class="jop-noMdConv">abcd</td></tr></thead></table>

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -44,7 +44,33 @@ export default function TurndownService (options) {
       return node.isBlock ? '\n\n' : ''
     },
     keepReplacement: function (content, node) {
-      return node.isBlock ? '\n\n' + node.outerHTML + '\n\n' : node.outerHTML
+      // In markdown, multiple blank lines end an HTML block. We thus
+      // include an HTML comment to make otherwise blank lines not blank.
+      const mutliBlankLineRegex = /\n([ \t\r]*)\n/g;
+
+      // We run the replacement multiple times to handle multiple blank
+      // lines in a row.
+      //
+      // For example,
+      // ```
+      // Foo
+      //
+      //
+      // Bar
+      // ```
+      // in which the first replacement produces
+      // ```
+      // Foo
+      // <!-- -->
+      //
+      // Bar
+      // ```
+      let html = node.outerHTML;
+      while (html.match(mutliBlankLineRegex)) {
+        html = html.replace(mutliBlankLineRegex, '\n<!-- -->$1\n');
+      }
+
+      return node.isBlock ? '\n\n' + html + '\n\n' : html
     },
     defaultReplacement: function (content, node) {
       return node.isBlock ? '\n\n' + content + '\n\n' : content

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -51,20 +51,8 @@ export default function TurndownService (options) {
       // We run the replacement multiple times to handle multiple blank
       // lines in a row.
       //
-      // For example,
-      // ```
-      // Foo
-      //
-      //
-      // Bar
-      // ```
-      // in which the first replacement produces
-      // ```
-      // Foo
-      // <!-- -->
-      //
-      // Bar
-      // ```
+      // For example, "Foo\n\n\nBar" becomes "Foo\n<!-- -->\n\nBar" after the
+      // first replacement.
       let html = node.outerHTML;
       while (html.match(mutliBlankLineRegex)) {
         html = html.replace(mutliBlankLineRegex, '\n<!-- -->$1\n');


### PR DESCRIPTION
# Summary

Fixes #9586 by replacing empty lines with `<!-- -->` in Turndown `keep` rules.

(**Partially** fixes #9544).

# Testing

This pull request contains an automated test.

It has also been tested manually with the following steps:
1. Create a new note
2. Open the rich text editor
3. Create a 2x2 table
4. Add a code block to the top right cell
5. Mark the language as `javascript`
6. Mark the content as
```
function foo() {
    // This
    
    // is

    alert('Test');
}
// A test. </code></pre>
foo();
```
7. Switch to the markdown editor and back

This has been successfully tested on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
