### PR TITLE
Chore: Default plugins: Refactor `git checkout` in default plugins build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -569,6 +569,7 @@ packages/default-plugins/build.js
 packages/default-plugins/buildDefaultPlugins.js
 packages/default-plugins/commands/buildAll.js
 packages/default-plugins/commands/editPatch.js
+packages/default-plugins/utils/getCurrentCommitHash.js
 packages/default-plugins/utils/getPathToPatchFileFor.js
 packages/default-plugins/utils/readRepositoryJson.js
 packages/default-plugins/utils/waitForCliInput.js

--- a/.gitignore
+++ b/.gitignore
@@ -549,6 +549,7 @@ packages/default-plugins/build.js
 packages/default-plugins/buildDefaultPlugins.js
 packages/default-plugins/commands/buildAll.js
 packages/default-plugins/commands/editPatch.js
+packages/default-plugins/utils/getCurrentCommitHash.js
 packages/default-plugins/utils/getPathToPatchFileFor.js
 packages/default-plugins/utils/readRepositoryJson.js
 packages/default-plugins/utils/waitForCliInput.js

--- a/packages/default-plugins/buildDefaultPlugins.ts
+++ b/packages/default-plugins/buildDefaultPlugins.ts
@@ -10,6 +10,7 @@ import { glob } from 'glob';
 import readRepositoryJson from './utils/readRepositoryJson';
 import waitForCliInput from './utils/waitForCliInput';
 import getPathToPatchFileFor from './utils/getPathToPatchFileFor';
+import getCurrentCommitHash from './utils/getCurrentCommitHash';
 
 type BeforeEachInstallCallback = (buildDir: string, pluginName: string)=> Promise<void>;
 
@@ -41,20 +42,21 @@ const buildDefaultPlugins = async (outputParentDir: string|null, beforeInstall: 
 			}
 
 			chdir(pluginDir);
-			const currentCommitHash = (await execCommand(['git', 'rev-parse', 'HEAD~'])).trim();
 			const expectedCommitHash = repositoryData.commit;
 
-			if (currentCommitHash !== expectedCommitHash) {
-				logStatus(`Switching to commit ${expectedCommitHash}`);
-				await execCommand(['git', 'switch', repositoryData.branch]);
+			logStatus(`Switching to commit ${expectedCommitHash}`);
+			await execCommand(['git', 'switch', repositoryData.branch]);
 
-				try {
-					await execCommand(['git', 'checkout', expectedCommitHash]);
-				} catch (error) {
-					logStatus(`git checkout failed with error ${error}. Fetching...`);
-					await execCommand(['git', 'fetch']);
-					await execCommand(['git', 'checkout', expectedCommitHash]);
-				}
+			try {
+				await execCommand(['git', 'checkout', expectedCommitHash]);
+			} catch (error) {
+				logStatus(`git checkout failed with error ${error}. Fetching...`);
+				await execCommand(['git', 'fetch']);
+				await execCommand(['git', 'checkout', expectedCommitHash]);
+			}
+
+			if (await getCurrentCommitHash() !== expectedCommitHash) {
+				throw new Error(`Unable to checkout commit ${expectedCommitHash}`);
 			}
 
 			logStatus('Copying repository files...');

--- a/packages/default-plugins/utils/getCurrentCommitHash.ts
+++ b/packages/default-plugins/utils/getCurrentCommitHash.ts
@@ -1,0 +1,7 @@
+import { execCommand } from '@joplin/utils';
+
+const getCurrentCommitHash = async () => {
+	return (await execCommand(['git', 'rev-parse', '--verify', 'HEAD^{commit}'])).trim();
+};
+
+export default getCurrentCommitHash;


### PR DESCRIPTION
# Summary

This is a follow-up pull request to 86a1b4d00f5e2223c4a2308684c8fb41e4048241 that, before building,
1. Always attempts to `checkout` the target commit (rather than comparing the current commit hash from `git rev-parse HEAD` with the expected first)
2. Checks the output of `git rev-parse HEAD` *after* running `git checkout` as an assertion that `HEAD` points to the correct commit.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
