### PR TITLE
Chore: Fix build failures when compiled .js files are out-of-date

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,4 +27,8 @@
 		"Modules/**/*",
 		"packages/server/dist",
 	],
+
+	"ts-node": {
+		"preferTsExts": true
+	}
 }


### PR DESCRIPTION
# Summary

Previously, `ts-node` imported and ran `.js` files if available, even if a `.ts` file with the same name exists. This could lead to build failures when the `.js` files generated from `.ts` files were out-of-date. 

See:
- [A related post on Joplin's Discord](https://discord.com/channels/610762468960239627/919979500765335613/1220741013295861860)
- The [`preferTsExts` ts-node](https://typestrong.org/ts-node/docs/options/#prefertsexts) documentation.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->