### PR TITLE
Android,Desktop: Plugin API: Fix unable to require `@codemirror/search` 

### DIFF
--- a/packages/editor/CodeMirror/pluginApi/codeMirrorRequire.ts
+++ b/packages/editor/CodeMirror/pluginApi/codeMirrorRequire.ts
@@ -1,6 +1,7 @@
 
 import * as codeMirrorView from '@codemirror/view';
 import * as codeMirrorState from '@codemirror/state';
+import * as codeMirrorSearch from '@codemirror/search';
 import * as codeMirrorLanguage from '@codemirror/language';
 import * as codeMirrorAutocomplete from '@codemirror/autocomplete';
 import * as codeMirrorCommands from '@codemirror/commands';
@@ -21,6 +22,7 @@ import * as lezerMarkdown from '@lezer/markdown';
 const libraryNameToPackage: Record<string, any> = {
 	'@codemirror/view': codeMirrorView,
 	'@codemirror/state': codeMirrorState,
+	'@codemirror/search': codeMirrorSearch,
 	'@codemirror/language': codeMirrorLanguage,
 	'@codemirror/autocomplete': codeMirrorAutocomplete,
 	'@codemirror/commands': codeMirrorCommands,

--- a/packages/generator-joplin/generators/app/templates/webpack.config.js
+++ b/packages/generator-joplin/generators/app/templates/webpack.config.js
@@ -224,6 +224,7 @@ const pluginConfig = { ...baseConfig, entry: './src/index.ts',
 const externalContentScriptLibraries = [
 	'@codemirror/view',
 	'@codemirror/state',
+	'@codemirror/search',
 	'@codemirror/language',
 	'@codemirror/autocomplete',
 	'@codemirror/commands',


### PR DESCRIPTION
# Summary

Allows requiring the Joplin built-in version of [`@codemirror/search`](https://codemirror.net/docs/ref/#search) from the plugin API. This allows plugins to toggle CodeMirror search, get the current search query, and move between search matches.

# Testing

1. Apply the following diff:
```diff
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/package-lock.json b/packages/app-cli/tests/support/plugins/codemirror6/package-lock.json
index caef3d189..a99ca752a 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/package-lock.json
+++ b/packages/app-cli/tests/support/plugins/codemirror6/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@codemirror/autocomplete": "6.12.0",
+        "@codemirror/search": "^6.5.6",
         "@codemirror/view": "6.22.2",
         "@joplin/lib": "~2.9",
         "@types/node": "^18.7.13",
@@ -959,6 +960,17 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.6.tgz",
+      "integrity": "sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
@@ -3554,6 +3566,12 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/package.json b/packages/app-cli/tests/support/plugins/codemirror6/package.json
index a918e5811..4abd3f99f 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/package.json
+++ b/packages/app-cli/tests/support/plugins/codemirror6/package.json
@@ -15,6 +15,10 @@
     "publish"
   ],
   "devDependencies": {
+    "@codemirror/autocomplete": "6.12.0",
+    "@codemirror/search": "^6.5.6",
+    "@codemirror/view": "6.22.2",
+    "@joplin/lib": "~2.9",
     "@types/node": "^18.7.13",
     "chalk": "^4.1.0",
     "copy-webpack-plugin": "^11.0.0",
@@ -24,9 +28,6 @@
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.2",
     "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0",
-    "@joplin/lib": "~2.9",
-    "@codemirror/view": "6.22.2",
-    "@codemirror/autocomplete": "6.12.0"
+    "webpack-cli": "^4.10.0"
   }
 }
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
index fe9e4a89a..2a6e261bb 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/src/contentScript.ts
@@ -4,7 +4,8 @@
 // This is necessary. Having multiple copies of the CodeMirror libraries loaded can cause
 // the editor to not work properly.
 //
-import { lineNumbers, highlightActiveLineGutter, EditorView } from '@codemirror/view';
+import { lineNumbers, highlightActiveLineGutter, EditorView, keymap } from '@codemirror/view';
+import { findNext } from '@codemirror/search';
 import { completeFromList } from '@codemirror/autocomplete';
 import { MarkdownEditorContentScriptModule, ContentScriptContext } from 'api/types';
 //
@@ -43,6 +44,10 @@ export default (_context: ContentScriptContext): MarkdownEditorContentScriptModu
 				// Joplin also exposes a Facet that allows enabling or disabling CodeMirror's
 				// built-in autocompletions. These apply, for example, to HTML tags.
 				codeMirrorWrapper.joplinExtensions.enableLanguageDataAutocomplete.of(true),
+
+				keymap.of([
+					{ key: 'a', run: findNext },
+				]),
 			]);
 
 			// We can also register editor commands. These commands can be later executed with:
diff --git a/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js b/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
index 525fcf2d4..ab40972eb 100644
--- a/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
+++ b/packages/app-cli/tests/support/plugins/codemirror6/webpack.config.js
@@ -221,6 +221,7 @@ const pluginConfig = { ...baseConfig, entry: './src/index.ts',
 const externalContentScriptLibraries = [
 	'@codemirror/view',
 	'@codemirror/state',
+	'@codemirror/search',
 	'@codemirror/language',
 	'@codemirror/autocomplete',
 	'@codemirror/commands',
```

2. Add the `codemirror6` demo plugin.
3. Search for something not containing the letter `a` that has multiple matches with <kbd>ctrl</kbd>-<kbd>f</kbd> (<kbd>cmd</kbd>-<kbd>f</kbd> on Mac?)
4. Click on the main editor and press <kbd>a</kbd>. Verify that this moves to the next match.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->