### PR TITLE
Desktop: Fixes #10078: Fixed auto scrolling with moving a note

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -77,6 +77,9 @@ const NoteList = (props: Props) => {
 		props.showCompletedTodos,
 		props.notes,
 		props.selectedFolderInTrash,
+		makeItemIndexVisible,
+		focusNote,
+		props.dispatch,
 	);
 
 	const noteItemStyle = useMemo(() => {

--- a/packages/app-desktop/gui/NoteList/utils/useMoveNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useMoveNote.ts
@@ -3,8 +3,10 @@ import Note from '@joplin/lib/models/Note';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import { useCallback } from 'react';
 import canManuallySortNotes from './canManuallySortNotes';
+import { FocusNote } from './useFocusNote';
+import { Dispatch } from 'redux';
 
-const useMoveNote = (notesParentType: string, noteSortOrder: string, selectedNoteIds: string[], selectedFolderId: string, uncompletedTodosOnTop: boolean, showCompletedTodos: boolean, notes: NoteEntity[], selectedFolderInTrash: boolean) => {
+const useMoveNote = (notesParentType: string, noteSortOrder: string, selectedNoteIds: string[], selectedFolderId: string, uncompletedTodosOnTop: boolean, showCompletedTodos: boolean, notes: NoteEntity[], selectedFolderInTrash: boolean, makeItemIndexVisible: (itemIndex: number)=> void, focusNote: FocusNote, dispatch: Dispatch) => {
 	const moveNote = useCallback((direction: number, inc: number) => {
 		if (!canManuallySortNotes(notesParentType, noteSortOrder, selectedFolderInTrash)) return;
 
@@ -17,7 +19,17 @@ const useMoveNote = (notesParentType: string, noteSortOrder: string, selectedNot
 			targetNoteIndex -= inc;
 		}
 		void Note.insertNotesAt(selectedFolderId, selectedNoteIds, targetNoteIndex, uncompletedTodosOnTop, showCompletedTodos);
-	}, [selectedFolderId, noteSortOrder, notes, notesParentType, selectedNoteIds, uncompletedTodosOnTop, showCompletedTodos, selectedFolderInTrash]);
+
+		// The note will be moved to the target index, so we need to update the scroll amount to make it visible
+		dispatch({
+			type: 'NOTE_SELECT',
+			id: noteId,
+		});
+
+		makeItemIndexVisible(targetNoteIndex);
+
+		focusNote(noteId);
+	}, [selectedFolderId, noteSortOrder, notes, notesParentType, selectedNoteIds, uncompletedTodosOnTop, showCompletedTodos, selectedFolderInTrash, makeItemIndexVisible, focusNote, dispatch]);
 
 	return moveNote;
 };


### PR DESCRIPTION
- ### Fixes #10078 

Update the scroll amount whenever a note is moved.



### RESULT
[Screencast from 2024-03-24 00-50-37.webm](https://github.com/laurent22/joplin/assets/71315378/614925b2-ffc8-402d-9f34-aebf612d7064)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->