### PR TITLE
Update Dockerfile.server

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -56,7 +56,8 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 FROM node:18-bullseye-slim
 
 ARG user=joplin
-RUN useradd --create-home --shell /bin/bash $user
+ARG group=joplin
+RUN groupadd -g ${USERMAP_GID} $group && useradd -u ${USERMAP_UID} -g $group --create-home --shell /bin/bash $user
 
 USER $user
 


### PR DESCRIPTION
Add a possibility to overwrite UID and GID, to prevent any EACCESS errors.

This is not tested, but this is the idea. If you now try to create a volume to a files folder and use that same path as the filestorage for joplin server, you will get EACCESS errors as docker overwrites those permissions. Paperless-ng fixes this by giving the option to override the UID and GID. It would be good if joplin server has this option as well

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->