### PR TITLE
Desktop: PDF search text: Remove NULL characters early to avoid possible sync issues

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1002,6 +1002,8 @@ packages/lib/types.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/processStartFlags.js
+packages/lib/utils/replaceUnsupportedCharacters.test.js
+packages/lib/utils/replaceUnsupportedCharacters.js
 packages/lib/utils/userFetcher.js
 packages/lib/utils/webDAVUtils.test.js
 packages/lib/utils/webDAVUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -982,6 +982,8 @@ packages/lib/types.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/joplinCloud.js
 packages/lib/utils/processStartFlags.js
+packages/lib/utils/replaceUnsupportedCharacters.test.js
+packages/lib/utils/replaceUnsupportedCharacters.js
 packages/lib/utils/userFetcher.js
 packages/lib/utils/webDAVUtils.test.js
 packages/lib/utils/webDAVUtils.js

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -322,10 +322,21 @@ describe('services/SearchEngine', () => {
 	}));
 
 	it('should support searching through documents that contain null characters', (async () => {
-		await Note.save({ title: 'Test', body: 'Test\x00testing' });
+		await Note.save({
+			title: 'Test',
+			body: `
+				NUL characters, "\x00", have been known to break FTS search.
+				Previously, all characters after a NUL (\x00) character in a note
+				would not show up in search results. NUL characters may have also
+				broken search for other notes.
+
+				In this note, "testing" only appears after the NUL characters.
+			`,
+		});
 
 		await engine.syncTables();
 
+		expect((await engine.search('previously')).length).toBe(1);
 		expect((await engine.search('testing')).length).toBe(1);
 	}));
 

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -13,6 +13,7 @@ import JoplinDatabase from '../../JoplinDatabase';
 import NoteResource from '../../models/NoteResource';
 import BaseItem from '../../models/BaseItem';
 import { isCallbackUrl, parseCallbackUrl } from '../../callbackUrlUtils';
+import replaceUnsupportedCharacters from '../../utils/replaceUnsupportedCharacters';
 const { sprintf } = require('sprintf-js');
 const { pregQuote, scriptType, removeDiacritics } = require('../../string-utils.js');
 
@@ -603,9 +604,8 @@ export default class SearchEngine {
 	private normalizeText_(text: string) {
 		let normalizedText = text.normalize ? text.normalize() : text;
 
-		// Null characters can break FTS. Remove them.
-		// eslint-disable-next-line no-control-regex
-		normalizedText = normalizedText.replace(/\x00/g, ' ');
+		// NULL characters can break FTS. Remove them.
+		normalizedText = replaceUnsupportedCharacters(normalizedText);
 
 		return removeDiacritics(normalizedText.toLowerCase());
 	}

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -10,6 +10,7 @@ import * as pdfJsNamespace from 'pdfjs-dist';
 import { writeFile } from 'fs/promises';
 import { ResourceEntity } from './services/database/types';
 import { TextItem } from 'pdfjs-dist/types/src/display/api';
+import replaceUnsupportedCharacters from './utils/replaceUnsupportedCharacters';
 
 const { FileApiDriverLocal } = require('./file-api-driver-local');
 const mimeUtils = require('./mime-utils.js').mime;
@@ -749,7 +750,10 @@ function shimInit(options: ShimInitOptions = null) {
 				const text = (item as TextItem).str ?? '';
 				return text;
 			}).join('\n');
-			textByPage.push(strings);
+
+			// Some PDFs contain unsupported characters that can lead to hard-to-debug issues.
+			// We remove them here.
+			textByPage.push(replaceUnsupportedCharacters(strings));
 		}
 
 		return textByPage;

--- a/packages/lib/utils/replaceUnsupportedCharacters.test.ts
+++ b/packages/lib/utils/replaceUnsupportedCharacters.test.ts
@@ -1,0 +1,8 @@
+import replaceUnsupportedCharacters from './replaceUnsupportedCharacters';
+
+describe('replaceUnsupportedCharacters', () => {
+	test('should replace NULL characters', () => {
+		expect(replaceUnsupportedCharacters('Test\x00...')).toBe('Test�...');
+		expect(replaceUnsupportedCharacters('\x00Test\x00...')).toBe('�Test�...');
+	});
+});

--- a/packages/lib/utils/replaceUnsupportedCharacters.ts
+++ b/packages/lib/utils/replaceUnsupportedCharacters.ts
@@ -1,0 +1,17 @@
+
+const replaceUnsupportedCharacters = (text: string) => {
+	// In the past, NULL characters have caused sync and search issues.
+	// Because these issues are often difficult to debug, we remove these characters entirely.
+	//
+	// See
+	// - Sync issue: https://github.com/laurent22/joplin/issues/5046
+	// - Search issue: https://github.com/laurent22/joplin/issues/9775
+	//
+	// As per the commonmark spec, we replace \x00 with the replacement character.
+	// (see https://spec.commonmark.org/0.31.2/#insecure-characters).
+	//
+	// eslint-disable-next-line no-control-regex
+	return text.replace(/\x00/g, '\uFFFD');
+};
+
+export default replaceUnsupportedCharacters;


### PR DESCRIPTION
# Summary

We now skip OCR when a PDF already has embedded text. However, embedded PDF text may contain NUL characters ([sample PDF](https://mml-book.github.io/book/mml-book.pdf)). This pull request removes such NUL characters just after extracting search text from PDFs.

NUL characters are also known to cause [search issues](https://github.com/laurent22/joplin/issues/9775) and [possibly sync issues](https://github.com/laurent22/joplin/issues/5046).


This is a follow-up pull request to https://github.com/laurent22/joplin/pull/9774.

# Notes
- The PDF text extraction logic is new and both https://github.com/laurent22/joplin/issues/9775 (see https://github.com/laurent22/joplin/pull/9764#issuecomment-1905266196) and https://github.com/laurent22/joplin/issues/5046 were caused by NUL characters in PDFs.
- [SQLite's documentation](https://sqlite.org/nulinstr.html) warns against using NUL characters in strings because they can cause functions like `length` and `quote` to behave unexpectedly.
- The [CommonMark spec states that NUL characters should be replaced with "�"](https://spec.commonmark.org/0.31.2/#insecure-characters).



# See also
- https://sqlite.org/nulinstr.html
- https://spec.commonmark.org/0.31.2/#insecure-characters
- https://github.com/laurent22/joplin/issues/5046#issuecomment-854858439

# Notes

- It may also make sense to replace NUL characters when saving notes and other items. SQLite's documentation [suggests against using NUL characters in strings](https://sqlite.org/nulinstr.html), as doing so may break functions like `length` and `quote`.


# Testing

Automated tests should verify that:
1. Notes containing NUL characters are still searchable
2. Multiple NUL characters in the same string are replaced

I have additionally done the following manual testing on Ubuntu 23.10:
1. Enable OCR
2. [This PDF](https://mml-book.github.io/book/mml-book.pdf) previously caused FTS issues due to NUL characters. Download it and attach it to a note.
3. Wait about 30 seconds for the resource to become searchable.
4. Search for "Rumelhart" ([see original issue](https://github.com/laurent22/joplin/pull/9764#issuecomment-1905266196))
5. Verify that the PDF is shown as one of the results.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
