### PR TITLE
Desktop: Resolves #9980: Support Ctrl+Enter keyboard shortcut (Cmd+Enter on MacOS)

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useKeymap.ts
@@ -145,6 +145,7 @@ export default function useKeymap(CodeMirror: any) {
 			'Alt-Right': 'goLineEnd',
 			'Ctrl-Backspace': 'delGroupBefore',
 			'Ctrl-Delete': 'delGroupAfter',
+			'Ctrl-Enter': 'insertLineAfter',
 
 			'fallthrough': 'basic',
 		};
@@ -167,6 +168,7 @@ export default function useKeymap(CodeMirror: any) {
 				'Alt-Backspace': 'delGroupBefore',
 				'Alt-Delete': 'delGroupAfter',
 				'Cmd-Backspace': 'delWrappedLineLeft',
+				'Cmd-Enter': 'insertLineAfter',
 
 				'fallthrough': 'basic',
 			};

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -9,7 +9,7 @@ import { classHighlighter } from '@lezer/highlight';
 import {
 	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command, rectangularSelection,
 } from '@codemirror/view';
-import { history, undoDepth, redoDepth, standardKeymap, insertBlankLine } from '@codemirror/commands';
+import { history, undoDepth, redoDepth, standardKeymap } from '@codemirror/commands';
 
 import { keymap, KeyBinding } from '@codemirror/view';
 import { searchKeymap } from '@codemirror/search';
@@ -29,6 +29,7 @@ import { selectionFormattingEqual } from '../SelectionFormatting';
 import configFromSettings from './configFromSettings';
 import getScrollFraction from './getScrollFraction';
 import CodeMirrorControl from './CodeMirrorControl';
+import insertLineAfter from './editorCommands/insertLineAfter';
 
 const createEditor = (
 	parentElement: HTMLElement, props: EditorProps,
@@ -261,7 +262,10 @@ const createEditor = (
 					}),
 					keyCommand('Tab', insertOrIncreaseIndent, true),
 					keyCommand('Shift-Tab', decreaseIndent, true),
-					keyCommand('Mod-Enter', insertBlankLine, true),
+					keyCommand('Mod-Enter', (_: EditorView) => {
+						insertLineAfter(_);
+						return true;
+					}, true),
 
 					...standardKeymap, ...historyKeymap, ...searchKeymap,
 				]),

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -9,7 +9,7 @@ import { classHighlighter } from '@lezer/highlight';
 import {
 	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command, rectangularSelection,
 } from '@codemirror/view';
-import { history, undoDepth, redoDepth, standardKeymap } from '@codemirror/commands';
+import { history, undoDepth, redoDepth, standardKeymap, insertBlankLine } from '@codemirror/commands';
 
 import { keymap, KeyBinding } from '@codemirror/view';
 import { searchKeymap } from '@codemirror/search';
@@ -261,6 +261,7 @@ const createEditor = (
 					}),
 					keyCommand('Tab', insertOrIncreaseIndent, true),
 					keyCommand('Shift-Tab', decreaseIndent, true),
+					keyCommand('Mod-Enter', insertBlankLine, true),
 
 					...standardKeymap, ...historyKeymap, ...searchKeymap,
 				]),


### PR DESCRIPTION
Fixes #9980 by adding key bindings for Ctrl+Enter on Windows/Linux and Cmd+Enter on macOS. This adds functionality to add a new line after the line where the cursor currently is.

### Testing

This has been tested successfully on Windows 11 and Ubuntu.


https://github.com/laurent22/joplin/assets/91818868/585a8f92-7337-4c13-915e-72100f23cb69

