### PR TITLE
Mobile: Resolves #10288: Show plugin versions in settings

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -57,7 +57,6 @@ const onRecommendedPress = () => {
 const PluginIcon = (props: any) => <Icon {...props} source='puzzle'/>;
 
 const versionTextStyle: TextStyle = {
-	margin: 10,
 	opacity: 0.8,
 };
 
@@ -163,7 +162,7 @@ const PluginBox: React.FC<Props> = props => {
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
 
 	const titleComponent = <>
-		{manifest.name} <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
+		<Text variant='titleMedium'>{manifest.name}</Text> <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
 	</>;
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Icon, Card, Chip } from 'react-native-paper';
+import { Icon, Card, Chip, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { Alert, Linking, View } from 'react-native';
+import { Alert, Linking, TextStyle, View } from 'react-native';
 import { PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
@@ -55,6 +55,11 @@ const onRecommendedPress = () => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const PluginIcon = (props: any) => <Icon {...props} source='puzzle'/>;
+
+const versionTextStyle: TextStyle = {
+	margin: 10,
+	opacity: 0.8,
+};
 
 const PluginBox: React.FC<Props> = props => {
 	const manifest = props.item.manifest;
@@ -157,10 +162,13 @@ const PluginBox: React.FC<Props> = props => {
 
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
 
+	const titleComponent = <>
+		{manifest.name} <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
+	</>;
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>
 			<Card.Title
-				title={manifest.name}
+				title={titleComponent}
 				subtitle={manifest.description}
 				left={PluginIcon}
 			/>

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
@@ -86,6 +86,9 @@ describe('PluginStates', () => {
 		await switchClient(0);
 		pluginServiceSetup();
 		resetRepoApi();
+
+		await mockMobilePlatform('android');
+		await mockRepositoryApiConstructor();
 	});
 	afterEach(async () => {
 		for (const pluginId of PluginService.instance().pluginIds) {
@@ -136,5 +139,23 @@ describe('PluginStates', () => {
 		} else {
 			expect(await screen.queryByRole('button', backlinksToNoteQuery)).toBeNull();
 		}
+	});
+
+	it('should show the current plugin version on updatable plugins', async () => {
+		const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
+		const defaultPluginSettings: PluginSettings = { [abcPluginId]: defaultPluginSetting() };
+
+		const outdatedVersion = '0.0.1';
+		await loadMockPlugin(abcPluginId, 'ABC Sheet Music', outdatedVersion, defaultPluginSettings);
+		expect(PluginService.instance().plugins[abcPluginId]).toBeTruthy();
+
+		render(
+			<PluginStatesWrapper
+				initialPluginSettings={defaultPluginSettings}
+			/>,
+		);
+		expect(await screen.findByText('ABC Sheet Music')).toBeVisible();
+		expect(await screen.findByRole('button', { name: 'Update ABC Sheet Music', disabled: false })).toBeVisible();
+		expect(await screen.findByText(`v${outdatedVersion}`)).toBeVisible();
 	});
 });


### PR DESCRIPTION
# Summary

This pull request resolves #10288

# Screenshots

<img src="https://github.com/laurent22/joplin/assets/46334387/ad7d98c1-7fee-47d2-8f2a-2ff222688e2b" alt="screenshot: Version numbers included to the right of plugin card titles (dark mode)" width="400"/> <img src="https://github.com/laurent22/joplin/assets/46334387/041b4268-5691-4a1b-bc83-fef3d1f631b6" alt="screenshot: Version numbers included to the right of plugin card titles (light mode). Version numbers are a lighter gray than the plugin titles and included in both search results and cards." width="400"/>
<img alt="screenshot: Plugin settings page with version numbers in landscape mode" src="https://github.com/laurent22/joplin/assets/46334387/9e4a08bf-eb44-402c-b075-487348a55f09"/>

# Testing plan

Although this pull request has an automated test, it has also been tested manually by:
1. Opening the plugin settings screen on mobile.
2. Verifying that installed plugins are labeled with plugin versions (see screenshots above).
3. Verifying that plugins in search results are labeled with versions.

This has been tested successfully on an iOS 17.2 simulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->