### PR TITLE
CI: Bump action versions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -28,7 +28,7 @@ jobs:
           
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'yarn'

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-      - uses: olegtarasov/get-tag@v2.1
-      - uses: actions/setup-node@v2
+      - uses: olegtarasov/get-tag@v2.1.3
+      - uses: actions/setup-node@v4
         with:
           # We need to pin the version to 18.15, because 18.16+ fails with this error:
           # https://github.com/facebook/react-native/issues/36440
@@ -40,7 +40,7 @@ jobs:
           brew install pango
 
       # See github-action-main.yml for explanation
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'laurent22/joplin'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           # Use this to do a dry run from a pull request
           # debug-only: true

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -82,8 +82,8 @@ jobs:
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
       - uses: actions/checkout@v4
-      - uses: olegtarasov/get-tag@v2.1
-      - uses: actions/setup-node@v2
+      - uses: olegtarasov/get-tag@v2.1.3
+      - uses: actions/setup-node@v4
         with:
           # We need to pin the version to 18.15, because 18.16+ fails with this error:
           # https://github.com/facebook/react-native/issues/36440
@@ -109,7 +109,7 @@ jobs:
       # Python to an earlier version.
       # Fixes error `ModuleNotFoundError: No module named 'distutils'`
       # Ref: https://github.com/nodejs/node-gyp/issues/2869
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -183,7 +183,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'yarn'


### PR DESCRIPTION
This is for removing the warnings in CI

![图片](https://github.com/laurent22/joplin/assets/62299611/abd9539d-6c9a-4159-bf78-320b58d458dd)
![图片](https://github.com/laurent22/joplin/assets/62299611/e8937c3d-2e6c-46b9-b6ba-5da3d88f3798)

Here are the changes:
+ `actions/setup-node`: v2 -> v4
+ `actions/setup-python`: v4 -> v5
+ `actions/stale`: v4 -> v9
+ `olegtarasov/get-tag`: v2.1 -> v2.1.3

`contributor-assistant/github-action` is not updated because the latest release of it hasn't switched to Node 20 yet.
`quipper/comment-failure-action` is not updated because it has been unmaintained for years, and the CI script `comment-on-failure.yml` is disabled now.