### PR TITLE
Chore: Fix test plugin update script missing several recently-added plugins

### DIFF
--- a/packages/app-cli/tests/support/plugins/updatePlugins.sh
+++ b/packages/app-cli/tests/support/plugins/updatePlugins.sh
@@ -1,23 +1,40 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-cd "$SCRIPT_DIR/jpl_test/" && yo joplin --update --skip-install --silent
+update_plugin() {
+	echo "Updating $1..."
+	cd "$SCRIPT_DIR/$1" && yo joplin --update --skip-install --silent
+	echo "Done."
+}
+
+update_plugin jpl_test
 sed -i /*.jpl/d .gitignore
 
-cd "$SCRIPT_DIR/codemirror_content_script/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/content_script/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/dialog/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/editor_context_menu/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/events/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/json_export/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/menu/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/multi_selection/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/register_command/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/selected_text/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/settings/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/toc/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/withExternalModules/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/post_messages/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/nativeModule/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/external_assets/" && yo joplin --update --skip-install --silent
-cd "$SCRIPT_DIR/user_data/" && yo joplin --update --skip-install --silent
+PLUGINS_TO_UPDATE=(
+	"clipboard"
+	"codemirror6"
+	"codemirror_content_script"
+	"content_script"
+	"dialog"
+	"editor_context_menu"
+	"events"
+	"external_assets"
+	"imaging"
+	"json_export"
+	"load_css"
+	"menu"
+	"multi_selection"
+	"nativeModule"
+	"note_list_renderer"
+	"post_messages"
+	"register_command"
+	"selected_text"
+	"settings"
+	"toc"
+	"user_data"
+	"withExternalModules"
+)
+
+for PLUGIN in ${PLUGINS_TO_UPDATE[@]}; do
+	update_plugin "$PLUGIN"
+done


### PR DESCRIPTION
# Summary

Refactors `updatePlugins.sh` and adds several missing plugins to the list.

# Notes

- The `codemirror6` plugin relies on unreleased features of `generator-joplin`. Although it **is** included in the list, updating it with the script will break things unless "skip" is chosen in the Yeoman upgrade CLI rather than "all" or "overwrite".
- I have locally verified that the script still runs and applies updates to all plugins except `jsbundles`, `multi_plugins`, `simple`, and `testImport`.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
