### PR TITLE
Clipper, Desktop: Prevent race condition when download limit is reached

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -599,6 +599,10 @@ function shimInit(options: ShimInitOptions = null) {
 
 									try {
 										await gunzipFile(gzipFilePath, filePath);
+										// Calling request.destroy() within the downloadController can cause problems.
+										// The response.pipe(file) will continue even after request.destroy() is called,
+										// potentially causing the same promise to resolve while the cleanUpOnError
+										// is removing the file that have been downloaded by this function.
 										if (request.destroyed) return;
 										resolve(makeResponse(response));
 									} catch (error) {

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -599,6 +599,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 									try {
 										await gunzipFile(gzipFilePath, filePath);
+										if (request.destroyed) return;
 										resolve(makeResponse(response));
 									} catch (error) {
 										cleanUpOnError(error);
@@ -606,6 +607,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 									await shim.fsDriver().remove(gzipFilePath);
 								} else {
+									if (request.destroyed) return;
 									resolve(makeResponse(response));
 								}
 							});


### PR DESCRIPTION
The change here is to check if the `request.destroy()` method has already been called before resolving the `fetchBlob` function.

This change is necessary to address a potential race condition. 

When the `LimitedDownloadController` calls `request.destroy()`, it triggers the asynchronous `cleanUpOnError` function which unlinks the downloaded file and reject. But if before the function is rejected the `file.on('finish', ...)` is executed the function might appear to resolve successfully, returning a `path` property to a file that has been `unlinked` by the `cleanUpOnError` function.

By checking if `request.destroyed` is true, we can ensure the file hasn't been unlinked before resolving it.

---

I think my explanation might be a little confusing, but if needed I can give more information.