### PR TITLE
Desktop: Fixes #9817: Fix scrollbars shown unnecessarily when opening the tag dialog

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -90,6 +90,7 @@ export default class PromptDialog extends React.Component<Props, any> {
 			left: 0,
 			width: width,
 			height: height,
+			boxSizing: 'border-box',
 			backgroundColor: 'rgba(0,0,0,0.6)',
 			display: visible ? 'flex' : 'none',
 			alignItems: 'flex-start',


### PR DESCRIPTION
# Summary

Changes the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) such that an issue where dialog backgrounds could be larger than the screen size is fixed.

Fixes #9817.

# Testing plan

1. Open the tags dialog
    - ![screenshot](https://github.com/laurent22/joplin/assets/46334387/d7149c9a-8b90-42a6-980f-5f06383c8248)
2. Close the tags dialog

This has been successfully tested on Ubuntu 23.10.

**Remaining issue**: When the development tools are docked to the main window, there is still unnecessary scroll. It may be necessary to close the development tools to fix this issue.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
