### PR TITLE
All: Resolves #10199: Add custom tooltip for Richtext Editor hyperlinks

### DIFF
--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -109,7 +109,6 @@ export default function(href: string, options: Options = null): LinkReplacementR
 	const attrHtml = [];
 	attrHtml.push('data-from-md');
 	if (resourceIdAttr) attrHtml.push(resourceIdAttr);
-	if (title) attrHtml.push(`title='${htmlentities(title)}'`);
 	if (mime) attrHtml.push(`type='${htmlentities(mime)}'`);
 
 	let resourceFullPath = resource && options?.ResourceModel?.fullPath ? options.ResourceModel.fullPath(resource) : null;
@@ -120,9 +119,11 @@ export default function(href: string, options: Options = null): LinkReplacementR
 		resourceFullPath = url;
 	} else if (options.plainResourceRendering || options.linkRenderingType === 2) {
 		icon = '';
+		if (title) attrHtml.push(`title='Ctrl + Click to open ${htmlentities(title)}'`);
 		attrHtml.push(`href='${htmlentities(href)}'`);
 	} else {
 		attrHtml.push(`href='${htmlentities(hrefAttr)}'`);
+		if (title) attrHtml.push(`title='${htmlentities(title)}'`);
 		if (js) attrHtml.push(js);
 	}
 


### PR DESCRIPTION
References #10199
Prepend "Ctrl + Click to open" before hyperlink tooltips in Richtext Editor only. The MD editor shows the original tooltip.

[Screencast_20240326_162257.webm](https://github.com/laurent22/joplin/assets/59203815/dd8e31e9-1678-47f8-8963-1ddc4f415e51)
