### PR TITLE
Desktop: Fixes #10685: Fix shift-delete asks to permanently delete the current note, rather than cut text, when the editor is selected.

### DIFF
--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -104,10 +104,17 @@ const useOnKeyDown = (
 			event.preventDefault();
 		}
 
-		if (noteIds.length && (key === 'Delete' || (key === 'Backspace' && event.metaKey))) {
-			event.preventDefault();
-			if (CommandService.instance().isEnabled('deleteNote')) {
-				void CommandService.instance().execute('deleteNote', noteIds);
+		if (noteIds.length) {
+			if (key === 'Delete' && event.shiftKey) {
+				event.preventDefault();
+				if (CommandService.instance().isEnabled('permanentlyDeleteNote')) {
+					void CommandService.instance().execute('permanentlyDeleteNote', noteIds);
+				}
+			} else if (key === 'Delete' || (key === 'Backspace' && event.metaKey)) {
+				event.preventDefault();
+				if (CommandService.instance().isEnabled('deleteNote')) {
+					void CommandService.instance().execute('deleteNote', noteIds);
+				}
 			}
 		}
 

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
+import activateMainMenuItem from './util/activateMainMenuItem';
+import setMessageBoxResponse from './util/setMessageBoxResponse';
 
 test.describe('noteList', () => {
 	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow }) => {
@@ -34,5 +36,43 @@ test.describe('noteList', () => {
 
 		// Updating the title should force the sidebar to update sooner
 		await expect(editor.noteTitleInput).toHaveValue('note-1');
+	});
+
+	test('shift-delete should ask to permanently delete notes, but only when the note list is focused', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		const sidebar = mainScreen.sidebar;
+
+		const folderBHeader = await sidebar.createNewFolder('Folder B');
+		const folderAHeader = await sidebar.createNewFolder('Folder A');
+		await expect(folderAHeader).toBeVisible();
+
+		await mainScreen.createNewNote('test note 1');
+		await mainScreen.createNewNote('test note 2');
+
+		await activateMainMenuItem(electronApp, 'Note list', 'Focus');
+		await expect(mainScreen.noteListContainer.getByText('test note 1')).toBeVisible();
+
+		await setMessageBoxResponse(electronApp, /^Delete/i);
+
+		const pressShiftDelete = async () => {
+			await mainWindow.keyboard.press('Shift');
+			await mainWindow.keyboard.press('Delete');
+			await mainWindow.keyboard.up('Delete');
+			await mainWindow.keyboard.up('Shift');
+		};
+		await pressShiftDelete();
+
+		await folderBHeader.click();
+		await folderAHeader.click();
+		await expect(mainScreen.noteListContainer.getByText('test note 2')).not.toBeVisible();
+
+		// Should not delete when the editor is focused
+		await mainScreen.noteEditor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('test');
+		await pressShiftDelete();
+
+		await folderBHeader.click();
+		await folderAHeader.click();
+		await expect(mainScreen.noteListContainer.getByText('test note 1')).toBeVisible();
 	});
 });

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -108,7 +108,6 @@ const defaultKeymapItems = {
 		{ accelerator: 'Ctrl+Alt+1', command: 'switchProfile1' },
 		{ accelerator: 'Ctrl+Alt+2', command: 'switchProfile2' },
 		{ accelerator: 'Ctrl+Alt+3', command: 'switchProfile3' },
-		{ accelerator: 'Shift+Delete', command: 'permanentlyDeleteNote' },
 	],
 };
 


### PR DESCRIPTION
# Summary

Fixes #10685 by:
1. Handling <kbd>shift</kbd>-<kbd>delete</kbd> in the note list component, rather than with the global `KeymapService`.
2. Removing the default shift-delete modifier for `permanentlyDeleteNote` from the global keyboard shortcuts.

This also fixes an issue where <kbd>shift</kbd>-<kbd>delete</kbd> deleted notes to the trash, rather than permanently, when the note list was focused.

> [!NOTE]
>
> This pull request targets `release-3.0` because I consider <kbd>shift</kbd>-<kbd>delete</kbd> no longer cutting text to be a **regression**.
>

See 8c4aa7affbc063590a9d54287c4749989e17f94a for an alternate fix.

# Comparison with 8c4aa7affbc063590a9d54287c4749989e17f94a

- **Benefit**: It's possible to permanently delete the current note using Note > Permanently Delete Note, as before.
- **Benefit**: Shift-Delete still works, but only when the note list is focused.
- **Benefit**: It's possible to assign a **custom** keyboard shortcut to `permanentlyDeleteNote` that works regardless of what has focus.
- **Drawback**: The Shift-Delete default keyboard shortcut is now more difficult to discover -- it is no longer shown as the keyboard shortcut for "permanently delete note" by the Electron menu UI.

# Testing plan

This pull request contains an automated Playwright test that 1) delete a note permanently with <kbd>shift</kbd>-<kbd>delete</kbd> and 2) verifies that pressing <kbd>shift</kbd>-<kbd>delete</kbd> while the markdown editor is focused does not delete the current note.

It has also been verified (on Ubuntu 24.04) that:
- Note > "Permanently delete note" can be used to delete the focused note, even if the note list is not focused.
- Right-click > "Permanently delete note" can be used to permanently delete a note from the trash folder.
- Opening the Rich Text Editor, selecting text, then pressing <kbd>shift</kbd>-<kbd>delete</kbd> cuts the selected text to the clipboard.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->