### PR TITLE
Android: Fix plugin card titles are clipped

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, Card, Chip, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { Alert, Linking, TextStyle, View } from 'react-native';
+import { Alert, Linking, StyleSheet, View } from 'react-native';
 import { PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
@@ -56,9 +56,17 @@ const onRecommendedPress = () => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const PluginIcon = (props: any) => <Icon {...props} source='puzzle'/>;
 
-const versionTextStyle: TextStyle = {
-	opacity: 0.8,
-};
+const styles = StyleSheet.create({
+	versionText: {
+		opacity: 0.8,
+		marginLeft: 5,
+	},
+	titleWrapper: {
+		display: 'flex',
+		flexDirection: 'row',
+		alignItems: 'baseline',
+	},
+});
 
 const PluginBox: React.FC<Props> = props => {
 	const manifest = props.item.manifest;
@@ -161,9 +169,9 @@ const PluginBox: React.FC<Props> = props => {
 
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
 
-	const titleComponent = <>
-		<Text variant='titleMedium'>{manifest.name}</Text> <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
-	</>;
+	const titleComponent = <View style={styles.titleWrapper}>
+		<Text variant='titleMedium'>{manifest.name}</Text><Text variant='bodySmall' style={styles.versionText}>v{manifest.version}</Text>
+	</View>;
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>
 			<Card.Title

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, Card, Chip, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { Alert, Linking, StyleSheet, View } from 'react-native';
+import { Alert, Linking, View } from 'react-native';
 import { PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
@@ -56,17 +56,9 @@ const onRecommendedPress = () => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const PluginIcon = (props: any) => <Icon {...props} source='puzzle'/>;
 
-const styles = StyleSheet.create({
-	versionText: {
-		opacity: 0.8,
-		marginLeft: 5,
-	},
-	titleWrapper: {
-		display: 'flex',
-		flexDirection: 'row',
-		alignItems: 'baseline',
-	},
-});
+const versionTextStyle = {
+	opacity: 0.8,
+};
 
 const PluginBox: React.FC<Props> = props => {
 	const manifest = props.item.manifest;
@@ -169,9 +161,9 @@ const PluginBox: React.FC<Props> = props => {
 
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
 
-	const titleComponent = <View style={styles.titleWrapper}>
-		<Text variant='titleMedium'>{manifest.name}</Text><Text variant='bodySmall' style={styles.versionText}>v{manifest.version}</Text>
-	</View>;
+	const titleComponent = <>
+		{manifest.name} <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
+	</>;
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>
 			<Card.Title

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, Card, Chip, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import { Alert, Linking, View } from 'react-native';
+import { Alert, Linking, StyleSheet, View } from 'react-native';
 import { PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
@@ -56,9 +56,15 @@ const onRecommendedPress = () => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const PluginIcon = (props: any) => <Icon {...props} source='puzzle'/>;
 
-const versionTextStyle = {
-	opacity: 0.8,
-};
+const styles = StyleSheet.create({
+	versionText: {
+		opacity: 0.8,
+	},
+	title: {
+		// Prevents the title text from being clipped on Android
+		verticalAlign: 'middle',
+	},
+});
 
 const PluginBox: React.FC<Props> = props => {
 	const manifest = props.item.manifest;
@@ -162,12 +168,13 @@ const PluginBox: React.FC<Props> = props => {
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
 
 	const titleComponent = <>
-		{manifest.name} <Text variant='bodySmall' style={versionTextStyle}>v{manifest.version}</Text>
+		<Text variant='titleMedium'>{manifest.name}</Text> <Text variant='bodySmall' style={styles.versionText}>v{manifest.version}</Text>
 	</>;
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>
 			<Card.Title
 				title={titleComponent}
+				titleStyle={styles.title}
 				subtitle={manifest.description}
 				left={PluginIcon}
 			/>

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
@@ -127,8 +127,8 @@ describe('PluginStates', () => {
 				initialPluginSettings={defaultPluginSettings}
 			/>,
 		);
-		expect(await screen.findByText('ABC Sheet Music')).toBeVisible();
-		expect(await screen.findByText('Backlinks to note')).toBeVisible();
+		expect(await screen.findByText(/^ABC Sheet Music/)).toBeVisible();
+		expect(await screen.findByText(/^Backlinks to note/)).toBeVisible();
 
 		expect(await screen.findByRole('button', { name: 'Update ABC Sheet Music', disabled: false })).toBeVisible();
 
@@ -154,7 +154,7 @@ describe('PluginStates', () => {
 				initialPluginSettings={defaultPluginSettings}
 			/>,
 		);
-		expect(await screen.findByText('ABC Sheet Music')).toBeVisible();
+		expect(await screen.findByText(/^ABC Sheet Music/)).toBeVisible();
 		expect(await screen.findByRole('button', { name: 'Update ABC Sheet Music', disabled: false })).toBeVisible();
 		expect(await screen.findByText(`v${outdatedVersion}`)).toBeVisible();
 	});


### PR DESCRIPTION
# Summary

This pull request fixes a regression caused by https://github.com/laurent22/joplin/commit/681d1d67f38c15b6eb45de9b8a8a28cecf08f429 — plugin card titles are clipped by their container on Android (but not iOS).

**Before**:
<img alt="before: screenshot: Tops of plugin titles are clipped" src="https://github.com/laurent22/joplin/assets/46334387/5b5ff5bf-0bf5-4122-a741-f3e20f052356" width="300"/>

**After**:
<img alt="after: screenshot: Tops of plugin titles are no longer clipped" src="https://github.com/laurent22/joplin/assets/46334387/79494343-431e-4de0-9593-6f5c939a09e3" width="300"/>

# Testing

1. Open the plugin settings screen.
2. Verify that installed plugin titles are not clipped by their container.
3. Search for "ABC"
4. Verify that search results are not clipped by their container.

This has been tested successfully on an Android 12 emulator and an iOS 17 simulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->