### PR TITLE
Mobile: Fixes #10170, #8779: Fix shared data lost if Joplin is closed immediately after receiving a share

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -587,7 +587,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	private title_changeText(text: string) {
 		shared.noteComponent_change(this, 'title', text);
 		this.setState({ newAndNoTitleChangeNoteId: null });
-		this.scheduleSave();
 	}
 
 	private onPlainEditorTextChange = (text: string) => {
@@ -598,7 +597,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		}
 
 		shared.noteComponent_change(this, 'body', text);
-		this.scheduleSave();
 	};
 
 	// Avoid saving immediately -- the NoteEditor's content isn't controlled by its props
@@ -607,7 +605,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	// See https://github.com/laurent22/joplin/issues/10130
 	private onMarkdownEditorTextChange = debounce((event: EditorChangeEvent) => {
 		shared.noteComponent_change(this, 'body', event.value);
-		this.scheduleSave();
 	}, 100);
 
 	private onPlainEditorSelectionChange = (event: NativeSyntheticEvent<any>) => {

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -17,6 +17,7 @@ export interface BaseNoteScreenComponent {
 	state: any;
 	setState: (newState: any)=> void;
 
+	scheduleSave(): void;
 	scheduleFocusUpdate(): void;
 	attachFile(asset: any, fileType: any): void;
 	lastLoadedNoteId_?: string;
@@ -185,6 +186,7 @@ shared.noteComponent_change = function(comp: BaseNoteScreenComponent, propName: 
 	newState.note = note;
 
 	comp.setState(newState);
+	comp.scheduleSave();
 };
 
 let resourceCache_: any = {};


### PR DESCRIPTION
# Summary

Previously, data shared to Joplin wasn't saved until either:
1. The user edited the note, or
2. The user navigated to a different screen using Joplin's back button.

A save was not triggered if the user closed Joplin immediately after receiving the share.

This pull request changes this behavior — a save is scheduled whenever `noteComponent_change` is called. Because `noteComponent_change` is called just after filling the editor and title inputs with data from a share, this saves shared data after loading the editor.

Fixes #10170.

# Notes

Almost all calls to `noteComponent_change` were followed by a `.scheduleSave` call. The exceptions were the `noteComponent_change` calls responsible for updating `Note.tsx` in response to a share**.

# Testing

Manual testing plan:

1. Close Joplin
2. Share text from another app with Joplin (e.g. from Chrome)
3. Close Joplin
4. Re-open Joplin
5. Verify that the shared data was saved
6. Share to Joplin again
7. Share to Joplin again
8. Close Joplin
9. Verify that shares from steps 6 and 7 were saved

This has been tested successfully on an Android 12 emulator.