### PR TITLE
Desktop: Fixes #9966: Beta editor plugins: Fix newlines break content scripts

### DIFF
--- a/packages/editor/CodeMirror/createEditor.test.ts
+++ b/packages/editor/CodeMirror/createEditor.test.ts
@@ -72,6 +72,7 @@ describe('createEditor', () => {
 			return `
 				exports.default = context => {
 					context.postMessage(context.pluginId);
+					return {};
 				};
 			`;
 		});
@@ -138,6 +139,7 @@ describe('createEditor', () => {
 			return `
 				exports.default = context => {
 					context.postMessage(context.pluginId);
+					return {};
 				};
 			`;
 		});

--- a/packages/editor/CodeMirror/pluginApi/PluginLoader.ts
+++ b/packages/editor/CodeMirror/pluginApi/PluginLoader.ts
@@ -75,7 +75,7 @@ export default class PluginLoader {
 					return;
 				}
 
-				scriptElement.innerText = `
+				scriptElement.appendChild(document.createTextNode(`
 				(async () => {
 					const exports = {};
 					const require = window.__pluginLoaderRequireFunctions[${JSON.stringify(this.pluginLoaderId)}];
@@ -87,7 +87,7 @@ export default class PluginLoader {
 		
 					window.__pluginLoaderScriptLoadCallbacks[${JSON.stringify(scriptId)}](exports);
 				})();
-				`;
+				`));
 
 				(window as any).__pluginLoaderScriptLoadCallbacks[scriptId] = onLoad;
 


### PR DESCRIPTION
# Summary

Fixes #9966 by using `.appendChild(document.createTextNode(...))` instead of `.innerText = ...`.

It seems that `.innerText` tries to convert newlines into `<br/>` elements, which can break content scripts. This is either due to the presence of `<br/>`s in content scripts or because inline comments don't end.

# Testing

This has been tested successfully by applying the following diff to the example CodeMirror 6 plugin:
```diff
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js b/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
index 525fcf2d4..715f0b317 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
+++ b/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
@@ -167,7 +167,8 @@ function onBuildCompleted() {
 }
 
 const baseConfig = {
-	mode: 'production',
+	mode: 'development',
+	devtool: 'nosources-source-map',
 	target: 'node',
 	stats: 'errors-only',
 	module: {
```

After applying the diff, the plugin was built and added as a development plugin. It was verified that the plugin loads successfully (line numbers are visible in the beta editor after loading the plugin).

The built plugin was inspected to verify that it does contain newlines and comments in its content script.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->