### PR TITLE
Mobile: Fix plugins not reloaded when the plugin runner reloads

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -674,6 +674,7 @@ packages/app-mobile/plugins/PluginRunner/dialogs/hooks/useWebViewSetup.js
 packages/app-mobile/plugins/PluginRunner/types.js
 packages/app-mobile/plugins/PluginRunner/utils/createOnLogHandler.js
 packages/app-mobile/plugins/hooks/usePlugin.js
+packages/app-mobile/plugins/loadPlugins.test.js
 packages/app-mobile/plugins/loadPlugins.js
 packages/app-mobile/root.js
 packages/app-mobile/services/AlarmServiceDriver.android.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -676,6 +676,7 @@ packages/app-mobile/plugins/PluginRunner/utils/createOnLogHandler.js
 packages/app-mobile/plugins/hooks/usePlugin.js
 packages/app-mobile/plugins/loadPlugins.test.js
 packages/app-mobile/plugins/loadPlugins.js
+packages/app-mobile/plugins/testing/MockPluginRunner.js
 packages/app-mobile/root.js
 packages/app-mobile/services/AlarmServiceDriver.android.js
 packages/app-mobile/services/AlarmServiceDriver.ios.js

--- a/.gitignore
+++ b/.gitignore
@@ -655,6 +655,7 @@ packages/app-mobile/plugins/PluginRunner/utils/createOnLogHandler.js
 packages/app-mobile/plugins/hooks/usePlugin.js
 packages/app-mobile/plugins/loadPlugins.test.js
 packages/app-mobile/plugins/loadPlugins.js
+packages/app-mobile/plugins/testing/MockPluginRunner.js
 packages/app-mobile/root.js
 packages/app-mobile/services/AlarmServiceDriver.android.js
 packages/app-mobile/services/AlarmServiceDriver.ios.js

--- a/.gitignore
+++ b/.gitignore
@@ -653,6 +653,7 @@ packages/app-mobile/plugins/PluginRunner/dialogs/hooks/useWebViewSetup.js
 packages/app-mobile/plugins/PluginRunner/types.js
 packages/app-mobile/plugins/PluginRunner/utils/createOnLogHandler.js
 packages/app-mobile/plugins/hooks/usePlugin.js
+packages/app-mobile/plugins/loadPlugins.test.js
 packages/app-mobile/plugins/loadPlugins.js
 packages/app-mobile/root.js
 packages/app-mobile/services/AlarmServiceDriver.android.js

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -29,12 +29,26 @@ jest.mock('react-native-device-info', () => {
 	};
 });
 
+// react-native-version-info doesn't work (returns undefined for .version) when
+// running in a testing environment.
+jest.doMock('react-native-version-info', () => {
+	return {
+		default: {
+			appVersion: require('./package.json').version,
+		},
+	};
+});
+
 // react-native-webview expects native iOS/Android code so needs to be mocked.
 jest.mock('react-native-webview', () => {
 	const { View } = require('react-native');
 	return {
 		WebView: View,
 	};
+});
+
+jest.mock('@react-native-clipboard/clipboard', () => {
+	return { default: { getString: jest.fn(), setString: jest.fn() } };
 });
 
 // react-native-fs's CachesDirectoryPath export doesn't work in a testing environment.

--- a/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/plugins/PluginRunner/PluginRunnerWebView.tsx
@@ -13,6 +13,7 @@ import { PluginHtmlContents, PluginStates } from '@joplin/lib/services/plugins/r
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import PluginDialogManager from './dialogs/PluginDialogManager';
 import { AppState } from '../../utils/types';
+import usePrevious from '@joplin/lib/hooks/usePrevious';
 
 const logger = Logger.create('PluginRunnerWebView');
 
