### PR TITLE
Server: Improve log quality by increasing specificity of error

### DIFF
--- a/packages/server/src/models/BaseModel.ts
+++ b/packages/server/src/models/BaseModel.ts
@@ -396,7 +396,7 @@ export default abstract class BaseModel<T> {
 	}
 
 	public async delete(id: string | string[] | number | number[], options: DeleteOptions = {}): Promise<void> {
-		if (!id) throw new Error('id cannot be empty');
+		if (!id) throw new ErrorBadRequest('id cannot be empty');
 
 		const ids = (typeof id === 'string' || typeof id === 'number') ? [id] : id;
 

--- a/packages/server/src/models/BaseModel.ts
+++ b/packages/server/src/models/BaseModel.ts
@@ -2,7 +2,7 @@ import { WithDates, WithUuid, databaseSchema, ItemType, Uuid, User } from '../se
 import { DbConnection, QueryContext } from '../db';
 import TransactionHandler from '../utils/TransactionHandler';
 import { uuidgen } from '@joplin/lib/uuid';
-import { ErrorUnprocessableEntity, ErrorBadRequest, ErrorNotFound } from '../utils/errors';
+import { ErrorUnprocessableEntity, ErrorBadRequest } from '../utils/errors';
 import { Models, NewModelFactoryHandler } from './factory';
 import { Config, Env } from '../utils/types';
 import personalizedUserContentBaseUrl from '@joplin/lib/services/joplinServer/personalizedUserContentBaseUrl';
@@ -390,7 +390,7 @@ export default abstract class BaseModel<T> {
 	}
 
 	public async load(id: Uuid | number, options: LoadOptions = {}): Promise<T> {
-		if (!id) throw new ErrorNotFound('id cannot be empty');
+		if (!id) throw new ErrorBadRequest('id cannot be empty');
 
 		return this.db(this.tableName).select(options.fields || this.defaultFields).where({ id: id }).first();
 	}

--- a/packages/server/src/models/BaseModel.ts
+++ b/packages/server/src/models/BaseModel.ts
@@ -2,7 +2,7 @@ import { WithDates, WithUuid, databaseSchema, ItemType, Uuid, User } from '../se
 import { DbConnection, QueryContext } from '../db';
 import TransactionHandler from '../utils/TransactionHandler';
 import { uuidgen } from '@joplin/lib/uuid';
-import { ErrorUnprocessableEntity, ErrorBadRequest } from '../utils/errors';
+import { ErrorUnprocessableEntity, ErrorBadRequest, ErrorNotFound } from '../utils/errors';
 import { Models, NewModelFactoryHandler } from './factory';
 import { Config, Env } from '../utils/types';
 import personalizedUserContentBaseUrl from '@joplin/lib/services/joplinServer/personalizedUserContentBaseUrl';
@@ -390,7 +390,7 @@ export default abstract class BaseModel<T> {
 	}
 
 	public async load(id: Uuid | number, options: LoadOptions = {}): Promise<T> {
-		if (!id) throw new Error('id cannot be empty');
+		if (!id) throw new ErrorNotFound('id cannot be empty');
 
 		return this.db(this.tableName).select(options.fields || this.defaultFields).where({ id: id }).first();
 	}


### PR DESCRIPTION
I changed the error class used in the `BaseModel.load` function.
The change can help clean up the server logs from 500 errors since in this case is more of a validation than a server error.

When we check if the id argument is empty we would, previously, throw the base Error class which can result in a 500 error from the server, with the new ErrorBadRequest we get a 400.

### Testing

I think it is not doable to test everything, but I went through where this function is called inside the server to see if any of the call places were relying on a specific error type and I couldn't find any case of that.