### PR TITLE
Chore: Fix flaky mermaid/KaTeX rendering test

### DIFF
--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -76,7 +76,8 @@ test.describe('main', () => {
 		).toBeVisible();
 
 		// Should render KaTeX (block)
-		await expect(viewerFrame.locator('.joplin-editable > .katex-display')).toBeVisible();
+		// toBeAttached: To be added to the DOM.
+		await expect(viewerFrame.locator('.joplin-editable > .katex-display').first()).toBeAttached();
 		await expect(
 			viewerFrame.locator(
 				'.katex-display *', { hasText: 'cos' },
@@ -84,7 +85,7 @@ test.describe('main', () => {
 		).toBeVisible();
 
 		// Should render KaTeX (inline)
-		await expect(viewerFrame.locator('.joplin-editable > .katex')).toBeVisible();
+		await expect(viewerFrame.locator('.joplin-editable > .katex').first()).toBeAttached();
 	});
 
 	test('HTML links should be preserved when editing a note in the WYSIWYG editor', async ({ electronApp, mainWindow }) => {


### PR DESCRIPTION
# Summary

Rather than checking that **all** matching KaTeX elements are **visible**, this pull request checks that **at least one** KaTeX element is **attached to the DOM**.

# Notes
- An example failure of the relevant test can be found here: https://github.com/laurent22/joplin/actions/runs/7358361313/job/20031505356#step:14:944

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
