### PR TITLE
Desktop: Fix prompt tag dialog input can be wider than its container

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -191,6 +191,8 @@ export default class PromptDialog extends React.Component<Props, any> {
 
 		this.styles_.desc = { ...theme.textStyle, marginTop: 10 };
 
+		this.styles_.dialog = { maxWidth: width };
+
 		return this.styles_;
 	}
 
@@ -304,7 +306,7 @@ export default class PromptDialog extends React.Component<Props, any> {
 		}
 
 		return (
-			<Dialog className='prompt-dialog'>
+			<Dialog className='prompt-dialog' contentStyle={styles.dialog}>
 				<label style={styles.label}>{this.props.label ? this.props.label : ''}</label>
 				<div style={{ display: 'inline-block', color: 'black', backgroundColor: theme.backgroundColor }}>
 					{inputComp}


### PR DESCRIPTION
# Summary

**This pull request fixes a recent regression.** The regression was likely [introduced by 596bcd8d8b0aff25f504050053c912dba94d929c](https://github.com/laurent22/joplin/commit/596bcd8d8b0aff25f504050053c912dba94d929c#diff-818cbb3eca0497e4766bb50217f8b4c2cfa4be26aeda804646636428be073487L114).

At certain zoom levels and on very large screens, the tag input could be wider than its containing dialog.

# Testing plan

1. Open a note.
2. Open the "Add tag" dialog.
3. Zoom as far out as possible.
4. Verify that the tag selection input still fits within the dialog.
5. Under file > switch profile, click "Create new profile...".
6. Zoom in as far as possible.
7. Verify that the input fits within the dialog at all zoom levels.

This has been tested successfully on MacOS.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->