### PR TITLE
Mobile: Fix cmd-i no longer italicizes text

### DIFF
--- a/packages/editor/CodeMirror/CodeMirrorControl.test.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.test.ts
@@ -61,6 +61,33 @@ describe('CodeMirrorControl', () => {
 		expect(command).toHaveBeenCalledTimes(1);
 	});
 
+	it.each([
+		{
+			before: 'Test',
+			selection: EditorSelection.range(0, 4),
+			shortcut: { key: 'i', code: 'KeyI', ctrlKey: true },
+			expected: '*Test*',
+		},
+		{
+			before: 'Test',
+			selection: EditorSelection.range(0, 4),
+			shortcut: { key: 'b', code: 'KeyB', ctrlKey: true },
+			expected: '**Test**',
+		},
+		{
+			before: 'Testing',
+			selection: EditorSelection.range(0, 4),
+			shortcut: { key: 'b', code: 'KeyB', ctrlKey: true },
+			expected: '**Test**ing',
+		},
+	])('markdown keyboard shortcuts should work (case %#)', ({ before, selection, shortcut, expected }) => {
+		const control = createEditorControl(before);
+		control.select(selection.anchor, selection.head);
+
+		pressReleaseKey(control.editor, shortcut);
+		expect(control.getValue()).toBe(expected);
+	});
+
 	it('should support overriding default keybindings', () => {
 		const control = createEditorControl('test');
 		control.execCommand(EditorCommandType.SelectAll);

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -63,7 +63,7 @@ const configFromSettings = (settings: EditorSettings) => {
 	}
 
 	if (!settings.ignoreModifiers) {
-		extensions.push(keymap.of(defaultKeymap));
+		extensions.push(Prec.low(keymap.of(defaultKeymap)));
 	}
 
 	return extensions;

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -181,11 +181,47 @@ const createEditor = (
 	const historyCompartment = new Compartment();
 	const dynamicConfig = new Compartment();
 
+	// Give the default keymap low precedence so that it is overridden
+	// by extensions with default precedence.
+	const keymapConfig = Prec.low(keymap.of([
+		// Custom mod-f binding: Toggle the external dialog implementation
+		// (don't show/hide the Panel dialog).
+		keyCommand('Mod-f', (_: EditorView) => {
+			if (searchVisible) {
+				hideSearchDialog();
+			} else {
+				showSearchDialog();
+			}
+			return true;
+		}),
+		// Markdown formatting keyboard shortcuts
+		keyCommand('Mod-b', toggleBolded),
+		keyCommand('Mod-i', toggleItalicized),
+		keyCommand('Mod-$', toggleMath),
+		keyCommand('Mod-`', toggleCode),
+		keyCommand('Mod-[', decreaseIndent),
+		keyCommand('Mod-]', increaseIndent),
+		keyCommand('Mod-k', (_: EditorView) => {
+			notifyLinkEditRequest();
+			return true;
+		}),
+		keyCommand('Tab', insertOrIncreaseIndent, true),
+		keyCommand('Shift-Tab', decreaseIndent, true),
+		keyCommand('Mod-Enter', (_: EditorView) => {
+			insertLineAfter(_);
+			return true;
+		}, true),
+
+		...standardKeymap, ...historyKeymap, ...searchKeymap,
+	]));
+
 	const editor = new EditorView({
 		state: EditorState.create({
 			// See https://github.com/codemirror/basic-setup/blob/main/src/codemirror.ts
 			// for a sample configuration.
 			extensions: [
+				keymapConfig,
+
 				dynamicConfig.of(configFromSettings(props.settings)),
 				historyCompartment.of(history()),
 
@@ -238,40 +274,6 @@ const createEditor = (
 					notifySelectionChange(viewUpdate);
 					notifySelectionFormattingChange(viewUpdate);
 				}),
-
-				// Give the default keymap low precedence so that it is overridden
-				// by extensions with default precedence.
-				Prec.low(keymap.of([
-					// Custom mod-f binding: Toggle the external dialog implementation
-					// (don't show/hide the Panel dialog).
-					keyCommand('Mod-f', (_: EditorView) => {
-						if (searchVisible) {
-							hideSearchDialog();
-						} else {
-							showSearchDialog();
-						}
-						return true;
-					}),
-					// Markdown formatting keyboard shortcuts
-					keyCommand('Mod-b', toggleBolded),
-					keyCommand('Mod-i', toggleItalicized),
-					keyCommand('Mod-$', toggleMath),
-					keyCommand('Mod-`', toggleCode),
-					keyCommand('Mod-[', decreaseIndent),
-					keyCommand('Mod-]', increaseIndent),
-					keyCommand('Mod-k', (_: EditorView) => {
-						notifyLinkEditRequest();
-						return true;
-					}),
-					keyCommand('Tab', insertOrIncreaseIndent, true),
-					keyCommand('Shift-Tab', decreaseIndent, true),
-					keyCommand('Mod-Enter', (_: EditorView) => {
-						insertLineAfter(_);
-						return true;
-					}, true),
-
-					...standardKeymap, ...historyKeymap, ...searchKeymap,
-				])),
 			],
 			doc: initialText,
 		}),

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -241,7 +241,7 @@ const createEditor = (
 
 				// Give the default keymap low precedence so that it is overridden
 				// by extensions with default precedence.
-				Prec.default(keymap.of([
+				Prec.low(keymap.of([
 					// Custom mod-f binding: Toggle the external dialog implementation
 					// (don't show/hide the Panel dialog).
 					keyCommand('Mod-f', (_: EditorView) => {
@@ -269,6 +269,7 @@ const createEditor = (
 						insertLineAfter(_);
 						return true;
 					}, true),
+
 					...standardKeymap, ...historyKeymap, ...searchKeymap,
 				])),
 			],

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -241,7 +241,7 @@ const createEditor = (
 
 				// Give the default keymap low precedence so that it is overridden
 				// by extensions with default precedence.
-				Prec.low(keymap.of([
+				Prec.default(keymap.of([
 					// Custom mod-f binding: Toggle the external dialog implementation
 					// (don't show/hide the Panel dialog).
 					keyCommand('Mod-f', (_: EditorView) => {
@@ -269,7 +269,6 @@ const createEditor = (
 						insertLineAfter(_);
 						return true;
 					}, true),
-
 					...standardKeymap, ...historyKeymap, ...searchKeymap,
 				])),
 			],


### PR DESCRIPTION
# Summary

This pull request fixes an issue where (only on mobile) some of Joplin's markdown keyboard shortcuts were overridden by the default CodeMirror keyboard shortcuts (e.g. ctrl-i for "navigate to parent syntax tree node").

This pull request fixes the precedence of different parts of the keymap so the markdown keyboard shortcuts take precedence.

# Testing plan

This pull request includes an automated test. This has also been manually tested (iOS 17) by:
1. In an iPadOS simulator, clicking the "capture pointer" button.
2. Opening the note editor, selecting text, and pressing <kbd>cmd</kbd>-<kbd>i</kbd>.
3. Verifying that the selected text has been italicized.

Additionally, on desktop (MacOS):
1. Change the "italicize" keyboard shortcut to <kbd>cmd</kbd>-<kbd>j</kbd>.
2. Restarting Joplin.
3. Selecting text and pressing <kbd>cmd</kbd>-<kbd>j</kbd>.
4. Verifying that the text has been italicized.
5. Selecting different text and pressing <kbd>cmd</kbd>-<kbd>i</kbd> and verifying that the selected text has not been italicized.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->