### PR TITLE
Android: Fix pasting PNG and JPEG images from the clipboard

### DIFF
--- a/packages/app-mobile/utils/image/getImageDimensions.ts
+++ b/packages/app-mobile/utils/image/getImageDimensions.ts
@@ -4,7 +4,7 @@ import { Image as NativeImage } from 'react-native';
 const getImageDimensions = async (uri: string): Promise<Size> => {
 	return new Promise((resolve, reject) => {
 		NativeImage.getSize(
-			uri,
+			`file://${uri}`,
 			(width: number, height: number) => {
 				resolve({ width: width, height: height });
 			},

--- a/packages/app-mobile/utils/image/getImageDimensions.ts
+++ b/packages/app-mobile/utils/image/getImageDimensions.ts
@@ -2,9 +2,13 @@ import { Size } from '@joplin/utils/types';
 import { Image as NativeImage } from 'react-native';
 
 const getImageDimensions = async (uri: string): Promise<Size> => {
+	if (uri.startsWith('/')) {
+		uri = `file://${uri}`;
+	}
+
 	return new Promise((resolve, reject) => {
 		NativeImage.getSize(
-			`file://${uri}`,
+			uri,
 			(width: number, height: number) => {
 				resolve({ width: width, height: height });
 			},


### PR DESCRIPTION
# Summary

This pull request fixes a regression that caused Joplin to fail to paste image files on Android. (Most testing for #10751 was done on iOS.) 

# Testing plan

## Regression testing

This pull request has been tested by:
1. Opening edit mode on a note.
2. Attaching a PNG or JPEG image.
    - JPEG on iOS, PNG on Android

This has been tested successfully on an iOS 17.4 simulator and an Android 13 device.

## Pasting images

On Android 13:
1. Copy a small PNG image from Chrome.
2. Paste the image into Joplin's note editor.
3. Verify that a resource is added.
4. Copy a large PNG image from Chrome.
5. Paste the image into Joplin's note editor.
6. Choose "yes" to decrease the image size.
7. Verify that a resource is added.
8. Switch to the note viewer. Verify that both images render.