### PR TITLE
Desktop: Fixes #10466: Fix tables missing source map attributes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1291,6 +1291,7 @@ packages/renderer/MdToHtml/rules/mermaid.js
 packages/renderer/MdToHtml/rules/sanitize_html.js
 packages/renderer/MdToHtml/rules/source_map.js
 packages/renderer/MdToHtml/rules/tableHorizontallyScrollable.js
+packages/renderer/MdToHtml/rules/utils/defaultRule.js
 packages/renderer/MdToHtml/setupLinkify.js
 packages/renderer/MdToHtml/validateLinks.js
 packages/renderer/assetsToHeaders.js

--- a/.gitignore
+++ b/.gitignore
@@ -1270,6 +1270,7 @@ packages/renderer/MdToHtml/rules/mermaid.js
 packages/renderer/MdToHtml/rules/sanitize_html.js
 packages/renderer/MdToHtml/rules/source_map.js
 packages/renderer/MdToHtml/rules/tableHorizontallyScrollable.js
+packages/renderer/MdToHtml/rules/utils/defaultRule.js
 packages/renderer/MdToHtml/setupLinkify.js
 packages/renderer/MdToHtml/validateLinks.js
 packages/renderer/assetsToHeaders.js

--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -49,6 +49,8 @@ describe('MdToHtml', () => {
 						checkboxRenderingType: 2,
 					},
 				};
+			} else if (mdFilename.startsWith('sourcemap_')) {
+				mdToHtmlOptions.mapsToLine = true;
 			}
 
 			const markdown = await shim.fsDriver().readFile(mdFilePath);

--- a/packages/app-cli/tests/md_to_html/sourcemap_table.html
+++ b/packages/app-cli/tests/md_to_html/sourcemap_table.html
@@ -1,0 +1,21 @@
+<div class="joplin-table-wrapper">
+<table class="maps-to-line" source-line="0" source-line-end="3">
+<thead>
+<tr>
+<th>This</th>
+<th>is</th>
+<th>a</th>
+<th>test</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>This</td>
+<td>table</td>
+<td>has</td>
+<td>line numbers</td>
+</tr>
+</tbody>
+</table>
+</div>
+<p class="maps-to-line" source-line="4" source-line-end="5">When <code class="inline-code">mapsToLine</code> is enabled for this file, the table above should have line numbers that link to the original markdown.</p>

--- a/packages/app-cli/tests/md_to_html/sourcemap_table.md
+++ b/packages/app-cli/tests/md_to_html/sourcemap_table.md
@@ -1,0 +1,5 @@
+| This | is | a | test |
+|------|----|---|------|
+| This | table | has | line numbers |
+
+When `mapsToLine` is enabled for this file, the table above should have line numbers that link to the original markdown.

--- a/packages/renderer/MdToHtml/rules/tableHorizontallyScrollable.ts
+++ b/packages/renderer/MdToHtml/rules/tableHorizontallyScrollable.ts
@@ -1,18 +1,21 @@
-import * as MarkdownIt from 'markdown-it';
+import type * as MarkdownIt from 'markdown-it';
+import type * as Renderer from 'markdown-it/lib/renderer';
+import defaultRule from './utils/defaultRule';
 
 export default {
 	// Make table horizontally scrollable by give table a div parent, so the width of the table is limited to the screen width.
 	// see https://github.com/laurent22/joplin/pull/10161
 	plugin: (markdownIt: MarkdownIt) => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		markdownIt.renderer.rules.table_open = function(tokens: MarkdownIt.Token[], idx: number, options: MarkdownIt.Options, _env: any, renderer: any) {
-			const current = renderer.renderToken(tokens, idx, options);
+		const defaultTableOpen = defaultRule(markdownIt, 'table_open');
+		markdownIt.renderer.rules.table_open = function(tokens: MarkdownIt.Token[], idx: number, options: MarkdownIt.Options, env: unknown, renderer: Renderer) {
+			const current = defaultTableOpen(tokens, idx, options, env, renderer);
 			// joplin-table-wrapper css is set in packages/renderer/noteStyle.ts
 			return `<div class="joplin-table-wrapper">\n${current}`;
 		};
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		markdownIt.renderer.rules.table_close = function(tokens: MarkdownIt.Token[], idx: number, options: MarkdownIt.Options, _env: any, renderer: any) {
-			const current = renderer.renderToken(tokens, idx, options);
+
+		const defaultTableClose = defaultRule(markdownIt, 'table_close');
+		markdownIt.renderer.rules.table_close = function(tokens: MarkdownIt.Token[], idx: number, options: MarkdownIt.Options, env: unknown, renderer: Renderer) {
+			const current = defaultTableClose(tokens, idx, options, env, renderer);
 			return `${current}</div>\n`;
 		};
 	},

--- a/packages/renderer/MdToHtml/rules/utils/defaultRule.ts
+++ b/packages/renderer/MdToHtml/rules/utils/defaultRule.ts
@@ -1,0 +1,9 @@
+import type * as MarkdownIt from 'markdown-it';
+import type * as Renderer from 'markdown-it/lib/renderer';
+
+const defaultRule = (markdownIt: MarkdownIt, key: keyof Renderer.RenderRuleRecord): Renderer.RenderRule => {
+	if (markdownIt.renderer.rules[key]) return markdownIt.renderer.rules[key];
+	return (tokens, idx, options, _env, renderer) => renderer.renderToken(tokens, idx, options);
+};
+
+export default defaultRule;


### PR DESCRIPTION
# Summary

This pull request fixes #10466 by causing [tableHorizontallyScrollable.ts](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/desktop/fix-missing-table-start-end?expand=1#diff-6f555b4acdd9ed6ad71d31cb37dc0fa299502e37319fdbc207929dd524b781ba) to use an existing renderer rule internally for `table_open` and `table_close`, if it exists, when rendering a table.

Previously, the `table_open` renderer rule assigned by the `table_open` rule was ignored.

# Testing plan

This pull request includes an automated test. It has also been tested manually by creating a note with a table and verifying that the table has `source-line` and `source-line-end` attributes.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->