### PR TITLE
Desktop: Resolves #10151: make editor always have dynamic size

### DIFF
--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -44,12 +44,12 @@ function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: Lay
 	const size: Size = itemSize(item, parent, sizes, true);
 
 	const className = `resizableLayoutItem rli-${item.key}`;
-	if (item.resizableRight || item.resizableBottom) {
+	if (item.resizableRight || item.resizableBottom || item.resizableLeft) {
 		const enable = {
 			top: false,
 			right: !!item.resizableRight && !isLastChild,
 			bottom: !!item.resizableBottom && !isLastChild,
-			left: false,
+			left: !!item.resizableLeft,
 			topRight: false,
 			bottomRight: false,
 			bottomLeft: false,

--- a/packages/app-desktop/gui/ResizableLayout/utils/types.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/types.ts
@@ -18,6 +18,7 @@ export interface LayoutItem {
 	children?: LayoutItem[];
 	direction?: LayoutItemDirection;
 	resizableRight?: boolean;
+	resizableLeft?: boolean;
 	resizableBottom?: boolean;
 	visible?: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/useLayoutItemSizes.test.ts
@@ -138,6 +138,64 @@ describe('useLayoutItemSizes', () => {
 		expect(itemSize(parent.children[1], parent, sizes, false)).toEqual({ width: 95, height: 50 });
 	});
 
+	test('should give elements resizeableRight, if editor is last element', () => {
+		const defaultLayout: LayoutItem = {
+			key: 'root',
+			children: [
+				{ key: 'sideBar', width: 250 },
+				{ key: 'noteList', width: 250 },
+				{ key: 'editor' },
+			],
+		};
+
+		const layout = validateLayout(defaultLayout);
+
+		const editor = layout.children.find(c => c.key === 'editor');
+		expect(editor).not.toHaveProperty('width');
+		expect(editor.resizableRight).toBe(undefined);
+		expect(editor.resizableLeft).toBe(undefined);
+
+		for (const child of layout.children) {
+			if (child.key === 'editor') continue;
+			expect(child.resizableRight).toBe(true);
+			expect(child.resizableLeft).toBe(undefined);
+		}
+	});
+
+	test('should give elements after editor resizeableLeft, if editor is not last element', () => {
+		const defaultLayout: LayoutItem = {
+			key: 'root',
+			children: [
+				{ key: 'sideBar', width: 250 },
+				{ key: 'editor' },
+				{ key: 'noteList', width: 250 },
+				{ key: 'some-extension', width: 250 },
+			],
+		};
+
+		const layout = validateLayout(defaultLayout);
+
+		const editor = layout.children.find(c => c.key === 'editor');
+		expect(editor).not.toHaveProperty('width');
+		expect(editor.resizableRight).toBe(undefined);
+		expect(editor.resizableLeft).toBe(undefined);
+
+		let flag = true;
+		for (const child of layout.children) {
+			if (child.key === 'editor') {
+				flag = !flag;
+				continue;
+			}
+			if (flag) {
+				expect(child.resizableRight).toBe(true);
+				expect(child.resizableLeft).toBe(undefined);
+			} else {
+				expect(child.resizableRight).toBe(undefined);
+				expect(child.resizableLeft).toBe(true);
+			}
+		}
+	});
+
 	test('should decrease size of the largest item if the total size would be larger than the container', () => {
 		const layout: LayoutItem = validateLayout({
 			key: 'root',

--- a/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
@@ -58,9 +58,24 @@ function updateItemSize(itemIndex: number, itemDraft: LayoutItem, parent: Layout
 // of a container.
 function updateResizeRules(itemIndex: number, itemDraft: LayoutItem, parent: LayoutItem) {
 	if (!parent) return;
-	const isLastVisibleChild = isLastVisible(itemIndex, itemDraft, parent);
-	itemDraft.resizableRight = parent.direction === LayoutItemDirection.Row && !isLastVisibleChild;
-	itemDraft.resizableBottom = parent.direction === LayoutItemDirection.Column && !isLastVisibleChild;
+
+	if (itemDraft.key === 'editor') return;
+
+	if (isElementAfterEditor(itemIndex, parent)) {
+		itemDraft.resizableLeft = true;
+	} else {
+		const isLastVisibleChild = isLastVisible(itemIndex, itemDraft, parent);
+		itemDraft.resizableRight = parent.direction === LayoutItemDirection.Row && !isLastVisibleChild;
+		itemDraft.resizableBottom = parent.direction === LayoutItemDirection.Column && !isLastVisibleChild;
+	}
+}
+
+// editor is dynamically sized, elements before it have resizableRight, elements after it have resizableLeft.
+function isElementAfterEditor(itemIndex: number, parent: LayoutItem) {
+	if (parent.key !== 'root') return false;
+
+	const editorIndex = parent.children.findIndex((child) => child.key === 'editor');
+	return itemIndex > editorIndex;
 }
 
 // Container direction should alternate between row (for the root) and


### PR DESCRIPTION
This resolves #10151.

By default all `layoutItem`s have a `resizeableRight` set as true if not last child.

This solution adds a `resizeableLeft` option in `LayoutItem` type.
And sets if as `true` if the `editor` is before that element.

This change should be apparent only if there are elements after `editor`.