### PR TITLE
Chore: Clipper: Fix wrong "unable to create property httpCode on string" error when clipping pages

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -228,8 +228,8 @@ function shimInit(options: ShimInitOptions = null) {
 			image.src = filePath;
 			await new Promise<void>((resolve, reject) => {
 				image.onload = () => resolve();
-				image.onerror = () => reject(`Image at ${filePath} failed to load.`);
-				image.onabort = () => reject(`Loading stopped for image at ${filePath}.`);
+				image.onerror = () => reject(new Error(`Image at ${filePath} failed to load.`));
+				image.onabort = () => reject(new Error(`Loading stopped for image at ${filePath}.`));
 			});
 			if (!image.complete || (image.width === 0 && image.height === 0)) {
 				throw new Error(`Image is invalid or does not exist: ${filePath}`);


### PR DESCRIPTION
# Summary

This pull request `reject`s with an `Error` instead of a string when loading an image to be resized. This **does not** fix #10365.

# Testing plan

The `main.spec.ts`/`'should correctly resize large images'` test covers the success case when loading an image to be resized.

I have tested the error case manually by:
1. Applying the following patch:
    ```diff
    diff --git a/packages/lib/shim-init-node.ts b/packages/lib/shim-init-node.ts
    index 78b8d68d2..8f0ba4c53 100644
    --- a/packages/lib/shim-init-node.ts
    +++ b/packages/lib/shim-init-node.ts
    @@ -225,7 +225,7 @@ function shimInit(options: ShimInitOptions = null) {
                            // original code).
     
                            const image = new Image();
    -                       image.src = filePath;
    +                       image.src = filePath + '.error';
                            await new Promise<void>((resolve, reject) => {
                                    image.onload = () => resolve();
                                    image.onerror = () => reject(new Error(`Image at ${filePath} failed to load.`));
    ```
2. Clipping `https://github.com/laurent22/joplin/pull/10286`

With this, I get the following error:
````error
There was some error creating the note: {"error":"Internal Server Error: Image at /home/builder/.config/joplindev-desktop/profile-0fof4zei/tmp/46334387_s_40_u_2d76498e7394c7b1_f610f8c8c02d4b78acd73ae053e64d5a.jpg failed to load.: \n\nError: Image at /home/builder/.config/joplindev-desktop/profile-0fof4zei/tmp/46334387_s_40_u_2d76498e7394c7b1_f610f8c8c02d4b78acd73ae053e64d5a.jpg failed to load.\n at image.onerror (/home/builder/Documents/joplin/packages/lib/shim-init-node.js:180:50)"}
````

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->