### PR TITLE
Desktop, Mobile: Hide links to login after process is successful

### DIFF
--- a/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useState } from 'react';
+import { Fragment, useEffect, useMemo, useReducer, useState } from 'react';
 import ButtonBar from './ConfigScreen/ButtonBar';
 import { _ } from '@joplin/lib/locale';
 import { clipboard } from 'electron';
@@ -77,22 +77,26 @@ const JoplinCloudScreenComponent = (props: Props) => {
 	return (
 		<div className="login-page">
 			<div className="page-container">
-				<p className="text">{_('To allow Joplin to synchronise with Joplin Cloud, please login using this URL:')}</p>
-				<div className="buttons-container">
-					<Button
-						onClick={onAuthorizeClicked}
-						title={_('Authorise')}
-						iconName='fa fa-external-link-alt'
-						level={ButtonLevel.Primary}
-					/>
-					<Button
-						onClick={onCopyToClipboardClicked}
-						title={_('Copy link to website')}
-						iconName='fa fa-clone'
-						level={ButtonLevel.Secondary}
-					/>
+				{state.active !== 'COMPLETED' ? (
+					<Fragment>
+						<p className="text">{_('To allow Joplin to synchronise with Joplin Cloud, please login using this URL:')}</p>
+						<div className="buttons-container">
+							<Button
+								onClick={onAuthorizeClicked}
+								title={_('Authorise')}
+								iconName='fa fa-external-link-alt'
+								level={ButtonLevel.Primary}
+							/>
+							<Button
+								onClick={onCopyToClipboardClicked}
+								title={_('Copy link to website')}
+								iconName='fa fa-clone'
+								level={ButtonLevel.Secondary}
+							/>
 
-				</div>
+						</div>
+					</Fragment>
+				) : null}
 				<p className={state.className}>{state.message()}
 					{state.active === 'ERROR' ? (
 						<span className={state.className}>{state.errorMessage}</span>

--- a/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
+++ b/packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx
@@ -145,28 +145,32 @@ const JoplinCloudScreenComponent = (props: Props) => {
 		<View style={styles.root}>
 			<ScreenHeader title={_('Joplin Cloud Login')} />
 			<View style={styles.containerStyle}>
-				<Text style={styles.text}>
-					{_('To allow Joplin to synchronise with Joplin Cloud, please login using this URL:')}
-				</Text>
-				<View style={styles.buttonsContainer}>
-					<View style={{ marginBottom: 20 }}>
-						<Button
-							onPress={onAuthoriseClicked}
-							icon='open-in-new'
-							mode='contained'
-						>
-							{_('Authorise')}
-						</Button>
-					</View>
-					<Text style={styles.smallTextStyle}>Or</Text>
-					<Button
-						onPress={onCopyToClipboardClicked}
-						icon='content-copy'
-						mode='outlined'
-					>{_('Copy link to website')}
-					</Button>
-
-				</View>
+				{ state.active !== 'COMPLETED' ?
+					<React.Fragment>
+						<Text style={styles.text}>
+							{_('To allow Joplin to synchronise with Joplin Cloud, please login using this URL:')}
+						</Text>
+						<View style={styles.buttonsContainer}>
+							<View style={{ marginBottom: 20 }}>
+								<Button
+									onPress={onAuthoriseClicked}
+									icon='open-in-new'
+									mode='contained'
+								>
+									{_('Authorise')}
+								</Button>
+							</View>
+							<Text style={styles.smallTextStyle}>{_('Or')}</Text>
+							<Button
+								onPress={onCopyToClipboardClicked}
+								icon='content-copy'
+								mode='outlined'
+							>{_('Copy link to website')}
+							</Button>
+						</View>
+					</React.Fragment>
+					: null
+				}
 				<Text style={styles[state.className]}>{state.message()}
 					{state.active === 'ERROR' ? (
 						<Text style={styles[state.className]}>{state.errorMessage}</Text>


### PR DESCRIPTION
I'm removing the buttons and links to login webpage inside the Joplin Cloud Login screen after the login process is successful.

<details><summary>Desktop</summary>

![2024-06-11_18-14](https://github.com/laurent22/joplin/assets/5051088/88688776-4378-44bb-a8ff-6679e1074d47)

</details> 

<details><summary>Mobile</summary>

![2024-06-11_18-13](https://github.com/laurent22/joplin/assets/5051088/a87d5af1-cd73-4400-9cfe-b589df11344d)

</details> 