### PR TITLE
All: Add a sleep in the note duplication test

### DIFF
--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -125,6 +125,8 @@ describe('models/Note', () => {
 		const folder1 = await Folder.save({ title: 'folder1' });
 		const note1 = await Note.save({ title: 'note', parent_id: folder1.id });
 
+		await msleep(1);
+
 		const duplicatedNote = await Note.duplicate(note1.id);
 
 		expect(duplicatedNote !== note1).toBe(true);


### PR DESCRIPTION
It could fail because of the same created/updated time before/after duplication, if the machine runs really fast.

For example: https://build.archlinuxcn.org/imlonghao-api/pkg/joplin/log/1720409375