### PR TITLE
Desktop: Resolves #6088: Highlight search terms in the rich text editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -277,6 +277,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useHighlightedSearchTerms.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js

--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useHighlightedSearchTerms.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -30,6 +30,7 @@ import { joplinCommandToTinyMceCommands, TinyMceCommand } from './utils/joplinCo
 import shouldPasteResources from './utils/shouldPasteResources';
 import lightTheme from '@joplin/lib/themes/light';
 import { Options as NoteStyleOptions } from '@joplin/renderer/noteStyle';
+import useHighlightedSearchTerms from './utils/useHighlightedSearchTerms';
 const md5 = require('md5');
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
@@ -937,6 +938,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			editor.getDoc().removeEventListener('click', onEditorContentClick);
 		};
 	}, [editor, onEditorContentClick]);
+
+	useHighlightedSearchTerms(editor, props.searchMarkers.keywords, props.themeId);
 
 	// This is to handle dropping notes on the editor. In this case, we add an
 	// overlay over the editor, which makes it a valid drop target. This in

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useHighlightedSearchTerms.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useHighlightedSearchTerms.ts
@@ -1,0 +1,128 @@
+import SearchEngine from '@joplin/lib/services/search/SearchEngine';
+import { themeStyle } from '@joplin/lib/theme';
+import { Theme } from '@joplin/lib/themes/type';
+import { useEffect, useMemo } from 'react';
+import { Editor } from 'tinymce';
+
+// TODO: Remove after upgrading TypeScript.
+// NOTE: While Highlight is Set-like, its API may be slightly different.
+declare global {
+	interface Window {
+		Highlight: any;
+		Range: any;
+		CSS: any;
+	}
+}
+
+const useHighlightedSearchTerms = (editor: Editor, searchTerms: string[], themeId: number) => {
+	const searchRegexes = useMemo(() => {
+		return searchTerms.map(term => {
+			if (typeof term === 'object') {
+				term = (term as any).value;
+			}
+			return new RegExp(SearchEngine.instance().queryTermToRegex(term), 'ig');
+		});
+	}, [searchTerms]);
+
+	useEffect(() => {
+		if (!editor) {
+			return () => {};
+		}
+
+		const theme: Theme = themeStyle(themeId);
+		const style = editor.dom.create('style', {}, `
+			::highlight(jop-search-highlight) {
+				background-color: ${theme.searchMarkerBackgroundColor};
+				color: ${theme.searchMarkerColor};
+			}
+
+			/* Try to work around a bug on chrome where misspellings also have the
+			   same color as search markers. */
+			::spelling-error, ::highlight(none) {
+				color: inherit;
+			}
+		`);
+		editor.getDoc().head.appendChild(style);
+
+		return () => {
+			style.remove();
+		};
+	}, [editor, themeId]);
+
+	useEffect(() => {
+		if (!editor) {
+			return () => {};
+		}
+
+		const editorWindow = editor.getWin();
+		const ranges: Map<Node, Range[]> = new Map();
+		let highlight: any = undefined;
+
+		const processNode = (node: Node) => {
+			for (const child of node.childNodes) {
+				if (child.nodeName === '#text') {
+					for (const term of searchRegexes) {
+						const matches = child.textContent.matchAll(term);
+						const childRanges = [];
+
+						for (const match of matches) {
+							const range: Range = new editorWindow.Range();
+							range.setStart(child, match.index ?? 0);
+							range.setEnd(child, (match.index ?? 0) + match[0].length);
+							childRanges.push(range);
+						}
+
+						ranges.set(child, childRanges);
+					}
+				} else {
+					processNode(child);
+				}
+			}
+		};
+
+		const rebuildHighlights = (element: Node) => {
+			highlight?.clear();
+
+			processNode(element);
+
+			highlight = new editorWindow.Highlight(...[...ranges.values()].flat());
+			editorWindow.CSS.highlights.set('jop-search-highlight', highlight);
+		};
+
+		const onNodeChange = ({ element }: any) => {
+			rebuildHighlights(element);
+		};
+
+		const onKeyUp = (_event: KeyboardEvent) => {
+			// Use selectedNode and not event.target -- event.target seems to always point
+			// to the body.
+			const selectedNode = editor.selection.getNode();
+			if (selectedNode) {
+				rebuildHighlights(selectedNode);
+			}
+		};
+
+		const onSetContent = () => {
+			rebuildHighlights(editorWindow.document.body);
+		};
+
+		editor.on('NodeChange', onNodeChange);
+		editor.on('SetContent', onSetContent);
+
+		// NodeChange doesn't fire while typing, so we also need keyup
+		editor.on('keyup', onKeyUp);
+
+		rebuildHighlights(editorWindow.document.body);
+
+		return () => {
+			highlight?.clear();
+			editorWindow.CSS.highlights.delete('jop-search-highlight');
+
+			editor.off('NodeChange', onNodeChange);
+			editor.off('keyup', onKeyUp);
+			editor.off('SetContent', onSetContent);
+		};
+	}, [searchRegexes, editor]);
+};
+
+export default useHighlightedSearchTerms;

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -6,6 +6,7 @@ import { RenderResult, RenderResultPluginAsset } from '@joplin/renderer/types';
 import { MarkupToHtmlOptions } from './useMarkupToHtml';
 import { Dispatch } from 'redux';
 import { ProcessResultsRow } from '@joplin/lib/services/search/SearchEngine';
+import { SearchMarkers } from './useSearchMarkers';
 
 export interface AllAssetsOptions {
 	contentMaxWidthTarget?: string;
@@ -90,7 +91,7 @@ export interface NoteBodyEditorProps {
 	dispatch: Function;
 	noteToolbar: any;
 	setLocalSearchResultCount(count: number): void;
-	searchMarkers: any;
+	searchMarkers: SearchMarkers;
 	visiblePanes: string[];
 	keyboardMode: string;
 	resourceInfos: ResourceInfos;

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -57,7 +57,7 @@ export interface ComplexTerm {
 	type: 'regex' | 'text';
 	value: string;
 	scriptType: any;
-	valueRegex?: RegExp;
+	valueRegex?: string;
 }
 
 export interface Terms {
@@ -491,7 +491,7 @@ export default class SearchEngine {
 	}
 
 	// https://stackoverflow.com/a/13818704/561309
-	public queryTermToRegex(term: any) {
+	public queryTermToRegex(term: any): string {
 		while (term.length && term.indexOf('*') === 0) {
 			term = term.substr(1);
 		}


### PR DESCRIPTION
# Summary

Highlights search matches in the rich text editor.

Fixes #6088.

# Notes

Because of what seems to be a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1524212) (this pull request uses a recently released `Highlight` API), misspellings on the same line as a search match currently are given the same color as the match:
![screenshot](https://github.com/laurent22/joplin/assets/46334387/e185e91d-6949-4872-9619-d91191427549)

We may want to postpone merging this until after upgrading Electron to a version compatible with Chromium 121 (the first version that supports the [`::spelling-error` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::spelling-error), which can be used to work around this issue).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
