### PR TITLE
Desktop: Fixes #10236: Fix note disappears while editing during search

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -456,6 +456,7 @@ packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
+packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js
 packages/app-desktop/integration-tests/simpleBackup.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -435,6 +435,7 @@ packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
+packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js
 packages/app-desktop/integration-tests/simpleBackup.spec.js

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -48,4 +48,9 @@ export default class MainScreen {
 			throw new Error('Unable to find settings menu item in application menus.');
 		}
 	}
+
+	public async search(text: string) {
+		const searchBar = this.page.getByPlaceholder('Search...');
+		await searchBar.fill(text);
+	}
 }

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './util/test';
+import MainScreen from './models/MainScreen';
+
+test.describe('noteList', () => {
+	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		const sidebar = mainScreen.sidebar;
+
+		const folderAHeader = await sidebar.createNewFolder('Folder A');
+		await expect(folderAHeader).toBeVisible();
+
+		const folderBHeader = await sidebar.createNewFolder('Folder B');
+		await expect(folderBHeader).toBeVisible();
+		await folderBHeader.click();
+
+		await mainScreen.createNewNote('note-1');
+
+		await folderAHeader.click();
+		await mainScreen.createNewNote('note-2');
+
+		// Search for and focus a note different from the folder we were in before searching.
+		await mainScreen.search('/note-1');
+		const note1Result = mainScreen.noteListContainer.getByText('note-1');
+		await expect(note1Result).toBeAttached();
+		await note1Result.click();
+
+		// Typing should not cause the note to disappear
+		const editor = mainScreen.noteEditor;
+		await editor.codeMirrorEditor.click();
+		await mainWindow.keyboard.type('[Testing...](http://example.com/)');
+
+		// Wait to render
+		await expect(editor.getNoteViewerIframe().locator('a', { hasText: 'Testing...' })).toBeVisible();
+
+		// Updating the title should force the sidebar to update sooner
+		await expect(editor.noteTitleInput).toHaveValue('note-1');
+	});
+});

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -101,37 +101,4 @@ test.describe('sidebar', () => {
 		await expect(mainWindow.getByText('Another note in Folder A')).toBeAttached();
 		await expect(mainWindow.getByText('A note in Folder B')).toBeAttached();
 	});
-
-	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow }) => {
-		const mainScreen = new MainScreen(mainWindow);
-		const sidebar = mainScreen.sidebar;
-
-		const folderAHeader = await sidebar.createNewFolder('Folder A');
-		await expect(folderAHeader).toBeVisible();
-
-		const folderBHeader = await sidebar.createNewFolder('Folder B');
-		await expect(folderBHeader).toBeVisible();
-		await folderBHeader.click();
-
-		await mainScreen.createNewNote('note-1');
-
-		await folderAHeader.click();
-		await mainScreen.createNewNote('note-2');
-
-		// Search for and focus a note different from the folder we were in before searching.
-		await mainScreen.search('/note-1');
-		const note1Result = mainScreen.noteListContainer.getByText('note-1');
-		await expect(note1Result).toBeAttached();
-		await note1Result.click();
-
-		const editor = mainScreen.noteEditor;
-		await editor.codeMirrorEditor.click();
-		await mainWindow.keyboard.type('[Testing...](http://example.com/)');
-
-		// Wait to render
-		await expect(editor.getNoteViewerIframe().locator('a', { hasText: 'Testing...' })).toBeVisible();
-
-		// Updating the title should force the sidebar to update sooner
-		await expect(editor.noteTitleInput).toHaveValue('note-1');
-	});
 });

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -101,4 +101,37 @@ test.describe('sidebar', () => {
 		await expect(mainWindow.getByText('Another note in Folder A')).toBeAttached();
 		await expect(mainWindow.getByText('A note in Folder B')).toBeAttached();
 	});
