### PR TITLE
Chore: Fix spelling of `react-native` in `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -109,9 +109,9 @@
 		// upgrading React Native.
 		"@babel/preset-env",
 		"@babel/runtime",
-		"@tsconfig/ive",
-		"@types/ive",
-		"@testing-library/ive",
+		"@tsconfig/react-native",
+		"@types/react-native",
+		"@testing-library/react-native",
 		"androidx.appcompat:appcompat",
 		"babel-plugin-module-resolver",
 		"com.android.tools.build:gradle",
@@ -123,12 +123,12 @@
 		"de.undercouch:gradle-download-task",
 		"jsc-android",
 		"org.robolectric:robolectric",
-		"ive",
+		"react-native",
 		"activesupport",
 
 		// We currently don't have automated tests that verify that the
 		// sidemenus work correctly in the mobile app. Because an update to
-		// ive-reanimated has previously broken the sidemenu
+		// react-native-reanimated has previously broken the sidemenu
 		// (https://github.com/laurent22/joplin/issues/8456), we disable auto
 		// updates for it:
 		"react-native-reanimated",


### PR DESCRIPTION
# Summary

Fixes a typo where `react-native` was included as `ive` in `renovate.json5`.

See 33286efe9a22b64d5a3343b40e256f585169b756.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->