### PR TITLE
Mobile: #10589: Fixed notebook picker on new notes not working

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1631,10 +1631,24 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 			return <VoiceTypingDialog locale={currentLocale()} onText={this.voiceTypingDialog_onText} onDismiss={this.voiceTypingDialog_onDismiss}/>;
 		};
 
+		const folderPickerOptions = {
+			enabled: !this.state.readOnly,
+			selectedFolderId: this.state.note.parent_id,
+			onValueChange: async (folderIdSelected: string) => {
+				this.setState({
+					note: { ...this.state.note, parent_id: folderIdSelected },
+				});
+				this.props.dispatch({
+					type: 'NOTE_SELECT',
+					action: { id: note.id },
+				});
+			},
+		};
+
 		return (
 			<View style={this.rootStyle(this.props.themeId).root}>
 				<ScreenHeader
-					folderPickerOptions={this.folderPickerOptions()}
+					folderPickerOptions={folderPickerOptions}
 					menuOptions={this.menuOptions()}
 					showSaveButton={showSaveButton}
 					saveButtonDisabled={saveButtonDisabled}

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -16,7 +16,6 @@ const { connect } = require('react-redux');
 import Note from '@joplin/lib/models/Note';
 import BaseItem from '@joplin/lib/models/BaseItem';
 import Resource from '@joplin/lib/models/Resource';
-import Folder from '@joplin/lib/models/Folder';
 const Clipboard = require('@react-native-clipboard/clipboard').default;
 const md5 = require('md5');
 const { BackButtonService } = require('../../services/back-button.js');
@@ -143,8 +142,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	private menuOptionsCache_: Record<string, any>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private focusUpdateIID_: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private folderPickerOptions_: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public dialogbox: any;
 
@@ -322,7 +319,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		this.showOnMap_onPress = this.showOnMap_onPress.bind(this);
 		this.onMarkForDownload = this.onMarkForDownload.bind(this);
 		this.sideMenuOptions = this.sideMenuOptions.bind(this);
-		this.folderPickerOptions_valueChanged = this.folderPickerOptions_valueChanged.bind(this);
 		this.saveNoteButton_press = this.saveNoteButton_press.bind(this);
 		this.onAlarmDialogAccept = this.onAlarmDialogAccept.bind(this);
 		this.onAlarmDialogReject = this.onAlarmDialogReject.bind(this);
@@ -1388,40 +1384,6 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private async folderPickerOptions_valueChanged(itemValue: any) {
-		const note = this.state.note;
-		const isProvisionalNote = this.props.provisionalNoteIds.includes(note.id);
-
-		if (isProvisionalNote) {
-			await this.saveNoteButton_press(itemValue);
-		} else {
-			await Note.moveToFolder(note.id, itemValue);
-		}
-
-		note.parent_id = itemValue;
-
-		const folder = await Folder.load(note.parent_id);
-
-		this.setState({
-			lastSavedNote: { ...note },
-			note: note,
-			folder: folder,
-		});
-	}
-
-	public folderPickerOptions() {
-		const options = {
-			enabled: !this.state.readOnly,
-			selectedFolderId: this.state.folder ? this.state.folder.id : null,
-			onValueChange: this.folderPickerOptions_valueChanged,
-		};
-
-		if (this.folderPickerOptions_ && options.selectedFolderId === this.folderPickerOptions_.selectedFolderId) return this.folderPickerOptions_;
-
-		this.folderPickerOptions_ = options;
-		return this.folderPickerOptions_;
-	}
-
 	public onBodyViewerLoadEnd() {
 		shim.setTimeout(() => {
 			this.setState({ HACK_webviewLoadingState: 1 });


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10589

# Summary

Creating a New note or a New to-do from the floating action button would make the notebook picker behave inconsistently. Sometimes the wrong note would be changed, sometimes the notebook picker would be disabled, etc.

The bug is fixed and from testing, I couldn't find any other bugs introduced yet, but since it is not clear to me why the code was implemented as it was or if I could be introducing other regression I'm opening this as a draft so we can discuss it it is worth trying to add the change right now or not.

I tried to understand what was causing the bug but I couldn't wrap my head yet. I know that part of the faulty behavior was because of `props.noteId` not updating after the new note is moved, but the logical steps to get there are still fuzzy to me.

I think it is worth to take a second look before this is ready to merge.

### Improvement

The back button behavior is to go back to the initial notebook instead of the one where the note is now situated, this is confusing, it is worth take a look to improve the user experience.

# Testing

1. Create two notebooks
2. Select one (behavior is not observed if 'All notes' is selected)
3. Use the floating action button to create a new note
4. Press on notebook name
5. Select other notebook
6. Notebook should be the selected one and note should be created inside of it
