### PR TITLE
Desktop: fix #10036: Applied font family and font size to RTE

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -568,8 +568,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	useEffect(() => {
 		if (!scriptLoaded) return;
 
-		const theme = themeStyle(props.themeId);
-
 		const loadEditor = async () => {
 			const language = closestSupportedLocale(props.locale, true, supportedLocales);
 
@@ -603,9 +601,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			];
 
 			const editors = await (window as any).tinymce.init({
-				content_style: `* {font-size: ${props.fontSize}px; font-family: ${props.fontFamily}; line-height: ${theme.lineHeight};}
-					code, code * {font-family: monospace}
-					.katex * {font-family: KaTeX_Main, Times New Roman, serif;}`,
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
 				body_class: 'jop-tinymce',
@@ -954,6 +949,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				contentMaxWidthTarget: '.mce-content-body',
 				themeId: props.contentMarkupLanguage === MarkupLanguage.Html ? 1 : null,
 				whiteBackgroundNoteRendering: props.whiteBackgroundNoteRendering,
+				fontStyle: `${props.fontSize}px ${props.fontFamily};`,
 			};
 
 			const allAssets = await props.allAssets(props.contentMarkupLanguage, allAssetsOptions);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -568,6 +568,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	useEffect(() => {
 		if (!scriptLoaded) return;
 
+		const theme = themeStyle(props.themeId);
+
 		const loadEditor = async () => {
 			const language = closestSupportedLocale(props.locale, true, supportedLocales);
 
@@ -601,6 +603,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			];
 
 			const editors = await (window as any).tinymce.init({
+				content_style: `* {font-size: ${props.fontSize}px; font-family: ${props.fontFamily}; line-height: ${theme.lineHeight};}
+					code, code * {font-family: monospace}
+					.katex * {font-family: KaTeX_Main, Times New Roman, serif;}`,
 				selector: `#${rootIdRef.current}`,
 				width: '100%',
 				body_class: 'jop-tinymce',

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -464,6 +464,7 @@ function NoteEditor(props: NoteEditorProps) {
 		noteToolbarButtonInfos: props.toolbarButtonInfos,
 		plugins: props.plugins,
 		fontSize: Setting.value('style.editor.fontSize'),
+		fontFamily: `${JSON.stringify(Setting.value('style.editor.fontFamily'))}, Avenir, Arial, sans-serif`,
 		contentMaxWidth: props.contentMaxWidth,
 		isSafeMode: props.isSafeMode,
 		useCustomPdfViewer: props.useCustomPdfViewer,

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -193,6 +193,7 @@ function NoteEditor(props: NoteEditorProps) {
 			contentMaxWidth: props.contentMaxWidth,
 			contentMaxWidthTarget: options.contentMaxWidthTarget,
 			whiteBackgroundNoteRendering: options.whiteBackgroundNoteRendering,
+			fontStyle: options.fontStyle,
 		});
 	}, [props.themeId, props.customCss, props.contentMaxWidth]);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -11,6 +11,7 @@ export interface AllAssetsOptions {
 	contentMaxWidthTarget?: string;
 	themeId?: number;
 	whiteBackgroundNoteRendering?: boolean;
+	fontStyle?: string;
 }
 
 export interface ToolbarButtonInfos {

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -118,6 +118,7 @@ export interface NoteBodyEditorProps {
 	noteToolbarButtonInfos: ToolbarButtonInfo[];
 	plugins: PluginStates;
 	fontSize: number;
+	fontFamily: string;
 	contentMaxWidth: number;
 	isSafeMode: boolean;
 	noteId: string;

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -12,6 +12,7 @@ export interface Options {
 	contentMaxWidthTarget?: string;
 	themeId?: number;
 	whiteBackgroundNoteRendering?: boolean;
+	fontStyle?: string;
 }
 
 // If we are viewing an HTML note, it means it comes from the web clipper or
@@ -79,9 +80,10 @@ export default function(theme: any, options: Options = null) {
 			font-size: ${formatCssSize(theme.noteViewerFontSize)};
 			color: ${theme.color};
 			word-wrap: break-word;
-			line-height: ${theme.lineHeight};
 			background-color: ${theme.backgroundColor};
 			font-family: ${fontFamily};
+			font: ${options.fontStyle};
+			line-height: ${theme.lineHeight};
 			padding-bottom: ${formatCssSize(theme.bodyPaddingBottom)};
 			padding-top: ${formatCssSize(theme.bodyPaddingTop)};
 		}
@@ -283,6 +285,7 @@ export default function(theme: any, options: Options = null) {
 			font-size: ${theme.noteViewerFontSize};
 			color: ${theme.color};
 			font-family: ${fontFamily};
+			font: ${options.fontStyle};
 		}
 
 		.jop-tinymce table td,


### PR DESCRIPTION
fixes #10036 

### Screenshot
![code_math](https://github.com/laurent22/joplin/assets/113056556/5152d589-919b-4472-8f4e-a088eb4fd6f3)

### Output
- The `font-family` and `font-size` changes in Settings > Appearance are applied to RTE
- Made sure the default `font-family` in RTE is the same as in the MD editor
- Made sure the code blocks and math formulas (`katex`) are not affected by `font-family` changes.
