### PR TITLE
Desktop, Mobile: Fix #10292: Email to note address not presented in configuration screen before synchronisation

### DIFF
--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -311,4 +311,7 @@ export default class JoplinServerApi {
 		}
 	}
 
+	public async loadSession() {
+		await this.session();
+	}
 }

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -3,6 +3,9 @@ import Setting from '../models/Setting';
 import { ApplicationPlatform, ApplicationType } from '../types';
 import shim from '../shim';
 import { _ } from '../locale';
+import eventManager, { EventName } from '../eventManager';
+import { fetchSyncInfo } from './synchronizer/syncInfoUtils';
+import { reg } from '../registry';
 
 type ActionType = 'LINK_USED' | 'COMPLETED' | 'ERROR';
 type Action = {
@@ -108,6 +111,9 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
 
 		Setting.setValue('sync.10.username', jsonBody.id);
 		Setting.setValue('sync.10.password', jsonBody.password);
+		const fileApi = await reg.syncTarget().fileApi();
+		await fetchSyncInfo(fileApi);
+		eventManager.emit(EventName.SessionEstablished);
 		return { success: true };
 	};
 

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -4,7 +4,6 @@ import { ApplicationPlatform, ApplicationType } from '../types';
 import shim from '../shim';
 import { _ } from '../locale';
 import eventManager, { EventName } from '../eventManager';
-import { fetchSyncInfo } from './synchronizer/syncInfoUtils';
 import { reg } from '../registry';
 
 type ActionType = 'LINK_USED' | 'COMPLETED' | 'ERROR';
@@ -111,9 +110,11 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
 
 		Setting.setValue('sync.10.username', jsonBody.id);
 		Setting.setValue('sync.10.password', jsonBody.password);
+
 		const fileApi = await reg.syncTarget().fileApi();
-		await fetchSyncInfo(fileApi);
+		await fileApi.driver().api().loadSession();
 		eventManager.emit(EventName.SessionEstablished);
+
 		return { success: true };
 	};
 


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/10292

Modifying the Joplin Cloud login process to fetch user information just after it is confirmed that the user has valid credentials.

Before this fix if the user accessed Joplin Cloud configuration screen on Desktop or Mobile, before synchronisation but after the login was successful, the email to note field would be empty.


### Testing

- Open Destop or Mobile application without any prior state (you need to delete local files in Desktop or clean app data on Mobile)
- Connect to Joplin Cloud with a Pro or a Teams account
- Go to Joplin Cloud screen
- Email to note field should **NOT** be empty anymore
