### PR TITLE
Desktop : Fix error when deploying with ansible

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -17,12 +17,13 @@ handleError() {
 # Variables
 #-----------------------------------------------------
 # tput command will fail if $TERM is unset (ex : ansible deployment)
-[[ -z ${TERM} ]] && export TERM="xterm-256color"
-COLOR_RED=`tput setaf 1`
-COLOR_GREEN=`tput setaf 2`
-COLOR_YELLOW=`tput setaf 3`
-COLOR_BLUE=`tput setaf 4`
-COLOR_RESET=`tput sgr0`
+if [[ -z ${TERM} ]] ; then
+    COLOR_RED=`tput setaf 1`
+    COLOR_GREEN=`tput setaf 2`
+    COLOR_YELLOW=`tput setaf 3`
+    COLOR_BLUE=`tput setaf 4`
+    COLOR_RESET=`tput sgr0`
+fi
 SILENT=false
 ALLOW_ROOT=false
 SHOW_CHANGELOG=false

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -17,7 +17,7 @@ handleError() {
 # Variables
 #-----------------------------------------------------
 # tput command will fail if $TERM is unset (ex : ansible deployment)
-if [[ -z ${TERM} ]] ; then
+if [[ -n ${TERM} ]] ; then
     COLOR_RED=`tput setaf 1`
     COLOR_GREEN=`tput setaf 2`
     COLOR_YELLOW=`tput setaf 3`

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -16,8 +16,8 @@ handleError() {
 #-----------------------------------------------------
 # Variables
 #-----------------------------------------------------
-# tput command will fail if $TERM is unset (ex : ansible deployment)
-if [[ "${TERM}" != "unknown" ]] ; then
+# tput command will fail if $TERM is set to dumb (ex : ansible deployment)
+if [[ "${TERM}" != "dumb" ]] ; then
     COLOR_RED=`tput setaf 1`
     COLOR_GREEN=`tput setaf 2`
     COLOR_YELLOW=`tput setaf 3`

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -17,7 +17,7 @@ handleError() {
 # Variables
 #-----------------------------------------------------
 # tput command will fail if $TERM is unset (ex : ansible deployment)
-[[ -z ${TERM} ]] && TERM="xterm-256color"
+[[ -z ${TERM} ]] && export TERM="xterm-256color"
 COLOR_RED=`tput setaf 1`
 COLOR_GREEN=`tput setaf 2`
 COLOR_YELLOW=`tput setaf 3`

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -17,6 +17,8 @@ handleError() {
 # Variables
 #-----------------------------------------------------
 # tput command will fail if $TERM is unset (ex : ansible deployment)
+echo "TERM=***${TERM}***"
+exit 1
 if [[ -n ${TERM} ]] ; then
     COLOR_RED=`tput setaf 1`
     COLOR_GREEN=`tput setaf 2`

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -16,6 +16,8 @@ handleError() {
 #-----------------------------------------------------
 # Variables
 #-----------------------------------------------------
+# tput command will fail if $TERM is unset (ex : ansible deployment)
+[[ -z ${TERM} ]] && TERM="xterm-256color"
 COLOR_RED=`tput setaf 1`
 COLOR_GREEN=`tput setaf 2`
 COLOR_YELLOW=`tput setaf 3`

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -17,9 +17,7 @@ handleError() {
 # Variables
 #-----------------------------------------------------
 # tput command will fail if $TERM is unset (ex : ansible deployment)
-echo "TERM=***${TERM}***"
-exit 1
-if [[ -n ${TERM} ]] ; then
+if [[ "${TERM}" != "unknown" ]] ; then
     COLOR_RED=`tput setaf 1`
     COLOR_GREEN=`tput setaf 2`
     COLOR_YELLOW=`tput setaf 3`


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

Fixes : #9767

Deploying install script with ansible leads to following error : tput: "No value for $TERM and no -T specified" because $TERM is set to "Dumb" in this case.
Simply add a condition to skip tput settings when $TERM is set to Dumb allow installation with ansible
