### PR TITLE
Desktop: Resolves #10306: Enforce unsigned commits in buildDefaultPlugins.ts

### DIFF
--- a/packages/default-plugins/buildDefaultPlugins.ts
+++ b/packages/default-plugins/buildDefaultPlugins.ts
@@ -75,6 +75,7 @@ const buildDefaultPlugins = async (outputParentDir: string|null, beforeInstall: 
 			await execCommand('git add .');
 			await execCommand(['git', 'config', 'user.name', 'Build script']);
 			await execCommand(['git', 'config', 'user.email', '']);
+			await execCommand(['git', 'config', 'commit.gpgsign', 'false']);
 			await execCommand(['git', 'commit', '-m', 'Initial commit']);
 
 			const patchFile = getPathToPatchFileFor(pluginId);


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

`git config commit.gpgsign false`  command added to the script.
This will not change most of the builds, because unsigned commits are  default in `git`.

On machines with signing enabled this particular repo (the one, that is created by the script) will not be signed by default.