### PR TITLE
Mobile: Fixes #10130: Improve note editor performance when quickly entering text

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -320,7 +320,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		this.screenHeader_redoButtonPress = this.screenHeader_redoButtonPress.bind(this);
 		this.onBodyViewerLoadEnd = this.onBodyViewerLoadEnd.bind(this);
 		this.onBodyViewerCheckboxChange = this.onBodyViewerCheckboxChange.bind(this);
-		this.onBodyChange = this.onBodyChange.bind(this);
 		this.onUndoRedoDepthChange = this.onUndoRedoDepthChange.bind(this);
 		this.voiceTypingDialog_onText = this.voiceTypingDialog_onText.bind(this);
 		this.voiceTypingDialog_onDismiss = this.voiceTypingDialog_onDismiss.bind(this);
@@ -330,14 +329,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		return this.props.useEditorBeta;
 	}
 
-	// Avoid saving immediately -- the NoteEditor's content isn't controlled by its props
-	// and updating this.state.note immediately causes slow rerenders.
-	//
-	// See https://github.com/laurent22/joplin/issues/10130
-	private onBodyChange = debounce((event: EditorChangeEvent) => {
-		shared.noteComponent_change(this, 'body', event.value);
-		this.scheduleSave();
-	}, 100);
 
 	private onUndoRedoDepthChange(event: UndoRedoDepthChangeEvent) {
 		if (this.useEditorBeta()) {
@@ -599,7 +590,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		this.scheduleSave();
 	}
 
-	private legacyEditorBody_changeText(text: string) {
+	private onPlainEditorTextChange = (text: string) => {
 		if (!this.undoRedoService_.canUndo) {
 			this.undoRedoService_.push(this.undoState());
 		} else {
@@ -608,7 +599,16 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 
 		shared.noteComponent_change(this, 'body', text);
 		this.scheduleSave();
-	}
+	};
+
+	// Avoid saving immediately -- the NoteEditor's content isn't controlled by its props
+	// and updating this.state.note immediately causes slow rerenders.
+	//
+	// See https://github.com/laurent22/joplin/issues/10130
+	private onMarkdownEditorTextChange = debounce((event: EditorChangeEvent) => {
+		shared.noteComponent_change(this, 'body', event.value);
+		this.scheduleSave();
+	}, 100);
 
 	private onPlainEditorSelectionChange = (event: NativeSyntheticEvent<any>) => {
 		this.selection = event.nativeEvent.selection;
@@ -1506,7 +1506,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 						ref="noteBodyTextField"
 						multiline={true}
 						value={note.body}
-						onChangeText={(text: string) => this.legacyEditorBody_changeText(text)}
+						onChangeText={this.onPlainEditorTextChange}
 						onSelectionChange={this.onPlainEditorSelectionChange}
 						blurOnSubmit={false}
 						selectionColor={theme.textSelectionColor}
@@ -1528,7 +1528,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 					themeId={this.props.themeId}
 					initialText={note.body}
 					initialSelection={this.selection}
-					onChange={this.onBodyChange}
+					onChange={this.onMarkdownEditorTextChange}
 					onSelectionChange={this.onMarkdownEditorSelectionChange}
 					onUndoRedoDepthChange={this.onUndoRedoDepthChange}
 					onAttach={() => this.showAttachMenu()}

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -19,7 +19,6 @@ const injectedJs = {
 	codeMirrorBundle: require('../lib/rnInjectedJs/codeMirrorBundle.bundle'),
 	svgEditorBundle: require('../lib/rnInjectedJs/svgEditorBundle.bundle'),
 	pluginBackgroundPage: require('../lib/rnInjectedJs/pluginBackgroundPage.bundle'),
-	noteBodyViewerBundle: require('../lib/rnInjectedJs/noteBodyViewerBundle.bundle'),
 };
 
 function shimInit() {


### PR DESCRIPTION
# Summary

This fixes #10130 by decreasing the frequency at which `Note.tsx` updates `state.note` based on editor events.

# Explanation

Previously, the rerender caused by updating `note.body` could take longer than the time between body updates (for example, on my tablet, when entering text with an external keyboard). This seems to have caused events to queue while waiting for rendering to complete.

Logging just before changing the content of `note.body` reveals that state can be set several seconds after actually typing the text. (See the description of #10130). As a result, this **may also fix issues raised related to the last edit not being saved** (e.g. if the user closes the app before `Note.tsx` works through the backlog of update events).

# Screen recordings

## Before

https://github.com/laurent22/joplin/assets/46334387/0d6a0ba1-e6b9-4822-83f0-dc5c783435b3

Note: The "toggle overflow" button is clicked at roughly 11s. It takes about 20s for the overflow menu to be shown.


## After

https://github.com/laurent22/joplin/assets/46334387/535ab0ac-41f6-4525-b487-e96f6b820ef0

# Testing

1. Open the editor
2. Type several sentences very quickly (or use a tool to type it quickly (e.g. `adb shell input text`)
3. Click the "toggle overflow" button
4. Verify that it takes < 1 second to show the overflow menu
5. Type several sentences very quickly
6. Click on the back arrow
7. Verify that the last typed text is saved and that the note editor opened quickl

This has been tested successfully on an Android 12 emulator.