### PR TITLE
Desktop: Fixes #10082: Fix text not shown in plugin message boxes

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -288,9 +288,7 @@ export class Bridge {
 	}
 
 	/* returns the index of the clicked button */
-	public showMessageBox(message: string, options: MessageDialogOptions = null) {
-		if (options === null) options = { message: '' };
-
+	public showMessageBox(message: string, options: MessageDialogOptions = {}) {
 		const result = this.showMessageBox_(this.window(), { type: 'question',
 			message: message,
 			buttons: [_('OK'), _('Cancel')], ...options });


### PR DESCRIPTION
# Summary

Fixes an issue where the default `message` in `showMessageBox`'s options would override the `message` parameter, resulting in an empty alert dialog.

Fixes #10082.

# Testing

This has been manually tested by:
1. Right-click deleting a notebook
2. Verifying that the "Move notebook ... to the trash" dialog appears and can be canceled.
3. Running `await joplin.views.dialogs.showMessageBox("Foo")` from the development tools for a development plugin.
4. Verifying that the message box that appears has text.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->