### PR TITLE
Mobile: Fixes #10396: Fix Dropbox sync

### DIFF
--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -151,9 +151,11 @@ class FileApiDriverDropbox {
 				} catch (_error) {
 					// Since roughly May 2nd, 2024, sending a GET request to files/download sometimes fails
 					// until another file is requested. Because POST requests with empty bodies don't work on iOS,
-					// we send a request for a different file, then request the original.
+					// we send a request for a different file, then re-request the original.
 					//
-					// This workaround seems to require that the file we request exist.
+					// See https://github.com/laurent22/joplin/issues/10396
+
+					// This workaround requires that the file we request exist.
 					const { items } = await this.list();
 					const files = items.filter(item => !item.isDir);
 

--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -149,7 +149,7 @@ class FileApiDriverDropbox {
 				try {
 					response = await fetchPath('GET', path);
 				} catch (_error) {
-					// Since roughly May 2nd, 2024, sending a GET request to files/download sometimes fails
+					// May 2024: Sending a GET request to files/download sometimes fails
 					// until another file is requested. Because POST requests with empty bodies don't work on iOS,
 					// we send a request for a different file, then re-request the original.
 					//
@@ -157,7 +157,7 @@ class FileApiDriverDropbox {
 
 					// This workaround requires that the file we request exist.
 					const { items } = await this.list();
-					const files = items.filter(item => !item.isDir);
+					const files = items.filter(item => !item.isDir && item.path !== path);
 
 					if (files.length > 0) {
 						await fetchPath('GET', files[0].path);


### PR DESCRIPTION
# Summary

This pull request applies a workaround to fix a Dropbox sync issue on mobile:
- On iOS: When a `GET` request to `/files/download` fails:
    1. List files on Dropbox and find the first **non-directory** file.
    2. Send a `GET` request for that file.
    3. Re-request the original file.
- On Android and desktop: Uses a `POST` request to download files from Dropbox instead of a `GET` request.
    - The Dropbox API documentation uses `POST` requests rather than `GET` requests for `/files/download`. [This forum post](https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Error-1017-quot-cannot-parse-response-quot/td-p/589595) is linked as an explanation for why `POST` won't work for this on iOS.
    - `GET` requests seem to fail if multiple requests are sent for the same file, but `POST` requests don't.

Fixes #10396.

> [!NOTE]
>
> This pull request targets the `release-2.14` branch.
>

# Notes for releasing

Before this change can be released for iOS, we may need to add an [iOS privacy manifest for a Joplin update to be accepted by Apple](https://github.com/react-native-community/discussions-and-proposals/discussions/776).

Based on [the forum post](https://discourse.joplinapp.org/t/ios-sync-broke-due-to-network-request-failing-with-dropbox/37915) and attempts to reproduce this issue in a local NodeJS REPL, the issue only impacts mobile.

# Testing plan

I was able to consistently reproduce the original issue by creating a note, then syncing. As such, it should be verified that:
- It's possible to create and sync a note.
- It's possible to download the note on another device.
- It's possible to download changes to the note on the original device.

I plan to test on the following platforms:
- [x] Android 14
- [x] iOS 17
- [x] Desktop (MacOS)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->