### PR TITLE
Desktop: Fixes #10062: Fix pasting images from the rich text editor into the rich text editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -138,16 +138,10 @@ export async function getResourcesFromPasteEvent(event: any) {
 	return output;
 }
 
-export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHandler | null, mdToHtml: MarkupToHtmlHandler | null) {
+
+const processImagesInPastedHtml = async (html: string) => {
 	const allImageUrls: string[] = [];
 	const mappedResources: Record<string, string> = {};
-
-	// When copying text from eg. GitHub, the HTML might contain non-breaking
-	// spaces instead of regular spaces. If these non-breaking spaces are
-	// inserted into the TinyMCE editor (using insertContent), they will be
-	// dropped. So here we convert them to regular spaces.
-	// https://stackoverflow.com/a/31790544/561309
-	html = html.replace(/[\u202F\u00A0]/g, ' ');
 
 	htmlUtils.replaceImageUrls(html, (src: string) => {
 		allImageUrls.push(src);
@@ -200,6 +194,19 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 
 	await Promise.all(downloadImages);
 
+	return htmlUtils.replaceImageUrls(html, (src: string) => mappedResources[src]);
+};
+
+export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHandler | null, mdToHtml: MarkupToHtmlHandler | null) {
+	// When copying text from eg. GitHub, the HTML might contain non-breaking
+	// spaces instead of regular spaces. If these non-breaking spaces are
+	// inserted into the TinyMCE editor (using insertContent), they will be
+	// dropped. So here we convert them to regular spaces.
+	// https://stackoverflow.com/a/31790544/561309
+	html = html.replace(/[\u202F\u00A0]/g, ' ');
+
+	html = await processImagesInPastedHtml(html);
+
 	// TinyMCE can accept any type of HTML, including HTML that may not be preserved once saved as
 	// Markdown. For example the content may have a dark background which would be supported by
 	// TinyMCE, but lost once the note is saved. So here we convert the HTML to Markdown then back
@@ -209,11 +216,7 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 		html = (await mdToHtml(MarkupLanguage.Markdown, md, markupRenderOptions({ bodyOnly: true }))).html;
 	}
 
-	return extractHtmlBody(rendererHtmlUtils.sanitizeHtml(
-		htmlUtils.replaceImageUrls(html, (src: string) => {
-			return mappedResources[src];
-		}), {
-			allowedFilePrefixes: [Setting.value('resourceDir')],
-		},
-	));
+	return extractHtmlBody(rendererHtmlUtils.sanitizeHtml(html, {
+		allowedFilePrefixes: [Setting.value('resourceDir')],
+	}));
 }


### PR DESCRIPTION
# Summary

Fixes #10062 by replacing image URLs before cache breakers (`?t=someidhere`s) are added.

> [!NOTE]
>
> This pull request targets version 2.14 because this seems to be a regression. (Comparing with version 2.13.8).
>

# Testing

1. Create a note with images in the rich text editor
2. Select everything
3. Paste it
4. Switch to the markdown editor
5. Switch back to the rich text editor
6. Verify that images are still visible

This has been tested successfully on Ubuntu 23.10.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->