### PR TITLE
All: Don't render empty title page for Fountain

### DIFF
--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -107,12 +107,19 @@ const pluginAssets = function() {
 function renderFountainScript(markdownIt: any, content: string) {
 	const result = fountain.parse(content);
 
-	return `
-		<div class="fountain joplin-editable">
-			<pre class="joplin-source" data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
+	let optionalTitlePage = '';
+	if (result.html.title_page) {
+		optionalTitlePage = `
 			<div class="title-page">
 				${result.html.title_page}
 			</div>
+		`;
+	}
+
+	return `
+		<div class="fountain joplin-editable">
+			<pre class="joplin-source" data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
+			${optionalTitlePage}
 			<div class="page">
 				${result.html.script}
 			</div>

--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -107,9 +107,9 @@ const pluginAssets = function() {
 function renderFountainScript(markdownIt: any, content: string) {
 	const result = fountain.parse(content);
 
-	let optionalTitlePage = '';
+	let titlePageHtml = '';
 	if (result.html.title_page) {
-		optionalTitlePage = `
+		titlePageHtml = `
 			<div class="title-page">
 				${result.html.title_page}
 			</div>
@@ -119,7 +119,7 @@ function renderFountainScript(markdownIt: any, content: string) {
 	return `
 		<div class="fountain joplin-editable">
 			<pre class="joplin-source" data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
-			${optionalTitlePage}
+			${titlePageHtml} 
 			<div class="page">
 				${result.html.script}
 			</div>

--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -119,7 +119,7 @@ function renderFountainScript(markdownIt: any, content: string) {
 	return `
 		<div class="fountain joplin-editable">
 			<pre class="joplin-source" data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
-			${titlePageHtml} 
+			${titlePageHtml}
 			<div class="page">
 				${result.html.script}
 			</div>


### PR DESCRIPTION
A title page is rendered to HTML even if not given in the Markdown Fountain syntax. Based on [Fountain's documentation](https://fountain.io/syntax/#title-page), the title page is optional:
> The **_optional_** Title Page is always the first thing in a Fountain document.

This PR fixes the current method of rendering so a separate title page is not rendered if it is empty.