### PR TITLE
Desktop: Accessibility: Improve settings screen keyboard navigation and screen reader accessibility

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -464,6 +464,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
+packages/app-desktop/integration-tests/settings.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js
 packages/app-desktop/integration-tests/simpleBackup.spec.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -167,9 +167,13 @@ packages/app-desktop/gui/Button/Button.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
-packages/app-desktop/gui/ConfigScreen/FontSearch.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/FontSearch.js
 packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingDescription.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingHeader.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingLabel.js
 packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js

--- a/.gitignore
+++ b/.gitignore
@@ -443,6 +443,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
+packages/app-desktop/integration-tests/settings.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js
 packages/app-desktop/integration-tests/simpleBackup.spec.js
 packages/app-desktop/integration-tests/util/activateMainMenuItem.js

--- a/.gitignore
+++ b/.gitignore
@@ -146,9 +146,13 @@ packages/app-desktop/gui/Button/Button.js
 packages/app-desktop/gui/ClipperConfigScreen.js
 packages/app-desktop/gui/ConfigScreen/ButtonBar.js
 packages/app-desktop/gui/ConfigScreen/ConfigScreen.js
-packages/app-desktop/gui/ConfigScreen/FontSearch.js
 packages/app-desktop/gui/ConfigScreen/Sidebar.js
+packages/app-desktop/gui/ConfigScreen/controls/FontSearch.js
 packages/app-desktop/gui/ConfigScreen/controls/MissingPasswordHelpLink.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingDescription.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingHeader.js
