### PR TITLE
Desktop: Fixes #10679: Fix incorrect text rendering on MacOS by changing the default font to `Avenir Next`

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -204,7 +204,7 @@ class Application extends BaseApplication {
 	public updateEditorFont() {
 		const fontFamilies = [];
 		if (Setting.value('style.editor.fontFamily')) fontFamilies.push(`"${Setting.value('style.editor.fontFamily')}"`);
-		fontFamilies.push('Avenir, Arial, sans-serif');
+		fontFamilies.push('\'Avenir Next\', Avenir, Arial, sans-serif');
 
 		// The '*' and '!important' parts are necessary to make sure Russian text is displayed properly
 		// https://github.com/laurent22/joplin/issues/155

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -58,7 +58,7 @@ export default function(theme: any, options: Options = null) {
 
 	theme = theme ? theme : {};
 
-	const fontFamily = '\'Avenir\', \'Arial\', sans-serif';
+	const fontFamily = '\'Avenir Next\', \'Avenir\', \'Arial\', sans-serif';
 
 	const maxWidthTarget = options.contentMaxWidthTarget ? options.contentMaxWidthTarget : '#rendered-md';
 	const maxWidthCss = options.contentMaxWidth ? `


### PR DESCRIPTION
# Summary

This is one possible fix for #10679.

See [this discussion post](https://discourse.joplinapp.org/t/text-of-notes-is-garbled-in-macos-intel-client-version-3/38900/16) for a confirmation that using "Avenir Next" seems to fix the issue.


> [!IMPORTANT]
> 
> I am unable to reproduce this locally (MacOS Sonoma 14.5, Intel, all plugins disabled). It's [unclear how many users this affects](https://discourse.joplinapp.org/t/text-of-notes-is-garbled-in-macos-intel-client-version-3/38900/11?u=personalizedrefriger).
>


# Comparison between Avenir and Avenir Next

![screenshot: Avenir Next bold is slightly bolder](https://github.com/laurent22/joplin/assets/46334387/0f8a5d0b-4e56-43f6-8ba6-d82b9e7f860b)

# Comparison to other possible fixes

**Benefits**:
- Relatively simple fix
- We have confirmation that this, or a similar change, fixes the issue from a user on the Joplin Forum.

**Drawbacks**:
- **Affects all platforms** that have `Avenir Next` installed (MacOS, iOS, and MacOS viewing published notes).
- Somewhat changes the appearance of rendered notes. Has a noticeable effect on bold text (screenshots to be attached).

**Possible alternatives**:
- Try upgrading Electron.
   - There are a [few bugs](https://issues.chromium.org/issues?q=avenir) in the Chromium issue tracker that might be related: - https://issues.chromium.org/issues/328279705 (tagged as a duplicate of a WONTFIX(infeasible) bug), different repro conditions.
- Use Montserrat as the default font and bundle it. Montserrat seems similar to Avenir and is licensed under the [Open Font License](https://fonts.google.com/specimen/Montserrat).
  - I don't think we can bundle Avenir, due to licensing restrictions.

# Testing

1. Start Joplin.
2. Open a note.
3. Verify that the note renders in a sans-serif-style font.
4. Open the Rich Text editor.
5. Verify that the note is still rendered in a sans-serif-style font.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->