### PR TITLE
Desktop: fix #10142: Made math formulas (katex) and code keep their own font-family

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -600,7 +600,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			];
 
 			const editors = await (window as any).tinymce.init({
-				content_style: `* {font-size: ${props.fontSize}px; font-family: "${props.fontFamily}"; line-height: ${theme.lineHeight};}`,
+				content_style:
+					`* {font-size: ${props.fontSize}px; font-family: "${props.fontFamily}"; line-height: ${theme.lineHeight};}` +
+					'code, code * {font-family: monospace}' +
+					'.katex * {font-family: KaTeX_Main, Times New Roman, serif;}',
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
 				body_class: 'jop-tinymce',


### PR DESCRIPTION
fixes #10142

### Screenshot
![code_math](https://github.com/laurent22/joplin/assets/113056556/c2aa43fe-c4d1-4590-8b98-21d0bbd0208e)

### Behavior
- The code blocks keep its `font-family`, however the user changes the font family in `Settings > Appearance`
- The same goes for math formulas (`katex`), so the not-equal signs appears as it should