### PR TITLE
Desktop: Fix crash on opening certain plugin dialogs

### DIFF
--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -116,7 +116,7 @@ const useDialogClassNames = (dialogElement: HTMLElement|null, classNames: undefi
 		// The React className prop can include multiple space-separated classes
 		const newClassNames = classNames
 			.split(/\s+/)
-			.filter(name => !dialogElement.classList.contains(name));
+			.filter(name => name.length && !dialogElement.classList.contains(name));
 		dialogElement.classList.add(...newClassNames);
 
 		return () => {


### PR DESCRIPTION
# Summary

This pull request fixes a crash from `.classList.add`:
```
Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.
```

This was caused by certain dialogs that have a `className` property that starts or ends with a space, including the dialog created by the Freehand Drawing plugin. In particular, `"these are css-class-names ".split(/\s+/)` is `['these', 'are', 'css-class-names', '']`, which includes an invalid CSS class name.

# Testing plan

1. Open the Freehand Drawing plugin's drawing dialog.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->