### PR TITLE
Mobile: Fixes #10253: Move accessibility focus to first menu option once it opens

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { PureComponent, ReactElement, RefObject } from 'react';
+import { PureComponent, ReactElement, RefObject, Component } from 'react';
 import { connect } from 'react-redux';
 import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView, Dimensions, ViewStyle, findNodeHandle, AccessibilityInfo } from 'react-native';
 const Icon = require('react-native-vector-icons/Ionicons').default;
 const { BackButtonService } = require('../../services/back-button.js');
 import NavService from '@joplin/lib/services/NavService';
-import { Menu, MenuOptions, MenuOption, MenuTrigger } from 'react-native-popup-menu';
+import { Menu, MenuOptions, MenuOption, MenuTrigger, MenuOptionProps } from 'react-native-popup-menu';
 import { _, _n } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
@@ -89,7 +89,7 @@ interface ScreenHeaderState {
 class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeaderState> {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private cachedStyles: any;
-	private menuOptionsRef: RefObject<View>;
+	private menuOptionsRef: RefObject<Component<MenuOptionProps>>;
 	public dialogbox?: typeof DialogBox;
 	public constructor(props: ScreenHeaderProps) {
 		super(props);


### PR DESCRIPTION
## Summary


On opening the note menu, moved the accessibility focus to the first item in it using `AccessibilityInfo.setAccessibilityFocus`
- Fixes #10253 


## Rationale

1. added a ref to the first item in the note menu
2. when the `onOpen` event of the Menu is triggered, set the accessibility focus to first item using ref.
3. used `setTimeout` because the value of ref was initially null for a few milliseconds.

## Demo


https://github.com/laurent22/joplin/assets/97161173/9b9bfc7a-9955-4640-af40-af5a2ede55e0



## Manual Testing

1. Enable TalkBack
2. Open a note
3. Focus the note actions button (top right of screen)
4. Activate it (double-tap), the focus should move to the first item on the menu
5. Move focus to the next item (swipe right), the focus goes to the second item on the menu

Tested successfully on android 13 physical device