### PR TITLE
Desktop: Disable built-in copy of Simple Backup by default in Joplin Portable

### DIFF
--- a/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
+++ b/packages/app-cli/tests/services/plugins/defaultPluginsUtils.ts
@@ -172,6 +172,34 @@ describe('defaultPluginsUtils', () => {
 		expect(Setting.value('plugin-io.github.jackgruber.backup.path')).toBe('initial-path');
 	});
 
+	it('should support disabled-by-default plugins', async () => {
+		const service = newPluginService();
+
+		const plugin = await service.loadPluginFromJsBundle('', sampleJsBundlePlugin);
+		plugin.builtIn = false;
+		await service.runPlugin(plugin);
+
+		const defaultPluginsInfo: DefaultPluginsInfo = {
+			'joplin.plugin.ambrt.backlinksToNote': {
+				enabled: false,
+			},
+			'org.joplinapp.plugins.ToggleSidebars': {},
+		};
+		Setting.setValue('installedDefaultPlugins', []);
+
+		const { pluginSettings } = await getDefaultPluginPathsAndSettings(
+			testDefaultPluginsDir, defaultPluginsInfo, {}, service,
+		);
+
+		expect(pluginSettings).toMatchObject({
+			'joplin.plugin.ambrt.backlinksToNote': {
+				enabled: false,
+				deleted: false,
+			},
+			'org.joplinapp.plugins.ToggleSidebars': defaultPluginSetting(),
+		});
+	});
+
 	it('should not throw error on missing setting key', async () => {
 
 		const service = newPluginService();

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,6 +34,7 @@ export interface SettingAndValue {
 
 export interface DefaultPluginSettings {
 	settings?: SettingAndValue;
+	enabled?: boolean;
 }
 
 export interface DefaultPluginsInfo {

--- a/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
+++ b/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
@@ -65,6 +65,11 @@ export const getDefaultPluginPathsAndSettings = async (
 			// As such, we recreate the plugin state if necessary.
 			if (!draft[pluginId]) {
 				draft[pluginId] = defaultPluginSetting();
+
+				const enabledByDefault = defaultPluginsInfo[pluginId].enabled;
+				if (typeof enabledByDefault === 'boolean') {
+					draft[pluginId].enabled = enabledByDefault;
+				}
 			}
 		});
 	}

--- a/packages/lib/services/plugins/defaultPlugins/desktopDefaultPluginsInfo.ts
+++ b/packages/lib/services/plugins/defaultPlugins/desktopDefaultPluginsInfo.ts
@@ -1,5 +1,6 @@
 import { DefaultPluginsInfo } from '../PluginService';
 import Setting from '../../../models/Setting';
+import shim from '../../../shim';
 
 const getDefaultPluginsInfo = (): DefaultPluginsInfo => {
 	const defaultPlugins = {
@@ -7,6 +8,11 @@ const getDefaultPluginsInfo = (): DefaultPluginsInfo => {
 			settings: {
 				'path': `${Setting.value('profileDir')}`,
 			},
+
+			// Joplin Portable is more likely to run on a device with low write speeds
+			// and memory. Because Simple Backup has auto-backup enabled by default,
+			// we disable it in Joplin Portable.
+			enabled: !shim.isPortable(),
 		},
 	};
 	return defaultPlugins;


### PR DESCRIPTION
# Summary

Disables the built-in version of Simple Backup by default in Joplin Portable.

# Rationale

Joplin Portable is intended to be usable on external drives (e.g. thumbdrives/SD cards). These storage media often have low memory and slow write speeds.

(The idea for this pull request was originally discussed with @laurent22 and @pedr.)

# Testing

1. Remove Joplin's profile directory (`rm -r ~/.config/joplindev-desktop`)
2. Start Joplin in dev mode
3. Verify that Simple Backup is not disabled
4. Close Joplin
5. Simulate Joplin portable by running
```zsh
zsh$ mkdir /tmp/foo
zsh$ export PORTABLE_EXECUTABLE_DIR="/tmp/foo/"
```
6. Start Joplin in dev mode
7. Verify that Simple backup is disabled
8. Enable Simple Backup
9. Restart Joplin
10. Verify that Simple Backup is now enabled.

This has been tested successfully on Ubuntu 23.10.