### PR TITLE
Desktop,Mobile,Cli: Fixes #8891: Fix AWS S3 sync error

### DIFF
--- a/packages/lib/file-api-driver-amazon-s3.js
+++ b/packages/lib/file-api-driver-amazon-s3.js
@@ -177,6 +177,8 @@ class FileApiDriverAmazonS3 {
 	metadataToStats_(mds) {
 		// aws-sdk-js-v3 can rerturn undefined instead of an empty array when there is
 		// no metadata in some cases.
+		//
+		// Thus, we handle the !mds case.
 		if (!mds) return [];
 
 		const output = [];
@@ -216,7 +218,6 @@ class FileApiDriverAmazonS3 {
 
 		let response = await this.s3ListObjects(prefixPath);
 
-		// In aws-sdk-js-v3 if there are no contents, response.Contents is undefined.
 		let output = this.metadataToStats_(response.Contents, prefixPath);
 
 		while (response.IsTruncated) {

--- a/packages/lib/file-api-driver-amazon-s3.js
+++ b/packages/lib/file-api-driver-amazon-s3.js
@@ -175,6 +175,10 @@ class FileApiDriverAmazonS3 {
 	}
 
 	metadataToStats_(mds) {
+		// aws-sdk-js-v3 can rerturn undefined instead of an empty array when there is
+		// no metadata in some cases.
+		if (!mds) return [];
+
 		const output = [];
 		for (let i = 0; i < mds.length; i++) {
 			output.push(this.metadataToStat_(mds[i], mds[i].Key));
@@ -212,10 +216,7 @@ class FileApiDriverAmazonS3 {
 
 		let response = await this.s3ListObjects(prefixPath);
 
-		// In aws-sdk-js-v3 if there are no contents it no longer returns
-		// an empty array. This creates an Empty array to pass onward.
-		if (response.Contents === undefined) response.Contents = [];
-
+		// In aws-sdk-js-v3 if there are no contents, response.Contents is undefined.
 		let output = this.metadataToStats_(response.Contents, prefixPath);
 
 		while (response.IsTruncated) {


### PR DESCRIPTION
# Summary

Fixes a "cannot read property `length` of `undefined`" error when syncing with Amazon S3.

The check for `undefined`/`null` is moved to `metadataToStats_` from the method that calls it.

# Notes

- **I have not tested this**, as I have not set up Amazon S3 sync.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
