### PR TITLE
Desktop: Fixes #10023: Beta editor plugins: Fix opening and closing settings can break some plugins with legacy code

### DIFF
--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.test.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.test.ts
@@ -108,4 +108,22 @@ describe('CodeMirror5Emulation', () => {
 		// additional times if its option hasn't updated.
 		expect(onOtherOptionUpdate).toHaveBeenCalledTimes(1);
 	});
+
+	it('defineExtension should override previous extensions with the same name', () => {
+		const codeMirror = makeCodeMirrorEmulation('Test...');
+		const testExtensionFn1 = jest.fn();
+		const testExtensionFn2 = jest.fn();
+
+		codeMirror.defineExtension('defineExtensionShouldOverride', testExtensionFn1);
+
+		(codeMirror as any).defineExtensionShouldOverride();
+		expect(testExtensionFn1).toHaveBeenCalledTimes(1);
+		expect(testExtensionFn2).toHaveBeenCalledTimes(0);
+
+		codeMirror.defineExtension('defineExtensionShouldOverride', testExtensionFn2);
+
+		(codeMirror as any).defineExtensionShouldOverride();
+		expect(testExtensionFn1).toHaveBeenCalledTimes(1);
+		expect(testExtensionFn2).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -272,7 +272,7 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 	}
 
 	public defineExtension(name: string, value: any) {
-		(CodeMirror5Emulation.prototype as any)[name] ??= value;
+		(CodeMirror5Emulation.prototype as any)[name] = value;
 	}
 
 	public defineOption(name: string, defaultValue: any, onUpdate: OptionUpdateCallback) {


### PR DESCRIPTION
# Summary

This fixes an issue where opening and closing settings could break some legacy plugins. A similar change was also made as a part of #9928.

Fixes #10023.

# Testing

Follow reproduction steps in #10023:

1. Apply the following diff:
```diff
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
index af0532dcf..3a816a16c 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
@@ -47,7 +47,7 @@ export default (_context: ContentScriptContext): CodeMirrorContentScriptModule =
 
 			// We can also register editor commands. These commands can be later executed with:
 			//   joplin.commands.execute('editor.execCommand', { name: 'name-here', args: [] })
-			codeMirrorWrapper.registerCommand('wrap-selection-with-tag', (tagName: string) => {
+			(codeMirrorWrapper as any).defineExtension('wrap-selection-with-tag', (tagName: string) => {
 				const editor: EditorView = codeMirrorWrapper.editor;
 
 				// See https://codemirror.net/examples/change/
```
2. Build and add the CodeMirror 6 demo plugin (`packages/app-cli/tests/support/plugins/codemirror6/`) as a development plugin.
3. Verify that running `:underline` from the command palette works.
4. Open settings
5. Close settings
6. Verify that running `:underline` from the command palette still works.

This has been tested successfully on Ubuntu 23.10.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->