### PR TITLE
Mobile: Simplify Dropbox sync workarond

### DIFF
--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -149,7 +149,10 @@ class FileApiDriverDropbox {
 				// Use a random If-None-Match value to prevent React Native from using the cache.
 				// Passing "cache: no-store" doesn't seem to be sufficient, so If-None-Match is set to a value
 				// that will never match the ETag.
+				//
 				// Something similar is done for WebDAV.
+				//
+				// See https://github.com/laurent22/joplin/issues/10396
 				response = await fetchPath('GET', path, { 'If-None-Match': `JoplinIgnore-${Math.floor(Math.random() * 100000)}` });
 			}
 			return response;

--- a/packages/lib/file-api-driver-dropbox.js
+++ b/packages/lib/file-api-driver-dropbox.js
@@ -1,9 +1,6 @@
 const time = require('./time').default;
 const shim = require('./shim').default;
 const JoplinError = require('./JoplinError').default;
-const Logger = require('@joplin/utils/Logger').default;
-
-const logger = Logger.create('file-api-driver-dropbox');
 
 class FileApiDriverDropbox {
 	constructor(api) {
@@ -100,14 +97,14 @@ class FileApiDriverDropbox {
 		}
 	}
 
-	async list(path, options) {
+	async list(path) {
 		let response = await this.api().exec('POST', 'files/list_folder', {
 			path: this.makePath_(path),
 		});
 
 		let output = this.metadataToStats_(response.entries);
 
-		while (response.has_more && !options?.firstPageOnly) {
+		while (response.has_more) {
 			response = await this.api().exec('POST', 'files/list_folder/continue', {
 				cursor: response.cursor,
 			});
@@ -117,7 +114,7 @@ class FileApiDriverDropbox {
 
 		return {
 			items: output,
-			hasMore: !!response.has_more,
+			hasMore: false,
 			context: { cursor: response.cursor },
 		};
 	}
@@ -135,12 +132,12 @@ class FileApiDriverDropbox {
 			// https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/Error-1017-quot-cannot-parse-response-quot/td-p/589595
 			const needsFetchWorkaround = shim.mobilePlatform() === 'ios';
 
-			const fetchPath = (method, path) => {
+			const fetchPath = (method, path, extraHeaders) => {
 				return this.api().exec(
 					method,
 					'files/download',
 					null,
-					{ 'Dropbox-API-Arg': JSON.stringify({ path: this.makePath_(path) }) },
+					{ 'Dropbox-API-Arg': JSON.stringify({ path: this.makePath_(path) }), ...extraHeaders },
 					options,
 				);
 			};
@@ -149,26 +146,11 @@ class FileApiDriverDropbox {
 			if (!needsFetchWorkaround) {
 				response = await fetchPath('POST', path);
 			} else {
-				try {
-					response = await fetchPath('GET', path);
-				} catch (error) {
-					logger.warn('Request to files/download failed. Retrying with workaround. Error: ', error);
-					// May 2024: Sending a GET request to files/download sometimes fails
-					// until another file is requested. Because POST requests with empty bodies don't work on iOS,
-					// we send a request for a different file, then re-request the original.
-					//
-					// See https://github.com/laurent22/joplin/issues/10396
-
-					// This workaround requires that the file we request exist.
-					const { items } = await this.list('', { firstPageOnly: true });
-					const files = items.filter(item => !item.isDir && item.path !== path);
-
-					if (files.length > 0) {
-						await fetchPath('GET', files[0].path);
-					}
-
-					response = await fetchPath('GET', path);
-				}
+				// Use a random If-None-Match value to prevent React Native from using the cache.
+				// Passing "cache: no-store" doesn't seem to be sufficient, so If-None-Match is set to a value
+				// that will never match the ETag.
+				// Something similar is done for WebDAV.
+				response = await fetchPath('GET', path, { 'If-None-Match': `JoplinIgnore-${Math.floor(Math.random() * 100000)}` });
 			}
 			return response;
 		} catch (error) {


### PR DESCRIPTION
# Summary

This pull request adjusts the Dropbox sync workaround to prevent `fetch` from using the cache using `If-None-Match`. This is similar to a workaround for WebDAV sync on iOS:
https://github.com/laurent22/joplin/blob/a9fecb31c3c59c3bc6cf4335cc8fa34511a44d36/packages/lib/WebDavApi.js#L363-L378

This is based on a suggestion from @laurent22.

# Notes

- Based on the description on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) docs, this should prevent the cache from being used, which, based on network logs from XCode, is related to the network error.
- The alternatives of setting [`cache`](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#cache) to `no-store` and/or the [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) header don't seem to help.
- See [this post on the Dropbox forum](https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/GET-request-to-files-download-fails-with-quot-The-network/m-p/769397/highlight/true#M33637) for additional details.

# Testing

This has been tested by:
1. Starting with an existing Dropbox sync target.
2. From a desktop client, just over hundred notes.
3. Adding a new note on the mobile client.
4. Syncing the mobile client.
5. Verifying that no errors are logged while syncing the mobile client.

This has been tested successfully on an iOS 17.4 device.

To-do:
- [ ] Re-run the synchronizer tests with Dropbox.
    - A test run failed with several [HTTP 504 errors.](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->