### PR TITLE
Mobile: Fixes #10593: Fix plugin list not cached in config screen

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/newRepoApi.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/newRepoApi.ts
@@ -6,7 +6,7 @@ import { createTempDir, supportDir } from '@joplin/lib/testing/test-utils';
 const newRepoApi = async (installMode: InstallMode, appVersion = '3.0.0'): Promise<RepositoryApi> => {
 	const appInfo = { type: AppType.Mobile, version: appVersion };
 	const repo = new RepositoryApi(`${supportDir}/pluginRepo`, await createTempDir(), appInfo, installMode);
-	await repo.initialize();
+	await repo.reinitialize();
 	return repo;
 };
 

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/useRepoApi.ts
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/utils/useRepoApi.ts
@@ -35,7 +35,7 @@ const useRepoApi = ({ reloadRepoCounter, setRepoApiError, onRepoApiLoaded }: Pro
 
 		setRepoApiError(null);
 		try {
-			await repoApi.initialize();
+			await repoApi.reinitialize();
 		} catch (error) {
 			logger.error(error);
 			setRepoApiError(error);

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -109,7 +109,7 @@ export default class RepositoryApi {
 
 	public async reinitialize() {
 		// Refresh at most once per minute
-		if (Date.now() - this.lastInitializedTime_ > 60000) {
+		if (Date.now() - this.lastInitializedTime_ > 5 * 60000) {
 			await this.initialize();
 		}
 	}

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -91,7 +91,7 @@ export default class RepositoryApi {
 		return new RepositoryApi('https://github.com/joplin/plugins', tempDirPath, appInfo, installMode);
 	}
 
-	private async initialize() {
+	public async initialize() {
 		// https://github.com/joplin/plugins
 		// https://api.github.com/repos/joplin/plugins/releases
 		this.githubApiUrl_ = this.baseUrl_.replace(/^(https:\/\/)(github\.com\/)(.*)$/, '$1api.$2repos/$3');

--- a/packages/lib/services/plugins/RepositoryApi.ts
+++ b/packages/lib/services/plugins/RepositoryApi.ts
@@ -77,6 +77,7 @@ export default class RepositoryApi {
 	private githubApiUrl_: string;
 	private contentBaseUrl_: string;
 	private isUsingDefaultContentUrl_ = true;
+	private lastInitializedTime_ = 0;
 
 	public constructor(baseUrl: string, tempDir: string, appInfo: AppInfo, installMode: InstallMode) {
 		this.installMode_ = installMode;
@@ -90,7 +91,7 @@ export default class RepositoryApi {
 		return new RepositoryApi('https://github.com/joplin/plugins', tempDirPath, appInfo, installMode);
 	}
 
-	public async initialize() {
+	private async initialize() {
 		// https://github.com/joplin/plugins
 		// https://api.github.com/repos/joplin/plugins/releases
 		this.githubApiUrl_ = this.baseUrl_.replace(/^(https:\/\/)(github\.com\/)(.*)$/, '$1api.$2repos/$3');
@@ -102,6 +103,15 @@ export default class RepositoryApi {
 
 		await this.loadManifests();
 		await this.loadRelease();
+
+		this.lastInitializedTime_ = Date.now();
+	}
+
+	public async reinitialize() {
+		// Refresh at most once per minute
+		if (Date.now() - this.lastInitializedTime_ > 60000) {
+			await this.initialize();
+		}
 	}
 
 	private async loadManifests() {


### PR DESCRIPTION
# Summary

This pull request fixes a logic error that caused the plugin list to not be cached. The plugin list is now refreshed at most once per minute.

Fixes #10593.

# Testing plan

1. Open the settings screen.
2. Open the plugins section.
4. Switch to a different tab.
5. Switch back to the plugins section.
6. Verify that the loading banner didn't appear.
7. Search for and install a plugin.

This has been tested successfully on iOS 17.4.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->