### PR TITLE
Desktop: Fixes #10416: Work around checkbox toggle broken when editor is hidden

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -352,7 +352,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 		return {
 			language: isHTMLNote ? EditorLanguageType.Html : EditorLanguageType.Markdown,
-			readOnly: props.disabled || props.visiblePanes.indexOf('editor') < 0,
+			readOnly: props.disabled,
 			katexEnabled: Setting.value('markdown.plugin.katex'),
 			themeData: {
 				...styles.globalTheme,
@@ -366,8 +366,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			indentWithTabs: true,
 		};
 	}, [
-		props.contentMarkupLanguage, props.disabled, props.visiblePanes,
-		props.keyboardMode, styles.globalTheme,
+		props.contentMarkupLanguage, props.disabled, props.keyboardMode, styles.globalTheme,
 	]);
 
 	// Update the editor's value


### PR DESCRIPTION
# Summary

This PR **works around** an upstream change in the codemirror-vim package (which we use for CM5 emulation). This **is a workaround**.

Currently, we use `codemirror-vim` to provided a polyfill for several CodeMirror 5 methods, including `replaceSelection`. `codemirror-vim` now disables some of these when the editor is read-only. (Ideally, we should not depend on this compatibility layer for core application logic or fork it).

Fixes #10416.

# Why was the editor marked as `readOnly` when hidden?

The CodeMirror 6 editor component is a fork of the CodeMirror 5 editor component. Based on the following comment ([added in this commit](https://github.com/laurent22/joplin/commit/a8c8539e7a5ba59030d6aa9f40c1cb3231e2c54a#diff-d198e16e9880a76c16b09901264fa7752a08a7883ed2047bdca358fb96a6064cR350)), I suspect that the editor was originally hidden in a different way:

https://github.com/laurent22/joplin/blob/32e16f6e518b08cee932419357baab509e7f77d2/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx#L694

The note viewer, for example, was historically hidden by setting its width to `1px`:

https://github.com/laurent22/joplin/commit/a8c8539e7a5ba59030d6aa9f40c1cb3231e2c54a#diff-d198e16e9880a76c16b09901264fa7752a08a7883ed2047bdca358fb96a6064cR362

If the CodeMirror editor was hidden in a similar way, it would still be focusable and thus need to be readonly.

Even if the editor is not marked as `readOnly` when only the viewer is visible, the correct commands remain disabled in the toolbar:
![screenshot: Most editor buttons disabled.](https://github.com/laurent22/joplin/assets/46334387/3563365a-1baa-4b80-a229-a6ef27282d5d)


# Testing plan

This pull request modifies the `CodeMirror.tsx` component, which currently does not have automated tests. Ideally, these automated tests would be run with either Playwright or [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)[^1]. This would be a large change, however.

This pull request can be manually tested with the following steps:
1. Create a new note with checkboxes. For example,
    ````md
    - [ ] test
    - [ ] test 2
    ````
2. Enable the beta editor (if not enabled).
3. Switch to view-only mode.
4. Check both checkboxes.
5. Show the editor.
6. Verify that the checkboxes are checked.

This has been tested successfully on Ubuntu 24.04.


[^1]: This would require adding a dependency. I propose this library because we currently depend on `@testing-library/react-hooks` and, on mobile, [React Native Testing Library](https://testing-library.com/docs/react-native-testing-library/intro). Playwright tests would also work here, but they can be more difficult to run and more fragile (as, with the current setup, they would require using Joplin's UI to enable the beta editor).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->