### PR TITLE
Android: Fix crash on opening settings on old versions of Android

### DIFF
--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -7,10 +7,11 @@ import { _ } from '@joplin/lib/locale';
 
 const getWebViewVersionText = () => {
 	if (Platform.OS === 'android') {
-		const constants = NativeModules.SystemVersionInformationModule.getConstants();
+		// SystemVersionInformationModule is unavailable on older versions of Android.
+		const constants = NativeModules.SystemVersionInformationModule?.getConstants();
 		return [
-			_('WebView version: %s', constants.webViewVersion),
-			_('WebView package: %s', constants.webViewPackage),
+			_('WebView version: %s', constants?.webViewVersion ?? 'Unknown'),
+			_('WebView package: %s', constants?.webViewPackage ?? 'Unknown'),
 		].join('\n');
 	}
 	return null;

--- a/packages/app-mobile/utils/getVersionInfoText.ts
+++ b/packages/app-mobile/utils/getVersionInfoText.ts
@@ -10,8 +10,8 @@ const getWebViewVersionText = () => {
 		// SystemVersionInformationModule is unavailable on older versions of Android.
 		const constants = NativeModules.SystemVersionInformationModule?.getConstants();
 		return [
-			_('WebView version: %s', constants?.webViewVersion ?? 'Unknown'),
-			_('WebView package: %s', constants?.webViewPackage ?? 'Unknown'),
+			_('WebView version: %s', constants?.webViewVersion ?? _('Unknown')),
+			_('WebView package: %s', constants?.webViewPackage ?? _('Unknown')),
 		].join('\n');
 	}
 	return null;


### PR DESCRIPTION
# Summary

On Android 7, `NativeModules.SystemVersionInformationModule` seems to be `undefined`. This causes a crash when attempting to generate the version information section of the configuration screen.


# Testing plan

1. Start Joplin
2. Open "Configuration". Verify that a list of settings sections is shown.
3. Verify that the "More info" tab can be opened.

This has been tested successfully on Android 7.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->