### PR TITLE
plugin generator: update manifest.json to include promo tile

### DIFF
--- a/packages/generator-joplin/generators/app/templates/src/manifest.json
+++ b/packages/generator-joplin/generators/app/templates/src/manifest.json
@@ -11,5 +11,6 @@
 	"keywords": [],
 	"categories": [],
 	"screenshots": [],
-	"icons": {}
+	"icons": {},
+	"promo_tile": {}
 }


### PR DESCRIPTION
Add new `promo_tile` property to the generated plugin manifest file.
