### PR TITLE
Desktop: Fixes #8736: Fix images with SVG data URLs corrupted in the rich text editor

### DIFF
--- a/packages/app-cli/tests/html_to_md/image_utf8_data_url.html
+++ b/packages/app-cli/tests/html_to_md/image_utf8_data_url.html
@@ -1,0 +1,9 @@
+<p>
+	SVG image:
+
+	<img src="data:image/svg+xml;utf8,
+		<svg width=&quot;1700&quot; height=&quot;1536&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot;>
+			<path d=&quot;m0,0%20l100,1000%20l200,0%20z&quot;/>
+		</svg>"/>
+</p>
+<p>PNG image: <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAR0lEQVQIW4XLMQoAIQwF0flpBEHwtOlUsPW6gZTushfYqd8IuHtvxhhI4pyD1lq3905EYGa01tB9m3N+IjNxd/S711oppfAAOjQiFPMurHkAAAAASUVORK5CYII="></p>

--- a/packages/app-cli/tests/html_to_md/image_utf8_data_url.md
+++ b/packages/app-cli/tests/html_to_md/image_utf8_data_url.md
@@ -1,0 +1,3 @@
+SVG image: ![](data:image/svg+xml;utf8,%0A%09%09<svg%20width="1700"%20height="1536"%20xmlns="http://www.w3.org/2000/svg">%0A%09%09%09<path%20d="m0,0%20l100,1000%20l200,0%20z"/>%0A%09%09</svg>)
+
+PNG image: ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAR0lEQVQIW4XLMQoAIQwF0flpBEHwtOlUsPW6gZTushfYqd8IuHtvxhhI4pyD1lq3905EYGa01tB9m3N+IjNxd/S711oppfAAOjQiFPMurHkAAAAASUVORK5CYII=)

--- a/packages/app-cli/tests/md_to_html/image_with_data_url.html
+++ b/packages/app-cli/tests/md_to_html/image_with_data_url.html
@@ -1,0 +1,2 @@
+<p>SVG image: <img src="data:image/svg+xml;utf8,%3Csvg%20width=%221700%22%20height=%221536%22%20xmlns=%22http://www.w3.org/2000/svg%22%3E%20%3Cpath%20d=%22m0,0%20l100,1000%20l200,0%20z%22/%3E%20%3C/svg%3E" alt=""></p>
+<p>PNG image: <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAR0lEQVQIW4XLMQoAIQwF0flpBEHwtOlUsPW6gZTushfYqd8IuHtvxhhI4pyD1lq3905EYGa01tB9m3N+IjNxd/S711oppfAAOjQiFPMurHkAAAAASUVORK5CYII=" alt=""></p>

--- a/packages/app-cli/tests/md_to_html/image_with_data_url.md
+++ b/packages/app-cli/tests/md_to_html/image_with_data_url.md
@@ -1,0 +1,3 @@
+SVG image: ![](data:image/svg+xml;utf8,<svg%20width="1700"%20height="1536"%20xmlns="http://www.w3.org/2000/svg">%20<path%20d="m0,0%20l100,1000%20l200,0%20z"/>%20</svg>)
+
+PNG image: ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAR0lEQVQIW4XLMQoAIQwF0flpBEHwtOlUsPW6gZTushfYqd8IuHtvxhhI4pyD1lq3905EYGa01tB9m3N+IjNxd/S711oppfAAOjQiFPMurHkAAAAASUVORK5CYII=)

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -608,6 +608,14 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				localization_function: _,
 				contextmenu: false,
 				browser_spellcheck: true,
+
+				// Work around an issue where images with a base64 SVG data URL would be broken.
+				//
+				// See https://github.com/tinymce/tinymce/issues/3864
+				//
+				// This was fixed in TinyMCE 6.1, so remove it when we upgrade.
+				images_dataimg_filter: (img: HTMLImageElement) => !img.src.startsWith('data:'),
+
 				formats: {
 					joplinHighlight: { inline: 'mark', remove: 'all' },
 					joplinStrikethrough: { inline: 's', remove: 'all' },

--- a/packages/renderer/MdToHtml/validateLinks.ts
+++ b/packages/renderer/MdToHtml/validateLinks.ts
@@ -7,7 +7,7 @@ export default function(url: string) {
 	// url should be normalized at this point, and existing entities are decoded
 	const str = url.trim().toLowerCase();
 
-	if (str.indexOf('data:image/svg+xml,') === 0) {
+	if (str.startsWith('data:image/svg+xml,') || str.startsWith('data:image/svg+xml;utf8,')) {
 		return true;
 	}
 

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -293,6 +293,9 @@ function filterLinkHref (href) {
   // Replace the spaces with %20 because otherwise they can cause problems for some
   // renderer and space is not a valid URL character anyway.
   href = href.replace(/ /g, '%20');
+  // Newlines and tabs also break renderers
+  href = href.replace(/\n/g, '%0A');
+  href = href.replace(/\t/g, '%09');
   // Brackets also should be escaped
   href = href.replace(/\(/g, '%28');
   href = href.replace(/\)/g, '%29');


### PR DESCRIPTION
# Summary

Fixes the corruption of SVG data URLs when switching to the rich text editor.

- Applies a workaround to fix https://github.com/laurent22/joplin/issues/8736.
- Fixes `![](data:image/svg+xml;utf8,...)`-style markdown wasn't rendered.
   - Because `markdown-it` converts `<img src="data:image/svg+xml;utf8,..."/>` to `![](data:image/svg+xml;utf8,...)`, this is necessary.
   - It seems that spaces need to be escaped as `%20` in `![](data:/image/svg+xml;utf8,...)`-style images, but not in `<img src="data:image/svg+xml;utf8,..."/>`-style images. As such, it might make sense to leave such images as more-readable HTML (rather than convert to markdown).
- Fixes HTML->MD when images contain tabs and newlines in their `src`.

# Testing

1. Create a note with the following (markdown) content:
```markdown
SVG image:

<img src="data:image/svg+xml;utf8,
	<svg width=&quot;1700&quot; height=&quot;1536&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot;>
		<path d=&quot;m0,0%20l100,1000%20l200,0%20z&quot;/>
	</svg>"/>

PNG image: ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAR0lEQVQIW4XLMQoAIQwF0flpBEHwtOlUsPW6gZTushfYqd8IuHtvxhhI4pyD1lq3905EYGa01tB9m3N+IjNxd/S711oppfAAOjQiFPMurHkAAAAASUVORK5CYII=)
```

2. Make a change to the note in the rich text editor
3. Switch notes
4. Switch back to the original note
5. Verify that the images are still present.

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
