### PR TITLE
Desktop: Fixes #9832: Fix user-installed versions of built-in plugins can't access resources in some cases

### DIFF
--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -9,10 +9,13 @@ import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
 import { expectNotThrow, setupDatabaseAndSynchronizer, switchClient, expectThrow, createTempDir, supportDir } from '@joplin/lib/testing/test-utils';
 import { newPluginScript } from '../../testUtils';
+import { join } from 'path';
 
 const testPluginDir = `${supportDir}/plugins`;
+const testPluginRepoDir = `${supportDir}/pluginRepo`;
 
-function newPluginService(appVersion = '1.4') {
+
+function newPluginService(appVersion = '2.4') {
 	const runner = new PluginRunner();
 	const service = new PluginService();
 	service.initialize(
@@ -332,5 +335,46 @@ describe('services_PluginService', () => {
 		// Should clear deleted plugins from settings
 		expect(newPluginSettings[pluginId1]).toBe(undefined);
 		expect(newPluginSettings[pluginId2]).toBe(undefined);
+	});
+
+	it('should refuse to unpack a jpl plugin to the same directory as a running plugin', async () => {
+		const tempDir = await createTempDir();
+		const unpackDir = await createTempDir();
+
+		try {
+			const service = newPluginService();
+
+			// The unpack base directory is where the .jpl files will be extracted. This prevents
+			// unpacking done in previous tests from conflicting with this test.
+			service.setUnpackBaseDirectory(unpackDir);
+
+			const pluginId1 = 'org.joplinapp.FirstJplPlugin';
+			const pluginId2 = 'org.joplinapp.plugins.ToggleSidebars';
+			const pluginPath1 = `${testPluginDir}/jpl_test/${pluginId1}.jpl`;
+			const pluginPath2 = `${testPluginRepoDir}/plugins/${pluginId2}/plugin.jpl`;
+
+			// This copy should have the same name as plugin2 --- this may cause Joplin
+			// to try to extract it to the same location as plugin2.
+			const renamedPluginPath2 = join(tempDir, `${pluginId1}.jpl`);
+			await fs.copyFile(pluginPath2, renamedPluginPath2);
+
+			const pluginSettings: PluginSettings = {
+				[pluginId1]: { enabled: true, deleted: false, hasBeenUpdated: false },
+				[pluginId2]: { enabled: true, deleted: false, hasBeenUpdated: false },
+			};
+
+			let lastError = null;
+			const onError = jest.fn(error => lastError = error);
+
+			await service.loadAndRunPlugins([pluginPath1], pluginSettings, { devMode: false, builtIn: false, onError });
+			expect(onError).not.toHaveBeenCalled();
+
+			await service.loadAndRunPlugins([renamedPluginPath2], pluginSettings, { devMode: false, builtIn: false, onError });
+			expect(onError).toHaveBeenCalled();
+			expect(`${lastError}`).toMatch(/Refusing to overwrite the unpack directory of a running plugin/);
+		} finally {
+			await fs.remove(tempDir);
+			await fs.remove(unpackDir);
+		}
 	});
 });

--- a/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
+++ b/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
@@ -35,7 +35,7 @@ describe('defaultPluginsUtils', () => {
 		await switchClient(1);
 	});
 
-	it('should load default plugins when nor previously installed', (async () => {
+	it('should load default plugins when not previously installed', (async () => {
 		const testPluginDir = `${supportDir}/testDefaultPlugins`;
 		Setting.setValue('installedDefaultPlugins', []);
 
@@ -47,7 +47,9 @@ describe('defaultPluginsUtils', () => {
 			expect(pluginSettings[pluginId]).toBeFalsy();
 		}
 
-		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(testPluginDir, defaultPluginsInfo, pluginSettings);
+		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(
+			testPluginDir, defaultPluginsInfo, pluginSettings, service,
+		);
 
 		for (const pluginId of pluginsId) {
 			expect(
@@ -66,7 +68,7 @@ describe('defaultPluginsUtils', () => {
 		const service = newPluginService('2.1');
 
 		const pluginSettings = service.unserializePluginSettings(Setting.value('plugins.states'));
-		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(testPluginDir, defaultPluginsInfo, pluginSettings);
+		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(testPluginDir, defaultPluginsInfo, pluginSettings, service);
 
 		// Should still be disabled
 		expect(
@@ -201,5 +203,4 @@ describe('defaultPluginsUtils', () => {
 		expect(Setting.value('plugin-io.github.jackgruber.backup.path')).toBe(`${Setting.value('profileDir')}`);
 		await service.destroy();
 	});
-
 });

--- a/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
+++ b/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
@@ -4,8 +4,9 @@ import { checkThrow, setupDatabaseAndSynchronizer, supportDir, switchClient } fr
 import PluginService, { defaultPluginSetting, DefaultPluginsInfo } from '@joplin/lib/services/plugins/PluginService';
 import Setting from '@joplin/lib/models/Setting';
 
+const testDefaultPluginsDir = `${supportDir}/testDefaultPlugins`;
 
-function newPluginService(appVersion = '1.4') {
+function newPluginService(appVersion = '2.4') {
 	const runner = new PluginRunner();
 	const service = new PluginService();
 	service.initialize(
@@ -36,7 +37,6 @@ describe('defaultPluginsUtils', () => {
 	});
 
 	it('should load default plugins when not previously installed', (async () => {
-		const testPluginDir = `${supportDir}/testDefaultPlugins`;
 		Setting.setValue('installedDefaultPlugins', []);
 
 		const service = newPluginService('2.1');
@@ -48,7 +48,7 @@ describe('defaultPluginsUtils', () => {
 		}
 
 		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(
-			testPluginDir, defaultPluginsInfo, pluginSettings, service,
+			testDefaultPluginsDir, defaultPluginsInfo, pluginSettings, service,
 		);
 
 		for (const pluginId of pluginsId) {
@@ -59,7 +59,6 @@ describe('defaultPluginsUtils', () => {
 	}));
 
 	it('should keep already created default plugins disabled with previous default plugins installed', (async () => {
-		const testPluginDir = `${supportDir}/testDefaultPlugins`;
 		Setting.setValue('installedDefaultPlugins', ['org.joplinapp.plugins.ToggleSidebars']);
 		Setting.setValue('plugins.states', {
 			'org.joplinapp.plugins.ToggleSidebars': { ...defaultPluginSetting(), enabled: false },
@@ -68,7 +67,7 @@ describe('defaultPluginsUtils', () => {
 		const service = newPluginService('2.1');
 
 		const pluginSettings = service.unserializePluginSettings(Setting.value('plugins.states'));
-		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(testPluginDir, defaultPluginsInfo, pluginSettings, service);
+		const pluginPathsAndNewSettings = await getDefaultPluginPathsAndSettings(testDefaultPluginsDir, defaultPluginsInfo, pluginSettings, service);
 
 		// Should still be disabled
 		expect(
@@ -202,5 +201,36 @@ describe('defaultPluginsUtils', () => {
 		expect(checkThrow(() => afterDefaultPluginsLoaded(runningPlugins, defaultPluginsInfo, pluginSettings))).toBe(false);
 		expect(Setting.value('plugin-io.github.jackgruber.backup.path')).toBe(`${Setting.value('profileDir')}`);
 		await service.destroy();
+	});
+
+	// Only returning not-yet-loaded plugins prevents non-default versions of built-in plugins
+	// from being overwritten by PluginService.
+	it('getDefaultPluginPathsAndSettings should return only plugins that haven\'t been loaded', async () => {
+		const service = newPluginService();
+
+		const testPluginId = 'org.joplinapp.plugins.ToggleSidebars';
+		const testPluginPath = `${supportDir}/pluginRepo/plugins/${testPluginId}/plugin.jpl`;
+
+		const pluginSettings = {
+			[testPluginId]: defaultPluginSetting(),
+		};
+
+		await service.loadAndRunPlugins([testPluginPath], pluginSettings, { devMode: false, builtIn: false });
+
+		// Should be running
+		expect(service.isPluginLoaded(testPluginId)).toBe(true);
+
+		const testDefaultPluginsInfo = {
+			[testPluginId]: {},
+			'joplin.plugin.ambrt.backlinksToNote': {},
+		};
+
+		const { pluginPaths } = await getDefaultPluginPathsAndSettings(
+			testDefaultPluginsDir, testDefaultPluginsInfo, pluginSettings, service,
+		);
+
+		// Should only return plugins that aren't loaded.
+		expect(pluginPaths).toHaveLength(1);
+		expect(pluginPaths[0]).toContain('joplin.plugin.ambrt.backlinksToNote');
 	});
 });

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -91,7 +91,6 @@ export default class PluginService extends BaseService {
 	private plugins_: Plugins = {};
 	private runner_: BasePluginRunner = null;
 	private startedPlugins_: Record<string, boolean> = {};
-	private unpackBaseDirectory_: string = Setting.value('cacheDir');
 	private isSafeMode_ = false;
 
 	public initialize(appVersion: string, platformImplementation: any, runner: BasePluginRunner, store: any) {
@@ -99,12 +98,6 @@ export default class PluginService extends BaseService {
 		this.store_ = store;
 		this.runner_ = runner;
 		this.platformImplementation_ = platformImplementation;
-	}
-
-	// For automated testing -- using different unpack directories can help
-	// isolate different test cases.
-	public setUnpackBaseDirectory(baseDirectory: string) {
-		this.unpackBaseDirectory_ = baseDirectory;
 	}
 
 	public get plugins(): Plugins {
@@ -235,7 +228,7 @@ export default class PluginService extends BaseService {
 		const fname = filename(path);
 		const hash = await shim.fsDriver().md5File(path);
 
-		const unpackDir = `${this.unpackBaseDirectory_}/${fname}`;
+		const unpackDir = `${Setting.value('cacheDir')}/${fname}`;
 		const manifestFilePath = `${unpackDir}/manifest.json`;
 
 		let manifest: any = await this.loadManifestToObject(manifestFilePath);

--- a/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
+++ b/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
@@ -49,6 +49,8 @@ export const getDefaultPluginPathsAndSettings = async (
 			continue;
 		}
 
+		// We skip plugins that are already loaded -- attempting to unpack a different version of a plugin
+		// that has already been loaded causes errors (see #9832).
 		if (pluginService.isPluginLoaded(pluginId)) {
 			logger.info(`Not loading default plugin ${pluginId} -- a plugin with the same ID is already loaded.`);
 			continue;

--- a/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
+++ b/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
@@ -11,7 +11,10 @@ const logger = Logger.create('defaultPluginsUtils');
 // Use loadAndRunDefaultPlugins
 // Exported for testing.
 export const getDefaultPluginPathsAndSettings = async (
-	defaultPluginsDir: string, defaultPluginsInfo: DefaultPluginsInfo, pluginSettings: PluginSettings,
+	defaultPluginsDir: string,
+	defaultPluginsInfo: DefaultPluginsInfo,
+	pluginSettings: PluginSettings,
+	pluginService: PluginService,
 ) => {
 	const pluginPaths: string[] = [];
 
@@ -46,6 +49,11 @@ export const getDefaultPluginPathsAndSettings = async (
 			continue;
 		}
 
+		if (pluginService.isPluginLoaded(pluginId)) {
+			logger.info(`Not loading default plugin ${pluginId} -- a plugin with the same ID is already loaded.`);
+			continue;
+		}
+
 		pluginPaths.push(join(defaultPluginsDir, pluginFileName));
 
 		pluginSettings = produce(pluginSettings, (draft: PluginSettings) => {
@@ -69,7 +77,7 @@ export const loadAndRunDefaultPlugins = async (
 	originalPluginSettings: PluginSettings,
 ): Promise<PluginSettings> => {
 	const { pluginPaths, pluginSettings } = await getDefaultPluginPathsAndSettings(
-		defaultPluginsDir, defaultPluginsInfo, originalPluginSettings,
+		defaultPluginsDir, defaultPluginsInfo, originalPluginSettings, service,
 	) ?? { pluginPaths: [], pluginSettings: originalPluginSettings };
 
 	await service.loadAndRunPlugins(pluginPaths, pluginSettings, { builtIn: true, devMode: false });


### PR DESCRIPTION
# Summary

Fixes an issue where built-in plugins would overwrite the unpack directory for a user-installed version of the plugin. In the case of Simple Backup, this caused user-installed versions of the plugin to be unable to access 7Zip.

Fixes #9832.

# Testing

1. Download the [JPL file for Simple Backup from joplinapp.org/plugins](https://joplinapp.org/plugins/downloadPlugin.html?plugin=io.github.jackgruber.backup?from-tab=home).
2. Use "install from file" in plugin settings to install the JPL file.
3. Restart Joplin
4. Configure Simple Backup to create 7zip-archive backups
5. Create a backup
    - Verify that the plugin can access 7Zip
6. Uninstall the non-built-in copy of Simple Backup and restart Joplin
7. Create a backup
    - Verify that the built-in version of the plugin can access 7Zip.

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
