### PR TITLE
Desktop: Fixes  #10125:  ENEX import change resource-links if resource has same title with existing notes.

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -110,6 +110,7 @@
     "jsdom": "22.1.0",
     "metro-react-native-babel-preset": "0.73.9",
     "nodemon": "3.0.3",
+    "punycode": "2.3.1",
     "react-test-renderer": "18.2.0",
     "sqlite3": "5.1.6",
     "ts-jest": "29.1.1",
@@ -117,7 +118,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.2.2",
     "uglify-js": "3.17.4",
-    "punycode": "2.3.1",
     "webpack": "5.74.0"
   }
 }

--- a/packages/lib/import-enex.ts
+++ b/packages/lib/import-enex.ts
@@ -126,6 +126,7 @@ interface ExtractedNote extends NoteEntity {
 interface SavedNote {
 	id: string;
 	body: string;
+	resourceIds: string[];
 }
 
 // At this point we have the resource as it's been parsed from the XML, but
@@ -309,8 +310,9 @@ const restoreNoteLinks = async (notes: SavedNote[], noteTitlesToIds: Record<stri
 		let noteChanged = false;
 
 		for (const link of links) {
+			const isResourceLink = note.resourceIds.includes(link.url.slice(2));
 			const matchingNoteIds = noteTitlesToIds[link.title];
-			if (matchingNoteIds && matchingNoteIds.length === 1) {
+			if (!isResourceLink && matchingNoteIds && matchingNoteIds.length === 1) {
 				note.body = note.body.replace(link.url, `:/${matchingNoteIds[0]}`);
 				noteChanged = true;
 			}
@@ -480,6 +482,7 @@ const parseNotes = async (parentFolderId: string, filePath: string, importOption
 					savedNotes.push({
 						id: note.id,
 						body: note.body,
+						resourceIds: note.resources.map((r: ExtractedResource) => r.id),
 					});
 
 					progressState.created++;


### PR DESCRIPTION
# Causes
When import ENEX, [restore-note-link](https://github.com/laurent22/joplin/blob/dev/packages/lib/import-enex.ts#L297) converts Evernote's note-link to Joplin's note-link. If a resource (attachment of ENEX) title is identical with an existing note's title, it mistakes that as a note-link, but in fact it's a resource-link. 
=> Changing resource-link causing the attachment failed to loads.

![image](https://github.com/laurent22/joplin/assets/42113313/87eee837-5b63-486d-a2c9-cab29a690687)

# Solution 
To distinguish the resource-link from note-link: 
After imported ENEX, track the created resources ids, if any link inside ENEX points to a resource id, then don't change the link.



# Testing 
Sample file: [test-pdf-evernote.pdf.enex.zip](https://github.com/laurent22/joplin/files/14608816/test-pdf-evernote.pdf.enex.zip)
This ENEX file contains a note with a pdf attachment, both note and pdf titles has identical name. 
1. Open Joplin 
2. File -> Import -> Import ENEX (as Markdown) 
3. Note should be imported, its content should include the pdf attachment, the pdf should be rendered. 
And the link (hash value) of pdf must be: `cd892fa62f1bc4115cb2eceda654143c`

**Before fix: Follow same steps above, the hash would be different, cause pdf to not rendered (wrong resource path)** 


