### PR TITLE
Chore: Strengthen `eventManager` types

### DIFF
--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -77,8 +77,8 @@ export default class NoteListUtils {
 						const note = await Note.load(noteIds[i]);
 						const newNote = Note.changeNoteType(note, type);
 						if (newNote === note) continue;
-						await Note.save(newNote, { userSideValidation: true });
-						eventManager.emit(EventName.NoteTypeToggle, { noteId: note.id });
+						const savedNote = await Note.save(newNote, { userSideValidation: true });
+						eventManager.emit(EventName.NoteTypeToggle, { noteId: note.id, note: savedNote });
 					}
 				};
 

--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -74,7 +74,7 @@ type EventArgs = {
 type EventListenerCallbacks = {
 	[n in EventName]: (...args: EventArgs[n])=> void;
 };
-export type EventListenerCallback<T extends EventName> = EventListenerCallbacks[T];
+export type EventListenerCallback<Name extends EventName> = EventListenerCallbacks[Name];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
 type AppStateChangeCallback = (event: { value: any })=> void;
@@ -101,19 +101,19 @@ export class EventManager {
 		this.appStateListeners_ = {};
 	}
 
-	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public on<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		return this.emitter_.on(eventName, callback);
 	}
 
-	public emit<T extends EventName>(eventName: T, ...args: EventArgs[T]) {
+	public emit<Name extends EventName>(eventName: Name, ...args: EventArgs[Name]) {
 		return this.emitter_.emit(eventName, ...args);
 	}
 
-	public removeListener<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public removeListener<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		return this.emitter_.removeListener(eventName, callback);
 	}
 
-	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public off<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		return this.removeListener(eventName, callback);
 	}
 
@@ -207,7 +207,7 @@ export class EventManager {
 		}
 	}
 
-	public once<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public once<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		return this.emitter_.once(eventName, callback);
 	}
 

--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -1,6 +1,8 @@
 const fastDeepEqual = require('fast-deep-equal');
 import { EventEmitter } from 'events';
 import type { State as AppState } from './reducer';
