### PR TITLE
Desktop: Fixes #8960: Fix cursor jump in the Rich Text Editor on sync

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1240,8 +1240,11 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			}
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		async function onKeyDown(event: any) {
+		async function onKeyDown(event: KeyboardEvent) {
+			// Although the onChangeHandler also marks the editor content as changed, it's important
+			// to set changed to true as soon as possible. See https://github.com/laurent22/joplin/issues/8960.
+			props.setChanged(true);
+
 			// It seems "paste as text" is handled automatically on Windows and Linux,
 			// so we need to run the below code only on macOS. If we were to run this
 			// on Windows/Linux, we would have this double-paste issue:

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -84,7 +84,7 @@ function NoteEditor(props: NoteEditorProps) {
 
 	const effectiveNoteId = useEffectiveNoteId(props);
 
-	const { formNote, setFormNote, isNewNote, resourceInfos } = useFormNote({
+	const { formNote, setFormNote, isNewNote, resourceInfos, setChanged } = useFormNote({
 		syncStarted: props.syncStarted,
 		decryptionStarted: props.decryptionStarted,
 		noteId: effectiveNoteId,
@@ -396,6 +396,7 @@ function NoteEditor(props: NoteEditorProps) {
 		whiteBackgroundNoteRendering,
 		onChange: onBodyChange,
 		onWillChange: onBodyWillChange,
+		setChanged,
 		onMessage: onMessage,
 		content: formNote.body,
 		contentMarkupLanguage: formNote.markup_language,

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -105,6 +105,7 @@ export interface NoteBodyEditorProps {
 	contentKey: string;
 	contentMarkupLanguage: number;
 	contentOriginalCss: string;
+	setChanged(changed: boolean): void;
 	onChange(event: OnChangeEvent): void;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	onWillChange(event: any): void;

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -306,10 +306,17 @@ export default function useFormNote(dependencies: HookDependencies) {
 		}
 	}, [setFormNote]);
 
+	const setChanged = useCallback((changed: boolean) => {
+		if (formNoteRef.current.hasChanged !== changed) {
+			onSetFormNote({ ...formNoteRef.current, hasChanged: changed });
+		}
+	}, [onSetFormNote]);
+
 	return {
 		isNewNote,
 		formNote,
 		setFormNote: onSetFormNote,
+		setChanged,
 		resourceInfos,
 	};
 }


### PR DESCRIPTION
# Summary

This pull request tries to fix #8960 (#10449 seems to have failed to do so). It does so by marking the current note as changed immediately after a key is pressed (rather than waiting for an `onChange` event to be received).

In particular, this pull request focuses on the Rich Text Editor because it's simpler to implement and I am not certain that this will fix the issue. If it does, a similar change can be made to the beta and legacy markdown editors.

May fix #8960.

# Rationale

Logs [collected before #10449 was merged](https://github.com/laurent22/joplin/issues/8960#issuecomment-2123481861)  suggest that #8960 was caused by a race condition where:
1. The user types something. 
2. Sync completes. The form note updates and doesn't match the editor's content. The editor isn't marked as changed by the user, so is updated. This moves the cursor to the start of the note.
3. The note is marked as changed by step 1, too late to stop the editor's contents from being replaced by step 2.

#10449 eliminated the need for a React re-render between the editor's `change` event and marking the editor's content as changed (in step 3). If #8960 is still happening because the `change` event isn't firing soon enough after the editor is changed, marking the editor as changed on key down events might fix the issue.

# Testing plan

Regression testing:

1. Create a new note.
5. Type several paragraphs in the Rich Text editor.
6. Switch notes.
7. Switch back to the original note.
8. Verify that changes made to the original were saved.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->