### PR TITLE
Chore: Fixes #10139: Mobile: Fix error on startup

### DIFF
--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -19,7 +19,6 @@ const injectedJs = {
 	codeMirrorBundle: require('../lib/rnInjectedJs/codeMirrorBundle.bundle'),
 	svgEditorBundle: require('../lib/rnInjectedJs/svgEditorBundle.bundle'),
 	pluginBackgroundPage: require('../lib/rnInjectedJs/pluginBackgroundPage.bundle'),
-	noteBodyViewerBundle: require('../lib/rnInjectedJs/noteBodyViewerBundle.bundle'),
 };
 
 function shimInit() {


### PR DESCRIPTION
# Summary

Fixes an issue caused by an incomplete splitting of https://github.com/laurent22/joplin/pull/9652 into separate pull requests. A bundled file that does not exist was `require`d in `shim-init-react.js`.

While this built on my machine because the generated file was still present (it's `.gitignore`d), startup would fail after a clean build.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->