### PR TITLE
Mobile: Fixes: #10677: Following a link to a previously open note wouldn't work

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -574,18 +574,10 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 
 			this.props.dispatch({
 				type: 'NAV_GO',
-				routeName: 'Notes',
-				folderId: this.state.note.parent_id,
+				routeName: 'Note',
+				noteId: noteId,
+				noteHash: noteHash,
 			});
-
-			shim.setTimeout(() => {
-				this.props.dispatch({
-					type: 'NAV_GO',
-					routeName: 'Note',
-					noteId: noteId,
-					noteHash: noteHash,
-				});
-			}, 5);
 		}
 	}
 
@@ -1688,6 +1680,16 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	}
 }
 
+// We added this change to reset the component state when the props.noteId is changed.
+// NoteScreenComponent original implementation assumed that noteId would never change,
+// which can cause some bugs where previously set state to another note would interfere
+// how the new note should be rendered
+const NoteScreenWrapper = (props: Props) => {
+	return (
+		<NoteScreenComponent key={props.noteId} {...props} />
+	);
+};
+
 const NoteScreen = connect((state: AppState) => {
 	return {
 		noteId: state.selectedNoteIds.length ? state.selectedNoteIds[0] : null,
@@ -1711,6 +1713,6 @@ const NoteScreen = connect((state: AppState) => {
 		// confusing.
 		useEditorBeta: !state.settings['editor.usePlainText'],
 	};
-})(NoteScreenComponent);
+})(NoteScreenWrapper);
 
 export default NoteScreen;


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10677

# Description

A common source of problems in mobile seems to be that the `NoteScreenComponent` needs a lot of "hacks" to be able to change from one note content to another.

In this issue I'm addressing the latest bug reported that has a similar source of problem.

The original problem was reported that following a link from A -> B -> A would make the link to B stop working, *when note A and B where on different notebooks*

I'm not 100% sure of the root cause, but the reason is that when we render A and B for the first time there is a call to `componentDidMount` which calls `note-screen-shared` `initState` which loads the note by the `props.noteId` property

But when following the link from B -> A, now A doesn't reload the `this.state.note`, which would result on the navigation sending the user to the **B notebook** and trying to open the **A note**.

To fix this, I added a wrapper to the component that will be re-rendered every time the `noteId` changes, making it unnecessary the "hack" of redirecting to Notes and after a timeout redirect to Note.


# Testing

Preparation
1. Create notebook_a  and notebook_b
2. Create a note_a on notebook_a 
3. Create a note_b on notebook_b
4. Add a link from note_a on note_b and vice versa 

Testing
1. Open note_a, follow link to note_b
1. note_b should be open, follow link to note_a
1. note_a should be opened
2. Before this PR, trying to follow link to note_b wouldn't cause any changes
3. After this PR, note_b should be opened 
