### PR TITLE
Desktop: Fixes #9855: Allow using editor commands in the command palette

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
@@ -54,6 +54,16 @@ describe('editorCommandDeclarations', () => {
 			},
 			true,
 		],
+		[
+			// In the Markdown editor, and the command palette is visible
+			{
+				markdownEditorPaneVisible: true,
+				richTextEditorVisible: false,
+				gotoAnythingVisible: true,
+				modalDialogVisible: true,
+			},
+			true,
+		],
 	])('should create the enabledCondition', (context: Record<string, any>, expected: boolean) => {
 		const condition = enabledCondition('textBold');
 		const wc = new WhenClause(condition);

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -11,8 +11,8 @@ export const enabledCondition = (commandName: string) => {
 	const noteMustBeMarkdown = !workWithHtmlNotes.includes(commandName);
 
 	const output = [
-		'!modalDialogVisible',
-		'!gotoAnythingVisible',
+		// gotoAnythingVisible: Allows usage of the commands from the command palette
+		'(!modalDialogVisible || gotoAnythingVisible)',
 		markdownEditorOnly ? 'markdownEditorPaneVisible' : '(markdownEditorPaneVisible || richTextEditorVisible)',
 		'oneNoteSelected',
 		noteMustBeMarkdown ? 'noteIsMarkdown' : '',

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -11,8 +11,9 @@ export const enabledCondition = (commandName: string) => {
 	const noteMustBeMarkdown = !workWithHtmlNotes.includes(commandName);
 
 	const output = [
-		// gotoAnythingVisible: Allows usage of the commands from the command palette
+		// gotoAnythingVisible: Enable if the command palette (which is a modal dialog) is visible
 		'(!modalDialogVisible || gotoAnythingVisible)',
+
 		markdownEditorOnly ? 'markdownEditorPaneVisible' : '(markdownEditorPaneVisible || richTextEditorVisible)',
 		'oneNoteSelected',
 		noteMustBeMarkdown ? 'noteIsMarkdown' : '',


### PR DESCRIPTION
# Summary

Enables editor commands when the command palette or goto anything are visible. Fixes #9855.

> [!WARNING]
>
> At present, this **pull request causes a regression**: While `gotoAnythingVisible`, editor keyboard shortcuts (<kbd>ctrl</kbd>-<kbd>i</kbd>, <kbd>ctrl</kbd>-<kbd>b</kbd>, ...) can be used to run editor commands.
>

# Testing plan

1. Open Joplin
2. Switch to the markdown editor
3. Select text
4. Open the command palette
5. Run `textBold`
6. Verify that the selected text has been bolded
7. Repeat steps 4-6 for `editor.indentMore` and `undo`
8. Switch to the rich text editor
9. Select text
10. Run `textBold` from the command palette
11. Verify that the selection has been bolded
12. Open the "tags" dialog
13. Try to bold/unbold the selection with <kbd>ctrl</kbd>-<kbd>b</kbd>
14. Verify that the selection's formatting doesn't change.

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
