### PR TITLE
iOS: Fixes #8557: Fix white flash when editing notes in dark mode

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -9,8 +9,6 @@ import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import { WebViewErrorEvent, WebViewEvent, WebViewSource } from 'react-native-webview/lib/WebViewTypes';
 
 import Setting from '@joplin/lib/models/Setting';
-import { themeStyle } from '@joplin/lib/theme';
-import { Theme } from '@joplin/lib/themes/type';
 import shim from '@joplin/lib/shim';
 import { StyleProp, ViewStyle } from 'react-native';
 
@@ -34,8 +32,6 @@ type OnLoadEndCallback = (event: WebViewEvent)=> void;
 type OnFileUpdateCallback = (event: SourceFileUpdateEvent)=> void;
 
 interface Props {
-	themeId: number;
-
 	// A name to be associated with the WebView (e.g. NoteEditor)
 	// This name should be unique.
 	webviewInstanceId: string;
@@ -67,7 +63,6 @@ interface Props {
 }
 
 const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
-	const theme: Theme = themeStyle(props.themeId);
 	const webviewRef = useRef(null);
 	const [source, setSource] = useState<WebViewSource|undefined>(undefined);
 
@@ -135,7 +130,10 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 	return (
 		<WebView
 			style={{
-				backgroundColor: theme.backgroundColor,
+				// `backgroundColor: transparent` prevents a white fhash on iOS.
+				// It seems that `backgroundColor: theme.backgroundColor` does not
+				// prevent the flash.
+				backgroundColor: 'transparent',
 				...(props.style as any),
 			}}
 			ref={webviewRef}

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -103,7 +103,6 @@ export default function NoteBodyViewer(props: Props) {
 			<ExtendedWebView
 				ref={webviewRef}
 				webviewInstanceId='NoteBodyViewer'
-				themeId={props.themeId}
 				style={webViewStyle}
 				html={html}
 				injectedJavaScript={injectedJs.join('\n')}

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -28,10 +28,6 @@ interface Props {
 	onLoadEnd?: ()=> void;
 }
 
-const webViewStyle = {
-	backgroundColor: 'transparent',
-};
-
 export default function NoteBodyViewer(props: Props) {
 	const dialogBoxRef = useRef(null);
 	const webviewRef = useRef<WebViewControl>(null);
@@ -103,7 +99,6 @@ export default function NoteBodyViewer(props: Props) {
 			<ExtendedWebView
 				ref={webviewRef}
 				webviewInstanceId='NoteBodyViewer'
-				style={webViewStyle}
 				html={html}
 				injectedJavaScript={injectedJs.join('\n')}
 				mixedContentMode="always"

--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -314,7 +314,6 @@ const ImageEditor = (props: Props) => {
 
 	return (
 		<ExtendedWebView
-			themeId={props.themeId}
 			html={html}
 			injectedJavaScript={injectedJavaScript}
 			allowFileAccessFromJs={true}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -488,7 +488,6 @@ function NoteEditor(props: Props, ref: any) {
 			}}>
 				<ExtendedWebView
 					webviewInstanceId='NoteEditor'
-					themeId={props.themeId}
 					scrollEnabled={true}
 					ref={webviewRef}
 					html={html}


### PR DESCRIPTION
# Summary

It seems that `backgroundColor: theme.backgroundColor` does not set the WebView's background color to `theme.backgroundColor` immediately on load. However, `backgroundColor: 'transparent'` **does** seem to apply on load.

Fixes #8557.

Related to https://github.com/react-native-webview/react-native-webview/issues/318#issuecomment-471314785

# Testing

On a device with dark mode enabled:
1. Create a new note
2. Verify that the screen didn't flicker when the editor was opened
3. Switch to the note viewer
4. Switch back to the note editor (verify that the screen doesn't flicker)
5. Draw a picture and set the background color to transparent
6. Save and close the drawing
7. Edit the drawing and verify that there is no white flash while opening the drawing screen

This has been tested successfully on an iOS 17 simulator and an Android 7 device.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->