### PR TITLE
Mobile: Resolves #10360: Make most plugins default to being desktop-only

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1071,6 +1071,7 @@ packages/lib/services/plugins/utils/getPluginIssueReportUrl.js
 packages/lib/services/plugins/utils/getPluginNamespacedSettingKey.js
 packages/lib/services/plugins/utils/getPluginSettingKeyPrefix.js
 packages/lib/services/plugins/utils/getPluginSettingValue.js
+packages/lib/services/plugins/utils/isCompatible/getDefaultPlatforms.js
 packages/lib/services/plugins/utils/isCompatible/index.test.js
 packages/lib/services/plugins/utils/isCompatible/index.js
 packages/lib/services/plugins/utils/isCompatible/minVersionForPlatform.js

--- a/.gitignore
+++ b/.gitignore
@@ -1051,6 +1051,7 @@ packages/lib/services/plugins/utils/getPluginIssueReportUrl.js
 packages/lib/services/plugins/utils/getPluginNamespacedSettingKey.js
 packages/lib/services/plugins/utils/getPluginSettingKeyPrefix.js
 packages/lib/services/plugins/utils/getPluginSettingValue.js
+packages/lib/services/plugins/utils/isCompatible/getDefaultPlatforms.js
 packages/lib/services/plugins/utils/isCompatible/index.test.js
 packages/lib/services/plugins/utils/isCompatible/index.js
 packages/lib/services/plugins/utils/isCompatible/minVersionForPlatform.js

