### PR TITLE
Desktop: Fixes #10740: Improve the reliability of fetching resources

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -590,6 +590,7 @@ function shimInit(options: ShimInitOptions = null) {
 						cleanUpOnError(error);
 					});
 
+					const requestStart = new Date();
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 					const request = http.request(requestOptions, (response: any) => {
 
@@ -629,7 +630,10 @@ function shimInit(options: ShimInitOptions = null) {
 					});
 
 					request.on('timeout', () => {
-						request.destroy(new Error(`Request timed out. Timeout value: ${requestOptions.timeout}ms.`));
+						// We choose to not destroy the request when a timeout value is not specified to keep
+						// the behavior we had before the addition of this event handler.
+						if (!requestOptions.timeout) return;
+						request.destroy(new Error(`Request timed out. Timeout value: ${requestOptions.timeout}ms. Actual connection time: ${new Date().getTime() - requestStart.getTime()}ms`));
 					});
 
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied


### PR DESCRIPTION
Fixes: https://github.com/laurent22/joplin/issues/10740

# Summary

As reported by the user, the new code, when `timeout` is set to undefined, uses the `http.globalAgent` which has a default timeout to 5 seconds.

Previously, this wouldn't be a problem because we didn't have an event handler for `timeout` event, so now I'm checking if the timeout was specified for this request, and if it wasn't I opt to **not** destroy the request.

I also added more information to the log message when the request timeout.

# Testing

To test this change I created a simple HTTP server, with a sleep function in the endpoint that returns one of the images from a static HTML page.

After that, I used the Web Clipper to save the full HTML page, which will use the `fetchBlob` function to download the image.

The sleep function should be higher than the timeout value, if that happens we can see the `timeout` event being generated.