### PR TITLE
Mobile: Plugins: Fix API incompatibility in arguments to `onMessage` listeners in panels

### DIFF
--- a/packages/app-cli/tests/support/plugins/post_messages/src/webview.js
+++ b/packages/app-cli/tests/support/plugins/post_messages/src/webview.js
@@ -10,5 +10,5 @@ document.addEventListener('click', async (event) => {
 })
 
 console.info('webview.js: registering message listener');
-webviewApi.onMessage((message) => console.info('webview.js: got message:', message));
+webviewApi.onMessage((event) => console.info('webview.js: got message:', event.message));
 

--- a/packages/app-mobile/plugins/PluginRunner/backgroundPage/initializeDialogWebView.ts
+++ b/packages/app-mobile/plugins/PluginRunner/backgroundPage/initializeDialogWebView.ts
@@ -1,8 +1,18 @@
-import { DialogWebViewApi, DialogMainProcessApi } from '../types';
+import { DialogWebViewApi, DialogMainProcessApi, WebViewPostMessageCallback, DialogSetOnMessageListenerCallback } from '../types';
 import reportUnhandledErrors from './utils/reportUnhandledErrors';
 import wrapConsoleLog from './utils/wrapConsoleLog';
 import WebViewToRNMessenger from '../../../utils/ipc/WebViewToRNMessenger';
 import getFormData from './utils/getFormData';
+
+interface ExtendedWindow extends Window {
+	webviewApi: {
+		postMessage: WebViewPostMessageCallback;
+		onMessage: DialogSetOnMessageListenerCallback;
+	};
+	exports: Record<string, unknown>;
+}
+
+declare const window: ExtendedWindow;
 
 let themeCssElement: HTMLStyleElement|null = null;
 
@@ -61,8 +71,7 @@ const initializeDialogWebView = (messageChannelId: string) => {
 	};
 	const messenger = new WebViewToRNMessenger<DialogWebViewApi, DialogMainProcessApi>(messageChannelId, localApi);
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	(window as any).webviewApi = {
+	window.webviewApi = {
 		postMessage: messenger.remoteApi.postMessage,
 		onMessage: messenger.remoteApi.onMessage,
 	};
@@ -72,8 +81,7 @@ const initializeDialogWebView = (messageChannelId: string) => {
 
 	// If dialog content scripts were bundled with Webpack for NodeJS,
 	// they may expect a global "exports" to be present.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	(window as any).exports ??= {};
+	window.exports ??= {};
 };
 
 export default initializeDialogWebView;

--- a/packages/app-mobile/plugins/PluginRunner/dialogs/hooks/useDialogMessenger.ts
+++ b/packages/app-mobile/plugins/PluginRunner/dialogs/hooks/useDialogMessenger.ts
@@ -30,7 +30,11 @@ const useDialogMessenger = (props: Props) => {
 				PostMessageService.instance().registerViewMessageHandler(
 					ResponderComponentType.UserWebview,
 					viewId,
-					callback,
+					(message: SerializableData) => {
+						// For compatibility with desktop, the message needs to be wrapped in
+						// an object.
+						return callback({ message });
+					},
 				);
 			},
 			onError: async (error: string) => {

--- a/packages/app-mobile/plugins/PluginRunner/types.ts
+++ b/packages/app-mobile/plugins/PluginRunner/types.ts
@@ -30,11 +30,19 @@ export interface DialogInfo {
 	html: string;
 }
 
-export type WebViewOnMessageCallback = (arg: SerializableData)=> void;
+export type WebViewPostMessageCallback = (message: SerializableData)=> Promise<SerializableData>;
+
+// To be compatible with the desktop app, onMessage handlers registered within a dialog
+// or panel are given an event with a message property.
+interface OnMessageEvent {
+	message: SerializableData;
+}
+export type DialogOnMessageListener = (event: OnMessageEvent)=> Promise<void|SerializableData>;
+export type DialogSetOnMessageListenerCallback = (onMessage: DialogOnMessageListener)=> Promise<void>;
 
 export interface DialogMainProcessApi {
-	postMessage: (message: SerializableData)=> Promise<SerializableData>;
-	onMessage: (callback: WebViewOnMessageCallback)=> void;
+	postMessage: WebViewPostMessageCallback;
+	onMessage: DialogSetOnMessageListenerCallback;
 	onError: (message: string)=> Promise<void>;
 	onLog: (level: LogLevel, message: string)=> Promise<void>;
 }


### PR DESCRIPTION
# Summary

Previously, `onMessage` callbacks in panels were given different arguments on mobile and desktop for the same `postMessage` calls. This caused errors to be logged when running the [Calendar](https://joplinapp.org/plugins/plugin/org.joplinapp.plugins.joplin-calendar/) plugin on mobile.

# Testing plan

1. Build the `post_message` demo
    - It may be necessary to run `export NODE_OPTIONS=--openssl-legacy-provider` and update the version of TypeScript referenced in its `package.json` for a build to work.
2. Load the demo on desktop. In Joplin's development tools, search for `webview.js: got message:` and verify that
    ```
    webview.js: got message: testingPluginMessage
    ```
    is printed.
3. Load the demo plugin on mobile. Restart Joplin. Open the panel registered by the plugin **very soon after the plugin loads** so that it receives the message. Inspect the plugin panel in the Chrome developer tools and verify that 
    ```
    webview.js: got message: testingPluginMessage
    ```
    is printed.

This has been tested successfully with Ubuntu 23.10 and an Android 10 emulator.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->