### PR TITLE
Chore: Plugin repo CLI: Support setting per-plugin defaults for manifest properties

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1217,6 +1217,8 @@ packages/pdf-viewer/ui/IconButtons.js
 packages/pdf-viewer/ui/ZoomControls.js
 packages/plugin-repo-cli/commands/updateRelease.js
 packages/plugin-repo-cli/index.js
+packages/plugin-repo-cli/lib/applyManifestDefaults.test.js
+packages/plugin-repo-cli/lib/applyManifestDefaults.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.js
 packages/plugin-repo-cli/lib/errorsHaveChanged.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1197,6 +1197,8 @@ packages/pdf-viewer/ui/IconButtons.js
 packages/pdf-viewer/ui/ZoomControls.js
 packages/plugin-repo-cli/commands/updateRelease.js
 packages/plugin-repo-cli/index.js
+packages/plugin-repo-cli/lib/applyManifestDefaults.test.js
+packages/plugin-repo-cli/lib/applyManifestDefaults.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.js
 packages/plugin-repo-cli/lib/errorsHaveChanged.test.js

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -8,8 +8,9 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as process from 'process';
 import { resolveRelativePathWithinDir, gitPullTry, gitRepoCleanTry, gitRepoClean } from '@joplin/tools/tool-utils.js';
+import applyManifestDefaults, { readManifestDefaults } from './lib/applyManifestDefaults';
 import updateReadme from './lib/updateReadme';
-import { NpmPackage } from './lib/types';
+import { Manifests, NpmPackage } from './lib/types';
 import gitCompareUrl from './lib/gitCompareUrl';
 import commandUpdateRelease from './commands/updateRelease';
 import { isJoplinPluginPackage, readJsonFile } from './lib/utils';
