### PR TITLE
Desktop: Fix importing completed tasks

### DIFF
--- a/packages/app-cli/tests/support/test_notes/yaml/not_a_task.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/not_a_task.md
@@ -1,0 +1,5 @@
+---
+title: Not a task
+---
+
+This is a note.

--- a/packages/app-cli/tests/support/test_notes/yaml/task_completed.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/task_completed.md
@@ -1,0 +1,6 @@
+---
+title: Task
+completed?: yes
+---
+
+This is a test. This task should import as completed.

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -193,4 +193,15 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 		expect(note.is_todo).toBe(1);
 		expect(note.todo_completed).toBeGreaterThan(0);
 	});
+
+	test('should import notes that are not tasks', async () => {
+		const note = await importTestFile('not_a_task.md');
+
+		expect(note).toMatchObject({
+			title: 'Not a task',
+			body: 'This is a note.',
+			is_todo: 0,
+			todo_completed: 0,
+		});
+	});
 });

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -194,7 +194,7 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 		expect(note.todo_completed).toBeGreaterThan(0);
 	});
 
-	test('should import notes that are not tasks', async () => {
+	it('should import notes that are not tasks', async () => {
 		const note = await importTestFile('not_a_task.md');
 
 		expect(note).toMatchObject({

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -184,4 +184,13 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 		const tags = (await Tag.tagsByNoteId(note.id)).map(tag => tag.title).sort();
 		expect(tags).toMatchObject(['tag1', 'tag2']);
 	});
+
+	it('should import completed tasks', async () => {
+		const note = await importTestFile('task_completed.md');
+
+		expect(note.title).toBe('Task');
+		expect(note.body).toBe('This is a test. This task should import as completed.\n');
+		expect(note.is_todo).toBe(1);
+		expect(note.todo_completed).toBeGreaterThan(0);
+	});
 });

--- a/packages/lib/utils/frontMatter.ts
+++ b/packages/lib/utils/frontMatter.ts
@@ -101,7 +101,7 @@ export const serialize = async (modNote: NoteEntity, tagTitles: string[]) => {
 };
 
 function isTruthy(str: string): boolean {
-	return str.toLowerCase() in ['true', 'yes'];
+	return ['true', 'yes'].includes(str.toLowerCase());
 }
 
 // Enforces exactly 2 spaces in front of list items
@@ -227,7 +227,7 @@ export const parse = (note: string): ParsedMeta => {
 	if (metadata.is_todo) {
 		if (isTruthy(md['completed?'])) {
 			// Completed time isn't preserved, so we use a sane choice here
-			metadata['todo_completed'] = metadata['user_updated_time'];
+			metadata['todo_completed'] = metadata['user_updated_time'] ?? Date.now();
 		}
 		if ('due' in md) {
 			const due_date = time.anythingToMs(md['due'], null);


### PR DESCRIPTION
# Summary

Previously, tasks with `completed?: yes` were imported as incomplete tasks (with `completed_time: 0`). This was caused by incorrect use of JavaScript's `in` with arrays.

This pull request fixes an issue observed while testing https://github.com/laurent22/joplin/pull/10448.

# Testing

This pull request adds two new automated tests:
- A test that covers the case where a task has `completed?: yes` and there is no `user_updated_time`. 
- A test that covers the case where `completed?` is not present (the note is not a task).
   - None of the existing tests check that `is_todo` is `0` after importing.

The case where `completed?` is `false` is tested by `'should import file and set all metadata correctly'`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->