### PR TITLE
perf(turndown-plugin-gfm): fix cache memory leak

### DIFF
--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -205,17 +205,18 @@ function tableShouldBeSkipped(tableNode) {
   const cached = tableShouldBeSkippedCache_.get(tableNode);
   if (cached !== undefined) return cached;
 
-  const process = () => {
-    if (!tableNode) return true;
-    if (!tableNode.rows) return true;
-    if (tableNode.rows.length === 1 && tableNode.rows[0].childNodes.length <= 1) return true; // Table with only one cell
-    if (nodeContainsTable(tableNode)) return true;
-    return false;
-  }
+  const result = tableShouldBeSkipped_(tableNode);
 
-  const result = process();
   tableShouldBeSkippedCache_.set(tableNode, result);
   return result;
+}
+
+function tableShouldBeSkipped_ = (tableNode) => {
+  if (!tableNode) return true;
+  if (!tableNode.rows) return true;
+  if (tableNode.rows.length === 1 && tableNode.rows[0].childNodes.length <= 1) return true; // Table with only one cell
+  if (nodeContainsTable(tableNode)) return true;
+  return false;
 }
 
 function nodeParentTable(node) {

--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -211,7 +211,7 @@ function tableShouldBeSkipped(tableNode) {
   return result;
 }
 
-function tableShouldBeSkipped_ = (tableNode) => {
+function tableShouldBeSkipped_(tableNode) {
   if (!tableNode) return true;
   if (!tableNode.rows) return true;
   if (tableNode.rows.length === 1 && tableNode.rows[0].childNodes.length <= 1) return true; // Table with only one cell

--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -7,8 +7,8 @@ let isCodeBlock_ = null;
 
 // We need to cache the result of tableShouldBeSkipped() as it is expensive.
 // Caching it means we went from about 9000 ms for rendering down to 90 ms.
-// Fixes https://github.com/laurent22/joplin/issues/6736 
-const tableShouldBeSkippedCache_ = new Map();
+// Fixes https://github.com/laurent22/joplin/issues/6736
+const tableShouldBeSkippedCache_ = new WeakMap();
 
 function getAlignment(node) {
   return node ? (node.getAttribute('align') || node.style.textAlign || '').toLowerCase() : '';
@@ -88,7 +88,7 @@ rules.table = {
     var secondLine = content.trim().split('\n');
     if (secondLine.length >= 2) secondLine = secondLine[1]
     var secondLineIsDivider = /\| :?---/.test(secondLine);
-    
+
     var columnCount = tableColCount(node);
     var emptyHeader = ''
     if (columnCount && !secondLineIsDivider) {


### PR DESCRIPTION
The code in question is using a Map to cache the result of running `tableShouldBeSkipped` function on a given table node

However, given that the cache is never cleared, this causes a memory leak as garbage collector is never able to clean up the table nodes (as they are used by the map forever)

To fix that, this PR changes `Map` to [`WeakMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)

---

Additionally, given that the `tableShouldBeSkipped` function is in the hot path (called for every table, table row, table header and table cell), creating a lamda function inside of it is degrading performance (makes it harder for V8 to optimize the code)
This PR improves that by not re-creating a function on each call to `tableShouldBeSkipped` 
[More information on this optimization](https://marvinh.dev/blog/speeding-up-javascript-ecosystem/#:~:text=Inline%20functions%2C%20inline%20caches%20and%20recursion)