### PR TITLE
Desktop: Fixes #4217 Dragging note to folder, shouldn't affect tag listing

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -510,6 +510,10 @@ export default class BaseApplication {
 			}
 		}
 
+		if (action.type === 'NOTE_UPDATE_ONE') {
+			refreshNotes = true;
+		}
+
 		if (refreshNotes) {
 			await this.refreshNotes(newState, refreshNotesUseSelectedNoteId, refreshNotesHash);
 		}

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -510,7 +510,7 @@ export default class BaseApplication {
 			}
 		}
 
-		if (action.type === 'NOTE_UPDATE_ONE') {
+		if (action.type === 'NOTE_PARENT_UPDATE') {
 			refreshNotes = true;
 		}
 

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -625,6 +625,7 @@ export default class Note extends BaseItem {
 			updated_time: time.unixMs(),
 		};
 
+		this.dispatch({ type: 'NOTE_PARENT_UPDATE' });
 		return Note.save(modifiedNote, { autoTimestamp: false });
 	}
 


### PR DESCRIPTION
My approach to this was adding an if statement that refreshes notes on notes updates. 

before: 
![before_1](https://github.com/laurent22/joplin/assets/86894852/cea10d7c-6dec-4f16-9679-842123122faf)

after: 
![after](https://github.com/laurent22/joplin/assets/86894852/bd9ef7d3-0d5f-4299-959b-bcf0e345ec5d)
