### PR TITLE
Mobile,Desktop: Fixes #9971: Fix auto-indentation in some types of code blocks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -588,6 +588,9 @@ packages/editor/CodeMirror/editorCommands/insertLineAfter.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
 packages/editor/CodeMirror/markdown/decoratorExtension.test.js
@@ -600,7 +603,6 @@ packages/editor/CodeMirror/markdown/markdownMathParser.test.js
 packages/editor/CodeMirror/markdown/markdownMathParser.js
 packages/editor/CodeMirror/markdown/markdownReformatter.test.js
 packages/editor/CodeMirror/markdown/markdownReformatter.js
-packages/editor/CodeMirror/markdown/syntaxHighlightingLanguages.js
 packages/editor/CodeMirror/pluginApi/PluginLoader.js
 packages/editor/CodeMirror/pluginApi/codeMirrorRequire.js
 packages/editor/CodeMirror/testUtil/createEditorSettings.js

--- a/.gitignore
+++ b/.gitignore
@@ -568,6 +568,9 @@ packages/editor/CodeMirror/editorCommands/insertLineAfter.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/editorCommands/swapLine.js
 packages/editor/CodeMirror/getScrollFraction.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.js
+packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.test.js
 packages/editor/CodeMirror/markdown/computeSelectionFormatting.js
 packages/editor/CodeMirror/markdown/decoratorExtension.test.js
@@ -580,7 +583,6 @@ packages/editor/CodeMirror/markdown/markdownMathParser.test.js
 packages/editor/CodeMirror/markdown/markdownMathParser.js
 packages/editor/CodeMirror/markdown/markdownReformatter.test.js
 packages/editor/CodeMirror/markdown/markdownReformatter.js
-packages/editor/CodeMirror/markdown/syntaxHighlightingLanguages.js
 packages/editor/CodeMirror/pluginApi/PluginLoader.js
 packages/editor/CodeMirror/pluginApi/codeMirrorRequire.js
 packages/editor/CodeMirror/testUtil/createEditorSettings.js

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -6,7 +6,7 @@ import { EditorState } from '@codemirror/state';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { GFM as GitHubFlavoredMarkdownExtension } from '@lezer/markdown';
 import { MarkdownMathExtension } from './markdown/markdownMathParser';
-import syntaxHighlightingLanguages from './markdown/syntaxHighlightingLanguages';
+import lookUpLanguage from './markdown/codeBlockLanguages/lookUpLanguage';
 import { html } from '@codemirror/lang-html';
 import { defaultKeymap, emacsStyleKeymap } from '@codemirror/commands';
 import { vim } from '@replit/codemirror-vim';
@@ -26,7 +26,7 @@ const configFromSettings = (settings: EditorSettings) => {
 						// Don't highlight KaTeX if the user disabled it
 						settings.katexEnabled ? MarkdownMathExtension : [],
 					],
-					codeLanguages: syntaxHighlightingLanguages,
+					codeLanguages: lookUpLanguage,
 				}),
 				markdownLanguage.data.of({ closeBrackets: openingBrackets }),
 			];

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.ts
@@ -1,5 +1,3 @@
-
-
 import { LanguageDescription } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
 

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/allLanguages.ts
@@ -1,6 +1,4 @@
-//
-// Exports a list of languages that can be used in fenced code blocks.
-//
+
 
 import { LanguageDescription } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
