### PR TITLE
Seamless-Updates - added flow for automatic updates for releases

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -363,6 +363,7 @@ export default class ElectronAppWrapper {
 	}
 
 	public quit() {
+		this.stopLookingForUpdates();
 		this.electronApp_.quit();
 	}
 
@@ -471,6 +472,12 @@ export default class ElectronAppWrapper {
 		if (shim.isWindows() || shim.isMac()) {
 			this.updaterService_ = new AutoUpdaterService(this.win_, logger, initializedShim, devMode, includePreReleases);
 			this.updaterService_.startPeriodicUpdateCheck();
+		}
+	}
+
+	public stopLookingForUpdates() {
+		if (this.updaterService_ !== null) {
+			this.updaterService_.stopPeriodicUpdateCheck();
 		}
 	}
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -5,7 +5,8 @@ import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/Plug
 import resourceEditWatcherReducer, { defaultState as resourceEditWatcherDefaultState } from '@joplin/lib/services/ResourceEditWatcher/reducer';
 import PluginRunner from './services/plugins/PluginRunner';
 import PlatformImplementation from './services/plugins/PlatformImplementation';
-import shim from '@joplin/lib/shim';
+import type ShimType from '@joplin/lib/shim';
+const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import AlarmService from '@joplin/lib/services/AlarmService';
 import AlarmServiceDriverNode from '@joplin/lib/services/AlarmServiceDriverNode';
 import Logger, { TargetType } from '@joplin/utils/Logger';

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -59,7 +59,6 @@ const globalCommands = appCommands.concat(libCommands);
 import editorCommandDeclarations from './gui/NoteEditor/editorCommandDeclarations';
 import PerFolderSortOrderService from './services/sortOrder/PerFolderSortOrderService';
 import ShareService from '@joplin/lib/services/share/ShareService';
-import checkForUpdates from './checkForUpdates';
 import { AppState } from './app.reducer';
 import syncDebugLog from '@joplin/lib/services/synchronizer/syncDebugLog';
 import eventManager, { EventName } from '@joplin/lib/eventManager';
@@ -566,22 +565,6 @@ class Application extends BaseApplication {
 			value: Setting.value('flagOpenDevTools'),
 		});
 
