### PR TITLE
Desktop: Fixes #9453: Improve visibility of selected note in OLED dark theme

### DIFF
--- a/packages/lib/themes/oledDark.ts
+++ b/packages/lib/themes/oledDark.ts
@@ -7,7 +7,6 @@ const theme: Theme = {
 	color: '#dddddd',
 	colorFaded: '#777777',
 	dividerColor: '#3D444E',
-	selectedColor: '#333333',
 	urlColor: 'rgb(166,166,255)',
 	codeColor: '#ffffff',
 	raisedBackgroundColor: '#0F2051',


### PR DESCRIPTION
# Summary
I removed the `selectedColor` property from the "OLED dark" theme to inherit it from the "dark" theme as the rest of this navigation is inherited from it, too.

Fixes #9453.

# Before and after:
![before-after](https://github.com/laurent22/joplin/assets/68117355/28d26a96-56d4-4a88-b47e-fd2b202f01f9)

Tested in 2.14.17 (dev, linux).