### PR TITLE
Desktop: Fixes #10815: Fix Enter key submits dialogs even if a button has focus

### DIFF
--- a/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
+++ b/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { isInsideContainer } from '@joplin/lib/dom';
 
@@ -40,19 +41,21 @@ export default (props: Props) => {
 		return false;
 	};
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	const onKeyDown = useCallback((event: any) => {
+	const onKeyDown = useCallback((event: KeyboardEvent|React.KeyboardEvent) => {
 		// Early exit if it's neither ENTER nor ESCAPE, because isInSubModal
 		// function can be costly.
-		if (event.keyCode !== 13 && event.keyCode !== 27) return;
+		if (event.code !== 'Enter' && event.code !== 'Escape') return;
 
 		if (!isTopDialog() || isInSubModal(event.target)) return;
 
-		if (event.keyCode === 13) {
-			if (event.target.nodeName !== 'TEXTAREA') {
-				props.onOkButtonClick();
+		if (event.code === 'Enter') {
+			if ('nodeName' in event.target && event.target.nodeName === 'INPUT') {
+				const target = event.target as HTMLInputElement;
+				if (target.type !== 'button' && target.type !== 'checkbox') {
+					props.onOkButtonClick();
+				}
 			}
-		} else if (event.keyCode === 27) {
+		} else if (event.code === 'Escape') {
 			props.onCancelButtonClick();
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied

--- a/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
+++ b/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
@@ -44,18 +44,19 @@ export default (props: Props) => {
 	const onKeyDown = useCallback((event: KeyboardEvent|React.KeyboardEvent) => {
 		// Early exit if it's neither ENTER nor ESCAPE, because isInSubModal
 		// function can be costly.
-		if (event.code !== 'Enter' && event.code !== 'Escape') return;
+		if (event.keyCode !== 13 && event.keyCode !== 27) return;
 
 		if (!isTopDialog() || isInSubModal(event.target)) return;
 
-		if (event.code === 'Enter') {
+		if (event.keyCode === 13) {
 			if ('nodeName' in event.target && event.target.nodeName === 'INPUT') {
 				const target = event.target as HTMLInputElement;
+
 				if (target.type !== 'button' && target.type !== 'checkbox') {
 					props.onOkButtonClick();
 				}
 			}
-		} else if (event.code === 'Escape') {
+		} else if (event.keyCode === 27) {
 			props.onCancelButtonClick();
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied


### PR DESCRIPTION
# Summary

This pull request fixes several issues with the same underlying cause:
- Pressing <kbd>Enter</kbd> after focusing the "OK" button in the "Create Notebook" dialog created 3 notebooks rather than just 1.
- Pressing <kbd>Enter</kbd> when trying to edit a field in the Note Properties dialog closed the dialog and saved changes instead.
- Similar issues where <kbd>Enter</kbd> is intended by the user to activate a button or link, but instead dismisses the dialog.

This commit causes <kbd>Enter</kbd> to only submit a dialog if the "OK" button or an input has focus. This does not affect how the <kbd>Escape</kbd> key is handled.

Fixes #10815.

# Notes

- In many dialogs ("add tag", "add profile", "add notebook", and "note properties" dialogs) either a text `input` or the "OK" button has the default focus. As such, in these cases, pressing <kbd>Enter</kbd> with the default item focused still submits the dialog.
- This should not affect plugin dialogs.
   - Brief testing was done with the [note diff plugin](https://joplinapp.org/plugins/plugin/io.github.personalizedrefrigerator.diff-view/) by opening its note chooser dialog, selecting a note such that the "OK" button is visible, and pressing <kbd>Enter</kbd>.

# Testing plan

**Manual testing** (MacOS):
1. Open the "share" dialog for a notebook.
2. Enter a recipient's email and press <kbd>tab</kbd> to focus the "share" button.
3. Press <kbd>enter</kbd>.
4. Verify that the recipient is added to the recipient list **without the dialog closing**.
5. Press <kbd>escape</kbd>.
6. Verify that the dialog is now closed.
7. Open the "New Notebook" dialog.
8. Type a title.
9. Press <kbd>Enter</kbd>.
10. Verify that the new notebook has been created.
11. Repeat steps 7-8.
12. Navigate to the "OK" button with the <kbd>Tab</kbd> key.
13. Press <kbd>Enter</kbd>.
14. Verify that **just one** notebook is created.
15. Create a new note.
16. Open the "note properties" dialog.
17. Use the <kbd>tab</kbd> key to navigate to the "Edit" button for "Location".
18. Press <kbd>Enter</kbd>.
19. Verify that an input is shown and that the dialog is still visible.
20. Make a small change and press <kbd>Enter</kbd>.
21. Verify that the dialog has closed.
22. Re-open the dialog and verify that the change was saved.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->