### PR TITLE
Desktop: Fixes #9775: Fix search when note or OCR text contains null characters

### DIFF
--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -322,6 +322,14 @@ describe('services/SearchEngine', () => {
 		expect(rows[2].id).toBe(n3.id);
 	}));
 
+	it('should support searching through documents that contain null characters', (async () => {
+		await Note.save({ title: 'Test', body: 'Test\x00testing' });
+
+		await engine.syncTables();
+
+		expect((await engine.search('testing')).length).toBe(1);
+	}));
+
 	it('should supports various query types', (async () => {
 		let rows;
 

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -602,7 +602,12 @@ export default class SearchEngine {
 	}
 
 	private normalizeText_(text: string) {
-		const normalizedText = text.normalize ? text.normalize() : text;
+		let normalizedText = text.normalize ? text.normalize() : text;
+
+		// Null characters can break FTS. Remove them.
+		// eslint-disable-next-line no-control-regex
+		normalizedText = normalizedText.replace(/\x00/g, ' ');
+
 		return removeDiacritics(normalizedText.toLowerCase());
 	}
 


### PR DESCRIPTION
# Summary

Fixes search was broken when note or resource text contains null characters.

Fixes #9775

# Testing

This can be tested by:

1. Enable safe mode
2. Create a new note
3. Inspect the note's `textarea` in the developer tools
4. Select it (the developer tools should store a reference to it in `$0`)
5. Run `$0.value += 'Before the null character \x00 After the null character.'` in the console tab
6. Make a change to the note (e.g. add a space to the end)
7. Inspect `$0.value` to verify that the note contains a null character
8. Search for `After`

This has been successfully tested on Ubuntu 23.10.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
