### PR TITLE
Desktop: Fixes #10037: Changed the minimum width of layout items

### DIFF
--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -3,7 +3,7 @@ import { LayoutItem, Size } from './types';
 
 const dragBarThickness = 5;
 
-export const itemMinWidth = 110;
+export const itemMinWidth = 105;
 export const itemMinHeight = 40;
 
 export interface LayoutItemSizes {

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.ts
@@ -3,7 +3,7 @@ import { LayoutItem, Size } from './types';
 
 const dragBarThickness = 5;
 
-export const itemMinWidth = 40;
+export const itemMinWidth = 110;
 export const itemMinHeight = 40;
 
 export interface LayoutItemSizes {


### PR DESCRIPTION
This is a quick fix for #10037 
It may not be the best solution for the issue, but for now, it serves the purpose.

### Before

https://github.com/laurent22/joplin/assets/113056556/9584f8e5-b2a1-4bb8-8e38-0aefd0f80114

### After


https://github.com/laurent22/joplin/assets/113056556/652a5d8c-939e-4668-9a90-fdcdbeeb2ee2

