### PR TITLE
Mobile: Fixes #9905: Fix full text search broken on Android 7 and earlier

### DIFF
--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -796,9 +796,9 @@ export default class SearchEngine {
 						// Android <= 25 doesn't support the following syntax:
 						//    WHERE title MATCH ? OR body MATCH ?
 						// Thus, we skip resource search on these devices.
-						if (shim.mobilePlatform() !== 'android') {
-							this.logger().warn('Error searching in resources:', error);
-						}
+						this.logger().warn(
+							'Error searching in resources:', error, 'Only note results will be shown.',
+						);
 					}
 
 					const resourcesToNotes = await NoteResource.associatedResourceNotes(itemRows.map(r => r.item_id), { fields: ['note_id', 'parent_id'] });

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -777,18 +777,29 @@ export default class SearchEngine {
 				if (!queryHasFilters) {
 					const toSearch = parsedQuery.allTerms.map(t => t.value).join(' ');
 
-					let itemRows = await this.db().selectAll<ProcessResultsRow>(`
-						SELECT
-							id,
-							title,
-							user_updated_time,
-							offsets(items_fts) AS offsets,
-							matchinfo(items_fts, 'pcnalx') AS matchinfo,
-							item_id,
-							item_type
-						FROM items_fts
-						WHERE title MATCH ? OR body MATCH ?
-					`, [toSearch, toSearch]);
+					let itemRows: ProcessResultsRow[] = [];
+
+					try {
+						itemRows = await this.db().selectAll<ProcessResultsRow>(`
+								SELECT
+									id,
+									title,
+									user_updated_time,
+									offsets(items_fts) AS offsets,
+									matchinfo(items_fts, 'pcnalx') AS matchinfo,
+									item_id,
+									item_type
+								FROM items_fts
+								WHERE title MATCH ? OR body MATCH ?
+						`, [toSearch, toSearch]);
+					} catch (error) {
+						// Android <= 25 doesn't support the following syntax:
+						//    WHERE title MATCH ? OR body MATCH ?
+						// Thus, we skip resource search on these devices.
+						if (shim.mobilePlatform() !== 'android') {
+							this.logger().warn('Error searching in resources:', error);
+						}
+					}
 
 					const resourcesToNotes = await NoteResource.associatedResourceNotes(itemRows.map(r => r.item_id), { fields: ['note_id', 'parent_id'] });
 

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -781,24 +781,24 @@ export default class SearchEngine {
 
 					try {
 						itemRows = await this.db().selectAll<ProcessResultsRow>(`
-								SELECT
-									id,
-									title,
-									user_updated_time,
-									offsets(items_fts) AS offsets,
-									matchinfo(items_fts, 'pcnalx') AS matchinfo,
-									item_id,
-									item_type
-								FROM items_fts
-								WHERE title MATCH ? OR body MATCH ?
+							SELECT
+								id,
+								title,
+								user_updated_time,
+								offsets(items_fts) AS offsets,
+								matchinfo(items_fts, 'pcnalx') AS matchinfo,
+								item_id,
+								item_type
+							FROM items_fts
+							WHERE title MATCH ? OR body MATCH ?
 						`, [toSearch, toSearch]);
 					} catch (error) {
 						// Android <= 25 doesn't support the following syntax:
 						//    WHERE title MATCH ? OR body MATCH ?
 						// Thus, we skip resource search on these devices.
-						this.logger().warn(
-							'Error searching in resources:', error, 'Only note results will be shown.',
-						);
+						if (!error.message?.includes?.('unable to use function MATCH in the requested context')) {
+							throw error;
+						}
 					}
 
 					const resourcesToNotes = await NoteResource.associatedResourceNotes(itemRows.map(r => r.item_id), { fields: ['note_id', 'parent_id'] });


### PR DESCRIPTION
# Summary

On Android API ≤ 25, `WHERE title MATCH ? OR body MATCH ?` fails, breaking search. This pull request adds an additional `try`/`catch` to allow note search to continue to work even when resource search breaks.

Fixes #9905.

> [!NOTE]
>
> An alternative solution is to only search through the resource field `body`. See [this branch](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:joplin:pr/fix-item-search-on-old-android?expand=1) for an implementation. This alternative solution, however, introduces code that runs only on older versions of Android and is thus less maintainable.
>

# Testing

Android:

1. Start an instance of Joplin that has synced OCRed text.
2. Search for text that's present in a note.
3. Verify that there are search results.

This has been tested successfully on Android 7.

Desktop:

1. Start an instance of Joplin that contains OCRed text
2. Search for a term known to be in a specific resource
3. Verify that the resource can be found.

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->