-		// Note: Auto-update is a misnomer in the code.
-		// The code below only checks, if a new version is available.
-		// We only allow Windows and macOS users to automatically check for updates
-		if (shim.isWindows() || shim.isMac()) {
-			const runAutoUpdateCheck = () => {
-				if (Setting.value('autoUpdateEnabled')) {
-					void checkForUpdates(true, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
-				}
-			};
-
-			// Initial check on startup
-			shim.setTimeout(() => { runAutoUpdateCheck(); }, 5000);
-			// Then every x hours
-			shim.setInterval(() => { runAutoUpdateCheck(); }, 12 * 60 * 60 * 1000);
-		}
-
 		initializeUserFetcher();
 		shim.setInterval(() => { void userFetcher(); }, 1000 * 60 * 60);
 
@@ -684,6 +667,13 @@ class Application extends BaseApplication {
 		eventManager.on(EventName.NoteResourceIndexed, async () => {
 			SearchEngine.instance().scheduleSyncTables();
 		});
+
+		bridge().electronApp().initializeAutoUpdaterService(
+			Logger.create('AutoUpdaterService'),
+			shim,
+			Setting.value('env') === 'dev',
+			Setting.value('autoUpdate.includePreReleases'),
+		);
 
 		// setTimeout(() => {
 		// 	void populateDatabase(reg.db(), {

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -8,6 +8,7 @@ import { AutoUpdaterEvents } from '../../services/autoUpdater/AutoUpdaterService
 import { NotyfNotification } from 'notyf';
 import { _ } from '@joplin/lib/locale';
 import { htmlentities } from '@joplin/utils/html';
+import shim from '@joplin/lib/shim';
 
 interface UpdateNotificationProps {
 	themeId: number;
@@ -21,7 +22,7 @@ export enum UpdateNotificationEvents {
 const changelogLink = 'https://github.com/laurent22/joplin/releases';
 
 window.openChangelogLink = () => {
-	ipcRenderer.send('open-link', changelogLink);
+	shim.openUrl(changelogLink);
 };
 
 const UpdateNotification = ({ themeId }: UpdateNotificationProps) => {

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -112,9 +112,6 @@
         "MimeType": "x-scheme-handler/joplin;"
       },
       "target": "AppImage"
-    },
-    "dmg": {
-      "writeUpdateInfo": false
     }
   },
   "homepage": "https://github.com/laurent22/joplin#readme",

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -1,8 +1,8 @@
-import { app } from 'electron';
+import { BrowserWindow } from 'electron';
 import { autoUpdater, UpdateInfo } from 'electron-updater';
-import log from 'electron-log';
 import path = require('path');
 import { setInterval } from 'timers';
+import Logger, { LoggerWrapper } from '@joplin/utils/Logger';
 
 
 export enum AutoUpdaterEvents {
@@ -24,18 +24,33 @@ export interface AutoUpdaterServiceInterface {
 }
 
 export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
+	private window_: BrowserWindow;
+	private logger_: LoggerWrapper;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	private initializedShim_: any;
+	private devMode_: boolean;
 	private updatePollInterval_: ReturnType<typeof setInterval>|null = null;
+	private enableDevMode = true; // force the updater to work in "dev" mode
+	private enableAutoDownload = false; // automatically download an update when it is found
+	private allowPrerelease_ = false;
+	private allowDowngrade = false;
 
-	public constructor() {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	public constructor(mainWindow: BrowserWindow, logger: LoggerWrapper, initializedShim: any, devMode: boolean, allowPrereleaseUpdates: boolean) {
+		this.window_ = mainWindow;
+		this.logger_ = logger;
+		this.initializedShim_ = initializedShim;
+		this.devMode_ = devMode;
+		this.allowPrerelease_ = allowPrereleaseUpdates;
 		this.configureAutoUpdater();
 	}
 
 	public startPeriodicUpdateCheck = (interval: number = defaultUpdateInterval): void => {
 		this.stopPeriodicUpdateCheck();
-		this.updatePollInterval_ = setInterval(() => {
+		this.updatePollInterval_ = this.initializedShim_.setInterval(() => {
 			void this.checkForUpdates();
 		}, interval);
-		setTimeout(this.checkForUpdates, initialUpdateStartup);
+		this.initializedShim_.setTimeout(this.checkForUpdates, initialUpdateStartup);
 	};
 
 	public stopPeriodicUpdateCheck = (): void => {
@@ -47,25 +62,31 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 
 	public checkForUpdates = async (): Promise<void> => {
 		try {
-			await autoUpdater.checkForUpdates(); // Use async/await
+			if (this.allowPrerelease_) {
+				// If this is set to true, then it will compare the versions semantically and it will also look at tags, so we need to manually get the latest pre-release
+				this.logger_.info('To be implemented...');
+			} else {
+				await autoUpdater.checkForUpdates();
+			}
 		} catch (error) {
-			log.error('Failed to check for updates:', error);
+			this.logger_.error('Failed to check for updates:', error);
 			if (error.message.includes('ERR_CONNECTION_REFUSED')) {
-				log.info('Server is not reachable. Will try again later.');
+				this.logger_.info('Server is not reachable. Will try again later.');
 			}
 		}
 	};
 
 	private configureAutoUpdater = (): void => {
-		autoUpdater.logger = log;
-		log.transports.file.level = 'info';
-		if (this.electronIsDev()) {
-			log.info('Development mode: using dev-app-update.yml');
+		autoUpdater.logger = (this.logger_) as Logger;
+		if (this.devMode_) {
+			this.logger_.info('Development mode: using dev-app-update.yml');
 			autoUpdater.updateConfigPath = path.join(__dirname, 'dev-app-update.yml');
-			autoUpdater.forceDevUpdateConfig = true;
+			autoUpdater.forceDevUpdateConfig = this.enableDevMode;
 		}
 
-		autoUpdater.autoDownload = false;
+		autoUpdater.autoDownload = this.enableAutoDownload;
+		autoUpdater.allowPrerelease = this.allowPrerelease_;
+		autoUpdater.allowDowngrade = this.allowDowngrade;
 
 		autoUpdater.on(AutoUpdaterEvents.CheckingForUpdate, this.onCheckingForUpdate);
 		autoUpdater.on(AutoUpdaterEvents.UpdateNotAvailable, this.onUpdateNotAvailable);
@@ -75,34 +96,36 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 		autoUpdater.on(AutoUpdaterEvents.Error, this.onError);
 	};
 
-	private electronIsDev = (): boolean => !app.isPackaged;
-
 	private onCheckingForUpdate = () => {
-		log.info('Checking for update...');
+		this.logger_.info('Checking for update...');
 	};
 
 	private onUpdateNotAvailable = (_info: UpdateInfo): void => {
-		log.info('Update not available.');
+		this.logger_.info('Update not available.');
 	};
 
 	private onUpdateAvailable = (info: UpdateInfo): void => {
-		log.info(`Update available: ${info.version}.`);
+		this.logger_.info(`Update available: ${info.version}.`);
 	};
 
 	private onDownloadProgress = (progressObj: { bytesPerSecond: number; percent: number; transferred: number; total: number }): void => {
-		log.info(`Download progress... ${progressObj.percent}% completed`);
+		this.logger_.info(`Download progress... ${progressObj.percent}% completed`);
 	};
 
 	private onUpdateDownloaded = (info: UpdateInfo): void => {
-		log.info('Update downloaded. It will be installed on restart.');
+		this.logger_.info('Update downloaded.');
 		void this.promptUserToUpdate(info);
 	};
 
 	private onError = (error: Error): void => {
-		log.error('Error in auto-updater.', error);
+		this.logger_.error('Error in auto-updater.', error);
 	};
 
 	private promptUserToUpdate = async (info: UpdateInfo): Promise<void> => {
-		log.info(`Update is available: ${info.version}.`);
+		this.window_.webContents.send(AutoUpdaterEvents.UpdateDownloaded, info);
+	};
+
+	public updateApp = (): void => {
+		autoUpdater.quitAndInstall(false, true);
 	};
 }

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -54,7 +54,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 
 	public stopPeriodicUpdateCheck = (): void => {
 		if (this.updatePollInterval_) {
-			clearInterval(this.updatePollInterval_);
+			this.initializedShim_.clearInterval(this.updatePollInterval_);
 			this.updatePollInterval_ = null;
 		}
 	};

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1552,6 +1552,18 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Mobile],
 		},
 
+		'featureFlag.autoUpdaterServiceEnabled': {
+			value: true,
+			type: SettingItemType.Bool,
+			public: true,
+			storage: SettingStorage.File,
+			label: () => 'Enable auto-updates',
+			description: () => 'Enable this feature to receive notifications about updates and install them instead of manually downloading them. Restart app to start receiving auto-updates.',
+			section: 'application',
+			isGlobal: true,
+		},
+
+
 		// 'featureFlag.syncAccurateTimestamps': {
 		// 	value: false,
 		// 	type: SettingItemType.Bool,


### PR DESCRIPTION
This PR contains:
- The logic of triggering both auto updates and the update notification. 
  - Since the update won't be automatically downloaded, the notification won't pop up yet. I set on purpose `enableAutoDownload = false`. This will be set to true in another PR. I will check how VsCode handles downloads (whether it automatically downloads them or after the user agrees to update). 
  - The second reason for this is that I would like to test in another PR the updating flow, and I would like to test in these next two PRs if the versions are correctly identified and if the latest.yml files are correctly generated.
- Finally managed to use internal logger and shim for different features (setInterval, logging etc).
- Used an existing feature flag for checking if prereleases should be considered when the user wants to be notified about an update.
- Deleted  "writeUpdateInfo" in package.json because I want to generate "latest-mac.yml".

The reason why I gave the variable the name "initializedShim": inside the logic of fetching prereleases (which will be in the next PR), I can't use the boolean functions that check the platform type (ex: `isWindows()`), but I can use `setInterval()` and `setTimeout()` functions. If I also import it in the file under a different name, I can access the platform check functions, but not the `setInterval` and `setTimeout` functions. I'll try to see why this happens in the next PR.

**Also, even if all the review changes are implemented, please do not merge this until I fully test on platforms different from Windows.**