### PR TITLE
Desktop: Fixes #10768: Make `:w` trigger sync in the beta editor's Vim mode

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/utils/useKeymap.ts
@@ -160,7 +160,7 @@ export default function useKeymap(CodeMirror: any) {
 		keymapService.on(EventName.KeymapChange, registerKeymap);
 
 		setupEmacs();
-		setupVim(CodeMirror);
+		setupVim(CodeMirror, null);
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, []);
 }

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -12,6 +12,7 @@ import setupVim from '@joplin/editor/CodeMirror/utils/setupVim';
 import { dirname } from 'path';
 import useKeymap from './utils/useKeymap';
 import useEditorSearch from '../utils/useEditorSearchExtension';
+import CommandService from '@joplin/lib/services/CommandService';
 
 interface Props extends EditorProps {
 	style: React.CSSProperties;
@@ -145,7 +146,11 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 			return;
 		}
 
-		setupVim(editor);
+		setupVim(editor, {
+			sync: () => {
+				void CommandService.instance().execute('synchronize');
+			},
+		});
 	}, [editor]);
 
 	useKeymap(editor);

--- a/packages/editor/CodeMirror/utils/setupVim.ts
+++ b/packages/editor/CodeMirror/utils/setupVim.ts
@@ -1,12 +1,22 @@
 import CodeMirrorControl from '../CodeMirrorControl';
 
-const setupVim = (CodeMirror: CodeMirrorControl) => {
+interface AppCommands {
+	sync(): void;
+}
+
+const setupVim = (CodeMirror: CodeMirrorControl, commands: AppCommands|null) => {
 	CodeMirror.Vim.defineAction('swapLineDown', CodeMirror.commands.swapLineDown);
 	CodeMirror.Vim.mapCommand('<A-j>', 'action', 'swapLineDown', {}, { context: 'normal', isEdit: true });
 	CodeMirror.Vim.defineAction('swapLineUp', CodeMirror.commands.swapLineUp);
 	CodeMirror.Vim.mapCommand('<A-k>', 'action', 'swapLineUp', {}, { context: 'normal', isEdit: true });
 	CodeMirror.Vim.defineAction('insertListElement', CodeMirror.commands.vimInsertListElement);
 	CodeMirror.Vim.mapCommand('o', 'action', 'insertListElement', { after: true }, { context: 'normal', isEdit: true, interlaceInsertRepeat: true });
+
+	if (commands) {
+		CodeMirror.Vim.defineEx('write', 'w', () => {
+			commands.sync();
+		});
+	}
 };
 
 export default setupVim;


### PR DESCRIPTION
# Summary

This pull request fixes #10768 by mapping `:w` to "sync" in the beta markdown editor (as it is in the legacy CodeMirror 5 editor).

# Testing plan

1. Enable vim keybindings.
1. Enable the beta markdown editor.
2. Press <kbd>Escape</kbd> then <kbd>:w</kbd>.
3. Verify that the sync action is triggered.
    - For me, this resulted in the "select a sync target" dialog being shown.
4. Switch to the legacy markdown editor.
5. Repeat steps 2-3.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->