### PR TITLE
Desktop: Configure tinymce to handle the first table row as header

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -593,7 +593,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				'h1', 'h2', 'h3', '|',
 				'hr', '|',
 				'blockquote', '|',
-				'table', '|',
+				'tableWithHeader', '|',
 				`joplinInsertDateTime${toolbarPluginButtons}`,
 			];
 
@@ -680,6 +680,22 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 							return function() {
 								if (unbind) unbind();
 							};
+						},
+					});
+
+					editor.ui.registry.addMenuButton('tableWithHeader', {
+						icon: 'table',
+						tooltip: 'Table',
+						fetch: (callback) => {
+							callback([
+								{
+									type: 'fancymenuitem',
+									fancytype: 'inserttable',
+									onAction: (data) => {
+										editor.execCommand('mceInsertTable', false, { rows: data.numRows, columns: data.numColumns, options: { headerRows: 1 } });
+									},
+								},
+							]);
 						},
 					});
 


### PR DESCRIPTION
This was once implemented in #8163, but got accidentally reverted in #8393. Related forum discussion: https://discourse.joplinapp.org/t/how-do-i-create-tables-with-headers-in-rich-editor/35610

This PR doesn't change anything on the UI. Only the tables are inserted with header row by default.