### PR TITLE
Mobile: Fixes #10188: hide 'new note' button from trash

### DIFF
--- a/packages/app-mobile/components/NoteList.tsx
+++ b/packages/app-mobile/components/NoteList.tsx
@@ -11,6 +11,7 @@ import Folder from '@joplin/lib/models/Folder';
 const { _ } = require('@joplin/lib/locale');
 const { NoteItem } = require('./note-item.js');
 import { themeStyle } from './global-style';
+import { getTrashFolderId, itemIsInTrash } from '@joplin/lib/services/trash';
 
 interface NoteListProps {
 	themeId: number;
@@ -91,7 +92,13 @@ class NoteListComponent extends Component<NoteListProps> {
 				keyExtractor={item => item.id}
 			/>;
 		} else {
-			if (!Folder.atLeastOneRealFolderExists(this.props.folders)) {
+			const noteSource = this.props.notesSource ? JSON.parse(this.props.notesSource) : null;
+			const noteSourceFolder = this.props.folders.find(folder => folder.id === noteSource?.parentId);
+
+			if (noteSource?.parentId === getTrashFolderId() || itemIsInTrash(noteSourceFolder)) {
+				const noItemMessage = _('There are no notes here.');
+				return <Text style={this.styles().noItemMessage}>{noItemMessage}</Text>;
+			} else if (!Folder.atLeastOneRealFolderExists(this.props.folders)) {
 				const noItemMessage = _('You currently have no notebooks.');
 				return (
 					<View style={this.styles().noNotebookView}>

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -17,7 +17,7 @@ const { BaseScreenComponent } = require('../base-screen');
 const { BackButtonService } = require('../../services/back-button.js');
 import { AppState } from '../../utils/types';
 import { NoteEntity } from '@joplin/lib/services/database/types';
-import { itemIsInTrash } from '@joplin/lib/services/trash';
+import { getTrashFolderId, itemIsInTrash } from '@joplin/lib/services/trash';
 const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids.js');
 
 class NotesScreenComponent extends BaseScreenComponent<any> {
@@ -246,7 +246,7 @@ class NotesScreenComponent extends BaseScreenComponent<any> {
 				}
 				return buttonFolderId;
 			};
-			if (addFolderNoteButtons && this.props.folders.length > 0) {
+			if (addFolderNoteButtons && this.props.folders.length > 0 && this.props.activeFolderId !== getTrashFolderId()) {
 				const buttons = [];
 				buttons.push({
 					label: _('New to-do'),


### PR DESCRIPTION
Fixes issue #10188 
Now "New note" button is hidden from the trash

https://github.com/laurent22/joplin/assets/92685826/0884fe5b-b518-4ba6-9431-089f3433661b

