### PR TITLE
Mobile: Fix manual resource download mode

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/bundledJs/noteBodyViewerBundle.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/bundledJs/noteBodyViewerBundle.ts
@@ -1,16 +1,17 @@
 
 import WebViewToRNMessenger from '../../../utils/ipc/WebViewToRNMessenger';
-import { NoteViewerLocalApi, NoteViewerRemoteApi, RendererWebViewOptions } from './types';
+import { NoteViewerLocalApi, NoteViewerRemoteApi, RendererWebViewOptions, WebViewLib } from './types';
 import Renderer from './Renderer';
 
 declare global {
 	interface Window {
 		rendererWebViewOptions: RendererWebViewOptions;
+		webviewLib: WebViewLib;
 	}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-declare const webviewLib: any;
+declare const webviewLib: WebViewLib;
 
 const messenger = new WebViewToRNMessenger<NoteViewerLocalApi, NoteViewerRemoteApi>(
 	'note-viewer',
@@ -32,6 +33,8 @@ webviewLib.initialize({
 		messenger.remoteApi.onPostMessage(message);
 	},
 });
+
+window.webviewLib = webviewLib;
 
 const renderer = new Renderer({
 	...window.rendererWebViewOptions,

--- a/packages/app-mobile/components/NoteBodyViewer/bundledJs/types.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/bundledJs/types.ts
@@ -31,3 +31,8 @@ export interface NoteViewerRemoteApi {
 	onPostPluginMessage(contentScriptId: string, message: any): Promise<any>;
 	fsDriver: RendererFsDriver;
 }
+
+export interface WebViewLib {
+	initialize(config: unknown): void;
+}
+


### PR DESCRIPTION
# Summary

This pull request fixes a regression reported [on the forum](https://discourse.joplinapp.org/t/android-app-doesnt-download-attachments-pictures/39090) — tapping on a resource no longer downloads it in "manual" attachment download mode on mobile.

# Testing plan



This pull request has been manually tested by:
1. Setting up sync (with Dropbox).
2. Adding a drawing to a note on desktop.
3. Setting resource download mode to "manual" and syncing on mobile.
4. Tapping on the "download" icon for a resource on mobile.
5. Verifying that this causes the drawing to be downloaded.


An automated test for a similar change can be found in https://github.com/laurent22/joplin/pull/10747.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->