### PR TITLE
Chore: Default plugins: Rename patch to patch-plugin

### DIFF
--- a/packages/default-plugins/build.ts
+++ b/packages/default-plugins/build.ts
@@ -15,7 +15,7 @@ const build = () => {
 			await buildAll(args.outputDir);
 			process.exit(0);
 		})
-		.command('patch <plugin>', 'Edit the patch file for the given plugin ID', (yargs: any) => {
+		.command('patch-plugin <plugin>', 'Edit the patch file for the given plugin ID', (yargs: any) => {
 			yargs.positional('plugin', {
 				type: 'string',
 				describe: 'ID of the plugin to patch',

--- a/packages/default-plugins/package.json
+++ b/packages/default-plugins/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
-    "patch": "ts-node build.ts patch"
+    "patch-plugin": "ts-node build.ts patch-plugin"
   },
   "repository": {
     "type": "git",

--- a/readme/dev/spec/default_plugins.md
+++ b/readme/dev/spec/default_plugins.md
@@ -32,12 +32,12 @@ For example,
 
 ## Patching the plugin
 
-Some plugins need patching. To create or update a plugin's patch, run the `patch` command in the `packages/default-plugins/` directory.
+Some plugins need patching. To create or update a plugin's patch, run the `patch-plugin` command in the `packages/default-plugins/` directory.
 
 For example,
 ```shell
 $ cd packages/default-plugins
-$ yarn patch plugin.id.here
+$ yarn patch-plugin plugin.id.here
 ```
 
 The script will create a temporary directory in which changes can be made. Do not stage the changes that should appear in the patch.


### PR DESCRIPTION
# Summary

This pull request renames the default-plugins command from `patch` to `patch-plugin`.

Previously, the `patch-plugin` command had the same name as the `yarn` built-in command `patch`.

# Testing

Recompile (`yarn tsc`), then verify that a patch can be edited with `cd packages/default-plugins && yarn patch-plugin io.github.jackgruber.backup`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
