### PR TITLE
Resolved #10755 HTML image height cannot be specified

### DIFF
--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -315,7 +315,7 @@ export default function(theme: any, options: Options = null) {
 		}
 		img {
 			max-width: 100%;
-			height: auto;
+			height: revert-layer;
 		}
 		
 		.inline-code,


### PR DESCRIPTION
Changed the css property of the image tag in noteList.ts, where height was set to auto. Changed the height property to revert-layer.

I have run the yarn test command and I , hereby, confirm that there are no errors due to this change.

I have not written any additional tests for this change.

Here is the screenshot of the resolved issue : 

![Screenshot_20240720_160920](https://github.com/user-attachments/assets/a6df7745-2e75-4a09-b201-9ec36b279fc5)


Resolves #10755 

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md