### PR TITLE
Desktop, Mobile, Cli: Avoid unnecessary requests if credentials are empty

### DIFF
--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -80,6 +80,10 @@ export default class JoplinServerApi {
 
 		const clientInfo = await this.getClientInfo();
 
+		if (!this.options_.username() || !this.options_.password()) {
+			return null;
+		}
+
 		try {
 			this.session_ = await this.exec_('POST', 'api/sessions', null, {
 				email: this.options_.username(),


### PR DESCRIPTION
There isn't any check right now if the username or password fields were set before checking if the user credentials are valid with a request to the server.

I test the changes in Desktop, Mobile and Cli apps.

### Testing

- Set synchronisation target as Joplin Server on Desktop or Mobile app
- Let email and/or password field empty
- Before, when the app would check if the credentials are valid a request would be made to the server, even if the fields were empty
- Now, if the credentials are empty we can prevent the pointless request