### PR TITLE
Server: Fixes #10118: Missing record validation before trying to add item to user

### DIFF
--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -114,6 +114,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 
 	public async add(userId: Uuid, itemId: Uuid, options: SaveOptions = {}): Promise<void> {
 		const item = await this.models().item().load(itemId, { fields: ['id', 'name'] });
+		if (!item) return;
 		await this.addMulti(userId, [item], options);
 	}
 
@@ -123,6 +124,10 @@ export default class UserItemModel extends BaseModel<UserItem> {
 
 		await this.withTransaction(async () => {
 			for (const item of items) {
+				// Since we are getting items from outside transaction we can't be sure
+				// that the record still exists
+				if (!item) continue;
+
 				if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
 
 				await super.save({

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -114,7 +114,9 @@ export default class UserItemModel extends BaseModel<UserItem> {
 
 	public async add(userId: Uuid, itemId: Uuid, options: SaveOptions = {}): Promise<void> {
 		const item = await this.models().item().load(itemId, { fields: ['id', 'name'] });
-		if (!item) return;
+		if (!item) {
+			throw new ErrorNotFound(`No such item: ${itemId}`);
+		}
 		await this.addMulti(userId, [item], options);
 	}
 
@@ -124,10 +126,6 @@ export default class UserItemModel extends BaseModel<UserItem> {
 
 		await this.withTransaction(async () => {
 			for (const item of items) {
-				// Since we are getting items from outside transaction we can't be sure
-				// that the record still exists
-				if (!item) continue;
-
 				if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
 
 				await super.save({

--- a/packages/server/src/models/UserItemModels.test.ts
+++ b/packages/server/src/models/UserItemModels.test.ts
@@ -1,4 +1,4 @@
-import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
+import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
 
 describe('UserItemModel', () => {
 
@@ -14,10 +14,10 @@ describe('UserItemModel', () => {
 		await beforeEachDb();
 	});
 
-	test('should skip undefined values instead of crashing', async () => {
-		const { user } = await createUserAndSession(3, false);
-
-		expect(async () => models().userItem().addMulti(user.id, [undefined])).not.toThrow();
+	test('should throw error if item does not exist', async () => {
+		const mockUserId = 'not-a-real-user-id';
+		const mockId = 'not-a-real-item-id';
+		expect(async () => models().userItem().add(mockUserId, mockId)).rejects.toThrow('No such item: not-a-real-item-id');
 	});
 });
 

--- a/packages/server/src/models/UserItemModels.test.ts
+++ b/packages/server/src/models/UserItemModels.test.ts
@@ -1,0 +1,23 @@
+import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
+
+describe('UserItemModel', () => {
+
+	beforeAll(async () => {
+		await beforeAllDb('UserItemModel');
+	});
+
+	afterAll(async () => {
+		await afterAllTests();
+	});
+
+	beforeEach(async () => {
+		await beforeEachDb();
+	});
+
+	test('should skip undefined values', async () => {
+		const { user } = await createUserAndSession(3, false);
+
+		expect(await models().userItem().addMulti(user.id, [undefined])).toBe(undefined);
+	});
+});
+

--- a/packages/server/src/models/UserItemModels.test.ts
+++ b/packages/server/src/models/UserItemModels.test.ts
@@ -14,10 +14,10 @@ describe('UserItemModel', () => {
 		await beforeEachDb();
 	});
 
-	test('should skip undefined values', async () => {
+	test('should skip undefined values instead of crashing', async () => {
 		const { user } = await createUserAndSession(3, false);
 
-		expect(await models().userItem().addMulti(user.id, [undefined])).toBe(undefined);
+		expect(async () => models().userItem().addMulti(user.id, [undefined])).not.toThrow();
 	});
 });
 


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10118

The error:

```
app-1        | 07:50:18 0|app  | 2024-03-14 07:50:17: [error] TaskService: On #10 (Process orphaned items) TypeError: Cannot use 'in' operator to search for 'name' in undefined
app-1        | 07:50:18 0|app  |     at UserItemModel.<anonymous> (/home/joplin/packages/server/src/models/UserItemModel.ts:126:17)
app-1        | 07:50:18 0|app  |     at Generator.next (<anonymous>)
app-1        | 07:50:18 0|app  |     at /home/joplin/packages/server/dist/models/UserItemModel.js:8:71
app-1        | 07:50:18 0|app  |     at new Promise (<anonymous>)
app-1        | 07:50:18 0|app  |     at __awaiter (/home/joplin/packages/server/dist/models/UserItemModel.js:4:12)
app-1        | 07:50:18 0|app  |     at /home/joplin/packages/server/src/models/UserItemModel.ts:124:41
app-1        | 07:50:18 0|app  |     at UserItemModel.<anonymous> (/home/joplin/packages/server/src/models/BaseModel.ts:221:19)
app-1        | 07:50:18 0|app  |     at Generator.next (<anonymous>)
app-1        | 07:50:18 0|app  |     at fulfilled (/home/joplin/packages/server/dist/models/BaseModel.js:5:58)
app-1        | 07:50:18 0|app  |     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

While I could not reproduce the error, I think it is safe to assume that it could happen during the `ItemModel.processOrphanedItems`.

Basically what would happen is that a item would be orphaned, the `processOrphanedItems` would start and while it was happening the file was deleted before the process had time added the item back to the user collection.

That means that when `UserItemModel.add` happened, it would not found a item record anymore, which end up causing the error inside the `UserItemModel.addMulti`.

### Testing

At first, I tried to add a more complex test that emulated the behavior, but it was getting very complicated and taking a lot of time, If the reviewer's opinion is different I can try to reproduce the behavior, but the simple test I added already will cover the potential regression if someone removes one of the checks.
