### PR TITLE
Chore: Docs: Fix missing closing tag

### DIFF
--- a/readme/apps/drawing_tool.md
+++ b/readme/apps/drawing_tool.md
@@ -43,7 +43,7 @@ Here, the "insert drawing" button is part of the main editor toolbar:
 Double-click on an existing drawing to edit it:
 
 <figure>
-  <video src="/images/draw/edit-existing-drawing-on-desktop.mp4" alt="" controls="controls" width="90%"/>
+  <video src="/images/draw/edit-existing-drawing-on-desktop.mp4" alt="" controls="controls" width="90%"></video>
   <figcaption>In the Rich Text editor, double-clicking allows editing an existing drawing. This also works in the markdown viewer.</figcaption>
 </figure>
 


### PR DESCRIPTION
# Summary

Fixes a missing closing `</video>` tag in the drawing tool documentation.

# Rationale

[`<video>` is not a void element](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) and [thus needs a closing tag](https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->