### PR TITLE
Mobile: Fixes #10313: Fix error on retry or ignore attachment too large error

### DIFF
--- a/packages/lib/services/ReportService.test.ts
+++ b/packages/lib/services/ReportService.test.ts
@@ -1,10 +1,11 @@
-import SyncTargetRegistry from '../SyncTargetRegistry';
 import { _ } from '../locale';
 import ReportService, { ReportSection } from './ReportService';
-import { createNTestNotes, decryptionWorker, setupDatabaseAndSynchronizer, switchClient, synchronizerStart } from '../testing/test-utils';
+import { createNTestNotes, decryptionWorker, setupDatabaseAndSynchronizer, supportDir, switchClient, syncTargetId, synchronizer, synchronizerStart } from '../testing/test-utils';
 import Folder from '../models/Folder';
 import BaseItem from '../models/BaseItem';
 import DecryptionWorker from './DecryptionWorker';
+import Note from '../models/Note';
+import shim from '../shim';
 
 
 const getSectionsWithTitle = (report: ReportSection[], title: string) => {
@@ -32,8 +33,8 @@ const sectionBodyToText = (section: ReportSection) => {
 describe('ReportService', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
+		await setupDatabaseAndSynchronizer(2);
 		await switchClient(1);
-		await synchronizerStart();
 		// For compatibility with code that calls DecryptionWorker.instance()
 		DecryptionWorker.instance_ = decryptionWorker();
 	});
@@ -43,15 +44,14 @@ describe('ReportService', () => {
 		const noteCount = 5;
 		const testNotes = await createNTestNotes(noteCount, folder);
 		await synchronizerStart();
-		const syncTargetId = SyncTargetRegistry.nameToId('memory');
 
 		const disabledReason = 'Test reason';
 		for (const testNote of testNotes) {
-			await BaseItem.saveSyncDisabled(syncTargetId, testNote, disabledReason);
+			await BaseItem.saveSyncDisabled(syncTargetId(), testNote, disabledReason);
 		}
 
 		const service = new ReportService();
-		let report = await service.status(syncTargetId);
+		let report = await service.status(syncTargetId());
 
 		// Items should all initially be listed as "cannot be synchronized", but should be ignorable.
 		const unsyncableSection = getCannotSyncSection(report);
@@ -65,16 +65,16 @@ describe('ReportService', () => {
 		expect(sectionBodyToText(unsyncableSection)).toContain(disabledReason);
 
 		// Ignore all
-		expect(await BaseItem.syncDisabledItemsCount(syncTargetId)).toBe(noteCount);
-		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId)).toBe(noteCount);
+		expect(await BaseItem.syncDisabledItemsCount(syncTargetId())).toBe(noteCount);
+		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId())).toBe(noteCount);
 		for (const item of ignorableItems) {
 			await item.ignoreHandler();
 		}
-		expect(await BaseItem.syncDisabledItemsCount(syncTargetId)).toBe(0);
-		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId)).toBe(noteCount);
+		expect(await BaseItem.syncDisabledItemsCount(syncTargetId())).toBe(0);
+		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId())).toBe(noteCount);
 
 		await synchronizerStart();
-		report = await service.status(syncTargetId);
+		report = await service.status(syncTargetId());
 
 		// Should now be in the ignored section
 		const ignoredSection = getIgnoredSection(report);
@@ -92,7 +92,7 @@ describe('ReportService', () => {
 			}
 		}
 		// Should have the correct number of ignored items
-		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId)).toBe(ignoredItemCount);
+		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId())).toBe(ignoredItemCount);
 		expect(ignoredItemCount).toBe(noteCount);
 
 		// Clicking "retry" should un-ignore
@@ -103,6 +103,47 @@ describe('ReportService', () => {
 				break;
 			}
 		}
-		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId)).toBe(noteCount - 1);
+		expect(await BaseItem.syncDisabledItemsCountIncludingIgnored(syncTargetId())).toBe(noteCount - 1);
+	});
+
+	it('should support ignoring sync errors for resources that failed to download', async () => {
+		const createAttachmentDownloadError = async () => {
+			await switchClient(2);
+
+			const note1 = await Note.save({ title: 'note' });
+			await shim.attachFileToNote(note1, `${supportDir}/photo.jpg`);
+			await synchronizerStart();
+
+			await switchClient(1);
+
+			const previousMax = synchronizer().maxResourceSize_;
+			synchronizer().maxResourceSize_ = 1;
+			await synchronizerStart();
+			synchronizer().maxResourceSize_ = previousMax;
+		};
+		await createAttachmentDownloadError();
+
+		const service = new ReportService();
+		let report = await service.status(syncTargetId());
+
+		const unsyncableSection = getCannotSyncSection(report);
+		expect(sectionBodyToText(unsyncableSection)).toContain('could not be downloaded');
+
+		// Item for the download error should be ignorable
+		const ignorableItems = [];
+		for (const item of unsyncableSection.body) {
+			if (typeof item === 'object' && item.canIgnore) {
+				ignorableItems.push(item);
+			}
+		}
+		expect(ignorableItems).toHaveLength(1);
+
+		await ignorableItems[0].ignoreHandler();
+
+		// Should now be ignored.
+		report = await service.status(syncTargetId());
+		expect(
+			getIgnoredSection(report).body.some(item => typeof item === 'object' && item.canRetry === true),
+		).toBe(true);
 	});
 });

--- a/packages/lib/services/ReportService.ts
+++ b/packages/lib/services/ReportService.ts
@@ -194,16 +194,17 @@ export default class ReportService {
 					msg = _('Item "%s" could not be downloaded: %s', row.syncInfo.item_id, row.syncInfo.sync_disabled_reason);
 				}
 
+				const item = { type_: row.syncInfo.item_type, id: row.syncInfo.item_id };
 				section.body.push({
 					text: msg,
 					canRetry: true,
 					canRetryType: CanRetryType.ItemSync,
 					retryHandler: async () => {
-						await BaseItem.saveSyncEnabled(row.item.type_, row.item.id);
+						await BaseItem.saveSyncEnabled(item.type_, item.id);
 					},
 					canIgnore: !row.warning_ignored,
 					ignoreHandler: async () => {
-						await BaseItem.ignoreItemSyncWarning(syncTarget, row.item);
+						await BaseItem.ignoreItemSyncWarning(syncTarget, item);
 					},
 				});
 			};

--- a/packages/lib/services/ReportService.ts
+++ b/packages/lib/services/ReportService.ts
@@ -194,6 +194,7 @@ export default class ReportService {
 					msg = _('Item "%s" could not be downloaded: %s', row.syncInfo.item_id, row.syncInfo.sync_disabled_reason);
 				}
 
+				// row.item may be undefined when location !== SYNC_ITEM_LOCATION_LOCAL
 				const item = { type_: row.syncInfo.item_type, id: row.syncInfo.item_id };
 				section.body.push({
 					text: msg,


### PR DESCRIPTION
# Summary

Fixes an error caused by `ReportService` referencing an `undefined` property in `retryHandler` and `ignoreHandler`.

Fixes #10313.

> [!NOTE]
>
> This pull request is marked as `Mobile: ` because [`maxResourceSize` is `Infinity` on desktop and CLI](https://github.com/laurent22/joplin/blob/9fe31544f72b37e07a7a0346d4663a4752e171fa/packages/lib/Synchronizer.ts#L151).


# Testing plan

This pull request has an automated test. It has also been tested manually by 1) clicking "ignore" by an error for an item that failed to download and 2) verifying that the item is moved to the "ignored" section.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->