### PR TITLE
Desktop: Fixes #9588: Mermaid diagram download button is not working in the rich text editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -69,6 +69,8 @@ export default function(editor: any, plugins: PluginStates, dispatch: Function, 
 				resourceId = Resource.pathToId(element.href);
 				itemType = resourceId ? ContextMenuItemType.Resource : ContextMenuItemType.Link;
 				linkToCopy = element.getAttribute('href') || '';
+			} else if (element.nodeName === 'svg') {
+				itemType = ContextMenuItemType.Mermaid;
 			} else {
 				itemType = ContextMenuItemType.Text;
 			}

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -201,6 +201,11 @@ export function menuItems(dispatch: Function, htmlToMd: HtmlToMarkdownHandler, m
 			},
 			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType === ContextMenuItemType.Link || !!options.linkToCopy,
 		},
+		saveMermaid: {
+			label: _('To save mermaid graph, go to the markdown editor.'),
+			onAction: async () => {},
+			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.Mermaid,
+		},
 	};
 }
 

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
@@ -10,6 +10,7 @@ export enum ContextMenuItemType {
 	Resource = 'resource',
 	Text = 'text',
 	Link = 'link',
+	Mermaid = 'mermaid',
 }
 
 export interface ContextMenuOptions {

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -2,7 +2,7 @@ import { RuleOptions } from '../../MdToHtml';
 
 export default {
 
-	assets: function(theme: any) {
+	assets: function() {
 		return [
 			{ name: 'mermaid.min.js' },
 			{ name: 'mermaid_render.js' },
@@ -14,27 +14,6 @@ export default {
 				text: '.mermaid { width: 640px; }',
 				mime: 'text/css',
 			},
-			{
-				inline: true,
-				// Export button in mermaid graph should be shown only on hovering the mermaid graph
-				// ref: https://github.com/laurent22/joplin/issues/6101
-				text: `
-				.mermaid-export-graph {
-					opacity: 0;
-					height: 0;
-					z-index: 1;
-					position: relative;
-				} 
-				.joplin-editable:hover .mermaid-export-graph,
-				.joplin-editable .mermaid-export-graph:has(:focus-visible) {
-					opacity: 1;
-				}
-				.mermaid-export-graph > button:hover {
-					background-color: ${theme.backgroundColorHover3} !important;
-				}
-				`.trim(),
-				mime: 'text/css',
-			},
 		];
 	},
 
@@ -43,8 +22,6 @@ export default {
 		const defaultRender: Function = markdownIt.renderer.rules.fence || function(tokens: any[], idx: number, options: any, env: any, self: any) {
 			return self.renderToken(tokens, idx, options, env, self);
 		};
-
-		const exportButtonMarkup = isDesktop(ruleOptions.platformName) ? exportGraphButton(ruleOptions) : '';
 
 		markdownIt.renderer.rules.fence = function(tokens: any[], idx: number, options: any, env: any, self: any) {
 			const token = tokens[idx];
@@ -66,7 +43,6 @@ export default {
 			return `
 				<div class="joplin-editable">
 					<pre class="joplin-source" data-joplin-language="mermaid" data-joplin-source-open="\`\`\`mermaid&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${contentHtml}</pre>
-					${exportButtonMarkup}
 					<pre class="${cssClasses.join(' ')}">${contentHtml}</pre>
 				</div>
 			`;
@@ -74,45 +50,4 @@ export default {
 	},
 };
 
-const exportGraphButton = (ruleOptions: RuleOptions) => {
-	const theme = ruleOptions.theme;
-	// Clicking on export button manually triggers a right click context menu event
-	const onClickHandler = `
-		const target = arguments[0].target;
-		const button = target.closest("div.mermaid-export-graph");
-		if (!button) return false;
-		const $mermaid_elem = button.nextElementSibling;
-		const rightClickEvent = new PointerEvent("contextmenu", {bubbles: true});
-		rightClickEvent.target = $mermaid_elem;
-		$mermaid_elem.dispatchEvent(rightClickEvent);
-		return false;
-	`.trim();
-	const style = `
-		display: block;	
-		margin-left: auto;
-		border-radius: ${theme.buttonStyle.borderRadius}px;
-		font-size: ${theme.fontSize}px;
-		color: ${theme.color};
-		background: ${theme.buttonStyle.backgroundColor};
-		border: ${theme.buttonStyle.border};
-	`.trim();
 
-	return `
-		<div class="mermaid-export-graph">
-			<button onclick='${onClickHandler}' style="${style}" alt="Export mermaid graph">${downloadIcon()}</button>
-		</div>
-	`;
-};
-
-const downloadIcon = () => {
-	// https://www.svgrepo.com/svg/505363/download
-	return '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M20 15V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18L4 15M8 11L12 15M12 15L16 11M12 15V3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>';
-};
-
-const isDesktop = (platformName?: string) => {
-	if (!platformName) {
-		return false;
-	}
-
-	return ['darwin', 'linux', 'freebsd', 'win32'].includes(platformName);
-};


### PR DESCRIPTION
Fixes issue #9588
The download button in the mermaid diagram only deploys the context menu (right click) so I removed it. 
The only editor where the diagram can be downloaded is the markdown editor so I also added a button in the context menu of the rich text editor that guides the user to the markdown editor where the diagram can be downloaded.

There's a video with the solution:

https://github.com/laurent22/joplin/assets/102489241/1b84365e-c31e-48a0-96d2-52537469c9bf


