### PR TITLE
Desktop, Mobile: Add button on Synchronization to Joplin Cloud login screen

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -243,6 +243,24 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					</div>
 				);
 
+				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud')) {
+					const goToJoplinCloudLogin = () => {
+						this.props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'JoplinCloudLogin',
+						});
+					};
+					settingComps.push(
+						<div key="connect_to_joplin_cloud_button" style={this.rowStyle_}>
+							<Button
+								title={_('Connect to Joplin Cloud')}
+								level={ButtonLevel.Primary}
+								onClick={goToJoplinCloudLogin}
+							/>
+						</div>,
+					);
+				}
+
 				settingComps.push(
 					<div key="check_sync_config_button" style={this.rowStyle_}>
 						<Button

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -86,6 +86,10 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		shared.init(reg);
 	}
 
+	private goToJoplinCloudLogin_ = async () => {
+		await NavService.go('JoplinCloudLogin');
+	};
+
 	private checkSyncConfig_ = async () => {
 		if (this.state.settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud')) {
 			const isAuthenticated = await reg.syncTarget().isAuthenticated();
@@ -460,6 +464,10 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 							) : null}
 						</View>
 					);
+
+					if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud')) {
+						addSettingButton('go_to_joplin_cloud_login_button', _('Connect to Joplin Cloud'), this.goToJoplinCloudLogin_, { statusComp: statusComp });
+					}
 
 					addSettingButton('check_sync_config_button', _('Check synchronisation configuration'), this.checkSyncConfig_, { statusComp: statusComp });
 				}

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -466,7 +466,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 					);
 
 					if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinCloud')) {
-						addSettingButton('go_to_joplin_cloud_login_button', _('Connect to Joplin Cloud'), this.goToJoplinCloudLogin_, { statusComp: statusComp });
+						addSettingButton('go_to_joplin_cloud_login_button', _('Connect to Joplin Cloud'), this.goToJoplinCloudLogin_);
 					}
 
 					addSettingButton('check_sync_config_button', _('Check synchronisation configuration'), this.checkSyncConfig_, { statusComp: statusComp });


### PR DESCRIPTION
I'm adding a way for the user to go to Joplin Cloud login after he selects Joplin Cloud as the sync target.

The implementation is pretty straightforward, I check if the target is Joplin Cloud before rendering the button. I used a primary stle for the button on Desktop, but maybe that won't be necessary.

<details><summary>Desktop</summary>

![2024-06-11_15-22](https://github.com/laurent22/joplin/assets/5051088/44ab3d1b-6431-4e3f-af51-c0f2c231ae59)

</details> 


<details><summary>Mobile</summary>

![2024-06-11_15-21](https://github.com/laurent22/joplin/assets/5051088/5a4358bb-3a60-488c-85cc-1c1e15dd0af3)

</details> 