### PR TITLE
Chore: Mobile: Allow debugging iOS WebViews when running in dev mode

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -149,6 +149,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 			mixedContentMode={props.mixedContentMode}
 			allowFileAccess={true}
 			allowFileAccessFromFileURLs={props.allowFileAccessFromJs}
+			webviewDebuggingEnabled={Setting.value('env') === 'dev'}
 			injectedJavaScript={props.injectedJavaScript}
 			onMessage={props.onMessage}
 			onError={props.onError}


### PR DESCRIPTION
# Summary

[`webviewDebuggingEnabled`](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#webviewdebuggingenabled) must be set to `true` to allow debugging of `WebView`s through Safari's development tools on newer versions of iOS.

# Testing

1. Run the app in an iOS simulator
2. Click "Draw picture" (or open some other WebView)
3. Open Safari
4. Click "Develop", then launch the developer tools for the image editor's iframe.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
