### PR TITLE
Desktop: Resolves #10746: Fix "View OCR text" not present in context menu when right-clicking an image

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -150,7 +150,10 @@ export function menuItems(dispatch: Function, htmlToMd: HtmlToMarkdownHandler, m
 					bridge().showInfoMessageBox(_('This attachment does not have OCR data (Status: %s)', resourceOcrStatusToString(resource.ocr_status)));
 				}
 			},
-			isActive: (itemType: ContextMenuItemType, _options: ContextMenuOptions) => itemType === ContextMenuItemType.Resource,
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
+				if (itemType === ContextMenuItemType.Resource) return true;
+				return itemType === ContextMenuItemType.Image && options.resourceId;
+			},
 		},
 		copyPathToClipboard: {
 			label: _('Copy path to clipboard'),

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -151,8 +151,7 @@ export function menuItems(dispatch: Function, htmlToMd: HtmlToMarkdownHandler, m
 				}
 			},
 			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
-				if (itemType === ContextMenuItemType.Resource) return true;
-				return itemType === ContextMenuItemType.Image && options.resourceId;
+				return itemType === ContextMenuItemType.Resource || (itemType === ContextMenuItemType.Image && options.resourceId);
 			},
 		},
 		copyPathToClipboard: {


### PR DESCRIPTION
# Summary

This pull request shows the "View OCR text" context menu item when right-clicking on an image.

This should resolve #10746.

# Testing plan

1. If OCR is disabled, enable it.
2. Open the note viewer (not the Rich Text Editor).
3. Right-click on an image resource attached as an image (with `![...](:/...)` Markdown syntax).
4. Click "View OCR text".
5. Verify that OCR text is shown.
6. Right-click on an image resource attached as a resource link (with `[...](:/...)` Markdown syntax).\
7. Repeat steps 4-5.
8. Right-click on text in a web link.
9. Verify that "View OCR text" is **not** included in the context menu.
10. Switch to the Rich Text editor and repeat steps 3-9.

This has been tested successfully on Ubuntu 24.04.

> [!NOTE]
>
> While testing, I observed that right-clicking on a note link also shows "View OCR text". This issue also seems to be present in Joplin 3.0.13.
>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->