### PR TITLE
Desktop: Fixes #9304: Fix HTML resource links lost when editing notes in the rich text editor (Backport #9435)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -385,6 +385,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js
 packages/app-desktop/integration-tests/util/createStartupArgs.js
 packages/app-desktop/integration-tests/util/firstNonDevToolsWindow.js
+packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js

--- a/.gitignore
+++ b/.gitignore
@@ -367,6 +367,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js
 packages/app-desktop/integration-tests/util/createStartupArgs.js
 packages/app-desktop/integration-tests/util/firstNonDevToolsWindow.js
+packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -856,7 +856,18 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			const resourcesEqual = resourceInfosEqual(lastOnChangeEventInfo.current.resourceInfos, props.resourceInfos);
 
 			if (lastOnChangeEventInfo.current.content !== props.content || !resourcesEqual) {
-				const result = await props.markupToHtml(props.contentMarkupLanguage, props.content, markupRenderOptions({ resourceInfos: props.resourceInfos }));
+				const result = await props.markupToHtml(
+					props.contentMarkupLanguage,
+					props.content,
+					markupRenderOptions({
+						resourceInfos: props.resourceInfos,
+
+						// Allow file:// URLs that point to the resource directory.
+						// This prevents HTML-style resource URLs (e.g. <a href="file://path/to/resource/.../"></a>)
+						// from being discarded.
+						allowedFilePrefixes: [props.resourceDirectory],
+					}),
+				);
 				if (cancelled) return;
 
 				editor.setContent(awfulBrHack(result.html));

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -439,6 +439,7 @@ function NoteEditor(props: NoteEditorProps) {
 		contentMarkupLanguage: formNote.markup_language,
 		contentOriginalCss: formNote.originalCss,
 		resourceInfos: resourceInfos,
+		resourceDirectory: Setting.value('resourceDir'),
 		htmlToMarkdown: htmlToMarkdown,
 		markupToHtml: markupToHtml,
 		allAssets: allAssets,

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -82,6 +82,7 @@ export interface NoteBodyEditorProps {
 	visiblePanes: string[];
 	keyboardMode: string;
 	resourceInfos: ResourceInfos;
+	resourceDirectory: string;
 	locale: string;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onDrop: Function;

--- a/packages/app-desktop/gui/NoteEditor/utils/useMarkupToHtml.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMarkupToHtml.ts
@@ -26,6 +26,7 @@ export interface MarkupToHtmlOptions {
 	noteId?: string;
 	vendorDir?: string;
 	platformName?: string;
+	allowedFilePrefixes?: string[];
 }
 
 export default function useMarkupToHtml(deps: HookDependencies) {

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -7,6 +7,7 @@ import { writeFile } from 'fs-extra';
 import { join } from 'path';
 import createStartupArgs from './util/createStartupArgs';
 import firstNonDevToolsWindow from './util/firstNonDevToolsWindow';
+import setFilePickerResponse from './util/setFilePickerResponse';
 
 
 test.describe('main', () => {
@@ -20,17 +21,7 @@ test.describe('main', () => {
 
 	test('should be able to create and edit a new note', async ({ mainWindow }) => {
 		const mainScreen = new MainScreen(mainWindow);
-		await mainScreen.newNoteButton.click();
-
-		const editor = mainScreen.noteEditor;
-		await editor.waitFor();
-
-		// Wait for the title input to have the correct placeholder
-		await mainWindow.locator('input[placeholder^="Creating new note"]').waitFor();
-
-		// Fill the title
-		await editor.noteTitleInput.click();
-		await editor.noteTitleInput.fill('Test note');
+		const editor = await mainScreen.createNewNote('Test note');
 
 		// Note list should contain the new note
 		await expect(mainScreen.noteListContainer.getByText('Test note')).toBeVisible();
@@ -47,6 +38,50 @@ test.describe('main', () => {
 		// Should render
 		const viewerFrame = editor.getNoteViewerIframe();
 		await expect(viewerFrame.locator('h1')).toHaveText('Test note!');
+	});
+
+	test('HTML links should be preserved when editing a note in the WYSIWYG editor', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('Testing!');
+		const editor = mainScreen.noteEditor;
+
+		// Set the note's content
+		await editor.codeMirrorEditor.click();
+
+		// Attach this file to the note (create a resource ID)
+		await setFilePickerResponse(electronApp, [__filename]);
+		await editor.attachFileButton.click();
+
+		// Wait to render
+		const viewerFrame = editor.getNoteViewerIframe();
+		await viewerFrame.locator('a[data-from-md]').waitFor();
+
+		// Should have an attached resource
+		const codeMirrorContent = await editor.codeMirrorEditor.innerText();
+
+		const resourceUrlExpression = /\[.*\]\(:\/(\w+)\)/;
+		expect(codeMirrorContent).toMatch(resourceUrlExpression);
+		const resourceId = codeMirrorContent.match(resourceUrlExpression)[1];
+
+		// Create a new note with just an HTML link
+		await mainScreen.createNewNote('Another test');
+		await editor.codeMirrorEditor.click();
+		await mainWindow.keyboard.type(`<a href=":/${resourceId}">HTML Link</a>`);
+
+		// Switch to the RTE
+		await editor.toggleEditorsButton.click();
+		await editor.richTextEditor.waitFor();
+
+		// Edit the note to cause the original content to update
+		await editor.getTinyMCEFrameLocator().locator('a').click();
+		await mainWindow.keyboard.type('Test...');
+
+		await editor.toggleEditorsButton.click();
+		await editor.codeMirrorEditor.waitFor();
+
+		// Note should still contain the resource ID and note title
+		const finalCodeMirrorContent = await editor.codeMirrorEditor.innerText();
+		expect(finalCodeMirrorContent).toContain(`:/${resourceId}`);
 	});
 
 	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -6,7 +6,7 @@ export default class MainScreen {
 	public readonly noteListContainer: Locator;
 	public readonly noteEditor: NoteEditorScreen;
 
-	public constructor(page: Page) {
+	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
 		this.noteListContainer = page.locator('.rli-noteList');
 		this.noteEditor = new NoteEditorScreen(page);
@@ -16,5 +16,21 @@ export default class MainScreen {
 		await this.newNoteButton.waitFor();
 		await this.noteEditor.waitFor();
 		await this.noteListContainer.waitFor();
+	}
+
+	// Follows the steps a user would use to create a new note.
+	public async createNewNote(title: string) {
+		await this.waitFor();
+		await this.newNoteButton.click();
+		await this.noteEditor.waitFor();
+
+		// Wait for the title input to have the correct placeholder
+		await this.page.locator('input[placeholder^="Creating new note"]').waitFor();
+
+		// Fill the title
+		await this.noteEditor.noteTitleInput.click();
+		await this.noteEditor.noteTitleInput.fill(title);
+
+		return this.noteEditor;
 	}
 }

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -3,13 +3,19 @@ import { Locator, Page } from '@playwright/test';
 
 export default class NoteEditorPage {
 	public readonly codeMirrorEditor: Locator;
+	public readonly richTextEditor: Locator;
 	public readonly noteTitleInput: Locator;
+	public readonly attachFileButton: Locator;
+	public readonly toggleEditorsButton: Locator;
 	private readonly containerLocator: Locator;
 
 	public constructor(private readonly page: Page) {
 		this.containerLocator = page.locator('.rli-editor');
 		this.codeMirrorEditor = this.containerLocator.locator('.codeMirrorEditor');
+		this.richTextEditor = this.containerLocator.locator('iframe[title="Rich Text Area"]');
 		this.noteTitleInput = this.containerLocator.locator('.title-input');
+		this.attachFileButton = this.containerLocator.locator('[title^="Attach file"]');
+		this.toggleEditorsButton = this.containerLocator.locator('[title^="Toggle editors"]');
 	}
 
 	public getNoteViewerIframe() {
@@ -19,8 +25,15 @@ export default class NoteEditorPage {
 		return this.page.frame({ url: /.*note-viewer[/\\]index.html.*/ });
 	}
 
+	public getTinyMCEFrameLocator() {
+		// We use frameLocator(':scope') to convert the richTextEditor Locator into
+		// a FrameLocator. (:scope selects the locator itself).
+		// https://playwright.dev/docs/api/class-framelocator
+		return this.richTextEditor.frameLocator(':scope');
+	}
+
 	public async waitFor() {
-		await this.codeMirrorEditor.waitFor();
 		await this.noteTitleInput.waitFor();
+		await this.toggleEditorsButton.waitFor();
 	}
 }

--- a/packages/app-desktop/integration-tests/util/setFilePickerResponse.ts
+++ b/packages/app-desktop/integration-tests/util/setFilePickerResponse.ts
@@ -1,0 +1,13 @@
+import { ElectronApplication } from '@playwright/test';
+
+const setFilePickerResponse = (electronApp: ElectronApplication, response: string[]) => {
+	return electronApp.evaluate(async ({ dialog }, response) => {
+		dialog.showOpenDialog = async () => ({
+			canceled: false,
+			filePaths: response,
+		});
+		dialog.showOpenDialogSync = () => response;
+	}, response);
+};
+
+export default setFilePickerResponse;

--- a/packages/lib/import-enex-md-gen.test.ts
+++ b/packages/lib/import-enex-md-gen.test.ts
@@ -145,7 +145,7 @@ describe('import-enex-md-gen', () => {
 	// Disabled for now because the ENEX parser has become so error-tolerant
 	// that it's no longer possible to generate a note that would generate a
 	// failure.
-	
+
 	// it('should keep importing notes when one of them is corrupted', async () => {
 	// 	const filePath = `${enexSampleBaseDir}/ImportTestCorrupt.enex`;
 	// 	const errors: any[] = [];

--- a/packages/renderer/HtmlToHtml.ts
+++ b/packages/renderer/HtmlToHtml.ts
@@ -38,6 +38,7 @@ interface RenderOptions {
 	postMessageSyntax: string;
 	enableLongPress: boolean;
 	itemIdToUrl?: ItemIdToUrlHandler;
+	allowedFilePrefixes?: string[];
 }
 
 // https://github.com/es-shims/String.prototype.trimStart/blob/main/implementation.js
@@ -99,7 +100,9 @@ export default class HtmlToHtml {
 		let html = this.cache_.value(cacheKey);
 
 		if (!html) {
-			html = htmlUtils.sanitizeHtml(markup);
+			html = htmlUtils.sanitizeHtml(markup, {
+				allowedFilePrefixes: options.allowedFilePrefixes,
+			});
 
 			html = htmlUtils.processImageTags(html, (data: any) => {
 				if (!data.src) return null;

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -192,6 +192,10 @@ export interface RuleOptions {
 	vendorDir?: string;
 	itemIdToUrl?: ItemIdToUrlHandler;
 
+	// Passed to the HTML sanitizer: Allows file:// URLs with
+	// paths with the included prefixes.
+	allowedFilePrefixes?: string[];
+
 	platformName?: string;
 }
 

--- a/packages/renderer/MdToHtml/rules/sanitize_html.ts
+++ b/packages/renderer/MdToHtml/rules/sanitize_html.ts
@@ -34,7 +34,13 @@ export default {
 					// So the sanitizeHtml function must handle this kind of non-valid HTML.
 
 					if (!sanitizedContent) {
-						sanitizedContent = htmlUtils.sanitizeHtml(token.content, { addNoMdConvClass: true });
+						sanitizedContent = htmlUtils.sanitizeHtml(
+							token.content,
+							{
+								addNoMdConvClass: true,
+								allowedFilePrefixes: ruleOptions.allowedFilePrefixes,
+							},
+						);
 					}
 
 					token.content = sanitizedContent;

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -189,9 +189,11 @@ class HtmlUtils {
 			// If true, adds a "jop-noMdConv" class to all the tags.
 			// It can be used afterwards to restore HTML tags in Markdown.
 			addNoMdConvClass: false,
-			allowedFilePrefixes: [],
 			...options,
 		};
+
+		// If options.allowedFilePrefixes is `undefined`, default to [].
+		options.allowedFilePrefixes ??= [];
 
 		const output: string[] = [];
 


### PR DESCRIPTION
# Summary

Backports #9435 into `release-2.13`.

# Rationale

- Even though this doesn't fix a regression, #9304 combined with the issue fixed by https://github.com/laurent22/joplin/pull/9624 [is causing data loss for some users](https://discourse.joplinapp.org/t/the-docx-xlsx-txt-sh-yaml-files-imported-from-evernote-cannot-be-opened/34715/2).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