@@ -28,15 +29,17 @@ const usePlugins = (
 	webviewLoaded: boolean,
 	pluginSettings: PluginSettings,
 ) => {
-	const store = useStore();
+	const store = useStore<AppState>();
+	const lastPluginRunner = usePrevious(pluginRunner);
+	const reloadAll = pluginRunner !== lastPluginRunner;
 
 	useAsyncEffect(async (event) => {
 		if (!webviewLoaded) {
 			return;
 		}
 
-		void loadPlugins(pluginRunner, pluginSettings, store, event);
-	}, [pluginRunner, store, webviewLoaded, pluginSettings]);
+		void loadPlugins({ pluginRunner, pluginSettings, store, reloadAll, cancelEvent: event });
+	}, [pluginRunner, reloadAll, store, webviewLoaded, pluginSettings]);
 };
 
 const useUnloadPluginsOnGlobalDisable = (

--- a/packages/app-mobile/plugins/loadPlugins.test.ts
+++ b/packages/app-mobile/plugins/loadPlugins.test.ts
@@ -1,13 +1,12 @@
 import Setting from '@joplin/lib/models/Setting';
 import PluginService, { defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
-import Plugin from '@joplin/lib/services/plugins/Plugin';
 import { PluginManifest } from '@joplin/lib/services/plugins/utils/types';
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 import { writeFile } from 'fs-extra';
 import { join } from 'path';
 import loadPlugins, { Props as LoadPluginsProps } from './loadPlugins';
-import BasePluginRunner from '@joplin/lib/services/plugins/BasePluginRunner';
 import createMockReduxStore from '../utils/testing/createMockReduxStore';
+import MockPluginRunner from './testing/MockPluginRunner';
 
 const setPluginEnabled = (id: string, enabled: boolean) => {
 	const newPluginStates = {
@@ -30,22 +29,11 @@ const addPluginWithManifest = async (manifest: PluginManifest, enabled: boolean)
 			onStart: async function() { },
 		});
 	`;
-	const pluginPath = join(Setting.value('pluginDir'), 'plugin.js');
+	const pluginPath = join(Setting.value('pluginDir'), `${manifest.id}.js`);
 	await writeFile(pluginPath, pluginSource, 'utf-8');
 
 	setPluginEnabled(manifest.id, enabled);
 };
-
-class MockPluginRunner extends BasePluginRunner {
-	public runningPluginIds: string[] = [];
-	public override run = jest.fn(async (plugin: Plugin) => {
-		this.runningPluginIds.push(plugin.manifest.id);
-	});
-	public override stop = jest.fn(async (plugin: Plugin) => {
-		this.runningPluginIds = this.runningPluginIds.filter(id => id !== plugin.manifest.id);
-	});
-	public override async waitForSandboxCalls() {}
-}
 
 const defaultManifestProperties = {
 	manifest_version: 1,
@@ -58,10 +46,13 @@ describe('loadPlugins', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
+	});
 
+	afterEach(async () => {
 		for (const id of PluginService.instance().pluginIds) {
 			await PluginService.instance().unloadPlugin(id);
 		}
+		await PluginService.instance().destroy();
 	});
 
 	test('should load only enabled plugins', async () => {
@@ -70,9 +61,11 @@ describe('loadPlugins', () => {
 			id: 'this.is.a.test.1',
 			name: 'Disabled Plugin',
 		}, false);
+
+		const enabledPluginId = 'this.is.a.test.2';
 		await addPluginWithManifest({
 			...defaultManifestProperties,
-			id: 'this.is.a.test.2',
+			id: enabledPluginId,
 			name: 'Enabled Plugin',
 		}, true);
 
@@ -86,17 +79,21 @@ describe('loadPlugins', () => {
 			reloadAll: false,
 			cancelEvent: { cancelled: false },
 		};
+		expect(Object.keys(PluginService.instance().plugins)).toHaveLength(0);
 
 		await loadPlugins(loadPluginsOptions);
+		await pluginRunner.waitForAllToBeRunning([enabledPluginId]);
 
-		expect(pluginRunner.runningPluginIds).toMatchObject(['this.is.a.test.2']);
+		expect(pluginRunner.runningPluginIds).toMatchObject([enabledPluginId]);
 		// No plugins were running before, so none should be stopped.
-		expect(pluginRunner.stop).toHaveBeenCalledTimes(0);
-		expect(pluginRunner.run).toHaveBeenCalledTimes(1);
+		expect(pluginRunner.stopCalledTimes).toBe(0);
 
 		// Loading again should not re-run plugins
 		await loadPlugins(loadPluginsOptions);
-		expect(pluginRunner.run).toHaveBeenCalledTimes(1);
+
+		// Should have tried to stop at most the disabled plugin (which is a no-op).
+		expect(pluginRunner.stopCalledTimes).toBe(1);
+		expect(pluginRunner.runningPluginIds).toMatchObject([enabledPluginId]);
 	});
 
 	test('should reload all plugins when reloadAll is true', async () => {
@@ -104,7 +101,7 @@ describe('loadPlugins', () => {
 		for (let i = 0; i < enabledCount; i++) {
 			await addPluginWithManifest({
 				...defaultManifestProperties,
-				id: `test.plugin.${i}`,
+				id: `joplin.test.plugin.${i}`,
 				name: `Enabled Plugin ${i}`,
 			}, true);
 		}
@@ -113,7 +110,7 @@ describe('loadPlugins', () => {
 		for (let i = 0; i < disabledCount; i++) {
 			await addPluginWithManifest({
 				...defaultManifestProperties,
-				id: `test.plugin.disabled.${i}`,
+				id: `joplin.test.plugin.disabled.${i}`,
 				name: `Disabled Plugin ${i}`,
 			}, false);
 		}
@@ -128,19 +125,24 @@ describe('loadPlugins', () => {
 			cancelEvent: { cancelled: false },
 		};
 		await loadPlugins(loadPluginsOptions);
+		let expectedRunningIds = ['joplin.test.plugin.0', 'joplin.test.plugin.1', 'joplin.test.plugin.2'];
+		await pluginRunner.waitForAllToBeRunning(expectedRunningIds);
 
-		expect(pluginRunner.runningPluginIds.sort()).toMatchObject(['test.plugin.0', 'test.plugin.1', 'test.plugin.2']);
+		// No additional plugins should be running.
+		expect([...pluginRunner.runningPluginIds].sort()).toMatchObject(expectedRunningIds);
+
 		// No plugins were running before -- there were no plugins to stop
-		expect(pluginRunner.stop).toHaveBeenCalledTimes(0);
-		expect(pluginRunner.run).toHaveBeenCalledTimes(3);
+		expect(pluginRunner.stopCalledTimes).toBe(0);
+
+		// Enabling a plugin and reloading it should cause all plugins to load.
+		setPluginEnabled('joplin.test.plugin.disabled.2', true);
+		await loadPlugins({ ...loadPluginsOptions, pluginSettings: Setting.value('plugins.states') });
+		expectedRunningIds = ['joplin.test.plugin.0', 'joplin.test.plugin.1', 'joplin.test.plugin.2', 'joplin.test.plugin.disabled.2'];
+		await pluginRunner.waitForAllToBeRunning(expectedRunningIds);
 
 		// Reloading all should stop all plugins and rerun enabled plugins, even
 		// if not enabled previously.
-		setPluginEnabled('test.plugin.disabled.2', true);
-		await loadPlugins(loadPluginsOptions);
-
-		expect(pluginRunner.stop).toHaveBeenCalledTimes(3);
-		expect(pluginRunner.run).toHaveBeenCalledTimes(4);
-		expect(pluginRunner.runningPluginIds.includes('test.plugin.disabled.2')).toBe(true);
+		expect(pluginRunner.stopCalledTimes).toBe(disabledCount + enabledCount);
+		expect([...pluginRunner.runningPluginIds].sort()).toMatchObject(expectedRunningIds);
 	});
 });

--- a/packages/app-mobile/plugins/loadPlugins.test.ts
+++ b/packages/app-mobile/plugins/loadPlugins.test.ts
@@ -1,0 +1,146 @@
+import Setting from '@joplin/lib/models/Setting';
+import PluginService, { defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
+import Plugin from '@joplin/lib/services/plugins/Plugin';
+import { PluginManifest } from '@joplin/lib/services/plugins/utils/types';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+import { writeFile } from 'fs-extra';
+import { join } from 'path';
+import loadPlugins, { Props as LoadPluginsProps } from './loadPlugins';
+import BasePluginRunner from '@joplin/lib/services/plugins/BasePluginRunner';
+import createMockReduxStore from '../utils/testing/createMockReduxStore';
+
+const setPluginEnabled = (id: string, enabled: boolean) => {
+	const newPluginStates = {
+		...Setting.value('plugins.states'),
+		[id]: {
+			...defaultPluginSetting(),
+			enabled,
+		},
+	};
+	Setting.setValue('plugins.states', newPluginStates);
+};
+
+const addPluginWithManifest = async (manifest: PluginManifest, enabled: boolean) => {
+	const pluginSource = `
+		/* joplin-manifest:
+		${JSON.stringify(manifest)}
+		*/
+
+		joplin.plugins.register({
+			onStart: async function() { },
+		});
+	`;
+	const pluginPath = join(Setting.value('pluginDir'), 'plugin.js');
+	await writeFile(pluginPath, pluginSource, 'utf-8');
+
+	setPluginEnabled(manifest.id, enabled);
+};
+
+class MockPluginRunner extends BasePluginRunner {
+	public runningPluginIds: string[] = [];
+	public override run = jest.fn(async (plugin: Plugin) => {
+		this.runningPluginIds.push(plugin.manifest.id);
+	});
+	public override stop = jest.fn(async (plugin: Plugin) => {
+		this.runningPluginIds = this.runningPluginIds.filter(id => id !== plugin.manifest.id);
+	});
+	public override async waitForSandboxCalls() {}
+}
+
+const defaultManifestProperties = {
+	manifest_version: 1,
+	version: '0.1.0',
+	app_min_version: '2.3.4',
+	platforms: ['desktop', 'mobile'],
+};
+
+describe('loadPlugins', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+
+		for (const id of PluginService.instance().pluginIds) {
+			await PluginService.instance().unloadPlugin(id);
+		}
+	});
+
+	test('should load only enabled plugins', async () => {
+		await addPluginWithManifest({
+			...defaultManifestProperties,
+			id: 'this.is.a.test.1',
+			name: 'Disabled Plugin',
+		}, false);
+		await addPluginWithManifest({
+			...defaultManifestProperties,
+			id: 'this.is.a.test.2',
+			name: 'Enabled Plugin',
+		}, true);
+
+		const pluginRunner = new MockPluginRunner();
+		const store = createMockReduxStore();
+
+		const loadPluginsOptions: LoadPluginsProps = {
+			pluginRunner,
+			pluginSettings: Setting.value('plugins.states'),
+			store,
+			reloadAll: false,
+			cancelEvent: { cancelled: false },
+		};
+
+		await loadPlugins(loadPluginsOptions);
+
+		expect(pluginRunner.runningPluginIds).toMatchObject(['this.is.a.test.2']);
+		// No plugins were running before, so none should be stopped.
+		expect(pluginRunner.stop).toHaveBeenCalledTimes(0);
+		expect(pluginRunner.run).toHaveBeenCalledTimes(1);
+
+		// Loading again should not re-run plugins
+		await loadPlugins(loadPluginsOptions);
+		expect(pluginRunner.run).toHaveBeenCalledTimes(1);
+	});
+
+	test('should reload all plugins when reloadAll is true', async () => {
+		const enabledCount = 3;
+		for (let i = 0; i < enabledCount; i++) {
+			await addPluginWithManifest({
+				...defaultManifestProperties,
+				id: `test.plugin.${i}`,
+				name: `Enabled Plugin ${i}`,
+			}, true);
+		}
+
+		const disabledCount = 6;
+		for (let i = 0; i < disabledCount; i++) {
+			await addPluginWithManifest({
+				...defaultManifestProperties,
+				id: `test.plugin.disabled.${i}`,
+				name: `Disabled Plugin ${i}`,
+			}, false);
+		}
+
+		const pluginRunner = new MockPluginRunner();
+		const store = createMockReduxStore();
+		const loadPluginsOptions: LoadPluginsProps = {
+			pluginRunner,
+			pluginSettings: Setting.value('plugins.states'),
+			store,
+			reloadAll: true,
+			cancelEvent: { cancelled: false },
+		};
+		await loadPlugins(loadPluginsOptions);
+
+		expect(pluginRunner.runningPluginIds.sort()).toMatchObject(['test.plugin.0', 'test.plugin.1', 'test.plugin.2']);
+		// No plugins were running before -- there were no plugins to stop
+		expect(pluginRunner.stop).toHaveBeenCalledTimes(0);
+		expect(pluginRunner.run).toHaveBeenCalledTimes(3);
+
+		// Reloading all should stop all plugins and rerun enabled plugins, even
+		// if not enabled previously.
+		setPluginEnabled('test.plugin.disabled.2', true);
+		await loadPlugins(loadPluginsOptions);
+
+		expect(pluginRunner.stop).toHaveBeenCalledTimes(3);
+		expect(pluginRunner.run).toHaveBeenCalledTimes(4);
+		expect(pluginRunner.runningPluginIds.includes('test.plugin.disabled.2')).toBe(true);
+	});
+});

--- a/packages/app-mobile/plugins/loadPlugins.ts
+++ b/packages/app-mobile/plugins/loadPlugins.ts
@@ -32,13 +32,14 @@ const loadPlugins = async ({ pluginRunner, pluginSettings, store, reloadAll, can
 			logger.info('Reloading all plugins.');
 		}
 
-		for (const pluginId of Object.keys(pluginService.plugins)) {
+		for (const pluginId of pluginService.pluginIds) {
 			if (reloadAll || (pluginSettings[pluginId] && !pluginSettings[pluginId].enabled)) {
 				logger.info('Unloading plugin', pluginId);
 				await pluginService.unloadPlugin(pluginId);
 			}
 
 			if (cancelEvent.cancelled) {
+				logger.info('Cancelled.');
 				return;
 			}
 		}
@@ -49,6 +50,7 @@ const loadPlugins = async ({ pluginRunner, pluginSettings, store, reloadAll, can
 		}
 
 		if (cancelEvent.cancelled) {
+			logger.info('Cancelled.');
 			return;
 		}
 

--- a/packages/app-mobile/plugins/loadPlugins.ts
+++ b/packages/app-mobile/plugins/loadPlugins.ts
@@ -1,4 +1,3 @@
-
 import Setting from '@joplin/lib/models/Setting';
 import BasePluginRunner from '@joplin/lib/services/plugins/BasePluginRunner';
 import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
@@ -6,15 +5,21 @@ import PlatformImplementation from './PlatformImplementation';
 import { Store } from 'redux';
 import Logger from '@joplin/utils/Logger';
 import shim from '@joplin/lib/shim';
+import { AppState } from '../utils/types';
 
 const logger = Logger.create('loadPlugins');
 
 type CancelEvent = { cancelled: boolean };
 
-const loadPlugins = async (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	pluginRunner: BasePluginRunner, pluginSettings: PluginSettings, store: Store<any>, cancel: CancelEvent,
-) => {
+export interface Props {
+	pluginRunner: BasePluginRunner;
+	pluginSettings: PluginSettings;
+	store: Store<AppState>;
+	reloadAll: boolean;
+	cancelEvent: CancelEvent;
+}
+
+const loadPlugins = async ({ pluginRunner, pluginSettings, store, reloadAll, cancelEvent }: Props) => {
 	try {
 		const pluginService = PluginService.instance();
 		const platformImplementation = PlatformImplementation.instance();
@@ -23,13 +28,17 @@ const loadPlugins = async (
 		);
 		pluginService.isSafeMode = Setting.value('isSafeMode');
 
+		if (reloadAll) {
+			logger.info('Reloading all plugins.');
+		}
+
 		for (const pluginId of Object.keys(pluginService.plugins)) {
-			if (pluginSettings[pluginId] && !pluginSettings[pluginId].enabled) {
-				logger.info('Unloading disabled plugin', pluginId);
+			if (reloadAll || (pluginSettings[pluginId] && !pluginSettings[pluginId].enabled)) {
+				logger.info('Unloading plugin', pluginId);
 				await pluginService.unloadPlugin(pluginId);
 			}
 
-			if (cancel.cancelled) {
+			if (cancelEvent.cancelled) {
 				return;
 			}
 		}
@@ -39,7 +48,7 @@ const loadPlugins = async (
 			await pluginService.loadAndRunDevPlugins(pluginSettings);
 		}
 
-		if (cancel.cancelled) {
+		if (cancelEvent.cancelled) {
 			return;
 		}
 

--- a/packages/app-mobile/plugins/testing/MockPluginRunner.ts
+++ b/packages/app-mobile/plugins/testing/MockPluginRunner.ts
@@ -1,0 +1,47 @@
+import BasePluginRunner from '@joplin/lib/services/plugins/BasePluginRunner';
+import Plugin from '@joplin/lib/services/plugins/Plugin';
+
+
+export default class MockPluginRunner extends BasePluginRunner {
+	public runningPluginIds: string[] = [];
+	private onRunningPluginsChangedListeners_ = [() => {}];
+	private stopCalledTimes_ = 0;
+
+	public waitForAllToBeRunning(expectedIds: string[]) {
+		return new Promise<void>(resolve => {
+			const listener = () => {
+				let missingIds = false;
+				for (const id of expectedIds) {
+					if (!this.runningPluginIds.includes(id)) {
+						missingIds = true;
+						console.warn('Missing ID', id, 'in', this.runningPluginIds);
+						break;
+					}
+				}
+				if (!missingIds) {
+					this.onRunningPluginsChangedListeners_ = this.onRunningPluginsChangedListeners_.filter(l => l !== listener);
+					resolve();
+				}
+			};
+			this.onRunningPluginsChangedListeners_.push(listener);
+			listener();
+		});
+	}
+
+	public get stopCalledTimes() { return this.stopCalledTimes_; }
+
+	public override async run(plugin: Plugin) {
+		this.runningPluginIds.push(plugin.manifest.id);
+
+		for (const listener of this.onRunningPluginsChangedListeners_) {
+			listener();
+		}
+	}
+
+	public override async stop(plugin: Plugin) {
+		this.runningPluginIds = this.runningPluginIds.filter(id => id !== plugin.manifest.id);
+		this.stopCalledTimes_ ++;
+	}
+
+	public override async waitForSandboxCalls() {}
+}


### PR DESCRIPTION
# Summary

This pull request fixes an issue where plugins would appear broken because the `PluginRunner` WebView reloaded in the background and plugins that were using it were not also reloaded.

The `PluginRunner` WebView can reload while making changes to Joplin with React Native's fast refresh enabled.

This PR also adds related automated tests for `loadPlugins`.

# Testing plan

This pull request adds automated tests for `loadPlugins`. However, these tests don't verify that the interaction between `PluginStates` and `loadPlugins` is correct. As such, this pull request can also be tested manually:
1. Install the "quick links" plugin, if not installed already.
2. In `PluginRunnerWebView.tsx`, change `webviewInstanceId="PluginRunner"` to `webviewInstanceId="PluginRunner2"`. Allow the app to partially reload.
3. Open the note editor.
4. Type `@@` and verify that link suggestions are shown.

This has been tested successfully on an Android 12 emulator.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->