### PR TITLE
Fix plural of parenthesis

### DIFF
--- a/packages/app-cli/tests/support/plugins/clipboard/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/clipboard/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/codemirror5-and-codemirror6/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror5-and-codemirror6/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror6/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/codemirror_content_script/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/codemirror_content_script/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/content_script/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/content_script/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/dialog/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/dialog/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/editor_context_menu/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/editor_context_menu/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/events/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/events/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/external_assets/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/external_assets/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/imaging/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/imaging/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/jpl_test/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/jpl_test/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/json_export/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/json_export/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/load_css/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/load_css/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/menu/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/menu/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/multi_selection/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/multi_selection/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/nativeModule/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/nativeModule/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/note_list_renderer/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/note_list_renderer/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/post_messages/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/post_messages/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/register_command/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/register_command/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/selected_text/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/selected_text/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/settings/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/settings/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/toc/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/toc/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/user_data/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/user_data/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/app-cli/tests/support/plugins/withExternalModules/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/withExternalModules/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -43,9 +43,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -993,7 +993,7 @@ class Setting extends BaseModel {
 				public: true,
 				section: 'note',
 				appTypes: [AppType.Desktop],
-				label: () => _('Auto-pair braces, parenthesis, quotations, etc.'),
+				label: () => _('Auto-pair braces, parentheses, quotations, etc.'),
 				storage: SettingStorage.File,
 				isGlobal: true,
 			},

--- a/packages/lib/services/WhenClause.test.ts
+++ b/packages/lib/services/WhenClause.test.ts
@@ -16,7 +16,7 @@ describe('WhenClause', () => {
 		})).toBe(false);
 	});
 
