### PR TITLE
Desktop: Beta editor: Fix crash when switching between notes that use CRLF line endings

### DIFF
--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -103,4 +103,14 @@ describe('CodeMirrorControl', () => {
 		control.execCommand('deleteLine');
 		expect(control.getValue()).toBe('Hello\n');
 	});
+
+	it('should replace the editor body in a document with CRLF', () => {
+		const initialContent = 'Hello\r\nWorld\r\na';
+		const control = createEditorControl(initialContent);
+		control.setCursor(1, initialContent.length);
+
+		control.updateBody('Hello\r\nWorld\r\n');
+		control.updateBody('Hello\r\nWorld\r\ntest');
+		control.updateBody('Hello\r\n');
+	});
 });

--- a/packages/editor/CodeMirror/CodeMirrorControl.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.ts
@@ -102,7 +102,11 @@ export default class CodeMirrorControl extends CodeMirror5Emulation implements E
 			// to ensure that the selection stays within the document
 			// (and thus avoids an exception).
 			const mainCursorPosition = this.editor.state.selection.main.anchor;
-			const newCursorPosition = Math.min(mainCursorPosition, newBody.length);
+
+			// The maximum cursor position needs to be calculated using the EditorState,
+			// to correctly account for line endings.
+			const maxCursorPosition = this.editor.state.toText(newBody).length;
+			const newCursorPosition = Math.min(mainCursorPosition, maxCursorPosition);
 
 			this.editor.dispatch(this.editor.state.update({
 				changes: {


### PR DESCRIPTION
# Summary

This pull request fixes a [crash originally reported on the forum](https://discourse.joplinapp.org/t/joplin-encountered-a-fatal-error-and-could-not-continue/38410?u=personalizedrefriger) while using the desktop beta editor.

See [a reply to that post](https://discourse.joplinapp.org/t/joplin-encountered-a-fatal-error-and-could-not-continue/38410/2?u=personalizedrefriger) for an explanation of this fix.

# Testing

This pull request adds an automated test that failed before changes to `CodeMirrorControl.ts` were made and now passes.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->