### PR TITLE
Mobile: Plugins: Fix incorrect Node exports emulation

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useContentScripts.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useContentScripts.ts
@@ -59,8 +59,8 @@ const useContentScripts = (pluginStates: PluginStates) => {
 				if (event.cancelled) return;
 
 				const contentScriptModule = `(function () {
-					const module = { exports: null };
 					const exports = {};
+					const module = { exports: exports };
 
 					${content}
 

--- a/packages/editor/CodeMirror/pluginApi/PluginLoader.ts
+++ b/packages/editor/CodeMirror/pluginApi/PluginLoader.ts
@@ -82,7 +82,7 @@ export default class PluginLoader {
 				scriptElement.appendChild(document.createTextNode(`
 				(async () => {
 					const exports = {};
-					const module = {};
+					const module = { exports: exports };
 					const require = window.__pluginLoaderRequireFunctions[${JSON.stringify(this.pluginLoaderId)}];
 					const joplin = {
 						require,
@@ -90,7 +90,7 @@ export default class PluginLoader {
 		
 					${js};
 		
-					window.__pluginLoaderScriptLoadCallbacks[${JSON.stringify(scriptId)}](module.exports || exports);
+					window.__pluginLoaderScriptLoadCallbacks[${JSON.stringify(scriptId)}](module.exports);
 				})();
 				`));
 


### PR DESCRIPTION
# Summary

The mobile app provides both `module` and `exports` to support loading plugins that use CommonJS exports. However, it defined `module.exports` incorrectly (see [the relevant downstream issue](https://github.com/LightAPIs/joplin-copy-code-blocks/issues/5#issuecomment-2211980319)).

See [the relevant NodeJS documentation](https://nodejs.org/api/modules.html#moduleexports).

# Testing plan

**Regression testing:**
1. Install two plugins: "Markdown Table: Colorize" and "Joplin debug tool".
2. Verify that 1) the debug tool panel can be shown, and 2) a 2x2 markdown table added to a note is colorized.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->