### PR TITLE
Desktop: Fixes #10345: Linux/Wayland: Allow passing `--enable-wayland-ime` flag to fix input method issues on startup

### DIFF
--- a/packages/lib/utils/processStartFlags.ts
+++ b/packages/lib/utils/processStartFlags.ts
@@ -145,6 +145,14 @@ const processStartFlags = async (argv: string[], setDefaults = true) => {
 			continue;
 		}
 
+		if (arg.indexOf('--enable-wayland-ime') === 0) {
+			// Electron-specific flag - ignore it
+			// Enables input method support on Linux/Wayland
+			// See https://github.com/laurent22/joplin/issues/10345
+			argv.splice(0, 1);
+			continue;
+		}
+
 		if (arg.indexOf('--ozone-platform=') === 0) {
 			// Electron-specific flag - ignore it
 			// Allows users to run the app on native wayland


### PR DESCRIPTION
# Summary

Adds `--enable-wayland-ime` to the list of allowed flags.

Fixes #10345.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->