### PR TITLE
Mobile: Fix note editor's settings and plugins updated on every keystroke

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -147,16 +147,13 @@ const useEditorControl = (
 	setLinkDialogVisible: OnSetVisibleCallback,
 	setSearchState: OnSearchStateChangeCallback,
 ): EditorControl => {
-	const bodyControlRef = useRef(bodyControl);
-	bodyControlRef.current = bodyControl;
-
 	return useMemo(() => {
 		const execCommand = (command: EditorCommandType) => {
-			void bodyControlRef.current.execCommand(command);
+			void bodyControl.execCommand(command);
 		};
 
 		const setSearchStateCallback = (state: SearchState) => {
-			bodyControlRef.current.setSearchState(state);
+			bodyControl.setSearchState(state);
 			setSearchState(state);
 		};
 
@@ -165,29 +162,29 @@ const useEditorControl = (
 				return supportsCommand(command);
 			},
 			execCommand(command, ...args: any[]) {
-				return bodyControlRef.current.execCommand(command, ...args);
+				return bodyControl.execCommand(command, ...args);
 			},
 
 			undo() {
-				bodyControlRef.current.undo();
+				bodyControl.undo();
 			},
 			redo() {
-				bodyControlRef.current.redo();
+				bodyControl.redo();
 			},
 			select(anchor: number, head: number) {
-				bodyControlRef.current.select(anchor, head);
+				bodyControl.select(anchor, head);
 			},
 			setScrollPercent(fraction: number) {
-				bodyControlRef.current.setScrollPercent(fraction);
+				bodyControl.setScrollPercent(fraction);
 			},
 			insertText(text: string) {
-				bodyControlRef.current.insertText(text);
+				bodyControl.insertText(text);
 			},
 			updateBody(newBody: string) {
-				bodyControlRef.current.updateBody(newBody);
+				bodyControl.updateBody(newBody);
 			},
 			updateSettings(newSettings: EditorSettings) {
-				bodyControlRef.current.updateSettings(newSettings);
+				bodyControl.updateSettings(newSettings);
 			},
 
 			toggleBolded() {
@@ -235,7 +232,7 @@ const useEditorControl = (
 				execCommand(EditorCommandType.IndentLess);
 			},
 			updateLink(label: string, url: string) {
-				bodyControlRef.current.updateLink(label, url);
+				bodyControl.updateLink(label, url);
 			},
 			scrollSelectionIntoView() {
 				execCommand(EditorCommandType.ScrollSelectionIntoView);
@@ -251,7 +248,7 @@ const useEditorControl = (
 			},
 
 			setContentScripts: async (plugins: ContentScriptData[]) => {
-				return bodyControlRef.current.setContentScripts(plugins);
+				return bodyControl.setContentScripts(plugins);
 			},
 
 			setSearchState: setSearchStateCallback,
@@ -282,7 +279,7 @@ const useEditorControl = (
 		};
 
 		return control;
-	}, [webviewRef, setLinkDialogVisible, setSearchState]);
+	}, [webviewRef, bodyControl, setLinkDialogVisible, setSearchState]);
 };
 
 function NoteEditor(props: Props, ref: any) {


### PR DESCRIPTION
# Summary

Previously, whenever the `NoteEditor` rerendered, the editor settings (includes the theme) and information about the enabled plugins were re-sent to the editor. This caused delays in typing and higher memory usage.

Fixes an issue discovered while creating #10115.

# Cause

This was caused by an inline function's usage as a dependency of a React hook. This caused the hook to reload on every rerender, causing both settings and plugins to be re-sent to the editor on every rerender.

# Testing

1. Build the note editor (and other injectedJS) using `yarn watchInjectedJs`
    - This builds the injected JavaScript in development mode.
1. Launch the Android app
2. Open the note editor
3. Open Google Chrome's `chrome://inspect` page and inspect the note editor
4. Under the "sources" tab in Chrome's development tools, navigate to `WebViewToRNMessenger.ts` and add the following line
    ```ts
     // Just below this line
     if (typeof message.data === 'object' && message.origin === 'react-native') {
         // Add this:
         if (message.data.methodPath) console.log(message.data.methodPath);
     ```
5. Verify that showing and hiding search causes `['execCommand']` to be logged to the console.
6. Verify that typing in the editor **does not** cause a large number of messages to be logged to the console.

This has been tested successfully on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->