### PR TITLE
iOS: Fix crash on opening the sidebar

### DIFF
--- a/packages/app-mobile/components/accessibility/AccessibleView.tsx
+++ b/packages/app-mobile/components/accessibility/AccessibleView.tsx
@@ -33,11 +33,15 @@ const AccessibleView: React.FC<Props> = ({ inert, refocusCounter, children, ...v
 		if ((refocusCounter ?? null) === null) return;
 
 		const autoFocus = () => {
-			// react-native-web defines UIManager.focus for setting the keyboard focus. However,
-			// this property is not available in standard react-native. As such, access it using type
-			// narrowing:
-			// eslint-disable-next-line no-restricted-properties
-			if ('focus' in UIManager && typeof UIManager.focus === 'function') {
+			if (Platform.OS === 'web') {
+				// react-native-web defines UIManager.focus for setting the keyboard focus. However,
+				// this property is not available in standard react-native. As such, access it using type
+				// narrowing:
+				// eslint-disable-next-line no-restricted-properties
+				if (!('focus' in UIManager) || typeof UIManager.focus !== 'function') {
+					throw new Error('Failed to focus sidebar. UIManager.focus is not a function.');
+				}
+
 				// Disable the "use focusHandler for all focus calls" rule -- UIManager.focus requires
 				// an argument, which is not supported by focusHandler.
 				// eslint-disable-next-line no-restricted-properties


### PR DESCRIPTION
# Summary

This pull request fixes a crash on iOS when opening the sidebar, caused by web-app-only code being activated.

**Note**: It's possible that this crash only occurs in development mode or on certain devices.

# Testing plan


**On an iOS 17.4 simulator**:
1. Start Joplin
2. Open the sidebar
3. Verify that Joplin doesn't crash.

**On Web (regression testing)**:
1. Start Joplin
2. Open the sidebar
3. Press <kbd>tab</kbd>
4. Verify that the sidebar has focus.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->