### PR TITLE
Desktop: Fixes #5943: Export Pdf shouldn't include data-urls.

### DIFF
--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -85,6 +85,11 @@ export default class InteropServiceHelper {
 								// pdfs.
 								// https://github.com/laurent22/joplin/issues/6254.
 								await win.webContents.executeJavaScript('document.querySelectorAll(\'details\').forEach(el=>el.setAttribute(\'open\',\'\'))');
+								// The below line removes the href attribute
+								// if it contains data-urls, since embedding
+								// data-urls in pdfs is not supported.
+								// https://github.com/laurent22/joplin/issues/5943
+								await win.webContents.executeJavaScript('document.querySelectorAll(\'a[href^="data:"]\').forEach(el => el.removeAttribute(\'href\'))');
 								const data = await win.webContents.printToPDF(options as any);
 								resolve(data);
 							} catch (error) {


### PR DESCRIPTION
The problem arises during the conversion of a note to HTML, which is then used by `printToPDF()`. This conversion takes a note object and transforms it into HTML, including any attached files as raw data.

2. Example of Embedded Link in a Note:
    
    ```MD
    [fileName.txt](:/xxx)
    ```
    converted to: 
    ```html
     <a data-from-md="" title="_resources/xxx.txt" href="data:text/plain;base64,/*some data*/" download="xxx.txt">fileName.txt</a>
    ```
    The `href` attribute contains data that, when executed in a new browser tab, opens the original file. This behavior causes issues when exporting to HTML or PDF with large attached files, resulting in very large output files.

My approach to addressing this is to remove the `href` attribute if it starts with `data:`, This won’t affect images since they are rendered using the `<img>` tag.