### PR TITLE
All: Fixes #10581: English: Use the plural form of a localization for negative and zero items

### DIFF
--- a/packages/lib/locale.test.ts
+++ b/packages/lib/locale.test.ts
@@ -19,6 +19,8 @@ describe('locale', () => {
 		setLocale('en_GB');
 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copy Shareable Link');
 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 2)).toBe('Copy Shareable Links');
+		expect(_n('Copy Shareable Link', 'Copy Shareable Links', -2)).toBe('Copy Shareable Links');
+		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 0)).toBe('Copy Shareable Links');
 	});
 
 	it('should translate plurals - fr_FR', () => {

--- a/packages/lib/locale.ts
+++ b/packages/lib/locale.ts
@@ -691,7 +691,7 @@ function _(s: string, ...args: any[]): string {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 function _n(singular: string, plural: string, n: number, ...args: any[]) {
 	if (['en_GB', 'en_US'].includes(currentLocale_)) {
-		if (n > 1) return _(plural, ...args);
+		if (n !== 1) return _(plural, ...args);
 		return _(singular, ...args);
 	} else {
 		const pluralFn = getPluralFunction(currentLocale_);


### PR DESCRIPTION
# Summary

This pull request fixes an issue with the plural/singular selection of `_n(...)` in the `en_US` and `en_GB` locales.

Fixes #10581.

> [!NOTE]
>
> It's possible that this also needs to be adjusted for other locales. French, for example, [also uses `count > 1` to determine whether to use a plural form.](https://github.com/laurent22/joplin/blob/a0e3e4fefb4beb7830d34b65ba47f327edbd8c70/packages/lib/locales/index.js#L60)
>

# Testing plan

This pull request includes an automated test. However, it has also been tested manually by

1. Navigate to the plugin config screen with no plugins installed (uninstall plugins if present).
2. Verify that the installed plugins section reads "You currently have 0 plugins installed".
3. Install a plugin.
4. Verify that the installed plugins section reads "You currently have 1 plugin installed".

This has been tested successfully on Android 13.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->