### PR TITLE
Desktop: Resolves #10835: Allow specifying custom language data URLs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
 		'ReadableStreamDefaultReader': 'readonly',
 		'FileSystemCreateWritableOptions': 'readonly',
 		'FileSystemHandle': 'readonly',
+		'IDBTransactionMode': 'readonly',
 
 		// ServiceWorker
 		'ExtendableEvent': 'readonly',

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -104,6 +104,10 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			Setting.setValue('sync.startupOperation', SyncStartupOperation.ClearLocalData);
 			await Setting.saveAll();
 			await restart();
+		} else if (key === 'ocr.clearLanguageDataCacheButton') {
+			if (!confirm(_('Joplin needs to restart to apply this change. Do you want to continue?'))) return;
+			Setting.setValue('ocr.clearLanguageDataCache', true);
+			await restart();
 		} else if (key === 'sync.openSyncWizard') {
 			this.props.dispatch({
 				type: 'DIALOG_OPEN',

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -105,7 +105,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			await Setting.saveAll();
 			await restart();
 		} else if (key === 'ocr.clearLanguageDataCacheButton') {
-			if (!confirm(_('Joplin needs to restart to apply this change. Do you want to continue?'))) return;
+			if (!confirm(this.restartMessage())) return;
 			Setting.setValue('ocr.clearLanguageDataCache', true);
 			await restart();
 		} else if (key === 'sync.openSyncWizard') {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -504,7 +504,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 			public: true,
 			appTypes: [AppType.Desktop],
-			label: () => _('OCR: Language data URL or file path'),
+			label: () => _('OCR: Language data URL or path'),
 			storage: SettingStorage.File,
 			isGlobal: true,
 		},

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -513,14 +513,19 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'ocr.clearLanguageDataCache': {
 			value: false,
 			type: SettingItemType.Bool,
+			public: false,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.Database,
+		},
+
+		'ocr.clearLanguageDataCacheButton': {
+			value: null as null,
+			type: SettingItemType.Button,
 			advanced: true,
 			public: true,
 			appTypes: [AppType.Desktop],
 			label: () => _('OCR: Clear cache and re-download language data files'),
-			description: () => _('Re-downloads language data files on the next restart.'),
-			storage: SettingStorage.Database,
-			needRestart: true,
-			autoSave: true,
+			description: () => _('Re-downloads cached language data files on the next restart.'),
 		},
 
 		theme: {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -520,6 +520,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			description: () => _('Re-downloads language data files on the next restart.'),
 			storage: SettingStorage.Database,
 			needRestart: true,
+			autoSave: true,
 		},
 
 		theme: {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -498,6 +498,30 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'ocr.languageDataPath': {
+			value: '',
+			type: SettingItemType.String,
+			advanced: true,
+			public: true,
+			appTypes: [AppType.Desktop],
+			label: () => _('OCR: Language data URL'),
+			description: () => _('A URL or path to a directory with language data files for OCR. After the first download, language data files will be cached to the file system. Leave this blank to download OCR language data from the default website.'),
+			storage: SettingStorage.File,
+			isGlobal: true,
+		},
+
+		'ocr.clearLanguageDataCache': {
+			value: false,
+			type: SettingItemType.Bool,
+			advanced: true,
+			public: true,
+			appTypes: [AppType.Desktop],
+			label: () => _('OCR: Clear cache and re-download language data files'),
+			description: () => _('Re-downloads language data files on the next restart.'),
+			storage: SettingStorage.Database,
+			needRestart: true,
+		},
+
 		theme: {
 			value: Setting.THEME_LIGHT,
 			type: SettingItemType.Int,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -504,8 +504,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 			public: true,
 			appTypes: [AppType.Desktop],
-			label: () => _('OCR: Language data URL'),
-			description: () => _('A URL or path to a directory with language data files for OCR. After the first download, language data files will be cached to the file system. Leave this blank to download OCR language data from the default website.'),
+			label: () => _('OCR: Language data URL or file path'),
 			storage: SettingStorage.File,
 			isGlobal: true,
 		},
@@ -525,7 +524,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			public: true,
 			appTypes: [AppType.Desktop],
 			label: () => _('OCR: Clear cache and re-download language data files'),
-			description: () => _('Re-downloads cached language data files on the next restart.'),
 		},
 
 		theme: {

--- a/packages/lib/services/ocr/drivers/OcrDriverTesseract.ts
+++ b/packages/lib/services/ocr/drivers/OcrDriverTesseract.ts
@@ -76,9 +76,7 @@ export default class OcrDriverTesseract extends OcrDriverBase {
 		};
 
 		const allKeys = await requestAsPromise<string[]>(getStore('readonly').getAllKeys());
-		// cSpell:disable
 		const languageDataExtension = '.traineddata';
-		// cSpell:enable
 		const keysToClear = allKeys.filter(key => key.endsWith(languageDataExtension));
 		for (const key of keysToClear) {
 			logger.info('Clearing language data with key', key);

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1072,7 +1072,7 @@ const simulateReadOnlyShareEnv = (shareId: string, store?: Store) => {
 };
 
 export const newOcrService = () => {
-	const driver = new OcrDriverTesseract({ createWorker });
+	const driver = new OcrDriverTesseract({ createWorker }, { workerPath: null, corePath: null, languageDataPath: null });
 	return new OcrService(driver);
 };
 

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -121,3 +121,4 @@ COEP
 Stormlikes
 Stormlikes
 BYTV
+keyval

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -122,3 +122,4 @@ Stormlikes
 Stormlikes
 BYTV
 keyval
+traineddata

--- a/readme/apps/ocr.md
+++ b/readme/apps/ocr.md
@@ -32,6 +32,8 @@ This pluggable interface is present in the software but not currently exposed. W
 
 ## Custom OCR language data URL
 
-After enabling OCR, Joplin downloads language files from https://cdn.jsdelivr.net/npm/@tesseract.js-data/. This URL can be customized in settings > advanced > "OCR: Language data URL or file path".
+After enabling OCR, Joplin downloads language files from https://cdn.jsdelivr.net/npm/@tesseract.js-data/. This URL can be customized in settings > advanced > "OCR: Language data URL or path". This URL or path should point to a directory with a `.traineddata.gz` file for each language to be used for OCR.
+
+For reference, an example `.traineddata.gz` file can be found [here](https://cdn.jsdelivr.net/npm/@tesseract.js-data/eng/4.0.0_best_int/eng.traineddata.gz).
 
 To fully replace the cached language data with custom data, it may be necessary to click "Clear cache and re-download language data files".

--- a/readme/apps/ocr.md
+++ b/readme/apps/ocr.md
@@ -29,3 +29,9 @@ OCR is a technology that evolves rapidly especially with the recent advances in 
 Additionally in some cases it may make sense to use a cloud-based solution, or simply connect to your self-hosted or intranet-based server for OCR. The current system will allow this by writing specific drivers for these services.
 
 This pluggable interface is present in the software but not currently exposed. We will do so depending on feedback we receive and potential use cases. If you have any specific use case in mind or notice any issue with the current OCR system feel free to let us know [on the forum](https://discourse.joplinapp.org/).
+
+## Custom OCR language data URL
+
+After enabling OCR, Joplin downloads language files from https://cdn.jsdelivr.net/npm/@tesseract.js-data/. This URL can be customized in settings > advanced > "OCR: Language data URL or file path".
+
+To fully replace the cached language data with custom data, it may be necessary to click "Clear cache and re-download language data files".

--- a/readme/privacy.md
+++ b/readme/privacy.md
@@ -13,6 +13,7 @@ In order to provide certain features, Joplin may need to connect to third-party 
 | Spellchecker dictionary | On Linux and Windows, the desktop application downloads the spellchecker dictionary from `redirector.gvt1.com`. | Enabled | Yes <sup>(2)</sup> |
 | Plugin repository | The desktop application downloads the list of available plugins from the [official GitHub repository](https://github.com/joplin/plugins). If this repository is not accessible (eg. in China) the app will try to get the plugin list from [various mirrors](https://github.com/laurent22/joplin/blob/8ac6017c02017b6efd59f5fcab7e0b07f8d44164/packages/lib/services/plugins/RepositoryApi.ts#L22), in which case the plugin screen [works slightly differently](https://github.com/laurent22/joplin/issues/5161#issuecomment-925226975). | Enabled | No
 | Voice typing | If you use the voice typing feature on Android, the application will download the language files from https://alphacephei.com/vosk/models | Disabled | Yes
+| OCR | If you have enabled optical character recognition on desktop, the application will download the language files from https://cdn.jsdelivr.net/npm/@tesseract.js-data/. | Disabled | Yes 
 | Crash reports | If you have enabled crash auto-upload, the application will upload the report to Sentry when a crash happens. When Sentry is initialised it will also connect to `sentry.io`. | Disabled | Yes
 
 <sup>(1) https://github.com/laurent22/joplin/issues/5705</sup><br/>


### PR DESCRIPTION
# Summary

This pull request resolves #10835 by making it possible to set a custom URL for OCR `.traineddata.gz` files.

To allow users to switch from the internet-downloaded files to local files and to facilitate testing, this PR also,
1. Re-enables OCR language data file caching in dev mode.
   - Cached language data files seem to work for me in dev mode. As such, I suspect that the [issue that caused us to disable dev-mode caching](https://github.com/naptha/tesseract.js/issues/901) has either been fixed, or can be addressed by clearing the cache (see 2).
2. Adds a button to clear the language data cache.

# Screenshot

![screenshot: OCR Language data or path input, OCR: Clear cache and re-download language data files button](https://github.com/user-attachments/assets/93f0bdba-9b43-4458-9e1e-ba540974e2bb)



# Testing

1. Enable OCR if not yet enabled.
2. Attach an image with text to a note.
3. Open the development tools and navigate to the "Application" tab.
4. Verify that a database exists with name `keyval-store`.
5. Verify that a key with name `./eng.traineddata` is present in `keyval-store` (within an `objectStore` named `keyval`).
6. Set the application language to "Español (España)" and repeat steps 2-5.
7. Verify that a key with name `./spa.traineddata` is present in `keyval-store` (it may be necessary to click the "refresh" button in the database devtools first).
8. Set the app language back to English.
9. Open settings > general > advanced.
10. Download the English trianing data from jsdelivr (https://cdn.jsdelivr.net/npm/@tesseract.js-data/eng/4.0.0_best_int/eng.traineddata.gz). Store it in a folder.
11. Copy the folder path and paste it into the "OCR: Language data URL" input in settings
12. Click "Apply"
	- Possible improvement: Unsaved settings currently won't be saved without this.
14. Click "OCR: Clear cache and re-download language data files"
15. Restart the app.
16. Attach an image with text.
18. Open "Application" in the development tools.
19. Verify that the keyval table has only `./eng.traineddata`.
20. Check the "Network" tab and verify that no requests to `jsdelivr` were made.
	- **Note**: I cleared the network logs before inspecting them. As a result, I repeated steps 14-29 before proceeding to step 20.
21. Verify that `eng.traineddata.gz` is shown as being downloaded from a `file://` URL.
22. Convert the last-attached image to a link. Right-click on it and verify that OCR text was created.