### PR TITLE
Windows: Fixes #10525: Prevent notes with titles that differ only in case from being overwritten when exporting

### DIFF
--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -3,7 +3,6 @@ import Setting from './models/Setting';
 import { filename, fileExtension } from './path-utils';
 const md5 = require('md5');
 import { Buffer } from 'buffer';
-import shim from './shim';
 
 export interface Stat {
 	birthtime: Date;
@@ -154,18 +153,11 @@ export default class FsDriverBase {
 		let counter = 1;
 
 		// On Windows, ./FiLe.md and ./file.md are equivalent file paths.
-		const caseSensitiveCompare = !shim.isWindows();
-		if (!caseSensitiveCompare) {
-			// Simplify case-insensitive comparison by lowercasing all reserved names
-			// early.
-			reservedNames = reservedNames.map(name => name.toLowerCase());
-		}
-
+		// As such, to avoid overwriting reserved names, comparisons need to be
+		// case-insensitive.
+		reservedNames = reservedNames.map(name => name.toLowerCase());
 		const isReserved = (testName: string) => {
-			if (!caseSensitiveCompare) {
-				testName = testName.toLowerCase();
-			}
-			return reservedNames.includes(testName);
+			return reservedNames.includes(testName.toLowerCase());
 		};
 
 		const nameNoExt = filename(name, true);

--- a/packages/lib/fs-driver-base.ts
+++ b/packages/lib/fs-driver-base.ts
@@ -174,7 +174,7 @@ export default class FsDriverBase {
 		let nameToTry = nameNoExt + extension;
 		while (true) {
 			// Check if the filename does not exist in the filesystem and is not reserved
-			const exists = isReserved(nameToTry) || await this.exists(nameToTry);
+			const exists = await this.exists(nameToTry) || isReserved(nameToTry);
 			if (!exists) return nameToTry;
 			if (!markdownSafe) {
 				nameToTry = `${nameNoExt} (${counter})${extension}`;

--- a/packages/lib/fsDriver.test.ts
+++ b/packages/lib/fsDriver.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import FsDriverNode from './fs-driver-node';
 import shim from './shim';
-import { expectThrow, mockWindowsPlatform, supportDir } from './testing/test-utils';
+import { expectThrow, supportDir } from './testing/test-utils';
 
 const windowsPartitionLetter = __filename[0];
 
@@ -28,9 +28,7 @@ describe('fsDriver', () => {
 		await expectThrow(() => fsDriver.resolveRelativePathWithinDir('/test/temp', '/var/local/no.txt'));
 	});
 
-	it('should compare reserved names in a case-insensitive way in findUniqueFilename on Windows', async () => {
-		const windowsMock = mockWindowsPlatform();
-
+	it('should compare reserved names in a case-insensitive way in findUniqueFilename', async () => {
 		// Compare with filenames in the reserved list should be case insensitive
 		expect(
 			await shim.fsDriver().findUniqueFilename(
@@ -43,7 +41,5 @@ describe('fsDriver', () => {
 		expect(
 			await shim.fsDriver().findUniqueFilename(join(supportDir, 'this-file-does-not-exist.txt'), [join(supportDir, 'some-other-file.txt')]),
 		).toBe(join(supportDir, 'this-file-does-not-exist.txt'));
-
-		windowsMock.reset();
 	});
 });

--- a/packages/lib/fsDriver.test.ts
+++ b/packages/lib/fsDriver.test.ts
@@ -1,6 +1,7 @@
+import { join } from 'path';
 import FsDriverNode from './fs-driver-node';
 import shim from './shim';
-import { expectThrow } from './testing/test-utils';
+import { expectThrow, mockWindowsPlatform, supportDir } from './testing/test-utils';
 
 const windowsPartitionLetter = __filename[0];
 
@@ -15,7 +16,6 @@ function platformPath(path: string) {
 }
 
 describe('fsDriver', () => {
-
 	it('should resolveRelativePathWithinDir', async () => {
 		const fsDriver = new FsDriverNode();
 		expect(fsDriver.resolveRelativePathWithinDir('/test/temp', './my/file.txt').toLowerCase()).toBe(platformPath('/test/temp/my/file.txt'));
@@ -28,4 +28,22 @@ describe('fsDriver', () => {
 		await expectThrow(() => fsDriver.resolveRelativePathWithinDir('/test/temp', '/var/local/no.txt'));
 	});
 
+	it('should compare reserved names in a case-insensitive way in findUniqueFilename on Windows', async () => {
+		const windowsMock = mockWindowsPlatform();
+
+		// Compare with filenames in the reserved list should be case insensitive
+		expect(
+			await shim.fsDriver().findUniqueFilename(
+				join(supportDir, 'this-file-does-not-exist.txt'),
+				[join(supportDir, 'THIS-file-does-not-exist.txt'), join(supportDir, 'THIS-file-DOES-not-exist (1).txt')],
+			),
+		).toBe(join(supportDir, 'this-file-does-not-exist (2).txt'));
+
+		// Should still not match reserved names that aren't equivalent.
+		expect(
+			await shim.fsDriver().findUniqueFilename(join(supportDir, 'this-file-does-not-exist.txt'), [join(supportDir, 'some-other-file.txt')]),
+		).toBe(join(supportDir, 'this-file-does-not-exist.txt'));
+
+		windowsMock.reset();
+	});
 });

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1074,15 +1074,4 @@ export const mockMobilePlatform = (platform: string) => {
 	};
 };
 
-export const mockWindowsPlatform = () => {
-	const originalIsWindows = shim.isWindows;
-	shim.isWindows = () => true;
-
-	return {
-		reset: () => {
-			shim.isWindows = originalIsWindows;
-		},
-	};
-};
-
 export { supportDir, createNoteAndResource, createTempFile, createTestShareData, simulateReadOnlyShareEnv, waitForFolderCount, afterAllCleanUp, exportDir, synchronizerStart, afterEachCleanUp, syncTargetName, setSyncTargetName, syncDir, createTempDir, isNetworkSyncTarget, kvStore, expectThrow, logger, expectNotThrow, resourceService, resourceFetcher, tempFilePath, allSyncTargetItemsEncrypted, msleep, setupDatabase, revisionService, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync, checkThrow, encryptionService, loadEncryptionMasterKey, fileContentEqual, decryptionWorker, currentClientId, id, ids, sortedIds, at, createNTestNotes, createNTestFolders, createNTestTags, TestApp };

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1074,4 +1074,15 @@ export const mockMobilePlatform = (platform: string) => {
 	};
 };
 
+export const mockWindowsPlatform = () => {
+	const originalIsWindows = shim.isWindows;
+	shim.isWindows = () => true;
+
+	return {
+		reset: () => {
+			shim.isWindows = originalIsWindows;
+		},
+	};
+};
+
 export { supportDir, createNoteAndResource, createTempFile, createTestShareData, simulateReadOnlyShareEnv, waitForFolderCount, afterAllCleanUp, exportDir, synchronizerStart, afterEachCleanUp, syncTargetName, setSyncTargetName, syncDir, createTempDir, isNetworkSyncTarget, kvStore, expectThrow, logger, expectNotThrow, resourceService, resourceFetcher, tempFilePath, allSyncTargetItemsEncrypted, msleep, setupDatabase, revisionService, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync, checkThrow, encryptionService, loadEncryptionMasterKey, fileContentEqual, decryptionWorker, currentClientId, id, ids, sortedIds, at, createNTestNotes, createNTestFolders, createNTestTags, TestApp };


### PR DESCRIPTION
# Summary

Windows filesystem paths are case-insensitive. This was not taken into account when comparing with reserved filenames in `fsDriver.findUniqueFilename`.

Fixes #10525.

# Testing plan

This pull request contains an automated test. 

This can also be tested with the following steps:
1. Create a notebook, `test`.
2. Add two notes to the notebook. Title them `a` and `A`.
3. Export everything as markdown (File > Export all > MD - Markdown).
4. Verify that the exported `test` folder contains two files `a.md` and `A-1.md`.

This has been tested successfully on Windows 11. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->