### PR TITLE
Linux Desktop: Fixes #10354

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -253,7 +253,7 @@ if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cin
 Encoding=UTF-8
 Name=Joplin
 Comment=Joplin for Desktop
-Exec=${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
+Exec=env APPIMAGELAUNCHER_DISABLE=TRUE ${HOME}/.joplin/Joplin.AppImage ${SANDBOXPARAM} %u
 Icon=joplin
 StartupWMClass=Joplin
 Type=Application


### PR DESCRIPTION
Fixes the issue with Appimagelauncher interfering with Joplin's appimage.

The workaround is to add the environment variable `APPIMAGELAUNCHER_DISABLE=true` in the Joplin desktop file, as was described here https://github.com/TheAssassin/AppImageLauncher/issues/450#issuecomment-1203855655

The issue arises because appimagelauncher tries to create icons and desktop files for each appimage. But Joplin installer already does that, and appimagelauncher already know that.

Integrating with appimagelauncher is not a good workaround because it may hamper future updates.

Even if appimagelauncher is not installed, adding the environment variable `APPIMAGELAUNCHER_DISABLE=true` would not cause any problems.