### PR TITLE
Mobile: Fixes #7974: Andoid: Fix crash on opening settings on some devices

### DIFF
--- a/.yarn/patches/@react-native-community-slider-npm-4.4.4-d78e472f48.patch
+++ b/.yarn/patches/@react-native-community-slider-npm-4.4.4-d78e472f48.patch
@@ -1,0 +1,62 @@
+diff --git a/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java b/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+index a5bb95eec3337b93a2338a2869a2bda176c91cae..87817688eb280c2f702c26dc35558c6a0a4db1ea 100644
+--- a/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
++++ b/android/src/newarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+@@ -42,12 +42,20 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> implement
+             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
+               ReactSlider slider = (ReactSlider)seekbar;
+ 
+-              if(progress < slider.getLowerLimit()) {
+-                progress = slider.getLowerLimit();
+-                seekbar.setProgress(progress);
+-              } else if (progress > slider.getUpperLimit()) {
+-                progress = slider.getUpperLimit();
+-                seekbar.setProgress(progress);
++              // During initialization, lowerLimit can be greater than upperLimit.
++              //
++              // If a change event is received during this, we need a check to prevent
++              // infinite recursion.
++              //
++              // Issue: https://github.com/callstack/react-native-slider/issues/571
++              if (slider.getLowerLimit() <= slider.getUpperLimit()) {
++                if(progress < slider.getLowerLimit()) {
++                  progress = slider.getLowerLimit();
++                  seekbar.setProgress(progress);
++                } else if (progress > slider.getUpperLimit()) {
++                  progress = slider.getUpperLimit();
++                  seekbar.setProgress(progress);
++                }
+               }
+ 
+               ReactContext reactContext = (ReactContext) seekbar.getContext();
+diff --git a/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java b/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+index 3ff5930f85a3cd92c2549925f41058abb188a57e..ab3681fdfe0b736c97020e1434e450c8183e6f18 100644
+--- a/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
++++ b/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+@@ -30,12 +30,20 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
+             public void onProgressChanged(SeekBar seekbar, int progress, boolean fromUser) {
+               ReactSlider slider = (ReactSlider)seekbar;
+ 
+-              if(progress < slider.getLowerLimit()) {
+-                progress = slider.getLowerLimit();
+-                seekbar.setProgress(progress);
+-              } else if(progress > slider.getUpperLimit()) {
+-                progress = slider.getUpperLimit();
+-                seekbar.setProgress(progress);
++              // During initialization, lowerLimit can be greater than upperLimit.
++              //
++              // If a change event is received during this, we need a check to prevent
++              // infinite recursion.
++              //
++              // Issue: https://github.com/callstack/react-native-slider/issues/571
++              if (slider.getLowerLimit() <= slider.getUpperLimit()) {
++                if(progress < slider.getLowerLimit()) {
++                  progress = slider.getLowerLimit();
++                  seekbar.setProgress(progress);
++                } else if (progress > slider.getUpperLimit()) {
++                  progress = slider.getUpperLimit();
++                  seekbar.setProgress(progress);
++                }
+               }
+ 
+               ReactContext reactContext = (ReactContext) seekbar.getContext();

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "app-builder-lib@24.4.0": "patch:app-builder-lib@npm%3A24.4.0#./.yarn/patches/app-builder-lib-npm-24.4.0-05322ff057.patch",
     "react-native@0.71.10": "patch:react-native@npm%3A0.71.10#./.yarn/patches/react-native-animation-fix/react-native-npm-0.71.10-f9c32562d8.patch",
     "nanoid": "patch:nanoid@npm%3A3.3.7#./.yarn/patches/nanoid-npm-3.3.7-98824ba130.patch",
-    "pdfjs-dist": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch"
+    "pdfjs-dist": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch",
+    "@react-native-community/slider@4.4.4": "patch:@react-native-community/slider@npm%3A4.4.4#./.yarn/patches/@react-native-community-slider-npm-4.4.4-d78e472f48.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9367,6 +9367,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-community/slider@patch:@react-native-community/slider@npm%3A4.4.4#./.yarn/patches/@react-native-community-slider-npm-4.4.4-d78e472f48.patch::locator=root%40workspace%3A.":
+  version: 4.4.4
+  resolution: "@react-native-community/slider@patch:@react-native-community/slider@npm%3A4.4.4#./.yarn/patches/@react-native-community-slider-npm-4.4.4-d78e472f48.patch::version=4.4.4&hash=1120f2&locator=root%40workspace%3A."
+  checksum: c4397dd2e914f52e3d9b4058d3cf850e67d99c85a59492835647513af85ba62ba182c5c7655fd35d6f768155d45c0c8b5eb0adaad803165d9fec508b77b19a2b
+  languageName: node
+  linkType: hard
+
 "@react-native/assets@npm:1.0.0":
   version: 1.0.0
   resolution: "@react-native/assets@npm:1.0.0"


### PR DESCRIPTION
# Summary

Applies a patch to `react-native-slider` to [fix this upstream issue](https://github.com/callstack/react-native-slider/issues/571).

Fixes #7974.


# Testing

1. Open settings
2. Open the synchronization settings
3. Increase and decrease the "max concurrent connections" slider

This has been tested successfully on an Android 12 emulator.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
