### PR TITLE
Docs: Update the Markdown editor plugin tutorial to reflect recent Joplin changes

### DIFF
--- a/readme/api/tutorials/cm6_plugin.md
+++ b/readme/api/tutorials/cm6_plugin.md
@@ -7,9 +7,7 @@ This guide demonstrates how to create a Markdown editor plugin. It expects you t
 
 :::note
 
-This guide describes how to create a plugin for Joplin's [CodeMirror 6](https://codemirror.net/)-based Markdown editor, which is still in beta. It must be enabled in settings > general.
-
-Plugins for this editor may not work in Joplin 2.13 or earlier.
+This guide describes how to create a plugin for Joplin's [CodeMirror 6](https://codemirror.net/)-based Markdown editor. This is the text editor on mobile devices and newer versions of Joplin desktop (>= 3.1). Before v3.1, this editor was in beta and needed to be enabled under settings > general.
 
 :::
 
@@ -414,7 +412,9 @@ import { Compartment } from '@codemirror/state';
 		const highlightExtension = new Compartment();
 		codeMirrorWrapper.addExtension(highlightExtension.of([]));
 
-		codeMirrorWrapper.defineExtension('myExtension__setHighlightActiveLine', (highlighted: boolean) => {
+		// Registers a command with name "myExtension__setHighlightActiveLine" that can be
+		// called from the main plugin script with joplin.commands.execute('editor.execCommand', ...).
+		codeMirrorWrapper.registerCommand('myExtension__setHighlightActiveLine', (highlighted: boolean) => {
 			const extension = highlighted ? [ highlightActiveLine() ] : [ ];
 			codeMirrorWrapper.editor.dispatch({
 				effects: [ highlightExtension.reconfigure(extension) ],

--- a/readme/api/tutorials/cm6_plugin.md
+++ b/readme/api/tutorials/cm6_plugin.md
@@ -7,7 +7,7 @@ This guide demonstrates how to create a Markdown editor plugin. It expects you t
 
 :::note
 
-This guide describes how to create a plugin for Joplin's [CodeMirror 6](https://codemirror.net/)-based Markdown editor. This is the text editor on mobile devices and newer versions of Joplin desktop (>= 3.1). Before v3.1, this editor was in beta and needed to be enabled under settings > general.
+This guide describes how to create a plugin for Joplin's [CodeMirror 6](https://codemirror.net/)-based Markdown editor. The plugin created in this guide should work on both mobile and desktop. However, on Joplin desktop before version 3.1, the beta editor will need to be enabled in settings > general.
 
 :::
 


### PR DESCRIPTION
# Summary

This pull request updates the Markdown editor plugin tutorial to reflect recent and semi-recent changes to Joplin. In particular,
- The CodeMirror 6-based editor is no longer in beta (as of the upcoming Joplin 3.1 pre-release).
- Mobile editor plugins also target this editor.
- `.registerCommand` is preferred to `.defineExtension`.
    - [`.defineExtension`](https://codemirror.net/5/doc/manual.html#defineExtension) is present for CodeMirror 5 compatibility and sets properties on the CodeMirror 5 object.