### PR TITLE
Mobile, Desktop: Improve RTL support in the Markdown editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -796,6 +796,7 @@ packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/testUtil/pressReleaseKey.js
 packages/editor/CodeMirror/testUtil/typeText.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/utils/biDirectionalTextExtension.js
 packages/editor/CodeMirror/utils/formatting/RegionSpec.js
 packages/editor/CodeMirror/utils/formatting/findInlineMatch.test.js
 packages/editor/CodeMirror/utils/formatting/findInlineMatch.js

--- a/.gitignore
+++ b/.gitignore
@@ -775,6 +775,7 @@ packages/editor/CodeMirror/testUtil/loadLanguages.js
 packages/editor/CodeMirror/testUtil/pressReleaseKey.js
 packages/editor/CodeMirror/testUtil/typeText.js
 packages/editor/CodeMirror/theme.js
+packages/editor/CodeMirror/utils/biDirectionalTextExtension.js
 packages/editor/CodeMirror/utils/formatting/RegionSpec.js
 packages/editor/CodeMirror/utils/formatting/findInlineMatch.test.js
 packages/editor/CodeMirror/utils/formatting/findInlineMatch.js

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -31,6 +31,7 @@ import getScrollFraction from './getScrollFraction';
 import CodeMirrorControl from './CodeMirrorControl';
 import insertLineAfter from './editorCommands/insertLineAfter';
 import handlePasteEvent from './utils/handlePasteEvent';
+import biDirectionalTextExtension from './utils/biDirectionalTextExtension';
 
 const createEditor = (
 	parentElement: HTMLElement, props: EditorProps,
@@ -282,6 +283,7 @@ const createEditor = (
 
 				// Apply styles to entire lines (block-display decorations)
 				decoratorExtension,
+				biDirectionalTextExtension,
 
 				// Adds additional CSS classes to tokens (the default CSS classes are
 				// auto-generated and thus unstable).

--- a/packages/editor/CodeMirror/utils/biDirectionalTextExtension.ts
+++ b/packages/editor/CodeMirror/utils/biDirectionalTextExtension.ts
@@ -1,0 +1,40 @@
+import { Extension, RangeSetBuilder } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView, ViewPlugin, ViewUpdate } from '@codemirror/view';
+
+const autoTextDirectionDecoration = Decoration.line({
+	attributes: { dir: 'auto' },
+});
+
+const biDirectionalTextExtension: Extension = [
+	EditorView.perLineTextDirection.of(true),
+	ViewPlugin.fromClass(class {
+		public decorations: DecorationSet;
+		public constructor(view: EditorView) {
+			this.decorations = this.buildDecorations(view);
+		}
+
+		public update(update: ViewUpdate) {
+			if (update.docChanged || update.viewportChanged) {
+				this.decorations = this.buildDecorations(update.view);
+			}
+		}
+
+		private buildDecorations(view: EditorView) {
+			const builder = new RangeSetBuilder<Decoration>();
+			for (const { from, to } of view.visibleRanges) {
+				const fromLine = view.state.doc.lineAt(from);
+				const toLine = view.state.doc.lineAt(to);
+
+				for (let i = fromLine.number; i <= toLine.number; i++) {
+					const line = view.state.doc.line(i);
+					if (line.text) {
+						builder.add(line.from, line.from, autoTextDirectionDecoration);
+					}
+				}
+			}
+			return builder.finish();
+		}
+	}, { decorations: v => v.decorations }),
+];
+
+export default biDirectionalTextExtension;


### PR DESCRIPTION
# Summary

This pull request allows certain lines in the CodeMirror 6-based markdown editor to be presented in right-to-left mode.

**Linked issues**: This pull request does not resolve, but is related to #3991.

> [!NOTE]
>
> I do not read/write a language written right-to-left, so it's possible that there are more issues still present than are included in the "notes" section. Feedback on this change is welcome!
>

# Notes

This change:
- Only applies to the CodeMirror 6-based editor (not the CodeMirror 5-based editor).
    - Similar logic seems to already exist for the CodeMirror 5 editor.
- Related upstream discussion: https://discuss.codemirror.net/t/is-there-an-example-or-perlinetextdirection/5245
- There are still issues with markdown editing, list continuation in particular.

# Screen recording


https://github.com/user-attachments/assets/aefc042f-483b-4978-a10f-0d31e2ddadf7

The note shown in the video above contains RTL and LTR text. A few remaining issues are demonstrated:
1. Checked items in a checklist are always left-aligned, while unchecked items can be either right- or left- aligned.
2. When continuing a list, the list marker is initially on the left side of the screen, even if all other items in the list are right-aligned.

<details><summary>Compare with the legacy editor</summary>

https://github.com/user-attachments/assets/81159fbc-584c-497b-a8c7-3c76b9d37abc

</details>

# Additional manual testing


**Desktop**:
1. Create a new note and create a code block.
3. Paste the contents of Joplin's `yarn.lock` within the code block.
4. Scroll to the end of the document and type "Test...".
5. Verify that the editor doesn't freeze while typing.
    - **Note**: I originally experienced freezing while doing this. Disabling the Math Mode plugin fixed the issue.
6. Paste `هذا اختبار` into an empty line near the middle of the code block.
7. Verify that the pasted text is right-aligned while neighboring lines are still left-aligned.
8. Verify that the editor doesn't freeze just after pasting (move the cursor).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->