### PR TITLE
Fixed the fa-icons that were not being rendered in Read-Only Mode

### DIFF
--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -13,6 +13,12 @@ export default {
 			},
 			{
 				inline: true,
+				// This properly renders the fa-icons in both the Rich Text Editor and Markdown Pane / Read-Only Mode
+				text: '@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css");',
+				mime: 'text/css',
+			},
+			{
+				inline: true,
 				// Note: Mermaid is buggy when rendering below a certain width (500px?)
 				// so set an arbitrarily high width here for the container. Once the
 				// diagram is rendered it will be reset to 100% in mermaid_render.js


### PR DESCRIPTION
This PR fixes #8914 

Earlier the fa-icons of mermaid diagram were not being rendered in the Markdown Pane / Read-Only Mode 
Now changed the code in the file mermaid.ts to properly import the fa-icons and display it in Read-Only Mode too

Testing :

https://github.com/user-attachments/assets/0b86e133-f579-4f82-b8b4-6cd7788591eb



Steps to Test:

Create a new note
Add a code block with language mermaid
Set the following content:

 mindmap
      root((mindmap))
          Long history
          ::icon(fa fa-book)
Click "Ok" to render the graph
Switch between editors to check whether the icons are rendered or not
Let me know if any further changes or information are needed.