### PR TITLE
Desktop: Default plugins: Update Simple Backup to v1.3.5: Fix some notebooks exported twice while creating a backup

### DIFF
--- a/packages/default-plugins/pluginRepositories.json
+++ b/packages/default-plugins/pluginRepositories.json
@@ -2,6 +2,6 @@
 	"io.github.jackgruber.backup": {
 		"cloneUrl": "https://github.com/JackGruber/joplin-plugin-backup.git",
 		"branch": "master",
-		"commit": "021085cc37ed83a91a7950744e462782e27c04a6"
+		"commit": "bd49c665bf60c1e0dd9b9862b2ba69cad3d4c9ae"
 	}
 }


### PR DESCRIPTION
# Summary

Updates Simple Backup from version 1.3.4 to version 1.3.5, fixing an issue where some notebooks were exported twice while creating a JEX backup.

[View changes to the package here](https://github.com/JackGruber/joplin-plugin-backup/compare/021085cc37ed83a91a7950744e462782e27c04a6...bd49c665bf60c1e0dd9b9862b2ba69cad3d4c9ae).

# Testing

Although there are [automated tests that test Simple Backup](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/integration-tests/simpleBackup.spec.ts), it has been tested manually with the following steps:
1. Recompile `packages/default-plugins` with `yarn tsc`
2. Rebuild the desktop app with `yarn build`
3. Start the desktop app
4. Enable 7Zip compression in **settings** > **Backup** > **advanced** > **create archive**
5. Click **Tools** then **Create backup**
6. Verify that a "Backup completed" dialog box is shown

This has been tested manually on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
