### PR TITLE
Desktop: Fixes #10538: Fix wrong text selected when adding a link in the beta editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -758,8 +758,6 @@ packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.js
 packages/editor/CodeMirror/markdown/markdownCommands.js
 packages/editor/CodeMirror/markdown/markdownMathParser.test.js
 packages/editor/CodeMirror/markdown/markdownMathParser.js
-packages/editor/CodeMirror/markdown/markdownReformatter.test.js
-packages/editor/CodeMirror/markdown/markdownReformatter.js
 packages/editor/CodeMirror/pluginApi/PluginLoader.js
 packages/editor/CodeMirror/pluginApi/codeMirrorRequire.js
 packages/editor/CodeMirror/pluginApi/customEditorCompletion.test.js
@@ -772,6 +770,8 @@ packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/testUtil/pressReleaseKey.js
 packages/editor/CodeMirror/testUtil/typeText.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/util/editorStateUtils.test.js
+packages/editor/CodeMirror/util/editorStateUtils.js
 packages/editor/CodeMirror/util/isInSyntaxNode.js
 packages/editor/CodeMirror/util/setupVim.js
 packages/editor/SelectionFormatting.js

--- a/.gitignore
+++ b/.gitignore
@@ -737,8 +737,6 @@ packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.js
 packages/editor/CodeMirror/markdown/markdownCommands.js
 packages/editor/CodeMirror/markdown/markdownMathParser.test.js
 packages/editor/CodeMirror/markdown/markdownMathParser.js
-packages/editor/CodeMirror/markdown/markdownReformatter.test.js
-packages/editor/CodeMirror/markdown/markdownReformatter.js
 packages/editor/CodeMirror/pluginApi/PluginLoader.js
 packages/editor/CodeMirror/pluginApi/codeMirrorRequire.js
 packages/editor/CodeMirror/pluginApi/customEditorCompletion.test.js
@@ -751,6 +749,8 @@ packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/testUtil/pressReleaseKey.js
 packages/editor/CodeMirror/testUtil/typeText.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/util/editorStateUtils.test.js
+packages/editor/CodeMirror/util/editorStateUtils.js
 packages/editor/CodeMirror/util/isInSyntaxNode.js
 packages/editor/CodeMirror/util/setupVim.js
 packages/editor/SelectionFormatting.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -12,25 +12,6 @@ import { focus } from '@joplin/lib/utils/focusHandler';
 
 const logger = Logger.create('CodeMirror 6 commands');
 
-const wrapSelectionWithStrings = (editor: CodeMirrorControl, string1: string, string2 = '', defaultText = '') => {
-	if (editor.somethingSelected()) {
-		editor.wrapSelections(string1, string2);
-	} else {
-		editor.wrapSelections(string1 + defaultText, string2);
-
-		// Now select the default text so the user can replace it
-		const selections = editor.listSelections();
-		const newSelections = [];
-		for (let i = 0; i < selections.length; i++) {
-			const s = selections[i];
-			const anchor = { line: s.anchor.line, ch: s.anchor.ch + string1.length };
-			const head = { line: s.head.line, ch: s.head.ch - string2.length };
-			newSelections.push({ anchor: anchor, head: head });
-		}
-		editor.setSelections(newSelections);
-	}
-};
-
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	webviewRef: RefObject<any>;
@@ -92,7 +73,9 @@ const useEditorCommands = (props: Props) => {
 			textLink: async () => {
 				const url = await dialogs.prompt(_('Insert Hyperlink'));
 				focus('useEditorCommands::textLink', editorRef.current);
-				if (url) wrapSelectionWithStrings(editorRef.current, '[', `](${url})`);
+				if (url) {
+					editorRef.current.wrapSelections('[', `](${url})`);
+				}
 			},
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			insertText: (value: any) => editorRef.current.insertText(value),

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -9,7 +9,6 @@ import { StreamParser } from '@codemirror/language';
 import Decorator, { LineWidgetOptions, MarkTextOptions } from './Decorator';
 import insertLineAfter from '../editorCommands/insertLineAfter';
 import CodeMirror5BuiltInOptions from './CodeMirror5BuiltInOptions';
-import { RegionSpec, toggleInlineFormatGlobally } from '../util/editorStateUtils';
 const { pregQuote } = require('@joplin/lib/string-utils-common');
 
 
@@ -424,12 +423,6 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 			posFromDocumentPosition(doc, from),
 			posFromDocumentPosition(doc, to),
 			options,
-		);
-	}
-
-	public wrapSelections(start: string, end: string) {
-		this.editor.dispatch(
-			toggleInlineFormatGlobally(this.editor.state, RegionSpec.of({ template: { start, end } })),
 		);
 	}
 

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -9,6 +9,7 @@ import { StreamParser } from '@codemirror/language';
 import Decorator, { LineWidgetOptions, MarkTextOptions } from './Decorator';
 import insertLineAfter from '../editorCommands/insertLineAfter';
 import CodeMirror5BuiltInOptions from './CodeMirror5BuiltInOptions';
