### PR TITLE
Mobile: Describe the plugin settings page #10207

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginInfoButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginInfoButton.tsx
@@ -7,6 +7,7 @@ import getPluginIssueReportUrl from '@joplin/lib/services/plugins/utils/getPlugi
 import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 import DismissibleDialog from '../../../../DismissibleDialog';
 import openWebsiteForPlugin from '../utils/openWebsiteForPlugin';
+import categoryColors from './categoryColors';
 
 interface Props {
 	themeId: number;
@@ -28,6 +29,24 @@ const styles = StyleSheet.create({
 	fraudulentPluginButton: {
 		opacity: 0.6,
 	},
+	categoryContainer: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		marginTop: 10,
+		marginBottom: 10,
+	},
+	categoryBadge: {
+		paddingHorizontal: 8,
+		paddingVertical: 4,
+		borderRadius: 15,
+		marginRight: 5,
+		marginBottom: 5,
+		alignSelf: 'flex-start',
+	},
+	categoryText: {
+		color: 'white',
+		fontWeight: 'bold',
+	},
 });
 
 const PluginInfoModal: React.FC<Props> = props => {
@@ -38,6 +57,31 @@ const PluginInfoModal: React.FC<Props> = props => {
 			<Text style={styles.descriptionText}>{props.item.manifest.description ?? _('No description')}</Text>
 		</View>
 	);
+
+	const renderCategories = () => {
+		const categories = props.item.manifest.categories || [];
+
+		if (!categories || categories.length === 0) {
+			return (
+				<View style={[styles.categoryBadge, { backgroundColor: 'gray' }]}>
+					<Text style={styles.categoryText}>{_('Other')}</Text>
+				</View>
+			);
+		}
+
+		return (
+			<View style={styles.categoryContainer}>
+				{categories.map((category, index) => {
+					const lowerCaseCategory = category.toLowerCase();
+					return (
+						<View key={index} style={[styles.categoryBadge, { backgroundColor: categoryColors[lowerCaseCategory] }]}>
+							<Text style={styles.categoryText}>{category}</Text>
+						</View>
+					);
+				})}
+			</View>
+		);
+	};
 
 	const onAboutPress = useCallback(() => {
 		void openWebsiteForPlugin({ item: props.item });
@@ -63,6 +107,18 @@ const PluginInfoModal: React.FC<Props> = props => {
 		void Linking.openURL('https://github.com/laurent22/joplin/security/advisories/new');
 	}, []);
 
+	const onRepositoryPress = useCallback(() => {
+		if (props.item.manifest.repository_url) {
+			void Linking.openURL(props.item.manifest.repository_url);
+		}
+	}, [props.item.manifest.repository_url]);
+
+	const onHomepagePress = useCallback(() => {
+		if (props.item.manifest.homepage_url) {
+			void Linking.openURL(props.item.manifest.homepage_url);
+		}
+	}, [props.item.manifest.homepage_url]);
+
 	return (
 		<Portal>
 			<DismissibleDialog
@@ -72,11 +128,26 @@ const PluginInfoModal: React.FC<Props> = props => {
 			>
 				<ScrollView>
 					{aboutPlugin}
+					{renderCategories()}
 					<List.Item
 						left={props => <List.Icon {...props} icon='web'/>}
 						title={_('About')}
 						onPress={onAboutPress}
 					/>
+					{props.item.manifest.repository_url && (
+						<List.Item
+							left={props => <List.Icon {...props} icon='source-repository'/>}
+							title={_('Plugin\'s Repository')}
+							onPress={onRepositoryPress}
+						/>
+					)}
+					{props.item.manifest.homepage_url && (
+						<List.Item
+							left={props => <List.Icon {...props} icon='home'/>}
+							title={_('Plugin\'s Homepage')}
+							onPress={onHomepagePress}
+						/>
+					)}
 					{ reportIssueUrl ? reportIssueButton : null }
 				</ScrollView>
 				<Button

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/categoryColors.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/categoryColors.tsx
@@ -1,0 +1,15 @@
+const categoryColors: { [key: string]: string } = {
+	'appearance': '#1E90FF',
+	'developer tools': '#32CD32',
+	'productivity': '#FFA500',
+	'themes': '#FF69B4',
+	'integrations': '#8A2BE2',
+	'viewer': '#FF6347',
+	'search': '#4682B4',
+	'tags': '#ADFF2F',
+	'editor': '#FFD700',
+	'files': '#D2691E',
+	'personal knowledge management': '#9400D3',
+};
+
+export default categoryColors;

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -7,6 +7,7 @@ import shim from '@joplin/lib/shim';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
 import ActionButton, { PluginCallback } from './ActionButton';
 import PluginInfoButton from './PluginInfoButton';
+import categoryColors from './categoryColors';
 
 export enum InstallState {
 	NotInstalled,
@@ -65,6 +66,29 @@ const styles = StyleSheet.create({
 	title: {
 		// Prevents the title text from being clipped on Android
 		verticalAlign: 'middle',
+	},
+	cardHeader: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		position: 'relative',
+	},
+	categoryBadgeContainer: {
+		position: 'absolute',
+		top: 10,
+		right: 10,
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+	categoryBadge: {
+		paddingHorizontal: 8,
+		paddingVertical: 4,
+		borderRadius: 15,
+		marginLeft: 4,
+	},
+	categoryText: {
+		color: 'white',
+		fontWeight: 'bold',
 	},
 });
 
@@ -171,7 +195,11 @@ const PluginBox: React.FC<Props> = props => {
 		// If .onAboutPress is given (e.g. when searching), there's another way to get information
 		// about the plugin. In this case, we don't show the right-side information link.
 		if (props.onAboutPress) return null;
-		return <PluginInfoButton {...buttonProps} themeId={props.themeId} item={props.item}/>;
+		return (
+			<View style={{ paddingTop: 25 }}>
+				<PluginInfoButton {...buttonProps} themeId={props.themeId} item={props.item}/>
+			</View>
+		);
 	};
 
 	const updateStateIsIdle = props.updateState !== UpdateState.Idle;
@@ -179,15 +207,47 @@ const PluginBox: React.FC<Props> = props => {
 	const titleComponent = <>
 		<Text variant='titleMedium'>{manifest.name}</Text> <Text variant='bodySmall' style={styles.versionText}>v{manifest.version}</Text>
 	</>;
+
+	const renderCategoryBadge = () => {
+		if (!manifest.categories || manifest.categories.length === 0) {
+			return (
+				<View style={styles.categoryBadgeContainer}>
+					<View style={[styles.categoryBadge, { backgroundColor: categoryColors['other'] || 'gray' }]}>
+						<Text style={styles.categoryText}>{_('Other')}</Text>
+					</View>
+				</View>
+			);
+		}
+
+		const category = manifest.categories[0].toLowerCase();
+		const backgroundColor = categoryColors[category] || 'gray';
+
+		return (
+			<View style={styles.categoryBadgeContainer}>
+				<View style={[styles.categoryBadge, { backgroundColor }]}>
+					<Text style={styles.categoryText}>{manifest.categories[0]}</Text>
+				</View>
+				{manifest.categories.length > 1 && (
+					<View style={[styles.categoryBadge, { backgroundColor: 'gray' }]}>
+						<Text style={styles.categoryText}>+</Text>
+					</View>
+				)}
+			</View>
+		);
+	};
+
 	return (
 		<Card style={{ margin: 8, opacity: props.isCompatible ? undefined : 0.75 }} testID='plugin-card'>
-			<Card.Title
-				title={titleComponent}
-				titleStyle={styles.title}
-				subtitle={manifest.description}
-				left={PluginIcon}
-				right={renderRightEdgeButton}
-			/>
+			<View style={styles.cardHeader}>
+				<Card.Title
+					title={titleComponent}
+					titleStyle={styles.title}
+					subtitle={manifest.description}
+					left={PluginIcon}
+					right={renderRightEdgeButton}
+				/>
+				{renderCategoryBadge()}
+			</View>
 			<Card.Content>
 				<View style={{ flexDirection: 'row' }}>
 					{renderIncompatibleChip()}

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -228,6 +228,31 @@ export default class RepositoryApi {
 		return output;
 	}
 
+	public async filterSearch(results: PluginManifest[], category: string): Promise<PluginManifest[]> {
+		const output: PluginManifest[] = [];
+
+		for (const manifest of results) {
+			const v = manifest.categories;
+			if (!v) continue;
+
+			if (manifest.categories.includes(category)) {
+				output.push(manifest);
+			}
+		}
+
+		output.sort((m1, m2) => {
+			const m1Compatible = isCompatible(this.appVersion_, this.appType_, m1);
+			const m2Compatible = isCompatible(this.appVersion_, this.appType_, m2);
+			if (m1Compatible && !m2Compatible) return -1;
+			if (!m1Compatible && m2Compatible) return 1;
+			if (m1._recommended && !m2._recommended) return -1;
+			if (!m1._recommended && m2._recommended) return +1;
+			return m1.name.toLowerCase() < m2.name.toLowerCase() ? -1 : +1;
+		});
+
+		return output;
+	}
+
 	// Returns a temporary path, where the plugin has been downloaded to. Temp
 	// file should be deleted by caller.
 	public async downloadPlugin(pluginId: string): Promise<string> {


### PR DESCRIPTION
We chose not to proceed with the functionality topic related to GitHub
 mirror because during our analysis of the code in the mobile app, we
did not fully comprehend how integrating with GitHub mirror would be
 beneficial for the project. 
 We tried to fully understand how GitHub
mirror works and how it could be integrated into our project, but we
 concluded that the part of the code related to plugins did not seem
 suitable for using this functionality. 
 As we were unable to clearly
discern the objective or the benefits that GitHub mirror would bring
 in this specific context, we decided to direct our efforts to areas of
the project where we could have a more immediate and understandable impact.

We focused on the area of plugin categories. First and foremost, it's important to note that a single plugin can belong to more than one category. However, upon reviewing the plugins page, we found that the immediate information available (without clicking on each plugin's description) seemed insufficient in terms of providing comprehensive details about the categories each plugin falls into. Therefore, the first functionality we implemented was on the plugin search page, displaying one of the categories to which each plugin belonged. If a plugin belonged to more than one category, we showed the symbol "+" as there wasn't enough space to list them all.

Additionally, if a plugin didn't belong to any specific category, we added "Other" to indicate its classification.
We also added a plugin search filter by category, and on each specific plugin page, we included all of its categories.

Here are some screenshots demonstrating what we implemented:

![image](https://github.com/laurent22/joplin/assets/93351930/1736f78a-413c-4754-aa4c-a24310d5f9ed)

Plugin box:

![image](https://github.com/laurent22/joplin/assets/93351930/598495e5-6887-40c7-89fa-12e79ebf488d)

Filtered by... :

![image](https://github.com/laurent22/joplin/assets/93351930/3bccb998-b7c0-4891-9762-6ee109ff8c9a)

Filtered by "productivity" example:

![image](https://github.com/laurent22/joplin/assets/93351930/b571fa50-3937-4062-94b5-141c27ff854e)

