### PR TITLE
Desktop:  Fix #9879: unexpected behavior between importing/exporting screens and opening settings

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/showModalMessage.tsx
+++ b/packages/app-desktop/gui/MainScreen/commands/showModalMessage.tsx
@@ -14,14 +14,26 @@ export const runtime = (comp: any): CommandRuntime => {
 				return <div key={line} className="text">{line}</div>;
 			});
 
+
+			const hideModalMessage = () => {
+				comp.setState({ modalLayer: { visible: false, message: '' } });
+			};
+
 			comp.setState({
 				modalLayer: {
 					visible: true,
 					message:
-						<div className="modal-message">
-							<div id="loading-animation" />
-							<div className="text">
-								{lines}
+						<div className="import-message">
+							<div className="modal-message">
+								<div id="loading-animation"/>
+								<div className="text">
+									{lines}
+								</div>
+							</div>
+							<div className="close-modal">
+								<button className="close-button" onClick={hideModalMessage}
+								>Continue using the app while processing
+								</button>
 							</div>
 						</div>,
 				},

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -285,7 +285,7 @@ function useMenu(props: Props) {
 
 		if (Array.isArray(path)) path = path[0];
 
-		const modalMessage = _('Importing from "%s" as "%s" format. Please wait...', path, module.format);
+		const modalMessage = _('Importing from "%s" as "%s" format.', path, module.format);
 
 		void CommandService.instance().execute('showModalMessage', modalMessage);
 

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -122,6 +122,18 @@ a {
 	margin: 40px 20px;
 }
 
+.close-modal {
+	display: flex;
+	justify-content: center;
+}
+
+.close-button {
+	.icon-button:active;
+	color: var(--joplin-color);
+	padding: 12px 24px;
+	cursor: pointer;
+}
+
 #loading-animation {
 	margin-right: 20px;
 	width: 20px;


### PR DESCRIPTION
This issue implies that during the process of Importing and Exporting, opening and closing the settings screen closes the previous display that appears during those actions. 

That happens because the importing screen is a Modal, which means it appears over the main screen, making the setting screen go to the main screen when the back button is pressed and not the previously appearing modal. For that, I choose the following solution:
- a close button is added to show that the import and export processes are processes that happen on the back, and the users can continue using the app. This is an expected behavior that is intuitive and saves time for the user, increasing user experience. I fixed this issue by adding a button that goes with the style of the app:
- adding a button with a clicked-based function to close the modal on showModalMessage.tsx;
- styling on main.scss based on the previous implementation.

There's a video with the solution working:

https://github.com/laurent22/joplin/assets/94613613/da929b13-3f51-43c0-9d4c-de2a39ec921c

