### PR TITLE
Docs: Fix typo: Change "Table of Content" to "Table of Contents"

### DIFF
--- a/readme/api/tutorials/toc_plugin.md
+++ b/readme/api/tutorials/toc_plugin.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 1
 ---
-# Creating a table of content plugin
+# Creating a table of contents plugin
 
-This tutorial will guide you through the steps to create a table of content plugin for Joplin. It will display a view next to the current note that will contain links to the sections of a note. It will be possible to click on one of the header to jump to the relevant section.
+This tutorial will guide you through the steps to create a table of contents plugin for Joplin. It will display a view next to the current note that will contain links to the sections of a note. It will be possible to click on one of the header to jump to the relevant section.
 
 Through this tutorial you will learn about several aspect of the Joplin API, including:
 


### PR DESCRIPTION
# Summary

This pull request changes "Table of Content" to "Table of Contents".

**Notes**:
- "Table of Contents" is the spelling [used by the relevant Wikipedia article](https://en.wikipedia.org/wiki/Table_of_contents).
- Based on Google Books' Ngram viewer, "Table of Contents" seems to be significantly more popular than "Table of Content" ([usage graph for all English](https://books.google.com/ngrams/graph?content=table+of+content%2Ctable+of+contents&year_start=1800&year_end=2022&corpus=en&smoothing=3), [usage graph for British English](https://books.google.com/ngrams/graph?content=table+of+content%2Ctable+of+contents&year_start=1800&year_end=2022&corpus=en-GB&smoothing=3&case_insensitive=false)).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->