### PR TITLE
Mobile: Fixes #10270: Fix dropdowns invisble when opening settings by clicking "synchronize"

### DIFF
--- a/packages/app-mobile/components/Dropdown.tsx
+++ b/packages/app-mobile/components/Dropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TouchableOpacity, TouchableWithoutFeedback, Dimensions, Text, Modal, View, LayoutRectangle, ViewStyle, TextStyle, FlatList, LayoutChangeEvent } from 'react-native';
+import { TouchableOpacity, TouchableWithoutFeedback, Dimensions, Text, Modal, View, LayoutRectangle, ViewStyle, TextStyle, FlatList } from 'react-native';
 import { Component, ReactElement } from 'react';
 import { _ } from '@joplin/lib/locale';
 
@@ -54,17 +54,8 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 		};
 	}
 
-	private updateHeaderCoordinates = (event: LayoutChangeEvent) => {
+	private updateHeaderCoordinates = () => {
 		if (!this.headerRef) return;
-
-		const { width, height } = event.nativeEvent.layout;
-
-		const lastLayout = this.state.headerSize;
-		if (width !== lastLayout.width || height !== lastLayout.height) {
-			this.setState({
-				headerSize: { x: lastLayout.x, y: lastLayout.y, width, height },
-			});
-		}
 
 		// https://stackoverflow.com/questions/30096038/react-native-getting-the-position-of-an-element
 		this.headerRef.measure((_fx, _fy, width, height, px, py) => {
@@ -78,6 +69,10 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 	};
 
 	private onOpenList = () => {
+		// On iOS, we need to re-measure just before opening the list. Measurements from just after
+		// onLayout can be inaccurate in some cases (in the past, this had caused the menu to be
+		// drawn far offscreen).
+		this.updateHeaderCoordinates();
 		this.setState({ listVisible: true });
 	};
 	private onCloseList = () => {


### PR DESCRIPTION
# Summary

This pull request re-adds a measure call when clicking the "open list" button.

Fixes #10270.

# Notes

Previously, the dropdown was positioned and resized when the open dropdown button sent an `onLayout` event. While this allows the dropdown to adjust its size/position when the screen rotates or other components around it are changed, it could result in an incorrect location of the dropdown in some cases. In this case, opening settings from the "synchronize" button resulted in a very large x-coordinate for the dropdown when measured within the **first** `onLayout` event.

To work around this issue, a measure request is re-added to the `onOpenList` callback.

The layout logic for dropdowns was changed in https://github.com/laurent22/joplin/commit/d3e2d3fc4a8054420fa797f0adb826b400262119#diff-5007edf0cc6e7b53c729e5cd7c4aa296e49341f5631a2175eb2b659bb53cd91fR198 to allow resizing the dropdown when the plugin panel toggle was shown/hidden.

# Testing

Although there exist automated tests for `Dropdown.tsx`, this pull request is related to its layout and must be tested manually. To do this,
1. Clear the synchronization target
2. Go to the main Joplin page (e.g. click "All notes")
3. Click "Synchronise"
4. Verify that clicking on the sync target dropdown allows choosing a sync target.
5. Choose a sync target.
6. Open the dropdown.
7. Rotate the screen.
8. Clear the sync target using the dropdown. (Verify that the dropdown is in the correct location).
9. Install a plugin that adds a panel (e.g. "Note tabs")
10. Go back to "all notes".
11. Select a note
12. Open the "move to notebook" dropdown
    - Verify that the plugin panel toggle is hidden and the dropdown toggle grows to fill the newly-available space.
13. Rotate the screen
    - Verify that the dropdown resizes to match the new size of the "move to notebook" header.

This has been tested successfully on an iOS 17.2 simulator and an Android 12 emulator.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->