### PR TITLE
Server: Allow web client sync

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -131,6 +131,9 @@ async function main() {
 	// layout these dependencies in code but not clear how to do this.
 	const corsAllowedDomains = [
 		'https://joplinapp.org',
+
+		// Allows sync with the web version of Joplin
+		'https://app.joplincloud.com',
 	];
 
 	if (env === Env.Dev) {


### PR DESCRIPTION
# Summary

This pull request **should** allow browser sync with Joplin Server from a web client hosted at `app.joplincloud.com`.

# Testing plan

1. Replace `https://app.joplincloud.com` with `http://localhost:8088`.
2. Start the development server for the web client (`cd /path/to/web-app-repo/packages/app-mobile && yarn serve-web`)
3. Set Joplin Server as the sync target and click "Check Synchronization Configuration"
4. Verify that the connection is successful.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->