### PR TITLE
Chore: Fix failing Dropbox sync test

### DIFF
--- a/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
+++ b/packages/lib/services/synchronizer/synchronizer_LockHandler.test.ts
@@ -47,7 +47,8 @@ describe('synchronizer_LockHandler', () => {
 	it('should not use files that are not locks', (async () => {
 		if (lockHandler().useBuiltInLocks) return; // Doesn't make sense with built-in locks
 
-		await fileApi().put('locks/desktop.ini', 'a');
+		// Note: desktop.ini is blocked by Dropbox
+		await fileApi().put('locks/desktop.test.ini', 'a');
 		await fileApi().put('locks/exclusive.json', 'a');
 		await fileApi().put('locks/garbage.json', 'a');
 		await fileApi().put('locks/1_2_72c4d1b7253a4475bfb2f977117d26ed.json', 'a');


### PR DESCRIPTION
# Summary

This pull request fixes a test that was failing for the Dropbox sync target. See https://github.com/laurent22/joplin/pull/10400#issuecomment-2098670407.

# Testing

As the full suite of sync tests take several hours to run with Dropbox, I have only verified that the changed test passes.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->