### PR TITLE
Mobile: Show WebView version in settings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -692,6 +692,7 @@ packages/app-mobile/utils/fs-driver/tarExtract.js
 packages/app-mobile/utils/fs-driver/testUtil/createFilesFromPathRecord.js
 packages/app-mobile/utils/fs-driver/testUtil/verifyDirectoryMatches.js
 packages/app-mobile/utils/getPackageInfo.js
+packages/app-mobile/utils/getVersionInfoText.js
 packages/app-mobile/utils/initializeCommandService.js
 packages/app-mobile/utils/ipc/RNToWebViewMessenger.js
 packages/app-mobile/utils/ipc/WebViewToRNMessenger.js

--- a/.gitignore
+++ b/.gitignore
@@ -671,6 +671,7 @@ packages/app-mobile/utils/fs-driver/tarExtract.js
 packages/app-mobile/utils/fs-driver/testUtil/createFilesFromPathRecord.js
 packages/app-mobile/utils/fs-driver/testUtil/verifyDirectoryMatches.js
 packages/app-mobile/utils/getPackageInfo.js
+packages/app-mobile/utils/getVersionInfoText.js
 packages/app-mobile/utils/initializeCommandService.js
 packages/app-mobile/utils/ipc/RNToWebViewMessenger.js
 packages/app-mobile/utils/ipc/WebViewToRNMessenger.js

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.kt
@@ -11,7 +11,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
-import net.cozic.joplin.debug.DebugPackage
+import net.cozic.joplin.versioninfo.SystemVersionInformationPackage
 import net.cozic.joplin.share.SharePackage
 import net.cozic.joplin.ssl.SslPackage
 import net.cozic.joplin.textinput.TextInputPackage
@@ -24,7 +24,7 @@ class MainApplication : Application(), ReactApplication {
                     add(SharePackage())
                     add(SslPackage())
                     add(TextInputPackage())
-                    add(DebugPackage())
+                    add(SystemVersionInformationPackage())
                 }
 
         override fun getJSMainModuleName(): String = "index"

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/MainApplication.kt
@@ -11,6 +11,7 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.soloader.SoLoader
+import net.cozic.joplin.debug.DebugPackage
 import net.cozic.joplin.share.SharePackage
 import net.cozic.joplin.ssl.SslPackage
 import net.cozic.joplin.textinput.TextInputPackage
@@ -23,6 +24,7 @@ class MainApplication : Application(), ReactApplication {
                     add(SharePackage())
                     add(SslPackage())
                     add(TextInputPackage())
+                    add(DebugPackage())
                 }
 
         override fun getJSMainModuleName(): String = "index"

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/debug/DebugPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/debug/DebugPackage.java
@@ -21,40 +21,40 @@ import java.util.Map;
 
 public class DebugPackage implements ReactPackage {
 
-    @NonNull
-    @Override
-    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
-        return Collections.singletonList(new DebugModule(reactContext));
-    }
+	@NonNull
+	@Override
+	public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+		return Collections.singletonList(new DebugModule(reactContext));
+	}
 
-    @NonNull
-    @Override
-    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
-        return Collections.emptyList();
-    }
+	@NonNull
+	@Override
+	public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+		return Collections.emptyList();
+	}
 
-    public static class DebugModule extends ReactContextBaseJavaModule {
-        public DebugModule(@NonNull ReactApplicationContext context) {
-            super(context);
-        }
+	public static class DebugModule extends ReactContextBaseJavaModule {
+		public DebugModule(@NonNull ReactApplicationContext context) {
+			super(context);
+		}
 
-        @Override
+		@Override
 		public Map<String, Object> getConstants() {
-            final Map<String, Object> result = new HashMap<String, Object>();
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                PackageInfo webViewPackage = WebView.getCurrentWebViewPackage();
+			final Map<String, Object> result = new HashMap<String, Object>();
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				PackageInfo webViewPackage = WebView.getCurrentWebViewPackage();
 
-                if (webViewPackage != null) {
-                    result.put("webViewVersion", webViewPackage.versionName);
-                }
-            }
-            return result;
-        }
+				if (webViewPackage != null) {
+					result.put("webViewVersion", webViewPackage.versionName);
+				}
+			}
+			return result;
+		}
 
