### PR TITLE
Desktop: Fixes #8907: Fix sync spins for about 30 seconds before failing when offline (Joplin Cloud and other network sync)

### DIFF
--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -67,6 +67,9 @@ function requestCanBeRepeated(error: any) {
 	// so not repeating means there will be less noise in the log.
 	if (errorCode === 'failSafe') return false;
 
+	// If retrying the request was already attempted and failed elsewhere,
+	if (error.isJoplinFetchRetryFailure) return false;
+
 	return true;
 }
 

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -67,8 +67,10 @@ function requestCanBeRepeated(error: any) {
 	// so not repeating means there will be less noise in the log.
 	if (errorCode === 'failSafe') return false;
 
-	// If retrying the request was already attempted and failed elsewhere,
-	if (error.isJoplinFetchRetryFailure) return false;
+	// Prevents unnecessary retries when offline.
+	if (!shim.fetchRequestCanBeRetried(error, true)) {
+		return false;
+	}
 
 	return true;
 }

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -145,8 +145,8 @@ const shim = {
 	// Node requests can go wrong is so many different ways and with so
 	// many different error messages... This handler inspects the error
 	// and decides whether the request can safely be repeated or not.
-	fetchRequestCanBeRetried: (error: any) => {
-		if (!error) return false;
+	fetchRequestCanBeRetried: (error: any, retryUnknownErrors = false) => {
+		if (!error) return retryUnknownErrors;
 
 		// Unfortunately the error 'Network request failed' doesn't have a type
 		// or error code, so hopefully that message won't change and is not localized
@@ -182,7 +182,7 @@ const shim = {
 		// ECONNREFUSED is generally temporary
 		if (error.code === 'ECONNREFUSED') return true;
 
-		return false;
+		return retryUnknownErrors;
 	},
 
 	fetchMaxRetry_: 5,


### PR DESCRIPTION
# Summary

Prevents sync logic from retrying when fetch fails with errors that indicate the user is likely offline.

Fixes #8907.

See also https://github.com/node-fetch/node-fetch/issues/1243

# Notes

- Although I have not yet tested this pull request on Windows, I have verified that `EAI_AGAIN` errors are also emitted when unable to connect to Joplin Server/Cloud.
- In a separate pull request, it might make sense to add logic to allow cancelling `tryAndRepeat` and `shim.fetchWithRetry` during sync.

# Testing

1. Start Joplin in dev mode
2. Set the sync target to Joplin Cloud
3. Verify that Joplin can't connect to a dev instance of Joplin Cloud
4. Sync
    - Verify that sync fails quickly
6. Start a local instance of Joplin Server
7. Set the sync target to Joplin Server
8. Sync
    - Verify that sync is successful
9. Set the sync target to OneDrive
10. Close Joplin and go offline
11. Start Joplin and sync
    - Verify that sync stops immediately
12. Go online
13. Sync
    - Verify that sync works

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->