### PR TITLE
Desktop: Fixes #10586: Don't re-order the note list when in search

### DIFF
--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1049,7 +1049,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 			{
 				if (draft.notesParentType === 'Search') {
-					logger.info('Not sorting the note list -- sorting should be done by search.');
+					logger.debug('Not sorting the note list -- sorting should be done by search.');
 				} else {
 					draft.notes = Note.sortNotes(draft.notes, stateUtils.notesOrder(draft.settings), draft.settings.uncompletedTodosOnTop);
 				}

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -11,10 +11,13 @@ import { FolderEntity, NoteEntity } from './services/database/types';
 import { getListRendererIds } from './services/noteList/renderers';
 import { ProcessResultsRow } from './services/search/SearchEngine';
 import { getDisplayParentId } from './services/trash';
+import Logger from '@joplin/utils/Logger';
 const fastDeepEqual = require('fast-deep-equal');
 const { ALL_NOTES_FILTER_ID } = require('./reserved-ids');
 const { createSelectorCreator, defaultMemoize } = require('reselect');
 const { createCachedSelector } = require('re-reselect');
+
+const logger = Logger.create('lib/reducer');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const additionalReducers: any[] = [];
@@ -1045,7 +1048,11 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 		case 'NOTE_SORT':
 
 			{
-				draft.notes = Note.sortNotes(draft.notes, stateUtils.notesOrder(draft.settings), draft.settings.uncompletedTodosOnTop);
+				if (draft.notesParentType === 'Search') {
+					logger.info('Not sorting the note list -- sorting should be done by search.');
+				} else {
+					draft.notes = Note.sortNotes(draft.notes, stateUtils.notesOrder(draft.settings), draft.settings.uncompletedTodosOnTop);
+				}
 				draft.noteListLastSortTime = Date.now();
 			}
 			break;


### PR DESCRIPTION
# Summary

<strike>This pull request fixes a regression (possibly introduced in f95ee689fdda2e30c32a99df5b9692c38b620c8f) that caused the note list to resort (incorrectly) when searching for notes.</strike> 

This pull request prevents the note list from resorting while editing when viewing a search (see #10586). **The previous behavior might be intended**. If so, this pull request can be closed.

Fixes #10586.

# Testing plan

1. Search for a term with many results.
2. Edit a note near the middle of the list.
3. Wait several seconds.
4. Verify that the note list doesn't update.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->