@@ -13,13 +11,13 @@ const additionalAliases: Record<string, string[]> = {
 
 // Convert supportedLanguages to a CodeMirror-readable list
 // of LanguageDescriptions
-const syntaxHighlightingLanguages: LanguageDescription[] = [];
+export const allLanguages: LanguageDescription[] = [];
 
 for (const language of languages) {
 	const languageId = language.name.toLowerCase();
 
 	if (additionalAliases.hasOwnProperty(languageId)) {
-		syntaxHighlightingLanguages.push(LanguageDescription.of({
+		allLanguages.push(LanguageDescription.of({
 			name: language.name,
 			alias: [...language.alias, ...additionalAliases[languageId]],
 			extensions: language.extensions,
@@ -28,8 +26,8 @@ for (const language of languages) {
 			load: () => language.load.call(language),
 		}));
 	} else {
-		syntaxHighlightingLanguages.push(language);
+		allLanguages.push(language);
 	}
 }
 
-export default syntaxHighlightingLanguages;
+export default allLanguages;

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.ts
@@ -1,36 +1,18 @@
 import { LanguageDescription, LanguageSupport, StreamLanguage } from '@codemirror/language';
 
-// To allow auto-indent to work in an unrecognised language, we define a language
-// that provides just autoindent.
+// To allow auto-indent to work in an unrecognised language, we define an
+// empty language. Doing so seems to enable auto-indent in code blocks with
+// that language.
 const defaultLangauge = StreamLanguage.define({
-	startState: (indentUnit) => {
-		return {
-			indentUnit,
-			lastIndent: 0,
-			isLineStart: true,
-		};
-	},
-	token: (stream, state) => {
-		if (state.isLineStart) {
-			const indent = stream.eat(/\s*/) || '';
-			state.lastIndent = indent.length;
-			state.isLineStart = false;
-		} else {
-			const n = stream.next();
-			if (n === '\n') {
-				state.isLineStart = true;
-			}
-		}
+	token: (stream) => {
+		stream.next();
 		return null;
-	},
-	indent: (state) => {
-		return state.lastIndent;
 	},
 });
 
-const baseLanguageDescription = LanguageDescription.of({
+const defaultLanguageDescription = LanguageDescription.of({
 	name: 'default',
 	support: new LanguageSupport(defaultLangauge),
 });
 
-export default baseLanguageDescription;
+export default defaultLanguageDescription;

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/defaultLanguage.ts
@@ -1,0 +1,36 @@
+import { LanguageDescription, LanguageSupport, StreamLanguage } from '@codemirror/language';
+
+// To allow auto-indent to work in an unrecognised language, we define a language
+// that provides just autoindent.
+const defaultLangauge = StreamLanguage.define({
+	startState: (indentUnit) => {
+		return {
+			indentUnit,
+			lastIndent: 0,
+			isLineStart: true,
+		};
+	},
+	token: (stream, state) => {
+		if (state.isLineStart) {
+			const indent = stream.eat(/\s*/) || '';
+			state.lastIndent = indent.length;
+			state.isLineStart = false;
+		} else {
+			const n = stream.next();
+			if (n === '\n') {
+				state.isLineStart = true;
+			}
+		}
+		return null;
+	},
+	indent: (state) => {
+		return state.lastIndent;
+	},
+});
+
+const baseLanguageDescription = LanguageDescription.of({
+	name: 'default',
+	support: new LanguageSupport(defaultLangauge),
+});
+
+export default baseLanguageDescription;

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.ts
@@ -1,0 +1,14 @@
+//
+// Exports a list of languages that can be used in fenced code blocks.
+//
+
+import { LanguageDescription } from '@codemirror/language';
+import { languages } from '@codemirror/language-data';
+import defaultLanguage from './defaultLanguage';
+
+
+const lookUpLanguage = (languageInfo: string) => {
+	return LanguageDescription.matchLanguageName(languages, languageInfo) ?? defaultLanguage;
+};
+
+export default lookUpLanguage;

--- a/packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.ts
+++ b/packages/editor/CodeMirror/markdown/codeBlockLanguages/lookUpLanguage.ts
@@ -1,12 +1,8 @@
-//
-// Exports a list of languages that can be used in fenced code blocks.
-//
-
 import { LanguageDescription } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
 import defaultLanguage from './defaultLanguage';
 
-
+// Intended for use by the `markdown({ ... })` extension.
 const lookUpLanguage = (languageInfo: string) => {
 	return LanguageDescription.matchLanguageName(languages, languageInfo) ?? defaultLanguage;
 };

--- a/packages/editor/CodeMirror/testUtil/loadLanguages.ts
+++ b/packages/editor/CodeMirror/testUtil/loadLanguages.ts
@@ -1,10 +1,8 @@
-import syntaxHighlightingLanguages from '../markdown/syntaxHighlightingLanguages';
+import allLanguages from '../markdown/codeBlockLanguages/allLanguages';
 
 // Ensure languages we use are loaded. Without this, tests may randomly fail (LanguageDescriptions
 // are loaded asyncronously, in the background).
 const loadLangauges = async () => {
-	const allLanguages = syntaxHighlightingLanguages;
-
 	for (const lang of allLanguages) {
 		await lang.load();
 	}


### PR DESCRIPTION
# Summary

Fixes #9971 by registering a language that provides only auto-indentation when the type of a code block is otherwise unrecognised.

# Notes
- This does not affect autoindent behavior in code blocks with no specified type.
- This pull request has been tested manually on desktop and mobile by 1) creating a mermaid code block with indentation and 2) pressing enter at the end of an indented line. It has been verified that the next line is auto-indented.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->