### PR TITLE
Desktop: Security: Make attachment and file links safer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -474,6 +474,8 @@ packages/app-desktop/utils/7zip/pathToBundled7Zip.js
 packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js
+packages/app-desktop/utils/isSafeToOpen.test.js
+packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/markupLanguageUtils.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js

--- a/.gitignore
+++ b/.gitignore
@@ -454,6 +454,8 @@ packages/app-desktop/utils/7zip/pathToBundled7Zip.js
 packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js
+packages/app-desktop/utils/isSafeToOpen.test.js
+packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/markupLanguageUtils.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -137,6 +137,10 @@ class Application extends BaseApplication {
 			webFrame.setZoomFactor(Setting.value('windowContentZoomFactor') / 100);
 		}
 
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'linking.extraAllowedExtensions' || action.type === 'SETTING_UPDATE_ALL') {
+			bridge().extraAllowedOpenExtensions = Setting.value('linking.extraAllowedExtensions');
+		}
+
 		if (['EVENT_NOTE_ALARM_FIELD_CHANGE', 'NOTE_DELETE'].indexOf(action.type) >= 0) {
 			await AlarmService.updateNoteNotification(action.id, action.type === 'NOTE_DELETE');
 		}
@@ -609,6 +613,9 @@ class Application extends BaseApplication {
 		}
 
 		bridge().addEventListener('nativeThemeUpdated', this.bridge_nativeThemeUpdated);
+		bridge().setOnAllowedExtensionsChangeListener((newExtensions) => {
+			Setting.setValue('linking.extraAllowedExtensions', newExtensions);
+		});
 
 		await this.initPluginService();
 

--- a/packages/app-desktop/utils/isSafeToOpen.test.ts
+++ b/packages/app-desktop/utils/isSafeToOpen.test.ts
@@ -1,0 +1,32 @@
+import { remove, writeFile } from 'fs-extra';
+import { createTempDir } from '@joplin/lib/testing/test-utils';
+import { join } from 'path';
+import isUnsafeToOpen from './isSafeToOpen';
+
+
+describe('isUnsafeToOpen', () => {
+	test.each([
+		{ fileName: 'a.txt', expected: true },
+		{ fileName: 'a.json', expected: true },
+		{ fileName: 'a.JSON', expected: true },
+		{ fileName: 'a.tar.gz', expected: true },
+		{ fileName: 'a.exe', expected: false },
+		{ fileName: 'test.com', expected: false },
+		{ fileName: 'a.pyc', expected: false },
+		{ fileName: 'a.pyo', expected: false },
+		{ fileName: 'a.pyw', expected: false },
+		{ fileName: 'a.jar', expected: false },
+		{ fileName: 'a.bat', expected: false },
+		{ fileName: 'a.cmd', expected: false },
+		{ fileName: 'noExtension', expected: false },
+	])('should mark executable files as possibly unsafe to open (%j)', async ({ fileName, expected }) => {
+		const tempDir = await createTempDir();
+		try {
+			const fullPath = join(tempDir, fileName);
+			await writeFile(fullPath, 'test');
+			expect(await isUnsafeToOpen(fullPath)).toBe(expected);
+		} finally {
+			await remove(tempDir);
+		}
+	});
+});

