### PR TITLE
Mobile: Fixes #10166: Fix clicking on a link results in a blank screen

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -548,7 +548,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 			});
 		}
 
-		if (prevProps.noteId && prevProps.noteId !== this.props.noteId) {
+		if (prevProps.noteId && this.props.noteId && prevProps.noteId !== this.props.noteId) {
 			// Easier to just go back, then go to the note since
 			// the Note screen doesn't handle reloading a different note
 			const noteId = this.props.noteId;


### PR DESCRIPTION
# Summary

This pull request fixes a navigation issue related to `noteId` briefly being `null` while navigating between notes.

Fixes #10166.

> [!NOTE]
>
> This fixes #10166 in a different way from #10169.
>

# Testing

1. Install the "History" plugin
    - Configure it by setting a history note under its advanced settings.
2. Open a note
3. Follow a link using the History plugin
    - Verify that the link was actually followed.
4. Repeat step 3 several times.

This has been tested successfully on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->