### PR TITLE
Desktop: Fixes #10194: Fix note disappears while editing

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -517,8 +517,7 @@ const SidebarComponent = (props: Props) => {
 			type: 'SMART_FILTER_SELECT',
 			id: ALL_NOTES_FILTER_ID,
 		});
-		folderItem_click(ALL_NOTES_FILTER_ID);
-	}, [props.dispatch, folderItem_click]);
+	}, [props.dispatch]);
 
 	const anchorItemRef = (type: string, id: string) => {
 		if (!anchorItemRefs.current[type]) anchorItemRefs.current[type] = {};
@@ -801,7 +800,7 @@ const SidebarComponent = (props: Props) => {
 
 
 	if (props.folders.length) {
-		const allNotesSelected = props.selectedFolderId === ALL_NOTES_FILTER_ID;
+		const allNotesSelected = props.notesParentType === 'SmartFilter' && props.selectedSmartFilterId === ALL_NOTES_FILTER_ID;
 		const result = renderFolders(props, renderFolderItem);
 		const folderItems = [renderAllNotesItem(theme, allNotesSelected)].concat(result.items);
 		folderItemsOrder_.current = result.order;

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -4,7 +4,7 @@ import Setting from '@joplin/lib/models/Setting';
 import { AppState, createAppDefaultState } from '../../app.reducer';
 import eventManager from '@joplin/lib/eventManager';
 const { shimInit } = require('@joplin/lib/shim-init-node.js');
-const { ALL_NOTES_FILTER_ID } = require('../reserved-ids');
+const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 
 const folderId1 = 'aa012345678901234567890123456789';
 const folderId2 = 'bb012345678901234567890123456789';

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -1,18 +1,49 @@
 import PerFolderSortOrderService from './PerFolderSortOrderService';
 import { setNotesSortOrder } from './notesSortOrderUtils';
 import Setting from '@joplin/lib/models/Setting';
+import { AppState, createAppDefaultState } from '../../app.reducer';
+import eventManager from '@joplin/lib/eventManager';
 const { shimInit } = require('@joplin/lib/shim-init-node.js');
+const { ALL_NOTES_FILTER_ID } = require('../reserved-ids');
 
 const folderId1 = 'aa012345678901234567890123456789';
 const folderId2 = 'bb012345678901234567890123456789';
+
+let appState: AppState|null = null;
+const updateAppState = (update: Partial<AppState>) => {
+	appState = { ...appState, ...update };
+	eventManager.appStateEmit(appState);
+};
+
+const switchToFolder = (id: string) => {
+	updateAppState({
+		notesParentType: 'Folder',
+		selectedFolderId: id,
+	});
+};
+
+const switchToAllNotes = () => {
+	updateAppState({
+		notesParentType: 'SmartFilter',
+		selectedSmartFilterId: ALL_NOTES_FILTER_ID,
+	});
+};
 
 describe('PerFolderSortOrderService', () => {
 
 	beforeAll(async () => {
 		shimInit();
 		Setting.autoSaveEnabled = false;
+	});
+
+	beforeEach(() => {
 		PerFolderSortOrderService.initialize();
 		Setting.setValue('notes.perFolderSortOrderEnabled', true);
+		updateAppState(createAppDefaultState({}, {}));
+		switchToFolder(folderId1);
+	});
+	afterEach(() => {
+		Setting.setValue('notes.perFolderSortOrders', {});
 	});
 
 	test('get(), isSet() and set()', async () => {
@@ -38,5 +69,72 @@ describe('PerFolderSortOrderService', () => {
 
 		// Folder without per-folder sort order has no per-folder sort order
 		expect(PerFolderSortOrderService.get(folderId2)).toBeUndefined();
+	});
+
+	test('should allow specifying a sort order specific to a folder', () => {
+		switchToFolder(folderId1);
+
+		expect(PerFolderSortOrderService.isSet(folderId1)).toBe(false);
+		expect(PerFolderSortOrderService.isSet(folderId2)).toBe(false);
+
+		setNotesSortOrder('user_created_time', false);
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+
+		// Folder 2 should use the shared sort order.
+		switchToFolder(folderId2);
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+
+		// If changing the per-folder sort order for folder 1, folder 2 should continue
+		// to use the shared sort order.
+		switchToFolder(folderId1);
+		PerFolderSortOrderService.set(folderId1, true);
+
+		setNotesSortOrder('title', true);
+		expect(Setting.value('notes.sortOrder.field')).toBe('title');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(true);
+
+		switchToFolder(folderId2);
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+	});
+
+	test('should allow setting a sort order specific to All Notes', () => {
+		switchToFolder(folderId1);
+
+		expect(PerFolderSortOrderService.isSet(ALL_NOTES_FILTER_ID)).toBe(false);
+		expect(PerFolderSortOrderService.isSet(folderId1)).toBe(false);
+
+		// Set default shared sort order
+		setNotesSortOrder('user_created_time', false);
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+
+		// Switching to all notes should not change the default sort order.
+		switchToAllNotes();
+
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+
+		// It should be possible to enable per-folder sorting for all notes.
+		PerFolderSortOrderService.set(ALL_NOTES_FILTER_ID, true);
+		expect(PerFolderSortOrderService.isSet(ALL_NOTES_FILTER_ID)).toBe(true);
+
+		setNotesSortOrder('user_updated_time', true);
+
+		// Per-folder sorting should be respected for all notes
+		switchToFolder(folderId1);
+
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_created_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
+
+		// Shared sort order should be overriden by per-folder sorting
+		setNotesSortOrder('title', false);
+
+		switchToAllNotes();
+
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_updated_time');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(true);
 	});
 });

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
@@ -13,6 +13,7 @@ export interface SortOrder {
 interface FolderState {
 	notesParentType: string;
 	selectedFolderId: string;
+	selectedSmartFilterId: string;
 }
 
 interface SortOrderPool {
@@ -21,8 +22,10 @@ interface SortOrderPool {
 
 export default class PerFolderSortOrderService {
 
+	// To support a custom sort order in "all notebooks", previousFolderId
+	// can also be a smart filter ID.
 	private static previousFolderId: string = null;
-	private static folderState: FolderState = { notesParentType: '', selectedFolderId: '' };
+	private static folderState: FolderState = { notesParentType: '', selectedFolderId: '', selectedSmartFilterId: '' };
 	// Since perFolderSortOrders and sharedSortOrder is persisted using Setting,
 	// their structures are not nested.
 	private static perFolderSortOrders: SortOrderPool = null;
@@ -40,6 +43,7 @@ export default class PerFolderSortOrderService {
 		this.loadSharedSortOrder();
 		eventManager.appStateOn('notesParentType', this.onFolderSelectionMayChange.bind(this, 'notesParentType'));
 		eventManager.appStateOn('selectedFolderId', this.onFolderSelectionMayChange.bind(this, 'selectedFolderId'));
+		eventManager.appStateOn('selectedSmartFilterId', this.onFolderSelectionMayChange.bind(this, 'selectedSmartFilterId'));
 		this.previousFolderId = Setting.value('activeFolderId');
 	}
 
@@ -93,7 +97,9 @@ export default class PerFolderSortOrderService {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static onFolderSelectionMayChange(cause: string, event: any) {
-		if (cause !== 'notesParentType' && cause !== 'selectedFolderId') return;
+		if (cause !== 'notesParentType' && cause !== 'selectedFolderId' && cause !== 'selectedSmartFilterId') {
+			return;
+		}
 		this.folderState[cause] = event.value;
 		const selectedId = this.getSelectedFolderId();
 		if (this.previousFolderId === selectedId) return;
@@ -127,6 +133,8 @@ export default class PerFolderSortOrderService {
 	private static getSelectedFolderId(): string {
 		if (this.folderState.notesParentType === 'Folder') {
 			return this.folderState.selectedFolderId;
+		} else if (this.folderState.notesParentType === 'SmartFilter') {
+			return this.folderState.selectedSmartFilterId;
 		} else {
 			return '';
 		}


### PR DESCRIPTION
# Summary

This pull request fixes #10194.

**It also disables manually changing the order of notes in All Notes**. Support for this was added in https://github.com/laurent22/joplin/commit/7638bdf171ead3b8ac268bf79d9f2275af6ecb42 by setting `notesParentType` to `Folder` when All Notes is open. Having `notesParentType` set to `Folder` when All Notes is a smart filter seems to have caused #10194 and the similar issues, however.

A more complicated version of this pull request that keeps support of manually re-ordering notes in All Notes [can be found here.](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/desktop/fix-note-disappears-while-editing--fewer-regressions?expand=1)

> [!IMPORTANT]
>
> This pull request **does not fix** the issue where notes sometimes disappear from search results (#10236).
>

# Comparison to #10222

This pull request is #10222 with additional logic to prevent per-folder sorting from breaking in All Notes.

PR #10222 mostly reverts 7638bdf171ead3b8ac268bf79d9f2275af6ecb42. Specifically, it:
1. Reverts logic that sets `notesParentType` to `Folder` when opening "All Notes", and
2. Reverts a change to the check that determines whether the all notes folder is open (see [the diff for Sidebar.tsx](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:joplin:pr/desktop/fix-note-disappears-while-editing?expand=1#diff-e512c98e4f56ee020ee8f2a8d5abb0b60023aa9944c74c1a89dcdfefbfdd2d27)).

While this fixes the disappearing note issue, it seems to break the "toggle own sort order" right-click menu item in the "All Notes" folder. This is because [PerFolderSortOrderService.ts](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:joplin:pr/desktop/fix-note-disappears-while-editing?expand=1#diff-d9c03bd450eb5b221c5ca1b49eab4e889414778ada9f769a09768866947faa0c) previously relied on `notesParentType` being set to `Folder` when determining whether per-folder sorting is enabled.

# Screen recordings

## Checking for regressions — toggle own sort order

https://github.com/laurent22/joplin/assets/46334387/fa8c31ef-5965-4114-9a23-53efd906d869


## Attempting to reproduce the disappearing note issue with this pull request

At 1:20 in the video below, the active note disappears from the search results. As such, in at least some cases, this PR does not fix issue #10236.

https://github.com/laurent22/joplin/assets/46334387/90ec22e6-b45e-4114-840c-658578cb997a


# Tests

This pull request includes tests to check that [PerFolderSortOrderService.ts](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:joplin:pr/desktop/fix-note-disappears-while-editing?expand=1#diff-d9c03bd450eb5b221c5ca1b49eab4e889414778ada9f769a09768866947faa0c) supports enabling per-folder sorting for "All Notes".



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->