### PR TITLE
Desktop,Mobile: Resolves #10073, #10080: Fix conflicts notebook doesn't work with the trash feature

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -828,12 +828,14 @@ packages/lib/models/Tag.js
 packages/lib/models/dateTimeFormats.test.js
 packages/lib/models/settings/FileHandler.js
 packages/lib/models/settings/settingValidations.js
+packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/itemCanBeEncrypted.js
 packages/lib/models/utils/onFolderDrop.test.js
 packages/lib/models/utils/onFolderDrop.js
 packages/lib/models/utils/paginatedFeed.js
 packages/lib/models/utils/paginationToSql.js
+packages/lib/models/utils/readOnly.test.js
 packages/lib/models/utils/readOnly.js
 packages/lib/models/utils/resourceUtils.js
 packages/lib/models/utils/types.js
@@ -1082,8 +1084,10 @@ packages/lib/services/synchronizer/utils/syncDeleteStep.js
 packages/lib/services/synchronizer/utils/types.js
 packages/lib/services/trash/emptyTrash.test.js
 packages/lib/services/trash/emptyTrash.js
+packages/lib/services/trash/getTrashFolderId.js
 packages/lib/services/trash/index.test.js
 packages/lib/services/trash/index.js
+packages/lib/services/trash/isTrashableItem.js
 packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1088,6 +1088,7 @@ packages/lib/services/trash/getTrashFolderId.js
 packages/lib/services/trash/index.test.js
 packages/lib/services/trash/index.js
 packages/lib/services/trash/isTrashableItem.js
+packages/lib/services/trash/isTrashableNoteOrFolder.js
 packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -808,12 +808,14 @@ packages/lib/models/Tag.js
 packages/lib/models/dateTimeFormats.test.js
 packages/lib/models/settings/FileHandler.js
 packages/lib/models/settings/settingValidations.js
+packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/itemCanBeEncrypted.js
 packages/lib/models/utils/onFolderDrop.test.js
 packages/lib/models/utils/onFolderDrop.js
 packages/lib/models/utils/paginatedFeed.js
 packages/lib/models/utils/paginationToSql.js
+packages/lib/models/utils/readOnly.test.js
 packages/lib/models/utils/readOnly.js
 packages/lib/models/utils/resourceUtils.js
 packages/lib/models/utils/types.js
@@ -1062,8 +1064,10 @@ packages/lib/services/synchronizer/utils/syncDeleteStep.js
 packages/lib/services/synchronizer/utils/types.js
 packages/lib/services/trash/emptyTrash.test.js
 packages/lib/services/trash/emptyTrash.js
+packages/lib/services/trash/getTrashFolderId.js
 packages/lib/services/trash/index.test.js
 packages/lib/services/trash/index.js
+packages/lib/services/trash/isTrashableItem.js
 packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1068,6 +1068,7 @@ packages/lib/services/trash/getTrashFolderId.js
 packages/lib/services/trash/index.test.js
 packages/lib/services/trash/index.js
 packages/lib/services/trash/isTrashableItem.js
+packages/lib/services/trash/isTrashableNoteOrFolder.js
 packages/lib/services/trash/permanentlyDeleteOldItems.test.js
 packages/lib/services/trash/permanentlyDeleteOldItems.js
 packages/lib/services/trash/restoreItems.test.js

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -13,7 +13,9 @@ import syncDebugLog from '../services/synchronizer/syncDebugLog';
 import ResourceService from '../services/ResourceService';
 import { LoadOptions } from './utils/types';
 import ActionLogger from '../utils/ActionLogger';
-import { getTrashFolder, getTrashFolderId } from '../services/trash';
+import { getTrashFolder } from '../services/trash';
+import getConflictFolderId from './utils/getConflictFolderId';
+import getTrashFolderId from '../services/trash/getTrashFolderId';
 const { substrWithEllipsis } = require('../string-utils.js');
 
 const logger = Logger.create('models/Folder');
