### PR TITLE
Desktop: Sidebar: Remove redundant focus indicator

### DIFF
--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -85,7 +85,7 @@ export const StyledListItemAnchor = styled.a`
 	user-select: none;
 	height: 100%;
 
-	/* The background color of the selected item already shows the focus. */
+	/* A different background color is already used to indicate focus for sidebar list items. */
 	&:focus-visible {
 		outline: none;
 	}

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -84,6 +84,11 @@ export const StyledListItemAnchor = styled.a`
 	align-items: center;
 	user-select: none;
 	height: 100%;
+
+	/* The background color of the selected item already shows the focus. */
+	&:focus-visible {
+		outline: none;
+	}
 `;
 
 export const StyledShareIcon = styled.i`


### PR DESCRIPTION
# Summary

This pull request removes the orange focus outline for notebooks and tags in the sidebar. Focus is already indicated with a different background color.

## Before

<img alt="focused notebook is outlined" src="https://github.com/laurent22/joplin/assets/46334387/44b2bd46-eaac-4b03-989a-1c4a4cb5841a" width="400"/>

## After

<img alt="focused notebook is not outlined" src="https://github.com/laurent22/joplin/assets/46334387/38fcf562-f82e-4949-884b-cf90c8a07a44" width="400"/>

# Testing plan

1. Click on a notebook in the sidebar.
2. Use the arrow keys to navigate to the "Tags" heading.
   - The "Tags" heading should still have an orange focus outline.
3. Use the arrow keys to navigate to a tag in the sidebar.
   - The tag should have a darker background, but no orange focus indicator.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->