### PR TITLE
Desktop: Fixes #9752: CodeMirror 6 plugin API: Allow importing `@codemirror/lang-markdown` and `@lezer/highlight`

### DIFF
--- a/packages/editor/CodeMirror/pluginApi/codeMirrorRequire.ts
+++ b/packages/editor/CodeMirror/pluginApi/codeMirrorRequire.ts
@@ -5,11 +5,14 @@ import * as codeMirrorLanguage from '@codemirror/language';
 import * as codeMirrorAutocomplete from '@codemirror/autocomplete';
 import * as codeMirrorCommands from '@codemirror/commands';
 import * as codeMirrorLint from '@codemirror/lint';
+import * as codeMirrorLangHtml from '@codemirror/lang-html';
+import * as codeMirrorLangMarkdown from '@codemirror/lang-markdown';
+import * as codeMirrorLanguageData from '@codemirror/language-data';
+
 import * as lezerHighlight from '@lezer/highlight';
 import * as lezerCommon from '@lezer/common';
 import * as lezerMarkdown from '@lezer/markdown';
-import * as codeMirrorLangHtml from '@codemirror/lang-html';
-import * as codeMirrorLanguageData from '@codemirror/language-data';
+
 
 // Exposes CodeMirror libraries to plugins.
 //
@@ -21,12 +24,14 @@ const libraryNameToPackage: Record<string, any> = {
 	'@codemirror/language': codeMirrorLanguage,
 	'@codemirror/autocomplete': codeMirrorAutocomplete,
 	'@codemirror/commands': codeMirrorCommands,
-	'@codemirror/highlight': lezerHighlight,
 	'@codemirror/lint': codeMirrorLint,
 	'@codemirror/lang-html': codeMirrorLangHtml,
+	'@codemirror/lang-markdown': codeMirrorLangMarkdown,
 	'@codemirror/language-data': codeMirrorLanguageData,
+
 	'@lezer/common': lezerCommon,
 	'@lezer/markdown': lezerMarkdown,
+	'@lezer/highlight': lezerHighlight,
 };
 
 const codeMirrorRequire = (library: string) => {

--- a/packages/generator-joplin/generators/app/templates/webpack.config.js
+++ b/packages/generator-joplin/generators/app/templates/webpack.config.js
@@ -227,9 +227,11 @@ const externalContentScriptLibraries = [
 	'@codemirror/highlight',
 	'@codemirror/lint',
 	'@codemirror/lang-html',
+	'@codemirror/lang-markdown',
 	'@codemirror/language-data',
 	'@lezer/common',
 	'@lezer/markdown',
+	'@lezer/highlight',
 ];
 
 const extraScriptExternals = {};


### PR DESCRIPTION
# Summary

Allows plugins to import `@codemirror/lang-markdown` and `@lezer/highlight` without also bundling additional copies of the libraries.

# Testing

1. Create a plugin that uses the updated `webpack.config.js` (I copied `webpack.config.js` into an existing plugin).
2. Require both `@codemirror/lang-markdown` and `@lezer/highlight`
3. Inspect the generated bundle to verify that neither library has been included
4. Run the plugin and verify that both libraries were imported
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
