### PR TITLE
Mobile: Dismiss dialogs on background tap

### DIFF
--- a/packages/app-mobile/components/DismissibleDialog.tsx
+++ b/packages/app-mobile/components/DismissibleDialog.tsx
@@ -29,8 +29,8 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 
-		const maxWidth = size === DialogSize.Large ? Infinity : 500;
-		const maxHeight = size === DialogSize.Large ? Infinity : 700;
+		const maxWidth = size === DialogSize.Large ? windowSize.width * 0.97 : 500;
+		const maxHeight = size === DialogSize.Large ? windowSize.height * 0.9 : 700;
 
 		return StyleSheet.create({
 			webView: {
@@ -45,15 +45,13 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 				flexDirection: 'row',
 				justifyContent: 'flex-end',
 			},
-			dialog: {
-				backgroundColor: theme.backgroundColor,
-				borderRadius: 12,
-				padding: 10,
-
+			dialogContainer: {
 				// Use Math.min with width and height -- the maxWidth and maxHeight style
 				// properties don't seem to limit the size for this.
-				height: Math.min(maxHeight, windowSize.height * 0.9),
-				width: Math.min(maxWidth, windowSize.width * 0.97),
+				maxHeight,
+				maxWidth,
+				width: '100%',
+				height: '100%',
 				flexShrink: 1,
 
 				// Center
@@ -62,12 +60,12 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 
 				...containerStyle,
 			},
-			dialogContainer: {
-				display: 'flex',
-				flexDirection: 'row',
-				justifyContent: 'center',
-				alignItems: 'center',
-				flexGrow: 1,
+			dialogSurface: {
+				borderRadius: 12,
+				backgroundColor: theme.backgroundColor,
+				padding: 10,
+				width: '100%',
+				height: '100%',
 			},
 		});
 	}, [themeId, windowSize.width, windowSize.height, containerStyle, size]);
