### PR TITLE
Desktop: Resolves #9981: Fix Vim keymap error with beta editor

### DIFF
--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -11,6 +11,7 @@ import { html } from '@codemirror/lang-html';
 import { defaultKeymap, emacsStyleKeymap } from '@codemirror/commands';
 import { vim } from '@replit/codemirror-vim';
 import { indentUnit } from '@codemirror/language';
+import { Prec } from '@codemirror/state';
 
 const configFromSettings = (settings: EditorSettings) => {
 	const languageExtension = (() => {
@@ -56,7 +57,7 @@ const configFromSettings = (settings: EditorSettings) => {
 	}
 
 	if (settings.keymap === EditorKeymap.Vim) {
-		extensions.push(vim());
+		extensions.push(Prec.high(vim()));
 	} else if (settings.keymap === EditorKeymap.Emacs) {
 		extensions.push(keymap.of(emacsStyleKeymap));
 	}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -91,3 +91,4 @@ activatable
 titlewrapper
 notyf
 Notyf
+Prec


### PR DESCRIPTION
Fixes #9981 
### Summary
Fixes `Ctrl+u` and `Ctrl+d` not working as expected by setting a higher precedence to the vim plugin. 

![electron_fO6swViSDr](https://github.com/laurent22/joplin/assets/104646586/0779a52b-5a61-4395-abc9-cc359433bec0)

### Reference
https://codemirror.net/docs/ref/#state.Prec.high