### PR TITLE
Desktop: Resolves #10315: Do not trim markdown upon saving in rich text

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -95,7 +95,7 @@ export default function openEditDialog(editor: any, markupToHtml: any, dispatchD
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		onSubmit: async (dialogApi: any) => {
 			const newSource = newBlockSource(dialogApi.getData().languageInput, dialogApi.getData().codeTextArea, source);
-			const md = `${newSource.openCharacters}${newSource.content.trim()}${newSource.closeCharacters}`;
+			const md = `${newSource.openCharacters}${newSource.content}${newSource.closeCharacters}`;
 			const result = await markupToHtml.current(MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN, md, { bodyOnly: true });
 
 			// markupToHtml will return the complete editable HTML, but we only


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

This fixes #10315 where markdown was erroneously trimming leading and trailing whitespace. There are some cases where users would like to keep the markdown as is without any changes, as shown in cwesson/joplin-plugin-typograms#1. This PR removes the trim string method in the openEditDialog.tsx component. I am not entirely sure why it is in there in the first place nor can I think of a reason why markdown would need to be trimmed if the user wrote markdown with trailing whitespace in our use case, so I removed it.