### PR TITLE
Chore: Mobile: Increase test timeout to try to fix CI failure

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -240,8 +240,9 @@ describe('PluginStates.installed', () => {
 		expect(updateButton).toBeVisible();
 		await user.press(updateButton);
 
-		// After updating, the update button should read "updated"
-		const updatedButton = await screen.findByRole('button', { name: 'Updated', disabled: true, timeout: 8000 });
+		// After updating, the update button should read "updated". Use a large
+		// timeout because updating plugins can be slow, particularly in CI.
+		const updatedButton = await screen.findByRole('button', { name: 'Updated', disabled: true, timeout: 16000 });
 		expect(updatedButton).toBeVisible();
 
 		// Should be marked as updated.


### PR DESCRIPTION
# Summary

The CI failed
[here](https://github.com/laurent22/joplin/actions/runs/9405452447/job/25906649370?pr=10541#step:14:1017). This seems to be due to a timeout on one of the new mobile tests (waiting for a plugin to finish installing). This commit doubles the maximum timeout from 8s to 16s.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->