### PR TITLE
Desktop: Fixes #9960: Modified setting to store profile languages

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -564,7 +564,6 @@ async function initialize(dispatch: Function) {
 			reg.logger().info(`First start: detected locale as ${detectedLocale}`);
 
 			Setting.skipDefaultMigrations();
-			Setting.setValue('firstStart', 0);
 		} else {
 			Setting.applyDefaultMigrations();
 		}

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -748,7 +748,6 @@ export default class BaseApplication {
 				Setting.setValue('sync.interval', 3600);
 			}
 
-			Setting.setValue('firstStart', 0);
 		} else {
 			Setting.applyDefaultMigrations();
 			Setting.applyUserSettingMigration();

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1646,7 +1646,7 @@ class Setting extends BaseModel {
 
 			'spellChecker.enabled': { value: true, type: SettingItemType.Bool, isGlobal: true, storage: SettingStorage.File, public: false },
 			'spellChecker.language': { value: '', type: SettingItemType.String, isGlobal: true, storage: SettingStorage.File, public: false }, // Depreciated in favour of spellChecker.languages.
-			'spellChecker.languages': { value: [], type: SettingItemType.Array, isGlobal: true, storage: SettingStorage.File, public: false },
+			'spellChecker.languages': { value: [], type: SettingItemType.Array, isGlobal: false, storage: SettingStorage.File, public: false },
 
 			windowContentZoomFactor: {
 				value: 100,

--- a/packages/lib/services/spellChecker/SpellCheckerService.ts
+++ b/packages/lib/services/spellChecker/SpellCheckerService.ts
@@ -81,7 +81,13 @@ export default class SpellCheckerService {
 		} else {
 			enabledLanguages.push(language);
 		}
-		Setting.setValue('spellChecker.languages', enabledLanguages);
+
+		if (Setting.value('firstStart')) {
+			Setting.setValue('spellChecker.languages', [this.defaultLanguage]);
+			Setting.setValue('firstStart', 0);
+		} else {
+			Setting.setValue('spellChecker.languages', enabledLanguages);
+		}
 		this.applyStateToDriver();
 		void this.addLatestSelectedLanguage(language);
 	}


### PR DESCRIPTION
 Hi, This pr fixes [#9960](https://github.com/laurent22/joplin/issues/9960)

Quick summary of what I did:
- Modified  spellChecker.languages  isGlobe settingItem so that it store/take its value from profile setting itself (not from global setting.json)
- Modified SpellCheckerServices.ts to make default spellChecker language to set 'en-US' when profile is created for the first Time

Here are the test for windows:
![default](https://github.com/laurent22/joplin/assets/138118622/7eb3949b-5383-4162-a4ff-a6796b2f0d09)
![existing](https://github.com/laurent22/joplin/assets/138118622/4692736c-01ce-484b-a82e-f9060b103b5b)
![newProfile](https://github.com/laurent22/joplin/assets/138118622/f110a93d-6db9-431e-814e-cf65b1be5dda)

Here is a test video if needed: 

https://github.com/laurent22/joplin/assets/138118622/b117fb2b-bb9b-4a15-8bd5-b10c2af7afd7

I have tested this for windows.
I will be giving tests for Android soon


(P.S - This is my first PR so please guide me if anything is wrong)
<!--
Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

