### PR TITLE
Desktop: Fix error in plugin content scripts generated with Webpack

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -45,6 +45,9 @@
 	<script src="./scrollmap.js"></script>
 
 	<script>
+	// Fixes a warning when loading some TypeScript plugins generated with webpack.
+	window.exports = {};
+
 	// This is function used internally to send message from the webview to
 	// the host.
 	const ipcProxySendToHost = (methodName, arg) => {

--- a/packages/app-desktop/services/plugins/UserWebviewIndex.js
+++ b/packages/app-desktop/services/plugins/UserWebviewIndex.js
@@ -2,7 +2,7 @@
 const webviewApiPromises_ = {};
 let viewMessageHandler_ = () => {};
 
-// This silences a warning when running plugins generated with Webpacks.
+// This silences a warning when running plugins generated with Webpack.
 window.exports ??= {};
 
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars

--- a/packages/app-desktop/services/plugins/UserWebviewIndex.js
+++ b/packages/app-desktop/services/plugins/UserWebviewIndex.js
@@ -2,6 +2,9 @@
 const webviewApiPromises_ = {};
 let viewMessageHandler_ = () => {};
 
+// This silences a warning when running plugins generated with Webpacks.
+window.exports ??= {};
+
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 const webviewApi = {
 	postMessage: function(message) {


### PR DESCRIPTION
# Summary

This pull request silences a warning when:
1. renderer scripts generated with Webpack are loaded into the note viewer and
2. scripts generated with Webpack are added to a dialog.

[Similar logic is already present for mobile](https://github.com/laurent22/joplin/blob/7e4533d8115707e0a4ff3bdfb9f0ca3bdfc4bdac/packages/app-mobile/components/plugins/backgroundPage/initializeDialogWebView.ts#L84).

See https://github.com/personalizedrefrigerator/joplin-plugin-revealjs-slides/issues/4.

# Testing plan

1. Install Freehand Drawing and RevealJS Slides.
2. Start Joplin.
3. Switch to the markdown editor (if not already open).
4. Check the console for an "exports is not defined" error. Verify that it is not present.
5. Open the drawing dialog.
6. Check the console for an "exports is not defined" error. Verify that it is not present.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->