### PR TITLE
Server: Adding ARM64 support for both ARM servers and macOS

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -44,6 +44,7 @@ COPY packages/server ./packages/server
 # Note that `yarn install` ignores `NODE_ENV=production` and will install dev
 # dependencies too, but this is fine because we need them to build the app.
 
+RUN apt-get update && apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
     && yarn cache clean \
     && rm -rf .yarn/berry


### PR DESCRIPTION
This allows to build on arm64 + amd64, I use (and tested) this image to run on my Odroid ARM server.

Test image is at: https://hub.docker.com/repository/docker/peterwilli/joplin-server/general (has both arm64 and amd64)

How to build an universal image: `docker buildx build -f Dockerfile.server --tag=peterwilli/joplin-server --platform=linux/arm64,linux/amd64 --push`

Ofcourse, replace `peterwilli/joplin-server` with your own tag.