### PR TITLE
Desktop: Resolves #10332: Ubuntu 24.04: Work around unprivileged user namespace restrictions by adding the --no-sandbox flag to the launcher

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -202,25 +202,28 @@ if command -v lsb_release &> /dev/null; then
   DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
   DISTCODENAME=$(lsb_release -cs)
   DISTMAJOR=$(lsb_release -rs|cut -d. -f1)
+
   #-----------------------------------------------------
   # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
   # It is present in Debian 1X. A (temporary) patch will be applied at .desktop file
   # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
   #
   # TODO: Remove: This is likely no longer an issue. See https://issues.chromium.org/issues/40462640.
+  BAD_HELPER_BINARY=false
   if [[ $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]; then
     BAD_HELPER_BINARY=true
   fi
-  
+
   # Work around Ubuntu 23.10+'s restrictions on unprivileged user namespaces. Electron
   # uses these to sandbox processes. Unfortunately, it doesn't look like we can get around this
   # without writing the AppImage to a non-user-writable location (without invalidating other security
   # controls). See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/.
+  HAS_USERNS_RESTRICTIONS=false
   if [[ "$DISTVER" =~ ^Ubuntu && $DISTMAJOR -ge 23 ]]; then
     HAS_USERNS_RESTRICTIONS=true
   fi
 
-  if [[ $HAS_USERNS_RESTRICTIONS || $BAD_HELPER_BINARY ]]; then
+  if [[ $HAS_USERNS_RESTRICTIONS = true || $BAD_HELPER_BINARY = true ]]; then
     SANDBOXPARAM="--no-sandbox"
     print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled."
     print "    See https://discourse.joplinapp.org/t/32160/5 for details."

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -207,11 +207,20 @@ if command -v lsb_release &> /dev/null; then
   # It is present in Debian 1X. A (temporary) patch will be applied at .desktop file
   # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
   #
-  # This also works around Ubuntu 23.10+'s restrictions on unprivileged user namespaces. Electron
+  # TODO: Remove: This is likely no longer an issue. See https://issues.chromium.org/issues/40462640.
+  if [[ $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]; then
+    BAD_HELPER_BINARY=true
+  fi
+  
+  # Work around Ubuntu 23.10+'s restrictions on unprivileged user namespaces. Electron
   # uses these to sandbox processes. Unfortunately, it doesn't look like we can get around this
   # without writing the AppImage to a non-user-writable location (without invalidating other security
   # controls). See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/.
-  if [[ $DISTVER = "Ubuntu23.10" || $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]; then
+  if [[ "$DISTVER" =~ ^Ubuntu && $DISTMAJOR -ge 23 ]]; then
+    HAS_USERNS_RESTRICTIONS=true
+  fi
+
+  if [[ $HAS_USERNS_RESTRICTIONS || $BAD_HELPER_BINARY ]]; then
     SANDBOXPARAM="--no-sandbox"
     print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled."
     print "    See https://discourse.joplinapp.org/t/32160/5 for details."


### PR DESCRIPTION
# Summary

This pull request extends the unprivileged user namespace restriction workaround to Ubuntu 24.04. Previously, it was only enabled for Ubuntu 23.10.

Resolves #10332. 

<details><summary>Testing plan</summary>

# Testing plan

To test this change, in a **bash** shell, I've run:
```bash
print() {
    echo -e "$@"
}

DISTVER=$(lsb_release -is) && DISTVER=$DISTVER$(lsb_release -rs)
DISTCODENAME=$(lsb_release -cs)
DISTMAJOR=$(lsb_release -rs|cut -d. -f1)

sandbox_logic() {
  SANDBOXPARAM=""
  #--------------------------------------------------------
  # This is the modified version of the --no-sandbox logic
  #________________________________________________________
  echo " DISTVER: $DISTVER"
  echo " DISTCODENAME: $DISTCODENAME"
  echo " DISTMAJOR: $DISTMAJOR"

  #-----------------------------------------------------
  # Check for "The SUID sandbox helper binary was found, but is not configured correctly" problem.
  # It is present in Debian 1X. A (temporary) patch will be applied at .desktop file
  # Linux Mint 4 Debbie is based on Debian 10 and requires the same param handling.
  #
  # TODO: Remove: This is likely no longer an issue. See https://issues.chromium.org/issues/40462640.
  BAD_HELPER_BINARY=false
  if [[ $DISTVER =~ Debian1. || ( "$DISTVER" = "Linuxmint4" && "$DISTCODENAME" = "debbie" ) || ( "$DISTVER" = "CentOS" && "$DISTMAJOR" =~ 6|7 ) ]]; then
    BAD_HELPER_BINARY=true
  fi

  # Work around Ubuntu 23.10+'s restrictions on unprivileged user namespaces. Electron
  # uses these to sandbox processes. Unfortunately, it doesn't look like we can get around this
  # without writing the AppImage to a non-user-writable location (without invalidating other security
  # controls). See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/.
  HAS_USERNS_RESTRICTIONS=false
  if [[ "$DISTVER" =~ ^Ubuntu && $DISTMAJOR -ge 23 ]]; then
    HAS_USERNS_RESTRICTIONS=true
  fi

  if [[ $HAS_USERNS_RESTRICTIONS = true || $BAD_HELPER_BINARY = true ]]; then
    SANDBOXPARAM="--no-sandbox"
    print "${COLOR_YELLOW}WARNING${COLOR_RESET} Electron sandboxing disabled."
    print "    See https://discourse.joplinapp.org/t/32160/5 for details."
  fi

  #--------------------------------------------------------
  # End modified version of the --no-sandbox logic
  #________________________________________________________

  echo " Sandbox: $SANDBOXPARAM"
  echo ""
}


echo "Output for current OS"
sandbox_logic

echo "Output for Ubuntu 24.04"
DISTVER="Ubuntu24.04"
DISTCODENAME=noble
DISTMAJOR=$(echo "24.04"|cut -d. -f1)
sandbox_logic

echo "Output for Ubuntu 22.04"
DISTVER="Ubuntu22.04"
DISTCODENAME=jammy
DISTMAJOR=$(echo "22.04"|cut -d. -f1)
sandbox_logic

echo "Output for Linuxmint4"
DISTVER="Linuxmint4"
DISTCODENAME=debbie
DISTMAJOR=4
sandbox_logic

echo "Output for some other OS"
DISTVER="Some OS"
DISTCODENAME=osnamehere
DISTMAJOR=1234
sandbox_logic

```

## Test output

````
Output for current OS
 DISTVER: Ubuntu23.10
 DISTCODENAME: mantic
 DISTMAJOR: 23
WARNING Electron sandboxing disabled.
    See https://discourse.joplinapp.org/t/32160/5 for details.
 Sandbox: --no-sandbox

Output for Ubuntu 24.04
 DISTVER: Ubuntu24.04
 DISTCODENAME: noble
 DISTMAJOR: 24
WARNING Electron sandboxing disabled.
    See https://discourse.joplinapp.org/t/32160/5 for details.
 Sandbox: --no-sandbox

Output for Ubuntu 22.04
 DISTVER: Ubuntu22.04
 DISTCODENAME: jammy
 DISTMAJOR: 22
 Sandbox: 

Output for Linuxmint4
 DISTVER: Linuxmint4
 DISTCODENAME: debbie
 DISTMAJOR: 4
WARNING Electron sandboxing disabled.
    See https://discourse.joplinapp.org/t/32160/5 for details.
 Sandbox: --no-sandbox

Output for some other OS
 DISTVER: Some OS
 DISTCODENAME: osnamehere
 DISTMAJOR: 1234
 Sandbox: 

````

</details>



# Notes

- This pull request extends the existing `--no-sandbox` workaround to Ubuntu 24.04. See also [the similar pull request that added this workaround for Ubuntu 23.10](https://github.com/laurent22/joplin/pull/9137).
- Based on its [Any Linux Target](https://www.electron.build/configuration/linux) page, `electron-builder` also supports building `snap`s and `deb`s. One alternative could be to distribute an official `deb` or `snap` for Ubuntu users (see [the GitHub issue](https://github.com/laurent22/joplin/issues/10332) for information about how we might create an AppArmor profile if building a `deb`).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->