### PR TITLE
Desktop: Resolves #10199: Add link context option to TinyMCE init fucntion

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -610,6 +610,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
 				plugins: 'noneditable link joplinLists hr searchreplace codesample table',
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
+				link_context_toolbar: true,
 
 				// #p: Pad empty paragraphs with &nbsp; to prevent them from being removed.
 				// *[*]: Allow all elements and attributes -- we already filter in sanitize_html


### PR DESCRIPTION
Resolves #10199 
Displays a tooltip on clicking hyperlinks in the Rich Text Editor mode. (Limited to TinyMCE editing mode)
Added an additional option `link_context_toolbar: true,` to the tinymce.init({...}) function. 
[Reference this](https://www.tiny.cloud/docs/plugins/opensource/link/#link_context_toolbar)
![image](https://github.com/laurent22/joplin/assets/59203815/b922608c-f6e6-41e1-80e2-dab14d909e60)
