### PR TITLE
Mobile: Partially resolves #10207: display recommended plugin alert

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
@@ -102,17 +102,17 @@ const PluginBox: React.FC<Props> = props => {
 	const renderRecommendedChip = () => {
 		const onRecommendedPress = () => {
 			Alert.alert(
-				'Recommended Plugin',
-				'The Joplin team has vetted this plugin and it meets our standards for security and performance.',
+				_('Recommended Plugin'),
+				_('The Joplin team has vetted this plugin and it meets our standards for security and performance.'),
 				[
 					{
-						text: 'Learn More',
+						text: _('Learn More'),
 						onPress: async () => {
 							await Linking.openURL('https://github.com/joplin/plugins/blob/master/readme/recommended.md');
 						},
 					},
 					{
-						text: 'OK',
+						text: _('OK'),
 					},
 				],
 				{ cancelable: true },

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, Button, Card, Chip } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { Alert, View } from 'react-native';
+import { Alert, Linking, View } from 'react-native';
 import { ItemEvent, PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 
 export enum InstallState {
@@ -101,7 +101,22 @@ const PluginBox: React.FC<Props> = props => {
 
 	const renderRecommendedChip = () => {
 		const onRecommendedPress = () => {
-			Alert.alert('Recommended Plugin', 'The Joplin team has vetted this plugin and it meets our standards for security and performance.');
+			Alert.alert(
+				'Recommended Plugin',
+				'The Joplin team has vetted this plugin and it meets our standards for security and performance.',
+				[
+					{
+						text: 'Learn More',
+						onPress: async () => {
+							await Linking.openURL('https://github.com/joplin/plugins/blob/master/readme/recommended.md');
+						},
+					},
+					{
+						text: 'OK',
+					},
+				],
+				{ cancelable: true },
+			);
 		};
 
 		if (!props.item.manifest._recommended) {

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, Button, Card, Chip } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { View } from 'react-native';
+import { Alert, View } from 'react-native';
 import { ItemEvent, PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 
 export enum InstallState {
@@ -100,10 +100,20 @@ const PluginBox: React.FC<Props> = props => {
 	};
 
 	const renderRecommendedChip = () => {
+		const onRecommendedPress = () => {
+			Alert.alert('Recommended Plugin', 'The Joplin team has vetted this plugin and it meets our standards for security and performance.');
+		};
+
 		if (!props.item.manifest._recommended) {
 			return null;
 		}
-		return <Chip icon='crown' mode='outlined'>{_('Recommended')}</Chip>;
+		return <Chip
+			icon='crown'
+			mode='outlined'
+			onPress={() => onRecommendedPress()}
+		>
+			{_('Recommended')}
+		</Chip>;
 	};
 
 	const renderBuiltInChip = () => {


### PR DESCRIPTION
Partially resolves #10207

### Commit 1

<img src="https://github.com/laurent22/joplin/assets/59203815/1d159351-60a4-4ec7-9a2c-4eaf2235c889" width=250>
Created alert on the recommended chip that complies with the desktop message. Partially fixes #10207

### Commit 2


<img src="https://github.com/laurent22/joplin/assets/59203815/99323a9e-56ac-4eaf-b2e4-a43185e6a70b" width=250>


Added Learn More button to alert for opening this [link](https://github.com/joplin/plugins/blob/master/readme/recommended.md) 