### PR TITLE
Desktop: Fixes #9868: Fix markdown (frontmatter) notes that start with a UTF-8 BOM aren't imporetd correctly

### DIFF
--- a/packages/app-cli/tests/support/test_notes/yaml/note_with_byte_order_mark.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/note_with_byte_order_mark.md
@@ -5,4 +5,4 @@ tags:
   - tag2
 ---
 
-Test note
+This note begins with an invisible byte order mark, just before its frontmatter.

--- a/packages/app-cli/tests/support/test_notes/yaml/note_with_byte_order_mark.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/note_with_byte_order_mark.md
@@ -1,0 +1,8 @@
+﻿---
+title: Frontmatter test
+tags:
+  - tag1
+  - tag2
+---
+
+Test note

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -13,6 +13,7 @@ import { unique } from '../../ArrayUtils';
 const { pregQuote } = require('../../string-utils-common');
 import { MarkupToHtml } from '@joplin/renderer';
 import { isDataUrl } from '@joplin/utils/url';
+import { stripBom } from '../../string-utils';
 
 export default class InteropService_Importer_Md extends InteropService_Importer_Base {
 	protected importedNotes: Record<string, NoteEntity> = {};
@@ -167,7 +168,8 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 		if (!stat) throw new Error(`Cannot read ${resolvedPath}`);
 		const ext = fileExtension(resolvedPath);
 		const title = filename(resolvedPath);
-		const body = await shim.fsDriver().readFile(resolvedPath);
+		const body = stripBom(await shim.fsDriver().readFile(resolvedPath));
+
 		const note = {
 			parent_id: parentFolderId,
 			title: title,

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -173,4 +173,13 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 		const note = await importTestFile('note_with_dataurl_image.md');
 		expect(note.body).toBe('<img src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2023%2038%22%3E%3Cpath%20d%3D%22M16.6%2038.1h-5.5l-.2-2.9-.2%202.9h-5.5L5%2025.3l-.8%202a1.53%201.53%200%2001-1.9.9l-1.2-.4a1.58%201.58%200%2001-1-1.9v-.1c.3-.9%203.1-11.2%203.1-11.2a2.66%202.66%200%20012.3-2l.6-.5a6.93%206.93%200%20014.7-12%206.8%206.8%200%20014.9%202%207%207%200%20012%204.9%206.65%206.65%200%2001-2.2%205l.7.5a2.78%202.78%200%20012.4%202s2.9%2011.2%202.9%2011.3a1.53%201.53%200%2001-.9%201.9l-1.3.4a1.63%201.63%200%2001-1.9-.9l-.7-1.8-.1%2012.7zm-3.6-2h1.7L14.9%2020.3l1.9-.3%202.4%206.3.3-.1c-.2-.8-.8-3.2-2.8-10.9a.63.63%200%2000-.6-.5h-.6l-1.1-.9h-1.9l-.3-2a4.83%204.83%200%20003.5-4.7A4.78%204.78%200%200011%202.3H10.8a4.9%204.9%200%2000-1.4%209.6l-.3%202h-1.9l-1%20.9h-.6a.74.74%200%2000-.6.5c-2%207.5-2.7%2010-3%2010.9l.3.1L4.8%2020l1.9.3.2%2015.8h1.6l.6-8.4a1.52%201.52%200%20011.5-1.4%201.5%201.5%200%20011.5%201.4l.9%208.4zm-10.9-9.6zm17.5-.1z%22%20style%3D%22isolation%3Aisolate%22%20fill%3D%22%23333%22%20opacity%3D%22.7%22/%3E%3Cpath%20d%3D%22M5.9%2013.6l1.1-.9h7.8l1.2.9%22%20fill%3D%22%23ce592c%22/%3E%3Cellipse%20cx%3D%2210.9%22%20cy%3D%2213.1%22%20rx%3D%222.7%22%20ry%3D%22.3%22%20style%3D%22isolation%3Aisolate%22%20fill%3D%22%23ce592c%22%20opacity%3D%22.5%22/%3E%3Cpath%20d%3D%22M20.6%2026.1l-2.9-11.3a1.71%201.71%200%2000-1.6-1.2H5.699999999999999a1.69%201.69%200%2000-1.5%201.3l-3.1%2011.3a.61.61%200%2000.3.7l1.1.4a.61.61%200%2000.7-.3l2.7-6.7.2%2016.8h3.6l.6-9.3a.47.47%200%2001.44-.5h.06c.4%200%20.4.2.5.5l.6%209.3h3.6L15.7%2020.3l2.5%206.6a.52.52%200%2000.66.31l1.2-.4a.57.57%200%2000.5-.7z%22%20fill%3D%22%23fdbf2d%22/%3E%3Cpath%20d%3D%22M7%2013.6l3.9%206.7%203.9-6.7%22%20style%3D%22isolation%3Aisolate%22%20fill%3D%22%23cf572e%22%20opacity%3D%22.6%22/%3E%3Ccircle%20cx%3D%2210.9%22%20cy%3D%227%22%20r%3D%225.9%22%20fill%3D%22%23fdbf2d%22/%3E%3C/svg%3E" alt="Street View Pegman Control" style="height:30px;width:30px;position:absolute;transform:translate(-50%,-50%);pointer-events:none">');
 	});
+
+	it('should recognize frontmatter in a file that starts with a UTF8 byte order mark', async () => {
+		const note = await importTestFile('note_with_byte_order_mark.md');
+		expect(note.title).toBe('Frontmatter test');
+		expect(note.body).toBe('Test note\n');
+
+		const tags = (await Tag.tagsByNoteId(note.id)).map(tag => tag.title).sort();
+		expect(tags).toMatchObject(['tag1', 'tag2']);
+	});
 });

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -177,7 +177,7 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 	it('should recognize frontmatter in a file that starts with a UTF8 byte order mark', async () => {
 		const note = await importTestFile('note_with_byte_order_mark.md');
 		expect(note.title).toBe('Frontmatter test');
-		expect(note.body).toBe('Test note\n');
+		expect(note.body).toBe('This note begins with an invisible byte order mark, just before its frontmatter.\n');
 
 		const tags = (await Tag.tagsByNoteId(note.id)).map(tag => tag.title).sort();
 		expect(tags).toMatchObject(['tag1', 'tag2']);

--- a/packages/lib/string-utils.ts
+++ b/packages/lib/string-utils.ts
@@ -303,3 +303,11 @@ export function scriptType(s: string) {
 	return 'en';
 }
 
+// A UTF-8/UTF-16 byte order mark can appear at the start of a file and
+// can break logic that relies on a file starting with specific text.
+// See https://github.com/laurent22/joplin/issues/9868
+export const stripBom = (text: string) => {
+	// Remove the UTF-16 BOM --- NodeJS seems to convert UTF-8 BOMs to UTF-16 BOMs
+	// when reading files.
+	return text.replace(/^\ufeff/u, '');
+};


### PR DESCRIPTION
# Summary

Removes Unicode byte order marks before importing as markdown.

Fixes #9868.

# Testing

This pull request contains an automated test that imports [`app-cli/tests/support/test_notes/yaml/note_with_byte_order_mark.md`](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/importer-strip-bom?expand=1#diff-0cc5194ea92ad51f258930302dc3a2bffeda9061c1952c62c6048ca21ac0f486).

Inspecting this file with `xxd` (a hexdump utility) should reveal that it starts with the bytes `EF BB BF`.


This pull request has also been tested manually on Ubuntu 23.10 by downloading and importing [a file that starts with a UTF-8 BOM](https://github.com/laurent22/joplin/files/14188801/FrontmatterTest.md) as markdown with frontmatter.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
