### PR TITLE
Mobile: Fixes #9475: Increase space available for Notebook icon

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -87,6 +87,7 @@ const SideMenuContentComponent = (props: Props) => {
 			sidebarIcon: {
 				fontSize: 22,
 				color: theme.color,
+				width: 26,
 			},
 		};
 
@@ -103,7 +104,7 @@ const SideMenuContentComponent = (props: Props) => {
 		styles.sideButtonSelected = { ...styles.sideButton, backgroundColor: theme.selectedColor };
 		styles.sideButtonText = { ...styles.buttonText };
 
-		styles.emptyFolderIcon = { ...styles.sidebarIcon, marginRight: folderIconRightMargin, width: 21 };
+		styles.emptyFolderIcon = { ...styles.sidebarIcon, marginRight: folderIconRightMargin, width: 26 };
 
 		return StyleSheet.create(styles);
 	}, [props.themeId]);
@@ -317,9 +318,9 @@ const SideMenuContentComponent = (props: Props) => {
 		}
 
 		if (folderIcon.type === 1) { // FolderIconType.Emoji
-			return <Text style={{ fontSize: theme.fontSize, marginRight: folderIconRightMargin, width: 20 }}>{folderIcon.emoji}</Text>;
+			return <Text style={{ fontSize: theme.fontSize, marginRight: folderIconRightMargin, width: 26 }}>{folderIcon.emoji}</Text>;
 		} else if (folderIcon.type === 2) { // FolderIconType.DataUrl
-			return <Image style={{ width: 20, height: 20, marginRight: folderIconRightMargin, resizeMode: 'contain' }} source={{ uri: folderIcon.dataUrl }}/>;
+			return <Image style={{ width: 26, height: 20, marginRight: folderIconRightMargin, resizeMode: 'contain' }} source={{ uri: folderIcon.dataUrl }}/>;
 		} else {
 			throw new Error(`Unsupported folder icon type: ${folderIcon.type}`);
 		}

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -318,9 +318,9 @@ const SideMenuContentComponent = (props: Props) => {
 		}
 
 		if (folderIcon.type === 1) { // FolderIconType.Emoji
-			return <Text style={{ fontSize: theme.fontSize, marginRight: folderIconRightMargin, width: 26 }}>{folderIcon.emoji}</Text>;
+			return <Text style={{ fontSize: theme.fontSize, marginRight: folderIconRightMargin, width: 27 }}>{folderIcon.emoji}</Text>;
 		} else if (folderIcon.type === 2) { // FolderIconType.DataUrl
-			return <Image style={{ width: 26, height: 20, marginRight: folderIconRightMargin, resizeMode: 'contain' }} source={{ uri: folderIcon.dataUrl }}/>;
+			return <Image style={{ width: 27, height: 20, marginRight: folderIconRightMargin, resizeMode: 'contain' }} source={{ uri: folderIcon.dataUrl }}/>;
 		} else {
 			throw new Error(`Unsupported folder icon type: ${folderIcon.type}`);
 		}


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/9475

### Description

Increases the space available for the notebook icon to avoid icons being cut off in specific scenarios

<details><summary>Images</summary>

With default icon size:
![Screenshot from 2024-02-07 20-14-14](https://github.com/laurent22/joplin/assets/5051088/d017a08a-1b24-4b97-8f72-554530a9bdfa)

Increasing icon size to check how big it can be before cutting off:
![Screenshot from 2024-02-07 20-15-49](https://github.com/laurent22/joplin/assets/5051088/44553248-fd83-431c-9658-c7ceb0e13b32)

</details> 

### Testing

The best way to test that I found was creating an folder with an emoticon in the desktop app, synchronizing with the mobile app, and changing the font size inside the mobile app code (`side-menu-context.tsx`, function `renderFolderIcon`). That is how I managed to create the images above.