### PR TITLE
Mobile: Resolves #9783: Show an error message when the note editor fails to load

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -472,6 +472,7 @@ packages/app-mobile/components/NoteBodyViewer/hooks/useSource.js
 packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.js
 packages/app-mobile/components/NoteEditor/CodeMirror/webviewLogger.js
 packages/app-mobile/components/NoteEditor/EditLinkDialog.js
+packages/app-mobile/components/NoteEditor/ErrorBanner.js
 packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/autosave.js
 packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js

--- a/.gitignore
+++ b/.gitignore
@@ -452,6 +452,7 @@ packages/app-mobile/components/NoteBodyViewer/hooks/useSource.js
 packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.js
 packages/app-mobile/components/NoteEditor/CodeMirror/webviewLogger.js
 packages/app-mobile/components/NoteEditor/EditLinkDialog.js
+packages/app-mobile/components/NoteEditor/ErrorBanner.js
 packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/autosave.js
 packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js

--- a/packages/app-mobile/components/NoteEditor/ErrorBanner.tsx
+++ b/packages/app-mobile/components/NoteEditor/ErrorBanner.tsx
@@ -12,12 +12,15 @@ interface Props {
 const ErrorBanner: React.FC<Props> = props => {
 	const [dismissed, setDismissed] = useState(false);
 
-	const getAndroidResolutionMessage = () => {
-		if (shim.mobilePlatform() !== 'android') {
-			return '';
+	const getResolutionMessage = () => {
+		const platform = shim.mobilePlatform();
+		if (platform === 'android') {
+			return _('Checking for and installing updates for "Android System WebView" in the app store may fix this issue.');
+		} else if (platform === 'ios') {
+			return _('Please consider reporting this issue on GitHub. To work around this issue, enable the "Plain Editor" in Configuration > Note > "Use the plain editor".');
+		} else {
+			return 'Unknown mobile platform. This is a bug.';
 		}
-
-		return _('Because the note editor is powered by a WebView, checking for and installing updates for "Android System WebView" in the app store may fix this issue.');
 	};
 
 	return (
@@ -39,8 +42,8 @@ const ErrorBanner: React.FC<Props> = props => {
 			]}
 		>
 			{_('There was an error loading the note editor.')}
-			{'\n'}
-			{getAndroidResolutionMessage()}
+			{'\n\n'}
+			{getResolutionMessage()}
 		</Banner>
 	);
 };

--- a/packages/app-mobile/components/NoteEditor/ErrorBanner.tsx
+++ b/packages/app-mobile/components/NoteEditor/ErrorBanner.tsx
@@ -1,0 +1,48 @@
+import { _ } from '@joplin/lib/locale';
+import NavService from '@joplin/lib/services/NavService';
+import shim from '@joplin/lib/shim';
+import * as React from 'react';
+import { useState } from 'react';
+import { Banner } from 'react-native-paper';
+
+interface Props {
+	visible: boolean;
+}
+
+const ErrorBanner: React.FC<Props> = props => {
+	const [dismissed, setDismissed] = useState(false);
+
+	const getAndroidResolutionMessage = () => {
+		if (shim.mobilePlatform() !== 'android') {
+			return '';
+		}
+
+		return _('Because the note editor is powered by a WebView, checking for and installing updates for "Android System WebView" in the app store may fix this issue.');
+	};
+
+	return (
+		<Banner
+			visible={props.visible && !dismissed}
+			icon='alert-octagon-outline'
+			elevation={1}
+			actions={[
+				{
+					label: _('Ignore'),
+					onPress: () => setDismissed(true),
+					icon: 'close',
+				},
+				{
+					label: _('Show logs'),
+					onPress: () => NavService.go('Log', { defaultFilter: 'NoteEditor' }),
+					icon: 'information',
+				},
+			]}
+		>
+			{_('There was an error loading the note editor.')}
+			{'\n'}
+			{getAndroidResolutionMessage()}
+		</Banner>
+	);
+};
+
+export default ErrorBanner;

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -349,7 +349,6 @@ function NoteEditor(props: Props, ref: any) {
 				cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, settings);
 
 				${setInitialSelectionJS}
-				foo();
 
 				window.onresize = () => {
 					cm.execCommand('scrollSelectionIntoView');

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -349,6 +349,7 @@ function NoteEditor(props: Props, ref: any) {
 				cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, settings);
 
 				${setInitialSelectionJS}
+				foo();
 
 				window.onresize = () => {
 					cm.execCommand('scrollSelectionIntoView');
@@ -356,7 +357,7 @@ function NoteEditor(props: Props, ref: any) {
 
 				window.ReactNativeWebView.postMessage('started');
 			} catch (e) {
-				window.ReactNativeWebView.postMessage("error:" + e.message + ": " + JSON.stringify(e))
+				window.ReactNativeWebView.postMessage("error:" + e.message + ". Stack: " + e.stack);
 			}
 		}
 		true;

--- a/packages/lib/services/NavService.ts
+++ b/packages/lib/services/NavService.ts
@@ -6,7 +6,7 @@ export default class NavService {
 	public static dispatch: Function = () => {};
 	private static handlers_: OnNavigateCallback[] = [];
 
-	public static async go(routeName: string) {
+	public static async go(routeName: string, additionalProps: Record<string, any>|null = null) {
 		if (this.handlers_.length) {
 			const r = await this.handlers_[this.handlers_.length - 1]();
 			if (r) return r;
@@ -15,6 +15,7 @@ export default class NavService {
 		this.dispatch({
 			type: 'NAV_GO',
 			routeName: routeName,
+			...additionalProps,
 		});
 		return false;
 	}


### PR DESCRIPTION
# Summary

This pull request shows an error message when the editor fails to load.

> [!NOTE]
>
> If this failure is due to a syntax error (at least on Android), this error message is very bad (just `Script error`). Including the note editor JavaScript within a `<script>` tag produces much better error messages (however, that is outside the scope of this pull request. See https://github.com/laurent22/joplin/pull/9795/commits/58be251715d3fa7d035945a2d3806ac5f25ce17a).
>

Fixes #9783.

# Screenshot

![screenshot: Error message with buttons ignore and show logs. Text in error message: There was an error loading the note editor. Checking for and installing updates for "Android System WebView" in the app store may fix this issue.](https://github.com/laurent22/joplin/assets/46334387/58f46460-3f78-45bc-975a-eb113c741746)

# Testing

1. Modify `NoteEditor.tsx`'s injected JS to have a syntax error.

<details><summary>Example diff</summary>

```diff
diff --git a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
index 4b6131d08..537c62bb8 100644
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -337,7 +337,7 @@ function NoteEditor(props: Props, ref: any) {
 			// This variable is not used within this script
 			// but is called using "injectJavaScript" from
 			// the wrapper component.
-			window.cm = null;
+			window..cm = null;
 
 			try {
 				${shim.injectedJs('codeMirrorBundle')};
```

</details>

2. Open the note editor
    - Verify that an error message is visible.
3. Click "Show logs" and verify that `Script error in file . line 0 Stack: undefined` is shown
    - Error messages seem to be very bad for injectedJS syntax errors (see above for a possible solution).
4. Fix the error and back to the note editor
    - Verify that no dialog is shown.
6. Add a non-syntax error within the editor and reload

<details><summary>Example diff</summary>

```diff
diff --git a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
index 4b6131d08..35c3db5c7 100644
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -350,6 +350,8 @@ function NoteEditor(props: Props, ref: any) {
 
 				${setInitialSelectionJS}
 
+				foo();
+
 				window.onresize = () => {
 					cm.execCommand('scrollSelectionIntoView');
 				};
```
</details>

8. Verify that the error dialog is visible.


**To-do**: 
- [ ] Test on iOS
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
