### PR TITLE
Mobile,Desktop: Fix nonbreaking spaces and CRLF break search for adjacent words

### DIFF
--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -340,6 +340,20 @@ describe('services/SearchEngine', () => {
 		expect((await engine.search('testing')).length).toBe(1);
 	}));
 
+	it('should use nonbreaking spaces as separators', (async () => {
+		await Note.save({
+			title: 'Test',
+			body: 'This is\u00A0a\u00A0test\r\nof different\r\nspace separators.',
+		});
+
+		await engine.syncTables();
+
+		expect((await engine.search('test')).length).toBe(1);
+		expect((await engine.search('different')).length).toBe(1);
+		expect((await engine.search('space')).length).toBe(1);
+		expect((await engine.search('separators')).length).toBe(1);
+	}));
+
 	it('should supports various query types', (async () => {
 		let rows;
 

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -629,6 +629,9 @@ export default class SearchEngine {
 		// https://github.com/laurent22/joplin/issues/9694
 		normalizedText = htmlentitiesDecode(normalizedText);
 
+		// The FTS tokenizer doesn't understand nonbreaking spaces and CRLF.
+		normalizedText = normalizedText.replace(/\s/g, ' ');
+
 		return removeDiacritics(normalizedText.toLowerCase());
 	}
 

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -629,7 +629,8 @@ export default class SearchEngine {
 		// https://github.com/laurent22/joplin/issues/9694
 		normalizedText = htmlentitiesDecode(normalizedText);
 
-		// The FTS tokenizer doesn't understand nonbreaking spaces and CRLF.
+		// The FTS tokenizer doesn't understand some types of space,
+		// including nonbreaking spaces and CRLF.
 		normalizedText = normalizedText.replace(/\s/g, ' ');
 
 		return removeDiacritics(normalizedText.toLowerCase());


### PR DESCRIPTION
# Summary

This pull request fixes an issue reported on the forum: [Limitations of Searching in Joplin](https://discourse.joplinapp.org/t/limitations-of-searching-in-joplin/38018/3).

Previously, non-breaking spaces (`\u00A0`) and CRLF seem to have been treated as word characters instead of separators by the [FTS tokenizer](https://www.sqlite.org/fts3.html#tokenizer). This pull request converts them to space characters during text normalization, which are marked as separators.

> [!NOTE]
>
> Existing notes will need to be re-indexed for this change to apply.
>

# Testing

This pull request includes an automated test. However, it can also be tested manually by:
1. Creating a new note.
2. Giving it a title.
3. Opening Joplin's development tools and running `console.log('\u00A0searchquerytesta\r\nsearchquerytestb')`.
4. Copy the result and paste into Joplin.
5. Search for `searchquerytesta` and verify that the just-created note is in the results.
6. Search for `searchquerytestb` and verify that the just-created note is in the results.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->