### PR TITLE
Chore: Fixes #10721: Fix Playwright test failure in CI

### DIFF
--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -51,6 +51,7 @@ test.describe('noteList', () => {
 
 		await activateMainMenuItem(electronApp, 'Note list', 'Focus');
 		await expect(mainScreen.noteListContainer.getByText('test note 1')).toBeVisible();
+		await expect(mainScreen.noteListContainer.getByText('test note 2')).toBeVisible();
 
 		await setMessageBoxResponse(electronApp, /^Delete/i);
 
@@ -61,9 +62,6 @@ test.describe('noteList', () => {
 			await mainWindow.keyboard.up('Shift');
 		};
 		await pressShiftDelete();
-
-		await folderBHeader.click();
-		await folderAHeader.click();
 		await expect(mainScreen.noteListContainer.getByText('test note 2')).not.toBeVisible();
 
 		// Should not delete when the editor is focused


### PR DESCRIPTION
# Summary

This pull request adjusts the note list end-to-end test to check that a note has been added to the note list, **before** trying to delete it.

This may fix #10721.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->