### PR TITLE
Mobile: Plugin settings: Fix plugins without settings can't be disabled without reinstall

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -265,7 +265,7 @@ describe('PluginStates.installed', () => {
 		wrapper.unmount();
 	});
 
-	it('should consider running plugins without settings to be installed', async () => {
+	it('should be possible to disable plugins, even if missing from plugins.states', async () => {
 		await mockRepositoryApiConstructor();
 
 		const defaultPluginSettings: PluginSettings = {};

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -52,6 +52,9 @@ const showInstalledTab = async () => {
 	await userEvent.press(installedTab);
 };
 
+const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
+const backlinksPluginId = 'joplin.plugin.ambrt.backlinksToNote';
+
 describe('PluginStates.installed', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(0);
@@ -76,9 +79,6 @@ describe('PluginStates.installed', () => {
 		await mockMobilePlatform(platform);
 		expect(shim.mobilePlatform()).toBe(platform);
 		await mockRepositoryApiConstructor();
-
-		const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
-		const backlinksPluginId = 'joplin.plugin.ambrt.backlinksToNote';
 
 		const defaultPluginSettings: PluginSettings = {
 			[abcPluginId]: defaultPluginSetting(),
@@ -117,7 +117,6 @@ describe('PluginStates.installed', () => {
 	});
 
 	it('should show the current plugin version on updatable plugins', async () => {
-		const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
 		const defaultPluginSettings: PluginSettings = { [abcPluginId]: defaultPluginSetting() };
 
 		const outdatedVersion = '0.0.1';
@@ -173,7 +172,6 @@ describe('PluginStates.installed', () => {
 	});
 
 	it('should support disabling plugins from the info modal', async () => {
-		const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
 		const defaultPluginSettings: PluginSettings = { [abcPluginId]: defaultPluginSetting() };
 
 		await loadMockPlugin(abcPluginId, 'ABC Sheet Music', '1.2.3', defaultPluginSettings);
@@ -212,8 +210,6 @@ describe('PluginStates.installed', () => {
 
 	it('should support updating plugins from the info modal', async () => {
 		await mockRepositoryApiConstructor();
-
-		const abcPluginId = 'org.joplinapp.plugins.AbcSheetMusic';
 
 		const defaultPluginSettings: PluginSettings = {
 			[abcPluginId]: defaultPluginSetting(),
@@ -264,6 +260,43 @@ describe('PluginStates.installed', () => {
 		await waitFor(() => {
 			const versionText = screen.getAllByText('v0.0.2');
 			expect(versionText).toHaveLength(2);
+		});
+
+		wrapper.unmount();
+	});
+
+	it('should consider running plugins without settings to be installed', async () => {
+		await mockRepositoryApiConstructor();
+
+		const defaultPluginSettings: PluginSettings = {};
+		await loadMockPlugin(abcPluginId, 'ABC Sheet Music', '3.4.5', defaultPluginSettings);
+		expect(PluginService.instance().plugins[abcPluginId]).toBeTruthy();
+
+		const wrapper = render(
+			<WrappedPluginStates
+				initialPluginSettings={defaultPluginSettings}
+				store={reduxStore}
+			/>,
+		);
+		await showInstalledTab();
+
+		// Should be shown as installed.
+		const card = await screen.findByText('ABC Sheet Music');
+		expect(card).toBeVisible();
+
+		const user = userEvent.setup();
+		await user.press(card);
+
+		// Should be considered installed -- should be possible to disable:
+		const enabledSwitch = await screen.findByLabelText('Enabled');
+		expect(enabledSwitch).toBeVisible();
+		fireEvent(enabledSwitch, 'valueChange', false);
+
+		// Disabling should add the plugin to plugins.states, if not present before.
+		await waitFor(() => {
+			expect(Setting.value('plugins.states')).toMatchObject({
+				[abcPluginId]: { enabled: false },
+			});
 		});
 
 		wrapper.unmount();

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.ts
@@ -2,7 +2,7 @@ import { ItemEvent, OnPluginSettingChangeEvent } from '@joplin/lib/components/sh
 import useOnDeleteHandler from '@joplin/lib/components/shared/config/plugins/useOnDeleteHandler';
 import useOnInstallHandler from '@joplin/lib/components/shared/config/plugins/useOnInstallHandler';
 import NavService from '@joplin/lib/services/NavService';
-import { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
+import { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -29,14 +29,18 @@ const usePluginCallbacks = (props: Props) => {
 
 	const updatePluginEnabled = useCallback((pluginId: string, enabled: boolean) => {
 		const newSettings = { ...props.pluginSettings };
-		newSettings[pluginId].enabled = enabled;
+		newSettings[pluginId] = {
+			...defaultPluginSetting(),
+			...newSettings[pluginId],
+			enabled,
+		};
 
 		props.updatePluginStates(newSettings);
 	}, [props.pluginSettings, props.updatePluginStates]);
 
 	const onToggle = useCallback((event: ItemEvent) => {
 		const pluginId = event.item.manifest.id;
-		const settings = props.pluginSettings[pluginId];
+		const settings = props.pluginSettings[pluginId] ?? defaultPluginSetting();
 		updatePluginEnabled(pluginId, !settings.enabled);
 	}, [props.pluginSettings, updatePluginEnabled]);
 

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginItem.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginItem.ts
@@ -21,12 +21,14 @@ const usePluginItem = (id: string, pluginSettings: PluginSettings, initialItem: 
 		if (!manifest) return null;
 		const settings = pluginSettings[id];
 
+		const installed = !!settings || !!plugin;
+
 		return {
 			id,
 			manifest,
 
-			installed: !!settings,
-			enabled: settings?.enabled ?? false,
+			installed,
+			enabled: settings?.enabled ?? installed,
 			deleted: settings?.deleted ?? false,
 			hasBeenUpdated: settings?.hasBeenUpdated ?? false,
 			devMode: plugin?.devMode ?? false,


### PR DESCRIPTION
# Summary

Fixes an issue where, if a plugin lacks state settings (e.g. enabled/disabled/hasBeenUpdated), its info modal would not consider the plugin to be installed, even if it is running.

# Testing plan

This pull request contains an automated test. It has also been tested manually with the following steps:
1. Open "Install new plugins" in the plugin settings screen.
2. Search for ` ` such that most/all plugins are shown.
3. Install several plugins at once by quickly tapping `Install` by several plugins.
    - This seems to result in plugins that are not present in `plugins.states` (a separate issue).
4. Wait for the plugins to finish installing.
5. Open "Installed plugins".
6. Tap on each plugin. Disable 3-4 of them.
    - Previously, the "Enabled" toggle switch wasn't shown for plugins not present in `plugins.states` (instead, an "Install" button would be shown).
7. Verify that all plugins disable without errors.

This has been tested successfully on Android 13.

> [!NOTE]
>
> The mobile plugins screen tests are producing warnings related to not using fake timers. This seems unrelated to this pull request — I plan to fix it separately.
>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->