### PR TITLE
Mobile: Share screen: Update headings and labels for consistency with desktop

### DIFF
--- a/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
@@ -64,7 +64,7 @@ const AcceptedShareItem: React.FC<Props> = props => {
 		} catch (error) {
 			logger.error('Failed to leave share', error);
 			await shim.showMessageBox(
-				_('Failed to leave shared notebook. Please verify that Joplin is connected to the internet and able to sync.\nError: %s', error),
+				_('Error: %s', error),
 				{ buttons: [_('OK')] },
 			);
 		} finally {

--- a/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
@@ -79,7 +79,7 @@ const AcceptedShareItem: React.FC<Props> = props => {
 		<Card.Title
 			left={AcceptedIcon}
 			title={_('Notebook: %s (%s)', folderTitle, folderId)}
-			subtitle={_('Invitation from %s (%s)', sharer.full_name, sharer.email)}
+			subtitle={_('Share from %s (%s)', sharer.full_name, sharer.email)}
 		/>
 		<Card.Actions>
 			<Button

--- a/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx
@@ -64,7 +64,7 @@ const AcceptedShareItem: React.FC<Props> = props => {
 		} catch (error) {
 			logger.error('Failed to leave share', error);
 			await shim.showMessageBox(
-				_('Failed to leave share. Please verify that Joplin is connected to the internet and able to sync.\nError: %s', error),
+				_('Failed to leave shared notebook. Please verify that Joplin is connected to the internet and able to sync.\nError: %s', error),
 				{ buttons: [_('OK')] },
 			);
 		} finally {
@@ -79,7 +79,7 @@ const AcceptedShareItem: React.FC<Props> = props => {
 		<Card.Title
 			left={AcceptedIcon}
 			title={_('Notebook: %s (%s)', folderTitle, folderId)}
-			subtitle={_('Share from %s (%s)', sharer.full_name, sharer.email)}
+			subtitle={_('Invitation from %s (%s)', sharer.full_name, sharer.email)}
 		/>
 		<Card.Actions>
 			<Button
@@ -87,7 +87,7 @@ const AcceptedShareItem: React.FC<Props> = props => {
 				onPress={onLeaveShare}
 				disabled={props.processing || leaving || hasLeft}
 				loading={leaving || !folderTitle}
-			>{_('Leave share')}</Button>
+			>{_('Leave notebook')}</Button>
 		</Card.Actions>
 	</Card>;
 };

--- a/packages/app-mobile/components/screens/ShareManager/index.test.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/index.test.tsx
@@ -110,6 +110,6 @@ describe('ShareManager', () => {
 		render(<ShareManagerWrapper shareInvitations={shares} store={store}/>);
 
 		// Should now allow leaving
-		expect(await screen.findByRole('button', { name: 'Leave share' })).toBeVisible();
+		expect(await screen.findByRole('button', { name: 'Leave notebook' })).toBeVisible();
 	});
 });

--- a/packages/app-mobile/components/screens/ShareManager/index.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/index.tsx
@@ -89,13 +89,13 @@ export const ShareManagerComponent: React.FC<Props> = props => {
 
 	const renderNoIncomingShares = () => {
 		if (incomingShareComponents.length > 0) return null;
-		return <Text key='no-shares' style={styles.noSharesText}>{_('No incoming shares')}</Text>;
+		return <Text key='no-shares' style={styles.noSharesText}>{_('No new invitations')}</Text>;
 	};
 
 	const renderAcceptedShares = () => {
 		if (acceptedShareComponents.length === 0) return null;
 		return <>
-			<Text style={styles.header}>{_('Accepted shares')}</Text>
+			<Text style={styles.header}>{_('Accepted share invitations')}</Text>
 			<View style={styles.shareListContainer}>
 				{acceptedShareComponents}
 			</View>
@@ -117,7 +117,7 @@ export const ShareManagerComponent: React.FC<Props> = props => {
 				}
 				testID='refreshControl'
 			>
-				<Text style={styles.header}>{_('Incoming shares')}</Text>
+				<Text style={styles.header}>{_('New share invitations')}</Text>
 				<View style={styles.shareListContainer}>
 					{renderNoIncomingShares()}
 					{incomingShareComponents}

--- a/packages/app-mobile/components/screens/ShareManager/index.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/index.tsx
@@ -95,7 +95,7 @@ export const ShareManagerComponent: React.FC<Props> = props => {
 	const renderAcceptedShares = () => {
 		if (acceptedShareComponents.length === 0) return null;
 		return <>
-			<Text style={styles.header}>{_('Accepted share invitations')}</Text>
+			<Text style={styles.header}>{_('Accepted invitations')}</Text>
 			<View style={styles.shareListContainer}>
 				{acceptedShareComponents}
 			</View>
@@ -117,7 +117,7 @@ export const ShareManagerComponent: React.FC<Props> = props => {
 				}
 				testID='refreshControl'
 			>
-				<Text style={styles.header}>{_('New share invitations')}</Text>
+				<Text style={styles.header}>{_('New invitations')}</Text>
 				<View style={styles.shareListContainer}>
 					{renderNoIncomingShares()}
 					{incomingShareComponents}


### PR DESCRIPTION
# Summary

As requested elsewhere, this pull request updates the UI strings in the "accept share" screen to be closer to those used on desktop. As there is no analogous screen on desktop, **with the exception of "leave notebook", the changed UI strings are still new.**

# Screenshot

**Before**:
![screenshot: Headers are "incoming shares" and "accepted shares", button under "accepted share" is "leave share"](https://github.com/laurent22/joplin/assets/46334387/d2f0a9e7-9df5-46ad-9272-03f60ea12f18)


**After**:
![screenshot: Headers are "incoming invitations" and "accepted invitations", button under an accepted invitation is "leave notebook"](https://github.com/laurent22/joplin/assets/46334387/3709b5bf-9727-4f1c-9632-cb07076f3bb2)


<details><summary>Other possibility</summary>

The below screenshot uses "New" and "Accepted" headers. While "Accepted" is a new string, "New" already has a translation.

![screenshot](https://github.com/laurent22/joplin/assets/46334387/78f8aab9-1c2f-4cc0-9441-83e23e92e6eb)

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->