+packages/app-desktop/gui/ConfigScreen/controls/SettingLabel.js
 packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.js
 packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.js

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -36,6 +36,9 @@ interface Props {
 	isSquare?: boolean;
 	iconOnly?: boolean;
 	fontSize?: number;
+
+	'aria-controls'?: string;
+	'aria-expanded'?: string;
 }
 
 const StyledTitle = styled.span`
@@ -220,7 +223,14 @@ const Button = React.forwardRef((props: Props, ref: any) => {
 
 	function renderIcon() {
 		if (!props.iconName) return null;
-		return <StyledIcon aria-label={props.iconLabel} animation={props.iconAnimation} mr={iconOnly ? '0' : '6px'} color={props.color} className={props.iconName}/>;
+		return <StyledIcon
+			aria-label={props.iconLabel ?? ''}
+			animation={props.iconAnimation}
+			mr={iconOnly ? '0' : '6px'}
+			color={props.color}
+			className={props.iconName}
+			role='img'
+		/>;
 	}
 
 	function renderTitle() {
@@ -234,7 +244,22 @@ const Button = React.forwardRef((props: Props, ref: any) => {
 	}
 
 	return (
-		<StyledButton ref={ref} fontSize={props.fontSize} isSquare={props.isSquare} size={props.size} style={props.style} disabled={props.disabled} title={props.tooltip} className={props.className} iconOnly={iconOnly} onClick={onClick}>
+		<StyledButton
+			ref={ref}
+			fontSize={props.fontSize}
+			isSquare={props.isSquare}
+			size={props.size}
+			style={props.style}
+			disabled={props.disabled}
+			title={props.tooltip}
+			className={props.className}
+			iconOnly={iconOnly}
+			onClick={onClick}
+
+			aria-disabled={props.disabled}
+			aria-expanded={props['aria-expanded']}
+			aria-controls={props['aria-controls']}
+		>
 			{renderIcon()}
 			{renderTitle()}
 		</StyledButton>

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -228,7 +228,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			if (syncTargetMd.supportsConfigCheck) {
 				const messages = shared.checkSyncConfigMessages(this);
 				const statusComp = !messages.length ? null : (
-					<div style={statusStyle}>
+					<div style={statusStyle} aria-live='polite'>
 						{messages[0]}
 						{messages.length >= 1 ? <p>{messages[1]}</p> : null}
 					</div>
@@ -371,7 +371,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 
 		const settings = this.state.settings;
 
-		const containerStyle = {
+		const containerStyle: React.CSSProperties = {
 			overflow: 'auto',
 			padding: theme.configScreenPadding,
 			paddingTop: 0,
@@ -403,6 +403,35 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		const rightStyle = { ...style, flex: 1 };
 		delete style.width;
 
+		const tabComponents: React.ReactNode[] = [];
+		for (const section of sections) {
+			const sectionId = `setting-section-${section.name}`;
+			let content = null;
+			const visible = section.name === this.state.selectedSectionName;
+			if (visible) {
+				content = (
+					<>
+						{screenComp}
+						<div style={containerStyle}>{settingComps}</div>
+					</>
+				);
+			}
+
+			tabComponents.push(
+				<div
+					key={sectionId}
+					id={sectionId}
+					className={`setting-tab-panel ${!visible ? '-hidden' : ''}`}
+					hidden={!visible}
+					aria-labelledby={`setting-tab-${section.name}`}
+					tabIndex={0}
+					role='tabpanel'
+				>
+					{content}
+				</div>,
+			);
+		}
+
 		return (
 			<div className="config-screen" style={{ display: 'flex', flexDirection: 'row', height: this.props.style.height }}>
 				<Sidebar
@@ -411,9 +440,8 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					sections={sections}
 				/>
 				<div style={rightStyle}>
-					{screenComp}
 					{needRestartComp}
-					<div style={containerStyle}>{settingComps}</div>
+					{tabComponents}
 					<ButtonBar
 						hasChanges={hasChanges}
 						backButtonTitle={hasChanges && !screenComp ? _('Cancel') : _('Back')}

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import Sidebar from './Sidebar';
 import ButtonBar from './ButtonBar';
-import Button, { ButtonLevel, ButtonSize } from '../Button/Button';
+import Button, { ButtonLevel } from '../Button/Button';
 import { _ } from '@joplin/lib/locale';
 import bridge from '../../services/bridge';
-import Setting, { AppType, SettingItemSubType, SyncStartupOperation } from '@joplin/lib/models/Setting';
-import control_PluginsStates from './controls/plugins/PluginsStates';
+import Setting, { AppType, SettingValueType, SyncStartupOperation } from '@joplin/lib/models/Setting';
 import EncryptionConfigScreen from '../EncryptionConfigScreen/EncryptionConfigScreen';
 import { reg } from '@joplin/lib/registry';
 const { connect } = require('react-redux');
-const { themeStyle } = require('@joplin/lib/theme');
-import * as pathUtils from '@joplin/lib/path-utils';
+import { themeStyle } from '@joplin/lib/theme';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 import * as shared from '@joplin/lib/components/shared/config/config-shared.js';
 import ClipperConfigScreen from '../ClipperConfigScreen';
@@ -20,12 +18,8 @@ import ToggleAdvancedSettingsButton from './controls/ToggleAdvancedSettingsButto
 import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/config/shouldShowMissingPasswordWarning';
 import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
-import FontSearch from './FontSearch';
+import SettingComponent, { UpdateSettingValueEvent } from './controls/SettingComponent';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-const settingKeyToControl: any = {
-	'plugins.states': control_PluginsStates,
-};
 
 interface Font {
 	family: string;
@@ -67,9 +61,6 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		this.onCancelClick = this.onCancelClick.bind(this);
 		this.onSaveClick = this.onSaveClick.bind(this);
 		this.onApplyClick = this.onApplyClick.bind(this);
-		this.renderLabel = this.renderLabel.bind(this);
-		this.renderDescription = this.renderDescription.bind(this);
-		this.renderHeader = this.renderHeader.bind(this);
 		this.handleSettingButton = this.handleSettingButton.bind(this);
 	}
 
@@ -298,420 +289,26 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		);
 	}
 
-	private labelStyle(themeId: number) {
-		const theme = themeStyle(themeId);
-		return { ...theme.textStyle, display: 'block',
-			color: theme.color,
-			fontSize: theme.fontSize * 1.083333,
-			fontWeight: 500,
-			marginBottom: theme.mainPadding / 2 };
-	}
-
-	private descriptionStyle(themeId: number) {
-		const theme = themeStyle(themeId);
-		return { ...theme.textStyle, color: theme.colorFaded,
-			fontStyle: 'italic',
-			maxWidth: '70em',
-			marginTop: 5 };
-	}
-
-	private renderLabel(themeId: number, label: string) {
-		const labelStyle = this.labelStyle(themeId);
-		return (
-			<div style={labelStyle}>
-				<label>{label}</label>
-			</div>
-		);
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private renderHeader(themeId: number, label: string, style: any = null) {
-		const theme = themeStyle(themeId);
-
-		const labelStyle = { ...theme.textStyle, display: 'block',
-			color: theme.color,
-			fontSize: theme.fontSize * 1.25,
-			fontWeight: 500,
-			marginBottom: theme.mainPadding,
-			...style };
-
-		return (
-			<div style={labelStyle}>
-				<label>{label}</label>
-			</div>
-		);
-	}
-
-	private renderDescription(themeId: number, description: string) {
-		return description ? <div style={this.descriptionStyle(themeId)}>{description}</div> : null;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public settingToComponent(key: string, value: any) {
-		const theme = themeStyle(this.props.themeId);
-
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const output: any = null;
-
-		const rowStyle = {
-			marginBottom: theme.mainPadding * 1.5,
-		};
-
-		const labelStyle = this.labelStyle(this.props.themeId);
-
-		const subLabel = { ...labelStyle, display: 'block',
-			opacity: 0.7,
-			marginBottom: labelStyle.marginBottom };
-
-		const checkboxLabelStyle = { ...labelStyle, marginLeft: 8,
-			display: 'inline',
-			backgroundColor: 'transparent' };
-
-		const controlStyle = {
-			display: 'inline-block',
-			color: theme.color,
-			fontFamily: theme.fontFamily,
-			backgroundColor: theme.backgroundColor,
-		};
-
-		const textInputBaseStyle = { ...controlStyle, fontFamily: theme.fontFamily,
-			border: '1px solid',
-			padding: '4px 6px',
-			boxSizing: 'border-box',
-			borderColor: theme.borderColor4,
-			borderRadius: 3,
-			paddingLeft: 6,
-			paddingRight: 6,
-			paddingTop: 4,
-			paddingBottom: 4 };
-
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const updateSettingValue = (key: string, value: any) => {
-			const md = Setting.settingMetadata(key);
-			if (md.needRestart) {
-				this.setState({ needRestart: true });
-			}
-			shared.updateSettingValue(this, key, value);
-		};
-
+	private onUpdateSettingValue = ({ key, value }: UpdateSettingValueEvent) => {
 		const md = Setting.settingMetadata(key);
-
-		const descriptionText = Setting.keyDescription(key, AppType.Desktop);
-		const descriptionComp = this.renderDescription(this.props.themeId, descriptionText);
-
-		if (settingKeyToControl[key]) {
-			const SettingComponent = settingKeyToControl[key];
-			const label = md.label ? this.renderLabel(this.props.themeId, md.label()) : null;
-			return (
-				<div key={key} style={rowStyle}>
-					{label}
-					{this.renderDescription(this.props.themeId, md.description ? md.description(AppType.Desktop) : null)}
-					<SettingComponent
-						metadata={md}
-						value={value}
-						themeId={this.props.themeId}
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-						onChange={(event: any) => {
-							updateSettingValue(key, event.value);
-						}}
-						renderLabel={this.renderLabel}
-						renderDescription={this.renderDescription}
-						renderHeader={this.renderHeader}
-					/>
-				</div>
-			);
-		} else if (md.isEnum) {
-			const items = [];
-			const settingOptions = md.options();
-			const array = Setting.enumOptionsToValueLabels(settingOptions, md.optionsOrder ? md.optionsOrder() : [], {
-				valueKey: 'key',
-				labelKey: 'label',
-			});
-
-			for (let i = 0; i < array.length; i++) {
-				const e = array[i];
-				items.push(
-					<option value={e.key.toString()} key={e.key}>
-						{settingOptions[e.key]}
-					</option>,
-				);
-			}
-
-			const selectStyle = { ...controlStyle, paddingLeft: 6,
-				paddingRight: 6,
-				paddingTop: 4,
-				paddingBottom: 4,
-				borderColor: theme.borderColor4,
-				borderRadius: 3 };
-
-			return (
-				<div key={key} style={rowStyle}>
-					<div style={labelStyle}>
-						<label>{md.label()}</label>
-					</div>
-					<select
-						value={value}
-						style={selectStyle}
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-						onChange={(event: any) => {
-							updateSettingValue(key, event.target.value);
-						}}
-					>
-						{items}
-					</select>
-					{descriptionComp}
-				</div>
-			);
-		} else if (md.type === Setting.TYPE_BOOL) {
-			const onCheckboxClick = () => {
-				updateSettingValue(key, !value);
-			};
-
-			const checkboxSize = theme.fontSize * 1.1666666666666;
-
-			// Hack: The {key+value.toString()} is needed as otherwise the checkbox doesn't update when the state changes.
-			// There's probably a better way to do this but can't figure it out.
-
-			return (
-				<div key={key + (`${value}`).toString()} style={rowStyle}>
-					<div style={{ ...controlStyle, backgroundColor: 'transparent', display: 'flex', alignItems: 'center' }}>
-						<input
-							id={`setting_checkbox_${key}`}
-							type="checkbox"
-							checked={!!value}
-							onChange={() => {
-								onCheckboxClick();
-							}}
-							style={{ marginLeft: 0, width: checkboxSize, height: checkboxSize }}
-						/>
-						<label
-							onClick={() => {
-								onCheckboxClick();
-							}}
-							style={{ ...checkboxLabelStyle, marginLeft: 5, marginBottom: 0 }}
-							htmlFor={`setting_checkbox_${key}`}
-						>
-							{md.label()}
-						</label>
-					</div>
-					{descriptionComp}
-				</div>
-			);
-		} else if (md.type === Setting.TYPE_STRING) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const inputStyle: any = { ...textInputBaseStyle, width: '50%',
-				minWidth: '20em' };
-			const inputType = md.secure === true ? 'password' : 'text';
-
-			if (md.subType === 'file_path_and_args' || md.subType === 'file_path' || md.subType === 'directory_path') {
-				inputStyle.marginBottom = subLabel.marginBottom;
-
-				const splitCmd = (cmdString: string) => {
-					// Normally not necessary but certain plugins found a way to
-					// set the set the value to "undefined", leading to a crash.
-					// This is now fixed at the model level but to be sure we
-					// check here too, to handle any already existing data.
-					// https://github.com/laurent22/joplin/issues/7621
-					if (!cmdString) cmdString = '';
-					const path = pathUtils.extractExecutablePath(cmdString);
-					const args = cmdString.substr(path.length + 1);
-					return [pathUtils.unquotePath(path), args];
-				};
-
-				const joinCmd = (cmdArray: string[]) => {
-					if (!cmdArray[0] && !cmdArray[1]) return '';
-					let cmdString = pathUtils.quotePath(cmdArray[0]);
-					if (!cmdString) cmdString = '""';
-					if (cmdArray[1]) cmdString += ` ${cmdArray[1]}`;
-					return cmdString;
-				};
-
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				const onPathChange = (event: any) => {
-					if (md.subType === 'file_path_and_args') {
-						const cmd = splitCmd(this.state.settings[key]);
-						cmd[0] = event.target.value;
-						updateSettingValue(key, joinCmd(cmd));
-					} else {
-						updateSettingValue(key, event.target.value);
-					}
-				};
-
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				const onArgsChange = (event: any) => {
-					const cmd = splitCmd(this.state.settings[key]);
-					cmd[1] = event.target.value;
-					updateSettingValue(key, joinCmd(cmd));
-				};
-
-				const browseButtonClick = async () => {
-					if (md.subType === 'directory_path') {
-						const paths = await bridge().showOpenDialog({
-							properties: ['openDirectory'],
-						});
-						if (!paths || !paths.length) return;
-						updateSettingValue(key, paths[0]);
-					} else {
-						const paths = await bridge().showOpenDialog();
-						if (!paths || !paths.length) return;
-
-						if (md.subType === 'file_path') {
-							updateSettingValue(key, paths[0]);
-						} else {
-							const cmd = splitCmd(this.state.settings[key]);
-							cmd[0] = paths[0];
-							updateSettingValue(key, joinCmd(cmd));
-						}
-					}
-				};
-
-				const cmd = splitCmd(this.state.settings[key]);
-				const path = md.subType === 'file_path_and_args' ? cmd[0] : this.state.settings[key];
-
-				const argComp = md.subType !== 'file_path_and_args' ? null : (
-					<div style={{ ...rowStyle, marginBottom: 5 }}>
-						<div style={subLabel}>{_('Arguments:')}</div>
-						<input
-							type={inputType}
-							style={inputStyle}
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-							onChange={(event: any) => {
-								onArgsChange(event);
-							}}
-							value={cmd[1]}
-							spellCheck={false}
-						/>
-						<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
-							{descriptionComp}
-						</div>
-					</div>
-				);
-
-				return (
-					<div key={key} style={rowStyle}>
-						<div style={labelStyle}>
-							<label>{md.label()}</label>
-						</div>
-						<div style={{ display: 'flex' }}>
-							<div style={{ flex: 1 }}>
-								<div style={{ ...rowStyle, marginBottom: 5 }}>
-									<div style={subLabel}>{_('Path:')}</div>
-									<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: inputStyle.marginBottom }}>
-										<input
-											type={inputType}
-											style={{ ...inputStyle, marginBottom: 0, marginRight: 5 }}
-											// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-											onChange={(event: any) => {
-												onPathChange(event);
-											}}
-											value={path}
-											spellCheck={false}
-										/>
-										<Button
-											level={ButtonLevel.Secondary}
-											title={_('Browse...')}
-											onClick={browseButtonClick}
-											size={ButtonSize.Small}
-										/>
-									</div>
-									<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
-										{descriptionComp}
-									</div>
-								</div>
-							</div>
-						</div>
-						{argComp}
-					</div>
-				);
-			} else {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				const onTextChange = (event: any) => {
-					updateSettingValue(key, event.target.value);
-				};
-				return (
-					<div key={key} style={rowStyle}>
-						<div style={labelStyle}>
-							<label>{md.label()}</label>
-						</div>
-						{
-							md.subType === SettingItemSubType.FontFamily || md.subType === SettingItemSubType.MonospaceFontFamily ?
-								<FontSearch
-									type={inputType}
-									style={inputStyle}
-									value={this.state.settings[key]}
-									availableFonts={this.state.fonts}
-									onChange={fontFamily => updateSettingValue(key, fontFamily)}
-									subtype={md.subType}
-								/> :
-								<input
-									type={inputType}
-									style={inputStyle}
-									value={this.state.settings[key]}
-									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-									onChange={(event: any) => {
-										onTextChange(event);
-									}}
-									spellCheck={false}
-								/>
-						}
-						<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
-							{descriptionComp}
-						</div>
-					</div>
-				);
-			}
-		} else if (md.type === Setting.TYPE_INT) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const onNumChange = (event: any) => {
-				updateSettingValue(key, event.target.value);
-			};
-
-			const label = [md.label()];
-			if (md.unitLabel) label.push(`(${md.unitLabel(md.value)})`);
-
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const inputStyle: any = { ...textInputBaseStyle };
-
-			return (
-				<div key={key} style={rowStyle}>
-					<div style={labelStyle}>
-						<label>{label.join(' ')}</label>
-					</div>
-					<input
-						type="number"
-						style={inputStyle}
-						value={this.state.settings[key]}
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-						onChange={(event: any) => {
-							onNumChange(event);
-						}}
-						min={md.minimum}
-						max={md.maximum}
-						step={md.step}
-						spellCheck={false}
-					/>
-					{descriptionComp}
-				</div>
-			);
-		} else if (md.type === Setting.TYPE_BUTTON) {
-			const labelComp = md.hideLabel ? null : (
-				<div style={labelStyle}>
-					<label>{md.label()}</label>
-				</div>
-			);
-
-			return (
-				<div key={key} style={rowStyle}>
-					{labelComp}
-					<Button level={ButtonLevel.Secondary} title={md.label()} onClick={md.onClick ? md.onClick : () => this.handleSettingButton(key)}/>
-					{descriptionComp}
-				</div>
-			);
-		} else {
-			console.warn(`Type not implemented: ${key}`);
+		if (md.needRestart) {
+			this.setState({ needRestart: true });
 		}
+		shared.updateSettingValue(this, key, value);
+	};
 
-		return output;
+	public settingToComponent<T extends string>(key: T, value: SettingValueType<T>) {
+		return (
+			<SettingComponent
+				themeId={this.props.themeId}
+				key={key}
+				settingKey={key}
+				value={value}
+				fonts={this.state.fonts}
+				onUpdateSettingValue={this.onUpdateSettingValue}
+				onSettingButtonClick={this.handleSettingButton}
+			/>
+		);
 	}
 
 	private restartMessage() {

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -268,12 +268,14 @@ class ConfigScreenComponent extends React.Component<any, any> {
 
 		let advancedSettingsButton = null;
 		const advancedSettingsSectionStyle = { display: 'none' };
+		const advancedSettingsGroupId = `advanced_settings_${key}`;
 
 		if (advancedSettingComps.length) {
 			advancedSettingsButton = (
 				<ToggleAdvancedSettingsButton
 					onClick={() => shared.advancedSettingsButton_click(this)}
 					advancedSettingsVisible={this.state.showAdvancedSettings}
+					aria-controls={advancedSettingsGroupId}
 				/>
 			);
 			advancedSettingsSectionStyle.display = this.state.showAdvancedSettings ? 'block' : 'none';
@@ -284,7 +286,11 @@ class ConfigScreenComponent extends React.Component<any, any> {
 				{this.renderSectionDescription(section)}
 				<div>{settingComps}</div>
 				{advancedSettingsButton}
-				<div style={advancedSettingsSectionStyle}>{advancedSettingComps}</div>
+				<div
+					style={advancedSettingsSectionStyle}
+					id={advancedSettingsGroupId}
+					role='group'
+				>{advancedSettingComps}</div>
 			</div>
 		);
 	}

--- a/packages/app-desktop/gui/ConfigScreen/controls/FontSearch.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/FontSearch.tsx
@@ -9,6 +9,7 @@ interface Props {
 	style: CSSProperties;
 	value: string;
 	availableFonts: string[];
+	inputId: string;
 	onChange: (font: string)=> void;
 	subtype: string;
 }
@@ -108,6 +109,7 @@ const FontSearch = (props: Props) => {
 				onFocus={handleFocus}
 				onBlur={handleBlur}
 				spellCheck={false}
+				id={props.inputId}
 				ref={fontInputRef}
 			/>
 			<div

--- a/packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx
@@ -366,7 +366,7 @@ const SettingComponent: React.FC<Props> = props => {
 				<Button
 					level={ButtonLevel.Secondary}
 					title={md.label()}
-					onClick={md.onClick ? md.onClick : props.onSettingButtonClick}
+					onClick={md.onClick ? md.onClick : () => props.onSettingButtonClick(key)}
 				/>
 				{descriptionComp}
 			</div>

--- a/packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx
@@ -1,0 +1,381 @@
+import Setting, { AppType, SettingItemSubType } from '@joplin/lib/models/Setting';
+import { themeStyle } from '@joplin/lib/theme';
+import * as React from 'react';
+import { useCallback, useId } from 'react';
+import control_PluginsStates from './plugins/PluginsStates';
+import bridge from '../../../services/bridge';
+import { _ } from '@joplin/lib/locale';
+import Button, { ButtonLevel, ButtonSize } from '../../Button/Button';
+import FontSearch from './FontSearch';
+import * as pathUtils from '@joplin/lib/path-utils';
+import SettingLabel from './SettingLabel';
+import SettingDescription from './SettingDescription';
+
+const settingKeyToControl: Record<string, typeof control_PluginsStates> = {
+	'plugins.states': control_PluginsStates,
+};
+
+export interface UpdateSettingValueEvent {
+	key: string;
+	value: unknown;
+}
+
+interface Props {
+	themeId: number;
+	settingKey: string;
+	value: unknown;
+	fonts: string[];
+	onUpdateSettingValue: (event: UpdateSettingValueEvent)=> void;
+	onSettingButtonClick: (key: string)=> void;
+}
+
+const SettingComponent: React.FC<Props> = props => {
+	const theme = themeStyle(props.themeId);
+
+	const output: React.ReactNode = null;
+
+	const updateSettingValue = useCallback((key: string, value: unknown) => {
+		props.onUpdateSettingValue({ key, value });
+	}, [props.onUpdateSettingValue]);
+
+	const rowStyle = {
+		marginBottom: theme.mainPadding * 1.5,
+	};
+
+	const controlStyle = {
+		display: 'inline-block',
+		color: theme.color,
+		fontFamily: theme.fontFamily,
+		backgroundColor: theme.backgroundColor,
+	};
+
+	const textInputBaseStyle = { ...controlStyle, fontFamily: theme.fontFamily,
+		border: '1px solid',
+		padding: '4px 6px',
+		boxSizing: 'border-box',
+		borderColor: theme.borderColor4,
+		borderRadius: 3,
+		paddingLeft: 6,
+		paddingRight: 6,
+		paddingTop: 4,
+		paddingBottom: 4 };
+
+	const key = props.settingKey;
+	const md = Setting.settingMetadata(key);
+
+	const descriptionText = Setting.keyDescription(key, AppType.Desktop);
+	const inputId = useId();
+	const descriptionId = useId();
+	const descriptionComp = <SettingDescription id={descriptionId} text={descriptionText}/>;
+
+	if (key in settingKeyToControl) {
+		const CustomSettingComponent = settingKeyToControl[key];
+		const label = md.label ? <SettingLabel text={md.label()} htmlFor={null} /> : null;
+		return (
+			<div key={key} style={rowStyle}>
+				{label}
+				<SettingDescription id={descriptionId} text={md.description ? md.description(AppType.Desktop) : null}/>
+				<CustomSettingComponent
+					value={props.value}
+					themeId={props.themeId}
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+					onChange={(event: any) => {
+						updateSettingValue(key, event.value);
+					}}
+				/>
+			</div>
+		);
+	} else if (md.isEnum) {
+		const value = props.value as string;
+
+		const items = [];
+		const settingOptions = md.options();
+		const array = Setting.enumOptionsToValueLabels(settingOptions, md.optionsOrder ? md.optionsOrder() : [], {
+			valueKey: 'key',
+			labelKey: 'label',
+		});
+
+		for (let i = 0; i < array.length; i++) {
+			const e = array[i];
+			items.push(
+				<option value={e.key.toString()} key={e.key}>
+					{settingOptions[e.key]}
+				</option>,
+			);
+		}
+
+		const selectStyle = { ...controlStyle, paddingLeft: 6,
+			paddingRight: 6,
+			paddingTop: 4,
+			paddingBottom: 4,
+			borderColor: theme.borderColor4,
+			borderRadius: 3 };
+
+		return (
+			<div key={key} style={rowStyle}>
+				<SettingLabel htmlFor={inputId} text={md.label()}/>
+				<select
+					value={value}
+					style={selectStyle}
+					onChange={(event) => {
+						updateSettingValue(key, event.target.value);
+					}}
+					id={inputId}
+					aria-describedby={descriptionId}
+				>
+					{items}
+				</select>
+				{descriptionComp}
+			</div>
+		);
+	} else if (md.type === Setting.TYPE_BOOL) {
+		const value = props.value as boolean;
+
+		const onCheckboxClick = () => {
+			updateSettingValue(key, !value);
+		};
+
+		const checkboxSize = theme.fontSize * 1.1666666666666;
+
+		// Hack: The {key+value.toString()} is needed as otherwise the checkbox doesn't update when the state changes.
+		// There's probably a better way to do this but can't figure it out.
+
+		return (
+			<div key={key + (`${value}`).toString()} style={rowStyle}>
+				<div style={{ ...controlStyle, backgroundColor: 'transparent', display: 'flex', alignItems: 'center' }}>
+					<input
+						id={inputId}
+						type="checkbox"
+						checked={!!value}
+						onChange={() => {
+							onCheckboxClick();
+						}}
+						style={{ marginLeft: 0, width: checkboxSize, height: checkboxSize }}
+						aria-describedby={descriptionId}
+					/>
+					<label
+						onClick={() => {
+							onCheckboxClick();
+						}}
+						className='setting-label -for-checkbox'
+						htmlFor={inputId}
+					>
+						{md.label()}
+					</label>
+				</div>
+				{descriptionComp}
+			</div>
+		);
+	} else if (md.type === Setting.TYPE_STRING) {
+		const value = props.value as string;
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		const inputStyle: any = { ...textInputBaseStyle, width: '50%',
+			minWidth: '20em' };
+		const inputType = md.secure === true ? 'password' : 'text';
+
+		if (md.subType === 'file_path_and_args' || md.subType === 'file_path' || md.subType === 'directory_path') {
+			inputStyle.marginBottom = theme.mainPadding / 2;
+
+			const splitCmd = (cmdString: string) => {
+				// Normally not necessary but certain plugins found a way to
+				// set the set the value to "undefined", leading to a crash.
+				// This is now fixed at the model level but to be sure we
+				// check here too, to handle any already existing data.
+				// https://github.com/laurent22/joplin/issues/7621
+				if (!cmdString) cmdString = '';
+				const path = pathUtils.extractExecutablePath(cmdString);
+				const args = cmdString.substr(path.length + 1);
+				return [pathUtils.unquotePath(path), args];
+			};
+
+			const joinCmd = (cmdArray: string[]) => {
+				if (!cmdArray[0] && !cmdArray[1]) return '';
+				let cmdString = pathUtils.quotePath(cmdArray[0]);
+				if (!cmdString) cmdString = '""';
+				if (cmdArray[1]) cmdString += ` ${cmdArray[1]}`;
+				return cmdString;
+			};
+
+			const onPathChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+				if (md.subType === 'file_path_and_args') {
+					const cmd = splitCmd(value);
+					cmd[0] = event.target.value;
+					updateSettingValue(key, joinCmd(cmd));
+				} else {
+					updateSettingValue(key, event.target.value);
+				}
+			};
+
+			const onArgsChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+				const cmd = splitCmd(value);
+				cmd[1] = event.target.value;
+				updateSettingValue(key, joinCmd(cmd));
+			};
+
+			const browseButtonClick = async () => {
+				if (md.subType === 'directory_path') {
+					const paths = await bridge().showOpenDialog({
+						properties: ['openDirectory'],
+					});
+					if (!paths || !paths.length) return;
+					updateSettingValue(key, paths[0]);
+				} else {
+					const paths = await bridge().showOpenDialog();
+					if (!paths || !paths.length) return;
+
+					if (md.subType === 'file_path') {
+						updateSettingValue(key, paths[0]);
+					} else {
+						const cmd = splitCmd(value);
+						cmd[0] = paths[0];
+						updateSettingValue(key, joinCmd(cmd));
+					}
+				}
+			};
+
+			const cmd = splitCmd(value);
+			const path = md.subType === 'file_path_and_args' ? cmd[0] : value;
+
+			const argComp = md.subType !== 'file_path_and_args' ? null : (
+				<div style={{ ...rowStyle, marginBottom: 5 }}>
+					<div className='setting-label -sub-label'>{_('Arguments:')}</div>
+					<input
+						type={inputType}
+						style={inputStyle}
+						onChange={onArgsChange}
+						value={cmd[1]}
+						spellCheck={false}
+						aria-describedby={descriptionId}
+					/>
+					<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
+						{descriptionComp}
+					</div>
+				</div>
+			);
+
+			return (
+				<div key={key} style={rowStyle}>
+					<SettingLabel text={md.label()} htmlFor={inputId}/>
+					<div style={{ display: 'flex' }}>
+						<div style={{ flex: 1 }}>
+							<div style={{ ...rowStyle, marginBottom: 5 }}>
+								<label
+									className='setting-label -sub-label'
+									htmlFor={inputId}
+								>{_('Path:')}</label>
+								<div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: inputStyle.marginBottom }}>
+									<input
+										type={inputType}
+										style={{ ...inputStyle, marginBottom: 0, marginRight: 5 }}
+										onChange={onPathChange}
+										value={path}
+										spellCheck={false}
+										id={inputId}
+										aria-describedby={descriptionId}
+									/>
+									<Button
+										level={ButtonLevel.Secondary}
+										title={_('Browse...')}
+										onClick={browseButtonClick}
+										size={ButtonSize.Small}
+									/>
+								</div>
+								<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
+									{descriptionComp}
+								</div>
+							</div>
+						</div>
+					</div>
+					{argComp}
+				</div>
+			);
+		} else {
+			const onTextChange: React.ChangeEventHandler<HTMLInputElement> = event => {
+				updateSettingValue(key, event.target.value);
+			};
+			return (
+				<div key={key} style={rowStyle}>
+					<SettingLabel text={md.label()} htmlFor={inputId}/>
+					{
+						md.subType === SettingItemSubType.FontFamily || md.subType === SettingItemSubType.MonospaceFontFamily ?
+							<FontSearch
+								type={inputType}
+								style={inputStyle}
+								value={props.value as string}
+								availableFonts={props.fonts}
+								onChange={fontFamily => updateSettingValue(key, fontFamily)}
+								subtype={md.subType}
+								inputId={inputId}
+							/> :
+							<input
+								type={inputType}
+								style={inputStyle}
+								value={props.value as string|number}
+								onChange={onTextChange}
+								spellCheck={false}
+								id={inputId}
+								aria-describedby={descriptionId}
+							/>
+					}
+					<div style={{ width: inputStyle.width, minWidth: inputStyle.minWidth }}>
+						{descriptionComp}
+					</div>
+				</div>
+			);
+		}
+	} else if (md.type === Setting.TYPE_INT) {
+		const value = props.value as number;
+
+		const onNumChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+			updateSettingValue(key, event.target.value);
+		};
+
+		const label = [md.label()];
+		if (md.unitLabel) label.push(`(${md.unitLabel(md.value)})`);
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		const inputStyle: any = { ...textInputBaseStyle };
+
+		return (
+			<div key={key} style={rowStyle}>
+				<SettingLabel htmlFor={inputId} text={label.join(' ')}/>
+				<input
+					type="number"
+					style={inputStyle}
+					value={value}
+					onChange={onNumChange}
+					min={md.minimum}
+					max={md.maximum}
+					step={md.step}
+					spellCheck={false}
+					id={inputId}
+					aria-describedby={descriptionId}
+				/>
+				{descriptionComp}
+			</div>
+		);
+	} else if (md.type === Setting.TYPE_BUTTON) {
+		const labelComp = md.hideLabel ? null : (
+			<SettingLabel text={md.label()} htmlFor={null} />
+		);
+
+		return (
+			<div key={key} style={rowStyle}>
+				{labelComp}
+				<Button
+					level={ButtonLevel.Secondary}
+					title={md.label()}
+					onClick={md.onClick ? md.onClick : props.onSettingButtonClick}
+				/>
+				{descriptionComp}
+			</div>
+		);
+	} else {
+		console.warn(`Type not implemented: ${key}`);
+	}
+
+	return output;
+};
+
+export default SettingComponent;

--- a/packages/app-desktop/gui/ConfigScreen/controls/SettingDescription.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/SettingDescription.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+interface Props {
+	text: string;
+	id?: string;
+}
+
+const SettingDescription: React.FC<Props> = props => {
+	return props.text ? <div className='setting-description' id={props.id}>{props.text}</div> : null;
+};
+
+export default SettingDescription;

--- a/packages/app-desktop/gui/ConfigScreen/controls/SettingHeader.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/SettingHeader.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+interface Props {
+	text: string;
+}
+
+const SettingHeader: React.FC<Props> = props => {
+	return (
+		<div className='setting-header'>
+			<label>{props.text}</label>
+		</div>
+	);
+};
+
+export default SettingHeader;

--- a/packages/app-desktop/gui/ConfigScreen/controls/SettingLabel.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/SettingLabel.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+interface Props {
+	htmlFor: string|null;
+	text: string;
+}
+
+const SettingLabel: React.FC<Props> = props => {
+	return (
+		<div className='setting-label'>
+			<label htmlFor={props.htmlFor}>{props.text}</label>
+		</div>
+	);
+};
+
+export default SettingLabel;

--- a/packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.tsx
@@ -6,6 +6,7 @@ import { _ } from '@joplin/lib/locale';
 interface Props {
 	onClick: ()=> void;
 	advancedSettingsVisible: boolean;
+	'aria-controls': string;
 }
 
 const ToggleAdvancedSettingsButton: React.FunctionComponent<Props> = props => {
@@ -16,6 +17,10 @@ const ToggleAdvancedSettingsButton: React.FunctionComponent<Props> = props => {
 				level={ButtonLevel.Secondary}
 				onClick={props.onClick}
 				iconName={iconName}
+
+				aria-controls={props['aria-controls']}
+				aria-expanded={props.advancedSettingsVisible}
+
 				title={_('Show Advanced Settings')}
 			/>
 		</div>

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useId, useMemo } from 'react';
 import { _ } from '@joplin/lib/locale';
 import styled from 'styled-components';
 import ToggleButton from '../../../lib/ToggleButton/ToggleButton';
@@ -173,6 +173,7 @@ export default function(props: Props) {
 			themeId={props.themeId}
 			value={item.enabled}
 			onToggle={() => props.onToggle({ item })}
+			aria-label={_('Enabled')}
 		/>;
 	}
 
@@ -256,10 +257,17 @@ export default function(props: Props) {
 		return <RecommendedBadge href="#" title={_('The Joplin team has vetted this plugin and it meets our standards for security and performance.')} onClick={onRecommendedClick}><i className="fas fa-crown"></i></RecommendedBadge>;
 	}
 
+	const nameLabelId = useId();
+
 	return (
-		<CellRoot isCompatible={props.isCompatible}>
+		<CellRoot isCompatible={props.isCompatible} role='group' aria-labelledby={nameLabelId}>
 			<CellTop>
-				<StyledNameAndVersion mb={'5px'}><StyledName onClick={onNameClick} href="#" style={{ marginRight: 5 }}>{item.manifest.name} {item.deleted ? _('(%s)', 'Deleted') : ''}</StyledName><StyledVersion>v{item.manifest.version}</StyledVersion></StyledNameAndVersion>
+				<StyledNameAndVersion mb={'5px'}>
+					<StyledName onClick={onNameClick} href="#" style={{ marginRight: 5 }} id={nameLabelId}>
+						{item.manifest.name} {item.deleted ? _('(%s)', 'Deleted') : ''}
+					</StyledName>
+					<StyledVersion>v{item.manifest.version}</StyledVersion>
+				</StyledNameAndVersion>
 				{renderToggleButton()}
 				{renderRecommendedBadge()}
 			</CellTop>

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -17,6 +17,8 @@ import useOnDeleteHandler from '@joplin/lib/components/shared/config/plugins/use
 import Logger from '@joplin/utils/Logger';
 import StyledMessage from '../../../style/StyledMessage';
 import StyledLink from '../../../style/StyledLink';
+import SettingHeader from '../SettingHeader';
+import SettingDescription from '../SettingDescription';
 const { space } = require('styled-system');
 
 const logger = Logger.create('PluginState');
@@ -51,12 +53,6 @@ interface Props {
 	themeId: number;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onChange: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	renderLabel: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	renderDescription: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	renderHeader: Function;
 }
 
 let repoApi_: RepositoryApi = null;
@@ -281,7 +277,7 @@ export default function(props: Props) {
 		if (!pluginItems.length || allDeleted) {
 			return (
 				<UserPluginsRoot mb={'10px'}>
-					{props.renderDescription(props.themeId, _('You do not have any installed plugin.'))}
+					<SettingDescription text={_('You do not have any installed plugin.')}/>
 				</UserPluginsRoot>
 			);
 		} else {
@@ -311,7 +307,6 @@ export default function(props: Props) {
 					pluginSettings={pluginSettings}
 					onSearchQueryChange={onSearchQueryChange}
 					onPluginSettingsChange={onSearchPluginSettingsChange}
-					renderDescription={props.renderDescription}
 					repoApi={repoApi}
 				/>
 			</div>
@@ -333,7 +328,7 @@ export default function(props: Props) {
 				<div style={{ display: 'flex', flexDirection: 'row', maxWidth }}>
 					<ToolsButton size={ButtonSize.Small} tooltip={_('Plugin tools')} iconName="fas fa-cog" level={ButtonLevel.Secondary} onClick={onToolsClick}/>
 					<div style={{ display: 'flex', flex: 1 }}>
-						{props.renderHeader(props.themeId, _('Manage your plugins'))}
+						<SettingHeader text={_('Manage your plugins')}/>
 					</div>
 				</div>
 				{renderUserPlugins(pluginItems)}

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx
@@ -10,6 +10,7 @@ import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/Plug
 import { _ } from '@joplin/lib/locale';
 import useOnInstallHandler from '@joplin/lib/components/shared/config/plugins/useOnInstallHandler';
 import { themeStyle } from '@joplin/lib/theme';
+import SettingDescription from '../SettingDescription';
 
 const Root = styled.div`
 `;
@@ -26,8 +27,6 @@ interface Props {
 	pluginSettings: PluginSettings;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	onPluginSettingsChange(event: any): void;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	renderDescription: Function;
 	maxWidth: number;
 	repoApi(): RepositoryApi;
 	disabled: boolean;
@@ -81,7 +80,7 @@ export default function(props: Props) {
 	function renderResults(query: string, manifests: PluginManifest[]) {
 		if (query && !manifests.length) {
 			if (searchResultCount === null) return ''; // Search in progress
-			return props.renderDescription(props.themeId, _('No results'));
+			return <SettingDescription text={_('No results')}/>;
 		} else {
 			const output = [];
 

--- a/packages/app-desktop/gui/ConfigScreen/style.scss
+++ b/packages/app-desktop/gui/ConfigScreen/style.scss
@@ -1,3 +1,5 @@
+@use "./styles/index.scss";
+
 .config-screen-content-wrapper {
 	padding: 24px;
 	overflow: auto;

--- a/packages/app-desktop/gui/ConfigScreen/styles/index.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/index.scss
@@ -2,3 +2,4 @@
 @use "./setting-description.scss";
 @use "./setting-label.scss";
 @use "./setting-header.scss";
+@use "./setting-tab-panel.scss";

--- a/packages/app-desktop/gui/ConfigScreen/styles/index.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/index.scss
@@ -1,0 +1,4 @@
+
+@use "./setting-description.scss";
+@use "./setting-label.scss";
+@use "./setting-header.scss";

--- a/packages/app-desktop/gui/ConfigScreen/styles/setting-description.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/setting-description.scss
@@ -1,0 +1,8 @@
+
+.setting-description {
+	color: var(--joplin-color-faded);
+	font-size: var(--joplin-font-size);
+	font-style: italic;
+	max-width: 70em;
+	margin-top: 5px;
+}

--- a/packages/app-desktop/gui/ConfigScreen/styles/setting-description.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/setting-description.scss
@@ -2,6 +2,7 @@
 .setting-description {
 	color: var(--joplin-color-faded);
 	font-size: var(--joplin-font-size);
+	line-height: var(--joplin-line-height);
 	font-style: italic;
 	max-width: 70em;
 	margin-top: 5px;

--- a/packages/app-desktop/gui/ConfigScreen/styles/setting-header.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/setting-header.scss
@@ -1,0 +1,9 @@
+
+.setting-header {
+	display: block;
+	color: var(--joplin-color);
+	font-size: calc(var(--joplin-font-size) * 1.25);
+	font-weight: 500;
+	margin-bottom: var(--joplin-main-padding);
+	line-height: var(--joplin-line-height);
+}

--- a/packages/app-desktop/gui/ConfigScreen/styles/setting-label.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/setting-label.scss
@@ -1,0 +1,20 @@
+
+.setting-label {
+	display: block;
+	color: var(--joplin-color);
+	font-size: calc(var(--joplin-font-size) * 1.083333);
+	font-weight: 500;
+	margin-bottom: calc(var(--joplin-main-padding) / 2);
+	line-height: var(--joplin-line-height);
+
+	&.-sub-label {
+		opacity: 0.7;
+	}
+
+	&.-for-checkbox {
+		margin-left: 5px;
+		margin-bottom: 0;
+		display: inline;
+		background-color: transparent;
+	}
+}

--- a/packages/app-desktop/gui/ConfigScreen/styles/setting-tab-panel.scss
+++ b/packages/app-desktop/gui/ConfigScreen/styles/setting-tab-panel.scss
@@ -1,0 +1,18 @@
+
+.setting-tab-panel {
+	display: flex;
+	flex-grow: 1;
+	flex-shrink: 1;
+	min-height: 0;
+
+	&.-hidden {
+		display: none;
+	}
+
+	&:focus-visible {
+		// Use a border rather than an outline -- an outline would be shown outside of the screen
+		// and thus invisible.
+		border: 1px solid var(--joplin-focus-outline-color);
+		outline: none;
+	}
+}

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -10,7 +10,7 @@ import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { getEncryptionEnabled, masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, getMasterPasswordStatusMessage, masterPasswordIsValid, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
 import Button, { ButtonLevel } from '../Button/Button';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { AppState } from '../../app.reducer';
 import Setting from '@joplin/lib/models/Setting';
@@ -350,7 +350,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		t = `<p>${t}</p>`;
 
 		return (
-			<div>
+			<>
 				<h2>{_('Re-encryption')}</h2>
 				<p style={theme.textStyle} dangerouslySetInnerHTML={{ __html: t }}></p>
 				<span style={{ marginRight: 10 }}>
@@ -358,7 +358,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				</span>
 
 				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }
-			</div>
+			</>
 		);
 	};
 
@@ -368,6 +368,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		setShowAdvanced(!showAdvanced);
 	}, [showAdvanced]);
 
+	const advancedSettingsId = useId();
 	const renderAdvancedSection = () => {
 		const reEncryptSection = renderReencryptData();
 
@@ -378,8 +379,12 @@ const EncryptionConfigScreen = (props: Props) => {
 			<div>
 				<ToggleAdvancedSettingsButton
 					onClick={toggleAdvanced}
-					advancedSettingsVisible={showAdvanced}/>
-				{ showAdvanced ? reEncryptSection : null }
+					advancedSettingsVisible={showAdvanced}
+					aria-controls={advancedSettingsId}
+				/>
+				<div id={advancedSettingsId}>
+					{ showAdvanced ? reEncryptSection : null }
+				</div>
 			</div>
 		);
 	};

--- a/packages/app-desktop/gui/lib/ToggleButton/ToggleButton.tsx
+++ b/packages/app-desktop/gui/lib/ToggleButton/ToggleButton.tsx
@@ -24,6 +24,9 @@ export default function(props: Props) {
 			// Works around a bug in ReactToggleButton -- the hidden checkbox input associated
 			// with the toggle is always read as "unchecked" by screen readers.
 			checked: props.value,
+			// Silences a ReactJS warning: "You provided a `checked` prop to a form field without an `onChange` handler."
+			// Change events are handled by ReactToggleButton.
+			onChange: ()=>{},
 		};
 	}, [ariaLabel, props.value]);
 

--- a/packages/app-desktop/gui/lib/ToggleButton/ToggleButton.tsx
+++ b/packages/app-desktop/gui/lib/ToggleButton/ToggleButton.tsx
@@ -1,5 +1,6 @@
 import { themeStyle } from '@joplin/lib/theme';
 import * as React from 'react';
+import { useMemo } from 'react';
 const ReactToggleButton = require('react-toggle-button');
 const Color = require('color');
 
@@ -8,10 +9,23 @@ interface Props {
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onToggle: Function;
 	themeId: number;
+	'aria-label': string;
 }
 
 export default function(props: Props) {
 	const theme = themeStyle(props.themeId);
+
+	const ariaLabel = props['aria-label'];
+
+	const passThroughInputProps = useMemo(() => {
+		return {
+			'aria-label': ariaLabel,
+
+			// Works around a bug in ReactToggleButton -- the hidden checkbox input associated
+			// with the toggle is always read as "unchecked" by screen readers.
+			checked: props.value,
+		};
+	}, [ariaLabel, props.value]);
 
 	return (
 		<ReactToggleButton
@@ -33,6 +47,7 @@ export default function(props: Props) {
 			}}
 			inactiveLabel=""
 			activeLabel=""
+			passThroughInputProps={passThroughInputProps}
 		/>
 	);
 }

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
-import SettingsScreen from './models/SettingsScreen';
 import { _electron as electron } from '@playwright/test';
 import { writeFile } from 'fs-extra';
 import { join } from 'path';
@@ -144,36 +143,6 @@ test.describe('main', () => {
 
 		// Should keep aspect ratio (regression test for #9597)
 		expect(fullSize[0] / resizedSize[0]).toBeCloseTo(fullSize[1] / resizedSize[1]);
-	});
-
-	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {
-		const mainScreen = new MainScreen(mainWindow);
-		await mainScreen.waitFor();
-
-		// Sort order buttons should be visible by default
-		await expect(mainScreen.noteListContainer.locator('[title^="Toggle sort order"]')).toBeVisible();
-
-		await mainScreen.openSettings(electronApp);
-
-		// Should be on the settings screen
-		const settingsScreen = new SettingsScreen(mainWindow);
-		await settingsScreen.waitFor();
-
-		// Open the appearance tab
-		await settingsScreen.appearanceTabButton.click();
-
-		// Find the sort order visible checkbox
-		const sortOrderVisibleCheckbox = mainWindow.getByLabel(/^Show sort order/);
-
-		await expect(sortOrderVisibleCheckbox).toBeChecked();
-		await sortOrderVisibleCheckbox.click();
-		await expect(sortOrderVisibleCheckbox).not.toBeChecked();
-
-		// Save settings & close
-		await settingsScreen.okayButton.click();
-		await mainScreen.waitFor();
-
-		await expect(mainScreen.noteListContainer.locator('[title^="Toggle sort order"]')).not.toBeVisible();
 	});
 
 	test('clicking on an external link should try to launch a browser', async ({ electronApp, mainWindow }) => {

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -16,7 +16,7 @@ export default class MainScreen {
 		this.newNoteButton = page.locator('.new-note-button');
 		this.noteListContainer = page.locator('.rli-noteList');
 		this.sidebar = new Sidebar(page, this);
-		this.dialog = page.locator('.dialog-root');
+		this.dialog = page.locator('.dialog-modal-layer');
 		this.noteEditor = new NoteEditorScreen(page);
 		this.goToAnything = new GoToAnything(page, this);
 	}

--- a/packages/app-desktop/integration-tests/models/SettingsScreen.ts
+++ b/packages/app-desktop/integration-tests/models/SettingsScreen.ts
@@ -11,7 +11,7 @@ export default class SettingsScreen {
 	}
 
 	public getTabLocator(tabName: string) {
-		return this.page.locator('a[role="tab"] > span', { hasText: tabName });
+		return this.page.getByRole('tab', { name: tabName });
 	}
 
 	public async waitFor() {

--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from './util/test';
+import MainScreen from './models/MainScreen';
+import SettingsScreen from './models/SettingsScreen';
+
+test.describe('settings', () => {
+	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.waitFor();
+
+		// Sort order buttons should be visible by default
+		const sortOrderLocator = mainScreen.noteListContainer.locator('[title^="Toggle sort order"]');
+		await expect(sortOrderLocator).toBeVisible();
+
+		await mainScreen.openSettings(electronApp);
+
+		// Should be on the settings screen
+		const settingsScreen = new SettingsScreen(mainWindow);
+		await settingsScreen.waitFor();
+
+		// Open the appearance tab
+		await settingsScreen.appearanceTabButton.click();
+
+		// Find the sort order visible checkbox
+		const sortOrderVisibleCheckbox = mainWindow.getByLabel(/^Show sort order/);
+
+		await expect(sortOrderVisibleCheckbox).toBeChecked();
+		await sortOrderVisibleCheckbox.click();
+		await expect(sortOrderVisibleCheckbox).not.toBeChecked();
+
+		// Save settings & close
+		await settingsScreen.okayButton.click();
+		await mainScreen.waitFor();
+
+		await expect(sortOrderLocator).not.toBeVisible();
+	});
+
+	test('should be possible to navigate settings screen tabs with the arrow keys', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.waitFor();
+		await mainScreen.openSettings(electronApp);
+
+		const settingsScreen = new SettingsScreen(mainWindow);
+		await settingsScreen.waitFor();
+
+		const generalTab = settingsScreen.getTabLocator('General');
+		await generalTab.click();
+
+		const focusedItem = mainWindow.locator(':focus');
+
+		// Up/Down arrows should move to the next and previous items
+		await expect(focusedItem).toHaveText('General');
+		await mainWindow.keyboard.press('ArrowDown');
+		await expect(focusedItem).toHaveText('Application');
+		await mainWindow.keyboard.press('ArrowUp');
+		await expect(focusedItem).toHaveText('General');
+
+		// Pressing Up when the first item is focused should focus the last item
+		await mainWindow.keyboard.press('ArrowUp');
+		await expect(focusedItem).toHaveText('Backup');
+
+		await mainWindow.keyboard.press('ArrowDown');
+		await mainWindow.keyboard.press('ArrowDown');
+
+		await expect(focusedItem).toHaveText('Application');
+
+		// Pressing Tab should focus the tab container
+		await mainWindow.keyboard.press('Tab');
+		await expect(focusedItem).toHaveAttribute('role', 'tabpanel');
+
+		// The correct tab should be visible
+		await expect(mainWindow.getByLabel('Show tray icon')).toBeVisible();
+
+		// Shift+Tab should focus the sidebar again
+		await mainWindow.keyboard.press('Shift+Tab');
+		await expect(focusedItem).toHaveAttribute('role', 'tab');
+		await expect(focusedItem).toHaveText('Application');
+	});
+});
+

--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -34,6 +34,23 @@ test.describe('settings', () => {
 		await expect(sortOrderLocator).not.toBeVisible();
 	});
 
+	test('clicking the sync wizard button in settings should open a dialog', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.waitFor();
+		await mainScreen.openSettings(electronApp);
+
+		const settingsScreen = new SettingsScreen(mainWindow);
+		const generalTab = settingsScreen.getTabLocator('Synchronisation');
+		await generalTab.click();
+
+		await expect(mainScreen.dialog).not.toBeVisible();
+
+		const syncWizardButton = mainWindow.getByRole('button', { name: 'Open Sync Wizard' });
+		await syncWizardButton.click();
+
+		await expect(mainScreen.dialog).toBeVisible();
+	});
+
 	test('should be possible to navigate settings screen tabs with the arrow keys', async ({ electronApp, mainWindow }) => {
 		const mainScreen = new MainScreen(mainWindow);
 		await mainScreen.waitFor();

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -143,7 +143,7 @@ a {
 
 
 *:focus-visible {
-	outline: 1px solid var(--joplin-color-warn);
+	outline: 1px solid var(--joplin-focus-outline-color);
 }
 
 // The browser-default focus-visible indicator was originally removed for aesthetic

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -17,7 +17,7 @@ const logger = Logger.create('models/Setting');
 
 export * from './settings/types';
 
-type SettingValueType<T extends string> = (
+export type SettingValueType<T extends string> = (
 	T extends BuiltInMetadataKeys
 		? BuiltInMetadataValues[T]
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -110,6 +110,7 @@ export function extraStyles(theme: Theme) {
 	const bgColor4 = theme.backgroundColor4;
 	const borderColor4: string = Color(theme.color).alpha(0.3);
 	const iconColor = Color(theme.color).alpha(0.8);
+	const focusOutlineColor = theme.colorWarn;
 
 	const backgroundColor5 = theme.backgroundColor5 ?? theme.color4;
 	const backgroundColorHover5 = Color(backgroundColor5).darken(0.2).hex();
@@ -230,6 +231,7 @@ export function extraStyles(theme: Theme) {
 		backgroundColor5,
 		backgroundColorHover5,
 		backgroundColorActive5,
+		focusOutlineColor,
 
 		icon: {
 			...globalStyle.icon,


### PR DESCRIPTION
# Summary

This pull request makes several changes to the settings screen:
1. **Refactoring**: Moves the `settingToComponent` function to a separate component. (Commit 5e94b468daea9a916105943ea742df23130c6790).
    - This decreases the amount of code present in `ConfigScreen.tsx` and allows React's `useId` hook to be used to auto-generate unique IDs.
2. Programmatically associates `label`s with `input`s in more cases. This causes screen readers to announce the label associated with an entry when focusing it. (In 5e94b468daea9a916105943ea742df23130c6790).
3. Programmatically associates setting descriptions with `input`s using [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby). (In 5e94b468daea9a916105943ea742df23130c6790).
4. Adds `aria-expanded` information to the "Show Advanced Settings" button. This causes a screen reader to announce whether advanced settings is expanded or collapsed 1) after clicking the button and 2) when navigating to the button. (Commit aabe55a3b42acc57448b05c4b2b958a18d575c3b).
5. Follows the [W3 Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) for more standard keyboard navigation between different setting tabs. (In d99dd09c40b23406ff3c2c678a035b265ec7920d)
    - Previously, it was difficult to navigate from a tab to its content. In particular, the <kbd>Tab</kbd> key navigated to the next tab, rather than the tab content. See [the suggestions on the W3 Tabs Pattern page](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#keyboardinteraction) for additional details.
6. Adds tests for setting tab navigation. (In b643a357a53a923af32e2b669a91eb51584ce43f).
7. Prevents the screen reader from reading sidebar icons as text (included in d99dd09c40b23406ff3c2c678a035b265ec7920d).
    - Sidebar icons use an icon font and were previously included in screen reader output.
8. Improves accessibility labeling and grouping in the plugin config screen (commit 1aca332aa410f82637b7085ec532bd93d58ce31e).

This pull request is related to https://github.com/laurent22/joplin/issues/10795.

# Possible future work

- Put the "Back" / "OK" / "Apply" buttons in a `landmark` (`navigation`?) for easier access when using a screen reader.
- Put the settings sidebar in a `landmark` for easier access when using a screen reader.
- Migrate to a different toggle button library or use a custom toggle button component. At present,
    - Currently, a workaround is being used to make VoiceOver correctly announce the state of the button, and
    - keyboard focus isn't visible when the toggle button is focused.


# Testing plan

**MacOS**:
1. Enable VoiceOver.
2. Open Joplin's settings screen.
3. Navigate to the "Appearance" section using <kbd>control</kbd>-<kbd>option</kbd>-<kbd>right</kbd> and <kbd>control</kbd>-<kbd>option</kbd>-<kbd>space</kbd>.
   - These shortcuts test changing the VoiceOver focus -- they behave differently from navigating with just <kbd>tab</kbd> and the arrow keys.
4. Navigate to the content of the settings tab by pressing <kbd>tab</kbd>.
5. Navigate to the "theme" dropdown using <kbd>control</kbd>-<kbd>option</kbd>-<kbd>right</kbd>.
6. Change "theme" to "Solarized Light".
7. Navigate to the "show sort order buttons" using <kbd>control</kbd>-<kbd>option</kbd>-<kbd>right</kbd>.
8. Uncheck "show sort order buttons".
   - Verify that when the checkbox is selected, VoiceOver reads the checkbox's label in addition to the checkbox.
     - `Show sort order buttons, checked, checkbox` before unchecking, `Show sort order buttons, unchecked, checkbox` after unchecking.
   - Verify that moving to the next VoiceOver focus item (<kbd>control</kbd>-<kbd>option</kbd>-<kbd>right</kbd>) focuses "Editor font size", and not the label for the checkbox.
9. Navigate to the "OK" button using <kbd>control</kbd>-<kbd>option</kbd>-<kbd>right</kbd> and press <kbd>control</kbd>-<kbd>option</kbd>-<kbd>space</kbd> to save changes.
10. Verify that the changes are applied.
11. Open settings.
12. Navigate to the "Appearance" section using <kbd>Tab</kbd> and the <kbd>Down</kbd> arrow key.
13. Verify that the "Appearance" section is open.
14. Navigate to the "Theme" dropdown by pressing <kbd>Tab</kbd> twice (once to move to the tab container, once to move to the first control in the container).
15. Change the theme back to "Light" (navigate to it using <kbd>tab</kbd> and activate with <kbd>space</kbd>).
16. Check the "show sort order button" (navigate to it with <kbd>tab</kbd>).
17. Apply changes.
18. Using <kbd>tab</kbd> and the arrow keys, navigate to the "plugins" section.
19. Using <kbd>control</kbd>-<kbd>option</kbd>-arrow keys, disable a plugin.
	- Verify that VoiceOver reads "unchecked" after unchecking the "Enabled" checkbox.
	- Verify that the plugin disable button reads "Enabled, unchecked, checkbox" after 1) disabling the plugin, then 2) navigating away from the checkbox, and finally 3) navigating back to the checkbox.
	- Verify that entering and exiting the plugin box with <kbd>control</kbd>-<kbd>option</kbd>-arrow keys reads "plugin name, group" and "end of, plugin name, group", respectively (replacing "plugin name" with the name of a plugin).
21. Verify that a banner reading "The application must be restarted for these changes to take effect" is present at the top of the screen.
