### PR TITLE
Desktop: Fixes #9763: Suppress error that happens during desktop shutdown

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -394,6 +394,10 @@ export default class ElectronAppWrapper {
 			this.tray_.setContextMenu(contextMenu);
 
 			this.tray_.on('click', () => {
+				if (!this.window()) {
+					console.warn('The window object was not available during the click event from tray icon');
+					return;
+				}
 				this.window().show();
 			});
 		} catch (error) {


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/9763

### Description

The error reported in the issue describes a behavior that seems to happen during the shutdown process from the Desktop app. To prevent the error from happening we are checking if the window object still available, if not we just log a warn message

"The window object was not available during the click event from tray icon"

### Testing

To test the behavior I enable the tray icon in the settings and update the code in `ElectronAppWrapper` to set the `this.win_` to null just after the `this.win_.hide()` method is called.

After this, if I clicked the tray icon the message should be logged in the terminal.