### PR TITLE
Desktop: Fixes: #10030: Prevent application from crashing when the syncInfoCache is corrupted

### DIFF
--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -318,11 +318,11 @@ describe('syncInfoUtils', () => {
 		const result = localSyncInfo();
 
 		expect(result.activeMasterKeyId).toEqual('');
-		expect(result.version).toEqual(SyncInfo.defaultValues.version);
-		expect(result.ppk).toEqual(SyncInfo.defaultValues.ppk.value);
-		expect(result.e2ee).toEqual(SyncInfo.defaultValues.e2ee.value);
-		expect(result.appMinVersion).toEqual(SyncInfo.defaultValues.appMinVersion);
-		expect(result.masterKeys).toEqual(SyncInfo.defaultValues.masterKeys);
+		expect(result.version).toEqual(0);
+		expect(result.ppk).toEqual(null);
+		expect(result.e2ee).toEqual(false);
+		expect(result.appMinVersion).toEqual('0.0.0');
+		expect(result.masterKeys).toEqual([]);
 
 		Logger.globalLogger.enabled = true;
 	});

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -322,6 +322,7 @@ describe('syncInfoUtils', () => {
 		expect(result.ppk).toEqual(SyncInfo.defaultValues.ppk.value);
 		expect(result.e2ee).toEqual(SyncInfo.defaultValues.e2ee.value);
 		expect(result.appMinVersion).toEqual(SyncInfo.defaultValues.appMinVersion);
+		expect(result.masterKeys).toEqual(SyncInfo.defaultValues.masterKeys);
 
 		Logger.globalLogger.enabled = true;
 	});

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -13,6 +13,44 @@ const fastDeepEqual = require('fast-deep-equal');
 
 const logger = Logger.create('syncInfoUtils');
 
