### PR TITLE
Mobile: Fix dayjs-related startup error

### DIFF
--- a/packages/utils/time.ts
+++ b/packages/utils/time.ts
@@ -4,7 +4,12 @@
 // -----------------------------------------------------------------------------------------------
 
 import * as dayjs from 'dayjs';
-import * as dayJsRelativeTime from 'dayjs/plugin/relativeTime';
+
+// Separating this into a type import and a require seems to be necessary to support mobile:
+// - import = require syntax doesn't work when bundling
+// - import * as dayJsRelativeTimeType causes a runtime error.
+import type * as dayJsRelativeTimeType from 'dayjs/plugin/relativeTime';
+const dayJsRelativeTime: typeof dayJsRelativeTimeType = require('dayjs/plugin/relativeTime');
 
 const supportedLocales: Record<string, unknown> = {
 	'ar': require('dayjs/locale/ar'),


### PR DESCRIPTION
# Summary

This pull request fixes a runtime exception related to `utils/time.ts`.

# Related upstream GitHub issues

- https://github.com/iamkun/dayjs/issues/1185,  https://github.com/iamkun/dayjs/issues/1132
    - `import dayJsRelativeTime from 'dayjs/plugin/relativeTime';` gives an error: `This module is declared with 'export =' and can only be used with a default import when using the 'esModuleInterop' flag`.

# Testing plan

1. Recompile `packages/utils` and `packages/app-mobile`.
2. Start the mobile app.
3. Verify that the mobile app starts successfully.

This has been tested successfully on iOS 17.4.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->