--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -283,10 +283,11 @@ describe('services_PluginService', () => {
 			shouldRun: true,
 		},
 		{
+			// Should default to desktop-only
 			manifestPlatforms: [],
 			isDesktop: false,
 			appVersion: '3.0.8',
-			shouldRun: true,
+			shouldRun: false,
 		},
 	])('should enable and disable plugins depending on what platform(s) they support (case %#: %j)', async ({ manifestPlatforms, isDesktop, appVersion, shouldRun }) => {
 		const pluginScript = `

--- a/packages/lib/services/plugins/utils/isCompatible/getDefaultPlatforms.ts
+++ b/packages/lib/services/plugins/utils/isCompatible/getDefaultPlatforms.ts
@@ -1,0 +1,43 @@
+
+// Although `platforms: ['desktop', 'mobile']` is required to support both mobile
+// and desktop, no plugin authors have done this as of 04/25/2024. As such, we include
+// a list of plugins that have "platforms" default to ['desktop', 'mobile'] rather
+// than just ['desktop'].
+// cSpell:disable
+const defaultSupportMobile = [
+	'com.github.joplin.kanban',
+	'com.hieuthi.joplin.function-plot',
+	'com.hieuthi.joplin.markdown-table-colorize',
+	'com.joplin.copy.codeBlocks',
+	'com.whatever.inline-tags',
+	'com.whatever.quick-links',
+	'cx.evermeet.tessus.menu-shortcut-toolbar',
+	'io.github.personalizedrefrigerator.codemirror6-settings',
+	'io.github.personalizedrefrigerator.revealjs-integration',
+	'io.treymo.LinkGraph',
+	'jl15988.JoplinAlertsPerfectPlugin',
+	'jl15988.JoplinCodePerfectPlugin',
+	'joplin.plugin.alondmnt.history-panel',
+	'joplin.plugin.ambrt.backlinksToNote',
+	'joplin.plugin.ambrt.embedSearch',
+	'joplin.plugin.note.tabs',
+	'joplin.plugin.spoiler.cards',
+	'net.cwesson.joplin-plugin-typograms',
+	'org.joplinapp.plugins.AbcSheetMusic',
+	'org.joplinapp.plugins.admonition',
+	'org.joplinapp.plugins.joplin-calendar',
+	'outline',
+	'plugin.calebjohn.MathMode',
+	'plugin.calebjohn.rich-markdown',
+];
+// cSpell:enable
+
+const getDefaultPluginPlatforms = (id: string) => {
+	if (defaultSupportMobile.includes(id)) {
+		return ['desktop', 'mobile'];
+	} else {
+		return ['desktop'];
+	}
+};
+
+export default getDefaultPluginPlatforms;

--- a/packages/lib/services/plugins/utils/isCompatible/index.test.ts
+++ b/packages/lib/services/plugins/utils/isCompatible/index.test.ts
@@ -8,7 +8,7 @@ describe('isCompatible', () => {
 			manifest: { app_min_version: '2.0' },
 			appVersion: '2.1.0',
 			shouldSupportDesktop: true,
-			shouldSupportMobile: true,
+			shouldSupportMobile: false,
 		},
 		{
 			manifest: { app_min_version: '2.0' },
@@ -20,7 +20,7 @@ describe('isCompatible', () => {
 			manifest: { app_min_version: '3.0.2' },
 			appVersion: '3.0.2',
 			shouldSupportDesktop: true,
-			shouldSupportMobile: true,
+			shouldSupportMobile: false,
 		},
 
 		// Should support the case where only one platform is provided, with no version
@@ -83,9 +83,13 @@ describe('isCompatible', () => {
 			shouldSupportMobile: true,
 		},
 	])('should correctly return whether a plugin is compatible with a given version of Joplin (case %#: %j)', ({ manifest, appVersion, shouldSupportDesktop, shouldSupportMobile }) => {
-		const mobileCompatible = isCompatible(appVersion, AppType.Mobile, manifest);
+		const fullManifest = {
+			id: 'com.example.id',
+			...manifest,
+		};
+		const mobileCompatible = isCompatible(appVersion, AppType.Mobile, fullManifest);
 		expect(mobileCompatible).toBe(shouldSupportMobile);
-		const desktopCompatible = isCompatible(appVersion, AppType.Desktop, manifest);
+		const desktopCompatible = isCompatible(appVersion, AppType.Desktop, fullManifest);
 		expect(desktopCompatible).toBe(shouldSupportDesktop);
 	});
 });

--- a/packages/lib/services/plugins/utils/isCompatible/minVersionForPlatform.ts
+++ b/packages/lib/services/plugins/utils/isCompatible/minVersionForPlatform.ts
@@ -1,10 +1,15 @@
 import { AppType } from '../../../../models/Setting';
+import getDefaultPlatforms from './getDefaultPlatforms';
 import { ManifestSlice } from './types';
 
 // Returns false if the platform isn't supported at all,
 const minVersionForPlatform = (appPlatform: AppType, manifest: ManifestSlice): string|false => {
-	const platforms = manifest.platforms ?? [];
-	// If platforms is not specified (or empty), default to supporting all platforms.
+	let platforms = manifest.platforms;
+
+	if (!platforms || platforms.length === 0) {
+		platforms = getDefaultPlatforms(manifest.id);
+	}
+
 	const supported = platforms.length === 0 || platforms.includes(appPlatform);
 	if (!supported) {
 		return false;

--- a/packages/lib/services/plugins/utils/isCompatible/types.ts
+++ b/packages/lib/services/plugins/utils/isCompatible/types.ts
@@ -1,3 +1,3 @@
 import { PluginManifest } from '../types';
 
-export type ManifestSlice = Pick<PluginManifest, 'app_min_version'|'app_min_version_mobile'|'platforms'>;
+export type ManifestSlice = Pick<PluginManifest, 'id'|'app_min_version'|'app_min_version_mobile'|'platforms'>;

--- a/readme/api/references/plugin_manifest.md
+++ b/readme/api/references/plugin_manifest.md
@@ -22,7 +22,7 @@ Name | Type | Required? | Description
 
 ## Platforms
 
-A list that can contain `"desktop"` and/or `"mobile"`.
+A list that can contain `"desktop"` and/or `"mobile"`. If not given, it defaults to `[ "desktop" ]` for most plugins.
 
 ## Categories
 


### PR DESCRIPTION
# Summary

This pull request makes the manifest [platforms](https://joplinapp.org/help/api/references/plugin_manifest#platforms) entry default to `[ "desktop" ]` if not given.

This is an alternate solution to the one presented in https://github.com/laurent22/joplin/pull/10372.

Fixes #10360.

# Issues with this solution

- It may require extra maintenance to keep the plugin website aware of which plugins support mobile.
    - The plugin website will either need to depend on `@joplin/lib` for this or have a copy of the list included in [getDefaultPlatforms.ts](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/mobile-plugin-support/mark-most-plugins-as-desktop-only?expand=1#diff-eb5081aa9247fef49215cb13b38577cbc0acf288ef6b2875351d841b526eaf14).
- I only tested a small subset of all plugins for compatibility with mobile — until these plugins are updated to include `platforms: ["desktop","mobile"]` in their manifests, it won't be possible to install them on mobile.
    - At present, plugins that are determined to be incompatible with the current Joplin client can't be run at all. To allow testing other plugins on mobile (e.g. to suggest that unmaintained plugins be added to the list in [getDefaultPlatforms.ts](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/mobile-plugin-support/mark-most-plugins-as-desktop-only?expand=1#diff-eb5081aa9247fef49215cb13b38577cbc0acf288ef6b2875351d841b526eaf14)), it could make sense to allow overriding this behavior. This override might apply only to plugins installed using the "Install from file" button.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->