### PR TITLE
Desktop: Improve focus handling for notebook edit, share, and sync dialogs

### DIFF
--- a/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const IconSelector = (props: Props) => {
 	const [emojiButtonClassReady, setEmojiButtonClassReady] = useState<boolean>(false);
 	const [picker, setPicker] = useState<EmojiButton>();
-	const buttonRef = useRef(null);
+	const buttonRef = useRef<HTMLButtonElement>(null);
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		const loadScripts = async () => {
@@ -61,6 +61,7 @@ export const IconSelector = (props: Props) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const p: EmojiButton = new (window as any).EmojiButton({
 			zIndex: 10000,
+			rootElement: buttonRef.current?.parentElement,
 		});
 
 		const onEmoji = (selection: FolderIcon) => {
@@ -73,6 +74,7 @@ export const IconSelector = (props: Props) => {
 
 		return () => {
 			p.off('emoji', onEmoji);
+			p.destroyPicker();
 		};
 	}, [emojiButtonClassReady, props.onChange]);
 

--- a/packages/app-desktop/gui/SyncWizard/Dialog.tsx
+++ b/packages/app-desktop/gui/SyncWizard/Dialog.tsx
@@ -140,17 +140,16 @@ type SyncTargetInfoName = 'dropbox' | 'onedrive' | 'joplinCloud';
 export default function(props: Props) {
 	const joplinCloudDescriptionRef = useRef(null);
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	function closeDialog(dispatch: Function) {
-		dispatch({
+	const closeDialog = useCallback(() => {
+		props.dispatch({
 			type: 'DIALOG_CLOSE',
 			name: 'syncWizard',
 		});
-	}
+	}, [props.dispatch]);
 
 	const onButtonRowClick = useCallback(() => {
-		closeDialog(props.dispatch);
-	}, [props.dispatch]);
+		closeDialog();
+	}, [closeDialog]);
 
 	const { height: descriptionHeight } = useElementSize(joplinCloudDescriptionRef);
 
@@ -184,12 +183,12 @@ export default function(props: Props) {
 
 		Setting.setValue('sync.target', route.target);
 		await Setting.saveAll();
-		closeDialog(props.dispatch);
+		closeDialog();
 		props.dispatch({
 			type: 'NAV_GO',
 			routeName: route.name,
 		});
-	}, [props.dispatch]);
+	}, [props.dispatch, closeDialog]);
 
 	function renderSelectArea(info: SyncTargetInfo) {
 		return (
@@ -229,7 +228,7 @@ export default function(props: Props) {
 	}
 
 	const onSelfHostingClick = useCallback(() => {
-		closeDialog(props.dispatch);
+		closeDialog();
 
 		props.dispatch({
 			type: 'NAV_GO',
@@ -238,7 +237,7 @@ export default function(props: Props) {
 				defaultSection: 'sync',
 			},
 		});
-	}, [props.dispatch]);
+	}, [props.dispatch, closeDialog]);
 
 	function renderContent() {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -278,6 +277,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog renderContent={renderDialogWrapper}/>
+		<Dialog onClose={closeDialog} renderContent={renderDialogWrapper}/>
 	);
 }

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -1,0 +1,28 @@
+
+.dialog-modal-layer {
+	display: flex;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	align-items: flex-start;
+	justify-content: center;
+	border: none;
+	margin: 0;
+	background-color: transparent;
+
+	> .content {
+		background-color: var(--joplin-background-color);
+		padding: 16px;
+		box-shadow: 6px 6px 20px rgba(0,0,0,0.5);
+		margin: 20px;
+		min-height: fit-content;
+		display: flex;
+		flex-direction: column;
+		border-radius: 10px;
+	}
+
+	&::backdrop {
+		background-color: rgba(0,0,0,0.6);
+	}
+}

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -1,0 +1,2 @@
+
+@use './dialog-modal-layer.scss';

--- a/packages/app-desktop/style.scss
+++ b/packages/app-desktop/style.scss
@@ -10,4 +10,5 @@
 @use 'gui/NoteListHeader/style.scss' as note-list-header;
 @use 'gui/TrashNotification/style.scss' as trash-notification;
 @use 'gui/Sidebar/style.scss' as sidebar-styles;
+@use 'gui/styles/index.scss';
 @use 'main.scss' as main;


### PR DESCRIPTION
# Summary

This pull request switches many dialogs to the [HTML `<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#accessibility) element, which:
- Auto-focuses the first focusable item in the dialog (this can be customized by adding the `autofocus` attribute to a different element).
- Traps focus in the dialog. This means that repeatedly pressing `Tab` no longer causes focus to leave the dialog.
  - This is helpful when using a screen reader.
- Marks the dialog as a dialog for screen readers.
- Makes the dialog modal, showing it above other elements.

# Testing plan

1. Right-click on a notebook and select "edit".
2. Click "select emoji" and choose an Emoji using the Emoji picker.
3. Hold <kbd>tab</kbd>, verify that the focus cycles through the dialog without leaving it.
4. Close the dialog by clicking "OK".
5. Open the share dialog for the current notebook.
6. Share the notebook with another user.
7. Close the dialog.
8. Open the publish dialog for the current note.
9. Close the dialog by pressing <kbd>esc</kbd>.
10. Enable the web clipper.
11. Grant access to the web clipper by pressing <kbd>Enter</kbd>.
    - Similar issue: `Enter` **always** accepts the same button and closes the dialog, regardless of keyboard focus (unless in a `textarea`). ([Code that causes the issue](https://github.com/laurent22/joplin/blob/331f7ebe5cc3f96e9c6ae95409968cf3f8f46837/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts#L51)).

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->