### PR TITLE
Resolved console errors in dev mode

### DIFF
--- a/packages/app-desktop/gui/MainScreen/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen/MainScreen.tsx
@@ -343,8 +343,12 @@ class MainScreenComponent extends React.Component<Props, State> {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.updateMainLayout(produce(this.props.mainLayout, (draft: any) => {
 			const s = this.rootLayoutSize();
-			draft.width = s.width;
-			draft.height = s.height;
+			if (s) {
+				draft.width = s.width;
+				draft.height = s.height;
+			} else {
+				console.error('rootLayoutSize() returned null');
+			}
 		}));
 	}
 

--- a/packages/generate-plugin-doc/package.json
+++ b/packages/generate-plugin-doc/package.json
@@ -3,7 +3,7 @@
   "packageManager": "yarn@3.6.0",
   "private": true,
   "scripts": {
-     "buildPluginDoc_": "typedoc --exclude '../lib/models/**' --name 'Joplin Plugin API Documentation' --mode file -theme '../../Assets/PluginDocTheme/' --readme '../../Assets/PluginDocTheme/index.md' --excludeNotExported --excludeExternals --excludePrivate --excludeProtected --out ../../../joplin-website/docs/api/references/plugin_api ../lib/services/plugins/api/"
+    "buildPluginDoc_": "typedoc --exclude '../lib/models/**' --name 'Joplin Plugin API Documentation' --mode file -theme '../../Assets/PluginDocTheme/' --readme '../../Assets/PluginDocTheme/index.md' --excludeNotExported --excludeExternals --excludePrivate --excludeProtected --out ../../../joplin-website/docs/api/references/plugin_api ../lib/services/plugins/api/"
   },
   "dependencies": {
     "typedoc": "0.17.8",


### PR DESCRIPTION
### Addressing Issue: 
Desktop: Starting in dev mode with dev tools docked to main window logs error #9821

### Summary

This pull request addresses an issue where the application would throw a `TypeError` when started in development mode with dev tools docked to the main window.

### Problem

When starting the application in dev mode with dev tools docked to the main window, the following error was logged:


### Steps to Reproduce

1. Start the application in development mode.
2. Open dev tools and dock them to the main window.
3. Observe the console for the `TypeError`.

### Root Cause

The issue was caused by `this.rootLayoutSize()` returning `null`, leading to an attempt to set properties on a `null` value.

### Solution

The solution involves adding a null check before setting the `width` and `height` properties. Specifically:
- Modified `updateRootLayoutSize` to check if `this.rootLayoutSize()` returns `null`.
- If it returns `null`, log an error message instead of setting properties.

### Code Changes

```typescript
public updateRootLayoutSize() {
    this.updateMainLayout(produce(this.props.mainLayout, (draft: any) => {
        const s = this.rootLayoutSize();
        if (s) {
            draft.width = s.width;
            draft.height = s.height;
        } else {
            console.error('rootLayoutSize() returned null');
        }
    }));
}





