### PR TITLE
Mobile: Upgrade react-native-webview to 13.8.6 to fix CI

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -70,7 +70,7 @@
     "react-native-vector-icons": "10.1.0",
     "react-native-version-info": "1.1.1",
     "react-native-vosk": "0.1.12",
-    "react-native-webview": "13.8.4",
+    "react-native-webview": "13.8.6",
     "react-native-zip-archive": "6.1.0",
     "react-redux": "8.1.3",
     "redux": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6728,7 +6728,7 @@ __metadata:
     react-native-vector-icons: 10.1.0
     react-native-version-info: 1.1.1
     react-native-vosk: 0.1.12
-    react-native-webview: 13.8.4
+    react-native-webview: 13.8.6
     react-native-zip-archive: 6.1.0
     react-redux: 8.1.3
     react-test-renderer: 18.2.0
@@ -36040,16 +36040,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:13.8.4":
-  version: 13.8.4
-  resolution: "react-native-webview@npm:13.8.4"
+"react-native-webview@npm:13.8.6":
+  version: 13.8.6
+  resolution: "react-native-webview@npm:13.8.6"
   dependencies:
     escape-string-regexp: 2.0.0
     invariant: 2.2.4
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 58727996bde082101831b2999b02648641e70a658661a7f182a582137be8ebe7e75e588b7e4d1cb902fbbf00113ea0e70a5e6920f7e212ee4e89f9ec58542873
+  checksum: 5b2971499bdf67bb161918205b2f9e19d96160dd139f75cbbbc1e13e52e9133c623cdf06f5dd4846903029b55bd0c963277768cf17d5c47f8b7fcb8c5a1469a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

`react-native-webview` (upgraded to in https://github.com/laurent22/joplin/commit/912c9431148bffa77850f273f76de296aae83824) [broke TypeScript support in v13.8.3](https://github.com/react-native-webview/react-native-webview/issues/3374), and [fixed it in v13.8.6](https://github.com/react-native-webview/react-native-webview/releases/tag/v13.8.6).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->