### PR TITLE
Desktop: Fixes #9613: Fix rich text editor deletes HTML links to notes

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -593,7 +593,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				valid_elements: '#p,*[*]',
 
 				menubar: false,
-				convert_urls: false,
+				relative_urls: false,
 				branding: false,
 				statusbar: false,
 				target_list: false,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -593,7 +593,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				valid_elements: '#p,*[*]',
 
 				menubar: false,
-				relative_urls: false,
+				convert_urls: false,
 				branding: false,
 				statusbar: false,
 				target_list: false,

--- a/packages/renderer/HtmlToHtml.ts
+++ b/packages/renderer/HtmlToHtml.ts
@@ -38,6 +38,11 @@ interface RenderOptions {
 	postMessageSyntax: string;
 	enableLongPress: boolean;
 	itemIdToUrl?: ItemIdToUrlHandler;
+
+	// For compatibility with MdToHtml options:
+	plugins?: {
+		link_open?: { linkRenderingType?: number };
+	};
 }
 
 // https://github.com/es-shims/String.prototype.trimStart/blob/main/implementation.js
@@ -95,7 +100,7 @@ export default class HtmlToHtml {
 			...options,
 		};
 
-		const cacheKey = md5(escape(markup));
+		const cacheKey = md5(escape(JSON.stringify({ markup, options })));
 		let html = this.cache_.value(cacheKey);
 
 		if (!html) {
@@ -128,6 +133,7 @@ export default class HtmlToHtml {
 					ResourceModel: this.ResourceModel_,
 					postMessageSyntax: options.postMessageSyntax,
 					enableLongPress: options.enableLongPress,
+					...options.plugins?.link_open,
 				});
 
 				if (!r.html) return null;


### PR DESCRIPTION
# Summary

This only fixes #9613 in HTML notes. It is still an issue in markdown notes.


**Partially** fixes #9613.

# Notes

- **(Minor) remaining issue:** `<a href=":/2cdf0b7c25124dda92421d7a839c21be">Test</a>` has its `href` changed to `joplin://2cdf0b7c25124dda92421d7a839c21be`.
    - The `joplin://2cdf0b7c25124dda92421d7a839c21be` link is still clickable (so seems to be a minor issue).
- Adding [`convert_urls: false`](https://www.tiny.cloud/docs/configure/url-handling/#convert_urls) to the TinyMCE configuration object also seems to fix the issue in markdown notes. However, this change could lead to regressions (e.g. with pasting from the internet) and is thus best left for a separate pull request (not to be backported into `release-2.13`).
<!-- - Changes `relative_urls: false,` to `convert_urls: false,`.
    - The option was originally added in https://github.com/laurent22/joplin/commit/2050889590472a71a337f658732783f7e8fbbd46 to fix images/resource links
    - With `relative_urls: false`, in **markdown notes**, -->

Related: #9647.

# Testing

1. Create a new HTML note
2. Open the rich text editor
3. Drag and drop a note into the rich text editor to create a link
4. <kbd>Ctrl</kbd>-<kbd>Click</kbd> on the link
5. Go back
6. Edit the note
7. <kbd>Ctrl</kbd>-<kbd>Click</kbd> on the link again
8. Go back
9. Inspect the HTML for the note (Markup editor)
10. Click on the link in the preview pane

This has been successfully tested on Ubuntu 23.10.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
