### PR TITLE
Chore: Refactor EventManager to use stronger types

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -125,8 +125,7 @@ function NoteEditor(props: NoteEditorProps) {
 			return async function() {
 				const note = await formNoteToNote(formNote);
 				reg.logger().debug('Saving note...', note);
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				const savedNote: any = await Note.save(note);
+				const savedNote = await Note.save(note);
 
 				setFormNote((prev: FormNote) => {
 					return { ...prev, user_updated_time: savedNote.user_updated_time, hasChanged: false };

--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -115,13 +115,13 @@ export class EventManager {
 		this.appStateListeners_[propName].splice(idx, 1);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private stateValue_(state: AppState, propName: string): any {
+	private stateValue_(state: AppState, propName: string) {
 		const parts = propName.split('.');
-		let s = state;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code from before rule was applied.
+		let s: any = state;
 		for (const p of parts) {
 			if (!(p in s)) throw new Error(`Invalid state property path: ${propName}`);
-			s = s[p as keyof AppState];
+			s = s[p];
 		}
 		return s;
 	}

--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -1,6 +1,6 @@
 const fastDeepEqual = require('fast-deep-equal');
-
-const events = require('events');
+import { EventEmitter } from 'events';
+import type { State as AppState } from './reducer';
 
 export enum EventName {
 	ResourceCreate = 'resourceCreate',
@@ -20,30 +20,34 @@ export enum EventName {
 	NoteResourceIndexed = 'noteResourceIndexed',
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
+export type EventListenerCallback = (...args: any[])=> void;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
+type AppStateChangeCallback = (event: { value: any })=> void;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
+type FilterObject = any;
+export type FilterHandler = (object: FilterObject)=> FilterObject;
+
 export class EventManager {
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private emitter_: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private appStatePrevious_: any;
+	private emitter_: EventEmitter;
+	private appStatePrevious_: Record<string, AppState[keyof AppState]>;
 	private appStateWatchedProps_: string[];
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private appStateListeners_: any;
+	private appStateListeners_: Record<string, AppStateChangeCallback[]>;
 
 	public constructor() {
 		this.reset();
 	}
 
 	public reset() {
-		this.emitter_ = new events.EventEmitter();
+		this.emitter_ = new EventEmitter();
 
 		this.appStatePrevious_ = {};
 		this.appStateWatchedProps_ = [];
 		this.appStateListeners_ = {};
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public on(eventName: EventName, callback: Function) {
+	public on(eventName: EventName, callback: EventListenerCallback) {
 		return this.emitter_.on(eventName, callback);
 	}
 
@@ -52,23 +56,19 @@ export class EventManager {
 		return this.emitter_.emit(eventName, object);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public removeListener(eventName: string, callback: Function) {
+	public removeListener(eventName: string, callback: EventListenerCallback) {
 		return this.emitter_.removeListener(eventName, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public off(eventName: EventName, callback: Function) {
+	public off(eventName: EventName, callback: EventListenerCallback) {
 		return this.removeListener(eventName, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public filterOn(filterName: string, callback: Function) {
+	public filterOn(filterName: string, callback: FilterHandler) {
 		return this.emitter_.on(`filter:${filterName}`, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public filterOff(filterName: string, callback: Function) {
+	public filterOff(filterName: string, callback: FilterHandler) {
 		return this.removeListener(`filter:${filterName}`, callback);
 	}
 
@@ -95,8 +95,7 @@ export class EventManager {
 		return output;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public appStateOn(propName: string, callback: Function) {
+	public appStateOn(propName: string, callback: AppStateChangeCallback) {
 		if (!this.appStateListeners_[propName]) {
 			this.appStateListeners_[propName] = [];
 			this.appStateWatchedProps_.push(propName);
@@ -105,8 +104,7 @@ export class EventManager {
 		this.appStateListeners_[propName].push(callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public appStateOff(propName: string, callback: Function) {
+	public appStateOff(propName: string, callback: AppStateChangeCallback) {
 		if (!this.appStateListeners_[propName]) {
 			throw new Error('EventManager: Trying to unregister a state prop watch for a non-watched prop (1)');
 		}
@@ -118,12 +116,12 @@ export class EventManager {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private stateValue_(state: any, propName: string) {
+	private stateValue_(state: AppState, propName: string): any {
 		const parts = propName.split('.');
 		let s = state;
 		for (const p of parts) {
 			if (!(p in s)) throw new Error(`Invalid state property path: ${propName}`);
-			s = s[p];
+			s = s[p as keyof AppState];
 		}
 		return s;
 	}
@@ -131,8 +129,7 @@ export class EventManager {
 	// This function works by keeping a copy of the watched props and, whenever this function
 	// is called, comparing the previous and new values and emitting events if they have changed.
 	// The appStateEmit function should be called from a middleware.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public appStateEmit(state: any) {
+	public appStateEmit(state: AppState) {
 		if (!this.appStateWatchedProps_.length) return;
 
 		for (const propName of this.appStateWatchedProps_) {
@@ -157,8 +154,7 @@ export class EventManager {
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public once(eventName: string, callback: any) {
+	public once(eventName: string, callback: EventListenerCallback) {
 		return this.emitter_.once(eventName, callback);
 	}
 

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -1,4 +1,4 @@
-import eventManager, { EventName } from '../eventManager';
+import eventManager, { EventListenerCallback, EventName } from '../eventManager';
 import shim from '../shim';
 import { _ } from '../locale';
 import keysRegExp from './KeymapService_keysRegExp';
@@ -415,13 +415,11 @@ export default class KeymapService extends BaseService {
 		return parts.join('+');
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public on(eventName: EventName, callback: Function) {
+	public on(eventName: EventName, callback: EventListenerCallback) {
 		eventManager.on(eventName, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public off(eventName: EventName, callback: Function) {
+	public off(eventName: EventName, callback: EventListenerCallback) {
 		eventManager.off(eventName, callback);
 	}
 

--- a/packages/lib/services/plugins/api/JoplinFilters.ts
+++ b/packages/lib/services/plugins/api/JoplinFilters.ts
@@ -1,6 +1,7 @@
 /* eslint-disable multiline-comment-style */
 
-import eventManager from '../../../eventManager';
+import eventManager, { FilterHandler } from '../../../eventManager';
+
 
 /**
  * @ignore
@@ -9,13 +10,11 @@ import eventManager from '../../../eventManager';
  * so for now disable filters.
  */
 export default class JoplinFilters {
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async on(name: string, callback: Function) {
+	public async on(name: string, callback: FilterHandler) {
 		eventManager.filterOn(name, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async off(name: string, callback: Function) {
+	public async off(name: string, callback: FilterHandler) {
 		eventManager.filterOff(name, callback);
 	}
 }

--- a/packages/lib/services/plugins/api/JoplinWorkspace.ts
+++ b/packages/lib/services/plugins/api/JoplinWorkspace.ts
@@ -44,9 +44,28 @@ interface ResourceChangeEvent {
 	id: string;
 }
 
-type ItemChangeHandler = (event: ItemChangeEvent)=> void;
-type SyncStartHandler = (event: SyncStartEvent)=> void;
-type ResourceChangeHandler = (event: ResourceChangeEvent)=> void;
+interface NoteContentChangeEvent {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- No plugin-api-accessible Note type defined.
+	note: any;
+}
+
+interface NoteSelectionChangeEvent {
+	value: string[];
+}
+
+interface NoteAlarmTriggerEvent {
+	noteId: string;
+}
+
+interface SyncCompleteEvent {
+	withErrors: boolean;
+}
+
+type WorkspaceEventHandler<EventType> = (event: EventType)=> void;
+
+type ItemChangeHandler = WorkspaceEventHandler<ItemChangeEvent>;
+type SyncStartHandler = WorkspaceEventHandler<SyncStartEvent>;
+type ResourceChangeHandler = WorkspaceEventHandler<ResourceChangeEvent>;
 
 /**
  * The workspace service provides access to all the parts of Joplin that
@@ -71,7 +90,7 @@ export default class JoplinWorkspace {
 	 * Called when a new note or notes are selected.
 	 */
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async onNoteSelectionChange(callback: Function): Promise<Disposable> {
+	public async onNoteSelectionChange(callback: WorkspaceEventHandler<NoteSelectionChangeEvent>): Promise<Disposable> {
 		eventManager.appStateOn('selectedNoteIds', callback);
 
 		return {};
@@ -87,8 +106,7 @@ export default class JoplinWorkspace {
 	 * Called when the content of a note changes.
 	 * @deprecated Use `onNoteChange()` instead, which is reliably triggered whenever the note content, or any note property changes.
 	 */
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async onNoteContentChange(callback: Function) {
+	public async onNoteContentChange(callback: WorkspaceEventHandler<NoteContentChangeEvent>) {
 		eventManager.on(EventName.NoteContentChange, callback);
 	}
 
@@ -121,8 +139,7 @@ export default class JoplinWorkspace {
 	/**
 	 * Called when an alarm associated with a to-do is triggered.
 	 */
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async onNoteAlarmTrigger(handler: Function): Promise<Disposable> {
+	public async onNoteAlarmTrigger(handler: WorkspaceEventHandler<NoteAlarmTriggerEvent>): Promise<Disposable> {
 		return makeListener(eventManager, EventName.NoteAlarmTrigger, handler);
 	}
 
@@ -136,8 +153,7 @@ export default class JoplinWorkspace {
 	/**
 	 * Called when the synchronisation process has finished.
 	 */
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public async onSyncComplete(callback: Function): Promise<Disposable> {
+	public async onSyncComplete(callback: WorkspaceEventHandler<SyncCompleteEvent>): Promise<Disposable> {
 		return makeListener(eventManager, EventName.SyncComplete, callback);
 	}
 

--- a/packages/lib/services/plugins/utils/makeListener.ts
+++ b/packages/lib/services/plugins/utils/makeListener.ts
@@ -1,8 +1,7 @@
-import { EventManager, EventName } from '../../../eventManager';
+import { EventListenerCallback, EventManager, EventName } from '../../../eventManager';
 import { Disposable } from '../api/types';
 
-// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-export default function(eventManager: EventManager, eventName: EventName, callback: Function): Disposable {
+export default function(eventManager: EventManager, eventName: EventName, callback: EventListenerCallback): Disposable {
 	eventManager.on(eventName, callback);
 
 	return {};


### PR DESCRIPTION
# Summary

This pull request refactors the plugin `EventManager` to use stronger types (have fewer `: any`s). Its goal is to simplify fixing an event listener leak in `EventManager` when plugins are reloaded.

Related to https://github.com/laurent22/joplin/commit/2e2a2b3193b8bdaaf70935fc2a7bf288af8009de.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->