@@ -162,7 +164,7 @@ export default class Folder extends BaseItem {
 	}
 
 	public static conflictFolderId() {
-		return 'c04f1c7c04f1c7c04f1c7c04f1c7c04f';
+		return getConflictFolderId();
 	}
 
 	public static conflictFolder(): FolderEntity {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -405,6 +405,7 @@ export default class Note extends BaseItem {
 
 		if (parentId === Folder.conflictFolderId()) {
 			options.conditions.push('is_conflict = 1');
+			options.conditions.push('deleted_time = 0');
 		} else if (withinTrash) {
 			options.conditions.push('deleted_time > 0');
 		} else {
@@ -502,7 +503,8 @@ export default class Note extends BaseItem {
 
 	public static preview(noteId: string, options: any = null) {
 		if (!options) options = { fields: null };
-		return this.modelSelectOne(`SELECT ${this.previewFieldsSql(options.fields)} FROM notes WHERE is_conflict = 0 AND id = ?`, [noteId]);
+		const excludeConflictsSql = options.excludeConflicts ? 'is_conflict = 0 AND' : '';
+		return this.modelSelectOne(`SELECT ${this.previewFieldsSql(options.fields)} FROM notes WHERE ${excludeConflictsSql} id = ?`, [noteId]);
 	}
 
 	public static async search(options: any = null): Promise<NoteEntity[]> {
@@ -520,11 +522,11 @@ export default class Note extends BaseItem {
 	}
 
 	public static conflictedNotes() {
-		return this.modelSelectAll('SELECT * FROM notes WHERE is_conflict = 1');
+		return this.modelSelectAll('SELECT * FROM notes WHERE is_conflict = 1 AND deleted_time = 0');
 	}
 
 	public static async conflictedCount() {
-		const r = await this.db().selectOne('SELECT count(*) as total FROM notes WHERE is_conflict = 1');
+		const r = await this.db().selectOne('SELECT count(*) as total FROM notes WHERE is_conflict = 1 AND deleted_time = 0');
 		return r && r.total ? r.total : 0;
 	}
 

--- a/packages/lib/models/utils/getConflictFolderId.ts
+++ b/packages/lib/models/utils/getConflictFolderId.ts
@@ -1,0 +1,2 @@
+
+export default () => 'c04f1c7c04f1c7c04f1c7c04f1c7c04f';

--- a/packages/lib/models/utils/readOnly.test.ts
+++ b/packages/lib/models/utils/readOnly.test.ts
@@ -2,16 +2,24 @@ import { ModelType } from '../../BaseModel';
 import Folder from '../Folder';
 import ItemChange from '../ItemChange';
 import Note from '../Note';
-import { defaultState as defaultShareState } from '../../services/share/reducer';
+import { defaultState as defaultShareState, State as ShareState } from '../../services/share/reducer';
 import { ItemSlice, itemIsReadOnlySync } from './readOnly';
 import Resource from '../Resource';
 import shim from '../../shim';
-import { setupDatabaseAndSynchronizer, switchClient, tempFilePath } from '../../testing/test-utils';
+import { setupDatabaseAndSynchronizer, simulateReadOnlyShareEnv, switchClient, tempFilePath } from '../../testing/test-utils';
+import BaseItem from '../BaseItem';
 
 
-const checkUnsharedReadOnly = (itemType: ModelType, item: ItemSlice) => {
+const checkReadOnly = (itemType: ModelType, item: ItemSlice, shareData: ShareState = defaultShareState) => {
 	const syncUserId = '';
-	return itemIsReadOnlySync(itemType, ItemChange.SOURCE_UNSPECIFIED, item, syncUserId, defaultShareState);
+	return itemIsReadOnlySync(itemType, ItemChange.SOURCE_UNSPECIFIED, item, syncUserId, shareData);
+};
+
+const createTestResource = async () => {
+	const tempFile = tempFilePath('txt');
+	await shim.fsDriver().writeFile(tempFile, 'Test', 'utf8');
+	const note1 = await Note.save({ title: 'note' });
+	await shim.attachFileToNote(note1, tempFile);
 };
 
 describe('readOnly', () => {
@@ -24,8 +32,8 @@ describe('readOnly', () => {
 		let folder = await Folder.save({ title: 'Test' });
 		let note = await Note.save({ parent_id: folder.id, title: 'Test note' });
 
-		expect(checkUnsharedReadOnly(ModelType.Note, note as ItemSlice)).toBe(false);
-		expect(checkUnsharedReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(false);
+		expect(checkReadOnly(ModelType.Note, note as ItemSlice)).toBe(false);
+		expect(checkReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(false);
 
 		await Folder.delete(folder.id, { toTrash: true });
 
@@ -35,17 +43,25 @@ describe('readOnly', () => {
 		folder = await Folder.load(folder.id);
 		expect(folder.deleted_time).not.toBe(0);
 
-		expect(checkUnsharedReadOnly(ModelType.Note, note as ItemSlice)).toBe(true);
-		expect(checkUnsharedReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(true);
+		expect(checkReadOnly(ModelType.Note, note as ItemSlice)).toBe(true);
+		expect(checkReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(true);
 	});
 
-	test('should support checking if resources are read-only', async () => {
-		const tempFile = tempFilePath('txt');
-		await shim.fsDriver().writeFile(tempFile, 'Test', 'utf8');
-		const note1 = await Note.save({ title: 'note' });
-		await shim.attachFileToNote(note1, tempFile);
-
+	test('should support checking if resources are not read-only', async () => {
+		await createTestResource();
 		const resource = (await Resource.all())[0];
-		expect(checkUnsharedReadOnly(ModelType.Resource, resource)).toBe(false);
+		expect(checkReadOnly(ModelType.Resource, resource)).toBe(false);
+	});
+
+	test('should support checking that resources are read-only due to a share', async () => {
+		await createTestResource();
+
+		const share_id = '123456';
+		let resource = (await Resource.all())[0];
+		resource = await Resource.save({ ...resource, share_id });
+
+		const cleanup = simulateReadOnlyShareEnv(share_id);
+		expect(checkReadOnly(ModelType.Resource, resource, BaseItem.syncShareCache)).toBe(true);
+		cleanup();
 	});
 });

--- a/packages/lib/models/utils/readOnly.test.ts
+++ b/packages/lib/models/utils/readOnly.test.ts
@@ -1,0 +1,51 @@
+import { ModelType } from '../../BaseModel';
+import Folder from '../Folder';
+import ItemChange from '../ItemChange';
+import Note from '../Note';
+import { defaultState as defaultShareState } from '../../services/share/reducer';
+import { ItemSlice, itemIsReadOnlySync } from './readOnly';
+import Resource from '../Resource';
+import shim from '../../shim';
+import { setupDatabaseAndSynchronizer, switchClient, tempFilePath } from '../../testing/test-utils';
+
+
+const checkUnsharedReadOnly = (itemType: ModelType, item: ItemSlice) => {
+	const syncUserId = '';
+	return itemIsReadOnlySync(itemType, ItemChange.SOURCE_UNSPECIFIED, item, syncUserId, defaultShareState);
+};
+
+describe('readOnly', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	test('trashed items should be marked as read-only', async () => {
+		let folder = await Folder.save({ title: 'Test' });
+		let note = await Note.save({ parent_id: folder.id, title: 'Test note' });
+
+		expect(checkUnsharedReadOnly(ModelType.Note, note as ItemSlice)).toBe(false);
+		expect(checkUnsharedReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(false);
+
+		await Folder.delete(folder.id, { toTrash: true });
+
+		// Should be deleted
+		note = await Note.load(note.id);
+		expect(note.deleted_time).not.toBe(0);
+		folder = await Folder.load(folder.id);
+		expect(folder.deleted_time).not.toBe(0);
+
+		expect(checkUnsharedReadOnly(ModelType.Note, note as ItemSlice)).toBe(true);
+		expect(checkUnsharedReadOnly(ModelType.Folder, folder as ItemSlice)).toBe(true);
+	});
+
+	test('should support checking if resources are read-only', async () => {
+		const tempFile = tempFilePath('txt');
+		await shim.fsDriver().writeFile(tempFile, 'Test', 'utf8');
+		const note1 = await Note.save({ title: 'note' });
+		await shim.attachFileToNote(note1, tempFile);
+
+		const resource = (await Resource.all())[0];
+		expect(checkUnsharedReadOnly(ModelType.Resource, resource)).toBe(false);
+	});
+});

--- a/packages/lib/models/utils/readOnly.ts
+++ b/packages/lib/models/utils/readOnly.ts
@@ -6,6 +6,7 @@ import { State as ShareState } from '../../services/share/reducer';
 import ItemChange from '../ItemChange';
 import Setting from '../Setting';
 import { checkObjectHasProperties } from '@joplin/utils/object';
+import isTrashableItem from '../../services/trash/isTrashableItem';
 
 const logger = Logger.create('models/utils/readOnly');
 
@@ -75,12 +76,16 @@ export const checkIfItemCanBeAddedToFolder = async (itemType: ModelType, Folder:
 // extra `sharePermissionCheckOnly` boolean to do the check for one case or the other. A bit of a
 // hack but good enough for now.
 export const itemIsReadOnlySync = (itemType: ModelType, changeSource: number, item: ItemSlice, userId: string, shareState: ShareState, sharePermissionCheckOnly = false): boolean => {
-	checkObjectHasProperties(item, sharePermissionCheckOnly ? ['share_id'] : ['share_id', 'deleted_time']);
+	if (!sharePermissionCheckOnly && isTrashableItem({ id: item.id, type_: itemType })) {
+		checkObjectHasProperties(item, ['deleted_time']);
+	}
 
 	// Item is in trash
 	if (!sharePermissionCheckOnly && item.deleted_time) return true;
 
 	if (!needsShareReadOnlyChecks(itemType, changeSource, shareState)) return false;
+
+	checkObjectHasProperties(item, ['share_id']);
 
 	// Item is not shared
 	if (!item.share_id) return false;

--- a/packages/lib/models/utils/readOnly.ts
+++ b/packages/lib/models/utils/readOnly.ts
@@ -76,7 +76,7 @@ export const checkIfItemCanBeAddedToFolder = async (itemType: ModelType, Folder:
 // extra `sharePermissionCheckOnly` boolean to do the check for one case or the other. A bit of a
 // hack but good enough for now.
 export const itemIsReadOnlySync = (itemType: ModelType, changeSource: number, item: ItemSlice, userId: string, shareState: ShareState, sharePermissionCheckOnly = false): boolean => {
-	if (!sharePermissionCheckOnly && isTrashableItem({ id: item.id, type_: itemType })) {
+	if (!sharePermissionCheckOnly && isTrashableItem(itemType, item)) {
 		checkObjectHasProperties(item, ['deleted_time']);
 	}
 

--- a/packages/lib/services/trash/getTrashFolderId.ts
+++ b/packages/lib/services/trash/getTrashFolderId.ts
@@ -1,0 +1,6 @@
+
+const getTrashFolderId = () => {
+	return 'de1e7ede1e7ede1e7ede1e7ede1e7ede';
+};
+
+export default getTrashFolderId;

--- a/packages/lib/services/trash/index.test.ts
+++ b/packages/lib/services/trash/index.test.ts
@@ -1,4 +1,5 @@
 import { getDisplayParentId, getTrashFolderId } from '.';
+import { ModelType } from '../../BaseModel';
 
 describe('services/trash', () => {
 
@@ -7,9 +8,11 @@ describe('services/trash', () => {
 			{
 				deleted_time: 0,
 				parent_id: '1',
+				id: 'a',
 			},
 			{
 				deleted_time: 0,
+				id: '1',
 			},
 			'1',
 		],
@@ -17,9 +20,11 @@ describe('services/trash', () => {
 			{
 				deleted_time: 1000,
 				parent_id: '1',
+				id: 'b',
 			},
 			{
 				deleted_time: 0,
+				id: '1',
 			},
 			getTrashFolderId(),
 		],
@@ -27,14 +32,17 @@ describe('services/trash', () => {
 			{
 				deleted_time: 1000,
 				parent_id: '1',
+				id: 'a',
 			},
 			{
 				deleted_time: 1000,
+				id: '1',
 			},
 			'1',
 		],
-	])('should return the display parent ID', (item, itemParent, expected) => {
-		const actual = getDisplayParentId(item, itemParent);
+	])('should return the display parent ID (case %#)', (item, itemParent, expected) => {
+		const defaultProps = { type_: ModelType.Folder };
+		const actual = getDisplayParentId({ ...defaultProps, ...item }, { ...defaultProps, ...itemParent });
 		expect(actual).toBe(expected);
 	});
 

--- a/packages/lib/services/trash/index.ts
+++ b/packages/lib/services/trash/index.ts
@@ -4,7 +4,7 @@ import { _ } from '../../locale';
 import { FolderEntity, FolderIcon, FolderIconType, NoteEntity } from '../database/types';
 import Folder from '../../models/Folder';
 import getTrashFolderId from './getTrashFolderId';
-import isTrashableItem from './isTrashableItem';
+import isTrashableNoteOrFolder from './isTrashableNoteOrFolder';
 
 // When an item is deleted, all its properties are kept, including the parent ID
 // so that it can potentially be restored to the right folder. However, when
@@ -20,14 +20,14 @@ import isTrashableItem from './isTrashableItem';
 // folder with ID = item.parent_id
 export const getDisplayParentId = (item: FolderEntity | NoteEntity, originalItemParent: FolderEntity) => {
 	if (!('parent_id' in item)) throw new Error(`Missing "parent_id" property: ${JSON.stringify(item)}`);
-	if (!isTrashableItem(item)) {
+	if (!isTrashableNoteOrFolder(item)) {
 		return item.parent_id;
 	}
 
 	if (!('deleted_time' in item)) {
 		throw new Error(`Missing "deleted_time" property: ${JSON.stringify(item)}`);
 	}
-	if (originalItemParent && isTrashableItem(originalItemParent) && !('deleted_time' in originalItemParent)) {
+	if (originalItemParent && isTrashableNoteOrFolder(originalItemParent) && !('deleted_time' in originalItemParent)) {
 		throw new Error(`Missing "deleted_time" property: ${JSON.stringify(originalItemParent)}`);
 	}
 
@@ -84,7 +84,7 @@ export const getTrashFolderIcon = (type: FolderIconType): FolderIcon => {
 
 export const itemIsInTrash = (item: FolderEntity | NoteEntity) => {
 	if (!item) return false;
-	if (!isTrashableItem(item)) return false;
+	if (!isTrashableNoteOrFolder(item)) return false;
 
 	checkObjectHasProperties(item, ['id', 'deleted_time']);
 

--- a/packages/lib/services/trash/isTrashableItem.ts
+++ b/packages/lib/services/trash/isTrashableItem.ts
@@ -1,0 +1,14 @@
+import { ModelType } from '../../BaseModel';
+import conflictFolderId from '../../models/utils/getConflictFolderId';
+import getTrashFolderId from './getTrashFolderId';
+
+type ItemSlice = { id?: string; type_?: number };
+const isTrashableItem = (item: ItemSlice) => {
+	if (item.type_ !== ModelType.Folder && item.type_ !== ModelType.Note) {
+		return false;
+	}
+
+	return item.id !== conflictFolderId() && item.id !== getTrashFolderId();
+};
+
+export default isTrashableItem;

--- a/packages/lib/services/trash/isTrashableItem.ts
+++ b/packages/lib/services/trash/isTrashableItem.ts
@@ -1,14 +1,16 @@
+import { checkObjectHasProperties } from '@joplin/utils/object';
 import { ModelType } from '../../BaseModel';
-import conflictFolderId from '../../models/utils/getConflictFolderId';
-import getTrashFolderId from './getTrashFolderId';
+import isTrashableNoteOrFolder from './isTrashableNoteOrFolder';
 
-type ItemSlice = { id?: string; type_?: number };
-const isTrashableItem = (item: ItemSlice) => {
-	if (item.type_ !== ModelType.Folder && item.type_ !== ModelType.Note) {
+type ItemSlice = { id?: string };
+const isTrashableItem = (itemType: ModelType, item: ItemSlice) => {
+	checkObjectHasProperties(item, ['id']);
+
+	if (itemType !== ModelType.Folder && itemType !== ModelType.Note) {
 		return false;
 	}
 
-	return item.id !== conflictFolderId() && item.id !== getTrashFolderId();
+	return isTrashableNoteOrFolder(item);
 };
 
 export default isTrashableItem;

--- a/packages/lib/services/trash/isTrashableNoteOrFolder.ts
+++ b/packages/lib/services/trash/isTrashableNoteOrFolder.ts
@@ -1,0 +1,14 @@
+import { checkObjectHasProperties } from '@joplin/utils/object';
+import conflictFolderId from '../../models/utils/getConflictFolderId';
+import getTrashFolderId from './getTrashFolderId';
+
+type ItemSlice = { id?: string };
+
+// This function is separate from isTrashableItem to handle the case where we know that an item
+// is either a note or a folder, but don't know which.
+const isTrashableNoteOrFolder = (item: ItemSlice) => {
+	checkObjectHasProperties(item, ['id']);
+	return item.id !== conflictFolderId() && item.id !== getTrashFolderId();
+};
+
+export default isTrashableNoteOrFolder;

--- a/packages/lib/services/trash/restoreItems.test.ts
+++ b/packages/lib/services/trash/restoreItems.test.ts
@@ -88,4 +88,15 @@ describe('restoreItems', () => {
 		expect(noteReloaded.parent_id).toBe(folderReloaded2.id);
 	});
 
+	it('should restore a conflict', async () => {
+		const note = await Note.save({ is_conflict: 1, title: 'Test' });
+		await Note.delete(note.id, { toTrash: true });
+
+		await restoreItems(ModelType.Note, [await Note.load(note.id)]);
+
+		const noteReloaded = await Note.load(note.id);
+		expect(noteReloaded.title).toBe('Test');
+		expect(noteReloaded.is_conflict).toBe(1);
+		expect(noteReloaded.deleted_time).toBe(0);
+	});
 });

--- a/packages/lib/services/trash/restoreItems.ts
+++ b/packages/lib/services/trash/restoreItems.ts
@@ -54,7 +54,8 @@ const restoreItems = async (itemType: ModelType, itemsOrIds: NoteEntity[] | Fold
 		let toSave: FolderEntity | NoteEntity = null;
 
 		if (itemType === ModelType.Note) {
-			toSave = await Note.preview(item.id);
+			// We need to preview conflicts -- they can be trashed.
+			toSave = await Note.preview(item.id, { excludeConflicts: false });
 		} else {
 			toSave = await Folder.load(item.id);
 		}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -95,3 +95,4 @@ Notyf
 unresponded
 activeline
 Prec
+Trashable


### PR DESCRIPTION
# Summary

This pull request improves how conflicts are handled with the trash feature.

Fixes #10080 and #10073.

# Notes

This PR does the following:
- Fixes a crash when displaying the conflicts folder.
- Fixes deleting items in the conflicts folder.
    - Previously, clicking "delete" would move an item to the trash, but it would still be visible in the conflicts folder. Additionally, clicking "restore" on such items did nothing.
 - Fixes an issue where opening an item in the conflicts folder would throw a `Missing property "deleted_time"` exception.
     - This change also fixes #10080.
- Refactors `getConflictFolderId` and `getTrashFolderId` into separate files to prevent a circular import issue.

When a conflict is deleted to trash, it now
1. Keeps the conflict as a conflict (`is_conflict = 1`)
2. Marks the conflict as deleted (`deleted_time ≠ 0`)
3. Shows the conflict in trash, but not in the "conflicts" folder

When a conflict is restored from trash, it is moved back to the conflicts folder.

## Remaining issues

I've noticed the following remaining issues that could be addressed in a follow-up pull request:
- Currently, dragging a conflict note out of trash always moves it to "Conflicts".
- Editing a note in "Conflicts" causes the conflict note to disappear until another notebook is opened, then "Conflicts" is opened again.

# Testing

To manually test this change,
1. Launch Joplin Server.
2. Connect to two different Joplin Server accounts.
3. Share a notebook from one account to the other.
4. Verify that it's still possible to open and edit a shared note.
5. Verify that it's still possible to delete and restore a shared note.
6. Create a conflict and verify that it can be deleted to trash.
7. Verify that a conflict can be restored from trash back to the conflicts notebook.
8. Verify that a conflict can be moved out of the conflicts notebook.

This has been tested successfully on Ubuntu 23.10.


On Android:
1. Create a conflict.
2. Verify that the application doesn't crash.
3. Delete a note from the conflicts notebook.
4. Verify that it is moved to the trash folder.

This has been tested successfully on Android 13.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->