### PR TITLE
Doc: Plugin API: Update editor content script documentation to include information about the mobile and beta editors

### DIFF
--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -686,21 +686,21 @@ export enum ContentScriptType {
 	 * }
 	 * ```
 	 *
-	 * - The `context` argument is currently unused but could be used later on
-	 *   to provide access to your own plugin so that the content script and
-	 *   plugin can communicate.
+	 * - The `context` argument allows communicating with other parts of
+	 *   your plugin (see below).
 	 *
 	 * - The `plugin` key is your CodeMirror plugin. This is where you can
 	 *   register new commands with CodeMirror or interact with the CodeMirror
 	 *   instance as needed.
 	 *
-	 * - The `codeMirrorResources` key is an array of CodeMirror resources that
+	 * - **CodeMirror 5 only**: The `codeMirrorResources` key is an array of CodeMirror resources that
 	 *   will be loaded and attached to the CodeMirror module. These are made up
 	 *   of addons, keymaps, and modes. For example, for a plugin that want's to
 	 *   enable clojure highlighting in code blocks. `codeMirrorResources` would
 	 *   be set to `['mode/clojure/clojure']`.
+	 *   This field is ignored on mobile and when the desktop beta editor is enabled.
 	 *
-	 * - The `codeMirrorOptions` key contains all the
+	 * - **CodeMirror 5 only**: The `codeMirrorOptions` key contains all the
 	 *   [CodeMirror](https://codemirror.net/doc/manual.html#config) options
 	 *   that will be set or changed by this plugin. New options can alse be
 	 *   declared via
@@ -718,9 +718,11 @@ export enum ContentScriptType {
 	 * must be provided for the plugin to be valid. Having multiple or all
 	 * provided is also okay.
 	 *
-	 * See also the [demo
-	 * plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/codemirror_content_script)
-	 * for an example of all these keys being used in one plugin.
+	 * See also:
+	 * - The [demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/codemirror_content_script)
+	 *   for an example of all these keys being used in one plugin.
+	 * - See [the editor plugin tutorial](https://joplinapp.org/help/api/tutorials/cm6_plugin)
+	 *   for how to develop a plugin for the mobile editor and the desktop beta markdown editor.
 	 *
 	 * ## Posting messages from the content script to your plugin
 	 *


### PR DESCRIPTION
# Summary

Updates the plugin API documentation to include information about the CodeMirror 6-based editors on mobile and desktop.

This includes:
- Linking to the CodeMirror 6 plugin tutorial.
- Marking some options as CodeMirror 5-only.

# Screenshot of the rendered documentation

![Screenshot: Rendered version of the changed markdown --- includes an existing rendering issue -- the mermaid example link is left as markdown by the Typedoc renderer](https://github.com/laurent22/joplin/assets/46334387/fd85b7bf-6db3-4a69-8456-0e7ebc3d71a2)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->