@@ -164,8 +165,7 @@ async function processNpmPackage(npmPackage: NpmPackage, repoDir: string, dryRun
 	await execCommand('npm init --yes --loglevel silent', { quiet: true });
 
 	let actionType: ProcessingActionType = ProcessingActionType.Update;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	let manifests: any = {};
+	let manifests: Manifests = {};
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	let manifest: any = {};
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -200,6 +200,7 @@ async function processNpmPackage(npmPackage: NpmPackage, repoDir: string, dryRun
 			...manifests,
 		};
 
+		manifests = applyManifestDefaults(manifests, await readManifestDefaults(repoDir));
 		manifests = applyManifestOverrides(manifests, manifestOverrides);
 
 		await writeManifests(repoDir, manifests);

--- a/packages/plugin-repo-cli/lib/applyManifestDefaults.test.ts
+++ b/packages/plugin-repo-cli/lib/applyManifestDefaults.test.ts
@@ -1,0 +1,78 @@
+import applyManifestDefaults, { ManifestDefaults } from './applyManifestDefaults';
+
+
+const testManifests = {
+	'com.example.some.id.here': {
+		'manifest_version': 1,
+		'id': 'com.example.some.id.here',
+		'app_min_version': '2.10',
+		'version': '2.9.1',
+		'name': 'Test',
+		'description': 'A test plugin',
+		'keywords': [
+			'drawing',
+			'freehand-drawing',
+			'freehand',
+			'handwriting',
+		],
+		'categories': [
+			'editor',
+		],
+		'_publish_hash': 'sha256:0739686b11c848b9abe5ca08fba9626eb7eb7fab1cd57d92687afef02e06bd86',
+		'_publish_commit': 'master:fba9e01a0de67fea3adc6674e85b4706829f4756',
+	},
+	'org.joplinapp.plugins.Victor': {
+		'manifest_version': 1,
+		'id': 'org.joplinapp.plugins.Victor',
+		'app_min_version': '2.2',
+		'version': '1.0.3',
+		'name': 'Victor',
+		'description': 'Victor can be used to clear all your data - notes, notebooks, attachments, tags, etc. Convenient to start over.',
+		'author': 'Laurent Cozic',
+		'homepage_url': 'https://github.com/joplin/plugin-victor#readme',
+		'repository_url': 'https://github.com/joplin/plugin-victor',
+		'categories': ['developer tools', 'productivity'],
+		'icons': {},
+	},
+} as const;
+
+describe('applyManifestDefaults', () => {
+	test('should allow setting a default value for the "platforms" field', () => {
+		const defaults: ManifestDefaults = {
+			'com.example.some.id.here': {
+				platforms: ['desktop'],
+			},
+		};
+
+		expect(applyManifestDefaults(testManifests, defaults)).toMatchObject({
+			'com.example.some.id.here': {
+				...testManifests['com.example.some.id.here'],
+				platforms: ['desktop'],
+			},
+			'org.joplinapp.plugins.Victor': testManifests['org.joplinapp.plugins.Victor'],
+		});
+	});
+
+	test('should allow overriding a default value for a field', () => {
+		const defaults: ManifestDefaults = {
+			'org.joplinapp.plugins.Victor': {
+				platforms: ['desktop'],
+			},
+		};
+
+		const originalManifest = {
+			...testManifests['org.joplinapp.plugins.Victor'],
+			platforms: ['mobile', 'desktop'],
+		};
+		const manifests = {
+			...testManifests,
+			'org.joplinapp.plugins.Victor': originalManifest,
+		};
+
+		const updatedManifest = applyManifestDefaults(manifests, defaults)['org.joplinapp.plugins.Victor'];
+		expect(updatedManifest).toMatchObject({
+			...testManifests['org.joplinapp.plugins.Victor'],
+			platforms: ['mobile', 'desktop'],
+		});
+	});
+});

--- a/packages/plugin-repo-cli/lib/applyManifestDefaults.ts
+++ b/packages/plugin-repo-cli/lib/applyManifestDefaults.ts
@@ -1,0 +1,26 @@
+import { resolve } from 'path';
+import { readJsonFile } from './utils';
+import { Manifest, Manifests } from './types';
+
+export interface ManifestDefaults {
+	[pluginId: string]: Partial<Manifest>;
+}
+
+export const readManifestDefaults = (repoDir: string): Promise<ManifestDefaults> => {
+	return readJsonFile(resolve(repoDir, 'manifestDefaults.json'), {});
+};
+
+const applyManifestDefaults = (manifests: Manifests, manifestDefaults: ManifestDefaults) => {
+	const result = { ...manifests };
+	for (const [pluginId, defaults] of Object.entries(manifestDefaults)) {
+		if (Object.prototype.hasOwnProperty.call(result, pluginId)) {
+			result[pluginId] = {
+				...defaults,
+				...result[pluginId],
+			};
+		}
+	}
+	return result;
+};
+
+export default applyManifestDefaults;

--- a/packages/plugin-repo-cli/lib/overrideUtils.ts
+++ b/packages/plugin-repo-cli/lib/overrideUtils.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { readJsonFile } from './utils';
+import { Manifests } from './types';
 
 export interface ManifestOverride {
 	_obsolete?: boolean;
@@ -9,11 +10,9 @@ export interface ManifestOverride {
 
 export type ManifestOverrides = Record<string, ManifestOverride>;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function applyManifestOverrides(manifests: any, overrides: ManifestOverrides) {
+export function applyManifestOverrides(manifests: Manifests, overrides: ManifestOverrides) {
 	for (const [pluginId, override] of Object.entries(overrides)) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const manifest: any = manifests[pluginId];
+		const manifest = manifests[pluginId];
 
 		if (!manifest) {
 			// If the manifest does not exist in the destination, it means the
@@ -34,8 +33,7 @@ export function applyManifestOverrides(manifests: any, overrides: ManifestOverri
 }
 
 export function getObsoleteManifests(overrides: ManifestOverrides) {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	const output: any = {};
+	const output: Manifests = {};
 
 	for (const [pluginId, override] of Object.entries(overrides)) {
 		if (override._obsolete) {

--- a/packages/plugin-repo-cli/lib/types.ts
+++ b/packages/plugin-repo-cli/lib/types.ts
@@ -5,3 +5,9 @@ export interface NpmPackage {
 	version: string;
 	date: Date;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactoring of old code
+export type Manifest = Record<string, any>;
+export interface Manifests {
+	[pluginId: string]: Manifest;
+}


### PR DESCRIPTION
# Summary

The goal of this pull request is to allow marking certain plugins as desktop only by default (issue  https://github.com/laurent22/joplin/issues/10360). This is done by reading a `manifestDefaults.json` file, if present, and using it to provide different default property values for existing plugin manifests.

See [defaults.md](https://github.com/personalizedrefrigerator/joplin-plugin-repo-fork/blob/pr/mark-incompatible-plugins-v2/readme/defaults.md) in the corresponding [pull request on the plugin repository](https://github.com/joplin/plugins/pull/17) for how default manifest values can be set.

# Testing plan

This pull request has been tested manually by:
1. Cloning [this branch of my fork of the plugin repository](https://github.com/personalizedrefrigerator/joplin-plugin-repo-fork/tree/pr/mark-incompatible-plugins-v2),
2. Cocally running `cd packages/plugin-repo-cli/`, then `yarn start build /path/to/cloned/plugin/repo` (replacing `/path/to/cloned/plugin/repo` with the path of a cloned copy of [this branch of my fork of the plugin repository](https://github.com/personalizedrefrigerator/joplin-plugin-repo-fork/tree/pr/mark-incompatible-plugins-v2).
3. I stopped the CI script after it had processed 60-70 plugins — it had updated `joplin-plugin-templates` to version 2.4.0.
4. Verifying that none of the `"platform": ["desktop"]` entries were removed from `manifests.json` by the  commit
5. Resetting to the previous commit.
6. Removing the `"platform": ["desktop"]` for the templates plugin from `manifestDefaults.json`
7. Committing
8. Re-running `yarn start build /path/to/cloned/plugin/repo` and stopping it shortly after the templates plugin is processed
9. Verifying that this removes `"platforms": ["desktop"]` from `manifests.json` for the templates. I did this by observing that `git diff HEAD~` includes 
     ```diff
                    "version": "2.4.0",
                    "name": "Templates",
                    "description": "This plugin allows you to create and use templates in Joplin.",
    -               "platforms": ["desktop"],
                    "author": "Nishant Mittal",
                    "homepage_url": "https://github.com/joplin/plugin-templates",
                    "repository_url": "https://github.com/joplin/plugin-templates",
      ```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->