### PR TITLE
Desktop: Fixes #10077: Special characters in notebooks and tags are not sorted alphabetically

### DIFF
--- a/packages/app-desktop/gui/TagList.tsx
+++ b/packages/app-desktop/gui/TagList.tsx
@@ -31,7 +31,7 @@ function TagList(props: Props) {
 		const output = props.items.slice();
 
 		output.sort((a: any, b: any) => {
-			return a.title < b.title ? -1 : +1;
+			return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
 		});
 
 		return output;

--- a/packages/lib/components/shared/side-menu-shared.ts
+++ b/packages/lib/components/shared/side-menu-shared.ts
@@ -83,7 +83,7 @@ export const renderTags = (props: Props, renderItem: RenderTagItem) => {
 		// Note: while newly created tags are normalized and lowercase
 		// imported tags might be any case, so we need to do case-insensitive
 		// sort.
-		return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : +1;
+		return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
 	});
 	const tagItems = [];
 	const order: string[] = [];

--- a/packages/lib/models/Folder.test.ts
+++ b/packages/lib/models/Folder.test.ts
@@ -223,6 +223,34 @@ describe('models/Folder', () => {
 		expect(sortedFolderTree[2].id).toBe(f6.id);
 	}));
 
+	it('should sort folders with special chars alphabetically', (async () => {
+		const unsortedFolderTitles = ['ç', 'd', 'c', 'Ä', 'b', 'a'].map(firstChar => `${firstChar} folder`);
+		for (const folderTitle of unsortedFolderTitles) {
+			await Folder.save({ title: folderTitle });
+		}
+
+		const folders = await Folder.allAsTree();
+		const sortedFolderTree = await Folder.sortFolderTree(folders);
+
+		// same set of titles, but in alphabetical order
+		const sortedFolderTitles = ['a', 'Ä', 'b', 'c', 'ç', 'd'].map(firstChar => `${firstChar} folder`);
+		expect(sortedFolderTree.map(f => f.title)).toEqual(sortedFolderTitles);
+	}));
+
+	it('should sort numbers ascending', (async () => {
+		const unsortedFolderTitles = ['10', '1', '2'].map(firstChar => `${firstChar} folder`);
+		for (const folderTitle of unsortedFolderTitles) {
+			await Folder.save({ title: folderTitle });
+		}
+
+		const folders = await Folder.allAsTree();
+		const sortedFolderTree = await Folder.sortFolderTree(folders);
+
+		// same set of titles, but in ascending order
+		const sortedFolderTitles = ['1', '2', '10'].map(firstChar => `${firstChar} folder`);
+		expect(sortedFolderTree.map(f => f.title)).toEqual(sortedFolderTitles);
+	}));
+
 	it('should not allow setting a folder parent as itself', (async () => {
 		const f1 = await Folder.save({ title: 'folder1' });
 		const hasThrown = await checkThrowAsync(() => Folder.save({ id: f1.id, parent_id: f1.id }, { userSideValidation: true }));

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -297,6 +297,15 @@ export default class Folder extends BaseItem {
 			output = output.filter(f => !f.deleted_time);
 		}
 
+		// Output should come sorted from the sqlite query already.
+		// However, special characters are appended at the end.
+		// Do another sorting to get the correct order.
+		if (options && options.order && options.order.length && options.order.some((o => o.by === 'title'))) {
+			output.sort((a: FolderEntity, b: FolderEntity) => {
+				return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
+			});
+		}
+
 		if (options && options.includeTrash) {
 			output.push(getTrashFolder());
 		}


### PR DESCRIPTION
Fixes #10077

Current state (https://github.com/laurent22/joplin/commit/8a42e6f3146c59fd9d3cc13d2df7a79a46001766): The tag lists at the left sidebar and at the bottom of the note are sorted correctly.

![grafik](https://github.com/laurent22/joplin/assets/33229141/ee9643d4-6a51-4585-9499-ef151e231d0a)

Two questions in advance:

1. ~~Do you have any hint where the folders / notebooks get sorted? I couldn't find it. [Here](https://github.com/laurent22/joplin/blob/dev/packages/lib/components/shared/side-menu-shared.ts#L69) they are already sorted.~~
2. There are two similar fixes at the mobile app. The pattern is obviously the same, but I can't build and test it. Can I push the changes in this PR anyway?

```diff
diff --git a/packages/app-mobile/components/FolderPicker.tsx b/packages/app-mobile/components/FolderPicker.tsx
index 4839d9d90..dcf835a08 100644
--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -37,7 +37,7 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
                folders.sort((a, b) => {
                        const aTitle = a && a.title ? a.title : '';
                        const bTitle = b && b.title ? b.title : '';
-                       return aTitle.toLowerCase() < bTitle.toLowerCase() ? -1 : +1;
+                       return aTitle.localeCompare(bTitle, undefined, { sensitivity: 'accent' });
                });

                for (let i = 0; i < folders.length; i++) {
diff --git a/packages/app-mobile/components/screens/tags.js b/packages/app-mobile/components/screens/tags.js
index d5efdc4cf..859cc03e0 100644
--- a/packages/app-mobile/components/screens/tags.js
+++ b/packages/app-mobile/components/screens/tags.js
@@ -83,7 +83,7 @@ class TagsScreenComponent extends BaseScreenComponent {
        async componentDidMount() {
                const tags = await Tag.allWithNotes();
                tags.sort((a, b) => {
-                       return a.title.toLowerCase() < b.title.toLowerCase() ? -1 : +1;
+                       return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
                });
```