### PR TITLE
Desktop: Fixes #8960: Fix cursor jumps to the top of the note editor on sync

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -10,7 +10,7 @@ import useMessageHandler from './utils/useMessageHandler';
 import useWindowCommandHandler from './utils/useWindowCommandHandler';
 import useDropHandler from './utils/useDropHandler';
 import useMarkupToHtml from './utils/useMarkupToHtml';
-import useFormNote, { OnLoadEvent, SetFormNote } from './utils/useFormNote';
+import useFormNote, { OnLoadEvent, OnSetFormNote } from './utils/useFormNote';
 import useEffectiveNoteId from './utils/useEffectiveNoteId';
 import useFolder from './utils/useFolder';
 import styles_ from './styles';
@@ -68,7 +68,7 @@ function NoteEditor(props: NoteEditorProps) {
 	const isMountedRef = useRef(true);
 	const noteSearchBarRef = useRef(null);
 
-	const setFormNoteRef = useRef<SetFormNote>();
+	const setFormNoteRef = useRef<OnSetFormNote>();
 	const { saveNoteIfWillChange, scheduleSaveNote } = useScheduleSaveCallbacks({
 		setFormNote: setFormNoteRef, dispatch: props.dispatch, editorRef,
 	});

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, RefObject } from 'react';
+import { useState, useEffect, useCallback, RefObject, useRef } from 'react';
 import { FormNote, defaultFormNote, ResourceInfos } from './types';
 import { clearResourceCache, attachedResources } from './resourceHandling';
 import AsyncActionQueue from '@joplin/lib/AsyncActionQueue';
@@ -8,13 +8,15 @@ import Setting from '@joplin/lib/models/Setting';
 import usePrevious from '../../hooks/usePrevious';
 import ResourceEditWatcher from '@joplin/lib/services/ResourceEditWatcher/index';
 
-const { MarkupToHtml } = require('@joplin/renderer');
+import { MarkupToHtml } from '@joplin/renderer';
 import Note from '@joplin/lib/models/Note';
