### PR TITLE
Desktop: Accessibility: Restore keyboard focus when closing a dialog

### DIFF
--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -1,55 +1,108 @@
 import * as React from 'react';
-import { MouseEventHandler, ReactEventHandler, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type OnCancelListener = ()=> void;
 
 interface Props {
 	className?: string;
-	onCancel?: ()=> void;
+	onCancel?: OnCancelListener;
 	contentStyle?: React.CSSProperties;
 	children: ReactNode;
 }
 
-export default function Dialog(props: Props) {
-	const [dialogElement, setDialogRef] = useState<HTMLDialogElement>();
+const Dialog: React.FC<Props> = props => {
+	// For correct focus handling, the dialog element needs to be managed separately from React. In particular,
+	// just after creating the dialog, we need to call .showModal() and just **before** closing the dialog, we
+	// need to call .close(). This second requirement is particularly difficult, as this needs to happen even
+	// if the dialog is closed by removing its parent from the React DOM.
+	//
+	// Because useEffect cleanup can happen after an element is removed from the HTML DOM, the dialog is managed
+	// using native HTML APIs. This allows us to call .close() while the dialog is still attached to the DOM, which
+	// allows the browser to restore the focus from before the dialog was opened.
+	const dialogElement = useDialogElement(props.onCancel);
+	useDialogClassNames(dialogElement, props.className);
+
+	const [contentRendered, setContentRendered] = useState(false);
 
 	useEffect(() => {
-		if (!dialogElement) return;
+		if (!dialogElement || !contentRendered) return;
 
-		// Use .showModal instead of the open attribute: .showModal correctly
-		// traps the keyboard focus in the dialog
-		dialogElement.showModal();
-	}, [dialogElement]);
-
-	const onCancelRef = useRef(props.onCancel);
-	onCancelRef.current = props.onCancel;
-
-	const onCancel: ReactEventHandler<HTMLDialogElement> = useCallback((event) => {
-		const canCancel = !!onCancelRef.current;
-		if (!canCancel) {
-			// Prevents [Escape] from closing the dialog. In many places, this is handled
-			// elsewhere.
-			// See https://stackoverflow.com/a/61021326
-			event.preventDefault();
+		if (!dialogElement.open) {
+			dialogElement.showModal();
 		}
+	}, [dialogElement, contentRendered]);
+
+	if (dialogElement && !contentRendered) {
+		setContentRendered(true);
+	}
+
+	const content = (
+		<div className='content' style={props.contentStyle}>
+			{props.children}
+		</div>
+	);
+	return <>
+		{(dialogElement !== null) && createPortal(content, dialogElement)}
+	</>;
+};
+
+const useDialogElement = (onCancel: undefined|OnCancelListener) => {
+	const [dialogElement, setDialogElement] = useState<HTMLDialogElement|null>(null);
+
+	const onCancelRef = useRef(onCancel);
+	onCancelRef.current = onCancel;
+
+	useEffect(() => {
+		const dialog = document.createElement('dialog');
+		dialog.addEventListener('click', event => {
+			const onCancel = onCancelRef.current;
+			if (event.target === dialog && onCancel) {
+				onCancel();
+			}
+		});
+		dialog.classList.add('dialog-modal-layer');
+		dialog.addEventListener('cancel', event => {
+			const canCancel = !!onCancelRef.current;
+			if (!canCancel) {
+				// Prevents [Escape] from closing the dialog. In many places, this is handled
+				// elsewhere.
+				// See https://stackoverflow.com/a/61021326
+				event.preventDefault();
+			}
+		});
+		dialog.addEventListener('close', () => onCancelRef.current?.());
+		document.body.appendChild(dialog);
+
+		setDialogElement(dialog);
+
+		return () => {
+			if (dialog.open) {
+				dialog.close();
+			}
+			dialog.remove();
+		};
 	}, []);
 
-	const onContainerClick: MouseEventHandler<HTMLDialogElement> = useCallback((event) => {
-		const onCancel = onCancelRef.current;
-		if (event.target === dialogElement && onCancel) {
-			onCancel();
-		}
-	}, [dialogElement]);
+	return dialogElement;
+};
 
-	return (
-		<dialog
-			ref={setDialogRef}
-			className={`dialog-modal-layer ${props.className}`}
-			onClose={props.onCancel}
-			onCancel={onCancel}
-			onClick={onContainerClick}
-		>
-			<div className='content' style={props.contentStyle}>
-				{props.children}
-			</div>
-		</dialog>
-	);
-}
+const useDialogClassNames = (dialogElement: HTMLElement|null, classNames: undefined|string) => {
+	useEffect(() => {
+		if (!dialogElement || !classNames) {
+			return () => {};
+		}
+
+		// The React className prop can include multiple space-separated classes
+		const newClassNames = classNames
+			.split(/\s+/)
+			.filter(name => !dialogElement.classList.contains(name));
+		dialogElement.classList.add(...newClassNames);
+
+		return () => {
+			dialogElement.classList.remove(...newClassNames);
+		};
+	}, [dialogElement, classNames]);
+};
+
+export default Dialog;

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { blur, focus } from '@joplin/lib/utils/focusHandler';
 
 type OnCancelListener = ()=> void;
 
@@ -78,6 +79,15 @@ const useDialogElement = (onCancel: undefined|OnCancelListener) => {
 			const closedByCancel = dialog.returnValue !== removedReturnValue;
 			if (closedByCancel) {
 				onCancelRef.current?.();
+			}
+
+			// Work around what seems to be an Electron bug -- if an input or contenteditable region is refocused after
+			// dismissing a dialog, it won't be editable.
+			// Note: While this addresses the issue in the note title input, it does not address the issue in the Rich Text Editor.
+			if (document.activeElement?.tagName === 'INPUT') {
+				const element = document.activeElement as HTMLElement;
+				blur('Dialog', element);
+				focus('Dialog', element);
 			}
 		});
 		document.body.appendChild(dialog);

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -43,7 +43,7 @@ const Dialog: React.FC<Props> = props => {
 		</div>
 	);
 	return <>
-		{(dialogElement !== null) && createPortal(content, dialogElement)}
+		{dialogElement && createPortal(content, dialogElement)}
 	</>;
 };
 
