### PR TITLE
Desktop: Resolves #9683: Frontmatter importer: Support Notesnook-style timestamps

### DIFF
--- a/packages/app-cli/tests/support/test_notes/yaml/notesnook_updated_created.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/notesnook_updated_created.md
@@ -1,0 +1,9 @@
+---
+title: "Frontmatter test"
+created_at: 01-01-2024 01:23 AM
+updated_at: 02-01-2024 04:56 AM
+---
+
+# Frontmatter test
+
+A test note with frontmatter.

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -140,6 +140,13 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 		expect(note.title).toBe('Distill for R Markdown');
 		expect(note.author).toBe('JJ Allaire');
 	});
+	it('should import Notesnook files with created and update timestamps', async () => {
+		const note = await importTestFile('notesnook_updated_created.md');
+
+		expect(note.title).toBe('Frontmatter test');
+		expect(note.user_created_time).toBe(Date.parse('2024-01-01T01:23:00.000'));
+		expect(note.user_updated_time).toBe(Date.parse('2024-01-02T04:56:00.000'));
+	});
 	it('should handle date formats with timezone information', async () => {
 		const note = await importTestFile('utc.md');
 

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
@@ -111,6 +111,9 @@ export default class InteropService_Importer_Md_frontmatter extends InteropServi
 			metadata['user_created_time'] = time.anythingToMs(md['created'], Date.now());
 		} else if ('date' in md) {
 			metadata['user_created_time'] = time.anythingToMs(md['date'], Date.now());
+		} else if ('created_at' in md) {
+			// Add support for Notesnook
+			metadata['user_created_time'] = time.anythingToMs(md['created_at'], Date.now());
 		}
 
 		if ('updated' in md) {
@@ -120,6 +123,9 @@ export default class InteropService_Importer_Md_frontmatter extends InteropServi
 			metadata['user_updated_time'] = time.anythingToMs(md['lastmod'], Date.now());
 		} else if ('date' in md) {
 			metadata['user_updated_time'] = time.anythingToMs(md['date'], Date.now());
+		} else if ('updated_at' in md) {
+			// Notesnook
+			metadata['user_updated_time'] = time.anythingToMs(md['updated_at'], Date.now());
 		}
 
 		if ('latitude' in md) { metadata['latitude'] = md['latitude']; }


### PR DESCRIPTION
# Summary

Adds support for `updated_at` and `created_at` fields in frontmatter while importing.

Resolves #9683.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