+type MasterKey = {
+	created_time: number;
+	encryption_method: number;
+	hasBeenUsed: boolean;
+	id: string;
+	source_application: string;
+	updated_time: number;
+};
+
+type PPK = {
+	createdTime: number;
+	id: string;
+	keySize: number;
+	privateKey: {
+		ciphertext: string;
+		encryptionMethod: number;
+	};
+	publicKey: string;
+};
+
+type SyncInfoParsed = {
+	activeMasterKeyId: {
+		updatedTime: number;
+		value: string;
+	};
+	appMinVersion: string;
+	e2ee: {
+		updatedTime: number;
+		value: boolean;
+	};
+	masterKeys: MasterKey[];
+	ppk: {
+		updatedTime: number;
+		value: PPK;
+	};
+	version: number;
+};
+
 export interface SyncInfoValueBoolean {
 	value: boolean;
 	updatedTime: number;
@@ -269,7 +307,7 @@ export class SyncInfo {
 
 	public load(serialized: string) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		let s: any = {};
+		let s = SyncInfo.defaultValues;
 		try {
 			s = JSON.parse(serialized);
 		} catch (error) {
@@ -371,6 +409,21 @@ export class SyncInfo {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		(this as any)[`${name}_`].updatedTime = timestamp;
 	}
+
+	public static readonly defaultValues: SyncInfoParsed = {
+		activeMasterKeyId: {
+			updatedTime: 0, value: '',
+		},
+		appMinVersion: '0.0.0',
+		e2ee: {
+			updatedTime: 0, value: false,
+		},
+		masterKeys: [],
+		ppk: {
+			updatedTime: 0, value: null,
+		},
+		version: 0,
+	};
 
 }
 

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -34,21 +34,21 @@ type PPK = {
 };
 
 type SyncInfoParsed = {
-	activeMasterKeyId: {
+	activeMasterKeyId?: {
 		updatedTime: number;
 		value: string;
 	};
-	appMinVersion: string;
-	e2ee: {
+	appMinVersion?: string;
+	e2ee?: {
 		updatedTime: number;
 		value: boolean;
 	};
-	masterKeys: MasterKey[];
-	ppk: {
+	masterKeys?: MasterKey[];
+	ppk?: {
 		updatedTime: number;
 		value: PPK;
 	};
-	version: number;
+	version?: number;
 };
 
 export interface SyncInfoValueBoolean {
@@ -306,12 +306,11 @@ export class SyncInfo {
 	}
 
 	public load(serialized: string) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		let s = SyncInfo.defaultValues;
+		let s: SyncInfoParsed = {};
 		try {
 			s = JSON.parse(serialized);
 		} catch (error) {
-			logger.error('Error parsing sync info, using default values.', error);
+			logger.error(`Error parsing sync info, using default values. Sync info: ${JSON.stringify(serialized)}`, error);
 		}
 		this.version = 'version' in s ? s.version : 0;
 		this.e2ee_ = 'e2ee' in s ? s.e2ee : { value: false, updatedTime: 0 };
@@ -409,22 +408,6 @@ export class SyncInfo {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		(this as any)[`${name}_`].updatedTime = timestamp;
 	}
-
-	public static readonly defaultValues: SyncInfoParsed = {
-		activeMasterKeyId: {
-			updatedTime: 0, value: '',
-		},
-		appMinVersion: '0.0.0',
-		e2ee: {
-			updatedTime: 0, value: false,
-		},
-		masterKeys: [],
-		ppk: {
-			updatedTime: 0, value: null,
-		},
-		version: 0,
-	};
-
 }
 
 // ---------------------------------------------------------

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -13,44 +13,6 @@ const fastDeepEqual = require('fast-deep-equal');
 
 const logger = Logger.create('syncInfoUtils');
 
-type MasterKey = {
-	created_time: number;
-	encryption_method: number;
-	hasBeenUsed: boolean;
-	id: string;
-	source_application: string;
-	updated_time: number;
-};
-
-type PPK = {
-	createdTime: number;
-	id: string;
-	keySize: number;
-	privateKey: {
-		ciphertext: string;
-		encryptionMethod: number;
-	};
-	publicKey: string;
-};
-
-type SyncInfoParsed = {
-	activeMasterKeyId?: {
-		updatedTime: number;
-		value: string;
-	};
-	appMinVersion?: string;
-	e2ee?: {
-		updatedTime: number;
-		value: boolean;
-	};
-	masterKeys?: MasterKey[];
-	ppk?: {
-		updatedTime: number;
-		value: PPK;
-	};
-	version?: number;
-};
-
 export interface SyncInfoValueBoolean {
 	value: boolean;
 	updatedTime: number;
@@ -306,7 +268,9 @@ export class SyncInfo {
 	}
 
 	public load(serialized: string) {
-		let s: SyncInfoParsed = {};
+		// We probably should add validation after parsing at some point, but for now we are going to keep it simple
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		let s: any = {};
 		try {
 			s = JSON.parse(serialized);
 		} catch (error) {

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -269,7 +269,12 @@ export class SyncInfo {
 
 	public load(serialized: string) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const s: any = JSON.parse(serialized);
+		let s: any = {};
+		try {
+			s = JSON.parse(serialized);
+		} catch (error) {
+			logger.error('Error parsing sync info, using default values.', error);
+		}
 		this.version = 'version' in s ? s.version : 0;
 		this.e2ee_ = 'e2ee' in s ? s.e2ee : { value: false, updatedTime: 0 };
 		this.activeMasterKeyId_ = 'activeMasterKeyId' in s ? s.activeMasterKeyId : { value: '', updatedTime: 0 };


### PR DESCRIPTION
Fixes: https://github.com/laurent22/joplin/issues/10030

It was reported that one user had a setting `syncInfoCache` content corrupted. While the cause seems to be external (user device is faulty) in this PR I'm addressing the crashing that is happening because of this problem.

To fix it I'm changing the default behavior of `SyncInfo.load()` method to use default values if it crashes during the `JSON.parse`.

### Testing

I added two automated tests, one to check if the application is not crashing when it gets an invalid JSON and the other to check the default values that are being used if this happens.

I also made some manual tests, but I'm not familiar with how SyncInfo is used so there might be more cases that I didn't think of testing.

Manual testing that I did:

- Synched to Joplin Server with some notes
- Changed the value inside the `localSyncInfo` to emulate the problem:
![2024-06-05_15-23](https://github.com/laurent22/joplin/assets/5051088/1241bc73-6277-456d-943b-4529cbfb41dd)
- Change the `SyncInfo.load()` to stop crashing
- Deleted some notes
- Synched with server again and everything seems to be in order
