### PR TITLE
All: Fix logger tests by adding time

### DIFF
--- a/packages/utils/Logger.test.ts
+++ b/packages/utils/Logger.test.ts
@@ -38,7 +38,7 @@ describe('Logger', () => {
 	});
 
 	it('should log to file', async () => {
-		jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+		jest.useFakeTimers().setSystemTime(new Date('2020-01-01 00:00:00'));
 
 		const logger = createLogger();
 		logger.debug('one');
@@ -65,7 +65,7 @@ describe('Logger', () => {
 		[[''], ''],
 		[[{ that: 'is json', sub: { key1: 'abc', key2: 'def' } }], '{"that":"is json","sub":{"key1":"abc","key2":"def"}}'],
 	])('should format messages correctly', async (input, expected) => {
-		jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+		jest.useFakeTimers().setSystemTime(new Date('2020-01-01 00:00:00'));
 		const logger = createLogger();
 		logger.info(...input);
 		await logger.waitForFileWritesToComplete_();
@@ -74,7 +74,7 @@ describe('Logger', () => {
 	});
 
 	// it('should keep the last lines', async () => {
-	// 	jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+	// 	jest.useFakeTimers().setSystemTime(new Date('2020-01-01 00:00:00'));
 
 	// 	const logger = createLogger();
 	// 	logger.keptLineCount = 2;


### PR DESCRIPTION
When running Logger tests outside UTC we get a mismatch between time and the expected message:

```
  ● Logger › should format messages correctly

    expect(received).toBe(expected) // Object.is equality

    - Expected  - 1
    + Received  + 1

    - 2020-01-01 00:00:00: testing: {"that":"is json","sub":{"key1":"abc","key2":"def"}}
    + 2019-12-31 21:00:00: testing: {"that":"is json","sub":{"key1":"abc","key2":"def"}}
      ↵

      70 |              logger.info(...input);
      71 |              await logger.waitForFileWritesToComplete_();
    > 72 |              expect(await getLogContent()).toBe(`2020-01-01 00:00:00: testing: ${expected}\n`);
         |                                            ^
      73 |              jest.useRealTimers();
      74 |      });
      75 |

      at Logger.test.ts:72:33
      at fulfilled (Logger.test.ts:5:58)
      
```

(I'm at -3 UTC)

I'm adding time to the date to fix this issue.