### PR TITLE
Mobile: Fixes #9863: Fix share to Joplin when only "All notes" has been opened

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -981,9 +981,12 @@ class AppComponent extends React.Component {
 
 		if (sharedData) {
 			reg.logger().info('Received shared data');
-			if (this.props.selectedFolderId) {
+
+			// selectedFolderId can be null if "All notes" or a similar screen is open.
+			const targetFolder = this.props.selectedFolderId ?? (await Folder.defaultFolder())?.id;
+			if (targetFolder) {
 				logger.info('Sharing: handleShareData: Processing...');
-				await handleShared(sharedData, this.props.selectedFolderId, this.props.dispatch);
+				await handleShared(sharedData, targetFolder, this.props.dispatch);
 			} else {
 				reg.logger().info('Cannot handle share - default folder id is not set');
 			}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -982,7 +982,8 @@ class AppComponent extends React.Component {
 		if (sharedData) {
 			reg.logger().info('Received shared data');
 
-			// selectedFolderId can be null if "All notes" or a similar screen is open.
+			// selectedFolderId can be null if no screens other than "All notes"
+			// have been opened.
 			const targetFolder = this.props.selectedFolderId ?? (await Folder.defaultFolder())?.id;
 			if (targetFolder) {
 				logger.info('Sharing: handleShareData: Processing...');


### PR DESCRIPTION
# Summary

Fixes an issue where share to Joplin would fail when `selectedFolderId` was `null`. This can happen if no screens other than "All notes" have been opened since opening the app.

Fixes #9863.

# Testing

1. Open "All notes"
2. Close Joplin
3. Open another app (e.g. Google Chrome)
4. Share something to Joplin
    - Tested with a website URL from Chrome
5. Verify that Joplin opens and creates a new note with the shared data

This has been tested successfully on Android 7.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
