### PR TITLE
MacOS: Resolves #9488: Add "Window" menu to toolbar on MacOS

### DIFF
--- a/packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts
+++ b/packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts
@@ -20,6 +20,8 @@ const getLabel = (commandName: string): string => {
 		return _('Website and documentation');
 	case 'hideApp':
 		return _('Hide Joplin');
+	case 'minimizeWindow':
+		return _('Minimize');
 	case 'closeWindow':
 		return _('Close Window');
 	case 'config':

--- a/packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts
+++ b/packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts
@@ -21,7 +21,7 @@ const getLabel = (commandName: string): string => {
 	case 'hideApp':
 		return _('Hide Joplin');
 	case 'minimizeWindow':
-		return _('Minimize');
+		return _('Minimise');
 	case 'closeWindow':
 		return _('Close Window');
 	case 'config':

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -964,6 +964,7 @@ function useMenu(props: Props) {
 			}
 
 			const template = [
+				shim.isMac() ? rootMenus.macOsApp : null,
 				rootMenus.file,
 				rootMenus.edit,
 				rootMenus.view,
@@ -971,11 +972,9 @@ function useMenu(props: Props) {
 				rootMenus.folder,
 				rootMenus.note,
 				rootMenus.tools,
-				rootMenus.window,
+				shim.isMac() ? rootMenus.window : null,
 				rootMenus.help,
-			];
-
-			if (shim.isMac()) template.splice(0, 0, rootMenus.macOsApp);
+			].filter(item => item !== null);
 
 			if (props.routeName !== 'Main') {
 				setMenu(Menu.buildFromTemplate([

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -843,6 +843,24 @@ function useMenu(props: Props) {
 					label: _('&Tools'),
 					submenu: toolsItems,
 				},
+				window: {
+					id: 'window',
+
+					// Adds the default MacOS actions (e.g. "tile left") to the menu.
+					//
+					// Note: If the dev tools are shown on startup, this adds additional tab-related
+					// actions to the menu that are not otherwise shown. See https://stackoverflow.com/a/77458809
+					role: 'windowMenu',
+
+					label: _('&Window'),
+					visible: !!shim.isMac(),
+					submenu: [
+						{
+							role: 'minimize',
+							accelerator: shim.isMac() && keymapService.getAccelerator('minimizeWindow'),
+						},
+					],
+				},
 				help: {
 					label: _('&Help'),
 					role: 'help', // Makes it add the "Search" field on macOS
@@ -851,7 +869,7 @@ function useMenu(props: Props) {
 						accelerator: keymapService.getAccelerator('help'),
 						click() { void bridge().openExternal('https://joplinapp.org'); },
 					}, {
-						label: _('Joplin Forum'),
+						label: _('Joplin Forumm'),
 						click() { void bridge().openExternal('https://discourse.joplinapp.org'); },
 					}, {
 						label: _('Join us on Twitter'),
@@ -953,6 +971,7 @@ function useMenu(props: Props) {
 				rootMenus.folder,
 				rootMenus.note,
 				rootMenus.tools,
+				rootMenus.window,
 				rootMenus.help,
 			];
 

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -869,7 +869,7 @@ function useMenu(props: Props) {
 						accelerator: keymapService.getAccelerator('help'),
 						click() { void bridge().openExternal('https://joplinapp.org'); },
 					}, {
-						label: _('Joplin Forumm'),
+						label: _('Joplin Forum'),
 						click() { void bridge().openExternal('https://discourse.joplinapp.org'); },
 					}, {
 						label: _('Join us on Twitter'),

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -20,6 +20,7 @@ const defaultKeymapItems = {
 		{ accelerator: 'Cmd+Q', command: 'quit' },
 		{ accelerator: 'Cmd+,', command: 'config' },
 		{ accelerator: 'Cmd+W', command: 'closeWindow' },
+		{ accelerator: 'Cmd+M', command: 'minimizeWindow' },
 		{ accelerator: 'Cmd+C', command: 'textCopy' },
 		{ accelerator: 'Cmd+X', command: 'textCut' },
 		{ accelerator: 'Cmd+V', command: 'textPaste' },


### PR DESCRIPTION
# Summary

This pull request resolves #9488 by allowing the MacOS "Window" menu to be shown. This pull request also allows configuring "minimizeWindow" through Joplin's keyboard shortcut settings.

Other apps I've looked at (VSCode, Firefox, Finder, Calculator, Safari, Terminal) also show the "Window" menu. Additionally, [it's mentioned in Apple's Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/the-menu-bar/#Window-menu).

# Screenshot

<img width="585" alt="screenshot: Window menu contains Tile Window to Left of Screen, Tile Window to Right of Screen, Replace Tiled Window (greyed), Remove Window From Set (greyed), and Minimize" src="https://github.com/laurent22/joplin/assets/46334387/1edc9251-5afd-4cb2-85d1-f66e733ceedf"/>


# Notes

- If launching Joplin in development mode, the development tools are initially shown. This causes tab-related menu items to be shown in the menu. This does not seem to be an issue in release mode, where the development tools are not shown on startup. ([Related StackOverflow post](https://stackoverflow.com/a/77458809)).
    - <img width="970" alt="screenshot: Window menu shows extra items related to tabs" src="https://github.com/laurent22/joplin/assets/46334387/3a90ada5-1d0b-411a-ad11-b3ee3f588683">


# To-do

- [x] Test on a non-MacOS computer and verify that the "Window" menu is not shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->

# Testing

**MacOS**:
1. Start Joplin
2. Press <kbd>cmd</kbd>-<kbd>m</kbd> and verify that the window is minimized
3. Unminimize Joplin
4. Open Joplin's settings and change the keyboard shortcut for "minimise" to <kbd>cmd</kbd>-<kbd>shift</kbd>-<kbd>j</kbd>.
5. Close settings and press <kbd>cmd</kbd>-<kbd>shift</kbd>-<kbd>j</kbd>
6. Unminimize Joplin
7. Open the "Window" menu and click "minimize"
8. Verify that Joplin has been minimized.
9. Open the "Window" menu and click "Tile window to left of screen". Verify that the window has been tiled.

This has been successfully tested on MacOS Sonoma.

**Linux**:
1. Start Joplin
2. Verify that the "Window" menu is not visible
3. Open settings > Keyboard shortcuts
4. Verify that "minimise" is not a command in the  keyboard shortcut settings pane.

This has been tested successfully on Ubuntu 23.10.
