### PR TITLE
Mobile: Plugin API: Fix error when calling `plugins.dataDir`

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -116,7 +116,7 @@ import ProfileSwitcher from './components/ProfileSwitcher/ProfileSwitcher';
 import ProfileEditor from './components/ProfileSwitcher/ProfileEditor';
 import sensorInfo, { SensorInfo } from './components/biometrics/sensorInfo';
 import { getCurrentProfile } from '@joplin/lib/services/profileConfig';
-import { getDatabaseName, getProfilesRootDir, getResourceDir, setDispatch } from './services/profiles';
+import { getDatabaseName, getPluginDataDir, getProfilesRootDir, getResourceDir, setDispatch } from './services/profiles';
 import userFetcher, { initializeUserFetcher } from '@joplin/lib/utils/userFetcher';
 import { ReactNode } from 'react';
 import { parseShareCache } from '@joplin/lib/services/share/reducer';
@@ -495,6 +495,7 @@ async function initialize(dispatch: Function) {
 	const resourceDir = getResourceDir(currentProfile, isSubProfile);
 	Setting.setConstant('resourceDir', resourceDir);
 	Setting.setConstant('pluginDir', `${getProfilesRootDir()}/plugins`);
+	Setting.setConstant('pluginDataDir', getPluginDataDir(currentProfile, isSubProfile));
 
 	await shim.fsDriver().mkdir(resourceDir);
 

--- a/packages/app-mobile/services/profiles/index.ts
+++ b/packages/app-mobile/services/profiles/index.ts
@@ -26,6 +26,11 @@ export const getResourceDir = (profile: Profile, isSubProfile: boolean) => {
 	return `${getProfilesRootDir()}/resources-${profile.id}`;
 };
 
+export const getPluginDataDir = (profile: Profile, isSubProfile: boolean) => {
+	const suffix = isSubProfile ? `-${profile.id}` : '';
+	return `${getProfilesRootDir()}/plugin-data${suffix}`;
+};
+
 // The suffix is for debugging only
 export const getDatabaseName = (profile: Profile, isSubProfile: boolean, suffix = '') => {
 	if (!isSubProfile) return `joplin${suffix}.sqlite`;


### PR DESCRIPTION
# Summary

Fixes an `Error` that was thrown when calling `joplin.plugins.dataDir()` from a plugin on mobile. This was causing a startup failure in the resource search plugin. (Note, however, that even with this change, the resource search plugin still won't work on mobile.)

This error was caused by an attempt to write to a subfolder of the root directory (e.g. `/plugin.id.here/`) because the `pluginDataDir` setting was unset.

Note that mobile plugins still do not have filesystem access.

# Tests

1. Install the "resource search" plugin
2. Verify that the plugin fails with a "plugins.require(...).Database is not a constructor" error, rather than a "Directory could not be created" error.
    - In the built plugin, `plugins.require(...).Database` is called immediately after `plugins.dataDir()` (see lines 4870 and 4871 in [the built version of the plugin](https://joplinapp.org/plugins/view-source.html?plugin=net.rmusin.resource-search#index.js)).

This has been manually tested on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->