### PR TITLE
Mobile: Fix quickly enabling/disabling multiple plugins can lead to errors and missing plugins

### DIFF
--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -1,5 +1,5 @@
 import PluginRunner from '../../../app/services/plugins/PluginRunner';
-import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
 import MdToHtml from '@joplin/renderer/MdToHtml';
 import shim from '@joplin/lib/shim';
@@ -9,6 +9,7 @@ import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
 import { expectNotThrow, setupDatabaseAndSynchronizer, switchClient, expectThrow, createTempDir, supportDir, mockMobilePlatform } from '@joplin/lib/testing/test-utils';
 import { newPluginScript } from '../../testUtils';
+import { join } from 'path';
 
 const testPluginDir = `${supportDir}/plugins`;
 
@@ -395,5 +396,80 @@ describe('services_PluginService', () => {
 		// Should clear deleted plugins from settings
 		expect(newPluginSettings[pluginId1]).toBe(undefined);
 		expect(newPluginSettings[pluginId2]).toBe(undefined);
+	});
+
+	it('should reload plugins that have changed while keeping unchanged plugins running', async () => {
+		const testDir = await createTempDir();
+		try {
+			const loadCounterNote = await Note.save({ title: 'Plugin load counter' });
+			const readLoadCounterNote = async () => {
+				return (await Note.load(loadCounterNote.id)).body;
+			};
+			expect(await readLoadCounterNote()).toBe('');
+
+			const writePluginScript = async (version: string, id: string) => {
+				const script = `
+					/* joplin-manifest:
+					{
+						"id": ${JSON.stringify(id)},
+						"manifest_version": 1,
+						"app_min_version": "1.0.0",
+						"name": "JS Bundle test",
+						"version": ${JSON.stringify(version)}
+					}
+					*/
+
+					joplin.plugins.register({
+						onStart: async function() {
+							const noteId = ${JSON.stringify(loadCounterNote.id)};
+							const pluginId = ${JSON.stringify(id)};
+							const note = await joplin.data.get(['notes', noteId], { fields: ['body'] });
+							const loadCount = note.body.split(pluginId).length;
+							const newBody = note.body + '\\n' + pluginId + ' ' + loadCount;
+							await joplin.data.put(['notes', noteId], null, { body: newBody.trim() });
+						},
+					});
+				`;
+				await fs.writeFile(join(testDir, `${id}.bundle.js`), script);
+			};
+
+			const service = newPluginService();
+			const pluginId1 = 'org.joplinapp.testPlugin1';
+			await writePluginScript('0.0.1', pluginId1);
+			const pluginId2 = 'org.joplinapp.testPlugin2';
+			await writePluginScript('0.0.1', pluginId2);
+
+			let pluginSettings: PluginSettings = {
+				[pluginId1]: defaultPluginSetting(),
+				[pluginId2]: defaultPluginSetting(),
+			};
+			await service.loadAndRunPlugins(testDir, pluginSettings);
+
+			// Plugins should initially load once
+			expect(service.pluginIds).toHaveLength(2);
+			expect(service.pluginById(pluginId1).running).toBe(true);
+			expect(service.pluginById(pluginId2).running).toBe(true);
+			expect(await readLoadCounterNote()).toBe(`${pluginId1} 1\n${pluginId2} 1`);
+
+			// Updating just plugin 1 reload just plugin 1.
+			await writePluginScript('0.0.2', pluginId1);
+			await service.loadAndRunPlugins(testDir, pluginSettings);
+
+			expect(service.pluginById(pluginId1).running).toBe(true);
+			expect(service.pluginById(pluginId2).running).toBe(true);
+			expect(await readLoadCounterNote()).toBe(`${pluginId1} 1\n${pluginId2} 1\n${pluginId1} 2`);
+
+			// Disabling plugin 1 should not reload plugin 2
+			pluginSettings = { ...pluginSettings, [pluginId1]: { ...defaultPluginSetting(), enabled: false } };
+			await service.loadAndRunPlugins(testDir, pluginSettings);
+
+			expect(service.pluginById(pluginId1).running).toBe(false);
+			expect(service.pluginById(pluginId2).running).toBe(true);
+			expect(await readLoadCounterNote()).toBe(`${pluginId1} 1\n${pluginId2} 1\n${pluginId1} 2`);
+
+			await service.destroy();
+		} finally {
+			await fs.remove(testDir);
+		}
 	});
 });

