### PR TITLE
Doc: Mark several desktop-only plugin API features as "desktop-only"

### DIFF
--- a/packages/app-mobile/plugins/PlatformImplementation.ts
+++ b/packages/app-mobile/plugins/PlatformImplementation.ts
@@ -86,7 +86,6 @@ export default class PlatformImplementation extends BasePlatformImplementation {
 		return {
 			readText: () => Clipboard.getString(),
 			writeText: (text: string) => Clipboard.setString(text),
-			availableFormats: () => ['text/plain'],
 		};
 	}
 

--- a/packages/app-mobile/plugins/PlatformImplementation.ts
+++ b/packages/app-mobile/plugins/PlatformImplementation.ts
@@ -86,6 +86,7 @@ export default class PlatformImplementation extends BasePlatformImplementation {
 		return {
 			readText: () => Clipboard.getString(),
 			writeText: (text: string) => Clipboard.setString(text),
+			availableFormats: () => ['text/plain'],
 		};
 	}
 

--- a/packages/lib/services/plugins/api/Joplin.ts
+++ b/packages/lib/services/plugins/api/Joplin.ts
@@ -124,6 +124,8 @@ export default class Joplin {
 	 * - [fs-extra](https://www.npmjs.com/package/fs-extra)
 	 *
 	 * [View the demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/nativeModule)
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public require(_path: string): any {
 		// Just a stub. Implementation has to be done within plugin process, in plugin_index.js

--- a/packages/lib/services/plugins/api/JoplinClipboard.ts
+++ b/packages/lib/services/plugins/api/JoplinClipboard.ts
@@ -18,16 +18,20 @@ export default class JoplinClipboard {
 		this.electronClipboard_.writeText(text);
 	}
 
+	/** <span class="platform-desktop">desktop</span> */
 	public async readHtml(): Promise<string> {
 		return this.electronClipboard_.readHTML();
 	}
 
+	/** <span class="platform-desktop">desktop</span> */
 	public async writeHtml(html: string): Promise<void> {
 		this.electronClipboard_.writeHTML(html);
 	}
 
 	/**
 	 * Returns the image in [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) format.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public async readImage(): Promise<string> {
 		const image = this.electronClipboard_.readImage();
@@ -36,6 +40,8 @@ export default class JoplinClipboard {
 
 	/**
 	 * Takes an image in [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) format.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public async writeImage(dataUrl: string): Promise<void> {
 		this.electronClipboard_.writeImage(this.electronNativeImage_.createFromDataURL(dataUrl));

--- a/packages/lib/services/plugins/api/JoplinCommands.ts
+++ b/packages/lib/services/plugins/api/JoplinCommands.ts
@@ -24,6 +24,12 @@ import { Command } from './types';
  * To view what arguments are supported, you can open any of these files
  * and look at the `execute()` command.
  *
+ * Note that many of these commands only work on desktop. The more limited list of mobile
+ * commands can be found in these places:
+ *
+ * * [Global commands](https://github.com/laurent22/joplin/tree/dev/packages/app-mobile/commands)
+ * * [Editor commands](https://github.com/laurent22/joplin/blob/dev/packages/app-mobile/components/NoteEditor/commandDeclarations.ts)
+ *
  * ## Executing editor commands
  *
  * There might be a situation where you want to invoke editor commands

--- a/packages/lib/services/plugins/api/JoplinContentScripts.ts
+++ b/packages/lib/services/plugins/api/JoplinContentScripts.ts
@@ -29,7 +29,8 @@ export default class JoplinContentScripts {
 	 * for more information.
 	 *
 	 * * [View the renderer demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/content_script)
-	 * * [View the editor demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/codemirror_content_script)
+	 * * [View the editor plugin tutorial](https://joplinapp.org/help/api/tutorials/cm6_plugin)
+	 * * [View the legacy editor demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/codemirror_content_script)
 	 *
 	 * See also the [postMessage demo](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/post_messages)
 	 *

--- a/packages/lib/services/plugins/api/JoplinImaging.ts
+++ b/packages/lib/services/plugins/api/JoplinImaging.ts
@@ -39,6 +39,7 @@ interface Image {
  * [View the
  * example](https://github.com/laurent22/joplin/blob/dev/packages/app-cli/tests/support/plugins/imaging/src/index.ts)
  *
+ * <span class="platform-desktop">desktop</span>
  */
 export default class JoplinImaging {
 

--- a/packages/lib/services/plugins/api/JoplinInterop.ts
+++ b/packages/lib/services/plugins/api/JoplinInterop.ts
@@ -18,6 +18,9 @@ import { ExportModule, ImportModule } from './types';
  * See the documentation of the [[ExportModule]] and [[ImportModule]] for more information.
  *
  * You may also want to refer to the Joplin API documentation to see the list of properties for each item (note, notebook, etc.) - https://joplinapp.org/help/api/references/rest_api
+ *
+ * <span class="platform-desktop">desktop</span>: While it is possible to register import and export
+ * modules on mobile, there is no GUI to activate them.
  */
 export default class JoplinInterop {
 

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -78,6 +78,8 @@ export default class JoplinViewsDialogs {
 	 * Displays a dialog to select a file or a directory. Same options and
 	 * output as
 	 * https://www.electronjs.org/docs/latest/api/dialog#dialogshowopendialogbrowserwindow-options
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public async showOpenDialog(options: any): Promise<any> {
 		return this.implementation_.showOpenDialog(options);

--- a/packages/lib/services/plugins/api/JoplinViewsMenuItems.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsMenuItems.ts
@@ -10,6 +10,8 @@ import createViewHandle from '../utils/createViewHandle';
  * Allows creating and managing menu items.
  *
  * [View the demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/register_command)
+ *
+ * <span class="platform-desktop">desktop</span>
  */
 export default class JoplinViewsMenuItems {
 

--- a/packages/lib/services/plugins/api/JoplinViewsMenus.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsMenus.ts
@@ -10,6 +10,8 @@ import createViewHandle from '../utils/createViewHandle';
  * Allows creating menus.
  *
  * [View the demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/menu)
+ *
+ * <span class="platform-desktop">desktop</span>
  */
 export default class JoplinViewsMenus {
 

--- a/packages/lib/services/plugins/api/JoplinViewsNoteList.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsNoteList.ts
@@ -36,6 +36,7 @@ import { ListRenderer } from './noteListType';
  *
  * <img width="250px" src="https://global.discourse-cdn.com/standard14/uploads/cozic/optimized/3X/7/2/72acb1bab67d32482cb3da7bb053e54d44ad87b8_2_580x500.png"/>
  *
+ * <span class="platform-desktop">desktop</span>
  */
 export default class JoplinViewsNoteList {
 

--- a/packages/lib/services/plugins/api/JoplinViewsPanels.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsPanels.ts
@@ -6,11 +6,16 @@ import WebviewController, { ContainerType } from '../WebviewController';
 import { ViewHandle } from './types';
 
 /**
- * Allows creating and managing view panels. View panels currently are
- * displayed at the right of the sidebar and allows displaying any HTML
- * content (within a webview) and update it in real-time. For example it
+ * Allows creating and managing view panels. View panels allow displaying any HTML
+ * content (within a webview) and updating it in real-time. For example it
  * could be used to display a table of content for the active note, or
  * display various metadata or graph.
+ *
+ * On desktop, view panels currently are displayed at the right of the sidebar, though can
+ * be moved with "View" > "Change application layout".
+ *
+ * On mobile, view panels are shown in a tabbed dialog that can be opened using a
+ * toolbar button.
  *
  * [View the demo plugin](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/toc)
  */

--- a/packages/lib/services/plugins/api/JoplinWindow.ts
+++ b/packages/lib/services/plugins/api/JoplinWindow.ts
@@ -24,6 +24,8 @@ export default class JoplinWindow {
 	 * for the note viewer. It is the same as the "Custom stylesheet for
 	 * Joplin-wide app styles" setting. See the [Load CSS Demo](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/load_css)
 	 * for an example.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public async loadChromeCssFile(filePath: string) {
 		await this.implementation_.injectCustomStyles(`pluginStyles_${this.plugin_.id}`, filePath);
@@ -34,6 +36,8 @@ export default class JoplinWindow {
 	 * exported or printed note. It is the same as the "Custom stylesheet for
 	 * rendered Markdown" setting. See the [Load CSS Demo](https://github.com/laurent22/joplin/tree/dev/packages/app-cli/tests/support/plugins/load_css)
 	 * for an example.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public async loadNoteCssFile(filePath: string) {
 		const cssString = await shim.fsDriver().readFile(filePath, 'utf8');

--- a/packages/lib/services/plugins/api/JoplinWorkspace.ts
+++ b/packages/lib/services/plugins/api/JoplinWorkspace.ts
@@ -141,13 +141,15 @@ export default class JoplinWorkspace {
 	/**
 	 * Called just before the editor context menu is about to open. Allows
 	 * adding items to it.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	public filterEditorContextMenu(handler: FilterHandler<EditContextMenuFilterObject>) {
 		eventManager.filterOn('editorContextMenu', handler);
 	}
 
 	/**
-	 * Gets the currently selected note
+	 * Gets the currently selected note. Will be `null` if no note is selected.
 	 */
 	public async selectedNote(): Promise<any> {
 		const noteIds = this.store.getState().selectedNoteIds;

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -340,6 +340,8 @@ export type ButtonId = string;
 export enum ToolbarButtonLocation {
 	/**
 	 * This toolbar in the top right corner of the application. It applies to the note as a whole, including its metadata.
+	 *
+	 * <span class="platform-desktop">desktop</span>
 	 */
 	NoteToolbar = 'noteToolbar',
 


### PR DESCRIPTION
# Summary

Marks several desktop-only features as "desktop-only" in the plugin API documentation.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->