### PR TITLE
Desktop: Fixes #9045: Ubuntu: Fix window sometimes doesn't appear on startup (Backport #9561)

### DIFF
--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -58,10 +58,26 @@ const shim = {
 	},
 
 	isGNOME: () => {
+		if ((!shim.isLinux() && !shim.isFreeBSD()) || !process) {
+			return false;
+		}
+
+		const currentDesktop = process.env['XDG_CURRENT_DESKTOP'] ?? '';
+
 		// XDG_CURRENT_DESKTOP may be something like "ubuntu:GNOME" and not just "GNOME".
 		// Thus, we use .includes and not ===.
-		return (shim.isLinux() || shim.isFreeBSD())
-			&& process && (process.env['XDG_CURRENT_DESKTOP'] ?? '').includes('GNOME');
+		if (currentDesktop.includes('GNOME')) {
+			return true;
+		}
+
+		// On Ubuntu, "XDG_CURRENT_DESKTOP=ubuntu:GNOME" is replaced with "Unity" and
+		// ORIGINAL_XDG_CURRENT_DESKTOP stores the original desktop.
+		const originalCurrentDesktop = process.env['ORIGINAL_XDG_CURRENT_DESKTOP'] ?? '';
+		if (originalCurrentDesktop.includes('GNOME')) {
+			return true;
+		}
+
+		return false;
 	},
 
 	isFreeBSD: () => {


### PR DESCRIPTION
# Summary

- Applies a GNOME bug workaround to Ubuntu. See the original PR (#9561) for details.
- Backporting this commit was [suggested on the forum](https://discourse.joplinapp.org/t/joplin-wouldnt-start-reinstalled-it-lost-all-my-notes/34724/10) by @MrCarroll.

# Notes

- While this commit does not fix a regression, it is [causing confusion for new users on Ubuntu/GNOME systems](https://discourse.joplinapp.org/t/joplin-wouldnt-start-reinstalled-it-lost-all-my-notes/34724).

# Testing

Ubuntu 23.10:
- [x] Verified that Joplin still starts (production mode and dev mode).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
