### PR TITLE
Chore: Allow disabling deletion logging

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1107,6 +1107,7 @@ packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
 packages/lib/types.js
+packages/lib/utils/ActionLogger.test.js
 packages/lib/utils/ActionLogger.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/ipc/RemoteMessenger.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1087,6 +1087,7 @@ packages/lib/themes/solarizedLight.js
 packages/lib/themes/type.js
 packages/lib/time.js
 packages/lib/types.js
+packages/lib/utils/ActionLogger.test.js
 packages/lib/utils/ActionLogger.js
 packages/lib/utils/credentialFiles.js
 packages/lib/utils/ipc/RemoteMessenger.test.js

--- a/packages/lib/utils/ActionLogger.test.ts
+++ b/packages/lib/utils/ActionLogger.test.ts
@@ -1,0 +1,62 @@
+import Logger, { LogLevel, TargetType } from '@joplin/utils/Logger';
+import { setupDatabaseAndSynchronizer, switchClient } from '../testing/test-utils';
+import Note from '../models/Note';
+import ActionLogger from './ActionLogger';
+import Setting from '../models/Setting';
+import { pathExists, readFile, remove } from 'fs-extra';
+
+const getLogPath = () => `${Setting.value('profileDir')}/log.txt`;
+
+const logContainsEntryWith = async (...terms: string[]) => {
+	const lines = (await readFile(getLogPath(), 'utf8')).split('\n');
+	for (const line of lines) {
+		if (terms.every(t => line.includes(t))) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+describe('ActionLogger', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+
+		const logPath = getLogPath();
+		if (await pathExists(logPath)) {
+			await remove(logPath);
+		}
+
+		const logger = new Logger();
+		logger.addTarget(TargetType.File, { path: logPath });
+		logger.setLevel(LogLevel.Info);
+
+		Logger.initializeGlobalLogger(logger);
+	});
+
+	it('should log deletions', async () => {
+		const note = await Note.save({ title: 'MyTestNote' });
+		await Note.delete(note.id, { toTrash: false });
+		await Logger.globalLogger.waitForFileWritesToComplete_();
+
+		expect(
+			await logContainsEntryWith('DeleteAction', note.id, note.title),
+		).toBe(true);
+	});
+
+	it('should be possible to disable ActionLogger globally', async () => {
+		const note1 = await Note.save({ title: 'testNote1' });
+		const note2 = await Note.save({ title: 'testNote2' });
+
+		ActionLogger.setDisabled(false);
+		await Note.delete(note1.id, { toTrash: false });
+		ActionLogger.setDisabled(true);
+		await Note.delete(note2.id, { toTrash: false });
+		ActionLogger.setDisabled(false);
+		await Logger.globalLogger.waitForFileWritesToComplete_();
+
+		expect(await logContainsEntryWith('DeleteAction', note1.id)).toBe(true);
+		expect(await logContainsEntryWith('DeleteAction', note2.id)).toBe(false);
+	});
+});

--- a/packages/lib/utils/ActionLogger.ts
+++ b/packages/lib/utils/ActionLogger.ts
@@ -9,29 +9,29 @@ const actionTypeToLogger = {
 };
 
 export default class ActionLogger {
-	private descriptions: string[] = [];
+	private descriptions_: string[] = [];
 
 	private constructor(private source: string) { }
 
 	public clone() {
 		const clone = new ActionLogger(this.source);
-		clone.descriptions = [...this.descriptions];
+		clone.descriptions_ = [...this.descriptions_];
 		return clone;
 	}
 
 	// addDescription is used to add labels with information that may not be available
 	// when .log is called. For example, to include the title of a deleted note.
 	public addDescription(description: string) {
-		this.descriptions.push(description);
+		this.descriptions_.push(description);
 	}
 
 	public log(action: ItemActionType, itemIds: string|string[]) {
-		if (ActionLogger.disabled) {
+		if (!ActionLogger.enabled_) {
 			return;
 		}
 
 		const logger = actionTypeToLogger[action];
-		logger.info(`${this.source}: ${this.descriptions.join(',')}; Item IDs: ${JSON.stringify(itemIds)}`);
+		logger.info(`${this.source}: ${this.descriptions_.join(',')}; Item IDs: ${JSON.stringify(itemIds)}`);
 	}
 
 	public static from(source: ActionLogger|string|undefined) {
@@ -49,8 +49,13 @@ export default class ActionLogger {
 
 	// Disabling the action logger globally can be useful on Joplin Server/Cloud
 	// when many deletions are expected (e.g. for email-to-note).
-	private static disabled = false;
-	public static setDisabled(disabled: boolean) {
-		this.disabled = disabled;
+	private static enabled_ = true;
+
+	public static set enabled(v: boolean) {
+		this.enabled_ = v;
+	}
+
+	public static get enabled() {
+		return this.enabled_;
 	}
 }

--- a/packages/lib/utils/ActionLogger.ts
+++ b/packages/lib/utils/ActionLogger.ts
@@ -26,6 +26,10 @@ export default class ActionLogger {
 	}
 
 	public log(action: ItemActionType, itemIds: string|string[]) {
+		if (ActionLogger.disabled) {
+			return;
+		}
+
 		const logger = actionTypeToLogger[action];
 		logger.info(`${this.source}: ${this.descriptions.join(',')}; Item IDs: ${JSON.stringify(itemIds)}`);
 	}
@@ -40,5 +44,13 @@ export default class ActionLogger {
 		}
 
 		return source;
+	}
+
+
+	// Disabling the action logger globally can be useful on Joplin Server/Cloud
+	// when many deletions are expected (e.g. for email-to-note).
+	private static disabled = false;
+	public static setDisabled(disabled: boolean) {
+		this.disabled = disabled;
 	}
 }

--- a/packages/utils/Logger.ts
+++ b/packages/utils/Logger.ts
@@ -207,7 +207,7 @@ class Logger {
 	}
 
 	// Only for database at the moment
-	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null): Promise<string[]> {
+	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null) {
 		if (options === null) options = {};
 		if (!options.levels) options.levels = [LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error];
 		if (!options.levels.length) return [];

--- a/packages/utils/Logger.ts
+++ b/packages/utils/Logger.ts
@@ -207,7 +207,7 @@ class Logger {
 	}
 
 	// Only for database at the moment
-	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null) {
+	public async lastEntries(limit = 100, options: LastEntriesOptions|null = null): Promise<string[]> {
 		if (options === null) options = {};
 		if (!options.levels) options.levels = [LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error];
 		if (!options.levels.length) return [];
@@ -326,6 +326,13 @@ class Logger {
 				target.database.transactionExecBatch(queries);
 			}
 		}
+	}
+
+	// For tests
+	public async waitForFileWritesToComplete_() {
+		const release = await writeToFileMutex_.acquire();
+		release();
+		return;
 	}
 
 	public error(...object: any[]) {


### PR DESCRIPTION
# Summary

There are cases where we don't want to log all deletions. For example, when using `@joplin/lib` to create/delete resources on a server.

This pull request adds an API that can be used to disable `ActionLogger` (and thus disable logging all deletions).

To use this API, call `ActionLogger.enabled = false`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->