### PR TITLE
Desktop, Mobile: Fixes #10439: Maintain cursor position when changing list indentation

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
@@ -85,7 +85,7 @@ describe('markdownCommands', () => {
 
 	it('should set headers to the proper levels (when toggling)', async () => {
 		const initialDocText = 'Testing...\nThis is a test.';
-		const editor = await createTestEditor(initialDocText, EditorSelection.cursor(3), []);
+		const editor = await createTestEditor(initialDocText, EditorSelection.cursor('Testing...'.length), []);
 
 		toggleHeaderLevel(1)(editor);
 
@@ -124,7 +124,7 @@ describe('markdownCommands', () => {
 			'Testing...\n\n> # This is a test.\n> ...a test',
 		);
 		expect(mainSel.empty).toBe(true);
-		expect(mainSel.from).toBe('Testing...\n\n> # This is a test.'.length);
+		expect(mainSel.from).toBe('Testing...\n\n> # This'.length);
 
 		toggleHeaderLevel(3)(editor);
 
@@ -273,6 +273,24 @@ describe('markdownCommands', () => {
 		expect(editor.state.selection.main).toMatchObject({
 			from: finalText.length,
 			to: finalText.length,
+		});
+	});
+
+	it('insertOrIncreaseIndent should preserve the cursor location when in a list', async () => {
+		const initialText = '- a\n- b\n- c';
+		const editor = await createTestEditor(
+			initialText,
+			EditorSelection.cursor(5), // In the 2nd list item
+			['BulletList'],
+		);
+
+		insertOrIncreaseIndent(editor);
+
+		expect(editor.state.doc.toString()).toBe('- a\n\t- b\n- c');
+		expect(editor.state.selection.main).toMatchObject({
+			// The indent unit is a single tab, which has length 1.
+			from: 6,
+			to: 6,
 		});
 	});
 });


### PR DESCRIPTION
# Summary

This pull request **partially** resolves #10439 by maintaining the cursor location toggling lists/headers/line-start indentation.

# Screen recording


https://github.com/laurent22/joplin/assets/46334387/81b2a959-6bde-4021-9449-ab12e697c961

**Note**: Removing tabs in the middle of a paragraph was done with <kbd>backspace</kbd>, not <kbd>shift</kbd>-<kbd>tab</kbd>.


# Remaining issues

- Issue with cursor positioning when indenting numbered lists.
- Pressing <kbd>tab</kbd> when the cursor is in the middle of a list item should insert a tab character, not indent.
   - Indentation should only occur when at the start or end of a line?


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->