### PR TITLE
Desktop: Resolves #10025 Toggle external editing button overlaps with bold button fixes 

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -357,7 +357,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		document.head.appendChild(element);
 		element.appendChild(document.createTextNode(`
 			.joplin-tinymce .tox-editor-header {
-				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 2}px;
+				padding-left: ${styles.leftExtraToolbarContainer.width + styles.leftExtraToolbarContainer.padding * 8}px;
 				padding-right: ${styles.rightExtraToolbarContainer.width + styles.rightExtraToolbarContainer.padding * 2}px;
 			}
 			

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.ts
@@ -38,7 +38,7 @@ export default function styles(props: NoteBodyEditorProps) {
 			},
 			leftExtraToolbarContainer: {
 				...extraToolbarContainer,
-				width: 80,
+				width: 120,
 				left: 0,
 			},
 			rightExtraToolbarContainer: {


### PR DESCRIPTION
Before Changes:
[Screencast from 05-03-24 03:47:55 PM IST.webm](https://github.com/laurent22/joplin/assets/97527096/c8e65d15-f1c1-485f-8550-fdb2ad86e1af)

After Changes:
[Screencast from 05-03-24 03:51:28 PM IST.webm](https://github.com/laurent22/joplin/assets/97527096/b4c9aca5-eb72-4ef0-8a87-413c113303f6)

fixes #10025 