### PR TITLE
Chore: Mobile: Remove no-longer-necessary Icon warning workaround

### DIFF
--- a/packages/app-mobile/components/CameraView.tsx
+++ b/packages/app-mobile/components/CameraView.tsx
@@ -8,11 +8,6 @@ const { _ } = require('@joplin/lib/locale');
 import shim from '@joplin/lib/shim';
 import Setting from '@joplin/lib/models/Setting';
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any -- Old code before rule was applied
-Icon.loadFont().catch((error: any) => { console.info(error); });
-
 class CameraView extends Component {
 	public constructor() {
 		super();

--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -25,11 +25,6 @@ import { ContainerType } from '@joplin/lib/services/plugins/WebviewController';
 import { Dispatch } from 'redux';
 import WarningBanner from './WarningBanner';
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any -- Old code before rule was applied
-Icon.loadFont().catch((error: any) => { console.info(error); });
-
 // Rather than applying a padding to the whole bar, it is applied to each
 // individual component (button, picker, etc.) so that the touchable areas
 // are widder and to give more room to the picker component which has a larger

--- a/packages/app-mobile/components/checkbox.js
+++ b/packages/app-mobile/components/checkbox.js
@@ -2,10 +2,6 @@ const React = require('react');
 const Component = React.Component;
 const { View, TouchableHighlight } = require('react-native');
 const Icon = require('react-native-vector-icons/Ionicons').default;
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console
-Icon.loadFont().catch((error) => { console.info(error); });
 
 const styles = {
 	checkboxIcon: {

--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -11,11 +11,6 @@ import { AppState } from '../../utils/types';
 import { TagEntity } from '@joplin/lib/services/database/types';
 const naturalCompare = require('string-natural-compare');
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any -- Old code before rule was applied
-Icon.loadFont().catch((error: any) => { console.info(error); });
-
 interface Props {
 	themeId: number;
 	noteId: string|null;

--- a/packages/app-mobile/components/screens/search.tsx
+++ b/packages/app-mobile/components/screens/search.tsx
@@ -15,11 +15,6 @@ import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import { AppState } from '../../utils/types';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any -- Old code before rule was applied
-Icon.loadFont().catch((error: any) => { console.info(error); });
-
 class SearchScreenComponent extends BaseScreenComponent {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/app-mobile/components/side-menu-content-note.js
+++ b/packages/app-mobile/components/side-menu-content-note.js
@@ -5,11 +5,6 @@ const { connect } = require('react-redux');
 const Icon = require('react-native-vector-icons/Ionicons').default;
 const { themeStyle } = require('./global-style');
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console
-Icon.loadFont().catch((error) => { console.info(error); });
-
 class SideMenuContentNoteComponent extends Component {
 	constructor() {
 		super();

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -20,11 +20,6 @@ import emptyTrash from '@joplin/lib/services/trash/emptyTrash';
 import { ModelType } from '@joplin/lib/BaseModel';
 const { substrWithEllipsis } = require('@joplin/lib/string-utils');
 
-// We need this to suppress the useless warning
-// https://github.com/oblador/react-native-vector-icons/issues/1465
-// eslint-disable-next-line no-console, @typescript-eslint/no-explicit-any -- Old code before rule was applied
-Icon.loadFont().catch((error: any) => { console.info(error); });
-
 interface Props {
 	syncStarted: boolean;
 	themeId: number;


### PR DESCRIPTION
# Summary

Removes `Icon.loadFont().catch(...)`, which is no longer necessary  ([see the upstream issue](https://github.com/oblador/react-native-vector-icons/issues/1465)).

Note that the `Icon.loadFont()` calls are also causing warnings to be logged during automated testing [for this pull request](https://github.com/laurent22/joplin/pull/10300).

# Testing plan

1. Launch the app on iOS.
2. Open the camera view, the side menu, then the tags dialog.
3. Verify that no React Native Vector Icons warnings are shown.

**Note**: The camera view does produce a warning, but it seems unrelated to React Native Vector Icons and is still present if I add the `Icon.loadFont` workaround back to `CameraView.tsx`. Warning content: `Warning: Failed prop type: Camera: prop type 'ViewPropTypes' is invalid; it must be a function, usually from the prop-types package, but received object. This often happens because of typos...`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->