### PR TITLE
Android: Allow debugging plugins

### DIFF
--- a/packages/app-mobile/components/ExtendedWebView.tsx
+++ b/packages/app-mobile/components/ExtendedWebView.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import {
-	forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useRef, useState,
+	forwardRef, Ref, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState,
 } from 'react';
 import { WebView, WebViewMessageEvent } from 'react-native-webview';
 import { WebViewErrorEvent, WebViewEvent, WebViewSource } from 'react-native-webview/lib/WebViewTypes';
@@ -50,6 +50,7 @@ interface Props {
 	mixedContentMode?: 'never' | 'always';
 
 	allowFileAccessFromJs?: boolean;
+	hasPluginScripts?: boolean;
 
 	// Initial javascript. Must evaluate to true.
 	injectedJavaScript: string;
@@ -142,6 +143,10 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 		logger.error('Error', event.nativeEvent.description);
 	}, []);
 
+	const allowWebviewDebugging = useMemo(() => {
+		return Setting.value('env') === 'dev' || (!!props.hasPluginScripts && Setting.value('plugins.enableWebviewDebugging'));
+	}, [props.hasPluginScripts]);
+
 	// - `setSupportMultipleWindows` must be `true` for security reasons:
 	//   https://github.com/react-native-webview/react-native-webview/releases/tag/v11.0.0
 
@@ -172,7 +177,7 @@ const ExtendedWebView = (props: Props, ref: Ref<WebViewControl>) => {
 			mixedContentMode={props.mixedContentMode}
 			allowFileAccess={true}
 			allowFileAccessFromFileURLs={props.allowFileAccessFromJs}
-			webviewDebuggingEnabled={Setting.value('env') === 'dev'}
+			webviewDebuggingEnabled={allowWebviewDebugging}
 			injectedJavaScript={props.injectedJavaScript}
 			onMessage={props.onMessage}
 			onError={props.onError ?? onError}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -517,6 +517,7 @@ function NoteEditor(props: Props, ref: any) {
 					ref={webviewRef}
 					html={html}
 					injectedJavaScript={injectedJavaScript}
+					hasPluginScripts={codeMirrorPlugins.length > 0}
 					onMessage={onMessage}
 					onLoadEnd={onLoadEnd}
 					onError={onError}

--- a/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
@@ -107,13 +107,13 @@ const PluginRunnerWebViewComponent: React.FC<Props> = props => {
 			}
 		`;
 
-
 		return (
 			<>
 				<ExtendedWebView
 					webviewInstanceId='PluginRunner'
 					html={html}
 					injectedJavaScript={injectedJs}
+					hasPluginScripts={true}
 					onMessage={pluginRunner.onWebviewMessage}
 					onLoadEnd={onLoadEnd}
 					onLoadStart={onLoadStart}

--- a/packages/app-mobile/plugins/PluginRunner/dialogs/PluginUserWebView.tsx
+++ b/packages/app-mobile/plugins/PluginRunner/dialogs/PluginUserWebView.tsx
@@ -103,6 +103,7 @@ const PluginUserWebView = (props: Props) => {
 			baseUrl={plugin.baseDir}
 			webviewInstanceId='joplin__PluginDialogWebView'
 			html={html}
+			hasPluginScripts={true}
 			injectedJavaScript={injectedJs}
 			onMessage={messenger.onWebViewMessage}
 			onLoadEnd={onWebViewLoaded}

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1179,6 +1179,24 @@ class Setting extends BaseModel {
 				autoSave: true,
 			},
 
+			'plugins.enableWebviewDebugging': {
+				value: false,
+				type: SettingItemType.Bool,
+				section: 'plugins',
+				public: true,
+				appTypes: [AppType.Mobile],
+				show: (_settings) => {
+					// Hide on iOS due to App Store guidelines. See
+					// https://github.com/laurent22/joplin/pull/10086 for details.
+					return shim.mobilePlatform() !== 'ios';
+				},
+				needRestart: true,
+				advanced: true,
+
+				label: () => _('Plugin WebView debugging'),
+				description: () => _('Allows debugging mobile plugins. See %s for details.', 'https://https://joplinapp.org/help/api/references/mobile_plugin_debugging/'),
+			},
+
 			'plugins.devPluginPaths': {
 				value: '',
 				type: SettingItemType.String,

--- a/readme/api/references/mobile_plugin_debugging.md
+++ b/readme/api/references/mobile_plugin_debugging.md
@@ -1,0 +1,6 @@
+# Debugging mobile plugins
+
+On Android, it's possible to debug mobile plugins with the Chrome development tools. To do this,
+1. Enable plugin WebView debugging. To do this, go to "Configuration" > "Plugins" > "Advanced settings" and enable "Plugin webview debugging".
+2. Restart Joplin.
+3. Follow the [Chrome devtools instructions for debugging Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/).


### PR DESCRIPTION
# Summary

Allows users to enable [WebView debugging](https://developer.chrome.com/docs/devtools/remote-debugging/) for WebViews that contain plugin scripts (can include the background WebView, sometimes the note editor, and dialogs). This is one of the features on the [mobile plugins to-do list](https://discourse.joplinapp.org/t/mobile-plugin-support/35262).

# Notes


- This setting has no impact when Joplin is running in development mode.
- Before merging, be aware of [this section of the Android documentation](https://developer.android.com/reference/android/webkit/WebView.html#setWebContentsDebuggingEnabled(boolean)):
> Enabling web contents debugging allows the state of any WebView in the app to be inspected and modified by the user via adb. This is a security liability and should not be enabled in production builds of apps unless this is an explicitly intended use of the app. More info on [secure debug settings](https://developer.android.com/topic/security/risks/android-debuggable).

- It may make sense to display a warning when plugin debugging is enabled. This is not currently done.

# Testing

1. Build and install a release version of Joplin (Android).
2. Install at least one plugin.
3. Try to [debug a plugin WebView](https://developer.chrome.com/docs/devtools/remote-debugging). Doing so should not be possible.
4. Enable "Plugin WebView debugging"
5. Restart the application
6. Try to [debug a plugin WebView](https://developer.chrome.com/docs/devtools/remote-debugging). This should now be possible.

This has been tested successfully on Android 13.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->