@@ -78,6 +78,8 @@ const useDialogElement = (onCancel: undefined|OnCancelListener) => {
 
 		return () => {
 			if (dialog.open) {
+				// .close: Instructs the browser to restore keyboard focus to whatever was focused
+				// before the dialog.
 				dialog.close();
 			}
 			dialog.remove();

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -11,6 +11,10 @@
 	margin: 0;
 	background-color: transparent;
 
+	&:not([open]) {
+		display: none;
+	}
+
 	> .content {
 		background-color: var(--joplin-background-color);
 		color: var(--joplin-color);

--- a/packages/app-desktop/integration-tests/goToAnything.spec.ts
+++ b/packages/app-desktop/integration-tests/goToAnything.spec.ts
@@ -33,11 +33,11 @@ test.describe('goToAnything', () => {
 
 	test('closing go to anything should restore the original keyboard focus', async ({ electronApp, mainWindow }) => {
 		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('');
 
-		// Focus and start to fill the note title
-		await mainScreen.noteEditor.noteTitleInput.click();
-		await expect(mainScreen.noteEditor.noteTitleInput).toBeFocused();
-		await mainScreen.noteEditor.noteTitleInput.fill('Test');
+		// Focus and start to fill the editor
+		await mainScreen.noteEditor.codeMirrorEditor.click();
+		await mainWindow.keyboard.type('Test');
 
 		const goToAnything = mainScreen.goToAnything;
 		await goToAnything.open(electronApp);
@@ -46,10 +46,9 @@ test.describe('goToAnything', () => {
 		await goToAnything.inputLocator.press('Escape');
 		await goToAnything.expectToBeClosed();
 
-		// Keyboard focus should have returned to the note title
-		await expect(mainScreen.noteEditor.noteTitleInput).toBeFocused();
+		// Keyboard focus should have returned to the editor
 		await mainWindow.keyboard.type('ing...');
-		await expect(mainScreen.noteEditor.noteTitleInput).toHaveValue('Testing...');
+		await expect(mainScreen.noteEditor.codeMirrorEditor).toHaveText('Testing...');
 	});
 
 	test('should be possible to show the set tags dialog from goToAnything', async ({ electronApp, mainWindow }) => {

--- a/packages/app-desktop/integration-tests/goToAnything.spec.ts
+++ b/packages/app-desktop/integration-tests/goToAnything.spec.ts
@@ -31,6 +31,27 @@ test.describe('goToAnything', () => {
 		}
 	});
 
+	test('closing go to anything should restore the original keyboard focus', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+
+		// Focus and start to fill the note title
+		await mainScreen.noteEditor.noteTitleInput.click();
+		await expect(mainScreen.noteEditor.noteTitleInput).toBeFocused();
+		await mainScreen.noteEditor.noteTitleInput.fill('Test');
+
+		const goToAnything = mainScreen.goToAnything;
+		await goToAnything.open(electronApp);
+
+		await goToAnything.expectToBeOpen();
+		await goToAnything.inputLocator.press('Escape');
+		await goToAnything.expectToBeClosed();
+
+		// Keyboard focus should have returned to the note title
+		await expect(mainScreen.noteEditor.noteTitleInput).toBeFocused();
+		await mainWindow.keyboard.type('ing...');
+		await expect(mainScreen.noteEditor.noteTitleInput).toHaveValue('Testing...');
+	});
+
 	test('should be possible to show the set tags dialog from goToAnything', async ({ electronApp, mainWindow }) => {
 		const mainScreen = new MainScreen(mainWindow);
 		await mainScreen.createNewNote('Test note');

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -128,6 +128,7 @@
     "@types/jest": "29.5.8",
     "@types/node": "18.19.31",
     "@types/react": "18.2.58",
+    "@types/react-dom": "18.2.0",
     "@types/react-redux": "7.1.33",
     "@types/styled-components": "5.1.32",
     "@types/tesseract.js": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7575,6 +7575,7 @@ __metadata:
     "@types/mustache": 4.2.5
     "@types/node": 18.19.31
     "@types/react": 18.2.58
+    "@types/react-dom": 18.2.0
     "@types/react-redux": 7.1.33
     "@types/styled-components": 5.1.32
     "@types/tesseract.js": 2.0.0
@@ -12432,6 +12433,15 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:18.2.0":
+  version: 18.2.0
+  resolution: "@types/react-dom@npm:18.2.0"
+  dependencies:
+    "@types/react": "*"
+  checksum: 9212b3793707a763f10e2c608f6ccb5f729029da6cb84204f333634d3d7baafbc1b20b7faf7cf788a8fd385050a1fb579902031f9462473ef10607116f33f33c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request improves how the `Dialog` component handles focus by closing the dialog with the `.close()` method before removing it from the DOM. This causes the browser to restore keyboard focus to the item focused before the dialog was opened.

Previously, closing a dialog reset focus to the first focusable element on the page.

See also:
- [ARIA Authoring Guide: Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
- https://www.w3.org/WAI/WCAG22/Techniques/failures/F85.html

# Relevant WCAG success criterion

This change is related to success criterion 2.4.3 (Level A). See [failure condition 85, example 2](https://www.w3.org/WAI/WCAG22/Techniques/failures/F85.html#example-2-setting-focus-to-the-document-after-dismissing-a-menu-embedded-on-the-page).

# Remaining issue

> [!NOTE]
>
> **Update**: A workaround has been implemented for `input` elements. However, the issue is still present in the Rich Text Editor.
>

On some platforms (observed on Ubuntu 24.04 and MacOS), if an input is granted focus after closing a dialog, it isn't editable until unfocused, then refocused. In particular, if I:
  1. Focus the **title input**.
  2. Open Go to Anything.
  3. Close Go to Anything by pressing <kbd>Escape</kbd>.
  4. Type.
   
Then nothing happens. Adding additional styling to highlight the `:focus`ed element reveals that the title input does have focus (but doesn't seem to respond to keyboard events). If I then press <kbd>shift</kbd>-<kbd>tab</kbd>, then <kbd>tab</kbd>, the title input is editable.

I can reproduce a similar issue in the Rich Text editor, but not in the Markdown editor.


# Testing

This pull request includes an automated test that verifies:
- Keyboard focus is restored after dismissing Go to Anything.
   - The test only verifies this for the Markdown editor and title inputs.

Existing automated tests verify that:
- Clicking on the dimmed background of Go to Anything dismisses the Go to Anything dialog.
   - This dismissal is handled by `Dialog.tsx`.
- <kbd>Escape</kbd> dismisses the Go to Anything dialog. 
   - This dismissal is handled in part by Electron and in part by `Dialog.tsx`.
- It's possible to run a command from Go to Anything (and that this dismisses the Go to Anything dialog).

The following manual testing has been done on MacOS:
1. Focus the markdown editor.
6. Type `Test`.
7. Press <kbd>cmd</kbd>-<kbd>p</kbd>.
8. Verify that the Go to Anything dialog is focused.
9. Dismiss the dialog by pressing <kbd>Escape</kbd>.
10. Type `ing`.
11. Verify that the markdown editor is still focused and that the cursor is at the end of the word `Testing`.
12. Open settings, then the synchronisation tab.
13. <kbd>Tab</kbd> to the "Sync wizard" button.
14. Press <kbd>space</kbd>.
15. Verify that the sync wizard dialog is open.
16. Navigate to the "Close" button using <kbd>tab</kbd>.
17. Press <kbd>space</kbd>.
18. Verify that the sync wizard dialog has closed.
19. Verify that the "Sync wizard" button has keyboard focus.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->