### PR TITLE
Server: Fixes #9645: remove public exposing of Postgres port...

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -22,8 +22,6 @@ services:
         image: postgres:16
         volumes:
             - ./data/postgres:/var/lib/postgresql/data
-        ports:
-            - "5432:5432"
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}


### PR DESCRIPTION
...in Docker compose file.

The Postgres container does not need to (and should not) expose port 5432 publicly. (In Compose, containers that -- like Postgres -- expose ports per default can be reached by service-to-service communication inside the Compose network via that port. The port does not explicitly need to be exposed externally.)