### PR TITLE
Chore: Fixes #10306: Remove unnecessary initial commit in default plugins build

### DIFF
--- a/packages/default-plugins/commands/buildAll.ts
+++ b/packages/default-plugins/commands/buildAll.ts
@@ -1,7 +1,10 @@
 import buildDefaultPlugins from '../buildDefaultPlugins';
 
 const buildAll = (outputDirectory: string) => {
-	return buildDefaultPlugins(outputDirectory, async () => { });
+	return buildDefaultPlugins(outputDirectory, {
+		beforeInstall: async () => { },
+		beforePatch: async () => { },
+	});
 };
 
 export default buildAll;

--- a/packages/default-plugins/commands/editPatch.ts
+++ b/packages/default-plugins/commands/editPatch.ts
@@ -15,6 +15,7 @@ const editPatch = async (targetPluginId: string, outputParentDir: string|null) =
 			await execCommand('git add .');
 			await execCommand(['git', 'config', 'user.name', 'Build script']);
 			await execCommand(['git', 'config', 'user.email', '']);
+			await execCommand(['git', 'config', 'commit.gpgSign', 'false']);
 			await execCommand(['git', 'commit', '-m', 'Initial commit']);
 		},
 		beforeInstall: async (buildDir, pluginId) => {

--- a/packages/default-plugins/commands/editPatch.ts
+++ b/packages/default-plugins/commands/editPatch.ts
@@ -10,7 +10,7 @@ const editPatch = async (targetPluginId: string, outputParentDir: string|null) =
 
 	await buildDefaultPlugins(outputParentDir, {
 		beforePatch: async () => {
-			// To make editing the patch easier, a commit is created just before applying
+			// To make updating just the patch possible, a commit is created just before applying
 			// the patch.
 			await execCommand('git add .');
 			await execCommand(['git', 'config', 'user.name', 'Build script']);

--- a/packages/default-plugins/commands/editPatch.ts
+++ b/packages/default-plugins/commands/editPatch.ts
@@ -8,19 +8,29 @@ import getPathToPatchFileFor from '../utils/getPathToPatchFileFor';
 const editPatch = async (targetPluginId: string, outputParentDir: string|null) => {
 	let patchedPlugin = false;
 
-	await buildDefaultPlugins(outputParentDir, async (buildDir, pluginId) => {
-		if (pluginId !== targetPluginId) {
-			return;
-		}
+	await buildDefaultPlugins(outputParentDir, {
+		beforePatch: async () => {
+			// To make editing the patch easier, a commit is created just before applying
+			// the patch.
+			await execCommand('git add .');
+			await execCommand(['git', 'config', 'user.name', 'Build script']);
+			await execCommand(['git', 'config', 'user.email', '']);
+			await execCommand(['git', 'commit', '-m', 'Initial commit']);
+		},
+		beforeInstall: async (buildDir, pluginId) => {
+			if (pluginId !== targetPluginId) {
+				return;
+			}
 
-		// eslint-disable-next-line no-console
-		console.log('Make changes to', buildDir, 'to create a patch.');
-		await waitForCliInput();
-		await execCommand(['sh', '-c', 'git diff -p > diff.diff']);
+			// eslint-disable-next-line no-console
+			console.log('Make changes to', buildDir, 'to create a patch.');
+			await waitForCliInput();
+			await execCommand(['sh', '-c', 'git diff -p > diff.diff']);
 
-		await copy(join(buildDir, './diff.diff'), getPathToPatchFileFor(pluginId));
+			await copy(join(buildDir, './diff.diff'), getPathToPatchFileFor(pluginId));
 
-		patchedPlugin = true;
+			patchedPlugin = true;
+		},
 	});
 
 	if (!patchedPlugin) {

--- a/packages/default-plugins/commands/editPatch.ts
+++ b/packages/default-plugins/commands/editPatch.ts
@@ -15,7 +15,6 @@ const editPatch = async (targetPluginId: string, outputParentDir: string|null) =
 			await execCommand('git add .');
 			await execCommand(['git', 'config', 'user.name', 'Build script']);
 			await execCommand(['git', 'config', 'user.email', '']);
-			await execCommand(['git', 'config', 'commit.gpgSign', 'false']);
 			await execCommand(['git', 'commit', '-m', 'Initial commit']);
 		},
 		beforeInstall: async (buildDir, pluginId) => {


### PR DESCRIPTION
# Summary

This removes an initial commit step when initializing the default plugins build directory. The initial commit step is only necessary when updating a default plugin patch.

Fixes #10306.

**Edit**: Related to https://github.com/laurent22/joplin/pull/10307 (I didn't see the other PR until after creating this one).

# Testing plan

1. Run `yarn patch-plugin io.github.jackgruber.backup` from `packages/default-plugins`. Make a small change to the temporary directory then finish the build. Verify that the patch updates.
2. Run `yarn build` from the `packages/app-desktop`, verify that the build completes successfully.
    - **Note**: Automated Playwright tests exist to verify that the Backup plugin loads when launching the app.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->