### PR TITLE
Chore: Desktop: Fixes #9873: Fix Playwright test failure due to image not `visible`

### DIFF
--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -153,10 +153,12 @@ test.describe('main', () => {
 		await editor.attachFileButton.click();
 
 		const getImageSize = async () => {
-			// Wait for it to render
 			const viewerFrame = editor.getNoteViewerIframe();
 			const renderedImage = viewerFrame.getByAltText(filename);
-			await renderedImage.waitFor();
+
+			// Use state: 'attached' -- we don't need the image to be on the screen (just present
+			// in the DOM).
+			await renderedImage.waitFor({ state: 'attached' });
 
 			// We load a copy of the image to avoid returning an overriden width set with
 			//    .width = some_number


### PR DESCRIPTION
# Summary

By default, [`locator.waitFor`](https://playwright.dev/docs/api/class-locator#locator-wait-for) waits for `locator` to be visible (have a non-empty bounding box and not have `visibility: hidden`). This seems to fail in some instances for elements in the note viewer.

Fixes #9873.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
