### PR TITLE
Chore: Desktop: Remove duplicate `buildDir`-finding logic

### DIFF
--- a/packages/app-desktop/utils/7zip/pathToBundled7Zip.ts
+++ b/packages/app-desktop/utils/7zip/pathToBundled7Zip.ts
@@ -1,19 +1,11 @@
-import { join, resolve, basename, dirname } from 'path';
+import { join, resolve } from 'path';
+import bridge from '../../services/bridge';
 
 const pathToBundled7Zip = () => {
 	// 7zip-bin is very large -- return the path to a version of 7zip
 	// copied from 7zip-bin.
 	const executableName = process.platform === 'win32' ? '7za.exe' : '7za';
-
-	let rootDir = dirname(dirname(__dirname));
-
-	// When bundled, __dirname points to a file within app.asar. The build/ directory
-	// is outside of app.asar, and thus, we need an extra dirname(...).
-	if (basename(rootDir).startsWith('app.asar')) {
-		rootDir = dirname(rootDir);
-	}
-
-	const baseDir = join(rootDir, 'build', '7zip');
+	const baseDir = join(bridge().buildDir(), '7zip');
 
 	return { baseDir, executableName, fullPath: resolve(join(baseDir, executableName)) };
 };


### PR DESCRIPTION
# Summary

Removes duplicated logic to find `buildDir` in code that finds the location of the bundled copy of 7Zip.

This may [also fix 7Zip-related issues in 3rd-party distributions of Joplin](https://github.com/JackGruber/joplin-plugin-backup/issues/66#issuecomment-1913075357).

# Testing

1. Remove `~/.config/joplindev-desktop/cache`
2. Start Joplin in development mode and create a 7zip backup with the bundled Simple Backup plugin
3. Build Joplin (`yarn dist --publish=never`) and repeat

This has been successfully tested on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
