### PR TITLE
Desktop: Fixes error when Joplin Cloud login is finished before the settings are saved

### DIFF
--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -5,6 +5,7 @@ import shim from '../shim';
 import { _ } from '../locale';
 import eventManager, { EventName } from '../eventManager';
 import { reg } from '../registry';
+import SyncTargetRegistry from '../SyncTargetRegistry';
 
 type ActionType = 'LINK_USED' | 'COMPLETED' | 'ERROR';
 type Action = {
@@ -110,6 +111,7 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
 
 		Setting.setValue('sync.10.username', jsonBody.id);
 		Setting.setValue('sync.10.password', jsonBody.password);
+		Setting.setValue('sync.target', SyncTargetRegistry.nameToId('joplinCloud'));
 
 		const fileApi = await reg.syncTarget().fileApi();
 		await fileApi.driver().api().loadSession();


### PR DESCRIPTION
We are fixing a bug where the application wouldn't be able to load the user information after login because the `sync.target` setting hadn't been set yet. The error would happen because the `reg.syncTarget` wouldn't be loaded properly in these cases.

To ensure this won't happen, when the Joplin Cloud login process is finished we also set the `sync.target` value, together with the `username` and `password`

### Testing

1. Go to settings.
2. Set the sync target to "None".
3. Click "Apply".
4. Set the sync target to "Joplin Cloud" and **do not** click "apply".
6. Click "Connect to Joplin Cloud".
7. Click "Authorize".
8. Click "Authorise".
9. Go back to Joplin.
10. Previously a error message would appear:
     ```
    You were unable to connect to Joplin Cloud. Please check your credentials and try again. Error:Cannot read properties of null (reading 'driver').
    ```
11. Now it should show a successful message:
   ```
You are logged in into Joplin Cloud, you can leave this screen now.
```