### PR TITLE
Chore: Desktop: Fix test failure (test for `restartInSafeModeFromMain`)

### DIFF
--- a/packages/app-desktop/utils/restartInSafeModeFromMain.test.ts
+++ b/packages/app-desktop/utils/restartInSafeModeFromMain.test.ts
@@ -14,7 +14,7 @@ jest.doMock('../bridge', () => ({
 			// Only the following arguments are used.
 			'--profile', currentProfileDirectory,
 		],
-		env: () => 'dev',
+		appName: () => 'joplindev-desktop',
 	}),
 }));
 


### PR DESCRIPTION
# Summary

A mock for `bridge.ts` needed to be updated to support the new `appName` function. (See [comment](https://github.com/laurent22/joplin/commit/07aba918a075555caf7b31a9c9a25ed09fe5e257#r138402984)).

# Notes

Ideally, we wouldn't mock `bridge()`. However, `initBridge` depends on `ElectronAppWrapper` (which depends on `electron`).

An alternative could be to allow `wrapper: ElectronAppWrapper` to be `null` in tests. However, this may still require mocking for some functions. For example, `bridge().env()` currently calls `electronWrapper_.env()`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/CONTRIBUTING.md

-->
