### PR TITLE
Desktop: Rich Text Editor: Preserve cursor location when updating editor content

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -942,6 +942,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				);
 				if (cancelled) return;
 
+				// Use an offset bookmark -- the default bookmark type is not preserved after unloading
+				// and reloading the editor.
+				// See https://github.com/tinymce/tinymce/issues/9736 for a brief description of the
+				// different bookmark types. An offset bookmark seems to have the smallest change
+				// when the note content is updated externally.
+				const offsetBookmarkId = 2;
+				const bookmark = editor.selection.getBookmark(offsetBookmarkId);
 				editor.setContent(awfulInitHack(result.html));
 
 				if (lastOnChangeEventInfo.current.contentKey !== props.contentKey) {
@@ -960,6 +967,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					// times would result in an empty note.
 					// https://github.com/laurent22/joplin/issues/3534
 					editor.undoManager.reset();
+				} else {
+					// Restore the cursor location
+					editor.selection.bookmarkManager.moveToBookmark(bookmark);
 				}
 
 				lastOnChangeEventInfo.current = {


### PR DESCRIPTION
# Summary

This pull request preserves the Rich Text Editor's cursor location when the note content is updated externally.

This may partially fix #8960 (only the Rich Text Editor case).

This should:
- Preserve the cursor location and scroll position when a note open in the Rich Text Editor is changed by an external editor. This is useful when switching back and forth between the Rich Text Editor and an external editor with keyboard shortcuts (e.g. <kbd>alt</kbd>-<kbd>tab</kbd>).
- Prevent the cursor from jumping to the top of the note when changed by a sync.
    - Note: This has only been tested with a manual sync.


# Testing plan

This pull request has been manually tested by:
1. Ensure that the Rich Text Editor is open.
2. Create a new note.
3. Open the note in an external editor (gnome-text-editor).
4. Using the external editor, set the note content to a long file with KaTeX blocks, headings, and paragraphs (I used this content: [file.md](https://github.com/user-attachments/files/16370150/test.txt)).
5. In the Rich Text Editor, move the cursor to the last heading.
6. Delete the first math block from the external editor and save.
7. Verify that the cursor doesn't move more than a single line.
    - For me, the cursor moved down a single line.
8. In the external editor, undo and save again.
9. Verify that the Rich Text Editor cursor has moved back to the heading.
10. Switch to a different note.
11. Verify that the cursor has moved to the top of the note.
12. Switch back to the original note and move the cursor to the second-to-last heading.
13. Set up file system sync.
14. Sync another client.
15. On the just-synced client,
    - Delete one of the math blocks above the second-to-last heading.
    - Sync.
16. Sync the original client.
17. Verify that the cursor moves less than 1-2 lines.
    - For me, the cursor moves to the line just below the originally-selected heading.

This has been tested successfully on Ubuntu 24.04.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->