### PR TITLE
Mobile: Include commit information in version information screen

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -51,6 +51,7 @@ packages/app-desktop/node_modules
 packages/app-desktop/packageInfo.js
 packages/app-desktop/services/electron-context-menu.js
 packages/app-desktop/vendor/lib/
+packages/app-mobile/packageInfo.js
 packages/app-mobile/android
 packages/app-mobile/**/*.bundle.js
 packages/app-mobile/web/public/pluginAssets/**/*

--- a/packages/app-mobile/.gitignore
+++ b/packages/app-mobile/.gitignore
@@ -74,3 +74,5 @@ web/public/pluginAssets/*
 
 utils/fs-driver-android.js
 android/app/build-*
+
+packageInfo.js

--- a/packages/app-mobile/gulpfile.ts
+++ b/packages/app-mobile/gulpfile.ts
@@ -1,5 +1,6 @@
 const gulp = require('gulp');
 const utils = require('@joplin/tools/gulp/utils');
+const compilePackageInfo = require('@joplin/tools/compilePackageInfo');
 
 import injectedJsGulpTasks from './tools/buildInjectedJs/gulpTasks';
 
@@ -10,6 +11,12 @@ const tasks = {
 	copyWebAssets: {
 		fn: require('./tools/copyAssets').default,
 	},
+	compilePackageInfo: {
+		fn: async () => {
+			await compilePackageInfo(`${__dirname}/package.json`, `${__dirname}/packageInfo.js`);
+		},
+	},
+
 	...injectedJsGulpTasks,
 	podInstall: {
 		fn: require('./tools/podInstall'),
@@ -39,6 +46,7 @@ gulp.task('watchInjectedJs', gulp.series(
 ));
 
 gulp.task('build', gulp.series(
+	'compilePackageInfo',
 	'buildInjectedJs',
 	'copyWebAssets',
 	'encodeAssets',

--- a/packages/app-mobile/utils/getPackageInfo.ts
+++ b/packages/app-mobile/utils/getPackageInfo.ts
@@ -1,12 +1,16 @@
 import shim from '@joplin/lib/shim';
 import { PackageInfo } from '@joplin/lib/versionInfo';
 import ReactNativeVersionInfo from 'react-native-version-info';
+const basePackageInfo = require('../packageInfo.js');
 
 const getPackageInfo = (): PackageInfo => {
 	const version = shim.appVersion();
 	return {
-		description: 'Joplin for Mobile',
-		name: 'Joplin',
+		...basePackageInfo,
+
+		// Android, iOS, and Web have independent versions -- fetch this
+		// information at runtime:
+		name: 'Joplin Mobile',
 		version,
 		build: {
 			appId: ReactNativeVersionInfo.bundleIdentifier,


### PR DESCRIPTION
# Summary

This pull request updates the mobile app's about screen to include the commit hash and source branch. Commit information is stored in `packages/app-mobile/packageInfo.js` and is generated with `compilePackageInfo.js` — the same script that generates package information in the desktop app.

# Screenshot

![screenshot: Joplin Mobile 3.0.0 (dev, web)
Client ID: 7e4a146ba3ab4a07ba4a19e43968f48d
Sync Version: 3
Profile Version: 47
Keychain Supported: No
Revision: f12642a24 (pr/mobile/include-commit-info-in-build)\
User agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0
FTS enabled: 1
Hermes enabled: 0](https://github.com/user-attachments/assets/b6fc9791-88d6-4bba-807e-70bcc050c59e)


# Testing plan

This pull request has been manually tested on web by:
1. Re-running `yarn build`.
1. Staring the app (`yarn serve-web`).
2. Verifying that the "more information" tab in "configuration" includes a commit hash and branch information.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->