### PR TITLE
Desktop: Fixes #10382: Fix default values for plugin settings stored in `settings.json` not applied

### DIFF
--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -126,14 +126,11 @@ describe('models/Setting', () => {
 		expect(Setting.value('myCustom')).toBe('123');
 	}));
 
-	it.each([
-		SettingStorage.Database, SettingStorage.File,
-	])('should return values with correct type for custom settings (case %#)', (async (storage) => {
+	it('should return values with correct type for custom settings', (async () => {
 		await Setting.registerSetting('myCustom', {
 			public: true,
 			value: 123,
 			type: Setting.TYPE_INT,
-			storage,
 		});
 
 		Setting.setValue('myCustom', 456);
@@ -146,7 +143,6 @@ describe('models/Setting', () => {
 			public: true,
 			value: 123,
 			type: Setting.TYPE_INT,
-			storage,
 		});
 
 		expect(typeof Setting.value('myCustom')).toBe('number');

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -65,14 +65,19 @@ describe('models/Setting', () => {
 		await expectThrow(async () => Setting.value('itsgone'), 'unknown_key');
 	}));
 
-	it('should allow registering new settings dynamically', (async () => {
+	it.each([
+		SettingStorage.Database, SettingStorage.File,
+	])('should allow registering new settings dynamically (storage: %d)', (async (storage) => {
 		await expectThrow(async () => Setting.setValue('myCustom', '123'), 'unknown_key');
 
 		await Setting.registerSetting('myCustom', {
 			public: true,
 			value: 'default',
 			type: Setting.TYPE_STRING,
+			storage,
 		});
+
+		expect(Setting.value('myCustom')).toBe('default');
 
 		await expectNotThrow(async () => Setting.setValue('myCustom', '123'));
 
@@ -121,11 +126,14 @@ describe('models/Setting', () => {
 		expect(Setting.value('myCustom')).toBe('123');
 	}));
 
-	it('should return values with correct type for custom settings', (async () => {
+	it.each([
+		SettingStorage.Database, SettingStorage.File,
+	])('should return values with correct type for custom settings (case %#)', (async (storage) => {
 		await Setting.registerSetting('myCustom', {
 			public: true,
 			value: 123,
 			type: Setting.TYPE_INT,
+			storage,
 		});
 
 		Setting.setValue('myCustom', 456);
@@ -138,6 +146,7 @@ describe('models/Setting', () => {
 			public: true,
 			value: 123,
 			type: Setting.TYPE_INT,
+			storage,
 		});
 
 		expect(typeof Setting.value('myCustom')).toBe('number');
@@ -328,7 +337,7 @@ describe('models/Setting', () => {
 
 		expect((await Setting.loadOne('locale')).value).toBe('fr_FR');
 		expect((await Setting.loadOne('theme')).value).toBe(Setting.THEME_DARK);
-		expect((await Setting.loadOne('sync.target')).value).toBe(undefined);
+		expect((await Setting.loadOne('sync.target'))).toBe(null);
 	});
 
 	it('should save sub-profile settings', async () => {

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -2103,6 +2103,7 @@ class Setting extends BaseModel {
 	}
 
 	// Low-level method to load a setting directly from the database. Should not be used in most cases.
+	// Does not apply setting default values.
 	public static async loadOne(key: string): Promise<CacheItem | null> {
 		if (this.keyStorage(key) === SettingStorage.File) {
 			let fileSettings = await this.fileHandler.load();
@@ -2113,10 +2114,14 @@ class Setting extends BaseModel {
 				fileSettings = mergeGlobalAndLocalSettings(rootFileSettings, fileSettings);
 			}
 
-			return {
-				key,
-				value: fileSettings[key],
-			};
+			if (key in fileSettings) {
+				return {
+					key,
+					value: fileSettings[key],
+				};
+			} else {
+				return null;
+			}
 		}
 
 		// Always check in the database first, including for secure settings,


### PR DESCRIPTION
# Summary

This pull request fixes an issue where plugin settings saved using `SettingStorageType.File` did not use the setting's specified default value.

Fixes #10382.

# Notes

This pull request makes `Setting.loadOne` return `null` when a file setting has no saved value. This is consistent with the behavior for database settings. Previously, `loadOne` would return an object for a file setting, even when that setting had no saved value. This would cause the setting to be loaded into the cache (without using its default value):

https://github.com/laurent22/joplin/blob/443e04b3696103cccbbbf8abef884f4201ca4cb6/packages/lib/models/Setting.ts#L2014-L2023

# Testing plan

This pull request has an automated test. It has also been tested manually by:
1. Installing the CodeMirror 6 settings plugin
    - Remove `settings.json` if the plugin was previously installed.
2. Restarting Joplin
3. Verifying that the value for the "line numbers" setting is true.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->