### PR TITLE
Desktop: Fix "open profile directory" shows a warning message

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -362,7 +362,7 @@ export class Bridge {
 		if (await pathExists(fullPath)) {
 			const fileExtension = extname(fullPath);
 			const userAllowedExtension = this.extraAllowedOpenExtensions.includes(fileExtension);
-			if (userAllowedExtension || isSafeToOpen(fullPath)) {
+			if (userAllowedExtension || await isSafeToOpen(fullPath)) {
 				return shell.openPath(fullPath);
 			} else {
 				const allowOpenId = 2;

--- a/packages/app-desktop/utils/isSafeToOpen.test.ts
+++ b/packages/app-desktop/utils/isSafeToOpen.test.ts
@@ -1,10 +1,10 @@
 import { remove, writeFile } from 'fs-extra';
 import { createTempDir } from '@joplin/lib/testing/test-utils';
 import { join } from 'path';
-import isUnsafeToOpen from './isSafeToOpen';
+import isSafeToOpen from './isSafeToOpen';
 
 
-describe('isUnsafeToOpen', () => {
+describe('isSafeToOpen', () => {
 	test.each([
 		{ fileName: 'a.txt', expected: true },
 		{ fileName: 'a.json', expected: true },
@@ -24,7 +24,7 @@ describe('isUnsafeToOpen', () => {
 		try {
 			const fullPath = join(tempDir, fileName);
 			await writeFile(fullPath, 'test');
-			expect(await isUnsafeToOpen(fullPath)).toBe(expected);
+			expect(await isSafeToOpen(fullPath)).toBe(expected);
 		} finally {
 			await remove(tempDir);
 		}

--- a/packages/app-desktop/utils/isSafeToOpen.ts
+++ b/packages/app-desktop/utils/isSafeToOpen.ts
@@ -1,6 +1,8 @@
+import { stat } from 'fs-extra';
+import { extname } from 'path';
 
 
-const isSafeToOpen = (path: string) => {
+const isSafeToOpen = async (path: string) => {
 	// This is intended to fix an issue where some platforms would execute attachment
 	// files without confirmation depending on the file extension (e.g. .EXE). This is
 	// mostly for Windows.
@@ -173,6 +175,11 @@ const isSafeToOpen = (path: string) => {
 			return true;
 		}
 	}
+
+	if (extname(path) === '' && (await stat(path)).isDirectory()) {
+		return true;
+	}
+
 	return false;
 };
 


### PR DESCRIPTION
# Summary

This pull request fixes a regression where clicking "Help", then "open profile directory" would show an unnecessary warning dialog.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->