### PR TITLE
Chore: Mobile,Testing: Fix keychain warning

### DIFF
--- a/packages/lib/services/keychain/KeychainService.ts
+++ b/packages/lib/services/keychain/KeychainService.ts
@@ -31,7 +31,7 @@ export default class KeychainService extends BaseService {
 			if (await driver.supported()) {
 				this.drivers_.push(driver);
 			} else {
-				logger.warn(`Driver unsupported:${driver.driverId}`);
+				logger.info(`Driver unsupported:${driver.driverId}`);
 			}
 		}
 	}


### PR DESCRIPTION
# Summary

This pull request fixes a warning while running tests and during startup on mobile. Previously, `KeychainService` logged a warning when a keychain driver is unsupported on the current platform. However, while running tests and on mobile, this is expected behavior.

This pull request changes the log message's level from `warn` to `info`. An alternative fix would be to use an empty array rather than including  mock `KeychainServiceDriver`s that do not work on any platform.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->