### PR TITLE
Desktop: Fixes #9699: Beta editor: Fix `o` not working in Vim normal mode

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -246,7 +246,6 @@ packages/app-desktop/gui/Navigator.js
 packages/app-desktop/gui/NoteContentPropertiesDialog.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/index.js
-packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/setupVim.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js
@@ -573,6 +572,8 @@ packages/editor/CodeMirror/configFromSettings.js
 packages/editor/CodeMirror/createEditor.test.js
 packages/editor/CodeMirror/createEditor.js
 packages/editor/CodeMirror/editorCommands/editorCommands.js
+packages/editor/CodeMirror/editorCommands/insertLineAfter.test.js
+packages/editor/CodeMirror/editorCommands/insertLineAfter.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
@@ -597,6 +598,7 @@ packages/editor/CodeMirror/testUtil/forceFullParse.js
 packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/theme.js
 packages/editor/CodeMirror/util/isInSyntaxNode.js
+packages/editor/CodeMirror/util/setupVim.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js
 packages/editor/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -226,7 +226,6 @@ packages/app-desktop/gui/Navigator.js
 packages/app-desktop/gui/NoteContentPropertiesDialog.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/index.js
-packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/setupVim.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useCursorUtils.test.js
@@ -553,6 +552,8 @@ packages/editor/CodeMirror/configFromSettings.js
 packages/editor/CodeMirror/createEditor.test.js
 packages/editor/CodeMirror/createEditor.js
 packages/editor/CodeMirror/editorCommands/editorCommands.js
+packages/editor/CodeMirror/editorCommands/insertLineAfter.test.js
+packages/editor/CodeMirror/editorCommands/insertLineAfter.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
@@ -577,6 +578,7 @@ packages/editor/CodeMirror/testUtil/forceFullParse.js
 packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/theme.js
 packages/editor/CodeMirror/util/isInSyntaxNode.js
+packages/editor/CodeMirror/util/setupVim.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js
 packages/editor/types.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
@@ -4,7 +4,7 @@ import KeymapService, { KeymapItem } from '@joplin/lib/services/KeymapService';
 import { EditorCommand } from '../../../utils/types';
 import shim from '@joplin/lib/shim';
 import { reg } from '@joplin/lib/registry';
-import setupVim from './setupVim';
+import setupVim from '@joplin/editor/CodeMirror/util/setupVim';
 import { EventName } from '@joplin/lib/eventManager';
 
 export default function useKeymap(CodeMirror: any) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -8,7 +8,7 @@ import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