-import { reg } from '@joplin/lib/registry';
 import ResourceFetcher from '@joplin/lib/services/ResourceFetcher';
 import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('useFormNote');
 
 export interface OnLoadEvent {
 	formNote: FormNote;
@@ -32,7 +34,8 @@ export interface HookDependencies {
 	onAfterLoad(event: OnLoadEvent): void;
 }
 
-export type SetFormNote = ReturnType<typeof useState<FormNote>>[1];
+type MapFormNoteCallback = (previousFormNote: FormNote)=> FormNote;
+export type OnSetFormNote = (newFormNote: FormNote|MapFormNoteCallback)=> void;
 
 // eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 function installResourceChangeHandler(onResourceChangeHandler: Function) {
@@ -78,11 +81,14 @@ export default function useFormNote(dependencies: HookDependencies) {
 	const previousNoteId = usePrevious(formNote.id);
 	const [resourceInfos, setResourceInfos] = useState<ResourceInfos>({});
 
+	const formNoteRef = useRef(formNote);
+	formNoteRef.current = formNote;
+
 	// Increasing the value of this counter cancels any ongoing note refreshes and starts
 	// a new refresh.
 	const [formNoteRefreshScheduled, setFormNoteRefreshScheduled] = useState<number>(0);
 
-	async function initNoteState(n: NoteEntity) {
+	const initNoteState = useCallback(async (n: NoteEntity, isNewNote: boolean) => {
 		let originalCss = '';
 
 		if (n.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML) {
@@ -107,22 +113,39 @@ export default function useFormNote(dependencies: HookDependencies) {
 			encryption_applied: n.encryption_applied,
 		};
 
+		logger.debug('Initializing note state');
+
 		// Note that for performance reason,the call to setResourceInfos should
 		// be first because it loads the resource infos in an async way. If we
 		// swap them, the formNote will be updated first and rendered, then the
 		// the resources will load, and the note will be re-rendered.
-		setResourceInfos(await attachedResources(n.body));
+		const resources = await attachedResources(n.body);
+
+		// If the user changes the note while resources are loading, this can lead to
+		// a note being incorrectly marked as "unchanged".
+		if (!isNewNote && formNoteRef.current?.hasChanged) {
+			logger.info('Cancelled note refresh -- form note changed while loading attached resources.');
+			return null;
+		}
+
+		setResourceInfos(resources);
 		setFormNote(newFormNote);
+
+		logger.debug('Resource info and form note set.');
 
 		await handleResourceDownloadMode(n.body);
 
 		return newFormNote;
-	}
+	}, []);
 
 	useEffect(() => {
 		if (formNoteRefreshScheduled <= 0) return () => {};
+		if (formNoteRef.current.hasChanged) {
+			logger.info('Form note changed between scheduling a refresh and the refresh itself. Cancelling the refresh.');
+			return () => {};
+		}
 
-		reg.logger().info('Sync has finished and note has never been changed - reloading it');
+		logger.info('Sync has finished and note has never been changed - reloading it');
 
 		let cancelled = false;
 
@@ -134,11 +157,12 @@ export default function useFormNote(dependencies: HookDependencies) {
 			// it would not have been loaded in the editor (due to note selection changing
 			// on delete)
 			if (!n) {
-				reg.logger().warn('Trying to reload note that has been deleted:', noteId);
+				logger.warn('Trying to reload note that has been deleted:', noteId);
 				return;
 			}
 
-			await initNoteState(n);
+			await initNoteState(n, false);
+
 			setFormNoteRefreshScheduled(0);
 		};
 
@@ -147,7 +171,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 		return () => {
 			cancelled = true;
 		};
-	}, [formNoteRefreshScheduled, noteId]);
+	}, [formNoteRefreshScheduled, noteId, initNoteState]);
 
 	const refreshFormNote = useCallback(() => {
 		// Increase the counter to cancel any ongoing refresh attempts
@@ -164,7 +188,9 @@ export default function useFormNote(dependencies: HookDependencies) {
 		const syncJustEnded = prevSyncStarted && !syncStarted;
 
 		if (!decryptionJustEnded && !syncJustEnded) return;
-		if (formNote.hasChanged) return;
+		if (formNoteRef.current.hasChanged) return;
+
+		logger.debug('Sync or decryption finished with an unchanged formNote.');
 
 		// Refresh the form note.
 		// This is kept separate from the above logic so that when prevSyncStarted is changed
@@ -173,7 +199,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 	}, [
 		prevSyncStarted, syncStarted,
 		prevDecryptionStarted, decryptionStarted,
-		formNote.hasChanged, refreshFormNote,
+		refreshFormNote,
 	]);
 
 	useEffect(() => {
@@ -186,7 +212,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 
 		let cancelled = false;
 
-		reg.logger().debug('Loading existing note', noteId);
+		logger.debug('Loading existing note', noteId);
 
 		function handleAutoFocus(noteIsTodo: boolean) {
 			if (!isProvisional) return;
@@ -206,11 +232,11 @@ export default function useFormNote(dependencies: HookDependencies) {
 			const n = await Note.load(noteId);
 			if (cancelled) return;
 			if (!n) throw new Error(`Cannot find note with ID: ${noteId}`);
-			reg.logger().debug('Loaded note:', n);
+			logger.debug('Loaded note:', n);
 
 			await onBeforeLoad({ formNote });
 
-			const newFormNote = await initNoteState(n);
+			const newFormNote = await initNoteState(n, true);
 
 			setIsNewNote(isProvisional);
 
@@ -267,5 +293,24 @@ export default function useFormNote(dependencies: HookDependencies) {
 		};
 	}, [formNote.body]);
 
-	return { isNewNote, formNote, setFormNote, resourceInfos };
+	// Currently, useFormNote relies on formNoteRef being up-to-date immediately after the editor
+	// changes, with no delay during which async code can run. Even a small delay (e.g. that introduced
+	// by a setState -> useEffect) can lead to a race condition. See https://github.com/laurent22/joplin/issues/8960.
+	const onSetFormNote: OnSetFormNote = useCallback(newFormNote => {
+		if (typeof newFormNote === 'function') {
+			const newNote = newFormNote(formNoteRef.current);
+			formNoteRef.current = newNote;
+			setFormNote(newNote);
+		} else {
+			formNoteRef.current = newFormNote;
+			setFormNote(newFormNote);
+		}
+	}, [setFormNote]);
+
+	return {
+		isNewNote,
+		formNote,
+		setFormNote: onSetFormNote,
+		resourceInfos,
+	};
 }

--- a/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScheduleSaveCallbacks.ts
@@ -6,12 +6,12 @@ import ExternalEditWatcher from '@joplin/lib/services/ExternalEditWatcher';
 import Note from '@joplin/lib/models/Note';
 import type { Dispatch } from 'redux';
 import eventManager, { EventName } from '@joplin/lib/eventManager';
-import type { SetFormNote } from './useFormNote';
+import type { OnSetFormNote } from './useFormNote';
 
 const logger = Logger.create('useScheduleSaveCallbacks');
 
 interface Props {
-	setFormNote: RefObject<SetFormNote>;
+	setFormNote: RefObject<OnSetFormNote>;
 	dispatch: Dispatch;
 	editorRef: RefObject<NoteBodyEditorRef>;
 }


### PR DESCRIPTION
# Summary

>[!NOTE]
>
> **Update**: This does not seem to have resolved the issue.

This pull request fixes a race condition in [useFormNote.ts](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts) that sometimes caused the editor cursor to jump to the top of a note after a sync finishes.

May fix #8960.

# Details

More specifically, the issue was caused by `formNote.hasChanged` being out-of-date.

In `NoteEditor.tsx`, `.hasChanged` is set to true by changing the value of a state variable (`setFormNote`). This is done in a callback fired when the current note updates:
https://github.com/laurent22/joplin/blob/faf332a0e8db12e285014e138636efa5cf450a2b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx#L186

Previously, `.hasChanged` was checked just before scheduling a refresh:
https://github.com/laurent22/joplin/blob/faf332a0e8db12e285014e138636efa5cf450a2b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts#L167

After a refresh completed, `.hasChanged` was set to `false`:
https://github.com/laurent22/joplin/blob/faf332a0e8db12e285014e138636efa5cf450a2b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts#L105

The issue can occur if `.hasChanged` becomes `true` just after a refresh is scheduled. In this case, the refresh would still happen. The refresh would load the current copy of the note from the database (`n`).

Because the editor's recent changes haven't had time to be written to the database, `n.body` would not match the content of the editor. The CodeMirror 5 (and also the rich text?) editors handle this by changing the editor's content, clearing the editor's undo history, and resetting the cursor position. (The CodeMirror 6 editor [handles cursor positioning differently](https://github.com/laurent22/joplin/blob/faf332a0e8db12e285014e138636efa5cf450a2b/packages/editor/CodeMirror/CodeMirrorControl.ts#L105)).

Adding an additional `.hasChanged`-based check doesn't seem to be enough to fix the issue (see [comment](https://github.com/laurent22/joplin/issues/8960#issuecomment-2123481861)). It seems to be necessary to set `.hasChanged` immediately, without waiting for a re-render to update its value. This pull request does this by:
1. Exposing a custom `onSetFormNote` callback that wraps `setFormNote`.
2. Updating a `formNoteRef` within `onSetFormNote`.
3. Checking `formNoteRef.current.hasChanged` just before setting the new form note.

# Testing plan

The original issue is difficult to reproduce. As such, the following testing plan focuses on avoiding regressions:
1. Create a new note and trigger a manual sync with <kbd>ctrl</kbd>-<kbd>s</kbd> while typing.
    - Verify that the cursor doesn't jump to the beginning of the note. **Note**: This does not verify that the issue has been fixed.
2. Switch to a different note.
3. Switch back to the original note.
4. Verify that the content of the original note was saved.
5. Repeat steps 1-4 for the rich text editor and the CodeMirror 6-based beta editor.

This has been tested successfully on Ubuntu 24.04.

**Note**: Additional manual testing was done with an equivalent fix on [this branch](https://github.com/personalizedrefrigerator/joplin/tree/test/desktop/incorrect-reload) with additional debug logging and more frequent auto-sync enabled.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->