+import { ModelType } from './BaseModel';
+import { NoteEntity } from './services/database/types';
 
 export enum EventName {
 	ResourceCreate = 'resourceCreate',
@@ -20,8 +22,60 @@ export enum EventName {
 	NoteResourceIndexed = 'noteResourceIndexed',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
-export type EventListenerCallback = (...args: any[])=> void;
+interface ItemChangeEvent {
+	itemType: ModelType;
+	itemId: string;
+	eventType: number;
+}
+
+interface SyncCompleteEvent {
+	withErrors: boolean;
+}
+
+interface ResourceChangeEvent {
+	id: string;
+}
+
+interface NoteContentChangeEvent {
+	note: NoteEntity;
+}
+
+interface NoteAlarmTriggerEvent {
+	noteId: string;
+}
+
+interface SettingsChangeEvent {
+	keys: string[];
+}
+
+interface NoteChangeEvent {
+	noteId: string;
+	note: NoteEntity;
+}
+
+type EventArgs = {
+	[EventName.ResourceCreate]: [];
+	[EventName.ResourceChange]: [ResourceChangeEvent];
+	[EventName.SettingsChange]: [SettingsChangeEvent];
+	[EventName.TodoToggle]: [];
+	[EventName.NoteTypeToggle]: [NoteChangeEvent];
+	[EventName.SyncStart]: [];
+	[EventName.SessionEstablished]: [];
+	[EventName.SyncComplete]: [SyncCompleteEvent];
+	[EventName.ItemChange]: [ItemChangeEvent];
+	[EventName.NoteAlarmTrigger]: [NoteAlarmTriggerEvent];
+	[EventName.AlarmChange]: [NoteChangeEvent];
+	[EventName.KeymapChange]: [];
+	[EventName.NoteContentChange]: [NoteContentChangeEvent];
+	[EventName.OcrServiceResourcesProcessed]: [];
+	[EventName.NoteResourceIndexed]: [];
+};
+
+type EventListenerCallbacks = {
+	[n in EventName]: (...args: EventArgs[n])=> void;
+};
+export type EventListenerCallback<T extends EventName> = EventListenerCallbacks[T];
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
 type AppStateChangeCallback = (event: { value: any })=> void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
@@ -47,20 +101,19 @@ export class EventManager {
 		this.appStateListeners_ = {};
 	}
 
-	public on(eventName: EventName, callback: EventListenerCallback) {
+	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		return this.emitter_.on(eventName, callback);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public emit(eventName: EventName, object: any = null) {
-		return this.emitter_.emit(eventName, object);
+	public emit<T extends EventName>(eventName: T, ...args: EventArgs[T]) {
+		return this.emitter_.emit(eventName, ...args);
 	}
 
-	public removeListener(eventName: string, callback: EventListenerCallback) {
+	public removeListener<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		return this.emitter_.removeListener(eventName, callback);
 	}
 
-	public off(eventName: EventName, callback: EventListenerCallback) {
+	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		return this.removeListener(eventName, callback);
 	}
 
@@ -69,7 +122,7 @@ export class EventManager {
 	}
 
 	public filterOff(filterName: string, callback: FilterHandler) {
-		return this.removeListener(`filter:${filterName}`, callback);
+		return this.emitter_.off(`filter:${filterName}`, callback);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -154,7 +207,7 @@ export class EventManager {
 		}
 	}
 
-	public once(eventName: string, callback: EventListenerCallback) {
+	public once<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		return this.emitter_.once(eventName, callback);
 	}
 

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -124,11 +124,11 @@ export default class CommandService extends BaseService {
 		this.stateToWhenClauseContext_ = stateToWhenClauseContext;
 	}
 
-	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public on<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		eventManager.on(eventName, callback);
 	}
 
-	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public off<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		eventManager.off(eventName, callback);
 	}
 

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -124,11 +124,11 @@ export default class CommandService extends BaseService {
 		this.stateToWhenClauseContext_ = stateToWhenClauseContext;
 	}
 
-	public on(eventName: EventName, callback: EventListenerCallback) {
+	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		eventManager.on(eventName, callback);
 	}
 
-	public off(eventName: EventName, callback: EventListenerCallback) {
+	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		eventManager.off(eventName, callback);
 	}
 

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -416,11 +416,11 @@ export default class KeymapService extends BaseService {
 		return parts.join('+');
 	}
 
-	public on(eventName: EventName, callback: EventListenerCallback) {
+	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		eventManager.on(eventName, callback);
 	}
 
-	public off(eventName: EventName, callback: EventListenerCallback) {
+	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
 		eventManager.off(eventName, callback);
 	}
 

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -416,11 +416,11 @@ export default class KeymapService extends BaseService {
 		return parts.join('+');
 	}
 
-	public on<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public on<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		eventManager.on(eventName, callback);
 	}
 
-	public off<T extends EventName>(eventName: T, callback: EventListenerCallback<T>) {
+	public off<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {
 		eventManager.off(eventName, callback);
 	}
 

--- a/packages/lib/services/plugins/api/JoplinWorkspace.ts
+++ b/packages/lib/services/plugins/api/JoplinWorkspace.ts
@@ -35,12 +35,6 @@ interface ItemChangeEvent {
 	event: ItemChangeEventType;
 }
 
-interface SyncStartEvent {
-	// Tells whether there were errors during sync or not. The log will
-	// have the complete information about any error.
-	withErrors: boolean;
-}
-
 interface ResourceChangeEvent {
 	id: string;
 }
@@ -59,13 +53,15 @@ interface NoteAlarmTriggerEvent {
 }
 
 interface SyncCompleteEvent {
+	// Tells whether there were errors during sync or not. The log will
+	// have the complete information about any error.
 	withErrors: boolean;
 }
 
 type WorkspaceEventHandler<EventType> = (event: EventType)=> void;
 
 type ItemChangeHandler = WorkspaceEventHandler<ItemChangeEvent>;
-type SyncStartHandler = WorkspaceEventHandler<SyncStartEvent>;
+type SyncStartHandler = ()=> void;
 type ResourceChangeHandler = WorkspaceEventHandler<ResourceChangeEvent>;
 
 /**

--- a/packages/lib/services/plugins/utils/makeListener.ts
+++ b/packages/lib/services/plugins/utils/makeListener.ts
@@ -2,8 +2,8 @@ import Plugin from '../Plugin';
 import { EventListenerCallback, EventManager, EventName } from '../../../eventManager';
 import { Disposable } from '../api/types';
 
-export default function<NameType extends EventName>(
-	plugin: Plugin, eventManager: EventManager, eventName: NameType, callback: EventListenerCallback<NameType>,
+export default function<Name extends EventName>(
+	plugin: Plugin, eventManager: EventManager, eventName: Name, callback: EventListenerCallback<Name>,
 ): Disposable {
 	eventManager.on(eventName, callback);
 	const dispose = () => {

--- a/packages/lib/services/plugins/utils/makeListener.ts
+++ b/packages/lib/services/plugins/utils/makeListener.ts
@@ -2,8 +2,8 @@ import Plugin from '../Plugin';
 import { EventListenerCallback, EventManager, EventName } from '../../../eventManager';
 import { Disposable } from '../api/types';
 
-export default function(
-	plugin: Plugin, eventManager: EventManager, eventName: EventName, callback: EventListenerCallback,
+export default function<NameType extends EventName>(
+	plugin: Plugin, eventManager: EventManager, eventName: NameType, callback: EventListenerCallback<NameType>,
 ): Disposable {
 	eventManager.on(eventName, callback);
 	const dispose = () => {

--- a/packages/lib/utils/userFetcher.ts
+++ b/packages/lib/utils/userFetcher.ts
@@ -1,5 +1,5 @@
 import SyncTargetRegistry from '../SyncTargetRegistry';
-import eventManager from '../eventManager';
+import eventManager, { EventName } from '../eventManager';
 import Setting from '../models/Setting';
 import { reg } from '../registry';
 import Logger from '@joplin/utils/Logger';
@@ -44,7 +44,7 @@ const userFetcher = async () => {
 
 // Listen to the event only once
 export const initializeUserFetcher = () => {
-	eventManager.once('sessionEstablished', userFetcher);
+	eventManager.once(EventName.SessionEstablished, userFetcher);
 };
 
 export default userFetcher;


### PR DESCRIPTION
# Summary

This pull request uses [mapped types](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html) to strengthen the types of `.once`, `.on`, `.off`, `.removeListener`, and `.emit` in `eventManager`.

## Goal

Code similar to the following should fail to compile:
```ts
// 1. Firing an event with the wrong event argument type:
eventManager.emit(EventName.SyncComplete, { test: 'this is an invalid event object' });

// 2. Listening for an event with an invalid event argument type:
type InvalidArgumentType = { propertyThatDoesntExist: string };
eventManager.once(EventName.SyncComplete, ((r: InvalidArgumentType) => { } ));
```

# Notes

- Previously, a `SyncStartHandler` type in `JoplinWorkspace.ts` was incorrect. The event is emitted here with no arguments:
  https://github.com/laurent22/joplin/blob/50d08cd1787628c10b2d589097b23edf151a1038/packages/lib/Synchronizer.ts#L417
  However, `JoplinWorkspace.ts` defined the event type as `{ hasErrors: boolean; }`. As such, this pull request fixes the type in `JoplinWorkspace.ts`.
- `NoteTypeToggle` are emitted in both `NoteListUtils.ts` and [`toggleNoteType.ts`](https://github.com/laurent22/joplin/blob/50d08cd1787628c10b2d589097b23edf151a1038/packages/app-desktop/gui/MainScreen/commands/toggleNoteType.ts#L25). Only `toggleNoteType.ts` attached information about the note that triggered the event. To avoid making `note` an optional property, the saved note is now also attached in `NoteListUtils.ts`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->