### PR TITLE
Mobile: Fixes #10172: Fix trash folder sometimes has wrong icon

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -372,10 +372,10 @@ const SideMenuContentComponent = (props: Props) => {
 
 	const renderFolderIcon = (folderId: string, theme: any, folderIcon: FolderIcon) => {
 		if (!folderIcon) {
-			if (alwaysShowFolderIcons) {
-				return <Icon name="folder-outline" style={styles_.emptyFolderIcon} />;
-			} else if (folderId === getTrashFolderId()) {
+			if (folderId === getTrashFolderId()) {
 				folderIcon = getTrashFolderIcon(FolderIconType.Emoji);
+			} else if (alwaysShowFolderIcons) {
+				return <Icon name="folder-outline" style={styles_.emptyFolderIcon} />;
 			} else {
 				return null;
 			}


### PR DESCRIPTION
# Summary

Fixes an issue where the trash folder would use the default `folder-outline` icon instead of the trash due to an early return.

Fixes #10172.

# Screenshot

![screenshot: Shows trash icon visible in sidebar, along with other icons](https://github.com/laurent22/joplin/assets/46334387/ac9b29fa-c236-4f7d-8f8e-e901394d988d)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->