### PR TITLE
Mobile: Plugins: Fix warning after reloading plugins

### DIFF
--- a/packages/app-mobile/plugins/PluginRunner/PluginRunner.ts
+++ b/packages/app-mobile/plugins/PluginRunner/PluginRunner.ts
@@ -35,7 +35,7 @@ export default class PluginRunner extends BasePluginRunner {
 
 		const messageChannelId = `plugin-message-channel-${pluginId}-${Date.now()}`;
 		const messenger = new RNToWebViewMessenger<PluginMainProcessApi, PluginWebViewApi>(
-			messageChannelId, this.webviewRef.current, { api: pluginApi, onError, onLog },
+			messageChannelId, this.webviewRef, { api: pluginApi, onError, onLog },
 		);
 
 		this.messageEventListeners.push((event) => {


### PR DESCRIPTION
# Summary

Previously, when running a plugin, the `RNToWebViewMessenger` responsible for IPC between that plugin and React Native was given a `WebViewControl` object to communicate with the plugin running within that `WebView`. In some cases, that background `WebView` can be reloaded and the `WebViewControl` would become invalid. For example, when reloading the app in development mode.

If given a `RefObject<WebViewControl>` instead of a `WebViewControl`, the `RNToWebViewMessenger` checks whether its ref's `.current` is `null` before attempting to call `.injectJS`, preventing warnings.

# Testing

> [!NOTE]
>
> This issue can be difficult to reproduce -- it seems to require that a plugin 1) register a listener and 2) have the PluginRunnerWebview reload.
>

1. Disable all plugins.
2. Re-enable one plugin.
3. Switch notes.
4. Verify that no warning message is shown.

Tested successfully on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->