### PR TITLE
Chore: Remove unused `NoteTypeToggle` event

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/toggleNoteType.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/toggleNoteType.ts
@@ -1,7 +1,6 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
-import eventManager, { EventName } from '@joplin/lib/eventManager';
 
 export const declaration: CommandDeclaration = {
 	name: 'toggleNoteType',
@@ -15,14 +14,7 @@ export const runtime = (): CommandRuntime => {
 
 			for (let i = 0; i < noteIds.length; i++) {
 				const note = await Note.load(noteIds[i]);
-				const newNote = await Note.save(Note.toggleIsTodo(note), { userSideValidation: true });
-				const eventNote = {
-					id: newNote.id,
-					is_todo: newNote.is_todo,
-					todo_due: newNote.todo_due,
-					todo_completed: newNote.todo_completed,
-				};
-				eventManager.emit(EventName.NoteTypeToggle, { noteId: note.id, note: eventNote });
+				await Note.save(Note.toggleIsTodo(note), { userSideValidation: true });
 			}
 		},
 		enabledCondition: '!noteIsReadOnly',

--- a/packages/app-desktop/gui/utils/NoteListUtils.ts
+++ b/packages/app-desktop/gui/utils/NoteListUtils.ts
@@ -1,6 +1,5 @@
 import { utils as pluginUtils, PluginStates } from '@joplin/lib/services/plugins/reducer';
 import CommandService from '@joplin/lib/services/CommandService';
-import eventManager, { EventName } from '@joplin/lib/eventManager';
 import InteropService from '@joplin/lib/services/interop/InteropService';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import InteropServiceHelper from '../../InteropServiceHelper';
@@ -77,8 +76,7 @@ export default class NoteListUtils {
 						const note = await Note.load(noteIds[i]);
 						const newNote = Note.changeNoteType(note, type);
 						if (newNote === note) continue;
-						const savedNote = await Note.save(newNote, { userSideValidation: true });
-						eventManager.emit(EventName.NoteTypeToggle, { noteId: note.id, note: savedNote });
+						await Note.save(newNote, { userSideValidation: true });
 					}
 				};
 

--- a/packages/lib/eventManager.ts
+++ b/packages/lib/eventManager.ts
@@ -9,7 +9,6 @@ export enum EventName {
 	ResourceChange = 'resourceChange',
 	SettingsChange = 'settingsChange',
 	TodoToggle = 'todoToggle',
-	NoteTypeToggle = 'noteTypeToggle',
 	SyncStart = 'syncStart',
 	SessionEstablished = 'sessionEstablished',
 	SyncComplete = 'syncComplete',
@@ -48,7 +47,7 @@ interface SettingsChangeEvent {
 	keys: string[];
 }
 
-interface NoteChangeEvent {
+interface AlarmChangeEvent {
 	noteId: string;
 	note: NoteEntity;
 }
@@ -58,13 +57,12 @@ type EventArgs = {
 	[EventName.ResourceChange]: [ResourceChangeEvent];
 	[EventName.SettingsChange]: [SettingsChangeEvent];
 	[EventName.TodoToggle]: [];
-	[EventName.NoteTypeToggle]: [NoteChangeEvent];
 	[EventName.SyncStart]: [];
 	[EventName.SessionEstablished]: [];
 	[EventName.SyncComplete]: [SyncCompleteEvent];
 	[EventName.ItemChange]: [ItemChangeEvent];
 	[EventName.NoteAlarmTrigger]: [NoteAlarmTriggerEvent];
-	[EventName.AlarmChange]: [NoteChangeEvent];
+	[EventName.AlarmChange]: [AlarmChangeEvent];
 	[EventName.KeymapChange]: [];
 	[EventName.NoteContentChange]: [NoteContentChangeEvent];
 	[EventName.OcrServiceResourcesProcessed]: [];


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/laurent22/joplin/pull/10505. Based on a search through the git history, the last listener for NoteTypeToggle seems to have been removed in 51732a5adb72f9c3a2b95f4f9aa9f6e949aa3e42[^1].


[^1]: This is based on a search through the content of all git commits: `git log -p -G '(on|addListener).{1,10}noteTypeToggle'` (`-p`: "Patch format", `-G`: Check patch text for regex).

# Testing plan

1. Select multiple notes in the note list.
2. Click "switch to to-do type".
3. Check the console for errors and verify that the note types were changed.
4. Open the command palette and run `:toggleNoteType`.
5. Verify that the current note's type was changed.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->