### PR TITLE
Mobile: Plugin settings screen: Fix plugin states not set correctly when installing multiple plugins at once

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PluginService, { defaultPluginSetting, Plugins, PluginSetting, PluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import { _ } from '@joplin/lib/locale';
 import styled from 'styled-components';
@@ -214,8 +214,11 @@ export default function(props: Props) {
 		props.onChange({ value: pluginService.serializePluginSettings(event.value) });
 	}, [pluginService, props.onChange]);
 
-	const onDelete = useOnDeleteHandler(pluginSettings, onPluginSettingsChange, false);
-	const onUpdate = useOnInstallHandler(setUpdatingPluginIds, pluginSettings, repoApi, onPluginSettingsChange, true);
+	const pluginSettingsRef = useRef(pluginSettings);
+	pluginSettingsRef.current = pluginSettings;
+
+	const onDelete = useOnDeleteHandler(pluginSettingsRef, onPluginSettingsChange, false);
+	const onUpdate = useOnInstallHandler(setUpdatingPluginIds, pluginSettingsRef, repoApi, onPluginSettingsChange, true);
 
 	const onToolsClick = useCallback(async () => {
 		const template = [

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx
@@ -40,7 +40,10 @@ export default function(props: Props) {
 	const [installingPluginsIds, setInstallingPluginIds] = useState<Record<string, boolean>>({});
 	const [searchResultCount, setSearchResultCount] = useState(null);
 
-	const onInstall = useOnInstallHandler(setInstallingPluginIds, props.pluginSettings, props.repoApi, props.onPluginSettingsChange, false);
+	const pluginSettingsRef = useRef(props.pluginSettings);
+	pluginSettingsRef.current = props.pluginSettings;
+
+	const onInstall = useOnInstallHandler(setInstallingPluginIds, pluginSettingsRef, props.repoApi, props.onPluginSettingsChange, false);
 
 	useEffect(() => {
 		setSearchResultCount(null);

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.ts
@@ -4,7 +4,7 @@ import useOnInstallHandler from '@joplin/lib/components/shared/config/plugins/us
 import NavService from '@joplin/lib/services/NavService';
 import { PluginSettings } from '@joplin/lib/services/plugins/PluginService';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 interface Props {
 	updatePluginStates: (settingValue: PluginSettings)=> void;
@@ -40,14 +40,17 @@ const usePluginCallbacks = (props: Props) => {
 		updatePluginEnabled(pluginId, !settings.enabled);
 	}, [props.pluginSettings, updatePluginEnabled]);
 
-	const onDelete = useOnDeleteHandler(props.pluginSettings, onPluginSettingsChange, true);
+	const pluginSettingsRef = useRef(props.pluginSettings);
+	pluginSettingsRef.current = props.pluginSettings;
+
+	const onDelete = useOnDeleteHandler(pluginSettingsRef, onPluginSettingsChange, true);
 
 	const [updatingPluginIds, setUpdatingPluginIds] = useState<Record<string, boolean>>({});
-	const onUpdate = useOnInstallHandler(setUpdatingPluginIds, props.pluginSettings, props.repoApi, onPluginSettingsChange, true);
+	const onUpdate = useOnInstallHandler(setUpdatingPluginIds, pluginSettingsRef, props.repoApi, onPluginSettingsChange, true);
 
 	const [installingPluginIds, setInstallingPluginIds] = useState<Record<string, boolean>>({});
 	const onInstall = useOnInstallHandler(
-		setInstallingPluginIds, props.pluginSettings, props.repoApi, onPluginSettingsChange, false,
+		setInstallingPluginIds, pluginSettingsRef, props.repoApi, onPluginSettingsChange, false,
 	);
 
 	const onShowPluginLog = useCallback((event: ItemEvent) => {

--- a/packages/lib/components/shared/config/plugins/useOnDeleteHandler.ts
+++ b/packages/lib/components/shared/config/plugins/useOnDeleteHandler.ts
@@ -1,11 +1,12 @@
 import { _ } from '../../../../locale';
 import PluginService, { PluginSettings, defaultPluginSetting } from '../../../../services/plugins/PluginService';
+import type * as React from 'react';
 import shim from '../../../../shim';
 import produce from 'immer';
 import { ItemEvent, OnPluginSettingChangeHandler } from './types';
 
 const useOnDeleteHandler = (
-	pluginSettings: PluginSettings,
+	pluginSettingsRef: React.RefObject<PluginSettings>,
 	onSettingsChange: OnPluginSettingChangeHandler,
 	deleteNow: boolean,
 ) => {
@@ -14,11 +15,6 @@ const useOnDeleteHandler = (
 		const item = event.item;
 		const confirmed = await shim.showConfirmationDialog(_('Delete plugin "%s"?', item.manifest.name));
 		if (!confirmed) return;
-
-		let newSettings = produce(pluginSettings, (draft: PluginSettings) => {
-			if (!draft[item.manifest.id]) draft[item.manifest.id] = defaultPluginSetting();
-			draft[item.manifest.id].deleted = true;
-		});
 
 		if (deleteNow) {
 			const pluginService = PluginService.instance();
@@ -29,12 +25,28 @@ const useOnDeleteHandler = (
 			if (plugin) {
 				await pluginService.unloadPlugin(item.manifest.id);
 			}
-
-			newSettings = await pluginService.uninstallPlugins(newSettings);
 		}
 
-		onSettingsChange({ value: newSettings });
-	}, [pluginSettings, onSettingsChange, deleteNow]);
+		// Important: To avoid race conditions, don't run any async code between fetching plugin
+		// settings from the ref and calling onSettingsChange.
+		let newSettings = pluginSettingsRef.current;
+		if (deleteNow) {
+			newSettings = produce(newSettings, (draft: PluginSettings) => {
+				delete draft[item.manifest.id];
+			});
+			onSettingsChange({ value: newSettings });
+
+			await PluginService.instance().uninstallPlugin(item.manifest.id);
+		} else {
+			// Setting .deleted causes the app to delete this plugin on startup.
+			newSettings = produce(newSettings, (draft: PluginSettings) => {
+				if (!draft[item.manifest.id]) draft[item.manifest.id] = defaultPluginSetting();
+				draft[item.manifest.id].deleted = true;
+			});
+			onSettingsChange({ value: newSettings });
+		}
+
+	}, [pluginSettingsRef, onSettingsChange, deleteNow]);
 };
 
 export default useOnDeleteHandler;

--- a/packages/lib/components/shared/config/plugins/useOnInstallHandler.test.ts
+++ b/packages/lib/components/shared/config/plugins/useOnInstallHandler.test.ts
@@ -20,13 +20,13 @@ const itemEvent = ({
 } as ItemEvent);
 const callHook = (isUpdate: boolean, pluginEnabled = true, pluginInstalledViaGUI = true) => () => useOnInstallHandler(
 	setInstallingPluginIds,
-	{
+	{ current: {
 		[pluginId]: pluginInstalledViaGUI ? {
 			enabled: pluginEnabled,
 			deleted: false,
 			hasBeenUpdated: false,
 		} : undefined,
-	},
+	} },
 	repoApi,
 	onPluginSettingsChange,
 	isUpdate,

--- a/packages/lib/components/shared/config/plugins/useOnInstallHandler.ts
+++ b/packages/lib/components/shared/config/plugins/useOnInstallHandler.ts
@@ -13,7 +13,7 @@ type GetRepoApiCallback = ()=> RepositoryApi;
 
 const useOnInstallHandler = (
 	setInstallingPluginIds: React.Dispatch<React.SetStateAction<Record<string, boolean>>>,
-	pluginSettings: PluginSettings,
+	pluginSettingsRef: React.RefObject<PluginSettings>,
 	getRepoApi: GetRepoApiCallback|RepositoryApi,
 	onPluginSettingsChange: OnPluginSettingChangeHandler,
 	isUpdate: boolean,
@@ -45,6 +45,7 @@ const useOnInstallHandler = (
 		}
 
 		if (!installError) {
+			const pluginSettings = pluginSettingsRef.current;
 			const newSettings = produce(pluginSettings, (draft: PluginSettings) => {
 				draft[pluginId] = defaultPluginSetting();
 				if (isUpdate) {
@@ -71,7 +72,7 @@ const useOnInstallHandler = (
 				{ buttons: [_('OK')] },
 			);
 		}
-	}, [getRepoApi, isUpdate, pluginSettings, onPluginSettingsChange, setInstallingPluginIds]);
+	}, [getRepoApi, isUpdate, pluginSettingsRef, onPluginSettingsChange, setInstallingPluginIds]);
 };
 
 export default useOnInstallHandler;


### PR DESCRIPTION
# Summary

This pull request fixes a race condition that prevented plugin state settings from being set correctly while installing or deleting multiple plugins at once. This made it possible to observe the issue fixed by #10579.

More specifically, when `plugins.states` updates, it's set to a new object. As such, after the first install or delete task finishes, other ongoing install/delete tasks would have an outdated copy of `plugins.states`. 

To see why this is an issue, suppose that a user quickly clicks "install" by two plugins:
1. This starts two concurrent install tasks (task A and task B).
2. When task A finishes, it adds a plugin to `plugins.states`.
    - `plugins.states` is now `{ "plugin.a.id.here": { enabled: true, deleted: false, ... } }`
4. When the next task finishes, it overwrites `plugins.states` with a modified version of its outdated copy.
    - `plugins.states` is now `{ "plugin.b.id.here": { enabled: true, deleted: false, ... } }`. Observe that `"plugin.a.id.here"` is no longer present in `plugins.states`.

# Testing plan

1. Open the plugin settings screen and search for ` `.
6. Quickly click "Install" by multiple plugins.
7. (Desktop) Restart Joplin and verify that the plugins installed.
8. (Mobile) Navigate to "installed plugins". Tap to disable each of the installed plugins.
   - Until #10579 is merged, it won't be possible to disable plugins that lack settings in `plugins.states`. As such, the "disable" toggle's presence can be used to verify that a plugin has settings in `plugins.states`.

This has been tested successfully on Android 13 (mobile) and Ubuntu 24.04 (desktop).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->