### PR TITLE
Mobile,Desktop: Fixes #10191: Do not invite user to create new notes in the trash folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -795,6 +795,7 @@ packages/lib/commands/index.js
 packages/lib/commands/openMasterPasswordDialog.js
 packages/lib/commands/synchronize.js
 packages/lib/components/EncryptionConfigScreen/utils.js
+packages/lib/components/shared/NoteList/getEmptyFolderMessage.js
 packages/lib/components/shared/config/config-shared.js
 packages/lib/components/shared/config/plugins/types.js
 packages/lib/components/shared/config/plugins/useOnDeleteHandler.js

--- a/.gitignore
+++ b/.gitignore
@@ -775,6 +775,7 @@ packages/lib/commands/index.js
 packages/lib/commands/openMasterPasswordDialog.js
 packages/lib/commands/synchronize.js
 packages/lib/components/EncryptionConfigScreen/utils.js
+packages/lib/components/shared/NoteList/getEmptyFolderMessage.js
 packages/lib/components/shared/config/config-shared.js
 packages/lib/components/shared/config/plugins/types.js
 packages/lib/components/shared/config/plugins/useOnDeleteHandler.js

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { _ } from '@joplin/lib/locale';
 import { useMemo, useRef, useEffect } from 'react';
 import { AppState } from '../../app.reducer';
 import BaseModel, { ModelType } from '@joplin/lib/BaseModel';
@@ -22,6 +21,7 @@ import * as focusElementNoteList from './commands/focusElementNoteList';
 import CommandService from '@joplin/lib/services/CommandService';
 import useDragAndDrop from './utils/useDragAndDrop';
 import { itemIsInTrash } from '@joplin/lib/services/trash';
+import getEmptyFolderMessage from '@joplin/lib/components/shared/NoteList/getEmptyFolderMessage';
 import Folder from '@joplin/lib/models/Folder';
 const { connect } = require('react-redux');
 
@@ -187,7 +187,7 @@ const NoteList = (props: Props) => {
 
 	const renderEmptyList = () => {
 		if (props.notes.length) return null;
-		return <div className="emptylist">{props.folders.length ? _('No notes in here. Create one by clicking on "New note".') : _('There is currently no notebook. Create one by clicking on "New notebook".')}</div>;
+		return <div className="emptylist">{getEmptyFolderMessage(props.folders, props.selectedFolderId)}</div>;
 	};
 
 	const renderFiller = (key: string, style: React.CSSProperties) => {

--- a/packages/app-mobile/components/NoteList.tsx
+++ b/packages/app-mobile/components/NoteList.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { FlatList, Text, StyleSheet, Button, View } from 'react-native';
 import { FolderEntity, NoteEntity } from '@joplin/lib/services/database/types';
 import { AppState } from '../utils/types';
+import getEmptyFolderMessage from '@joplin/lib/components/shared/NoteList/getEmptyFolderMessage';
 import Folder from '@joplin/lib/models/Folder';
 
 const { _ } = require('@joplin/lib/locale');
@@ -102,8 +103,9 @@ class NoteListComponent extends Component<NoteListProps> {
 					</View>
 				);
 			} else {
-				const noItemMessage = _('There are currently no notes. Create one by clicking on the (+) button.');
-				return <Text style={this.styles().noItemMessage}>{noItemMessage}</Text>;
+				return <Text style={this.styles().noItemMessage}>
+					{getEmptyFolderMessage(this.props.folders, this.props.selectedFolderId)}
+				</Text>;
 			}
 		}
 	}
@@ -117,6 +119,7 @@ const NoteList = connect((state: AppState) => {
 		notesSource: state.notesSource,
 		themeId: state.settings.theme,
 		noteSelectionEnabled: state.noteSelectionEnabled,
+		selectedFolderId: state.selectedFolderId,
 	};
 })(NoteListComponent);
 

