### PR TITLE
Desktop: Fixes #10060: Fix "New note" button rendering when startup with Trash can selected.

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -24,7 +24,7 @@ interface Props {
 	width: number;
 	newNoteButtonEnabled: boolean;
 	newTodoButtonEnabled: boolean;
-	setNewNoteButtonRef: React.Dispatch<React.SetStateAction<Element>>;
+	setNewNoteButtonElement: React.Dispatch<React.SetStateAction<Element>>;
 	lineCount: number;
 	breakpoint: number;
 	dynamicBreakpoints: Breakpoints;
@@ -210,7 +210,7 @@ function NoteListControls(props: Props) {
 			<TopRow className="new-note-todo-buttons">
 				<StyledButton
 					ref={(el: Element) => {
-						props.setNewNoteButtonRef(el);
+						props.setNewNoteButtonElement(el);
 					}}
 					className="new-note-button"
 					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -24,7 +24,7 @@ interface Props {
 	width: number;
 	newNoteButtonEnabled: boolean;
 	newTodoButtonEnabled: boolean;
-	newNoteButtonRef: React.MutableRefObject<any>;
+	setNewNoteButtonRef: React.Dispatch<React.SetStateAction<Element>>;
 	lineCount: number;
 	breakpoint: number;
 	dynamicBreakpoints: Breakpoints;
@@ -208,7 +208,10 @@ function NoteListControls(props: Props) {
 
 		return (
 			<TopRow className="new-note-todo-buttons">
-				<StyledButton ref={props.newNoteButtonRef}
+				<StyledButton 
+          ref={(el:Element) => {
+            props.setNewNoteButtonRef(el);
+          }}
 					className="new-note-button"
 					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }
 					iconName={noteIcon}

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -208,10 +208,10 @@ function NoteListControls(props: Props) {
 
 		return (
 			<TopRow className="new-note-todo-buttons">
-				<StyledButton 
-          ref={(el:Element) => {
-            props.setNewNoteButtonRef(el);
-          }}
+				<StyledButton
+					ref={(el: Element) => {
+						props.setNewNoteButtonRef(el);
+					}}
 					className="new-note-button"
 					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }
 					iconName={noteIcon}

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -40,21 +40,21 @@ const StyledRoot = styled.div`
 	width: 100%;
 `;
 
-const getTextWidth = (newNoteRef: Element, text: string): number => {
+const getTextWidth = (newNoteButtonElement: Element, text: string): number => {
 	const canvas = document.createElement('canvas');
 	if (!canvas) throw new Error('Failed to create canvas element');
 	const ctx = canvas.getContext('2d');
 	if (!ctx) throw new Error('Failed to get context');
-	const fontWeight = getComputedStyle(newNoteRef).getPropertyValue('font-weight');
-	const fontSize = getComputedStyle(newNoteRef).getPropertyValue('font-size');
-	const fontFamily = getComputedStyle(newNoteRef).getPropertyValue('font-family');
+	const fontWeight = getComputedStyle(newNoteButtonElement).getPropertyValue('font-weight');
+	const fontSize = getComputedStyle(newNoteButtonElement).getPropertyValue('font-size');
+	const fontFamily = getComputedStyle(newNoteButtonElement).getPropertyValue('font-family');
 	ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
 	return ctx.measureText(text).width;
 };
 
 // Even though these calculations mostly concern the NoteListControls component, we do them here
 // because we need to know the height of that control to calculate the note list height.
-const useNoteListControlsBreakpoints = (width: number, newNoteRef: Element, selectedFolderId: string) => {
+const useNoteListControlsBreakpoints = (width: number, newNoteButtonElement: Element, selectedFolderId: string) => {
 	const [dynamicBreakpoints, setDynamicBreakpoints] = useState<Breakpoints>({ Sm: BaseBreakpoint.Sm, Md: BaseBreakpoint.Md, Lg: BaseBreakpoint.Lg, Xl: BaseBreakpoint.Xl });
 	const previousWidth = usePrevious(width);
 	const widthHasChanged = width !== previousWidth;
@@ -62,12 +62,12 @@ const useNoteListControlsBreakpoints = (width: number, newNoteRef: Element, sele
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {
-		if (!newNoteRef) return;
+		if (!newNoteButtonElement) return;
 		if (!showNewNoteButton) return;
 
 		// Use the longest string to calculate the amount of extra width needed
-		const smAdditional = getTextWidth(newNoteRef, _('note')) > getTextWidth(newNoteRef, _('to-do')) ? getTextWidth(newNoteRef, _('note')) : getTextWidth(newNoteRef, _('to-do'));
-		const mdAdditional = getTextWidth(newNoteRef, _('New note')) > getTextWidth(newNoteRef, _('New to-do')) ? getTextWidth(newNoteRef, _('New note')) : getTextWidth(newNoteRef, _('New to-do'));
+		const smAdditional = getTextWidth(newNoteButtonElement, _('note')) > getTextWidth(newNoteButtonElement, _('to-do')) ? getTextWidth(newNoteButtonElement, _('note')) : getTextWidth(newNoteButtonElement, _('to-do'));
+		const mdAdditional = getTextWidth(newNoteButtonElement, _('New note')) > getTextWidth(newNoteButtonElement, _('New to-do')) ? getTextWidth(newNoteButtonElement, _('New note')) : getTextWidth(newNoteButtonElement, _('New to-do'));
 
 		const Sm = BaseBreakpoint.Sm + smAdditional * 2;
 		const Md = BaseBreakpoint.Md + mdAdditional * 2;
@@ -75,7 +75,7 @@ const useNoteListControlsBreakpoints = (width: number, newNoteRef: Element, sele
 		const Xl = BaseBreakpoint.Xl;
 
 		setDynamicBreakpoints({ Sm, Md, Lg, Xl });
-	}, [newNoteRef, showNewNoteButton, widthHasChanged]);
+	}, [newNoteButtonElement, showNewNoteButton, widthHasChanged]);
 
 	const breakpoint: number = useMemo(() => {
 		// Find largest breakpoint that width is less than
@@ -107,11 +107,11 @@ export default function NoteListWrapper(props: Props) {
 	const theme = themeStyle(props.themeId);
 	const [controlHeight] = useState(theme.topRowHeight);
 	const listRenderer = useListRenderer(props.listRendererId, props.startupPluginsLoaded);
-	const [newNoteButtonRef, setNewNoteButtonRef] = useState<Element>(null);
+	const [newNoteButtonElement, setNewNoteButtonElement] = useState<Element>(null);
 	const isMultiColumns = listRenderer ? listRenderer.multiColumns : false;
 	const columns = isMultiColumns ? props.columns : null;
 
-	const { breakpoint, dynamicBreakpoints, lineCount } = useNoteListControlsBreakpoints(props.size.width, newNoteButtonRef, props.selectedFolderId);
+	const { breakpoint, dynamicBreakpoints, lineCount } = useNoteListControlsBreakpoints(props.size.width, newNoteButtonElement, props.selectedFolderId);
 
 	const noteListControlsButtonSize = ButtonSize.Small;
 	const noteListControlsPadding = theme.mainPadding;
@@ -177,7 +177,7 @@ export default function NoteListWrapper(props: Props) {
 			<NoteListControls
 				height={controlHeight}
 				width={noteListSize.width}
-				setNewNoteButtonRef={setNewNoteButtonRef}
+				setNewNoteButtonElement={setNewNoteButtonElement}
 				breakpoint={breakpoint}
 				dynamicBreakpoints={dynamicBreakpoints}
 				lineCount={lineCount}

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -1,6 +1,6 @@
 import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
-import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import NoteList2 from '../NoteList/NoteList2';
 import NoteListControls from '../NoteListControls/NoteListControls';
 import { Size } from '../ResizableLayout/utils/types';
@@ -40,21 +40,21 @@ const StyledRoot = styled.div`
 	width: 100%;
 `;
 
-const getTextWidth = (newNoteRef: React.MutableRefObject<any>, text: string): number => {
+const getTextWidth = (newNoteRef: Element, text: string): number => {
 	const canvas = document.createElement('canvas');
 	if (!canvas) throw new Error('Failed to create canvas element');
 	const ctx = canvas.getContext('2d');
 	if (!ctx) throw new Error('Failed to get context');
-	const fontWeight = getComputedStyle(newNoteRef.current).getPropertyValue('font-weight');
-	const fontSize = getComputedStyle(newNoteRef.current).getPropertyValue('font-size');
-	const fontFamily = getComputedStyle(newNoteRef.current).getPropertyValue('font-family');
+	const fontWeight = getComputedStyle(newNoteRef).getPropertyValue('font-weight');
+	const fontSize = getComputedStyle(newNoteRef).getPropertyValue('font-size');
+	const fontFamily = getComputedStyle(newNoteRef).getPropertyValue('font-family');
 	ctx.font = `${fontWeight} ${fontSize} ${fontFamily}`;
 	return ctx.measureText(text).width;
 };
 
 // Even though these calculations mostly concern the NoteListControls component, we do them here
 // because we need to know the height of that control to calculate the note list height.
-const useNoteListControlsBreakpoints = (width: number, newNoteRef: React.MutableRefObject<any>, selectedFolderId: string) => {
+const useNoteListControlsBreakpoints = (width: number, newNoteRef: Element, selectedFolderId: string) => {
 	const [dynamicBreakpoints, setDynamicBreakpoints] = useState<Breakpoints>({ Sm: BaseBreakpoint.Sm, Md: BaseBreakpoint.Md, Lg: BaseBreakpoint.Lg, Xl: BaseBreakpoint.Xl });
 	const previousWidth = usePrevious(width);
 	const widthHasChanged = width !== previousWidth;
@@ -62,8 +62,7 @@ const useNoteListControlsBreakpoints = (width: number, newNoteRef: React.Mutable
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {
-		if (!widthHasChanged) return;
-		if (!newNoteRef.current) return;
+		if (!newNoteRef) return;
 		if (!showNewNoteButton) return;
 
 		// Use the longest string to calculate the amount of extra width needed
@@ -108,7 +107,7 @@ export default function NoteListWrapper(props: Props) {
 	const theme = themeStyle(props.themeId);
 	const [controlHeight] = useState(theme.topRowHeight);
 	const listRenderer = useListRenderer(props.listRendererId, props.startupPluginsLoaded);
-	const newNoteButtonRef = useRef(null);
+	const [newNoteButtonRef, setNewNoteButtonRef] = useState<Element>(null);
 	const isMultiColumns = listRenderer ? listRenderer.multiColumns : false;
 	const columns = isMultiColumns ? props.columns : null;
 
@@ -178,7 +177,7 @@ export default function NoteListWrapper(props: Props) {
 			<NoteListControls
 				height={controlHeight}
 				width={noteListSize.width}
-				newNoteButtonRef={newNoteButtonRef}
+				setNewNoteButtonRef={setNewNoteButtonRef}
 				breakpoint={breakpoint}
 				dynamicBreakpoints={dynamicBreakpoints}
 				lineCount={lineCount}


### PR DESCRIPTION
# Summary
Previously, New note button ref is stored by useRef, which doesn't trigger rerender when ref change. This cause if the Trash can is selected in previous session, when reopen the app, the ref to New note is null by default, preventing the New note button to re-render into correct format.
More details and how to reproduce bugs: #10060.

# Solution notes 
- Changed useRef to useState instead for storing New note button element. 
- I think panel width unchanged should not prevent re-render. There might be cases where element change needs re-render but panel width doesn't change (toggle button visibility for example).
So i remove this line 
![image](https://github.com/laurent22/joplin/assets/42113313/1c033d27-3424-4561-9dd2-60ec89cee782)

 


# Testing
1. Open Joplin, create an empty notebook in root 
2. Click on Trash can (make sure the New note button is hidden, Trash can is collapsed)
3. Shrink the panel with search bar as small as possible.
4. Close & reopen Joplin
5. Click on the notebook in step 1, New note button should appear in correct format for small screen (which is an icon).