### PR TITLE
Desktop: Accessibility: Improve focus handling for plugin and prompt dialogs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -451,7 +451,9 @@ packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
+packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
+packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
@@ -469,6 +471,7 @@ packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js
+packages/app-desktop/services/autoUpdater/AutoUpdaterService.js
 packages/app-desktop/services/bridge.js
 packages/app-desktop/services/commands/stateToWhenClauseContext.js
 packages/app-desktop/services/commands/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -430,7 +430,9 @@ packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js
 packages/app-desktop/gulpfile.js
+packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
+packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
@@ -448,6 +450,7 @@ packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js
+packages/app-desktop/services/autoUpdater/AutoUpdaterService.js
 packages/app-desktop/services/bridge.js
 packages/app-desktop/services/commands/stateToWhenClauseContext.js
 packages/app-desktop/services/commands/types.js

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { ReactElement, ReactEventHandler, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactEventHandler, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 interface Props {
-	renderContent: ()=> ReactElement;
 	className?: string;
 	onClose?: ()=> void;
+	contentStyle?: React.CSSProperties;
+	children: ReactNode;
 }
 
 export default function Dialog(props: Props) {
@@ -38,8 +39,8 @@ export default function Dialog(props: Props) {
 			onClose={props.onClose}
 			onCancel={onCancel}
 		>
-			<div className='content'>
-				{props.renderContent()}
+			<div className='content' style={props.contentStyle}>
+				{props.children}
 			</div>
 		</dialog>
 	);

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -19,12 +19,12 @@ export default function Dialog(props: Props) {
 		dialogElement.showModal();
 	}, [dialogElement]);
 
-	const onCloseRef = useRef(props.onCancel);
-	onCloseRef.current = props.onCancel;
+	const onCancelRef = useRef(props.onCancel);
+	onCancelRef.current = props.onCancel;
 
 	const onCancel: ReactEventHandler<HTMLDialogElement> = useCallback((event) => {
-		const canCancel = !!onCloseRef.current;
-		if (canCancel) {
+		const canCancel = !!onCancelRef.current;
+		if (!canCancel) {
 			// Prevents [Escape] from closing the dialog. In many places, this is handled
 			// elsewhere.
 			// See https://stackoverflow.com/a/61021326
@@ -33,10 +33,11 @@ export default function Dialog(props: Props) {
 	}, []);
 
 	const onContainerClick: MouseEventHandler<HTMLDialogElement> = useCallback((event) => {
-		if (event.target === dialogElement && props.onCancel) {
-			props.onCancel?.();
+		const onCancel = onCancelRef.current;
+		if (event.target === dialogElement && onCancel) {
+			onCancel();
 		}
-	}, [dialogElement, props.onCancel]);
+	}, [dialogElement]);
 
 	return (
 		<dialog

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { ReactEventHandler, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { MouseEventHandler, ReactEventHandler, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 interface Props {
 	className?: string;
-	onClose?: ()=> void;
+	onCancel?: ()=> void;
 	contentStyle?: React.CSSProperties;
 	children: ReactNode;
 }
@@ -19,8 +19,8 @@ export default function Dialog(props: Props) {
 		dialogElement.showModal();
 	}, [dialogElement]);
 
-	const onCloseRef = useRef(props.onClose);
-	onCloseRef.current = props.onClose;
+	const onCloseRef = useRef(props.onCancel);
+	onCloseRef.current = props.onCancel;
 
 	const onCancel: ReactEventHandler<HTMLDialogElement> = useCallback((event) => {
 		const canCancel = !!onCloseRef.current;
@@ -32,12 +32,19 @@ export default function Dialog(props: Props) {
 		}
 	}, []);
 
+	const onContainerClick: MouseEventHandler<HTMLDialogElement> = useCallback((event) => {
+		if (event.target === dialogElement && props.onCancel) {
+			props.onCancel?.();
+		}
+	}, [dialogElement, props.onCancel]);
+
 	return (
 		<dialog
 			ref={setDialogRef}
 			className={`dialog-modal-layer ${props.className}`}
-			onClose={props.onClose}
+			onClose={props.onCancel}
 			onCancel={onCancel}
+			onClick={onContainerClick}
 		>
 			<div className='content' style={props.contentStyle}>
 				{props.children}

--- a/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
@@ -179,6 +179,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
+		<Dialog onCancel={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
@@ -179,6 +179,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={onClose} className="master-password-dialog" renderContent={renderDialogWrapper}/>
+		<Dialog onClose={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -240,6 +240,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
+		<Dialog onCancel={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -240,6 +240,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={onClose} className="master-password-dialog" renderContent={renderDialogWrapper}/>
+		<Dialog onClose={onClose} className="master-password-dialog">{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -159,7 +159,7 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	const readTimeLabel = _('Read time: %s min', formatReadTime(strippedReadTime));
 
 	return (
-		<Dialog onClose={props.onClose}>
+		<Dialog onCancel={props.onClose}>
 			<div style={dialogBoxHeadingStyle}>{_('Statistics')}</div>
 			<table>
 				<thead>

--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -5,13 +5,13 @@ import DialogButtonRow from './DialogButtonRow';
 const { themeStyle } = require('@joplin/lib/theme');
 const Countable = require('@joplin/lib/countable/Countable');
 import markupLanguageUtils from '../utils/markupLanguageUtils';
+import Dialog from './Dialog';
 
 interface NoteContentPropertiesDialogProps {
 	themeId: number;
 	text: string;
 	markupLanguage: number;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onClose: Function;
+	onClose: ()=> void;
 }
 
 interface TextPropertiesMap {
@@ -159,22 +159,20 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	const readTimeLabel = _('Read time: %s min', formatReadTime(strippedReadTime));
 
 	return (
-		<div style={theme.dialogModalLayer}>
-			<div style={theme.dialogBox}>
-				<div style={dialogBoxHeadingStyle}>{_('Statistics')}</div>
-				<table>
-					<thead>
-						{tableHeader}
-					</thead>
-					<tbody>
-						{tableBodyComps}
-					</tbody>
-				</table>
-				<div style={{ ...labelCompStyle, marginTop: 10 }}>
-					{readTimeLabel}
-				</div>
-				<DialogButtonRow themeId={props.themeId} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
+		<Dialog onClose={props.onClose}>
+			<div style={dialogBoxHeadingStyle}>{_('Statistics')}</div>
+			<table>
+				<thead>
+					{tableHeader}
+				</thead>
+				<tbody>
+					{tableBodyComps}
+				</tbody>
+			</table>
+			<div style={{ ...labelCompStyle, marginTop: 10 }}>
+				{readTimeLabel}
 			</div>
-		</div>
+			<DialogButtonRow themeId={props.themeId} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
+		</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -447,7 +447,7 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 		}
 
 		return (
-			<Dialog onClose={this.props.onClose}>
+			<Dialog onCancel={this.props.onClose}>
 				<div style={theme.dialogTitle} id='note-properties-dialog-title'>{_('Note properties')}</div>
 				<div role='table' aria-labelledby='note-properties-dialog-title'>
 					{noteComps}

--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -8,14 +8,14 @@ import bridge from '../services/bridge';
 import shim from '@joplin/lib/shim';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import Dialog from './Dialog';
 const Datetime = require('react-datetime').default;
 const { clipboard } = require('electron');
 const formatcoords = require('formatcoords');
 
 interface Props {
 	noteId: string;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onClose: Function;
+	onClose: ()=> void;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onRevisionLinkClick: Function;
 	themeId: number;
@@ -447,15 +447,13 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 		}
 
 		return (
-			<div style={theme.dialogModalLayer}>
-				<div style={theme.dialogBox}>
-					<div style={theme.dialogTitle} id='note-properties-dialog-title'>{_('Note properties')}</div>
-					<div role='table' aria-labelledby='note-properties-dialog-title'>
-						{noteComps}
-					</div>
-					<DialogButtonRow themeId={this.props.themeId} okButtonShow={!this.isReadOnly()} okButtonRef={this.okButton} onClick={this.buttonRow_click}/>
+			<Dialog onClose={this.props.onClose}>
+				<div style={theme.dialogTitle} id='note-properties-dialog-title'>{_('Note properties')}</div>
+				<div role='table' aria-labelledby='note-properties-dialog-title'>
+					{noteComps}
 				</div>
-			</div>
+				<DialogButtonRow themeId={this.props.themeId} okButtonShow={!this.isReadOnly()} okButtonRef={this.okButton} onClick={this.buttonRow_click}/>
+			</Dialog>
 		);
 	}
 }

--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -7,6 +7,8 @@ import CreatableSelect from 'react-select/creatable';
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import Dialog from './Dialog';
+
 interface Props {
 	themeId: number;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -89,31 +91,6 @@ export default class PromptDialog extends React.Component<Props, any> {
 		this.styleKey_ = styleKey;
 
 		this.styles_ = {};
-
-		const paddingTop = 20;
-
-		this.styles_.modalLayer = {
-			zIndex: 9999,
-			position: 'absolute',
-			top: 0,
-			left: 0,
-			width: width,
-			height: height,
-			boxSizing: 'border-box',
-			backgroundColor: 'rgba(0,0,0,0.6)',
-			display: visible ? 'flex' : 'none',
-			alignItems: 'flex-start',
-			justifyContent: 'center',
-			paddingTop: `${paddingTop}px`,
-		};
-
-		this.styles_.promptDialog = {
-			backgroundColor: theme.backgroundColor,
-			padding: 16,
-			display: 'inline-block',
-			maxWidth: width * 0.5,
-			boxShadow: '6px 6px 20px rgba(0,0,0,0.5)',
-		};
 
 		this.styles_.button = {
 			minWidth: theme.buttonMinWidth,
@@ -218,6 +195,8 @@ export default class PromptDialog extends React.Component<Props, any> {
 	}
 
 	public render() {
+		if (!this.state.visible) return null;
+
 		const style = this.props.style;
 		const theme = themeStyle(this.props.themeId);
 		const buttonTypes = this.props.buttons ? this.props.buttons : ['ok', 'cancel'];
@@ -309,9 +288,11 @@ export default class PromptDialog extends React.Component<Props, any> {
 				</button>,
 			);
 		}
+		let onCancel = null;
 		if (buttonTypes.indexOf('cancel') >= 0) {
+			onCancel = () => onClose(false, 'cancel');
 			buttonComps.push(
-				<button key="cancel" style={styles.button} onClick={() => onClose(false, 'cancel')}>
+				<button key="cancel" style={styles.button} onClick={onCancel}>
 					{_('Cancel')}
 				</button>,
 			);
@@ -325,16 +306,14 @@ export default class PromptDialog extends React.Component<Props, any> {
 		}
 
 		return (
-			<div className="modal-layer" style={styles.modalLayer}>
-				<div className="modal-dialog" style={styles.promptDialog}>
-					<label style={styles.label}>{this.props.label ? this.props.label : ''}</label>
-					<div style={{ display: 'inline-block', color: 'black', backgroundColor: theme.backgroundColor }}>
-						{inputComp}
-						{descComp}
-					</div>
-					<div style={{ textAlign: 'right', marginTop: 10 }}>{buttonComps}</div>
+			<Dialog className='prompt-dialog' onCancel={onCancel}>
+				<label style={styles.label}>{this.props.label ? this.props.label : ''}</label>
+				<div style={{ display: 'inline-block', color: 'black', backgroundColor: theme.backgroundColor }}>
+					{inputComp}
+					{descComp}
 				</div>
-			</div>
+				<div style={{ textAlign: 'right', marginTop: 10 }}>{buttonComps}</div>
+			</Dialog>
 		);
 	}
 }

--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -288,11 +288,9 @@ export default class PromptDialog extends React.Component<Props, any> {
 				</button>,
 			);
 		}
-		let onCancel = null;
 		if (buttonTypes.indexOf('cancel') >= 0) {
-			onCancel = () => onClose(false, 'cancel');
 			buttonComps.push(
-				<button key="cancel" style={styles.button} onClick={onCancel}>
+				<button key="cancel" style={styles.button} onClick={() => onClose(false, 'cancel')}>
 					{_('Cancel')}
 				</button>,
 			);
@@ -306,7 +304,7 @@ export default class PromptDialog extends React.Component<Props, any> {
 		}
 
 		return (
-			<Dialog className='prompt-dialog' onCancel={onCancel}>
+			<Dialog className='prompt-dialog'>
 				<label style={styles.label}>{this.props.label ? this.props.label : ''}</label>
 				<div style={{ display: 'inline-block', color: 'black', backgroundColor: theme.backgroundColor }}>
 					{inputComp}

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -167,7 +167,7 @@ class RootComponent extends React.Component<Props, any> {
 			);
 		};
 
-		return <Dialog renderContent={renderContent}/>;
+		return <Dialog>{renderContent()}</Dialog>;
 	}
 
 	private modalDialogProps(): ModalDialogProps {

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -407,7 +407,7 @@ function ShareFolderDialog(props: Props) {
 	}
 
 	return (
-		<Dialog renderContent={renderContent}/>
+		<Dialog>{renderContent()}</Dialog>
 	);
 }
 

--- a/packages/app-desktop/gui/ShareNoteDialog.tsx
+++ b/packages/app-desktop/gui/ShareNoteDialog.tsx
@@ -226,7 +226,7 @@ export function ShareNoteDialog(props: Props) {
 	};
 
 	return (
-		<Dialog renderContent={renderContent}/>
+		<Dialog>{renderContent()}</Dialog>
 	);
 }
 

--- a/packages/app-desktop/gui/SyncWizard/Dialog.tsx
+++ b/packages/app-desktop/gui/SyncWizard/Dialog.tsx
@@ -277,6 +277,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={closeDialog}>{renderDialogWrapper()}</Dialog>
+		<Dialog onCancel={closeDialog}>{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/SyncWizard/Dialog.tsx
+++ b/packages/app-desktop/gui/SyncWizard/Dialog.tsx
@@ -277,6 +277,6 @@ export default function(props: Props) {
 	}
 
 	return (
-		<Dialog onClose={closeDialog} renderContent={renderDialogWrapper}/>
+		<Dialog onClose={closeDialog}>{renderDialogWrapper()}</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -23,6 +23,6 @@
 	}
 
 	&::backdrop {
-		background-color: rgba(0,0,0,0.6);
+		background-color: rgba(0,0,0,0.5);
 	}
 }

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -13,6 +13,7 @@
 
 	> .content {
 		background-color: var(--joplin-background-color);
+		color: var(--joplin-color);
 		padding: 16px;
 		box-shadow: 6px 6px 20px rgba(0,0,0,0.5);
 		margin: 20px;

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -1,3 +1,4 @@
 
 @use './dialog-modal-layer.scss';
 @use './user-webview-dialog.scss';
+@use './prompt-dialog.scss';

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -1,2 +1,3 @@
 
 @use './dialog-modal-layer.scss';
+@use './user-webview-dialog.scss';

--- a/packages/app-desktop/gui/styles/prompt-dialog.scss
+++ b/packages/app-desktop/gui/styles/prompt-dialog.scss
@@ -1,0 +1,6 @@
+
+.prompt-dialog {
+	> .content {
+		display: inline-block;
+	}
+}

--- a/packages/app-desktop/gui/styles/prompt-dialog.scss
+++ b/packages/app-desktop/gui/styles/prompt-dialog.scss
@@ -2,5 +2,6 @@
 .prompt-dialog {
 	> .content {
 		display: inline-block;
+		max-width: 450px;
 	}
 }

--- a/packages/app-desktop/gui/styles/user-webview-dialog.scss
+++ b/packages/app-desktop/gui/styles/user-webview-dialog.scss
@@ -1,0 +1,22 @@
+
+.user-webview-dialog {
+	overflow: unset;
+	--content-width: 90vw;
+	--content-height: 90vh;
+
+	&.-fit {
+		--content-width: auto;
+		--content-height: auto;
+	}
+
+	> .content {
+		display: flex;
+		flex-direction: column;
+		background-color: var(--joplin-background-color);
+		padding: var(--joplin-main-padding);
+		border-radius: 4px;
+		box-shadow: 0 6px 10px #00000077;
+		width: var(--content-width);
+		height: var(--content-height);
+	}
+}

--- a/packages/app-desktop/gui/styles/user-webview-dialog.scss
+++ b/packages/app-desktop/gui/styles/user-webview-dialog.scss
@@ -1,6 +1,9 @@
 
 .user-webview-dialog {
+	// Overflow should be handled within WebView dialogs (rather than externally).
+	// Allowing external overflow can create space for a scrollbar in some cases.
 	overflow: unset;
+	align-items: center;
 	--content-width: 90vw;
 	--content-height: 90vh;
 

--- a/packages/app-desktop/integration-tests/goToAnything.spec.ts
+++ b/packages/app-desktop/integration-tests/goToAnything.spec.ts
@@ -1,0 +1,52 @@
+
+import { test, expect } from './util/test';
+import MainScreen from './models/MainScreen';
+
+test.describe('goToAnything', () => {
+	test('clicking outside of go to anything should close it', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.noteEditor.waitFor();
+		const goToAnything = mainScreen.goToAnything;
+		await goToAnything.open(electronApp);
+
+		await goToAnything.expectToBeOpen();
+
+		// Click outside of the dialog
+		await goToAnything.containerLocator.click({ position: { x: 0, y: 0 } });
+
+		await goToAnything.expectToBeClosed();
+	});
+
+	test('pressing escape in go to anything should close it ', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		const goToAnything = mainScreen.goToAnything;
+
+		// Pressing Escape to close the dialog should work even if opened multiple times in a row.
+		for (let i = 0; i < 3; i++) {
+			await goToAnything.open(electronApp);
+
+			await goToAnything.expectToBeOpen();
+			await goToAnything.inputLocator.press('Escape');
+			await goToAnything.expectToBeClosed();
+		}
+	});
+
+	test('should be possible to show the set tags dialog from goToAnything', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('Test note');
+
+		const goToAnything = mainScreen.goToAnything;
+		await goToAnything.open(electronApp);
+		await goToAnything.inputLocator.fill(':setTags');
+
+		// Should show a matching command
+		await expect(goToAnything.containerLocator.getByText('Tags (setTags)')).toBeAttached();
+
+		await mainWindow.keyboard.press('Enter');
+		await goToAnything.expectToBeClosed();
+
+		// Should show the "set tags" dialog
+		const setTagsLabel = mainWindow.getByText('Add or remove tags:');
+		await expect(setTagsLabel).toBeVisible();
+	});
+});

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -1,0 +1,36 @@
+
+import { ElectronApplication, expect, Locator, Page } from '@playwright/test';
+import MainScreen from './MainScreen';
+import activateMainMenuItem from '../util/activateMainMenuItem';
+
+export default class GoToAnything {
+	public readonly containerLocator: Locator;
+	public readonly inputLocator: Locator;
+
+	public constructor(page: Page, private readonly mainScreen: MainScreen) {
+		this.containerLocator = page.locator('.go-to-anything-dialog[open]');
+		this.inputLocator = this.containerLocator.getByRole('textbox');
+	}
+
+	public async open(electronApp: ElectronApplication) {
+		await this.mainScreen.waitFor();
+
+		if (!await activateMainMenuItem(electronApp, 'Goto Anything...')) {
+			throw new Error('Menu item for opening Goto Anything not found');
+		}
+
+		return this.waitFor();
+	}
+
+	public async waitFor() {
+		await this.containerLocator.waitFor();
+	}
+
+	public async expectToBeClosed() {
+		await expect(this.containerLocator).not.toBeAttached();
+	}
+
+	public async expectToBeOpen() {
+		await expect(this.containerLocator).toBeAttached();
+	}
+}

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -2,6 +2,7 @@ import { Page, Locator, ElectronApplication } from '@playwright/test';
 import NoteEditorScreen from './NoteEditorScreen';
 import activateMainMenuItem from '../util/activateMainMenuItem';
 import Sidebar from './Sidebar';
+import GoToAnything from './GoToAnything';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
@@ -9,6 +10,7 @@ export default class MainScreen {
 	public readonly sidebar: Sidebar;
 	public readonly dialog: Locator;
 	public readonly noteEditor: NoteEditorScreen;
+	public readonly goToAnything: GoToAnything;
 
 	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
@@ -16,6 +18,7 @@ export default class MainScreen {
 		this.sidebar = new Sidebar(page, this);
 		this.dialog = page.locator('.dialog-root');
 		this.noteEditor = new NoteEditorScreen(page);
+		this.goToAnything = new GoToAnything(page, this);
 	}
 
 	public async waitFor() {

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -22,6 +22,7 @@ import Logger from '@joplin/utils/Logger';
 import { MarkupLanguage, MarkupToHtml } from '@joplin/renderer';
 import Resource from '@joplin/lib/models/Resource';
 import { NoteEntity, ResourceEntity } from '@joplin/lib/services/database/types';
+import Dialog from '../gui/Dialog';
 
 const logger = Logger.create('GotoAnything');
 
@@ -116,7 +117,7 @@ class GotoAnything {
 
 }
 
-class Dialog extends React.PureComponent<Props, State> {
+class DialogComponent extends React.PureComponent<Props, State> {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private styles_: any;
@@ -156,7 +157,6 @@ class Dialog extends React.PureComponent<Props, State> {
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.input_onChange = this.input_onChange.bind(this);
 		this.input_onKeyDown = this.input_onKeyDown.bind(this);
-		this.modalLayer_onClick = this.modalLayer_onClick.bind(this);
 		this.renderItem = this.renderItem.bind(this);
 		this.listItem_onClick = this.listItem_onClick.bind(this);
 		this.helpButton_onClick = this.helpButton_onClick.bind(this);
@@ -255,16 +255,13 @@ class Dialog extends React.PureComponent<Props, State> {
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private modalLayer_onClick(event: any) {
-		if (event.currentTarget === event.target) {
-			this.props.dispatch({
-				pluginName: PLUGIN_NAME,
-				type: 'PLUGINLEGACY_DIALOG_SET',
-				open: false,
-			});
-		}
-	}
+	private modalLayer_onDismiss = () => {
+		this.props.dispatch({
+			pluginName: PLUGIN_NAME,
+			type: 'PLUGINLEGACY_DIALOG_SET',
+			open: false,
+		});
+	};
 
 	private helpButton_onClick() {
 		this.setState({ showHelp: !this.state.showHelp });
@@ -646,21 +643,18 @@ class Dialog extends React.PureComponent<Props, State> {
 	}
 
 	public render() {
-		const theme = themeStyle(this.props.themeId);
 		const style = this.style();
 		const helpComp = !this.state.showHelp ? null : <div className="help-text" style={style.help}>{_('Type a note title or part of its content to jump to it. Or type # followed by a tag name, or @ followed by a notebook name. Or type : to search for commands.')}</div>;
 
 		return (
-			<div className="modal-layer" onClick={this.modalLayer_onClick} style={theme.dialogModalLayer}>
-				<div className="modal-dialog" style={style.dialogBox}>
-					{helpComp}
-					<div style={style.inputHelpWrapper}>
-						<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown} />
-						<HelpButton onClick={this.helpButton_onClick} />
-					</div>
-					{this.renderList()}
+			<Dialog className="go-to-anything-dialog" onCancel={this.modalLayer_onDismiss} contentStyle={style.dialogBox}>
+				{helpComp}
+				<div style={style.inputHelpWrapper}>
+					<input autoFocus type="text" style={style.input} ref={this.inputRef} value={this.state.query} onChange={this.input_onChange} onKeyDown={this.input_onKeyDown} />
+					<HelpButton onClick={this.helpButton_onClick} />
 				</div>
-			</div>
+				{this.renderList()}
+			</Dialog>
 		);
 	}
 
@@ -675,7 +669,7 @@ const mapStateToProps = (state: AppState) => {
 	};
 };
 
-GotoAnything.Dialog = connect(mapStateToProps)(Dialog);
+GotoAnything.Dialog = connect(mapStateToProps)(DialogComponent);
 
 GotoAnything.manifest = {
 

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -154,7 +154,6 @@ class DialogComponent extends React.PureComponent<Props, State> {
 		this.inputRef = React.createRef();
 		this.itemListRef = React.createRef();
 
-		this.onKeyDown = this.onKeyDown.bind(this);
 		this.input_onChange = this.input_onChange.bind(this);
 		this.input_onKeyDown = this.input_onKeyDown.bind(this);
 		this.renderItem = this.renderItem.bind(this);
@@ -226,8 +225,6 @@ class DialogComponent extends React.PureComponent<Props, State> {
 	}
 
 	public componentDidMount() {
-		document.addEventListener('keydown', this.onKeyDown);
-
 		this.props.dispatch({
 			type: 'VISIBLE_DIALOGS_ADD',
 			name: 'gotoAnything',
@@ -236,23 +233,11 @@ class DialogComponent extends React.PureComponent<Props, State> {
 
 	public componentWillUnmount() {
 		if (this.listUpdateIID_) shim.clearTimeout(this.listUpdateIID_);
-		document.removeEventListener('keydown', this.onKeyDown);
 
 		this.props.dispatch({
 			type: 'VISIBLE_DIALOGS_REMOVE',
 			name: 'gotoAnything',
 		});
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public onKeyDown(event: any) {
-		if (event.keyCode === 27) { // ESCAPE
-			this.props.dispatch({
-				pluginName: PLUGIN_NAME,
-				type: 'PLUGINLEGACY_DIALOG_SET',
-				open: false,
-			});
-		}
 	}
 
 	private modalLayer_onDismiss = () => {

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -6,39 +6,13 @@ import WebviewController from '@joplin/lib/services/plugins/WebviewController';
 import UserWebview, { Props as UserWebviewProps } from './UserWebview';
 import UserWebviewDialogButtonBar from './UserWebviewDialogButtonBar';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import Dialog from '../../gui/Dialog';
 const styled = require('styled-components').default;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-type StyleProps = any;
 
 interface Props extends UserWebviewProps {
 	buttons: ButtonSpec[];
 	fitToContent: boolean;
 }
-
-const StyledRoot = styled.div`
-	display: flex;
-	flex: 1;
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	height: 100%;
-	background-color: rgba(0,0,0,0.5);
-	box-sizing: border-box;
-	justify-content: center;
-	align-items: center;
-`;
-
-const Dialog = styled.div`
-	display: flex;
-	flex-direction: column;
-	background-color: ${(props: StyleProps) => props.theme.backgroundColor};
-	padding: ${(props: StyleProps) => `${props.theme.mainPadding}px`};
-	border-radius: 4px;
-	box-shadow: 0 6px 10px #00000077;
-	width: ${(props: StyleProps) => props.fitToContent ? 'auto' : '90vw'};
-	height: ${(props: StyleProps) => props.fitToContent ? 'auto' : '80vh'};
-`;
 
 const UserWebViewWrapper = styled.div`
 	display: flex;
@@ -109,25 +83,23 @@ export default function UserWebviewDialog(props: Props) {
 	}, []);
 
 	return (
-		<StyledRoot>
-			<Dialog fitToContent={props.fitToContent}>
-				<UserWebViewWrapper>
-					<UserWebview
-						ref={webviewRef}
-						html={props.html}
-						scripts={props.scripts}
-						pluginId={props.pluginId}
-						viewId={props.viewId}
-						themeId={props.themeId}
-						borderBottom={false}
-						fitToContent={props.fitToContent}
-						onSubmit={onSubmit}
-						onDismiss={onDismiss}
-						onReady={onReady}
-					/>
-				</UserWebViewWrapper>
-				<UserWebviewDialogButtonBar buttons={buttons}/>
-			</Dialog>
-		</StyledRoot>
+		<Dialog className={`user-webview-dialog ${props.fitToContent ? '-fit' : ''}`}>
+			<UserWebViewWrapper>
+				<UserWebview
+					ref={webviewRef}
+					html={props.html}
+					scripts={props.scripts}
+					pluginId={props.pluginId}
+					viewId={props.viewId}
+					themeId={props.themeId}
+					borderBottom={false}
+					fitToContent={props.fitToContent}
+					onSubmit={onSubmit}
+					onDismiss={onDismiss}
+					onReady={onReady}
+				/>
+			</UserWebViewWrapper>
+			<UserWebviewDialogButtonBar buttons={buttons}/>
+		</Dialog>
 	);
 }


### PR DESCRIPTION
# Summary

This pull request improves focus handling for additional dialog types in a way similar to #10779. Specifically, for
- the "go to anything" dialog,
- the note statistics and note properties dialogs,
- prompt dialogs (e.g. "add tags", "set alarm", ...), and
- plugin dialogs.

This is done by migrating these dialogs to the `gui/Dialog` component. Since #10779, `Dialog` prevents items behind the dialog modal container from having keyboard focus.

# Why?

This change brings Joplin closer to compliance with WCAG 2.2 (issue https://github.com/laurent22/joplin/issues/10795). 

From the WCAG 2.2's "Understanding [SC 2.4.11](https://w3.org/TR/WCAG22#focus-not-obscured-minimum): Focus Not Obscured (Minimum) (Level AA)",

> A dialog-like overlay that does not take focus on appearance and does not either constrain interaction to the overlay or dismiss itself on loss of focus (thus allowing focus to exit into the content behind it) will be at risk of failing this SC, where it is positioned such that it can obscure other focusable items.
> — https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum#dialogs

Before this pull request, it was possible for focus to be hidden by plugin, prompt, statistics, and the go-to-anything dialogs. This pull request uses a modal `<dialog>` element to prevent keyboard focus from escaping, and thus potentially being hidden by, visible dialogs.

# Stylistic changes

Switching to the `Dialog` component also changes the CSS used to style the dialog container. These changes are shown below.


**Prompt dialog/text**: Rounded corners and slightly more padding above:

![before after comparison screenshot](https://github.com/user-attachments/assets/38928934-0822-47fa-8430-e8d095dccc60)

---


**Prompt dialog/date time**: Rounded corners, the date time input now has focus by default. This currently causes the calendar to be visible by default. Previously, keyboard focus remained on the control that opened the dialog.

![before after comparison screenshot](https://github.com/user-attachments/assets/dcb11a8c-646a-4f1a-b7f1-4903bb727f69)



---

**Plugin dialogs/one dialog open**: When just one dialog is open, styles should be roughly the same:

![before after comparison screenshot](https://github.com/user-attachments/assets/2a21efc3-df51-48f5-b520-44c20964e3e6)


---

**Plugin dialogs/multiple dialogs open**: When multiple dialogs are opened, the last-opened dialog now needs to be dismissed before the other dialog(s) can be used:

![before after comparison screenshot](https://github.com/user-attachments/assets/3b47e068-90f4-4630-b154-4958da23bc47)

---

**Go-to-anything dialog**: Rounded corners:
![before after comparison screenshot](https://github.com/user-attachments/assets/bce7aade-805d-4f3b-beed-7c6dfccb0b63)



# Testing

This pull request includes automated tests for the following:
- Clicking outside "go to anything" dismisses the dialog.
    - This is now handled in `Dialog.tsx` (rather than in `GotoAnything.tsx`). As such, this also tests the relevant logic in `Dialog.tsx`.
- Pressing "Escape" while "go to anything" is open closes the dialog.
    - This is also handled by `Dialog.tsx`.
- "Go to anything" can be opened again after being closed.
- The "add or remove tags" dialog can be opened by running `:setTags` from "Go to anything".

The following manual testing has also been done on Ubuntu 24.04:
1. Create a task
2. Open the alarm dialog by clicking the alarm button.
3. Set the alarm for tomorrow.
4. Cycle through the focusable entries in the dialog by pressing <kbd>tab</kbd>.
5. Verify that after "Clear" is focused, pressing <kbd>tab</kbd> again focuses the alarm text field.
6. Close the dialog by clicking "OK".
7. Clear the alarm for the current task.
8. Repeat steps 2-5, but close the dialog by clicking "cancel". Verify that the alarm is still unset.
9. Open the sync wizard. Close it by pressing the <kbd>escape<kbd> key.
10. Open a plugin dialog (tested with "select a note to compare with" from the diff plugin).
11. Change the width of the element in the dialog with ID `joplin-plugin-content` using the developer tools (set to 500px).
12. Verify that the dialog container also changed size.
13. Open "Go to anything" and run `:insertDrawing` (from the Freehand Drawing plugin)
14. Verify that the drawing dialog is now open and is full screen (assumes that the Freehand Drawing "Dialog Mode" setting is unchecked).
15. Open settings.
16. Verify that neither plugin dialog is visible.
17. Close settings.
18. Verify that the "insert drawing" dialog is still visible.
19. Close the dialog by pressing "Exit", then "discard".
20. Choose a different note in the "select a note to compare with" dialog and click "OK".
21. Verify that all dialogs are now closed.
22. Open the "note properties" dialog.
23. Close the "note properties" dialog by pressing "escape".
24. Open the "statistics" dialog.
25. Close the "statistics" dialog by clicking "close".



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->