### PR TITLE
Android: Fix attaching PNG and JPEG images

### DIFF
--- a/packages/app-mobile/utils/image/getImageDimensions.ts
+++ b/packages/app-mobile/utils/image/getImageDimensions.ts
@@ -4,7 +4,7 @@ import { Image as NativeImage } from 'react-native';
 const getImageDimensions = async (uri: string): Promise<Size> => {
 	return new Promise((resolve, reject) => {
 		NativeImage.getSize(
-			uri,
+			`file://${uri}`,
 			(width: number, height: number) => {
 				resolve({ width: width, height: height });
 			},


### PR DESCRIPTION
# Summary

This commit fixes a recent regression related to attaching JPEG and PNG images. On Android, React Native's `getSize` requires URLs, rather than file paths.

# Testing plan

This pull request has been tested by:
1. Opening edit mode on a note.
2. Attaching a PNG or JPEG image.
    - JPEG on iOS, PNG on Android

This has been tested successfully on an iOS 17.4 simulator and an Android 13 device.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->