-	test('should work with parenthesis', async () => {
+	test('should work with parentheses', async () => {
 		const wc = new WhenClause('(test1 && test2) || test3 && (test4 && !test5)');
 
 		expect(wc.evaluate({

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -44,9 +44,9 @@ export interface Command {
 	 * Or | \|\| | "noteIsTodo \|\| noteTodoCompleted"
 	 * And | && | "oneNoteSelected && !inConflictFolder"
 	 *
-	 * Joplin, unlike VSCode, also supports parenthesis, which allows creating
+	 * Joplin, unlike VSCode, also supports parentheses, which allows creating
 	 * more complex expressions such as `cond1 || (cond2 && cond3)`. Only one
-	 * level of parenthesis is possible (nested ones aren't supported).
+	 * level of parentheses is possible (nested ones aren't supported).
 	 *
 	 * Currently the supported context variables aren't documented, but you can
 	 * find the list below:

--- a/packages/tools/locales/ar.po
+++ b/packages/tools/locales/ar.po
@@ -562,7 +562,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "ادراج النصف الآخر للأقواس و علامات الإقتباس."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/bg_BG.po
+++ b/packages/tools/locales/bg_BG.po
@@ -577,7 +577,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/bs_BA.po
+++ b/packages/tools/locales/bs_BA.po
@@ -577,7 +577,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automatski piši u paru sve zagrade, navodnike itd."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/ca.po
+++ b/packages/tools/locales/ca.po
@@ -570,7 +570,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Afegeix automàticament per a eliminar els comptes deshabilitats"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Aparellament automàtic de claus, parèntesis, cites, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/cs_CZ.po
+++ b/packages/tools/locales/cs_CZ.po
@@ -575,7 +575,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Automatické přidání zakázaných účtů k odstranění"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automaticky zdvojit uvozovky, závorky, apod."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/da_DK.po
+++ b/packages/tools/locales/da_DK.po
@@ -573,7 +573,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Føj automatisk deaktiverede konti til sletning"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto-par klammer, parenteser, citater, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/de_DE.po
+++ b/packages/tools/locales/de_DE.po
@@ -581,7 +581,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Automatisches Hinzufügen deaktivierter Accounts zur Löschliste"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 "Automatisches Hinzufügen von geschweiften Klammern, runden Klammern, "
 "Anführungszeichen usw."

--- a/packages/tools/locales/el_GR.po
+++ b/packages/tools/locales/el_GR.po
@@ -582,7 +582,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Αυτόματη προσθήκη απενεργοποιημένων λογαριασμών για διαγραφή"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Αυτόματη-σύζευξη αγκίστρων, παρενθέσεων, εισαγωγικών, κ.λπ."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/en_GB.po
+++ b/packages/tools/locales/en_GB.po
@@ -506,7 +506,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/en_US.po
+++ b/packages/tools/locales/en_US.po
@@ -540,7 +540,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/eo.po
+++ b/packages/tools/locales/eo.po
@@ -557,7 +557,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/es_ES.po
+++ b/packages/tools/locales/es_ES.po
@@ -577,7 +577,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Añadir automáticamente las cuentas deshabilitadas para su eliminación"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Autoemparejar llaves, paréntesis, comillas, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/et_EE.po
+++ b/packages/tools/locales/et_EE.po
@@ -573,7 +573,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automaatne sidumine traksid, sulg, noteeringud jne."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/eu.po
+++ b/packages/tools/locales/eu.po
@@ -573,7 +573,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/fa.po
+++ b/packages/tools/locales/fa.po
@@ -570,7 +570,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "افزودن خودکار حساب های غیرفعال برای حذف"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "جفت‌سازی خودکار کروشه، پرانتز، نقل قول و غیره."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/fi_FI.po
+++ b/packages/tools/locales/fi_FI.po
@@ -569,7 +569,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Lisää käytöstä poistetut tilit automaattisesti poistettavaksi"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Yhdistä sulut, sulkeet, lainaukset jne."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/fr_FR.po
+++ b/packages/tools/locales/fr_FR.po
@@ -570,7 +570,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Supprimer automatiquement les comptes désactivés"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto‑compléter les paires de parenthèses, guillemets, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/gl_ES.po
+++ b/packages/tools/locales/gl_ES.po
@@ -573,7 +573,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/hr_HR.po
+++ b/packages/tools/locales/hr_HR.po
@@ -571,7 +571,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Automatski dodaj deaktivirane račune za brisanje"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automatski uskladi zagrade, navodnike itd."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/hu_HU.po
+++ b/packages/tools/locales/hu_HU.po
@@ -557,7 +557,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto-párosítása az idézőjeleknek, zárójeleknek, stb."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/id_ID.po
+++ b/packages/tools/locales/id_ID.po
@@ -574,7 +574,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Tambahkan otomatis akun non-aktif untuk dihapus"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Pasangkan otomatis kurung kurawal, tanda kurung, tanda petik, dll."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/it_IT.po
+++ b/packages/tools/locales/it_IT.po
@@ -581,7 +581,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Aggiungi automaticamente gli account disabilitati per la cancellazione"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto- accoppia parentesi graffe, parentesi, citazione, ecc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/ja_JP.po
+++ b/packages/tools/locales/ja_JP.po
@@ -563,7 +563,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "無効アカウントを削除に自動追加"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "始めの括弧や引用符入力時に終わりの括弧や引用符を自動入力する。"
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/joplin.pot
+++ b/packages/tools/locales/joplin.pot
@@ -506,7 +506,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/ko.po
+++ b/packages/tools/locales/ko.po
@@ -564,7 +564,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "삭제를 위해 비활성화된 계정을 자동으로 추가"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "괄호, 중괄호, 인용 부호 등의 자동 완성."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/nb_NO.po
+++ b/packages/tools/locales/nb_NO.po
@@ -563,7 +563,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Legg automatisk til deaktiverte kontoer for sletting"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automatisk lukk klammer, paranteser, fnutter, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/nl_BE.po
+++ b/packages/tools/locales/nl_BE.po
@@ -576,7 +576,7 @@ msgstr ""
 
 # The "." at the end of the original text is not the period at the end of a sentence but merely the period to indicate that etc. is an abbreviation (of etcetera).
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Haakjes, aanhalingstekens, etc. automatisch aanvullen"
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/nl_NL.po
+++ b/packages/tools/locales/nl_NL.po
@@ -570,7 +570,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Voeg uitgeschakelde account automatisch toe voor verwijdering"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto-paar accolades, haakjes, citaten, enz."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/pl_PL.po
+++ b/packages/tools/locales/pl_PL.po
@@ -576,7 +576,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Automatycznie dodaj wyłączone konta do usunięcia"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Automatycznie zamykaj klamry, nawiasy, cudzysłowy itd."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/pt_BR.po
+++ b/packages/tools/locales/pt_BR.po
@@ -577,7 +577,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Adicionar automaticamente contas desabilitadas para deleção"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Parear automaticamente chaves, parênteses, aspas etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/pt_PT.po
+++ b/packages/tools/locales/pt_PT.po
@@ -571,7 +571,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr ""
 "Emparelhar automaticamente parênteses curvos, parênteses, citações, etc."
 

--- a/packages/tools/locales/ro.po
+++ b/packages/tools/locales/ro.po
@@ -578,7 +578,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Adăugarea automată a conturilor dezactivate pentru ștergere"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Auto-perechere de paranteze, paranteze, ghilimele etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/ru_RU.po
+++ b/packages/tools/locales/ru_RU.po
@@ -574,7 +574,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Автоматическое добавление отключенных учетных записей для удаления"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Автоматическое закрытие скобок, кавычек и т. д."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/sl_SI.po
+++ b/packages/tools/locales/sl_SI.po
@@ -569,7 +569,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Avtomatsko zapri oglate oklepaje, oklepaje, narekovaje, itd."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/sr_RS.po
+++ b/packages/tools/locales/sr_RS.po
@@ -571,7 +571,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Ауто-упари заграде, цитате, итд."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/sv.po
+++ b/packages/tools/locales/sv.po
@@ -574,7 +574,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Lägg automatiskt till inaktiverade konton för radering"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Para automatiskt hakparenteser, paranteser, situationstecken, etc."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/th_TH.po
+++ b/packages/tools/locales/th_TH.po
@@ -564,7 +564,7 @@ msgstr ""
 
 #: packages/lib/models/Setting.ts:996
 #, fuzzy
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "จับคู่อัตโนมัติ {}, (), \"\", ฯลฯ"
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/tr_TR.po
+++ b/packages/tools/locales/tr_TR.po
@@ -574,7 +574,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Silmek için devre dışı bırakılmış hesapları otomatik olarak ekle"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Parantez, çift tırnak gibi değerlerin çiftlerini otomatik ekle."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/uk_UA.po
+++ b/packages/tools/locales/uk_UA.po
@@ -572,7 +572,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "Автоматично додавати вимкнені облікові записи для видалення"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Автоматичне закриття дужок, лапок тощо."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/vi.po
+++ b/packages/tools/locales/vi.po
@@ -565,7 +565,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr ""
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "Tự động đóng ngoặc nhọn, ngoặc đơn, ngoặc kép, v.v..."
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/zh_CN.po
+++ b/packages/tools/locales/zh_CN.po
@@ -549,7 +549,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "自动添加已禁用的账户以便删除"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "自动配对花括号、圆括号、引号等。"
 
 #: packages/lib/models/Setting.ts:1471

--- a/packages/tools/locales/zh_TW.po
+++ b/packages/tools/locales/zh_TW.po
@@ -553,7 +553,7 @@ msgid "Auto-add disabled accounts for deletion"
 msgstr "自動於刪除清單中加入已停用帳戶"
 
 #: packages/lib/models/Setting.ts:996
-msgid "Auto-pair braces, parenthesis, quotations, etc."
+msgid "Auto-pair braces, parentheses, quotations, etc."
 msgstr "自動配對大括號、括號、引號等。"
 
 #: packages/lib/models/Setting.ts:1471


### PR DESCRIPTION
Fixes the plural of parenthesis -> parentheses in the source files, translation (po files) and comments.