### PR TITLE
Desktop, Mobile: Display a message when Joplin Cloud user don't have access to email to note feature

### DIFF
--- a/packages/app-desktop/gui/JoplinCloudConfigScreen.scss
+++ b/packages/app-desktop/gui/JoplinCloudConfigScreen.scss
@@ -1,3 +1,12 @@
 .inbox-email-value {
 	font-weight: bold;
 }
+
+.alert-warn {
+	background-color: var(--joplin-background-color);
+	width: fit-content;
+
+	p {
+		padding: calc(var(--joplin-font-size) * 0.8);
+	}
+}

--- a/packages/app-desktop/gui/JoplinCloudConfigScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudConfigScreen.tsx
@@ -6,6 +6,7 @@ import Button from './Button/Button';
 
 type JoplinCloudConfigScreenProps = {
 	inboxEmail: string;
+	joplinCloudAccountType: number;
 };
 
 const JoplinCloudConfigScreen = (props: JoplinCloudConfigScreenProps) => {
@@ -13,19 +14,29 @@ const JoplinCloudConfigScreen = (props: JoplinCloudConfigScreenProps) => {
 		clipboard.writeText(props.inboxEmail);
 	};
 
+	const isEmailToNoteAvailableInAccount = props.joplinCloudAccountType !== 1;
+
 	return (
 		<div>
 			<h2>{_('Email to note')}</h2>
 			<p>{_('Any email sent to this address will be converted into a note and added to your collection. The note will be saved into the Inbox notebook')}</p>
-			<p className='inbox-email-value'>{props.inboxEmail}</p>
-			<Button onClick={copyToClipboard} title={_('Copy to clipboard')} />
+			{
+				isEmailToNoteAvailableInAccount ? <>
+					<p className='inbox-email-value'>{props.inboxEmail}</p>
+					<Button onClick={copyToClipboard} title={_('Copy to clipboard')} />
+				</>
+					: <div className='alert-warn'>
+						<p>{_('Your account doesn\'t have access to this feature')}</p>
+					</div>
+			}
 		</div>
 	);
 };
 
 const mapStateToProps = (state: AppState) => {
 	return {
-		inboxEmail: state.settings['sync.10.inboxEmail'],
+		inboxEmail: state.settings,
+		joplinCloudAccountType: state.settings['sync.10.accountType'],
 	};
 };
 

--- a/packages/app-desktop/gui/JoplinCloudConfigScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudConfigScreen.tsx
@@ -3,6 +3,7 @@ import { AppState } from '../app.reducer';
 import { _ } from '@joplin/lib/locale';
 import { clipboard } from 'electron';
 import Button from './Button/Button';
