### PR TITLE
Desktop: Resolves #9747: CodeMirror 6 plugin API: Support non-inline CSS assets

### DIFF
--- a/packages/app-cli/tests/support/plugins/codemirror6/src/assets/style.css
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/assets/style.css
@@ -1,5 +1,5 @@
 
 .cm-gutter {
-	background-color: var(--joplin-background-color2);
-	color: var(--joplin-color2);
+	background-color: var(--joplin-background-color3);
+	color: var(--joplin-color3);
 }

--- a/packages/app-cli/tests/support/plugins/codemirror6/src/assets/style.css
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/assets/style.css
@@ -1,0 +1,5 @@
+
+.cm-gutter {
+	background-color: var(--joplin-background-color2);
+	color: var(--joplin-color2);
+}

--- a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
@@ -31,9 +31,11 @@ export default (_context: { contentScriptId: string }) => {
 			// options.
 		},
 
-		// CSS styles can be linked with the assets field, though you may want to consider creating
-		// a CodeMirror theme instead:
-		//   https://codemirror.net/examples/styling/#themes
+		// There are two main ways to style the CodeMirror editor:
+		// 1. With a CodeMirror6 theme extension (see https://codemirror.net/examples/styling/#themes)
+		// 2. With CSS assets
+		// 
+		// CSS assets can be added by exporting an `assets` function:
 		assets: () => [
 			// We can include styles by either referencing a file
 			{ name: './assets/style.css' },
@@ -42,7 +44,14 @@ export default (_context: { contentScriptId: string }) => {
 			{
 				inline: true,
 				mime: 'text/css',
-				text: '.cm-activeLineGutter { text-decoration: underline; }',
+				text: `
+					/* This CSS class is added by the highlightActiveLineGutter extension: */
+					.cm-gutter .cm-activeLineGutter {
+						text-decoration: underline;
+						color: var(--joplin-color2);
+						background-color: var(--joplin-background-color2);
+					}
+				`,
 			},
 		],
 	};

--- a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
@@ -4,7 +4,7 @@
 // This is necessary. Having multiple copies of the CodeMirror libraries loaded can cause
 // the editor to not work properly.
 //
-import { lineNumbers } from '@codemirror/view';
+import { lineNumbers, highlightActiveLineGutter, } from '@codemirror/view';
 //
 // For the above import to work, you may also need to add @codemirror/view as a dev dependency
 // to package.json. (For the type information only).
@@ -22,10 +22,28 @@ export default (_context: { contentScriptId: string }) => {
 			// We add the extension to CodeMirror using a helper method:
 			codeMirrorWrapper.addExtension([
 				lineNumbers(),
+
+				// We can include multiple extensions here:
+				highlightActiveLineGutter(),
 			]);
 
 			// See https://codemirror.net/ for more built-in extensions and configuration
 			// options.
 		},
+
+		// CSS styles can be linked with the assets field, though you may want to consider creating
+		// a CodeMirror theme instead:
+		//   https://codemirror.net/examples/styling/#themes
+		assets: () => [
+			// We can include styles by either referencing a file
+			{ name: './assets/style.css' },
+
+			// or including the style sheet inline
+			{
+				inline: true,
+				mime: 'text/css',
+				text: '.cm-activeLineGutter { text-decoration: underline; }',
+			},
+		],
 	};
 };

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -9,6 +9,7 @@ import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
 import setupVim from '@joplin/editor/CodeMirror/util/setupVim';
+import { dirname } from 'path';
 
 interface Props extends EditorProps {
 	style: React.CSSProperties;
@@ -66,6 +67,11 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 					pluginId,
 					contentScriptId: contentScript.id,
 					contentScriptJs: () => shim.fsDriver().readFile(contentScript.path),
+					loadCssAsset: (name: string) => {
+						const assetPath = dirname(contentScript.path);
+						const path = shim.fsDriver().resolveRelativePathWithinDir(assetPath, name);
+						return shim.fsDriver().readFile(path, 'utf8');
+					},
 					postMessageHandler: (message: any) => {
 						const plugin = PluginService.instance().pluginById(pluginId);
 						return plugin.emitContentScriptMessage(contentScript.id, message);

--- a/packages/editor/CodeMirror/createEditor.test.ts
+++ b/packages/editor/CodeMirror/createEditor.test.ts
@@ -76,12 +76,14 @@ describe('createEditor', () => {
 		const testPlugin1 = {
 			pluginId: 'a.plugin.id',
 			contentScriptId: 'a.plugin.id.contentScript',
+			loadCssAsset: async (_name: string) => '* { color: red; }',
 			contentScriptJs: getContentScriptJs,
 			postMessageHandler,
 		};
 		const testPlugin2 = {
 			pluginId: 'another.plugin.id',
 			contentScriptId: 'another.plugin.id.contentScript',
+			loadCssAsset: async (_name: string) => '...',
 			contentScriptJs: getContentScriptJs,
 			postMessageHandler,
 		};

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -68,6 +68,7 @@ export interface PluginData {
 	pluginId: string;
 	contentScriptId: string;
 	contentScriptJs: ()=> Promise<string>;
+	loadCssAsset: (name: string)=> Promise<string>;
 	postMessageHandler: (message: any)=> any;
 }
 


### PR DESCRIPTION
# Summary

Adds support for loading referenced CSS assets from CodeMirror 6 plugins.

Fixes #9747.

# Testing

CSS assets have been added to the example CodeMirror 6 plugin. As such, the changes to the plugin API can be tested by:
1. Building the example CodeMirror 6 plugin (`cd packages/app-cli/tests/support/plugins/codemirror6 && npm install`)
2. Adding the CodeMirror 6 plugin as a development plugin
3. Restarting Joplin
4. Verifying that the line numbers look similar to the following in light mode:
    - ![screenshot: Line numbers are gray text on a light gray background. The active line is light text on a dark background.](https://github.com/laurent22/joplin/assets/46334387/4345fa05-2604-4e43-af24-13cd091d5ed7)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
