### PR TITLE
Mobile: Don't show an "expand" arrow by "Installed plugins" when no plugins are installed

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -149,16 +149,17 @@ describe('PluginStates.installed', () => {
 				store={reduxStore}
 			/>,
 		);
-		await showInstalledTab();
 
-		// Initially, no plugins should be visible.
-		expect(screen.queryByText(/^ABC Sheet Music/)).toBeNull();
+		// Initially, no plugins should be installed
+		expect(screen.queryByText(/^You currently have 0 plugins? installed/)).toBeNull();
 
 		const testPluginId1 = 'org.joplinapp.plugins.AbcSheetMusic';
 		const testPluginId2 = 'org.joplinapp.plugins.test.plugin.id';
 		await act(() => loadMockPlugin(testPluginId1, 'ABC Sheet Music', '1.2.3', pluginSettings));
 		await act(() => loadMockPlugin(testPluginId2, 'A test plugin', '1.0.0', pluginSettings));
 		expect(PluginService.instance().plugins[testPluginId1]).toBeTruthy();
+
+		await showInstalledTab();
 
 		// Should update the list of installed plugins even though the plugin settings didn't change.
 		expect(await screen.findByText(/^ABC Sheet Music/)).toBeVisible();

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -189,11 +189,15 @@ const PluginStates: React.FC<Props> = props => {
 	// may be shown by the search.
 	const installedAccordionDescription = !isSearching ? _n('You currently have %d plugin installed.', 'You currently have %d plugins installed.', pluginIds.length, pluginIds.length) : null;
 
+	// Using a different wrapper prevents the installed item group from being openable when
+	// there are no plugins:
+	const InstalledItemWrapper = pluginIds.length ? List.Accordion : List.Item;
+
 	return (
 		<View>
 			{renderRepoApiStatus()}
 			<List.AccordionGroup>
-				<List.Accordion
+				<InstalledItemWrapper
 					title={_('Installed plugins')}
 					description={installedAccordionDescription}
 					id='installed'
@@ -201,7 +205,7 @@ const PluginStates: React.FC<Props> = props => {
 					<View style={styles.installedPluginsContainer}>
 						{installedPluginCards}
 					</View>
-				</List.Accordion>
+				</InstalledItemWrapper>
 				<Divider/>
 				{showSearch ? searchAccordion : null}
 				<Divider/>


### PR DESCRIPTION
# Summary

This pull request is related to #10582. It hides the "![show](https://github.com/laurent22/joplin/assets/46334387/3ba174af-389c-4dc3-8f38-31d3ce4caff8)" arrow when there are no plugins.

# Screenshots

![screenshot: Installed plugins \ You currently have 1 plugin installed. Arrow to toggle dropdown.](https://github.com/laurent22/joplin/assets/46334387/e7431f3b-7f10-4c46-b3b3-d2b787935d77)
![screenshot: Installed plugins \ You currently have 0 plugin installed. No down arrow to toggle dropdown.](https://github.com/laurent22/joplin/assets/46334387/cecfbe76-54b4-467b-8164-560a0479b7cf)


# Testing plan

1. Open the plugin configuration screen.
2. Uninstall all plugins.
3. Verify that the arrow to the right of "Installed plugins" is not visible.
4. Install a plugin.
5. Verify that the arrow to the right of "Installed plugins" is visible.
6. Expand "Installed plugins" by clicking on it.

This has been tested successfully on Android 13.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->