--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -448,7 +448,7 @@ describe('services_PluginService', () => {
 			expect(service.pluginIds).toHaveLength(2);
 			expect(service.pluginById(pluginId1).running).toBe(true);
 			expect(service.pluginById(pluginId2).running).toBe(true);
-			expect(await readLoadCounterNote()).toBe(`${pluginId1} 1\n${pluginId2} 1`);
+			expect(await readLoadCounterNote()).toBe(`${pluginId1}\n${pluginId2}`);
 
 			// Updating just plugin 1 reload just plugin 1.
 			await writePluginScript('0.0.2', pluginId1);

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.test.tsx
@@ -24,13 +24,12 @@ const shouldShowBasedOnSettingSearchQuery = ()=>true;
 const PluginStatesWrapper = (props: WrapperProps) => {
 	const styles = configScreenStyles(Setting.THEME_LIGHT);
 
-	const [pluginStates, setPluginStates] = useState(() => {
-		return PluginService.instance().serializePluginSettings(props.initialPluginSettings ?? {});
+	const [pluginSettings, setPluginSettings] = useState(() => {
+		return props.initialPluginSettings ?? {};
 	});
 
 	const updatePluginStates = useCallback((newStates: PluginSettings) => {
-		const serialized = PluginService.instance().serializePluginSettings(newStates);
-		setPluginStates(serialized);
+		setPluginSettings(newStates);
 	}, []);
 
 	return (
@@ -38,7 +37,7 @@ const PluginStatesWrapper = (props: WrapperProps) => {
 			themeId={Setting.THEME_LIGHT}
 			styles={styles}
 			updatePluginStates={updatePluginStates}
-			pluginSettings={pluginStates}
+			pluginSettings={pluginSettings}
 			shouldShowBasedOnSearchQuery={shouldShowBasedOnSettingSearchQuery}
 		/>
 	);

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -49,9 +49,12 @@ const useLoadedPluginIds = (pluginSettings: SerializedPluginSettings) => {
 
 	const [pluginReloadCounter, setPluginReloadCounter] = useState(0);
 	const loadedPluginIds = useMemo(() => {
+		if (pluginReloadCounter > 0) {
+			logger.debug(`Not all plugins were loaded in the last render. Re-loading (try ${pluginReloadCounter})`);
+		}
+
 		const pluginService = PluginService.instance();
 		return allPluginIds.filter(id => !!pluginService.plugins[id]);
-		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- This should reload when the counter increases.
 	}, [allPluginIds, pluginReloadCounter]);
 	const hasLoadingPlugins = loadedPluginIds.length !== allPluginIds.length;
 
@@ -62,7 +65,6 @@ const useLoadedPluginIds = (pluginSettings: SerializedPluginSettings) => {
 	const timeoutRef = useRef(null);
 	if (hasLoadingPlugins && !timeoutRef.current) {
 		timeoutRef.current = shim.setTimeout(() => {
-			logger.debug('Not all plugins are loaded. Re-rendering...');
 			timeoutRef.current = null;
 			setPluginReloadCounter(pluginReloadCounterRef.current + 1);
 		}, 1000);

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { ConfigScreenStyles } from '../configScreenStyles';
 import { View } from 'react-native';
 import { Banner, Button, Text } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
-import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, SerializedPluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import PluginToggle from './PluginToggle';
 import SearchPlugins from './SearchPlugins';
 import { ItemEvent } from '@joplin/lib/components/shared/config/plugins/types';
 import NavService from '@joplin/lib/services/NavService';
 import useRepoApi from './utils/useRepoApi';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
+import shim from '@joplin/lib/shim';
+import Logger from '@joplin/utils/Logger';
 
 interface Props {
 	themeId: number;
 	styles: ConfigScreenStyles;
-	pluginSettings: string;
+	pluginSettings: SerializedPluginSettings;
 	settingsSearchQuery?: string;
 
 	updatePluginStates: (settingValue: PluginSettings)=> void;
@@ -33,6 +35,40 @@ export const getSearchText = () => {
 	}
 	searchText.push(...searchInputSearchText());
 	return searchText;
+};
+
+const logger = Logger.create('PluginStates');
+
+// Loaded plugins: All plugins with available manifests.
+const useLoadedPluginIds = (pluginSettings: SerializedPluginSettings) => {
+	const allPluginIds = useMemo(() => {
+		return Object.keys(
+			PluginService.instance().unserializePluginSettings(pluginSettings),
+		);
+	}, [pluginSettings]);
+
+	const [pluginReloadCounter, setPluginReloadCounter] = useState(0);
+	const loadedPluginIds = useMemo(() => {
+		const pluginService = PluginService.instance();
+		return allPluginIds.filter(id => !!pluginService.plugins[id]);
+		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- This should reload when the counter increases.
+	}, [allPluginIds, pluginReloadCounter]);
+	const hasLoadingPlugins = loadedPluginIds.length !== allPluginIds.length;
+
+	// Force a re-render if not all plugins have available metadata. This can happen
+	// if plugins are still loading.
+	const pluginReloadCounterRef = useRef(0);
+	pluginReloadCounterRef.current = pluginReloadCounter;
+	const timeoutRef = useRef(null);
+	if (hasLoadingPlugins && !timeoutRef.current) {
+		timeoutRef.current = shim.setTimeout(() => {
+			logger.debug('Not all plugins are loaded. Re-rendering...');
+			timeoutRef.current = null;
+			setPluginReloadCounter(pluginReloadCounterRef.current + 1);
+		}, 1000);
+	}
+
+	return loadedPluginIds;
 };
 
 const PluginStates: React.FC<Props> = props => {
@@ -91,15 +127,17 @@ const PluginStates: React.FC<Props> = props => {
 
 	const installedPluginCards = [];
 	const pluginService = PluginService.instance();
-	for (const key in pluginService.plugins) {
-		const plugin = pluginService.plugins[key];
+
+	const pluginIds = useLoadedPluginIds(props.pluginSettings);
+	for (const pluginId of pluginIds) {
+		const plugin = pluginService.plugins[pluginId];
 
 		if (!props.shouldShowBasedOnSearchQuery || props.shouldShowBasedOnSearchQuery(plugin.manifest.name)) {
 			installedPluginCards.push(
 				<PluginToggle
-					key={`plugin-${key}`}
+					key={`plugin-${pluginId}`}
 					themeId={props.themeId}
-					pluginId={plugin.id}
+					pluginId={pluginId}
 					styles={props.styles}
 					pluginSettings={props.pluginSettings}
 					updatablePluginIds={updatablePluginIds}

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginToggle.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginToggle.tsx
@@ -1,7 +1,7 @@
 
 import * as React from 'react';
 import { ConfigScreenStyles } from '../configScreenStyles';
-import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, defaultPluginSetting, SerializedPluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import { useCallback, useMemo, useState } from 'react';
 import PluginBox, { UpdateState } from './PluginBox';
 import useOnDeleteHandler from '@joplin/lib/components/shared/config/plugins/useOnDeleteHandler';
@@ -13,7 +13,7 @@ interface Props {
 	pluginId: string;
 	themeId: number;
 	styles: ConfigScreenStyles;
-	pluginSettings: string;
+	pluginSettings: SerializedPluginSettings;
 	updatablePluginIds: Record<string, boolean>;
 	repoApi: RepositoryApi;
 

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginUploadButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginUploadButton.tsx
@@ -1,6 +1,6 @@
 
 import { _ } from '@joplin/lib/locale';
-import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, SerializedPluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import * as React from 'react';
 import { useCallback, useState } from 'react';
 import { Button } from 'react-native-paper';
@@ -14,7 +14,7 @@ import Setting from '@joplin/lib/models/Setting';
 
 interface Props {
 	updatePluginStates: (settingValue: PluginSettings)=> void;
-	pluginSettings: string;
+	pluginSettings: SerializedPluginSettings;
 }
 
 const logger = Logger.create('PluginUploadButton');

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.test.tsx
@@ -7,8 +7,7 @@ import '@testing-library/react-native/extend-expect';
 
 import SearchPlugins from './SearchPlugins';
 import Setting from '@joplin/lib/models/Setting';
-import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
-import { useMemo } from 'react';
+import { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import pluginServiceSetup from './testUtils/pluginServiceSetup';
 import newRepoApi from './testUtils/newRepoApi';
 
@@ -22,14 +21,10 @@ interface WrapperProps {
 const noOpFunction = ()=>{};
 
 const SearchWrapper = (props: WrapperProps) => {
-	const serializedPluginSettings = useMemo(() => {
-		return PluginService.instance().serializePluginSettings(props.pluginSettings ?? {});
-	}, [props.pluginSettings]);
-
 	return (
 		<SearchPlugins
 			themeId={Setting.THEME_LIGHT}
-			pluginSettings={serializedPluginSettings}
+			pluginSettings={props.pluginSettings ?? {}}
 			repoApiInitialized={props.repoApiInitialized ?? true}
 			repoApi={props.repoApi}
 			onUpdatePluginStates={props.onUpdatePluginStates ?? noOpFunction}

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.tsx
@@ -7,7 +7,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { FlatList, View } from 'react-native';
 import { Searchbar } from 'react-native-paper';
 import PluginBox, { InstallState } from './PluginBox';
-import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, SerializedPluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import useInstallHandler from '@joplin/lib/components/shared/config/plugins/useOnInstallHandler';
 import { OnPluginSettingChangeEvent, PluginItem } from '@joplin/lib/components/shared/config/plugins/types';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
@@ -15,7 +15,7 @@ import openWebsiteForPlugin from './utils/openWebsiteForPlugin';
 
 interface Props {
 	themeId: number;
-	pluginSettings: string;
+	pluginSettings: SerializedPluginSettings;
 	repoApiInitialized: boolean;
 	onUpdatePluginStates: (states: PluginSettings)=> void;
 	repoApi: RepositoryApi;

--- a/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
@@ -8,7 +8,7 @@ import loadPlugins from '../loadPlugins';
 import { connect, useStore } from 'react-redux';
 import Logger from '@joplin/utils/Logger';
 import { View } from 'react-native';
-import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import PluginService, { PluginSettings, SerializedPluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import { PluginHtmlContents, PluginStates } from '@joplin/lib/services/plugins/reducer';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import PluginDialogManager from './dialogs/PluginDialogManager';
@@ -16,7 +16,7 @@ import { AppState } from '../../utils/types';
 
 const logger = Logger.create('PluginRunnerWebView');
 
-const usePluginSettings = (serializedPluginSettings: string) => {
+const usePluginSettings = (serializedPluginSettings: SerializedPluginSettings) => {
 	return useMemo(() => {
 		const pluginService = PluginService.instance();
 		return pluginService.unserializePluginSettings(serializedPluginSettings);
@@ -41,7 +41,7 @@ const usePlugins = (
 
 
 interface Props {
-	serializedPluginSettings: string;
+	serializedPluginSettings: SerializedPluginSettings;
 	pluginStates: PluginStates;
 	pluginHtmlContents: PluginHtmlContents;
 	themeId: number;

--- a/packages/app-mobile/plugins/loadPlugins.ts
+++ b/packages/app-mobile/plugins/loadPlugins.ts
@@ -23,10 +23,11 @@ const loadPlugins = async (
 		);
 		pluginService.isSafeMode = Setting.value('isSafeMode');
 
-		// Unload any existing plugins (important for React Native's fast refresh)
-		logger.debug('Unloading plugins...');
-		for (const pluginId of pluginService.pluginIds) {
-			await pluginService.unloadPlugin(pluginId);
+		for (const pluginId of Object.keys(pluginService.plugins)) {
+			if (!pluginSettings[pluginId]?.enabled) {
+				logger.info('Unloading disabled plugin', pluginId);
+				await pluginService.unloadPlugin(pluginId);
+			}
 
 			if (cancel.cancelled) {
 				return;

--- a/packages/lib/services/plugins/Plugin.ts
+++ b/packages/lib/services/plugins/Plugin.ts
@@ -43,6 +43,7 @@ export default class Plugin {
 	private dataDir_: string;
 	private dataDirCreated_ = false;
 	private hasErrors_ = false;
+	private running_ = false;
 	private onUnloadListeners_: OnUnloadListener[] = [];
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
@@ -85,6 +86,14 @@ export default class Plugin {
 
 	public get baseDir(): string {
 		return this.baseDir_;
+	}
+
+	public get running(): boolean {
+		return this.running_;
+	}
+
+	public set running(running: boolean) {
+		this.running_ = running;
 	}
 
 	public async dataDir(): Promise<string> {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -68,6 +68,8 @@ export interface PluginSettings {
 	[pluginId: string]: PluginSetting;
 }
 
+export type SerializedPluginSettings = Record<string, Partial<PluginSetting>>|string;
+
 interface PluginLoadOptions {
 	devMode: boolean;
 	builtIn: boolean;
@@ -177,8 +179,11 @@ export default class PluginService extends BaseService {
 		return this.plugins_[id];
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public unserializePluginSettings(settings: any): PluginSettings {
+	public unserializePluginSettings(settings: SerializedPluginSettings): PluginSettings {
+		if (typeof settings === 'string') {
+			settings = JSON.parse(settings) as PluginSettings;
+		}
+
 		const output = { ...settings };
 
 		for (const pluginId in output) {
@@ -188,7 +193,7 @@ export default class PluginService extends BaseService {
 			};
 		}
 
-		return output;
+		return output as PluginSettings;
 	}
 
 	public serializePluginSettings(settings: PluginSettings): string {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -68,7 +68,7 @@ export interface PluginSettings {
 	[pluginId: string]: PluginSetting;
 }
 
-export type SerializedPluginSettings = Record<string, Partial<PluginSetting>>|string;
+export type SerializedPluginSettings = Record<string, Partial<PluginSetting>>;
 
 interface PluginLoadOptions {
 	devMode: boolean;
@@ -181,10 +181,6 @@ export default class PluginService extends BaseService {
 	}
 
 	public unserializePluginSettings(settings: SerializedPluginSettings): PluginSettings {
-		if (typeof settings === 'string') {
-			settings = JSON.parse(settings) as PluginSettings;
-		}
-
 		const output = { ...settings };
 
 		for (const pluginId in output) {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -425,7 +425,9 @@ export default class PluginService extends BaseService {
 					// On mobile, plugins can reload without restarting the app. If a plugin is currently
 					// running and hasn't changed, it doesn't need to be reloaded.
 					if (isSamePlugin) {
-						const isSameVersion = existingPlugin.manifest.version === plugin.manifest.version && existingPlugin.manifest._package_hash === plugin.manifest._package_hash;
+						const isSameVersion =
+							existingPlugin.manifest.version === plugin.manifest.version
+							&& existingPlugin.manifest._package_hash === plugin.manifest._package_hash;
 						if (isSameVersion && existingPlugin.running === enabled) {
 							logger.debug('Not reloading same-version plugin', plugin.id);
 							continue;
@@ -462,7 +464,7 @@ export default class PluginService extends BaseService {
 	}
 
 	public async loadAndRunDevPlugins(settings: PluginSettings) {
-		const devPluginOptions = { devMode: true, builtIn: false, skipRunning: true };
+		const devPluginOptions = { devMode: true, builtIn: false };
 
 		if (Setting.value('plugins.devPluginPaths')) {
 			const paths = Setting.value('plugins.devPluginPaths').split(',').map((p: string) => p.trim());


### PR DESCRIPTION
# Summary

This pull request fixes #10379 by doing the following:
1. In the plugins settings screen, if a plugin is present in settings but isn't loaded, repeatedly check for the plugin to load.
   - Previously, if the settings screen rendered after a plugin had been unloaded, but before the plugin had been reloaded, the plugin would not be shown in the list of plugins. This seems to be more frequent/noticeable with change 2.
2. When loading plugins on mobile, only unload and reload plugins that have changed.
   - Previously, when a plugin was updated or enabled/disabled, all plugins would reload. Not only was this slow, but if multiple plugins were changed, errors could occur when two plugin loading tasks run at roughly the same time.
   - Plugin loading tasks could previously only be canceled just after unloading a plugins or just before reloading all plugins.

# Testing plan

To manually test on mobile,
1. Install multiple plugins (space indenter, history panel, quick links, inline tags, codemirror 6 settings)
2. Quickly click "disable" next to each plugin
3. Wait for all plugins be marked as disabled
4. Quickly click "enable" next to each plugin
5. Verify that, after loading, all plugins are visible in the plugins list
6. Verify that the Quick Links plugin can be used and that the history panel can be opened.

This has been tested successfully on Android 13.

To test for regressions on desktop (**in progress**),
1. Install the backup plugin from a .jpl file. Verify that the user-installed backup plugin is loaded rather than the built-in copy.
2. Uninstall the user-installed version of the backup plugin.
3. Add the backup plugin as a dev-mode plugin. Verify that the dev-mode plugin is run instead of the built-in version of the plugin.
    - Note: If the version installed from a `.jpl` file is present, the dev-mode version of Backup won't run.

This has been tested successfully on Ubuntu 22.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->