### PR TITLE
Mobile: Fixes #10589: Fix selected note changes on moving to a different folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -964,6 +964,7 @@ packages/lib/ntp.js
 packages/lib/onedrive-api.test.js
 packages/lib/onedrive-api.js
 packages/lib/path-utils.js
+packages/lib/reducer.test.js
 packages/lib/reducer.js
 packages/lib/registry.test.js
 packages/lib/registry.js

--- a/.gitignore
+++ b/.gitignore
@@ -943,6 +943,7 @@ packages/lib/ntp.js
 packages/lib/onedrive-api.test.js
 packages/lib/onedrive-api.js
 packages/lib/path-utils.js
+packages/lib/reducer.test.js
 packages/lib/reducer.js
 packages/lib/registry.test.js
 packages/lib/registry.js

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -1399,15 +1399,18 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		}, 50);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private async folderPickerOptions_valueChanged(itemValue: any) {
+	private async folderPickerOptions_valueChanged(itemValue: string) {
 		const note = this.state.note;
 		const isProvisionalNote = this.props.provisionalNoteIds.includes(note.id);
 
 		if (isProvisionalNote) {
 			await this.saveNoteButton_press(itemValue);
 		} else {
-			await Note.moveToFolder(note.id, itemValue);
+			await Note.moveToFolder(
+				note.id,
+				itemValue,
+				{ dispatchOptions: { preserveSelection: true } },
+			);
 		}
 
 		note.parent_id = itemValue;
@@ -1428,7 +1431,13 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 			onValueChange: this.folderPickerOptions_valueChanged,
 		};
 
-		if (this.folderPickerOptions_ && options.selectedFolderId === this.folderPickerOptions_.selectedFolderId) return this.folderPickerOptions_;
+		if (
+			this.folderPickerOptions_
+			&& options.selectedFolderId === this.folderPickerOptions_.selectedFolderId
+			&& options.enabled === this.folderPickerOptions_.enabled
+		) {
+			return this.folderPickerOptions_;
+		}
 
 		this.folderPickerOptions_ = options;
 		return this.folderPickerOptions_;
@@ -1683,7 +1692,6 @@ const NoteScreen = connect((state: AppState) => {
 	return {
 		noteId: state.selectedNoteIds.length ? state.selectedNoteIds[0] : null,
 		noteHash: state.selectedNoteHash,
-		folderId: state.selectedFolderId,
 		itemType: state.selectedItemType,
 		folders: state.folders,
 		searchQuery: state.searchQuery,

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -102,6 +102,7 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, fold
 	const saveOptions = {
 		userSideValidation: true,
 		fields: BaseModel.diffObjectsFields(comp.state.lastSavedNote, note),
+		dispatchOptions: { preserveSelection: true },
 	};
 
 	const hasAutoTitle = comp.state.newAndNoTitleChangeNoteId || (isProvisionalNote && !note.title);

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -624,7 +624,7 @@ export default class Note extends BaseItem {
 		});
 	}
 
-	public static async moveToFolder(noteId: string, folderId: string) {
+	public static async moveToFolder(noteId: string, folderId: string, saveOptions: SaveOptions|null = null) {
 		if (folderId === this.getClass('Folder').conflictFolderId()) throw new Error(_('Cannot move note to "%s" notebook', this.getClass('Folder').conflictFolderTitle()));
 
 		// When moving a note to a different folder, the user timestamp is not
@@ -643,7 +643,7 @@ export default class Note extends BaseItem {
 			updated_time: time.unixMs(),
 		};
 
-		return Note.save(modifiedNote, { autoTimestamp: false });
+		return Note.save(modifiedNote, { autoTimestamp: false, ...saveOptions });
 	}
 
 	public static changeNoteType(note: NoteEntity, type: string) {
@@ -841,6 +841,7 @@ export default class Note extends BaseItem {
 				provisional: isProvisional,
 				ignoreProvisionalFlag: ignoreProvisionalFlag,
 				changedFields: changedFields,
+				...options?.dispatchOptions,
 			});
 		}
 

--- a/packages/lib/models/utils/types.ts
+++ b/packages/lib/models/utils/types.ts
@@ -49,6 +49,7 @@ export interface SaveOptions {
 	provisional?: boolean;
 	ignoreProvisionalFlag?: boolean;
 	dispatchUpdateAction?: boolean;
+	dispatchOptions?: { preserveSelection: boolean };
 	changeSource?: number;
 	disableReadOnlyCheck?: boolean;
 }

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -892,7 +892,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 			break;
 
 		case 'FOLDER_SELECT':
-			changeSelectedFolder(draft, action, { clearSelectedNoteIds: action.clearSelectedNoteIds ?? true });
+			changeSelectedFolder(draft, action, { clearSelectedNoteIds: true });
 			break;
 
 		case 'FOLDER_AND_NOTE_SELECT':

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -892,7 +892,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 			break;
 
 		case 'FOLDER_SELECT':
-			changeSelectedFolder(draft, action, { clearSelectedNoteIds: true });
+			changeSelectedFolder(draft, action, { clearSelectedNoteIds: action.clearSelectedNoteIds ?? true });
 			break;
 
 		case 'FOLDER_AND_NOTE_SELECT':
@@ -1005,7 +1005,11 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 
 				draft.notes = newNotes;
 
-				if (noteFolderHasChanged) {
+				// Ensure that the selected note is still in the current folder.
+				// For example, if the user drags the current note to a different folder,
+				// a new note should be selected.
+				// In some cases, however, the selection needs to be preserved (e.g. the mobile app).
+				if (noteFolderHasChanged && !action.preserveSelection) {
 					let newIndex = movedNotePreviousIndex;
 					if (newIndex >= newNotes.length) newIndex = newNotes.length - 1;
 					if (!newNotes.length) newIndex = -1;


### PR DESCRIPTION
# Summary

This pull request updates `reducer.ts` to not change the selected note when its parent ID changes in more cases. In particular, it allows the mobile app to specify that the selected note should not change, while preserving existing behavior on desktop.

Fixes #10589.

# Testing plan

1. Start Joplin and create a new note.
2. Before editing, move that note to a new folder.
    - On mobile, verify that the same note is still selected. Verify that the note can be edited.
    - On desktop, verify that a different note is selected.
3. Switch notes to an existing note. Move it to a new folder.
    - On mobile, verify that the same note is still selected. Verify that the note can be edited. Verify that the notebook selector can still be used.
    - On desktop, verify that a different note is selected.

Test on:
- [x] Android 13 (mobile)
- [x] Ubuntu 24.04 (desktop)
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->