### PR TITLE
Mobile: Mark plugin support as in beta

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -515,6 +515,7 @@ packages/app-mobile/commands/scrollToHash.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/components/ActionButton.js
 packages/app-mobile/components/BackButtonDialogBox.js
+packages/app-mobile/components/BetaChip.js
 packages/app-mobile/components/CameraView.js
 packages/app-mobile/components/DismissibleDialog.js
 packages/app-mobile/components/Dropdown.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -494,6 +494,7 @@ packages/app-mobile/commands/scrollToHash.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/components/ActionButton.js
 packages/app-mobile/components/BackButtonDialogBox.js
+packages/app-mobile/components/BetaChip.js
 packages/app-mobile/components/CameraView.js
 packages/app-mobile/components/DismissibleDialog.js
 packages/app-mobile/components/Dropdown.test.js

--- a/packages/app-mobile/components/BetaChip.tsx
+++ b/packages/app-mobile/components/BetaChip.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { themeStyle } from './global-style';
+import { useMemo } from 'react';
+import { _ } from '@joplin/lib/locale';
+import { connect } from 'react-redux';
+import { AppState } from '../utils/types';
+
+interface Props {
+	themeId: number;
+	size: number;
+}
+
+const useStyles = (themeId: number, size: number) => {
+	return useMemo(() => {
+		const theme = themeStyle(themeId);
+
+		return StyleSheet.create({
+			container: {
+				borderColor: theme.color4,
+				color: theme.color4,
+				fontSize: size,
+				opacity: 0.8,
+				borderRadius: 12,
+				borderWidth: 1,
+				padding: 4,
+				flexGrow: 0,
+				textAlign: 'center',
+				textAlignVertical: 'center',
+			},
+		});
+	}, [themeId, size]);
+};
+
+const BetaChip: React.FC<Props> = props => {
+	const styles = useStyles(props.themeId, props.size);
+	return <View><Text style={styles.container}>{_('Beta')}</Text></View>;
+};
+
+export default connect((state: AppState) => ({ themeId: state.settings.theme }))(BetaChip);

--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
@@ -8,6 +8,7 @@ import { settingsSections } from '@joplin/lib/components/shared/config/config-sh
 import Icon from '../../Icon';
 import { _ } from '@joplin/lib/locale';
 import { TouchableRipple } from 'react-native-paper';
+import BetaChip from '../../BetaChip';
 
 interface Props {
 	styles: ConfigScreenStyles;
@@ -46,6 +47,8 @@ const SectionSelector: FunctionComponent<Props> = props => {
 			/>
 		) : null;
 
+		const betaChip = item.name === 'plugins' ? <BetaChip size={10}/> : null;
+
 		return (
 			<TouchableRipple
 				key={section.name}
@@ -62,12 +65,16 @@ const SectionSelector: FunctionComponent<Props> = props => {
 						style={styles.sidebarIcon}
 					/>
 					<View style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-						<Text
-							numberOfLines={1}
-							style={titleStyle}
-						>
-							{label}
-						</Text>
+						<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+							<Text
+								numberOfLines={1}
+								style={titleStyle}
+							>
+								{label}
+							</Text>
+
+							{betaChip}
+						</View>
 						<Text
 							style={styles.sidebarButtonDescriptionText}
 							numberOfLines={1}

--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector.tsx
@@ -47,7 +47,8 @@ const SectionSelector: FunctionComponent<Props> = props => {
 			/>
 		) : null;
 
-		const betaChip = item.name === 'plugins' ? <BetaChip size={10}/> : null;
+		const isBeta = item.name === 'plugins';
+		const betaChip = isBeta ? <BetaChip size={10}/> : null;
 
 		return (
 			<TouchableRipple

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -194,9 +194,9 @@ const PluginStates: React.FC<Props> = props => {
 		<View>
 			{renderRepoApiStatus()}
 			<Banner visible={true} elevation={0} icon={() => <BetaChip size={13}/>}>
-				<Text>Plugin support on mobile is still in beta. For now, many plugins only support Joplin desktop or have only partial support for Joplin mobile.</Text>
+				<Text>Plugin support on mobile is still in beta. Plugins may cause performance issues. Some have only partial support for Joplin mobile.</Text>
 			</Banner>
-			<Divider bold={true}/>
+			<Divider/>
 
 			<List.AccordionGroup>
 				<List.Accordion

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -12,6 +12,7 @@ import useRepoApi from './utils/useRepoApi';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
 import PluginInfoModal from './PluginInfoModal';
 import usePluginCallbacks from './utils/usePluginCallbacks';
+import BetaChip from '../../../BetaChip';
 
 interface Props {
 	themeId: number;
@@ -192,6 +193,11 @@ const PluginStates: React.FC<Props> = props => {
 	return (
 		<View>
 			{renderRepoApiStatus()}
+			<Banner visible={true} elevation={0} icon={() => <BetaChip size={13}/>}>
+				<Text>Plugin support on mobile is still in beta. For now, many plugins only support Joplin desktop or have only partial support for Joplin mobile.</Text>
+			</Banner>
+			<Divider bold={true}/>
+
 			<List.AccordionGroup>
 				<List.Accordion
 					title={_('Installed plugins')}


### PR DESCRIPTION
# Summary

This pull request adds a "beta" chip to the plugin support tab on mobile.

## Why?

- Performance issues.
    - Loading large plugins involves sending large plugin scripts over IPC.
- Some plugins that can be installed are still only partially compatible.

# Screenshot


![screenshot: "Plugin support on mobile is still in beta. Plugins may cause performance issues. Some are only partially compatible with Joplin mobile".](https://github.com/laurent22/joplin/assets/46334387/fb7399ea-031e-4182-8a13-25fbb06f442c)


# Testing plan

1. Open settings.
2. Enable plugin support.
3. Verify that the "beta" chip and alert are visible.

This has been tested successfully on iOS 17.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->