-        @NonNull
-        @Override
-        public String getName() {
-            return "DebugModule";
-        }
-    }
+		@NonNull
+		@Override
+		public String getName() {
+			return "DebugModule";
+		}
+	}
 }

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/debug/DebugPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/debug/DebugPackage.java
@@ -1,0 +1,60 @@
+package net.cozic.joplin.debug;
+
+import android.content.pm.PackageInfo;
+import android.os.Build;
+import android.webkit.WebView;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+
+import androidx.annotation.NonNull;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DebugPackage implements ReactPackage {
+
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+        return Collections.singletonList(new DebugModule(reactContext));
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    public static class DebugModule extends ReactContextBaseJavaModule {
+        public DebugModule(@NonNull ReactApplicationContext context) {
+            super(context);
+        }
+
+        @Override
+		public Map<String, Object> getConstants() {
+            final Map<String, Object> result = new HashMap<String, Object>();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                PackageInfo webViewPackage = WebView.getCurrentWebViewPackage();
+
+                if (webViewPackage != null) {
+                    result.put("webViewVersion", webViewPackage.versionName);
+                }
+            }
+            return result;
+        }
+
+        @NonNull
+        @Override
+        public String getName() {
+            return "DebugModule";
+        }
+    }
+}

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/versioninfo/SystemVersionInformationPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/versioninfo/SystemVersionInformationPackage.java
@@ -46,6 +46,7 @@ public class SystemVersionInformationPackage implements ReactPackage {
 
 				if (webViewPackage != null) {
 					result.put("webViewVersion", webViewPackage.versionName);
+					result.put("webViewPackage", webViewPackage.packageName);
 				}
 			}
 			return result;

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/versioninfo/SystemVersionInformationPackage.java
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/versioninfo/SystemVersionInformationPackage.java
@@ -1,4 +1,4 @@
-package net.cozic.joplin.debug;
+package net.cozic.joplin.versioninfo;
 
 import android.content.pm.PackageInfo;
 import android.os.Build;
