### PR TITLE
Desktop: Fixes #9725: Fix warning logged when uninstalling multiple plugins

### DIFF
--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -505,7 +505,7 @@ export default class PluginService extends BaseService {
 		for (const pluginId in settings) {
 			if (settings[pluginId].deleted) {
 				await this.uninstallPlugin(pluginId);
-				newSettings = { ...settings };
+				newSettings = { ...newSettings };
 				delete newSettings[pluginId];
 			}
 		}


### PR DESCRIPTION
# Summary

Fixes #9725 &mdash; previously `uninstallPlugins` returned a copy of the original `PluginSettings` with only the last deletion applied.

(Related to #9652).

# Testing

This pull request contains an automated test and has also been manually tested by:
1. Installing three plugins
2. Restarting Joplin
3. Uninstalling the three plugins
4. Checking for warnings in the development console.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
