### PR TITLE
 #10060 : resolved new-note btn overflow problem because of stratup on trash notebook

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -24,7 +24,7 @@ interface Props {
 	width: number;
 	newNoteButtonEnabled: boolean;
 	newTodoButtonEnabled: boolean;
-	newNoteButtonRef: React.MutableRefObject<any>;
+	newNoteButtonRef: (eltRef: React.MutableRefObject<any>) => void;
 	lineCount: number;
 	breakpoint: number;
 	dynamicBreakpoints: Breakpoints;
@@ -204,11 +204,13 @@ function NoteListControls(props: Props) {
 	}
 
 	function renderNewNoteButtons() {
-		if (!props.showNewNoteButtons) return null;
-
+		// TODO: when Ref.current is initilised then calculate breakpoints
+		const Ref = React.useRef(null); 
+		React.useEffect(() => { props.newNoteButtonRef(Ref); }, [Ref, Ref?.current]);
 		return (
+			!props.showNewNoteButtons ? <></> :
 			<TopRow className="new-note-todo-buttons">
-				<StyledButton ref={props.newNoteButtonRef}
+				<StyledButton ref={Ref}
 					className="new-note-button"
 					tooltip={ showTooltip ? CommandService.instance().label('newNote') : '' }
 					iconName={noteIcon}

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -1,6 +1,6 @@
 import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
-import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import NoteList2 from '../NoteList/NoteList2';
 import NoteListControls from '../NoteListControls/NoteListControls';
 import { Size } from '../ResizableLayout/utils/types';
@@ -62,9 +62,9 @@ const useNoteListControlsBreakpoints = (width: number, newNoteRef: React.Mutable
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {
-		if (!widthHasChanged) return;
-		if (!newNoteRef.current) return;
+		// if (!widthHasChanged) return;
 		if (!showNewNoteButton) return;
+		if (!newNoteRef.current) return;
 
 		// Use the longest string to calculate the amount of extra width needed
 		const smAdditional = getTextWidth(newNoteRef, _('note')) > getTextWidth(newNoteRef, _('to-do')) ? getTextWidth(newNoteRef, _('note')) : getTextWidth(newNoteRef, _('to-do'));
@@ -76,7 +76,7 @@ const useNoteListControlsBreakpoints = (width: number, newNoteRef: React.Mutable
 		const Xl = BaseBreakpoint.Xl;
 
 		setDynamicBreakpoints({ Sm, Md, Lg, Xl });
-	}, [newNoteRef, showNewNoteButton, widthHasChanged]);
+	}, [newNoteRef, showNewNoteButton, widthHasChanged, newNoteRef?.current]);
 
 	const breakpoint: number = useMemo(() => {
 		// Find largest breakpoint that width is less than
@@ -108,7 +108,7 @@ export default function NoteListWrapper(props: Props) {
 	const theme = themeStyle(props.themeId);
 	const [controlHeight] = useState(theme.topRowHeight);
 	const listRenderer = useListRenderer(props.listRendererId, props.startupPluginsLoaded);
-	const newNoteButtonRef = useRef(null);
+	const [newNoteButtonRef, setNewNoteButtonRef] = useState<React.MutableRefObject<any>>(null);
 	const isMultiColumns = listRenderer ? listRenderer.multiColumns : false;
 	const columns = isMultiColumns ? props.columns : null;
 
@@ -178,8 +178,8 @@ export default function NoteListWrapper(props: Props) {
 			<NoteListControls
 				height={controlHeight}
 				width={noteListSize.width}
-				newNoteButtonRef={newNoteButtonRef}
 				breakpoint={breakpoint}
+				newNoteButtonRef={(eltRef: React.MutableRefObject<any>) => setNewNoteButtonRef(eltRef)}
 				dynamicBreakpoints={dynamicBreakpoints}
 				lineCount={lineCount}
 				buttonSize={noteListControlsButtonSize}


### PR DESCRIPTION
So, I jumped in to fix an issue on Joplin's GitHub repository, which was causing some trouble with the breakpoints in the NoteListWrapper component. Basically, the problem was that the content was overflowing due to incorrect breakpoints being set.

To tackle this, I decided to use ReactState to directly handle the reference (Ref) of the note button. The root cause of the issue was that the useNoteListControlsBreakpoints() function in gui/NoteListWrapper/NoteListWrapper.tsx was using the previous reference value of the note button instead of the current one.

To solve this, I made sure to control the reference of the button right from the renderNewNoteButtons function during initialization. This way, I ensured that the correct reference value was being used, preventing any incorrect breakpoints and subsequent content overflow.