+
+	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		const sidebar = mainScreen.sidebar;
+
+		const folderAHeader = await sidebar.createNewFolder('Folder A');
+		await expect(folderAHeader).toBeVisible();
+
+		const folderBHeader = await sidebar.createNewFolder('Folder B');
+		await expect(folderBHeader).toBeVisible();
+		await folderBHeader.click();
+
+		await mainScreen.createNewNote('note-1');
+
+		await folderAHeader.click();
+		await mainScreen.createNewNote('note-2');
+
+		// Search for and focus a note different from the folder we were in before searching.
+		await mainScreen.search('/note-1');
+		const note1Result = mainScreen.noteListContainer.getByText('note-1');
+		await expect(note1Result).toBeAttached();
+		await note1Result.click();
+
+		const editor = mainScreen.noteEditor;
+		await editor.codeMirrorEditor.click();
+		await mainWindow.keyboard.type('[Testing...](http://example.com/)');
+
+		// Wait to render
+		await expect(editor.getNoteViewerIframe().locator('a', { hasText: 'Testing...' })).toBeVisible();
+
+		// Updating the title should force the sidebar to update sooner
+		await expect(editor.noteTitleInput).toHaveValue('note-1');
+	});
 });

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -963,13 +963,14 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 				for (let i = 0; i < newNotes.length; i++) {
 					const n = newNotes[i];
 					if (n.id === modNote.id) {
+						const previousDisplayParentId = ('parent_id' in n) ? getDisplayParentId(n, draft.folders.find(f => f.id === n.parent_id)) : '';
 						if (n.is_conflict && !modNote.is_conflict) {
 							// Note was a conflict but was moved outside of
 							// the conflict folder
 							newNotes.splice(i, 1);
 							noteFolderHasChanged = true;
 							movedNotePreviousIndex = i;
-						} else if (isViewingAllNotes || noteIsInFolder(modNote, draft.selectedFolderId)) {
+						} else if (isViewingAllNotes || noteIsInFolder(modNote, previousDisplayParentId)) {
 							// Note is still in the same folder
 							// Merge the properties that have changed (in modNote) into
 							// the object we already have.


### PR DESCRIPTION
# Summary

This pull request fixes a bug in the updated logic for `NOTE_UPDATE_ONE` introduced in https://github.com/laurent22/joplin/pull/9671/commits/d63615b19c6610237aac0c796309b0e5dffd451c. 

Prior to d63615b19c6610237aac0c796309b0e5dffd451c, a note was considered "in the same folder" if it had the same `parent_id`. With the introduction of a virtual trash folder, a note's `parent_id` property might not be its displayed parent folder.[^1] When the trash folder is selected, restoring a folder doesn't change its `parent_id`, but does change its displayed parent ID. The UI should show that a restored item is no longer in the trash folder. d63615b19c6610237aac0c796309b0e5dffd451c handled this by checking whether the note was still displayed in `selectedFolderId`. This, however, was problematic when a search or tag, rather than a folder, was selected.

Rather than comparing the new display parent ID with `selectedFolderId`, this pull request compares the old display parent ID with the new display parent ID.

Fixes #10388.
Fixes #10236.

[^1]: Previously, this was also the case for conflicts. However, those [are handled differently.](https://github.com/laurent22/joplin/blob/7ee5cad21e0e2f0ee652eb22ae61177f178f421f/packages/lib/reducer.ts#L954)

# Testing

This pull request includes an automated regression test. However, for now, it doesn't verify that 1) restoring from trash still works and 2) editing a note after selecting a tag still works. These have been tested manually by:
1. Opening a notebook.
2. Selecting a tag.
3. Selecting a note not in the notebook selected in step 1.
4. Editing the note.
5. Verifying that the note doesn't disappear.
6. Sort by "updated date" with most recent first.
7. Edit a different note.
8. Verify that it is moved to the top of the note list.
9. Delete a note.
10. Open the trash folder and restore the note.
11. Verify that the note disappears from the trash.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->