### PR TITLE
Mobile: Plugin API: Fix crash when a plugin registers an enum setting with no default

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SettingComponent.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SettingComponent.tsx
@@ -38,7 +38,7 @@ const SettingComponent: React.FunctionComponent<Props> = props => {
 	const containerStyle = props.styles.getContainerStyle(!!settingDescription);
 
 	if (md.isEnum) {
-		const value = props.value.toString();
+		const value = props.value?.toString();
 
 		const items = Setting.enumOptionsToValueLabels(md.options(), md.optionsOrder ? md.optionsOrder() : []);
 


### PR DESCRIPTION
# Summary

Fixes a plugin-related crash when a plugin settings tab is opened and it contains an enum option with no default value.

# Testing

1. Apply the following diff to the example settings plugin:
    ````diff
    diff --git a/packages/app-cli/tests/support/plugins/settings/src/index.ts b/packages/app-cli/tests/support/plugins/settings/src/index.ts
    index d1da528db..baa447cd8 100644
    --- a/packages/app-cli/tests/support/plugins/settings/src/index.ts
    +++ b/packages/app-cli/tests/support/plugins/settings/src/index.ts
    @@ -18,7 +18,7 @@ joplin.plugins.register({
 			    },
     
 			    'multiOptionTest': {
    -				value: 'en',
    +				value: null,
 				    type: SettingItemType.String,
 				    section: 'myCustomSection',
 				    isEnum: true,
    ````
2. Build and add the settings demo plugin to the mobile app (use "install from file")
3. Close and open settings
4. Open the tab for the demo settings plugin
5. Verify that the app doesn't crash and the default setting value for `Multi-options test` is `...`.

This has been tested successfully on an Android 12 emulator.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->