### PR TITLE
iOS: Fixes #10396: Fix Dropbox sync for large file collections

### DIFF
--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -1,6 +1,9 @@
 const time = require('./time').default;
 const shim = require('./shim').default;
 const JoplinError = require('./JoplinError').default;
+const Logger = require('@joplin/utils/Logger').default;
+
+const logger = Logger.create('file-api-driver-dropbox');
 
 class FileApiDriverDropbox {
 	constructor(api) {
@@ -97,14 +100,14 @@ class FileApiDriverDropbox {
 		}
 	}
 
-	async list(path) {
+	async list(path, options) {
 		let response = await this.api().exec('POST', 'files/list_folder', {
 			path: this.makePath_(path),
 		});
 
 		let output = this.metadataToStats_(response.entries);
 
-		while (response.has_more) {
+		while (response.has_more && !options?.firstPageOnly) {
 			response = await this.api().exec('POST', 'files/list_folder/continue', {
 				cursor: response.cursor,
 			});
@@ -114,7 +117,7 @@ class FileApiDriverDropbox {
 
 		return {
 			items: output,
-			hasMore: false,
+			hasMore: !!response.has_more,
 			context: { cursor: response.cursor },
 		};
 	}
@@ -148,7 +151,8 @@ class FileApiDriverDropbox {
 			} else {
 				try {
 					response = await fetchPath('GET', path);
-				} catch (_error) {
+				} catch (error) {
+					logger.warn('Request to files/download failed. Retrying with workaround. Error: ', error);
 					// May 2024: Sending a GET request to files/download sometimes fails
 					// until another file is requested. Because POST requests with empty bodies don't work on iOS,
 					// we send a request for a different file, then re-request the original.
@@ -156,7 +160,7 @@ class FileApiDriverDropbox {
 					// See https://github.com/laurent22/joplin/issues/10396
 
 					// This workaround requires that the file we request exist.
-					const { items } = await this.list();
+					const { items } = await this.list('', { firstPageOnly: true });
 					const files = items.filter(item => !item.isDir && item.path !== path);
 
 					if (files.length > 0) {


### PR DESCRIPTION
# Summary

This pull request **might** resolve #10396. It adjusts the original workaround added in https://github.com/laurent22/joplin/pull/10400 to be more efficient when there are many files on the sync target.

See also:
- https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/GET-request-to-files-download-fails-with-quot-The-network/td-p/768270/highlight/true
- https://discourse.joplinapp.org/t/ios-sync-broke-due-to-network-request-failing-with-dropbox/37915/24

# Notes

- Users on the forum are reporting a different "lock has expired" error that does not match the errors I've experienced while testing locally.
    - So far, local tests have been done with a small number of notes/notebooks.
- In #10400, I assumed that `this.list()` would be fast for a large number of remote files, only returning the first page of results. Although the Dropbox API used by `list()` is paginated, `list()` sends a request for each page.
    - My largest test for #10396 was with around 20 notes and a few notebooks/resources. **This pull request should be stress-tested with a much larger number of notes**.
- In my (very limited) tests, the sync workaround is triggered about once per sync.
- **Unrelated errors trigger the workaround.**
    - One option would be to check for a "Network request failed" error message. However, if Dropbox and/or iOS changes such that the error message becomes more descriptive, this could break our sync logic in the future. **To-test**: Is the error message localized?


# Testing plan

1. Set up Dropbox sync.
2. Create a note.
3. Sync.
4. Verify that sync completes successfully.
5. Make copies of/duplicate notes until the "Sync status" screen shows roughly 100 items.
6. Sync.

> [!NOTE]
>
> This has not yet been tested with a larger collection of notes.
>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->