--- a/packages/app-mobile/components/NoteList.tsx
+++ b/packages/app-mobile/components/NoteList.tsx
@@ -21,7 +21,7 @@ interface NoteListProps {
 	items: NoteEntity[];
 	folders: FolderEntity[];
 	noteSelectionEnabled?: boolean;
-	selectedFolderId?: string;
+	selectedFolderId: string|null;
 }
 
 class NoteListComponent extends Component<NoteListProps> {

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -4,10 +4,10 @@ import Setting from '../../../models/Setting';
 import { FolderEntity } from '../../../services/database/types';
 import { getTrashFolderId, itemIsInTrash } from '../../../services/trash';
 
-const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string) => {
+const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string|null) => {
 	if (selectedFolderId === getTrashFolderId()) {
 		return _('There are no notes in the trash folder.');
-	} else if (itemIsInTrash(Folder.byId(folders, selectedFolderId))) {
+	} else if (selectedFolderId && itemIsInTrash(Folder.byId(folders, selectedFolderId))) {
 		return _('This subfolder of the trash has no notes.');
 	}
 

--- a/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
+++ b/packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts
@@ -1,0 +1,21 @@
+import { _ } from '../../../locale';
+import Folder from '../../../models/Folder';
+import Setting from '../../../models/Setting';
+import { FolderEntity } from '../../../services/database/types';
+import { getTrashFolderId, itemIsInTrash } from '../../../services/trash';
+
+const getEmptyFolderMessage = (folders: FolderEntity[], selectedFolderId: string) => {
+	if (selectedFolderId === getTrashFolderId()) {
+		return _('There are no notes in the trash folder.');
+	} else if (itemIsInTrash(Folder.byId(folders, selectedFolderId))) {
+		return _('This subfolder of the trash has no notes.');
+	}
+
+	if (Setting.value('appType') === 'desktop') {
+		return _('No notes in here. Create one by clicking on "New note".');
+	} else {
+		return _('There are currently no notes. Create one by clicking on the (+) button.');
+	}
+};
+
+export default getEmptyFolderMessage;


### PR DESCRIPTION
# Summary

This pull request changes the prompt in the trash folder from `There are currently no notes. Create one by clicking on the (+) button.` to `There are no notes in the trash folder.` or `This subfolder of the trash has no notes.`.

The new text states "there are no **notes** in the trash folder"  rather than "the trash folder is empty" because it can be shown if only folders are in the trash.

Fixes #10191.

# Screenshots

## Android

**A folder that isn't in the trash**:
<img src="https://github.com/laurent22/joplin/assets/46334387/637c72f1-08c1-4f20-b2ef-3fa897d58d87" width="400"/>

**An empty folder that is in the trash**:
<img src="https://github.com/laurent22/joplin/assets/46334387/cd46616a-6776-4253-b55c-0c8ddf4fd794" width="400"/>

**An empty trash folder**: 
<img src="https://github.com/laurent22/joplin/assets/46334387/ed9c3682-ae2e-49f5-a962-b8f25c58ee90" width="400"/>

## Desktop

![screenshot: There are no notes in the trash folder banner underneath the search bar](https://github.com/laurent22/joplin/assets/46334387/fd6395c1-584b-4a51-9fac-dc09ba64722e)
![screenshot: This subfolder of the trash has no notes below the search bar and create note/to-do buttons](https://github.com/laurent22/joplin/assets/46334387/4cdf3955-77d6-49a8-81ef-cad71f5c32eb)

# Testing plan

1. Create an empty folder and open it.
    - Verify that the `There are currently no notes. Create one by clicking on the (+) button.` message is shown on mobile and `No notes in here. Create one by clicking on "New note".` is shown on desktop.
2. Move the folder to the trash and open it.
    - Verify that the `This subfolder of the trash has no notes.` message is shown.
3. Open the trash folder (empty it if there are notes).
    - Verify that the `There are no notes in the trash folder.` message is shown.

This has been tested successfully on Ubuntu 23.10 and Android 7.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->