### PR TITLE
Chore: Plugin API: Rename `CodeMirrorContentScriptModule` to `MarkdownEditorContentScriptModule`

### DIFF
--- a/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
@@ -535,7 +535,7 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 
 type EditorCommandCallback = (...args: any[])=> any;
 
-export interface CodeMirrorControl {
+export interface MarkdownEditorControl {
 	/** Points to a CodeMirror 6 EditorView instance. */
 	editor: any;
 	cm6: any;
@@ -566,8 +566,8 @@ export interface CodeMirrorControl {
 	};
 }
 
-export interface CodeMirrorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (codeMirrorControl: CodeMirrorControl)=> void;
+export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
+	plugin: (editorControl: MarkdownEditorControl)=> void;
 }
 
 export enum ContentScriptType {

--- a/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
@@ -535,7 +535,7 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 
 type EditorCommandCallback = (...args: any[])=> any;
 
-export interface MarkdownEditorControl {
+export interface CodeMirrorControl {
 	/** Points to a CodeMirror 6 EditorView instance. */
 	editor: any;
 	cm6: any;
@@ -567,7 +567,7 @@ export interface MarkdownEditorControl {
 }
 
 export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (editorControl: MarkdownEditorControl)=> void;
+	plugin: (editorControl: CodeMirrorControl)=> void;
 }
 
 export enum ContentScriptType {

--- a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
@@ -6,7 +6,7 @@
 //
 import { lineNumbers, highlightActiveLineGutter, EditorView } from '@codemirror/view';
 import { completeFromList } from '@codemirror/autocomplete';
-import { CodeMirrorContentScriptModule, ContentScriptContext } from 'api/types';
+import { MarkdownEditorContentScriptModule, ContentScriptContext } from 'api/types';
 //
 // For the above import to work, you may also need to add @codemirror/view as a dev dependency
 // to package.json. (For the type information only).
@@ -15,7 +15,7 @@ import { CodeMirrorContentScriptModule, ContentScriptContext } from 'api/types';
 //  const { lineNumbers } = joplin.require('@codemirror/view');
 
 
-export default (_context: ContentScriptContext): CodeMirrorContentScriptModule => {
+export default (_context: ContentScriptContext): MarkdownEditorContentScriptModule => {
 	return {
 		// - codeMirrorWrapper: A thin wrapper around CodeMirror 6, designed to be similar to the
 		//     CodeMirror 5 API. If running in CodeMirror 5, a CodeMirror object is provided instead.

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -533,6 +533,43 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 	plugin: (markdownIt: any, options: any)=> any;
 }
 
+type EditorCommandCallback = (...args: any[])=> any;
+
+export interface MarkdownEditorControl {
+	/** Points to a CodeMirror 6 EditorView instance. */
+	editor: any;
+	cm6: any;
+
+	/** `extension` should be a [CodeMirror 6 extension](https://codemirror.net/docs/ref/#state.Extension). */
+	addExtension(extension: any|any[]): void;
+
+	supportsCommand(name: string): boolean;
+	execCommand(name: string, ...args: any[]): any;
+	registerCommand(name: string, callback: EditorCommandCallback): void;
+
+	joplinExtensions: {
+		/**
+		 * Returns a [CodeMirror 6 extension](https://codemirror.net/docs/ref/#state.Extension) that
+		 * registers the given [CompletionSource](https://codemirror.net/docs/ref/#autocomplete.CompletionSource).
+		 *
+		 * Use this extension rather than the built-in CodeMirror [`autocompletion`](https://codemirror.net/docs/ref/#autocomplete.autocompletion)
+		 * if you don't want to use [languageData-based autocompletion](https://codemirror.net/docs/ref/#autocomplete.autocompletion^config.override).
+		 *
+		 * Using `autocompletion({ override: [ ... ]})` causes errors when done by multiple plugins.
+		 */
+		completionSource(completionSource: any): any;
+
+		/**
+		 * Creates an extension that enables or disables [`languageData`-based autocompletion](https://codemirror.net/docs/ref/#autocomplete.autocompletion^config.override).
+		 */
+		enableLanguageDataAutocomplete: { of: (enabled: boolean)=> any };
+	};
+}
+
+export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
+	plugin: (editorControl: MarkdownEditorControl)=> void;
+}
+
 export enum ContentScriptType {
 	/**
 	 * Registers a new Markdown-It plugin, which should follow the template

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -533,43 +533,6 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 	plugin: (markdownIt: any, options: any)=> any;
 }
 
-type EditorCommandCallback = (...args: any[])=> any;
-
-export interface CodeMirrorControl {
-	/** Points to a CodeMirror 6 EditorView instance. */
-	editor: any;
-	cm6: any;
-
-	/** `extension` should be a [CodeMirror 6 extension](https://codemirror.net/docs/ref/#state.Extension). */
-	addExtension(extension: any|any[]): void;
-
-	supportsCommand(name: string): boolean;
-	execCommand(name: string, ...args: any[]): any;
-	registerCommand(name: string, callback: EditorCommandCallback): void;
-
-	joplinExtensions: {
-		/**
-		 * Returns a [CodeMirror 6 extension](https://codemirror.net/docs/ref/#state.Extension) that
-		 * registers the given [CompletionSource](https://codemirror.net/docs/ref/#autocomplete.CompletionSource).
-		 *
-		 * Use this extension rather than the built-in CodeMirror [`autocompletion`](https://codemirror.net/docs/ref/#autocomplete.autocompletion)
-		 * if you don't want to use [languageData-based autocompletion](https://codemirror.net/docs/ref/#autocomplete.autocompletion^config.override).
-		 *
-		 * Using `autocompletion({ override: [ ... ]})` causes errors when done by multiple plugins.
-		 */
-		completionSource(completionSource: any): any;
-
-		/**
-		 * Creates an extension that enables or disables [`languageData`-based autocompletion](https://codemirror.net/docs/ref/#autocomplete.autocompletion^config.override).
-		 */
-		enableLanguageDataAutocomplete: { of: (enabled: boolean)=> any };
-	};
-}
-
-export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (editorControl: CodeMirrorControl)=> void;
-}
-
 export enum ContentScriptType {
 	/**
 	 * Registers a new Markdown-It plugin, which should follow the template

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -535,7 +535,7 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 
 type EditorCommandCallback = (...args: any[])=> any;
 
-export interface MarkdownEditorControl {
+export interface CodeMirrorControl {
 	/** Points to a CodeMirror 6 EditorView instance. */
 	editor: any;
 	cm6: any;
@@ -567,7 +567,7 @@ export interface MarkdownEditorControl {
 }
 
 export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (editorControl: MarkdownEditorControl)=> void;
+	plugin: (editorControl: CodeMirrorControl)=> void;
 }
 
 export enum ContentScriptType {

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -535,7 +535,7 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 
 type EditorCommandCallback = (...args: any[])=> any;
 
-export interface CodeMirrorControl {
+export interface MarkdownEditorControl {
 	/** Points to a CodeMirror 6 EditorView instance. */
 	editor: any;
 	cm6: any;
@@ -566,8 +566,8 @@ export interface CodeMirrorControl {
 	};
 }
 
-export interface CodeMirrorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (codeMirrorControl: CodeMirrorControl)=> void;
+export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
+	plugin: (editorControl: MarkdownEditorControl)=> void;
 }
 
 export enum ContentScriptType {

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -535,7 +535,7 @@ export interface MarkdownItContentScriptModule extends Omit<ContentScriptModule,
 
 type EditorCommandCallback = (...args: any[])=> any;
 
-export interface MarkdownEditorControl {
+export interface CodeMirrorControl {
 	/** Points to a CodeMirror 6 EditorView instance. */
 	editor: any;
 	cm6: any;
@@ -567,7 +567,7 @@ export interface MarkdownEditorControl {
 }
 
 export interface MarkdownEditorContentScriptModule extends Omit<ContentScriptModule, 'plugin'> {
-	plugin: (editorControl: MarkdownEditorControl)=> void;
+	plugin: (editorControl: CodeMirrorControl)=> void;
 }
 
 export enum ContentScriptType {


### PR DESCRIPTION
# Summary

See https://github.com/laurent22/joplin/pull/10010#discussion_r1504499244

# Notes

I've left `CodeMirrorControl` as-is. This matches the corresponding type name in the main Joplin codebase and makes it clearer that `.addExtension` adds CodeMirror6 `Extension` objects.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->