### PR TITLE
Android: Plugin API: Support `clipboard.availableFormats`

### DIFF
--- a/packages/app-mobile/plugins/PlatformImplementation.ts
+++ b/packages/app-mobile/plugins/PlatformImplementation.ts
@@ -86,6 +86,7 @@ export default class PlatformImplementation extends BasePlatformImplementation {
 		return {
 			readText: () => Clipboard.getString(),
 			writeText: (text: string) => Clipboard.setString(text),
+			availableFormats: () => ['text/plain'],
 		};
 	}
 


### PR DESCRIPTION
# Summary

Adds support for the `joplin.clipboard.availableFormats` method on mobile. 

# Testing

1. Run Joplin in development mode on Android.
2. Connect to `PluginRunner.html` in `chrome://inspect` on a connected desktop device (see [mobile plugin debugging](https://joplinapp.org/help/api/references/mobile_plugin_debugging)).
3. Select `about:srcdoc` as the frame to debug: ![screenshot: Choosing to debug about:srcdoc](https://github.com/laurent22/joplin/assets/46334387/0bff016a-aded-47aa-b3f0-b4e78582371e)
4. Run `await joplin.clipboard.availableFormats()` in the console
5. Verify that the output is `['text/plain']`

This has been tested successfully while connected to an Android 13 device.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->