### PR TITLE
Mobile: Fixes #10596: remove search bar from plugins screen

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -834,7 +834,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 		if (currentSectionName) {
 			screenHeadingText = Setting.sectionNameToLabel(currentSectionName);
-			showSearchButton = screenHeadingText !== _('Plugins');
+			showSearchButton = currentSectionName !== 'plugins';
 		}
 
 		return (

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -830,8 +830,11 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		let screenHeadingText = _('Configuration');
+		let showSearchButton = true;
+
 		if (currentSectionName) {
 			screenHeadingText = Setting.sectionNameToLabel(currentSectionName);
+			showSearchButton = screenHeadingText !== _('Plugins');
 		}
 
 		return (
@@ -839,7 +842,7 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				<ScreenHeader
 					title={screenHeadingText}
 					showSaveButton={true}
-					showSearchButton={true}
+					showSearchButton={showSearchButton}
 					showSideMenuButton={false}
 					saveButtonDisabled={!this.hasUnsavedChanges()}
 					onSaveButtonPress={this.saveButton_press}


### PR DESCRIPTION
## Summary
Removed the search bar from the plugins screen in settings.

## Testing
1. Open side bar by pressing hamburger menu and go to configurations.
2. Open the plugins page, the search bar should not appear in the header