### PR TITLE
Desktop: Fix "new notebook" shown in context menu when right-clicking on the "Tags" header

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -79,17 +79,6 @@ const useOnRenderItem = (props: Props) => {
 		}
 	}, []);
 
-
-	const header_contextMenu = useCallback(async () => {
-		const menu = new Menu();
-
-		menu.append(
-			new MenuItem(menuUtils.commandToStatefulMenuItem('newFolder')),
-		);
-
-		menu.popup({ window: bridge().window() });
-	}, []);
-
 	const onItemContextMenu: ItemContextMenuListener = useCallback(async event => {
 		const itemId = event.currentTarget.getAttribute('data-id');
 		if (itemId === Folder.conflictFolderId()) return;
@@ -396,7 +385,6 @@ const useOnRenderItem = (props: Props) => {
 				key={item.id}
 				item={item}
 				anchorRef={anchorRefCallback}
-				contextMenuHandler={header_contextMenu}
 				onDrop={item.supportsFolderDrop ? onFolderDrop_ : null}
 			/>;
 		} else if (item.kind === ListItemType.AllNotes) {
@@ -415,7 +403,6 @@ const useOnRenderItem = (props: Props) => {
 		}
 	}, [
 		folderItem_click,
-		header_contextMenu,
 		onFolderDragOver_,
 		onFolderDragStart_,
 		onFolderDrop_,

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -2,12 +2,19 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { ButtonLevel } from '../../Button/Button';
 import { StyledAddButton, StyledHeader, StyledHeaderIcon, StyledHeaderLabel } from '../styles';
-import { HeaderListItem, ItemContextMenuListener } from '../types';
+import { HeaderId, HeaderListItem } from '../types';
 import { _ } from '@joplin/lib/locale';
+import bridge from '../../../services/bridge';
+import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
+import CommandService from '@joplin/lib/services/CommandService';
+
+const Menu = bridge().Menu;
+const MenuItem = bridge().MenuItem;
+const menuUtils = new MenuUtils(CommandService.instance());
+
 
 interface Props {
 	item: HeaderListItem;
-	contextMenuHandler: ItemContextMenuListener|null;
 	onDrop: React.DragEventHandler|null;
 	anchorRef: React.Ref<HTMLElement>;
 }
@@ -23,6 +30,18 @@ const HeaderItem: React.FC<Props> = props => {
 		}
 	}, [onItemClick, itemId]);
 
+	const onContextMenu = useCallback(async () => {
+		if (itemId === HeaderId.FolderHeader) {
+			const menu = new Menu();
+
+			menu.append(
+				new MenuItem(menuUtils.commandToStatefulMenuItem('newFolder')),
+			);
+
+			menu.popup({ window: bridge().window() });
+		}
+	}, [itemId]);
+
 	const addButton = <StyledAddButton
 		iconLabel={_('New')}
 		onClick={item.onPlusButtonClick}
@@ -37,7 +56,7 @@ const HeaderItem: React.FC<Props> = props => {
 			onDrop={props.onDrop}
 		>
 			<StyledHeader
-				onContextMenu={props.contextMenuHandler}
+				onContextMenu={onContextMenu}
 				onClick={onClick}
 				tabIndex={0}
 				ref={props.anchorRef}


### PR DESCRIPTION
# Summary

This pull request fixes a regression caused by #10331. The "new notebook" context menu item was incorrectly shown when right-clicking on the "TAGS" header.

# Testing plan

1. Right-click on the "TAGS" header and verify that there is no context menu.
2. Right-click on the "NOTEBOOKS" header and verify that the context menu has one item: "New notebook".
3. Create a new notebook with the context menu item.

This has been tested successfully on MacOS 14.4.1.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->