### PR TITLE
Desktop: Fixes #10514: Fix focusing the note list doesn't work when the selected note is off screen

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -65,7 +65,7 @@ const NoteList = (props: Props) => {
 		props.notes.length,
 	);
 
-	const focusNote = useFocusNote(itemRefs);
+	const focusNote = useFocusNote(itemRefs, props.notes, makeItemIndexVisible);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -4,9 +4,9 @@ import { focus } from '@joplin/lib/utils/focusHandler';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
 export type FocusNote = (noteId: string)=> void;
-
 type ItemRefs = MutableRefObject<Record<string, HTMLDivElement>>;
 type OnMakeIndexVisible = (i: number)=> void;
+
 const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible) => {
 	const focusItemIID = useRef(null);
 
@@ -16,8 +16,9 @@ const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisi
 	const focusNote: FocusNote = useCallback((noteId: string) => {
 		// - We need to focus the item manually otherwise focus might be lost when the
 		//   list is scrolled and items within it are being rebuilt.
-		// - We need to use an interval because when leaving the arrow pressed, the rendering
-		//   of items might lag behind and so the ref is not yet available at this point.
+		// - We need to use an interval because when leaving the arrow pressed or scrolling
+		//   offscreen items into view, the rendering of items might lag behind and so the
+		//   ref is not yet available at this point.
 
 		if (!itemRefs.current[noteId]) {
 			const targetIndex = notesRef.current.findIndex(note => note.id === noteId);

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -1,11 +1,17 @@
 import shim from '@joplin/lib/shim';
 import { useRef, useCallback, MutableRefObject } from 'react';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import { NoteEntity } from '@joplin/lib/services/database/types';
 
 export type FocusNote = (noteId: string)=> void;
 
-const useFocusNote = (itemRefs: MutableRefObject<Record<string, HTMLDivElement>>) => {
+type ItemRefs = MutableRefObject<Record<string, HTMLDivElement>>;
+type OnMakeIndexVisible = (i: number)=> void;
+const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible) => {
 	const focusItemIID = useRef(null);
+
+	const notesRef = useRef(notes);
+	notesRef.current = notes;
 
 	const focusNote: FocusNote = useCallback((noteId: string) => {
 		// - We need to focus the item manually otherwise focus might be lost when the
@@ -14,6 +20,11 @@ const useFocusNote = (itemRefs: MutableRefObject<Record<string, HTMLDivElement>>
 		//   of items might lag behind and so the ref is not yet available at this point.
 
 		if (!itemRefs.current[noteId]) {
+			const targetIndex = notesRef.current.findIndex(note => note.id === noteId);
+			if (targetIndex > -1) {
+				makeItemIndexVisible(targetIndex);
+			}
+
 			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
 			focusItemIID.current = shim.setInterval(() => {
 				if (itemRefs.current[noteId]) {
@@ -26,7 +37,7 @@ const useFocusNote = (itemRefs: MutableRefObject<Record<string, HTMLDivElement>>
 			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
 			focus('useFocusNote2', itemRefs.current[noteId]);
 		}
-	}, [itemRefs]);
+	}, [itemRefs, makeItemIndexVisible]);
 
 	return focusNote;
 };


### PR DESCRIPTION
# Summary

This pull request fixes #10514 by scrolling the selected note list item into view before attempting to focus it.

Previously, calling `focusNote` would not focus the selected note if not visible in the note list.

# Testing plan

1. Open a notebook with a large number of notes.
2. Select a note.
3. Press and hold the down arrow to scroll down.
4. Verify that the note list scrolls.
5. Scroll the note list such that the currently selected note is offscreen.
6. Click on the current notebook in the notebook list.
7. Press <kbd>tab</kbd>.
8. Verify that the note list has scrolled the selected note into view.
9. Scroll the selected note offscreen.
10. Open the command palette and run `:focusElementNoteList`
11. Verify that the selected note has been focused.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->