### PR TITLE
Desktop: Fixes #10182: Detailed note list doesn't follow preferred date and time formats

### DIFF
--- a/packages/lib/time.ts
+++ b/packages/lib/time.ts
@@ -1,3 +1,4 @@
+import Setting from './models/Setting';
 import shim from './shim';
 const moment = require('moment');
 
@@ -90,7 +91,8 @@ class Time {
 	}
 
 	public unixMsToLocalDateTime(ms: number): string {
-		return moment.unix(ms / 1000).format('DD/MM/YYYY HH:mm');
+		const format = `${Setting.value("dateFormat")} ${Setting.value("timeFormat")}`;
+		return moment.unix(ms / 1000).format(format);
 	}
 
 	public unixMsToLocalHms(ms: number) {


### PR DESCRIPTION
### Summary
Made changes so that the format of date and time shown in the detailed note list matches the format selected under General > Date format and Time format.

Fixes #10182 

### Testing

1. Enable detailed list view via View > Note list style > Detailed
2. In the note list, show any date field, like Updated and Created
3. Now, all dates and times are in the format selected by the user.

This has been tested successfully on Windows 11 and Linux.  