+import { RegionSpec, toggleInlineFormatGlobally } from '../util/editorStateUtils';
 const { pregQuote } = require('@joplin/lib/string-utils-common');
 
 
@@ -426,32 +427,10 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		);
 	}
 
-	// TODO: Currently copied from useCursorUtils.ts.
-	// TODO: Remove the duplicate code when CodeMirror 5 is eventually removed.
-	public wrapSelections(string1: string, string2: string) {
-		const selectedStrings = this.getSelections();
-
-		// Batches the insert operations, if this wasn't done the inserts
-		// could potentially overwrite one another
-		this.operation(() => {
-			for (let i = 0; i < selectedStrings.length; i++) {
-				const selected = selectedStrings[i];
-
-				// Remove white space on either side of selection
-				const start = selected.search(/[^\s]/);
-				const end = selected.search(/[^\s](?=[\s]*$)/);
-				const core = selected.substring(start, end - start + 1);
-
-				// If selection can be toggled do that
-				if (core.startsWith(string1) && core.endsWith(string2)) {
-					const inside = core.substring(string1.length, core.length - string1.length - string2.length);
-					selectedStrings[i] = selected.substring(0, start) + inside + selected.substring(end + 1);
-				} else {
-					selectedStrings[i] = selected.substring(0, start) + string1 + core + string2 + selected.substring(end + 1);
-				}
-			}
-			this.replaceSelections(selectedStrings);
-		});
+	public wrapSelections(start: string, end: string) {
+		this.editor.dispatch(
+			toggleInlineFormatGlobally(this.editor.state, RegionSpec.of({ template: { start, end } })),
+		);
 	}
 
 	public static commands = (() => {

--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -2,6 +2,7 @@ import { ViewPlugin } from '@codemirror/view';
 import createEditorControl from './testUtil/createEditorControl';
 import { EditorCommandType } from '../types';
 import pressReleaseKey from './testUtil/pressReleaseKey';
+import { EditorSelection } from '@codemirror/state';
 
 describe('CodeMirrorControl', () => {
 	it('clearHistory should clear the undo/redo history', () => {
@@ -112,5 +113,72 @@ describe('CodeMirrorControl', () => {
 		control.updateBody('Hello\r\nWorld\r\n');
 		control.updateBody('Hello\r\nWorld\r\ntest');
 		control.updateBody('Hello\r\n');
+	});
+
+	it.each([
+		{
+			initialText: 'Hello\nWorld',
+			selection: EditorSelection.cursor(5),
+			left: '[[',
+			right: ']].',
+			typeText: null,
+			expected: 'Hello[[]].\nWorld',
+		},
+		{
+			initialText: 'Hello\nWorld',
+			selection: EditorSelection.cursor(0),
+			left: 'before',
+			right: 'after.',
+			typeText: ' cursor ',
+			expected: 'before cursor after.Hello\nWorld',
+		},
+		{
+			initialText: 'Hello\nWorld',
+			selection: EditorSelection.range(0, 5),
+			left: '[',
+			right: '](test)',
+			typeText: null,
+			expected: '[Hello](test)\nWorld',
+		},
+		{
+			initialText: 'Hello\nWorld',
+			selection: EditorSelection.range(0, 5),
+			left: '[',
+			right: '](test)',
+			typeText: 'replaced',
+			expected: '[replaced](test)\nWorld',
+		},
+		{
+			initialText: 'Hello\nWorld',
+			selection: EditorSelection.create([
+				EditorSelection.cursor(0), EditorSelection.cursor(5),
+			]),
+			left: '[',
+			right: '](test)',
+			typeText: 'cursor',
+			expected: '[cursor](test)Hello[cursor](test)\nWorld',
+		},
+		{
+			initialText: 'This is a\ntest',
+			selection: EditorSelection.create([
+				EditorSelection.range(5, 9), EditorSelection.cursor(14),
+			]),
+			left: '[',
+			right: ']',
+			typeText: 'cursor',
+			expected: 'This [cursor]\ntest[cursor]',
+		},
+	])('wrapSelections should surround all selections with the given text (case %#)', ({ initialText, selection, typeText, left, right, expected }) => {
+		const control = createEditorControl(initialText);
+		control.editor.dispatch({
+			selection,
+		});
+		control.wrapSelections(left, right);
+
+		if (typeText) {
+			control.insertText(typeText);
+		}
+
+		expect(control.editor.state.doc.toString()).toBe(expected);
 	});
 });

--- a/packages/editor/CodeMirror/CodeMirrorControl.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.ts
@@ -8,6 +8,7 @@ import { SearchQuery, setSearchQuery } from '@codemirror/search';
 import PluginLoader from './pluginApi/PluginLoader';
 import customEditorCompletion, { editorCompletionSource, enableLanguageDataAutocomplete } from './pluginApi/customEditorCompletion';
 import { CompletionSource } from '@codemirror/autocomplete';
+import { RegionSpec, toggleInlineSelectionFormat } from './util/editorStateUtils';
 
 interface Callbacks {
 	onUndoRedo(): void;
@@ -91,6 +92,25 @@ export default class CodeMirrorControl extends CodeMirror5Emulation implements E
 
 	public insertText(text: string, userEvent?: UserEventSource) {
 		this.editor.dispatch(this.editor.state.replaceSelection(text), { userEvent });
+	}
+
+	public wrapSelections(start: string, end: string) {
+		const regionSpec = RegionSpec.of({ template: { start, end } });
+
+		this.editor.dispatch(
+			this.editor.state.changeByRange(range => {
+				const update = toggleInlineSelectionFormat(this.editor.state, regionSpec, range);
+				if (!update.range.empty) {
+					// Deselect the start and end characters (roughly preserve the original
+					// selection).
+					update.range = EditorSelection.range(
+						update.range.from + start.length,
+						update.range.to - end.length,
+					);
+				}
+				return update;
+			}),
+		);
 	}
 
 	public updateBody(newBody: string) {

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -11,7 +11,7 @@ import {
 	RegionSpec, growSelectionToNode, renumberSelectedLists,
 	toggleInlineFormatGlobally, toggleRegionFormatGlobally, toggleSelectedLinesStartWith,
 	isIndentationEquivalent, stripBlockquote, tabsToSpaces,
-} from './markdownReformatter';
+} from '../util/editorStateUtils';
 import intersectsSyntaxNode from '../util/isInSyntaxNode';
 
 const startingSpaceRegex = /^(\s*)/;

--- a/packages/editor/CodeMirror/util/editorStateUtils.test.ts
+++ b/packages/editor/CodeMirror/util/editorStateUtils.test.ts
@@ -1,6 +1,6 @@
 import {
 	findInlineMatch, MatchSide, RegionSpec, renumberSelectedLists, tabsToSpaces, toggleRegionFormatGlobally,
-} from './markdownReformatter';
+} from './editorStateUtils';
 import { Text as DocumentText, EditorSelection, EditorState } from '@codemirror/state';
 import { indentUnit } from '@codemirror/language';
 import createTestEditor from '../testUtil/createTestEditor';

--- a/packages/editor/CodeMirror/util/editorStateUtils.ts
+++ b/packages/editor/CodeMirror/util/editorStateUtils.ts
@@ -268,7 +268,7 @@ const toggleInlineRegionSurrounded = (
 
 		changes.push({
 			from: sel.to,
-			insert: spec.template.start,
+			insert: spec.template.end,
 		});
 
 		// If not a caret,


### PR DESCRIPTION
# Summary

This pull request fixes #10538 by migrating `wrapSelections` away from legacy CodeMirror 5 APIs.

> [!NOTE]
>
> Although this pull request does some refactoring in the `editor` package, additional refactoring should be done in a follow-up PR
>

# Testing plan

This pull request contains automated tests that **partially** test this change. As such, this pull request has also been tested manually by:
1. Opening an existing note in the beta editor.
2. Clicking the "hyperlink" button.
3. Typing "http://example.com/" into the dialog box.
4. Clicking "OK"
5. Verifying that the cursor is placed in the middle of the `[` `]`s for the new link.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->