### PR TITLE
Desktop: Fixes #10036: Applied font family and font size to RTE

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -565,6 +565,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	useEffect(() => {
 		if (!scriptLoaded) return;
 
+		const theme = themeStyle(props.themeId);
+
 		const loadEditor = async () => {
 			const language = closestSupportedLocale(props.locale, true, supportedLocales);
 
@@ -598,7 +600,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			];
 
 			const editors = await (window as any).tinymce.init({
-				content_style: `* {font-size: ${props.fontSize}px; font-family: "${props.fontFamily}"; line-height: 1.5;}`,
+				content_style: `* {font-size: ${props.fontSize}px; font-family: "${props.fontFamily}"; line-height: ${theme.lineHeight};}`,
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
 				body_class: 'jop-tinymce',

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -598,6 +598,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			];
 
 			const editors = await (window as any).tinymce.init({
+				content_style: `* {font-size: ${props.fontSize}px; font-family: "${props.fontFamily}"; line-height: 1.5;}`,
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
 				body_class: 'jop-tinymce',

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -464,6 +464,7 @@ function NoteEditor(props: NoteEditorProps) {
 		noteToolbarButtonInfos: props.toolbarButtonInfos,
 		plugins: props.plugins,
 		fontSize: Setting.value('style.editor.fontSize'),
+		fontFamily: Setting.value('style.editor.fontFamily'),
 		contentMaxWidth: props.contentMaxWidth,
 		isSafeMode: props.isSafeMode,
 		useCustomPdfViewer: props.useCustomPdfViewer,

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -118,6 +118,7 @@ export interface NoteBodyEditorProps {
 	noteToolbarButtonInfos: ToolbarButtonInfo[];
 	plugins: PluginStates;
 	fontSize: number;
+	fontFamily: string;
 	contentMaxWidth: number;
 	isSafeMode: boolean;
 	noteId: string;


### PR DESCRIPTION
Fixes #10036 

### Behavior:
Font size and font family are applied to RTE

### Screenshot
![After](https://github.com/laurent22/joplin/assets/113056556/cc6fe03d-9c95-4749-8e46-32b6c2e8ec72)

### Changes:
- Exported the font family from Setting and added it to NoteBodyEditorProps
- Added style properties to TinyMCE init()

### GSoC Details
- My introduction on forums: https://discourse.joplinapp.org/t/introducing-abdelrrahman-elhaddad/36410
- @PackElend Please label me 😊