### PR TITLE
Docs: Mobile plugins: Document using the web app to run mobile plugins

### DIFF
--- a/readme/api/references/mobile_plugin_debugging.md
+++ b/readme/api/references/mobile_plugin_debugging.md
@@ -2,13 +2,13 @@
 
 ## Running on web
 
-Plugins can be installed from `.jpl` files in the [web build](https://joplin.github.io/web-app/) of the mobile app. This can help with mobile plugin development in a few ways:
+Plugins can be installed from `.jpl` files in the [web build](https://app.joplincloud.com/) of the mobile app. This can help with mobile plugin development in a few ways:
 - Eliminates the need to transfer the plugin's built `.jpl` file to an Android device after every change.
 - It may be easier to inspect running plugins from a browser's development tools.
 
 To install a custom plugin on web,
 1. Build your plugin (run `npm run dist` from the plugin's directory).
-2. Open [web build](https://joplin.github.io/web-app/) of Joplin mobile.
+2. Open [web build](https://app.joplincloud.com/) of Joplin mobile.
 3. Go to "Configuration" > "Plugins" > "Enable plugin support" > "Advanced".
 4. Click "Install from file".
 5. Navigate to the base directory of your plugin.

--- a/readme/api/references/mobile_plugin_debugging.md
+++ b/readme/api/references/mobile_plugin_debugging.md
@@ -33,23 +33,23 @@ After loading, plugins are run in an `<iframe>` with an `about:srcdoc` URL. To v
    - If using Chrome's DevTools, the [`debug`](https://developer.chrome.com/docs/devtools/console/utilities#debug-function) and other console utility function may be helpful.
 
 
-## Getting console output
-
-By default, messages logged with `console.info`, `console.warn`, and `console.error` are added to Joplin's logs. To view these logs,
-1. Open Joplin's log screen (Configuration > Tools > Logs).
-2. Click "Search".
-3. Type your plugin's ID (or a large part of it) into the "filter" input.
-
-If Joplin is running in development mode, messages logged with `console.log` are also added to Joplin's logs.
-
-
 ## Android: Inspecting a WebView
 
-On mobile, all plugins run in a `WebView`.
+On mobile, all plugins run in `iframe`s within a `WebView`.
 
 On Android, it's possible to inspect this `WebView` with Google Chrome's development tools. To do this,
 1. Enable plugin WebView debugging. To do this, go to "Configuration" > "Plugins" > "Advanced settings" and enable "Plugin webview debugging".
 2. Restart Joplin.
 3. Follow the [Chrome devtools instructions for debugging Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/).
+
+
+## Getting console output from Joplin's logs
+
+By default, messages logged with `console.info`, `console.warn`, and `console.error` are added to Joplin's logs. To view these logs,
+1. Open Joplin's log screen (Configuration > Tools > Logs).
+2. Click "Search".
+3. A search box labeled "filter" should be available. Enter your plugin's ID (or a large part of it).
+
+If Joplin is running in development mode, messages logged with `console.log` are also added to Joplin's logs.
 
 

--- a/readme/api/references/mobile_plugin_debugging.md
+++ b/readme/api/references/mobile_plugin_debugging.md
@@ -1,6 +1,46 @@
 # Debugging mobile plugins
 
-On Android, it's possible to debug mobile plugins with the Chrome development tools. To do this,
+## Running on web
+
+It may be easiest to test custom mobile plugins in the [web build](https://joplin.github.io/web-app/) of Joplin mobile. This eliminates the need to transfer the plugin's built `.jpl` file to an Android device after every change.
+
+To install a custom plugin on web,
+1. Build your plugin (run `npm run dist` from the plugin's directory).
+2. Open [web build](https://joplin.github.io/web-app/) of Joplin mobile.
+3. Go to "Configuration" > "Plugins" > "Enable plugin support" > "Advanced".
+4. Click "Install from file".
+5. Navigate to the base directory of your plugin.
+6. Open the `publish/` folder.
+7. Select the `.jpl` file.
+
+Your plugin should now be loaded!
+
+:::note
+
+If you encounter an "incompatible with Joplin mobile" error, be sure that `"platforms": ["mobile", "desktop"]` is included in your plugin's `manifest.json` ([documentation](./plugin_manifest.md)).
+
+:::
+
+After loading, plugins are run in an `<iframe>` with an `about:srcdoc` URL.
+
+
+## Getting console output
+
+By default, messages logged with `console.info`, `console.warn`, and `console.error` are added to Joplin's logs. To view these logs,
+1. Open Joplin's log screen (Configuration > Tools > Logs).
+2. Click "Search".
+3. Type your plugin's ID (or a large part of it) into the "filter" input.
+
+If Joplin is running in development mode, messages logged with `console.log` are also added to Joplin's logs.
+
+
+## Android: Inspecting a WebView
+
+On mobile, all plugins run in a `WebView`.
+
+On Android, it's possible to inspect this `WebView` with Google Chrome's development tools. To do this,
 1. Enable plugin WebView debugging. To do this, go to "Configuration" > "Plugins" > "Advanced settings" and enable "Plugin webview debugging".
 2. Restart Joplin.
 3. Follow the [Chrome devtools instructions for debugging Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/).
+
+

--- a/readme/api/references/mobile_plugin_debugging.md
+++ b/readme/api/references/mobile_plugin_debugging.md
@@ -2,7 +2,9 @@
 
 ## Running on web
 
-It may be easiest to test custom mobile plugins in the [web build](https://joplin.github.io/web-app/) of Joplin mobile. This eliminates the need to transfer the plugin's built `.jpl` file to an Android device after every change.
+Plugins can be installed from `.jpl` files in the [web build](https://joplin.github.io/web-app/) of the mobile app. This can help with mobile plugin development in a few ways:
+- Eliminates the need to transfer the plugin's built `.jpl` file to an Android device after every change.
+- It may be easier to inspect running plugins from a browser's development tools.
 
 To install a custom plugin on web,
 1. Build your plugin (run `npm run dist` from the plugin's directory).
@@ -21,7 +23,14 @@ If you encounter an "incompatible with Joplin mobile" error, be sure that `"plat
 
 :::
 
-After loading, plugins are run in an `<iframe>` with an `about:srcdoc` URL.
+After loading, plugins are run in an `<iframe>` with an `about:srcdoc` URL. To view the plugin's console output and interact with global plugin variables (e.g. `joplin.commands`),
+1. Open your browser's development tools.
+   - On most desktop browsers, this can be done by pressing <kbd>F12</kbd>.
+   - The following steps were tested on Firefox, Chrome, and Safari desktop.
+2. Click on the "Console" tab.
+3. To run JavaScript in the context of your plugin, [select its JavaScript context](https://developer.chrome.com/docs/devtools/console/reference#context).
+   - The JavaScript context will be named `about:srcdoc`.
+   - If using Chrome's DevTools, the [`debug`](https://developer.chrome.com/docs/devtools/console/utilities#debug-function) and other console utility function may be helpful.
 
 
 ## Getting console output


### PR DESCRIPTION
# Summary

This pull request adds instructions for running custom mobile plugins on the web build of Joplin mobile.

The web build of Joplin mobile can simplify mobile plugin development particularly if a plugin author does not have access to an Android device with Joplin.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->