### PR TITLE
Desktop,Mobile: Resolves #9594: Fix table-of-contents links to headings with duplicate content

### DIFF
--- a/packages/app-cli/tests/md_to_html/toc_duplicate_items.html
+++ b/packages/app-cli/tests/md_to_html/toc_duplicate_items.html
@@ -1,0 +1,3 @@
+<nav class="table-of-contents"><ul><li><a href="#test">test</a></li><li><a href="#test-2">test</a></li><li><a href="#test2">test2</a></li></ul></nav><h1 id="test">test</h1>
+<h1 id="test-2">test</h1>
+<h1 id="test2">test2</h1>

--- a/packages/app-cli/tests/md_to_html/toc_duplicate_items.md
+++ b/packages/app-cli/tests/md_to_html/toc_duplicate_items.md
@@ -1,0 +1,5 @@
+[toc]
+
+# test
+# test
+# test2

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -88,7 +88,7 @@ const plugins: RendererPlugins = {
 	emoji: { module: require('markdown-it-emoji') },
 	insert: { module: require('markdown-it-ins') },
 	multitable: { module: require('markdown-it-multimd-table'), options: { multiline: true, rowspan: true, headerless: true } },
-	toc: { module: require('markdown-it-toc-done-right'), options: { listType: 'ul', slugify: slugify } },
+	toc: { module: require('markdown-it-toc-done-right'), options: { listType: 'ul', slugify: slugify, uniqueSlugStartIndex: 2 } },
 	expand_tabs: { module: require('markdown-it-expand-tabs'), options: { tabWidth: 4 } },
 };
 const defaultNoteStyle = require('./defaultNoteStyle');


### PR DESCRIPTION
# Summary

Sets `uniqueSlugStartIndex` to `2` to match the behavior of the version of `markdown-it-anchor` we're using (v5).

This fixes table-of-contents links to duplicate headings.

See also:
- https://github.com/laurent22/joplin/issues/4650

Fixes #9594.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
