### PR TITLE
Desktop: Re-render note when resources are changed

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -1,7 +1,9 @@
 import Note from '@joplin/lib/models/Note';
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import useFormNote, { HookDependencies } from './useFormNote';
+import shim from '@joplin/lib/shim';
+import Resource from '@joplin/lib/models/Resource';
 
 const defaultFormNoteProps: HookDependencies = {
 	syncStarted: false,
@@ -75,6 +77,8 @@ describe('useFormNote', () => {
 				title: 'Test Note!',
 			});
 		});
+
+		formNote.unmount();
 	});
 
 	// It seems this test is crashing the worker on CI (out of memory), so disabling it for now.
@@ -109,4 +113,43 @@ describe('useFormNote', () => {
 	// 	});
 	// });
 
+	test('should refresh resource infos when changed outside the editor', async () => {
+		let note = await Note.save({});
+		note = await shim.attachFileToNote(note, __filename);
+		const resourceIds = Note.linkedItemIds(note.body);
+		const resource = await Resource.load(resourceIds[0]);
+
+		const makeFormNoteProps = (syncStarted: boolean, decryptionStarted: boolean): HookDependencies => {
+			return {
+				...defaultFormNoteProps,
+				syncStarted,
+				decryptionStarted,
+				noteId: note.id,
+			};
+		};
+
+		const formNote = renderHook(props => useFormNote(props), {
+			initialProps: makeFormNoteProps(true, false),
+		});
+
+		await formNote.waitFor(() => {
+			return Object.values(formNote.result.current.resourceInfos).length > 0;
+		});
+		const initialResourceInfos = formNote.result.current.resourceInfos;
+		expect(initialResourceInfos).toMatchObject({
+			[resource.id]: { item: { id: resource.id } },
+		});
+
+		await act(async () => {
+			await Resource.save({ ...resource, filename: 'test.ts' });
+		});
+		await formNote.waitFor(() => {
+			const resourceInfo = formNote.result.current.resourceInfos[resource.id];
+			expect(resourceInfo.item).toMatchObject({
+				id: resource.id, filename: 'test.ts',
+			});
+		});
+
+		formNote.unmount();
+	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -271,7 +271,8 @@ export default function useFormNote(dependencies: HookDependencies) {
 		const resourceIds = await Note.linkedResourceIds(formNote.body);
 		if (!event || resourceIds.indexOf(event.id) >= 0) {
 			clearResourceCache();
-			setResourceInfos(await attachedResources(formNote.body));
+			const newResourceInfos = await attachedResources(formNote.body);
+			setResourceInfos(newResourceInfos);
 		}
 	}, [formNote.body]);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -14,6 +14,7 @@ import { NoteEntity } from '@joplin/lib/services/database/types';
 import { focus } from '@joplin/lib/utils/focusHandler';
 import Logger from '@joplin/utils/Logger';
 import eventManager, { EventName } from '@joplin/lib/eventManager';
+import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 
 const logger = Logger.create('useFormNote');
 
@@ -39,12 +40,14 @@ export type OnSetFormNote = (newFormNote: FormNote|MapFormNoteCallback)=> void;
 function installResourceChangeHandler(onResourceChangeHandler: ()=> void) {
 	ResourceFetcher.instance().on('downloadComplete', onResourceChangeHandler);
 	ResourceFetcher.instance().on('downloadStarted', onResourceChangeHandler);
+	DecryptionWorker.instance().on('resourceDecrypted', onResourceChangeHandler);
 	eventManager.on(EventName.ResourceChange, onResourceChangeHandler);
 }
 
 function uninstallResourceChangeHandler(onResourceChangeHandler: ()=> void) {
 	ResourceFetcher.instance().off('downloadComplete', onResourceChangeHandler);
 	ResourceFetcher.instance().off('downloadStarted', onResourceChangeHandler);
+	DecryptionWorker.instance().off('resourceDecrypted', onResourceChangeHandler);
 	eventManager.off(EventName.ResourceChange, onResourceChangeHandler);
 }
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -201,24 +201,6 @@ export default function useFormNote(dependencies: HookDependencies) {
 	]);
 
 	useEffect(() => {
-		if (!noteId) return ()=>{};
-
-		type ChangeEventSlice = { itemId: string };
-		const listener = ({ itemId }: ChangeEventSlice) => {
-			if (itemId === noteId) {
-				if (formNoteRef.current.hasChanged) return;
-
-				refreshFormNote();
-			}
-		};
-		eventManager.on(EventName.ItemChange, listener);
-
-		return () => {
-			eventManager.off(EventName.ItemChange, listener);
-		};
-	}, [noteId, refreshFormNote]);
-
-	useEffect(() => {
 		if (!noteId) {
 			if (formNote.id) setFormNote(defaultFormNote());
 			return () => {};

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -637,7 +637,7 @@ export default class Resource extends BaseItem {
 		}
 
 		const output = await super.save(resource, options);
-		if (isNew) eventManager.emit(EventName.ResourceCreate);
+		eventManager.emit(isNew ? EventName.ResourceCreate : EventName.ResourceChange);
 		return output;
 	}
 

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -637,7 +637,7 @@ export default class Resource extends BaseItem {
 		}
 
 		const output = await super.save(resource, options);
-		eventManager.emit(isNew ? EventName.ResourceCreate : EventName.ResourceChange);
+		eventManager.emit(isNew ? EventName.ResourceCreate : EventName.ResourceChange, { id: output.id });
 		return output;
 	}
 


### PR DESCRIPTION
# Summary

This pull request causes notes to be re-rendered when resources change. This is intended specifically to show changes to resources through the plugin/data API, but also applies to other changes made with `Resource.save`.

# Notes

- Previously, notes would re-render when resources changed, but only in certain cases: when watched by the ResourceEditWatcher, when finished downloading/decrypting, and when download starts. This **did not** handle the case where a resource is updated through the data API.
- This allows removing an only-partially-working [workaround](https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/blob/aa8677a3c1a38dfb17b2bcafb92b0fcc0fa5cd0c/src/contentScripts/markdownIt.ts#L20) in the Freehand Drawing plugin.
- This may be important for https://github.com/laurent22/joplin/pull/10448 when resource mirroring is implemented.


# Testing plan

In addition to this pull request's automated test, this can be tested by:
1. Installing the Freehand Drawing plugin (if not already installed)
2. Adding a new drawing
3. Selecting the drawing's resource ID
4. Opening the command palette and running `:insertDrawing__newWindow`
    - Prior to this pull request, changes made in a new window were not reflected in the note viewer without switching notes.
5. Making a change to the drawing
6. Clicking "save"
7. Verifying that the drawing updates

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->