### PR TITLE
Desktop: Fixes #9629: Fix horizontal touchpad scrolling of code blocks

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -594,12 +594,20 @@
 			// calculate by yourself by accumulating wheel events.
 			// https://github.com/laurent22/joplin/pull/5496
 			// When the Electron/Chromium bug is fixed, remove this listener.
+			//
+			// 2024-02-01: The bug seems to be fixed, remove the above when we're not in
+			//             feature-freeze.
 
 			// If scrollTop ever has a fraction part, zoomFactor is not 1.
 			if (zoomFactorIsNotOne || !Number.isInteger(contentElement.scrollTop)) {
 				zoomFactorIsNotOne = true;
-				customScroll(e, true);
-				e.preventDefault();
+
+				// The custom scroll logic breaks horizontal scroll in child DOM nodes
+				// (e.g. scrollable code blocks). Disable it:
+				if (e.deltaY !== 0) {
+					customScroll(e, true);
+					e.preventDefault();
+				}
 			}
 		}));
 


### PR DESCRIPTION
# Summary

The workaround added in https://github.com/laurent22/joplin/pull/5606 breaks scrolling child-elements. Thus, this pull request:
- Updates the note viewer to use native browser scroll when scrolling horizontally.
- Keeps the workaround enabled when scrolling vertically.

As the workaround is related to vertical scroll sync between the note editor and the viewer, using native browser horizontal scrolling should be fine.

Fixes #9629.

# Notes

If I remove the workaround completely, I am unable to reproduce the original bug. Note, however, that I have only tested on Linux (Ubuntu 23.10 through XWayland). It's possible the bug is still present on Windows or MacOS.

# Testing

1. Create a note with the following content:

<details>

````markdown
This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.


This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

```js
function veryLongFunctionNameThatCausesScroll(a, b, c, d, e, f) { // This comment makes the line even longer.
	;;;
}
```


This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.

This is a test note. It is long enough to have vertical scroll. Additionally, because it contains a long code block, that code block can be scrolled horizontally.
````

</details>

2. Open the note in a version of Joplin **without** the pull request applied
3. Try to scroll the code block horizontally with the touchpad -- zoom in if such scrolling is possible
4. Close Joplin, apply the changes from this pull request
5. Build & start Joplin
6. Open the note
7. Verify that the code block can now be scrolled horizontally.
8. Verify that vertical scroll is still synced between the viewer and editor.

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
