### PR TITLE
Desktop: Fixes #10381: Fix plugin settings stored in `settings.json` are lost on startup

### DIFF
--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -150,6 +150,7 @@ describe('models/Setting', () => {
 
 		await Setting.saveAll();
 		await Setting.reset();
+		await Setting.load();
 
 		await registerCustom();
 		expect(Setting.value('myCustom')).toBe('test2');

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -426,4 +426,25 @@ describe('models/Setting', () => {
 		}
 	});
 
+	test('should not lose the values of file settings that are registered after the first settings save', async () => {
+		const registerCustom = async () => {
+			await Setting.registerSetting('myCustom', {
+				public: true,
+				value: 'test',
+				type: Setting.TYPE_STRING,
+				storage: SettingStorage.File,
+			});
+		};
+
+		await registerCustom();
+		Setting.setValue('myCustom', 'test2');
+		await Setting.saveAll();
+
+		await Setting.reset();
+		await Setting.load();
+		await Setting.saveAll();
+
+		await registerCustom();
+		expect(Setting.value('myCustom')).toBe('test2');
+	});
 });

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -331,7 +331,6 @@ class Setting extends BaseModel {
 	private static keychainService_: any = null;
 	private static keys_: string[] = null;
 	private static cache_: CacheItem[] = [];
-	private static cachedUnknownSettings_: CacheItem[] = [];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static saveTimeoutId_: any = null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -361,7 +360,6 @@ class Setting extends BaseModel {
 		this.metadata_ = null;
 		this.keys_ = null;
 		this.cache_ = [];
-		this.cachedUnknownSettings_ = [];
 		this.customMetadata_ = {};
 		this.fileHandler_ = null;
 		this.rootFileHandler_ = null;
@@ -2033,13 +2031,12 @@ class Setting extends BaseModel {
 			this.keys_ = null;
 
 			// Reload the value from the database, if it was already present
-			const valueRow = await this.loadOne(key) || this.cachedUnknownSettings_.find(item => item.key === key);
+			const valueRow = await this.loadOne(key);
 			if (valueRow) {
 				// Remove any duplicate copies of the setting -- if multiple items in cache_
 				// have the same key, we may encounter unique key errors while saving to the
 				// database.
 				this.cache_ = this.cache_.filter(setting => setting.key !== key);
-				this.cachedUnknownSettings_ = this.cachedUnknownSettings_.filter(setting => setting.key !== key);
 
 				this.cache_.push({
 					key: key,
@@ -2178,12 +2175,7 @@ class Setting extends BaseModel {
 			for (let i = 0; i < items.length; i++) {
 				const c = items[i];
 
-				if (!this.keyExists(c.key)) {
-					// Cache the setting differently -- it may be registered later, in which case
-					// its value is still needed.
-					this.cachedUnknownSettings_.push(c);
-					continue;
-				}
+				if (!this.keyExists(c.key)) continue;
 
 				c.value = this.formatValue(c.key, c.value);
 				c.value = this.filterValue(c.key, c.value);
@@ -2585,6 +2577,10 @@ class Setting extends BaseModel {
 		const keys = this.keys();
 
 		const valuesForFile: SettingValues = {};
+		for (const key of keys) {
+			// undefined => Delete from settings JSON file.
+			valuesForFile[key] = undefined;
+		}
 
 		const queries = [];
 		queries.push(`DELETE FROM settings WHERE key IN ("${keys.join('","')}")`);

--- a/packages/lib/models/settings/FileHandler.ts
+++ b/packages/lib/models/settings/FileHandler.ts
@@ -11,6 +11,7 @@ export default class FileHandler {
 
 	private filePath_: string;
 	private valueJsonCache_: string = null;
+	private parsedJsonCache_: SettingValues = null;
 
 	public constructor(filePath: string) {
 		this.filePath_ = filePath;
@@ -23,24 +24,42 @@ export default class FileHandler {
 			} else {
 				this.valueJsonCache_ = await shim.fsDriver().readFile(this.filePath_, 'utf8');
 			}
+			this.parsedJsonCache_ = null;
 		}
 
+		if (this.parsedJsonCache_) return this.parsedJsonCache_;
+
+		let result: SettingValues;
 		try {
 			const values = JSON.parse(this.valueJsonCache_);
 			delete values['$id'];
 			delete values['$schema'];
-			return values;
+			result = values;
 		} catch (error) {
 			// Most likely the user entered invalid JSON - in this case we move
 			// the broken file to a new name (otherwise it would be overwritten
 			// by valid JSON and user will lose all their settings).
 			logger.error(`Could not parse JSON file: ${this.filePath_}`, error);
 			await shim.fsDriver().move(this.filePath_, `${this.filePath_}-${Date.now()}-invalid.bak`);
-			return {};
+			result = {};
 		}
+
+		this.parsedJsonCache_ = result;
+
+		return result;
 	}
 
 	public async save(values: SettingValues) {
+		values = { ...values };
+
+		// Don't delete settings that haven't been loaded
+		for (const key in this.parsedJsonCache_) {
+			const includesSetting = Object.prototype.hasOwnProperty.call(values, key);
+			if (!includesSetting) {
+				values[key] = this.parsedJsonCache_[key];
+			}
+		}
+
 		const json = `${JSON.stringify({
 			'$schema': Setting.schemaUrl,
 			...values,

--- a/packages/lib/models/settings/FileHandler.ts
+++ b/packages/lib/models/settings/FileHandler.ts
@@ -52,7 +52,8 @@ export default class FileHandler {
 	public async save(values: SettingValues) {
 		values = { ...values };
 
-		// Don't delete settings that haven't been loaded
+		// Merge with existing settings. This prevents settings stored by disabled or not-yet-loaded
+		// plugins from being deleted.
 		for (const key in this.parsedJsonCache_) {
 			const includesSetting = Object.prototype.hasOwnProperty.call(values, key);
 			if (!includesSetting) {


### PR DESCRIPTION
# Summary

This pull request fixes an issue where plugin settings saved with [`SettingStorageType.File`](https://joplinapp.org/api/references/plugin_api/enums/settingstorage.html#file) could be lost if settings were saved before custom plugin settings could be registered.

Fixes #10381.

# Testing plan

This pull request includes automated tests. However, it has also been tested manually by:
1. Installing the "CodeMirror 6 snippets" plugin and setting the snippet note ID.
2. Saving settings and disabling the snippets plugin.
3. Restarting Joplin.
4. Enabling the snippets plugin.
5. Restarting Joplin.
6. Verifying that the snippets plugin settings haven't been reset.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->