### PR TITLE
chore: use latest node18 for action runs

### DIFF
--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -23,9 +23,7 @@ jobs:
       - uses: olegtarasov/get-tag@v2.1
       - uses: actions/setup-node@v2
         with:
-          # We need to pin the version to 18.15, because 18.16+ fails with this error:
-          # https://github.com/facebook/react-native/issues/36440
-          node-version: '18.15.0'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install Yarn

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -85,16 +85,14 @@ jobs:
       - uses: olegtarasov/get-tag@v2.1
       - uses: actions/setup-node@v2
         with:
-          # We need to pin the version to 18.15, because 18.16+ fails with this error:
-          # https://github.com/facebook/react-native/issues/36440
-          node-version: '18.15.0'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install Yarn
         run: |
           # https://yarnpkg.com/getting-started/install
           corepack enable
-      
+
       # Login to Docker only if we're on a server release tag. If we run this on
       # a pull request it will fail because the PR doesn't have access to
       # secrets
@@ -202,7 +200,7 @@ jobs:
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
           docker run joplin/server:0.0.0-beta node dist/app.js migrate list
- 
+
       - name: Check HTTP request
         run: |
           # Need to pass environment variables:
@@ -214,23 +212,22 @@ jobs:
           # Check if status code is correct
           # if the actual_status DOES NOT include the expected_status
           # it exits the process with code 1
-          
+
           expected_status="HTTP/1.1 200 OK"
           actual_status=$(curl -I -X GET http://localhost:22300/api/ping | head -n 1)
-          if [[ ! "$actual_status" =~ "$expected_status" ]]; then 
+          if [[ ! "$actual_status" =~ "$expected_status" ]]; then
             echo 'Failed while checking the status code after request to /api/ping'
             echo 'expected: ' $expected_status
             echo 'actual:   ' $actual_status
-            exit 1; 
+            exit 1;
           fi
-          
+
           # Check if the body response is correct
           # if the actual_body is different of expected_body exit with code 1
           expected_body='{"status":"ok","message":"Joplin Server is running"}'
           actual_body=$(curl http://localhost:22300/api/ping)
-          
+
           if [[ "$actual_body" != "$expected_body" ]]; then
             echo 'Failed while checking the body response after request to /api/ping'
             exit 1;
           fi
-


### PR DESCRIPTION
Bump to use latest node18 per https://github.com/facebook/react-native/issues/36440#issuecomment-1836298262 

(not sure what is the process of bumping to use latest node LTS release, node v20)