### PR TITLE
iOS: Fix voice typing URL setting incorrectly visible

### DIFF
--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1907,6 +1907,8 @@ class Setting extends BaseModel {
 				appTypes: [AppType.Mobile],
 				description: () => _('Leave it blank to download the language files from the default website'),
 				label: () => _('Voice typing language files (URL)'),
+				// For now, iOS doesn't support voice typing.
+				show: () => shim.mobilePlatform() !== 'ios',
 				section: 'note',
 			},
 


### PR DESCRIPTION
# Summary

This pull request hides the "Voice Typing URL" setting on iOS — it's only supported on Android.

# Testing plan

**iOS**:
- Open settings > note.
- Verify that no "Voice typing URL" setting is visible.


**Android**:
- Open settings > note.
- Verify that the "Voice typing URL" setting is visible.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->