### PR TITLE
Chore: Desktop: Fix slow startup issue: defaultPlugins directory not cleaned on rebuild

### DIFF
--- a/packages/app-desktop/gulpfile.ts
+++ b/packages/app-desktop/gulpfile.ts
@@ -4,6 +4,7 @@ const compileSass = require('@joplin/tools/compileSass');
 const compilePackageInfo = require('@joplin/tools/compilePackageInfo');
 import buildDefaultPlugins from '@joplin/default-plugins/commands/buildAll';
 import copy7Zip from './tools/copy7Zip';
+import { remove } from 'fs-extra';
 
 const tasks = {
 	compileScripts: {
@@ -34,6 +35,7 @@ const tasks = {
 	buildDefaultPlugins: {
 		fn: async () => {
 			const outputDir = `${__dirname}/build/defaultPlugins/`;
+			await remove(outputDir);
 			await buildDefaultPlugins(outputDir);
 		},
 	},


### PR DESCRIPTION
# Summary

Fixes a slow startup issue caused by multiple copies of default plugins in the `app-desktop/build/defaultPlugins` directory.

This issue was caused by 13da286b55114438688f24b385bfca9f9f2df516 and only affects Joplin workspaces that had built default plugins with commits prior to 13da286b55114438688f24b385bfca9f9f2df516. As such, it should not affect the released version of [v2.14.11](https://github.com/laurent22/joplin/releases/tag/v2.14.11).

The issue is fixed by cleaning the build directory before building default plugins.

# Testing

1. `git checkout pr/fix-default-plugins-build`
2. `yarn tsc && yarn postinstall`
3. `cd packages/app-desktop`
4. `yarn start`
5. Close & open a new terminal in Joplin's root directory
6. `git checkout HEAD~`
7. `yarn tsc && yarn postinstall`
8. In the terminal in `packages/app-desktop`, run `yarn start`
    - Verify that the app doesn't take 20-30 seconds to start

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