@@ -96,7 +94,7 @@ const DismissibleDialog: React.FC<Props> = props => {
 			backgroundColor='rgba(0, 0, 0, 0.1)'
 			transparent={true}
 		>
-			<Surface style={styles.dialog} elevation={1}>
+			<Surface style={styles.dialogSurface} elevation={1}>
 				{closeButton}
 				{props.children}
 			</Surface>

--- a/packages/app-mobile/components/DismissibleDialog.tsx
+++ b/packages/app-mobile/components/DismissibleDialog.tsx
@@ -29,8 +29,8 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 
-		const maxWidth = size === DialogSize.Large ? windowSize.width * 0.97 : 500;
-		const maxHeight = size === DialogSize.Large ? windowSize.height * 0.9 : 700;
+		const maxWidth = size === DialogSize.Large ? windowSize.width : 500;
+		const maxHeight = size === DialogSize.Large ? windowSize.height : 700;
 
 		return StyleSheet.create({
 			webView: {
@@ -55,6 +55,8 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 				// Center
 				marginLeft: 'auto',
 				marginRight: 'auto',
+				paddingLeft: 6,
+				paddingRight: 6,
 
 				...containerStyle,
 			},

--- a/packages/app-mobile/components/DismissibleDialog.tsx
+++ b/packages/app-mobile/components/DismissibleDialog.tsx
@@ -46,8 +46,6 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogSize)
 				justifyContent: 'flex-end',
 			},
 			dialogContainer: {
-				// Use Math.min with width and height -- the maxWidth and maxHeight style
-				// properties don't seem to limit the size for this.
 				maxHeight,
 				maxWidth,
 				width: '100%',

--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -13,17 +13,21 @@ const useStyles = (backgroundColor?: string) => {
 	const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 	const isLandscape = windowWidth > windowHeight;
 	return useMemo(() => {
+		const backgroundPadding: ViewStyle = isLandscape ? {
+			paddingRight: hasNotch() ? 60 : 0,
+			paddingLeft: hasNotch() ? 60 : 0,
+			paddingTop: 15,
+			paddingBottom: 15,
+		} : {
+			paddingTop: hasNotch() ? 65 : 15,
+			paddingBottom: hasNotch() ? 35 : 15,
+		};
 		return StyleSheet.create({
-			contentWrapper: isLandscape ? {
-				marginRight: hasNotch() ? 60 : 0,
-				marginLeft: hasNotch() ? 60 : 0,
-				marginTop: 15,
-				marginBottom: 15,
-			} : {
-				marginTop: hasNotch() ? 65 : 15,
-				marginBottom: hasNotch() ? 35 : 15,
+			modalBackground: {
+				...backgroundPadding,
+				backgroundColor,
+				flexGrow: 1,
 			},
-			modalBackground: { backgroundColor, flexGrow: 1 },
 		});
 	}, [isLandscape, backgroundColor]);
 };
@@ -53,13 +57,13 @@ const ModalElement: React.FC<ModalElementProps> = ({
 	// contentWrapper adds padding. To allow styling the region outside of the modal
 	// (e.g. to add a background), the content is wrapped twice.
 	const content = (
-		<View style={[styles.contentWrapper, containerStyle]}>
+		<View style={containerStyle}>
 			{children}
 		</View>
 	);
 
-	const backdropRef = useRef<View>();
-	const { onShouldBackgroundCaptureTouch, onBackdropTouchFinished } = useBackdropTouchListeners(modalProps.onRequestClose, backdropRef);
+	const backgroundRef = useRef<View>();
+	const { onShouldBackgroundCaptureTouch, onBackdropTouchFinished } = useBackdropTouchListeners(modalProps.onRequestClose, backgroundRef);
 
 	// supportedOrientations: On iOS, this allows the dialog to be shown in non-portrait orientations.
 	return (
@@ -68,7 +72,7 @@ const ModalElement: React.FC<ModalElementProps> = ({
 			{...modalProps}
 		>
 			<View
-				ref={backdropRef}
+				ref={backgroundRef}
 				style={styles.modalBackground}
 				onStartShouldSetResponder={onShouldBackgroundCaptureTouch}
 				onResponderRelease={onBackdropTouchFinished}

--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -32,18 +32,18 @@ const useStyles = (backgroundColor?: string) => {
 	}, [isLandscape, backgroundColor]);
 };
 
-const useBackdropTouchListeners = (onRequestClose: (event: GestureResponderEvent)=> void, backdropRef: RefObject<View>) => {
+const useBackgroundTouchListeners = (onRequestClose: (event: GestureResponderEvent)=> void, backdropRef: RefObject<View>) => {
 	const onShouldBackgroundCaptureTouch = useCallback((event: GestureResponderEvent) => {
 		return event.target === backdropRef.current && event.nativeEvent.touches.length === 1;
 	}, [backdropRef]);
 
-	const onBackdropTouchFinished = useCallback((event: GestureResponderEvent) => {
+	const onBackgroundTouchFinished = useCallback((event: GestureResponderEvent) => {
 		if (event.target === backdropRef.current) {
 			onRequestClose?.(event);
 		}
 	}, [onRequestClose, backdropRef]);
 
-	return { onShouldBackgroundCaptureTouch, onBackdropTouchFinished };
+	return { onShouldBackgroundCaptureTouch, onBackgroundTouchFinished };
 };
 
 const ModalElement: React.FC<ModalElementProps> = ({
@@ -63,7 +63,7 @@ const ModalElement: React.FC<ModalElementProps> = ({
 	);
 
 	const backgroundRef = useRef<View>();
-	const { onShouldBackgroundCaptureTouch, onBackdropTouchFinished } = useBackdropTouchListeners(modalProps.onRequestClose, backgroundRef);
+	const { onShouldBackgroundCaptureTouch, onBackgroundTouchFinished } = useBackgroundTouchListeners(modalProps.onRequestClose, backgroundRef);
 
 	// supportedOrientations: On iOS, this allows the dialog to be shown in non-portrait orientations.
 	return (
@@ -75,7 +75,7 @@ const ModalElement: React.FC<ModalElementProps> = ({
 				ref={backgroundRef}
 				style={styles.modalBackground}
 				onStartShouldSetResponder={onShouldBackgroundCaptureTouch}
-				onResponderRelease={onBackdropTouchFinished}
+				onResponderRelease={onBackgroundTouchFinished}
 			>{content}</View>
 		</Modal>
 	);


### PR DESCRIPTION
# Summary

This pull request dismisses the plugin, tag, and link modals when a user taps outside of them. This matches similar behavior in the dropdown menu modals.

# Screen recording



https://github.com/laurent22/joplin/assets/46334387/2935b755-bb8d-405f-8a37-7fc2c211b6e8



# Testing plan
1. Open the plugin info dialog in settings.
   - Interact with the dialog (e.g. scroll). Verify that it doesn't close.
   - Dismiss the dialog by tapping on its background.
2. Open the plugin panels dialog. Dismiss it by tapping on its close button.
3. Open the link dialog in a note. Dismiss it by tapping on its background.
4. Open the tag dialog. Dismiss it by pressing "cancel".

This has been tested successfully on an Android 14 emulator (no notch) and similar testing was done on an iOS 17 simulator (notch).