### PR TITLE
Desktop: Fixes #9829: Fix mermaid save button creates additional space above diagrams

### DIFF
--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -19,9 +19,17 @@ export default {
 				// Export button in mermaid graph should be shown only on hovering the mermaid graph
 				// ref: https://github.com/laurent22/joplin/issues/6101
 				text: `
-				.mermaid-export-graph { visibility: hidden; } 
-				.joplin-editable:hover .mermaid-export-graph { visibility: visible; }
-				.mermaid-export-graph:hover { background-color: ${theme.backgroundColorHover3} !important; }
+				.mermaid-export-graph {
+					opacity: 0;
+					height: 0;
+				} 
+				.joplin-editable:hover .mermaid-export-graph,
+				.joplin-editable .mermaid-export-graph:has(:focus-visible) {
+					opacity: 1;
+				}
+				.mermaid-export-graph > button:hover {
+					background-color: ${theme.backgroundColorHover3} !important;
+				}
 				`.trim(),
 				mime: 'text/css',
 			},
@@ -69,7 +77,7 @@ const exportGraphButton = (ruleOptions: RuleOptions) => {
 	// Clicking on export button manually triggers a right click context menu event
 	const onClickHandler = `
 		const target = arguments[0].target;
-		const button = target.closest("button.mermaid-export-graph");
+		const button = target.closest("div.mermaid-export-graph");
 		if (!button) return false;
 		const $mermaid_elem = button.nextElementSibling;
 		const rightClickEvent = new PointerEvent("contextmenu", {bubbles: true});
@@ -87,7 +95,11 @@ const exportGraphButton = (ruleOptions: RuleOptions) => {
 		border: ${theme.buttonStyle.border};
 	`.trim();
 
-	return `<button class="mermaid-export-graph" onclick='${onClickHandler}' style="${style}" alt="Export mermaid graph">${downloadIcon()}</button>`;
+	return `
+		<div class="mermaid-export-graph">
+			<button onclick='${onClickHandler}' style="${style}" alt="Export mermaid graph">${downloadIcon()}</button>
+		</div>
+	`;
 };
 
 const downloadIcon = () => {


### PR DESCRIPTION
# Summary

Fixes #9829 by wrapping the mermaid save button in a zero-height container.

**Note**: This does **not** fix the existing issue where the download button appears over mermaid diagrams in the rich text editor but is nonfunctional.

# Testing

1. Create a note with a mermaid diagram:
<details>

````markdown

# Test

Start:
```mermaid
gitGraph
    commit
    commit
    commit
```
Another diagram:
```mermaid
flowchart
	postMessage1(["postMessage({ kind: RemoteReady, ... })"])
	rm1--1-->postMessage1--2-->rm2
	subgraph MainProcess
		rm1["m1 = RemoteMessenger< MainProcApi,WebViewApi >"]
	end
	subgraph WebView
		rm2["RemoteMessenger< WebViewApi,MainProcApi >"]
	end
```
End.
````
</details>

2. Verify that the diagrams are vertically centered.
3. Hover over one of the diagrams and click the "save" button, then click "copy path to clipboard"
4. Paste the path into the note
5. Verify that the button is invisible when no longer hovering.

This has been successfully tested on Ubuntu 23.10.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
