### PR TITLE
Mobile: Fix plugin API memory leak

### DIFF
--- a/packages/lib/utils/ipc/RemoteMessenger.ts
+++ b/packages/lib/utils/ipc/RemoteMessenger.ts
@@ -153,8 +153,6 @@ export default abstract class RemoteMessenger<LocalInterface, RemoteInterface> {
 		for (const id in idToCallbacks) {
 			this.argumentCallbacks.set(id, idToCallbacks[id]);
 		}
-		// TODO(1): Add logic to remove idToCallbacks from argumentCallbacks
-		//          when the remote drops all references to it.
 	}
 
 	private lastCallbackDropTime_ = 0;

--- a/packages/lib/utils/ipc/TestMessenger.ts
+++ b/packages/lib/utils/ipc/TestMessenger.ts
@@ -33,4 +33,11 @@ export default class TestMessenger<LocalInterface, RemoteInterface> extends Remo
 	protected override onClose(): void {
 		this.remoteMessenger = null;
 	}
+
+
+	// Test utility methods
+	//
+	public mockCallbackDropped(callbackId: string) {
+		this.dropRemoteCallback_(callbackId);
+	}
 }

--- a/packages/lib/utils/ipc/utils/mergeCallbacksAndSerializable.test.ts
+++ b/packages/lib/utils/ipc/utils/mergeCallbacksAndSerializable.test.ts
@@ -27,7 +27,7 @@ describe('mergeCallbacksAndSerializable', () => {
 		};
 
 		const callMethodWithId = jest.fn();
-		const merged: any = mergeCallbacksAndSerializable(data, callbacks, callMethodWithId);
+		const merged: any = mergeCallbacksAndSerializable(data, callbacks, callMethodWithId, ()=>{});
 
 		// Should have created functions
 		merged.foo.fn1(3, 4);


### PR DESCRIPTION
# Summary

Uses a `FinalizationRegistry` to clean remote copies of callbacks when  garbage collected.

# Notes

`FinalizationRegistry` is not supported by Hermes. As such, this only allows garbage collection of callbacks created within a `WebView`. Because both the note editor and main plugin script run within `WebView`s, this change should still significantly decrease memory usage.

# Testing

On an Android 12 emulator,
1. With a copy of the code that contains this change, edited a note and inspected memory usage.
2. Repeated 1 with a copy that does not contain this change.
3. Verified that the memory usage is lower in case 1 than case 2. (This is a very rough estimate -- both tests were run on the same device, but at different times and for different lengths of time).

**Note**: This has not yet been tested on iOS.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->