### PR TITLE
Chore: Fixes #9710: Default plugins build: Fetch when checkout fails

### DIFF
--- a/packages/default-plugins/buildDefaultPlugins.ts
+++ b/packages/default-plugins/buildDefaultPlugins.ts
@@ -47,7 +47,14 @@ const buildDefaultPlugins = async (outputParentDir: string|null, beforeInstall: 
 			if (currentCommitHash !== expectedCommitHash) {
 				logStatus(`Switching to commit ${expectedCommitHash}`);
 				await execCommand(['git', 'switch', repositoryData.branch]);
-				await execCommand(['git', 'checkout', expectedCommitHash]);
+
+				try {
+					await execCommand(['git', 'checkout', expectedCommitHash]);
+				} catch (error) {
+					logStatus(`git checkout failed with error ${error}. Fetching...`);
+					await execCommand(['git', 'fetch']);
+					await execCommand(['git', 'checkout', expectedCommitHash]);
+				}
 			}
 
 			logStatus('Copying repository files...');


### PR DESCRIPTION
# Summary

While building default plugins, fetches from GitHub when `git checkout` fails.

Such a failure can happen when the commit hash is updated in `pluginRepositories.json` and the cached repository hasn't been fetched the commit from GitHub.

Fixes #9710.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
