### PR TITLE
Server: Fixes #9931: Add task to delete events older than a week

### DIFF
--- a/packages/server/src/models/EventModel.test.ts
+++ b/packages/server/src/models/EventModel.test.ts
@@ -40,7 +40,7 @@ describe('EventModel', () => {
 	test('should delete events older than a week', async () => {
 		const now = Date.now();
 		const aWeekAgo = now - Week;
-		for (const difference of [-10, 5, 0, 5, 10]) {
+		for (const difference of [-10, -5, 0, 5, 10]) {
 			await models().event().create(EventType.TaskStarted, 'deleteExpiredTokens', aWeekAgo + difference);
 		}
 
@@ -49,7 +49,7 @@ describe('EventModel', () => {
 
 		await models().event().deleteOldEvents(aWeekAgo);
 		const remainingEvents = (await models().event().all());
-		expect(allEvents.length).toBe(3);
+		expect(remainingEvents.length).toBe(3);
 		for (const event of remainingEvents) {
 			expect(event.created_time).toBeGreaterThanOrEqual(aWeekAgo);
 		}

--- a/packages/server/src/models/EventModel.ts
+++ b/packages/server/src/models/EventModel.ts
@@ -1,7 +1,5 @@
 import { Event, EventType } from '../services/database/types';
 import BaseModel, { UuidType } from './BaseModel';
-import { Week } from '../utils/time';
-
 
 export default class EventModel extends BaseModel<Event> {
 
@@ -34,10 +32,10 @@ export default class EventModel extends BaseModel<Event> {
 			.first();
 	}
 
-	public async deleteOldEvents(beforeMillis: number = Date.now() - Week) {
+	public async deleteOldEvents(before: number) {
 		return this.withTransaction(async () => {
 			await this.db(this.tableName)
-				.where('created_time', '<', beforeMillis)
+				.where('created_time', '<', before)
 				.delete();
 		}, 'EventModel::deleteOldEvents');
 	}

--- a/packages/server/src/models/EventModel.ts
+++ b/packages/server/src/models/EventModel.ts
@@ -15,11 +15,11 @@ export default class EventModel extends BaseModel<Event> {
 		return UuidType.Native;
 	}
 
-	public async create(type: EventType, name = '') {
+	public async create(type: EventType, name = '', created_time = Date.now()) {
 		await this.save({
 			name,
 			type,
-			created_time: Date.now(),
+			created_time,
 		});
 	}
 

--- a/packages/server/src/models/EventModel.ts
+++ b/packages/server/src/models/EventModel.ts
@@ -1,5 +1,6 @@
 import { Event, EventType } from '../services/database/types';
 import BaseModel, { UuidType } from './BaseModel';
+import { Week } from '../utils/time';
 
 
 export default class EventModel extends BaseModel<Event> {
@@ -33,4 +34,11 @@ export default class EventModel extends BaseModel<Event> {
 			.first();
 	}
 
+	public async deleteOldEvents(beforeMillis: number = Date.now() - Week) {
+		return this.withTransaction(async () => {
+			await this.db(this.tableName)
+				.where('created_time', '<', beforeMillis)
+				.delete();
+		}, 'EventModel::deleteOldEvents');
+	}
 }

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -31,6 +31,7 @@ export const taskIdToLabel = (taskId: TaskId): string => {
 		[TaskId.ProcessOrphanedItems]: 'Process orphaned items',
 		[TaskId.ProcessShares]: 'Process shared items',
 		[TaskId.ProcessEmails]: 'Process emails',
+		[TaskId.DeleteOldEvents]: 'Delete old events',
 	};
 
 	const s = strings[taskId];

--- a/packages/server/src/services/database/types.ts
+++ b/packages/server/src/services/database/types.ts
@@ -135,6 +135,7 @@ export enum TaskId {
 	ProcessOrphanedItems,
 	ProcessShares,
 	ProcessEmails,
+	DeleteOldEvents,
 }
 
 // AUTO-GENERATED-TYPES

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -74,6 +74,13 @@ export default async function(env: Env, models: Models, config: Config, services
 			schedule: '* * * * *',
 			run: (_models: Models, services: Services) => services.email.runMaintenance(),
 		},
+
+		{
+			id: TaskId.DeleteOldEvents,
+			description: taskIdToLabel(TaskId.DeleteOldEvents),
+			schedule: '0 0 * * *',
+			run: (models: Models) => models.event().deleteOldEvents(),
+		},
 	];
 
 	if (config.USER_DATA_AUTO_DELETE_ENABLED) {

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -3,6 +3,7 @@ import { TaskId } from '../services/database/types';
 import TaskService, { Task, taskIdToLabel } from '../services/TaskService';
 import { Services } from '../services/types';
 import { Config, Env } from './types';
+import { Week } from './time';
 
 export default async function(env: Env, models: Models, config: Config, services: Services): Promise<TaskService> {
 	const taskService = new TaskService(env, models, config, services);
@@ -79,7 +80,7 @@ export default async function(env: Env, models: Models, config: Config, services
 			id: TaskId.DeleteOldEvents,
 			description: taskIdToLabel(TaskId.DeleteOldEvents),
 			schedule: '0 0 * * *',
-			run: (models: Models) => models.event().deleteOldEvents(),
+			run: (models: Models) => models.event().deleteOldEvents(Date.now() - Week),
 		},
 	];
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
This fixes #9931 through adding a task that deletes any tasks older than a week.

The task in question looks like this:
```ts
public async deleteOldEvents(beforeMillis: number = Date.now() - Week) {
	return this.withTransaction(async () => {
		await this.db(this.tableName)
			.where('created_time', '<', beforeMillis)
			.delete();
	}, 'EventModel::deleteOldEvents');
}
```