-import setupVim from '../utils/setupVim';
+import setupVim from '@joplin/editor/CodeMirror/util/setupVim';
 
 interface Props extends EditorProps {
 	style: React.CSSProperties;

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -7,6 +7,7 @@ import editorCommands from '../editorCommands/editorCommands';
 import { StateEffect } from '@codemirror/state';
 import { StreamParser } from '@codemirror/language';
 import Decorator, { LineWidgetOptions } from './Decorator';
+import insertLineAfter from '../editorCommands/insertLineAfter';
 const { pregQuote } = require('@joplin/lib/string-utils-common');
 
 
@@ -354,12 +355,14 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 	public static commands = (() => {
 		const commands: Record<string, CodeMirror5Command> = {
 			...BaseCodeMirror5Emulation.commands,
+
+			vimInsertListElement: (codeMirror: CodeMirror5Emulation) => insertLineAfter(codeMirror.cm6),
 		};
 
 		for (const commandName in editorCommands) {
 			const command = editorCommands[commandName as keyof typeof editorCommands];
 
-			commands[commandName] = (codeMirror: CodeMirror5Emulation) => command(codeMirror.editor);
+			commands[commandName] = (codeMirror: CodeMirror5Emulation) => command(codeMirror.cm6);
 		}
 
 		// as any: Required to properly extend the base class -- without this,

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -356,13 +356,16 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		const commands: Record<string, CodeMirror5Command> = {
 			...BaseCodeMirror5Emulation.commands,
 
-			vimInsertListElement: (codeMirror: CodeMirror5Emulation) => insertLineAfter(codeMirror.cm6),
+			vimInsertListElement: (codeMirror: BaseCodeMirror5Emulation) => {
+				insertLineAfter(codeMirror.cm6);
+				Vim.handleKey(codeMirror, 'i', 'macro');
+			},
 		};
 
 		for (const commandName in editorCommands) {
 			const command = editorCommands[commandName as keyof typeof editorCommands];
 
-			commands[commandName] = (codeMirror: CodeMirror5Emulation) => command(codeMirror.cm6);
+			commands[commandName] = (codeMirror: BaseCodeMirror5Emulation) => command(codeMirror.cm6);
 		}
 
 		// as any: Required to properly extend the base class -- without this,

--- a/packages/editor/CodeMirror/editorCommands/insertLineAfter.test.ts
+++ b/packages/editor/CodeMirror/editorCommands/insertLineAfter.test.ts
@@ -1,0 +1,20 @@
+import { EditorSelection } from '@codemirror/state';
+import createTestEditor from '../testUtil/createTestEditor';
+import insertLineAfter from './insertLineAfter';
+
+describe('insertLineAfter', () => {
+	test('should continue lists', async () => {
+		const editor = await createTestEditor(
+			'- This\n- is\n- a test',
+			EditorSelection.cursor(1),
+			['BulletList'],
+		);
+		insertLineAfter(editor);
+		expect(editor.state.doc.toString()).toBe([
+			'- This',
+			'- ',
+			'- is',
+			'- a test',
+		].join('\n'));
+	});
+});

--- a/packages/editor/CodeMirror/editorCommands/insertLineAfter.ts
+++ b/packages/editor/CodeMirror/editorCommands/insertLineAfter.ts
@@ -1,0 +1,23 @@
+import { insertNewlineAndIndent } from '@codemirror/commands';
+import { insertNewlineContinueMarkup } from '@codemirror/lang-markdown';
+import { EditorSelection, SelectionRange } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+const insertLineAfter = (view: EditorView) => {
+	const state = view.state;
+	view.dispatch(state.changeByRange((sel: SelectionRange) => {
+		const line = state.doc.lineAt(sel.anchor);
+		return {
+			range: EditorSelection.cursor(line.to),
+		};
+	}));
+
+	// insertNewlineContinueMarkup does nothing if not in markdown -- we thus
+	// need a fallback case
+	const addedNewLine = insertNewlineContinueMarkup(view);
+	if (!addedNewLine) {
+		insertNewlineAndIndent(view);
+	}
+};
+
+export default insertLineAfter;

--- a/packages/editor/CodeMirror/util/setupVim.ts
+++ b/packages/editor/CodeMirror/util/setupVim.ts
@@ -1,4 +1,4 @@
-import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
+import CodeMirrorControl from '../CodeMirrorControl';
 
 const setupVim = (CodeMirror: CodeMirrorControl) => {
 	CodeMirror.Vim.defineAction('swapLineDown', CodeMirror.commands.swapLineDown);


### PR DESCRIPTION
# Summary

Fixes the `o` command in Joplin's CodeMirror 6 Vim emulation.

`o` should open a new line and enter insert mode. It was failing because our CodeMirror5 version of this command tried to use `codemirror.commands.vimInsertListElement`, which wasn't registered for CodeMirror5Emulation.

Fixes #9699.

# Testing

1. Enable the beta editor
2. Enable Vim emulation
3. Click on a non-list line
4. Press `o`
    - A new line should be opened after the current, the editor should be in insert mode
5. Type something, then press <kbd>Escape</kbd>
7. Click on a line in a list
8. Press `o`
    - A new line should be opened and the list should be continued.
9. Repeat steps 2-8 for the legacy CM5 editor.

This has been successfully tested on Ubuntu 23.10.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
