### PR TITLE
Desktop, Mobile: Fixes #10674: Fix sidebar performance regression with many nested notebooks

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { FolderListItem, HeaderId, HeaderListItem, ListItem, ListItemType, TagListItem } from '../types';
 import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
-import { renderFolders, renderTags } from '@joplin/lib/components/shared/side-menu-shared';
+import { buildFolderTree, renderFolders, renderTags } from '@joplin/lib/components/shared/side-menu-shared';
 import { _ } from '@joplin/lib/locale';
 import CommandService from '@joplin/lib/services/CommandService';
 import Setting from '@joplin/lib/models/Setting';
@@ -35,10 +35,13 @@ const useSidebarListData = (props: Props): ListItem[] => {
 		});
 	}, [props.tags]);
 
+	const folderTree = useMemo(() => {
+		return buildFolderTree(props.folders);
+	}, [props.folders]);
 
 	const folderItems = useMemo(() => {
 		const renderProps = {
-			folders: props.folders,
+			folderTree,
 			collapsedFolderIds: props.collapsedFolderIds,
 		};
 		return renderFolders<ListItem>(renderProps, (folder, hasChildren, depth): FolderListItem => {
@@ -50,7 +53,7 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				key: folder.id,
 			};
 		});
-	}, [props.folders, props.collapsedFolderIds]);
+	}, [folderTree, props.collapsedFolderIds]);
 
 	return useMemo(() => {
 		const foldersHeader: HeaderListItem = {

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -561,11 +561,7 @@ const SideMenuContentComponent = (props: Props) => {
 	items.push(renderSidebarButton('folder_header', _('Notebooks'), 'folder'));
 
 	const folderTree = useMemo(() => {
-		reg.logger().info('!!! Building folder tree');
-		const ft = buildFolderTree(props.folders);
-		reg.logger().info('!!! Done');
-
-		return ft;
+		return buildFolderTree(props.folders);
 	}, [props.folders]);
 
 	if (props.folders.length) {

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -8,7 +8,7 @@ import Synchronizer from '@joplin/lib/Synchronizer';
 import NavService from '@joplin/lib/services/NavService';
 import { _ } from '@joplin/lib/locale';
 import { ThemeStyle, themeStyle } from './global-style';
-import { isFolderSelected, renderFolders } from '@joplin/lib/components/shared/side-menu-shared';
+import { buildFolderTree, isFolderSelected, renderFolders } from '@joplin/lib/components/shared/side-menu-shared';
 import { FolderEntity, FolderIcon, FolderIconType } from '@joplin/lib/services/database/types';
 import { AppState } from '../utils/types';
 import Setting from '@joplin/lib/models/Setting';
@@ -560,8 +560,20 @@ const SideMenuContentComponent = (props: Props) => {
 
 	items.push(renderSidebarButton('folder_header', _('Notebooks'), 'folder'));
 
+	const folderTree = useMemo(() => {
+		reg.logger().info('!!! Building folder tree');
+		const ft = buildFolderTree(props.folders);
+		reg.logger().info('!!! Done');
+
+		return ft;
+	}, [props.folders]);
+
 	if (props.folders.length) {
-		const result = renderFolders(props, renderFolderItem);
+		const result = renderFolders({
+			folderTree,
+			collapsedFolderIds: props.collapsedFolderIds,
+		}, renderFolderItem);
+
 		const folderItems = result.items;
 		items = items.concat(folderItems);
 	}

--- a/packages/lib/components/shared/side-menu-shared.test.ts
+++ b/packages/lib/components/shared/side-menu-shared.test.ts
@@ -1,6 +1,6 @@
 import { FolderEntity } from '../../services/database/types';
 import { getTrashFolder, getTrashFolderId } from '../../services/trash';
-import { renderFolders } from './side-menu-shared';
+import { buildFolderTree, renderFolders } from './side-menu-shared';
 
 const renderItem = (folder: FolderEntity, hasChildren: boolean, depth: number) => {
 	return [folder.id, hasChildren, depth];
@@ -86,8 +86,52 @@ describe('side-menu-shared', () => {
 				order: ['1', getTrashFolderId(), '2'],
 			},
 		],
-	])('should render folders', (props, expected) => {
-		const actual = renderFolders(props, renderItem);
+
+		// Should not render id: 4 because it's contained within the child of a collapsed folder.
+		[
+			{
+				collapsedFolderIds: ['2'],
+				folders: [
+					{
+						id: '1',
+						parent_id: '',
+						deleted_time: 0,
+					},
+					{
+						id: '2',
+						parent_id: '',
+						deleted_time: 0,
+					},
+					{
+						id: '3',
+						parent_id: '2',
+						deleted_time: 0,
+					},
+					{
+						id: '4',
+						parent_id: '3',
+						deleted_time: 0,
+					},
+					getTrashFolder(),
+				],
+				notesParentType: 'Folder',
+				selectedFolderId: '',
+				selectedTagId: '',
+			},
+			{
+				items: [
+					['1', false, 0],
+					['2', true, 0],
+					[getTrashFolderId(), false, 0],
+				],
+				order: ['1', '2', getTrashFolderId()],
+			},
+		],
+	])('should render folders (case %#)', (props, expected) => {
+		const actual = renderFolders({
+			folderTree: buildFolderTree(props.folders),
+			collapsedFolderIds: props.collapsedFolderIds,
+		}, renderItem);
 		expect(actual).toEqual(expected);
 	});
 

--- a/packages/lib/components/shared/side-menu-shared.ts
+++ b/packages/lib/components/shared/side-menu-shared.ts
@@ -1,38 +1,9 @@
-import Folder from '../../models/Folder';
-import BaseModel from '../../BaseModel';
 import { FolderEntity, TagEntity, TagsWithNoteCountEntity } from '../../services/database/types';
-import { getDisplayParentId, getTrashFolderId } from '../../services/trash';
+import { getDisplayParentId } from '../../services/trash';
 import { getCollator } from '../../models/utils/getCollator';
 
 export type RenderFolderItem<T> = (folder: FolderEntity, hasChildren: boolean, depth: number)=> T;
 export type RenderTagItem<T> = (tag: TagsWithNoteCountEntity)=> T;
-
-function folderHasChildren_(folders: FolderEntity[], folderId: string) {
-	if (folderId === getTrashFolderId()) {
-		return !!folders.find(f => !!f.deleted_time);
-	}
-
-	for (let i = 0; i < folders.length; i++) {
-		const folder = folders[i];
-		const folderParentId = getDisplayParentId(folder, folders.find(f => f.id === folder.parent_id));
-		if (folderParentId === folderId) return true;
-	}
-
-	return false;
-}
-
-function folderIsCollapsed(folders: FolderEntity[], folderId: string, collapsedFolderIds: string[]) {
-	if (!collapsedFolderIds || !collapsedFolderIds.length) return false;
-
-	while (true) {
-		const folder: FolderEntity = BaseModel.byId(folders, folderId);
-		if (!folder) throw new Error(`No folder with id ${folder.id}`);
-		const folderParentId = getDisplayParentId(folder, folders.find(f => f.id === folder.parent_id));
-		if (!folderParentId) return false;
-		if (collapsedFolderIds.indexOf(folderParentId) >= 0) return true;
-		folderId = folderParentId;
-	}
-}
 
 interface FolderSelectedContext {
 	selectedFolderId: string;
@@ -48,21 +19,37 @@ type ItemsWithOrder<ItemType> = {
 	order: string[];
 };
 
-interface RenderFoldersProps {
+interface FolderTree {
 	folders: FolderEntity[];
+	parentIdToChildren: Map<string, FolderEntity[]>;
+	idToItem: Map<string, FolderEntity>;
+}
+
+interface RenderFoldersProps {
+	// All folders
+	folderTree: FolderTree;
 	collapsedFolderIds: string[];
 }
 
+function folderIsCollapsed(context: RenderFoldersProps, folderId: string) {
+	if (!context.collapsedFolderIds || !context.collapsedFolderIds.length) return false;
+
+	while (true) {
+		const folder = context.folderTree.idToItem.get(folderId);
+		const folderParentId = getDisplayParentId(folder, context.folderTree.idToItem.get(folder.parent_id));
+		if (!folderParentId) return false;
+		if (context.collapsedFolderIds.includes(folderParentId)) return true;
+		folderId = folderParentId;
+	}
+}
+
 function renderFoldersRecursive_<T>(props: RenderFoldersProps, renderItem: RenderFolderItem<T>, items: T[], parentId: string, depth: number, order: string[]): ItemsWithOrder<T> {
-	const folders = props.folders;
-	for (let i = 0; i < folders.length; i++) {
-		const folder = folders[i];
+	const folders = props.folderTree.parentIdToChildren.get(parentId ?? '');
+	const parentIdToChildren = props.folderTree.parentIdToChildren;
+	for (const folder of folders) {
+		if (folderIsCollapsed(props, folder.id)) continue;
 
-		const folderParentId = getDisplayParentId(folder, props.folders.find(f => f.id === folder.parent_id));
-
-		if (!Folder.idsEqual(folderParentId, parentId)) continue;
-		if (folderIsCollapsed(props.folders, folder.id, props.collapsedFolderIds)) continue;
-		const hasChildren = folderHasChildren_(folders, folder.id);
+		const hasChildren = parentIdToChildren.has(folder.id);
 		order.push(folder.id);
 		items.push(renderItem(folder, hasChildren, depth));
 		if (hasChildren) {
@@ -79,6 +66,24 @@ function renderFoldersRecursive_<T>(props: RenderFoldersProps, renderItem: Rende
 
 export const renderFolders = <T> (props: RenderFoldersProps, renderItem: RenderFolderItem<T>): ItemsWithOrder<T> => {
 	return renderFoldersRecursive_(props, renderItem, [], '', 0, []);
+};
+
+export const buildFolderTree = (folders: FolderEntity[]): FolderTree => {
+	const idToItem = new Map<string, FolderEntity>();
+	for (const folder of folders) {
+		idToItem.set(folder.id, folder);
+	}
+
+	const parentIdToChildren = new Map<string, FolderEntity[]>();
+	for (const folder of folders) {
+		const displayParentId = getDisplayParentId(folder, idToItem.get(folder.parent_id)) ?? '';
+		if (!parentIdToChildren.has(displayParentId)) {
+			parentIdToChildren.set(displayParentId, []);
+		}
+		parentIdToChildren.get(displayParentId).push(folder);
+	}
+
+	return { folders, parentIdToChildren, idToItem };
 };
 
 const sortTags = (tags: TagEntity[]) => {

--- a/packages/lib/components/shared/side-menu-shared.ts
+++ b/packages/lib/components/shared/side-menu-shared.ts
@@ -26,7 +26,6 @@ interface FolderTree {
 }
 
 interface RenderFoldersProps {
-	// All folders
 	folderTree: FolderTree;
 	collapsedFolderIds: string[];
 }
@@ -44,7 +43,7 @@ function folderIsCollapsed(context: RenderFoldersProps, folderId: string) {
 }
 
 function renderFoldersRecursive_<T>(props: RenderFoldersProps, renderItem: RenderFolderItem<T>, items: T[], parentId: string, depth: number, order: string[]): ItemsWithOrder<T> {
-	const folders = props.folderTree.parentIdToChildren.get(parentId ?? '');
+	const folders = props.folderTree.parentIdToChildren.get(parentId ?? '') ?? [];
 	const parentIdToChildren = props.folderTree.parentIdToChildren;
 	for (const folder of folders) {
 		if (folderIsCollapsed(props, folder.id)) continue;


### PR DESCRIPTION
# Summary

This pull request fixes a performance regression related to the time complexity of [side-menu-shared/renderFolders](https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/lib/components/shared/side-menu-shared.ts#L17).

In particular, f19b1c536439bc0a9f04253203371c15b60f65b3 changed how parent folders are determined. In particular, it added an additional loop over all folders (with `.find`) when determining the parent of an item in `renderFolders`.

Fixes #10674, #9889.

<details><summary>More detailed explanation</summary>

Based on code changes, the regression seems to have been introduced by f19b1c536439bc0a9f04253203371c15b60f65b3, with the change in how folders' display parent ID is calculated. For example, this change [added an additional loop within `folderHasChildren_`](https://github.com/laurent22/joplin/commit/f19b1c536439bc0a9f04253203371c15b60f65b3#diff-140e280bc3d1b4d47e288dff827f35fcbf1a506135e7b073cc150f83df935524R18): 
```diff
for (let i = 0; i < folders.length; i++) {
	const folder = folders[i];
-	if (folder.parent_id === folderId) return true;
+	const folderParentId = getDisplayParentId(folder, folders.find(f => f.id === folder.parent_id));
+	if (folderParentId === folderId) return true;
}
```

This change caused `folderHasChildren_` to be in $\mathcal{O}(n^2)$ time, where $n$ is `folders.length`. Previously, it was in $\mathcal{O}(n)$.

`folderHasChildren_` is itself [used in a loop over all folders](https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/lib/components/shared/side-menu-shared.ts#L65):
https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/lib/components/shared/side-menu-shared.ts#L58-L65

If the folder has children, it then recurses, passing the same `props`:

https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/lib/components/shared/side-menu-shared.ts#L66-L69

The recursive call then iterates over **all** folders and uses a nested loop (with `.find`) to determine the parent ID of each:
https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/lib/components/shared/side-menu-shared.ts#L58-L61

Based on this, the running time of `renderFoldersRecursive_` went from $\mathcal{O}\big((n)(n +T(n))\big)$ (where $T(n)$ represents the recursive case) to $\mathcal{O}((n)(n^2 + T(n)))$.

</details>

# Testing plan

## **On desktop**:
1. Create a folder tree several thousand folders and with up to three levels of nesting, with most nested under a single notebook.
2. Expand the toplevel notebook.
3. Verify that step 2 completed quickly.
4. Collapse the toplevel notebook.
5. Verify that step 4 completed quickly.

This has been tested successfully on Ubuntu 24.04.

Screen recording:

https://github.com/laurent22/joplin/assets/46334387/5e87a5c3-e818-4452-8b06-4450f462f9dc

## On mobile

1. Create 2-3 folders.
2. Nest one folder under another.
3. Collapse and expand the toplevel folder.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->