+import { Fragment } from 'react';
 
 type JoplinCloudConfigScreenProps = {
 	inboxEmail: string;
@@ -21,10 +22,10 @@ const JoplinCloudConfigScreen = (props: JoplinCloudConfigScreenProps) => {
 			<h2>{_('Email to note')}</h2>
 			<p>{_('Any email sent to this address will be converted into a note and added to your collection. The note will be saved into the Inbox notebook')}</p>
 			{
-				isEmailToNoteAvailableInAccount ? <>
+				isEmailToNoteAvailableInAccount ? <Fragment>
 					<p className='inbox-email-value'>{props.inboxEmail}</p>
 					<Button onClick={copyToClipboard} title={_('Copy to clipboard')} />
-				</>
+				</Fragment>
 					: <div className='alert-warn'>
 						<p>{_('Your account doesn\'t have access to this feature')}</p>
 					</div>
@@ -35,7 +36,7 @@ const JoplinCloudConfigScreen = (props: JoplinCloudConfigScreenProps) => {
 
 const mapStateToProps = (state: AppState) => {
 	return {
-		inboxEmail: state.settings,
+		inboxEmail: state.settings['sync.10.inboxEmail'],
 		joplinCloudAccountType: state.settings['sync.10.accountType'],
 	};
 };

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -525,7 +525,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 					{
 						!isEmailToNoteAvailableInAccount && (
 							<View style={this.styles().styleSheet.settingContainerNoBottomBorder}>
-								<Text style={this.styles().styleSheet.descriptionText}>{_('Your account doesn\'t have access to this feature')}</Text>
+								<Text style={this.styles().styleSheet.descriptionAlert}>{_('Your account doesn\'t have access to this feature')}</Text>
 							</View>
 						)
 					}

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -345,6 +345,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				description={options?.description}
 				statusComponent={options?.statusComp}
 				styles={this.styles()}
+				disabled={options?.disabled}
 			/>
 		);
 	}
@@ -513,18 +514,27 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		if (section.name === 'joplinCloud') {
 			const label = _('Email to note');
 			const description = _('Any email sent to this address will be converted into a note and added to your collection. The note will be saved into the Inbox notebook');
+			const isEmailToNoteAvailableInAccount = this.props.settings['sync.10.accountType'] !== 1;
+			const inboxEmailValue = isEmailToNoteAvailableInAccount ? this.props.settings['sync.10.inboxEmail'] : '-';
 			addSettingComponent(
 				<View key="joplinCloud">
 					<View style={this.styles().styleSheet.settingContainerNoBottomBorder}>
 						<Text style={this.styles().styleSheet.settingText}>{label}</Text>
-						<Text style={this.styles().styleSheet.settingTextEmphasis}>{this.props.settings['sync.10.inboxEmail']}</Text>
+						<Text style={this.styles().styleSheet.settingTextEmphasis}>{inboxEmailValue}</Text>
 					</View>
+					{
+						!isEmailToNoteAvailableInAccount && (
+							<View style={this.styles().styleSheet.settingContainerNoBottomBorder}>
+								<Text style={this.styles().styleSheet.descriptionText}>{_('Your account doesn\'t have access to this feature')}</Text>
+							</View>
+						)
+					}
 					{
 						this.renderButton(
 							'sync.10.inboxEmail',
 							_('Copy to clipboard'),
-							() => Clipboard.setString(this.props.settings['sync.10.inboxEmail']),
-							{ description },
+							() => isEmailToNoteAvailableInAccount && Clipboard.setString(this.props.settings['sync.10.inboxEmail']),
+							{ description, disabled: !isEmailToNoteAvailableInAccount },
 						)
 					}
 				</View>,

--- a/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/configScreenStyles.ts
@@ -15,6 +15,7 @@ export interface ConfigScreenStyleSheet {
 	settingTextEmphasis: TextStyle;
 	linkText: TextStyle;
 	descriptionText: TextStyle;
+	descriptionAlert: TextStyle;
 	warningText: TextStyle;
 
 	sliderUnits: TextStyle;
@@ -116,6 +117,11 @@ const configScreenStyles = (themeId: number): ConfigScreenStyles => {
 		},
 		descriptionText: {
 			color: theme.colorFaded,
+			fontSize: theme.fontSizeSmaller,
+			flex: 1,
+		},
+		descriptionAlert: {
+			color: theme.color,
 			fontSize: theme.fontSizeSmaller,
 			flex: 1,
 		},


### PR DESCRIPTION
Display a message to the user indicating that the feature is currently disabled for that account.

In the mobile implementation I decided to keep the button visible but just disable it because the feature description is associated with the button in the code. Would it be better to hide the button and keep the feature description visible?

I'm open to suggestions on how we could present this.

<details><summary>Screenshots Desktop</summary>
<p>

![Screenshot from 2024-04-17 04-56-47](https://github.com/laurent22/joplin/assets/5051088/96d224e4-24f2-4338-b637-0c253d37901e)

![Screenshot from 2024-04-17 04-57-27](https://github.com/laurent22/joplin/assets/5051088/b03f7037-1097-4400-8786-41171f0f05ef)

</p>
</details> 


<details><summary>Screenshots Mobile</summary>
<p>

![Screenshot from 2024-04-17 05-30-42](https://github.com/laurent22/joplin/assets/5051088/1c1bdd2a-07c0-474a-ae0d-7866bbdf841a)
![Screenshot from 2024-04-17 05-31-23](https://github.com/laurent22/joplin/assets/5051088/0ea25499-c687-415d-98aa-4369fce3e84c)

</p>
</details> 