--- a/packages/app-desktop/utils/isSafeToOpen.ts
+++ b/packages/app-desktop/utils/isSafeToOpen.ts
@@ -1,0 +1,179 @@
+
+
+const isSafeToOpen = (path: string) => {
+	// This is intended to fix an issue where some platforms would execute attachment
+	// files without confirmation depending on the file extension (e.g. .EXE). This is
+	// mostly for Windows.
+	//
+	// Below is a list of extensions that we should be able to safely pass to shell.openItem
+	// without code execution.
+
+	// Prevent CSpell from marking file extensions as misspellings:
+	// cSpell:disable
+	const generallySafeExtensions = [
+		// Image files (see https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)
+		'.apng',
+		'.avif',
+		'.bmp',
+		'.gif',
+		'.heic',
+		'.heics',
+		'.ico',
+		'.jpeg',
+		'.jpg',
+		'.pjp',
+		'.pjpeg',
+		'.png',
+		'.svg',
+		'.svgz',
+		'.webp',
+		'.tiff',
+		'.tif',
+
+		// Video files
+		'.3g2',
+		'.3gp',
+		'.avi',
+		'.divx',
+		'.h261',
+		'.h263',
+		'.h264',
+		'.jpgv',
+		'.m4p',
+		'.m4v',
+		'.mk3d',
+		'.mkv',
+		'.mov',
+		'.movie',
+		'.mp4',
+		'.mp4v',
+		'.mpeg',
+		'.mpg',
+		'.mpg4',
+		'.ogv',
+		'.webm',
+		'.wmv',
+
+		// Audio files
+		// https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#browser_compatibility
+		'.3gp',
+		'.aac',
+		'.flac',
+		'.m2a',
+		'.m3a',
+		'.m4a',
+		'.mp2',
+		'.mp3',
+		'.mpga',
+		'.oga',
+		'.ogg',
+		'.wav',
+		'.wma',
+
+		// Document files
+		'.epub',
+		'.pdf',
+		'.txt',
+
+		// By default (as of Feb 2024), Word/Excel disable macros by default, and should thus
+		// be reasonably safe to include here. Pay attention to these Office extensions in the future.
+		'.docx', // Word (no macros)
+		'.odp',
+		'.ods',
+		'.odt',
+		'.pptx', // PowerPoint (no macros)
+		// '.psd', // PhotoShop
+		// MS Word can try to convert RTF files, causing security issues: https://en.wikipedia.org/wiki/Rich_Text_Format#Security_concerns
+		// However, macros are disabled by default in modern Office.
+		// '.rtf',
+		'.xlsx', // Excel (no macros)
+		// '.xopp', // Xournal++ -- Can include LaTeX. Verify it's safe before including.
+
+		// Text files
+		'.c',
+		'.cjs',
+		'.cpp',
+		'.css',
+		'.csv',
+		'.cxx',
+		'.dart',
+		'.go',
+		'.h',
+		'.hh',
+		'.f', // Fortran
+		'.for',
+		'.f77',
+		'.f90',
+		'.hmm',
+		'.hpp',
+		'.hxx',
+		'.java',
+		'.json',
+		'.json5',
+		'.jsx',
+		'.log',
+		'.m',
+		'.md',
+		'.markdown',
+		'.mdx',
+		'.mjs',
+		'.mm',
+		'.patch',
+		'.r',
+		'.rmd',
+		'.rs', // Rust
+		'.sass',
+		'.scss',
+		'.sha256',
+		'.sha512',
+		'.swift',
+		'.tex',
+		'.toml',
+		'.ts',
+		'.tsv',
+		'.tsx',
+		'.xml',
+		'.yaml',
+		// .js may be set to run with Windows Script Host on some systems
+		// .ml: OCaml
+		// .py may be set to run with the system Python interpreter on some systems
+		// .rkt: Racket
+
+		// Archives
+		'.7z',
+		'.tar.gz',
+		'.tar',
+		'.zip',
+
+		// Fonts
+		'.ttf',
+		'.woff',
+		'.otf',
+
+		// Calendar
+		'.ics',
+		'.ical',
+		'.icalendar',
+
+		// Joplin
+		'.jex',
+		// '.jpl', // Plugin files
+
+		// Other
+		'.htm',
+		'.html',
+		'.enex', // Evernote
+		// '.desktop', // May be auto-executed on some Linux systems
+	];
+	// cSpell:enable
+
+	const lowercasedPath = path.trim().toLowerCase();
+	for (const ext of generallySafeExtensions) {
+		if (lowercasedPath.endsWith(ext)) {
+			return true;
+		}
+	}
+	return false;
+};
+
+export default isSafeToOpen;

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1559,6 +1559,15 @@ class Setting extends BaseModel {
 				isGlobal: true,
 			},
 
+			'linking.extraAllowedExtensions': {
+				value: [],
+				type: SettingItemType.Array,
+				public: false,
+				appTypes: [AppType.Desktop],
+				label: () => 'Additional file types that can be opened without confirmation.',
+				storage: SettingStorage.File,
+			},
+
 			'net.customCertificates': {
 				value: '',
 				type: SettingItemType.String,

--- a/readme/apps/attachments.md
+++ b/readme/apps/attachments.md
@@ -11,3 +11,21 @@ Resources that are not attached to any note will be automatically deleted in acc
 ## Downloading attachments
 
 The way the attachments are downloaded during synchronisation can be customised in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md), under "Attachment download behaviour". The default option ("Always") is to download all the attachments, all the time, so that the data is available even when the device is offline. There is also the option to download the attachments manually (option "Manual"), by clicking on it, or automatically (Option "Auto"), in which case the attachments are downloaded only when a note is opened. These options should help saving disk space and network bandwidth, especially on mobile.
+
+## Opening attachments
+
+**In the note viewer,** clicking an attachment link opens that attachment.
+
+**In the rich text editor,** <kbd>ctrl</kbd>+<kbd>click</kbd> opens that attachment.
+
+In both cases, the attachment is opened in the default editor for that file type. The editor can generally be customised in system settings.
+
+### Unknown file type warning
+
+Opening some types of attachments can be dangerous. Some computers try to run some attachment types as programs. This means that opening attachments from an untrusted source could allow someone to steal information from your computer or worse.
+
+**When is it safe to open an unknown file type?** If you created the file, attached it to a Joplin note, and haven't shared the note with anyone, it should be safe to open. Otherwise, avoid opening the attachment, especially if you don't recognise the file type.
+
+If you're certain that a file type is always safe to open, regardless of its source, check the `Always open this file type without asking` box to stop receiving warnings for that file type. It might make sense to do this, for example, if you work with a large number of `.doc` files and know that they're safe to open in the version of Word you have installed.
+
+**What are some examples of unsafe file types?** This depends on your computer. For example, on most Windows systems, `.COM`, `.EXE`, and `.BAT` files are unsafe.


### PR DESCRIPTION
# Summary

This pull request makes clicking on links in untrusted notes safer. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->