@@ -19,12 +19,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class DebugPackage implements ReactPackage {
+public class SystemVersionInformationPackage implements ReactPackage {
 
 	@NonNull
 	@Override
 	public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
-		return Collections.singletonList(new DebugModule(reactContext));
+		return Collections.singletonList(new SystemVersionInformationModule(reactContext));
 	}
 
 	@NonNull
@@ -33,8 +33,8 @@ public class DebugPackage implements ReactPackage {
 		return Collections.emptyList();
 	}
 
-	public static class DebugModule extends ReactContextBaseJavaModule {
-		public DebugModule(@NonNull ReactApplicationContext context) {
+	public static class SystemVersionInformationModule extends ReactContextBaseJavaModule {
+		public SystemVersionInformationModule(@NonNull ReactApplicationContext context) {
 			super(context);
 		}
 
@@ -54,7 +54,7 @@ public class DebugPackage implements ReactPackage {
 		@NonNull
 		@Override
 		public String getName() {
-			return "DebugModule";
+			return "SystemVersionInformationModule";
 		}
 	}
 }

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -33,8 +33,7 @@ import PluginUploadButton, { canInstallPluginsFromFile, buttonLabel as pluginUpl
 import NoteImportButton, { importButtonDefaultTitle, importButtonDescription } from './NoteExportSection/NoteImportButton';
 import SectionDescription from './SectionDescription';
 import EnablePluginSupportPage from './plugins/EnablePluginSupportPage';
-import getPackageInfo from '../../../utils/getPackageInfo';
-import versionInfo from '@joplin/lib/versionInfo';
+import getVersionInfoText from '../../../utils/getVersionInfoText';
 
 interface ConfigScreenState {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -619,15 +618,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 			addSettingLink('website_link', _('Joplin website'), 'https://joplinapp.org/');
 			addSettingLink('privacy_link', _('Privacy Policy'), 'https://joplinapp.org/privacy/');
 
-			const packageInfo = getPackageInfo();
-			const appInfo = versionInfo(packageInfo, PluginService.instance().enabledPlugins(settings['plugins.states']));
-			const versionInfoText = [
-				appInfo.body,
-				'',
-				_('FTS enabled: %d', this.props.settings['db.ftsEnabled']),
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				_('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0),
-			].join('\n');
+			const versionInfoText = getVersionInfoText(settings['plugins.states']);
 
 			addSettingText('version_info', versionInfoText);
 			addSettingButton('copy_app_info', _('Copy version info'), () => {

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -1,0 +1,40 @@
+import versionInfo from '@joplin/lib/versionInfo';
+import { Platform, NativeModules } from 'react-native';
+import getPackageInfo from './getPackageInfo';
+import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import Setting from '@joplin/lib/models/Setting';
+import { _ } from '@joplin/lib/locale';
+
+const getWebViewVersion = (): string|null => {
+	if (Platform.OS === 'android') {
+		const constants = NativeModules.DebugModule.getConstants();
+		return constants.webViewVersion;
+	}
+	return null;
+};
+
+const getOSVersion = (): string => {
+	if (Platform.OS === 'android') {
+		return `API ${Platform.Version}`;
+	} else {
+		return Platform.Version as string;
+	}
+};
+
+const getVersionInfoText = (pluginStates: PluginSettings) => {
+	const packageInfo = getPackageInfo();
+	const appInfo = versionInfo(packageInfo, PluginService.instance().enabledPlugins(pluginStates));
+	const webViewVersion = getWebViewVersion();
+	const versionInfoText = [
+		appInfo.body,
+		'',
+		webViewVersion ? _('WebView version: %s', webViewVersion) : '',
+		_('OS version: %s', getOSVersion()),
+		_('FTS enabled: %d', Setting.value('db.ftsEnabled')),
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		_('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0),
+	].join('\n');
+	return versionInfoText;
+};
+
+export default getVersionInfoText;

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -15,7 +15,7 @@ const getWebViewVersion = (): string|null => {
 
 const getOSVersion = (): string => {
 	if (Platform.OS === 'android') {
-		return _('Android version: %s', `API ${Platform.Version}`);
+		return _('Android API level: %d', Platform.Version);
 	} else {
 		return _('iOS version: %s', Platform.Version);
 	}
@@ -24,17 +24,24 @@ const getOSVersion = (): string => {
 const getVersionInfoText = (pluginStates: PluginSettings) => {
 	const packageInfo = getPackageInfo();
 	const appInfo = versionInfo(packageInfo, PluginService.instance().enabledPlugins(pluginStates));
-	const webViewVersion = getWebViewVersion();
-	const versionInfoText = [
+	const versionInfoLines = [
 		appInfo.body,
 		'',
-		webViewVersion ? _('WebView version: %s', webViewVersion) : '',
+	];
+
+	const webViewVersion = getWebViewVersion();
+	if (webViewVersion) {
+		versionInfoLines.push(_('WebView version: %s', webViewVersion));
+	}
+
+	versionInfoLines.push(
 		getOSVersion(),
 		_('FTS enabled: %d', Setting.value('db.ftsEnabled')),
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code before rule was applied
 		_('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0),
-	].join('\n');
-	return versionInfoText;
+	);
+
+	return versionInfoLines.join('\n');
 };
 
 export default getVersionInfoText;

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -5,10 +5,13 @@ import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/Plug
 import Setting from '@joplin/lib/models/Setting';
 import { _ } from '@joplin/lib/locale';
 
-const getWebViewVersion = (): string|null => {
+const getWebViewVersionText = () => {
 	if (Platform.OS === 'android') {
 		const constants = NativeModules.SystemVersionInformationModule.getConstants();
-		return constants.webViewVersion;
+		return [
+			_('WebView version: %s', constants.webViewVersion),
+			_('WebView package: %s', constants.webViewPackage),
+		].join('\n');
 	}
 	return null;
 };
@@ -27,15 +30,15 @@ const getVersionInfoText = (pluginStates: PluginSettings) => {
 	const versionInfoLines = [
 		appInfo.body,
 		'',
+		getOSVersion(),
 	];
 
-	const webViewVersion = getWebViewVersion();
+	const webViewVersion = getWebViewVersionText();
 	if (webViewVersion) {
-		versionInfoLines.push(_('WebView version: %s', webViewVersion));
+		versionInfoLines.push(webViewVersion);
 	}
 
 	versionInfoLines.push(
-		getOSVersion(),
 		_('FTS enabled: %d', Setting.value('db.ftsEnabled')),
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code before rule was applied
 		_('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0),

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -7,7 +7,7 @@ import { _ } from '@joplin/lib/locale';
 
 const getWebViewVersion = (): string|null => {
 	if (Platform.OS === 'android') {
-		const constants = NativeModules.DebugModule.getConstants();
+		const constants = NativeModules.SystemVersionInformationModule.getConstants();
 		return constants.webViewVersion;
 	}
 	return null;

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -15,9 +15,9 @@ const getWebViewVersion = (): string|null => {
 
 const getOSVersion = (): string => {
 	if (Platform.OS === 'android') {
-		return `API ${Platform.Version}`;
+		return _('Android version: %s', `API ${Platform.Version}`);
 	} else {
-		return Platform.Version as string;
+		return _('iOS version: %s', Platform.Version);
 	}
 };
 
@@ -29,7 +29,7 @@ const getVersionInfoText = (pluginStates: PluginSettings) => {
 		appInfo.body,
 		'',
 		webViewVersion ? _('WebView version: %s', webViewVersion) : '',
-		_('OS version: %s', getOSVersion()),
+		getOSVersion(),
 		_('FTS enabled: %d', Setting.value('db.ftsEnabled')),
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		_('Hermes enabled: %d', (global as any).HermesInternal ? 1 : 0),


### PR DESCRIPTION
# Summary

This pull request adds OS and, on Android, WebView versions to the version info section in settings.

# Rationale

An outdated WebView version can mean that some APIs are unavailable. As such, having the system WebView version can help debug note editor and plugin issues because both use WebViews.

In particular, knowing the system WebView version could help [debug this issue](https://discourse.joplinapp.org/t/cursor-jumps-to-character-before-position-on-android-v3-0-3-release-from-github/38325).

# Screenshot

<img alt="webview version and api level listed at top of last block of info on the more information screen" src="https://github.com/laurent22/joplin/assets/46334387/501d65b2-fb2e-4322-a559-cfbf71a8882d" width="400"/>


# Testing plan

1. Open settings and navigate to the "more information" screen.
2. Verify that:
   - **On Android**: The WebView version and API levels are both visible.
   - **On iOS**: The OS version is visible.

This has been tested successfully on:
- [x] iOS
- [x] Android

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->