### PR TITLE
Mobile: Show sync version and client id in More Info

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -562,6 +562,8 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 			addSettingText('version_info_app', `Joplin ${VersionInfo.appVersion}`);
 			addSettingText('version_info_db', _('Database v%s', reg.db().version()));
+			addSettingText('version_info_sync', _('Sync Version: %s', Setting.value('syncVersion')));
+			addSettingText('version_info_client_id', _('Client ID: %s', Setting.value('clientId')));
 			addSettingText('version_info_fts', _('FTS enabled: %d', this.props.settings['db.ftsEnabled']));
 			addSettingText('version_info_hermes', _('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0));
 


### PR DESCRIPTION
The `More Information` window on mobile devices doesn't show the `Sync Version` and `Client ID` as the `About Joplin` window on desktop. So I added these items to the `More Information` window.

![图片](https://github.com/laurent22/joplin/assets/62299611/28a5eb66-c2bf-4094-b696-30090b93c9a7) ![image](https://github.com/laurent22/joplin/assets/62299611/dc39fb07-84b8-4c8c-8411-c0af04bba3f3)
