### PR TITLE
Desktop: Resolves #9959: Display description for settings field in the plugin customization screen

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -596,6 +596,9 @@ class ConfigScreenComponent extends React.Component<any, any> {
 											size={ButtonSize.Small}
 										/>
 									</div>
+									<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
+										{descriptionComp}
+									</div>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
Resolves: https://github.com/laurent22/joplin/issues/9959

In the plugin settings screen, when displaying an input of subtype `SettingItemSubType.DirectoryPath` the description would not be present, it was missing a call for the description component.

### Testing:

- Open Backup setting screen
- The description for the Backup Path and Temporary Export Path should be visible

![2024-05-24_17-56](https://github.com/laurent22/joplin/assets/5051088/70576565-1933-4565-8a03-3d1268c621fa)
