### PR TITLE
Desktop: Fixes #10828: Fix error when canceling bulk PDF export

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/exportPdf.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/exportPdf.ts
@@ -3,7 +3,7 @@ import shim from '@joplin/lib/shim';
 import InteropServiceHelper from '../../../InteropServiceHelper';
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
-const bridge = require('@electron/remote').require('./bridge').default;
+import bridge from '../../../services/bridge';
 
 export const declaration: CommandDeclaration = {
 	name: 'exportPdf',
@@ -29,6 +29,14 @@ export const runtime = (comp: any): CommandRuntime => {
 					path = await bridge().showOpenDialog({
 						properties: ['openDirectory', 'createDirectory'],
 					});
+				}
+
+				if (Array.isArray(path)) {
+					if (path.length > 1) {
+						throw new Error('Only one output directory can be selected');
+					}
+
+					path = path[0];
 				}
 
 				if (!path) return;


### PR DESCRIPTION
# Summary

This pull request fixes #10828 — `bridge().showOpenDialog()` returns `string|string[]`. When no output paths were selected, it returned an empty array (`[]`).

Existing code assumed that  `bridge().showOpenDialog()` always returns a `string`.

# Testing plan

1. Select two notes.
2. Click "Export" > "PDF".
3. Click "Cancel".
4. Verify that no error dialog is shown.
5. Select the same two notes.
6. Click "Export", then "PDF".
7. Select an empty output directory.
8. Click "Open".
9. Verify that the directory now contains two PDF files.

This has been tested successfully on Ubuntu 24.04.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->