### PR TITLE
Mobile: Fixes #10637: Fix refocusing the note editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -14,6 +14,7 @@ import createEditor from '@joplin/editor/CodeMirror/createEditor';
 import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
 import WebViewToRNMessenger from '../../../utils/ipc/WebViewToRNMessenger';
 import { WebViewToEditorApi } from '../types';
+import { focus } from '@joplin/lib/utils/focusHandler';
 
 export const initCodeMirror = (
 	parentElement: HTMLElement,
@@ -44,6 +45,15 @@ export const initCodeMirror = (
 		if (clipboardData.types.length === 1 && clipboardData.types[0] === 'text/uri-list') {
 			event.preventDefault();
 			control.insertText(clipboardData.getData('text/uri-list'));
+		}
+	});
+
+	// Note: Just adding an onclick listener seems sufficient to focus the editor when its background
+	// is tapped.
+	parentElement.addEventListener('click', (event) => {
+		const activeElement = document.querySelector(':focus');
+		if (!parentElement.contains(activeElement) && event.target === parentElement) {
+			focus('initial editor focus', control);
 		}
 	});
 

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -101,10 +101,6 @@ function useHtml(initialCss: string): string {
 						scrolling. */
 					.cm-scroller {
 						overflow: none;
-
-						/* Ensure that the editor can be focused by clicking on the lower half of the screen.
-							Don't use 100vh to prevent a scrollbar being present for empty notes. */
-						min-height: 80vh;
 					}
 				</style>
 				<style class=${JSON.stringify(themeStyleSheetClassName)}>


### PR DESCRIPTION
# Summary

This pull request focuses the mobile note editor when its parent element is clicked.

Fixes #10637.

# Notes

- At least on iOS, adding an empty `onclick` listener also seems to be sufficient to fix #10637.

# Testing plan

1. Create a new to-do.
2. Tap near the end of the note body.
3. Verify that the focus has moved to the note body.
4. Tap on the title input.
5. Tap on the note body input. Verify that the focus has moved to the note body.
6. Open a note with existing text.
7. Verify that the cursor can still be positioned by tapping on the editor.

This has been tested successfully on iOS 17.4 and Android 13.

<!--

Please prefix the title with the platform you are targeting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->