### PR TITLE
Chore: Mobile: Fix note viewer startup error

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -856,6 +856,7 @@ packages/lib/models/Tag.js
 packages/lib/models/dateTimeFormats.test.js
 packages/lib/models/settings/FileHandler.js
 packages/lib/models/settings/settingValidations.js
+packages/lib/models/utils/getCollator.js
 packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/itemCanBeEncrypted.js

--- a/.gitignore
+++ b/.gitignore
@@ -836,6 +836,7 @@ packages/lib/models/Tag.js
 packages/lib/models/dateTimeFormats.test.js
 packages/lib/models/settings/FileHandler.js
 packages/lib/models/settings/settingValidations.js
+packages/lib/models/utils/getCollator.js
 packages/lib/models/utils/getConflictFolderId.js
 packages/lib/models/utils/isItemId.js
 packages/lib/models/utils/itemCanBeEncrypted.js

--- a/packages/app-mobile/utils/shim-init-react.js
+++ b/packages/app-mobile/utils/shim-init-react.js
@@ -19,6 +19,7 @@ const injectedJs = {
 	codeMirrorBundle: require('../lib/rnInjectedJs/codeMirrorBundle.bundle'),
 	svgEditorBundle: require('../lib/rnInjectedJs/svgEditorBundle.bundle'),
 	pluginBackgroundPage: require('../lib/rnInjectedJs/pluginBackgroundPage.bundle'),
+	noteBodyViewerBundle: require('../lib/rnInjectedJs/noteBodyViewerBundle.bundle'),
 };
 
 function shimInit() {


### PR DESCRIPTION
# Summary

Fixes an issue related to a missing injectedJS registration in [shim-init-react.js](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:joplin:pr/mobile/fix-runtime-error?expand=1#diff-0d190f50ca9dd394a1661fe29a9ce2474de657b3dac42b0fe05d248f667c22b3).

- Fixes a merge issue related to mobile plugin support in the note viewer.
    - `noteBodyViewerBundle: require('../lib/rnInjectedJs/noteBodyViewerBundle.bundle'),` which had been incorrectly added in a previous pull request, was removed by another pull request. For the note viewer to work, it needs to be present.
- Runs `yarn updateIgnored` (required by a pre-commit hook)

# Testing plan

1. Open the note viewer
2. Verify that a note can be rendered

This has been tested successfully on an Android  12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->