### PR TITLE
Desktop: Fixes #9950: Link created by LINKIFY in WYSIWYG editor is not underlined until switch to another note

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1168,7 +1168,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.insertContent(result.html);
 				}
 			} else {
-				if (BaseItem.isMarkdownTag(pastedText)) { // Paste a link to a note
+				if (BaseItem.isMarkdownTag(pastedText) || BaseItem.isLink(pastedText)) { // Paste a link to a note
 					logger.info('onPaste: pasting as a Markdown tag');
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -34,6 +34,7 @@ import Logger from '@joplin/utils/Logger';
 const md5 = require('md5');
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
+import { isLink } from '@joplin/utils/url';
 
 const logger = Logger.create('TinyMCE');
 
@@ -1168,7 +1169,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.insertContent(result.html);
 				}
 			} else {
-				if (BaseItem.isMarkdownTag(pastedText) || BaseItem.isLink(pastedText)) { // Paste a link to a note
+				if (BaseItem.isMarkdownTag(pastedText) || isLink(pastedText)) { // Paste a link to a note
 					logger.info('onPaste: pasting as a Markdown tag');
 					const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, pastedText, markupRenderOptions({ bodyOnly: true }));
 					editor.insertContent(result.html);

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -967,9 +967,4 @@ export default class BaseItem extends BaseModel {
 		return !!md.match(/^\[.*?\]\(:\/[0-9a-zA-Z]{32}\)$/);
 	}
 
-	public static isLink(text: any) {
-		if (!text) return false;
-		const linkRegex = /^https?:\/\/[^)\s]+$/;
-		return !!text.match(linkRegex);
-	}
 }

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -967,4 +967,9 @@ export default class BaseItem extends BaseModel {
 		return !!md.match(/^\[.*?\]\(:\/[0-9a-zA-Z]{32}\)$/);
 	}
 
+	public static isLink(text: any) {
+		if (!text) return false;
+		const linkRegex = /^https?:\/\/[^)\s]+$/;
+		return !!text.match(linkRegex);
+	}
 }

--- a/packages/utils/url.ts
+++ b/packages/utils/url.ts
@@ -100,3 +100,10 @@ export const fileUriToPath = (path: string, platform = 'linux') => {
 export const isDataUrl = (path: string) => {
 	return path.startsWith('data:');
 };
+
+export const isLink = (text: string) => {
+	if (!text) return false;
+	const linkRegex = /^(https?|file|joplin):\/\/[^)\s]+$/;
+	return !!text.match(linkRegex);
+};
+


### PR DESCRIPTION
### Fixes : #9950 

The current behavior is such that when adding a link to a note using the WYSIWYG editor, the link is not immediately underlined. However, if you switch to another note and then return to the note created earlier, the link is underlined as expected. The expected behavior is that links should be underlined immediately upon insertion, without the need to leave and return to the note.

I found that the problem was that when I pasted the link it was considered as plainText, so I created a function that checks if the pasted text is a link and added this check to the markdowntags if.

### Here is the video without the bug fixed:
[Screencast from 26-03-2024 22:12:17.webm](https://github.com/laurent22/joplin/assets/93351930/76b5c444-d558-4f8f-8d22-654123887422)

### Here is the video after solving the bug:
[Screencast from 26-03-2024 22:10:57.webm](https://github.com/laurent22/joplin/assets/93351930/538ab276-88aa-4482-bdba-6870b9efb57b)




<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->