### PR TITLE
Desktop: Allow searching when only the note viewer is visible and sync search with editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -841,9 +841,11 @@ packages/editor/CodeMirror/utils/formatting/toggleRegionFormatGlobally.test.js
 packages/editor/CodeMirror/utils/formatting/toggleRegionFormatGlobally.js
 packages/editor/CodeMirror/utils/formatting/toggleSelectedLinesStartWith.js
 packages/editor/CodeMirror/utils/formatting/types.js
+packages/editor/CodeMirror/utils/getSearchState.js
 packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
+packages/editor/CodeMirror/utils/searchExtension.js
 packages/editor/CodeMirror/utils/setupVim.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js

--- a/.gitignore
+++ b/.gitignore
@@ -818,9 +818,11 @@ packages/editor/CodeMirror/utils/formatting/toggleRegionFormatGlobally.test.js
 packages/editor/CodeMirror/utils/formatting/toggleRegionFormatGlobally.js
 packages/editor/CodeMirror/utils/formatting/toggleSelectedLinesStartWith.js
 packages/editor/CodeMirror/utils/formatting/types.js
+packages/editor/CodeMirror/utils/getSearchState.js
 packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
+packages/editor/CodeMirror/utils/searchExtension.js
 packages/editor/CodeMirror/utils/setupVim.js
 packages/editor/SelectionFormatting.js
 packages/editor/events.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -686,6 +686,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		editorRef,
 		noteContent: props.content,
 		renderedBody,
+		showEditorMarkers: true,
 	});
 
 	const cellEditorStyle = useMemo(() => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -13,12 +13,15 @@ import { dirname } from 'path';
 import useKeymap from './utils/useKeymap';
 import useEditorSearch from '../utils/useEditorSearchExtension';
 import CommandService from '@joplin/lib/services/CommandService';
+import { SearchMarkers } from '../../../utils/useSearchMarkers';
 
 interface Props extends EditorProps {
 	style: React.CSSProperties;
 	pluginStates: PluginStates;
 
 	onEditorPaste: (event: Event)=> void;
+	externalSearch: SearchMarkers;
+	useLocalSearch: boolean;
 }
 
 const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
@@ -116,6 +119,25 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 		};
 	// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Should run just once
 	}, []);
+
+	useEffect(() => {
+		if (!editor) {
+			return;
+		}
+
+		const searchState = editor.getSearchState();
+		const externalSearchText = props.externalSearch.keywords.map(k => k.value).join(' ') || searchState.searchText;
+
+		if (externalSearchText === searchState.searchText && searchState.dialogVisible === props.useLocalSearch) {
+			return;
+		}
+
+		editor.setSearchState({
+			...searchState,
+			dialogVisible: props.useLocalSearch,
+			searchText: externalSearchText,
+		});
+	}, [editor, props.externalSearch, props.useLocalSearch]);
 
 	const theme = props.settings.themeData;
 	useEffect(() => {

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -411,6 +411,9 @@ function NoteEditor(props: NoteEditorProps) {
 		noteToolbar: null,
 		onScroll: onScroll,
 		setLocalSearchResultCount: setLocalSearchResultCount,
+		setLocalSearch: localSearch_change,
+		setShowLocalSearch,
+		useLocalSearch: showLocalSearch,
 		searchMarkers: searchMarkers,
 		visiblePanes: props.noteVisiblePanes || ['editor', 'viewer'],
 		keyboardMode: Setting.value('editor.keyboardMode'),
@@ -506,6 +509,7 @@ function NoteEditor(props: NoteEditorProps) {
 				onPrevious={localSearch_previous}
 				onClose={localSearch_close}
 				visiblePanes={props.noteVisiblePanes}
+				editorType={props.bodyEditor}
 			/>
 		);
 	}

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -6,6 +6,7 @@ import { RenderResult, RenderResultPluginAsset } from '@joplin/renderer/types';
 import { Dispatch } from 'redux';
 import { ProcessResultsRow } from '@joplin/lib/services/search/SearchEngine';
 import { DropHandler } from './useDropHandler';
+import { SearchMarkers } from './useSearchMarkers';
 
 export interface AllAssetsOptions {
 	contentMaxWidthTarget?: string;
@@ -119,8 +120,11 @@ export interface NoteBodyEditorProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	noteToolbar: any;
 	setLocalSearchResultCount(count: number): void;
+	setLocalSearch(search: string): void;
+	setShowLocalSearch(show: boolean): void;
+	useLocalSearch: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	searchMarkers: any;
+	searchMarkers: SearchMarkers;
 	visiblePanes: string[];
 	keyboardMode: string;
 	resourceInfos: ResourceInfos;

--- a/packages/app-desktop/gui/NoteSearchBar.tsx
+++ b/packages/app-desktop/gui/NoteSearchBar.tsx
@@ -18,6 +18,7 @@ interface Props {
 	resultCount: number;
 	selectedIndex: number;
 	visiblePanes: string[];
+	editorType: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	style: any;
 }
@@ -26,6 +27,7 @@ class NoteSearchBar extends React.Component<Props> {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private backgroundColor: any;
+	private searchInputRef: React.RefObject<HTMLInputElement>;
 
 	public constructor(props: Props) {
 		super(props);
@@ -40,6 +42,7 @@ class NoteSearchBar extends React.Component<Props> {
 		this.focus = this.focus.bind(this);
 
 		this.backgroundColor = undefined;
+		this.searchInputRef = React.createRef();
 	}
 
 	public style() {
@@ -133,10 +136,8 @@ class NoteSearchBar extends React.Component<Props> {
 	}
 
 	public focus() {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		focus('NoteSearchBar::focus', this.refs.searchInput as any);
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		(this.refs.searchInput as any).select();
+		focus('NoteSearchBar::focus', this.searchInputRef.current);
+		this.searchInputRef.current?.select();
 	}
 
 	public render() {
@@ -173,13 +174,17 @@ class NoteSearchBar extends React.Component<Props> {
 			</div>
 		) : null;
 
-		const allowScrolling = this.props.visiblePanes.indexOf('editor') >= 0;
+		const editorVisible = this.props.visiblePanes.includes('editor');
+		const usesEditorSearch = this.props.editorType === 'CodeMirror6' && editorVisible;
+		const allowScrolling = editorVisible;
 
 		const viewerWarning = (
 			<div style={textStyle}>
 				{'Jumping between matches is not available in the viewer, please toggle the editor'}
 			</div>
 		);
+
+		if (usesEditorSearch) return null;
 
 		return (
 			<div className="note-search-bar" style={this.props.style}>
@@ -190,7 +195,7 @@ class NoteSearchBar extends React.Component<Props> {
 						value={query}
 						onChange={this.searchInput_change}
 						onKeyDown={this.searchInput_keyDown}
-						ref="searchInput"
+						ref={this.searchInputRef}
 						type="text"
 						style={{ width: 200, marginRight: 5, backgroundColor: this.backgroundColor, color: theme.color }}
 					/>

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -84,7 +84,7 @@ test.describe('markdownEditor', () => {
 		const matches = viewer.locator('mark');
 		await expect(matches).toHaveCount(0);
 
-		await mainWindow.keyboard.press('Control+f');
+		await mainWindow.keyboard.press(process.platform === 'darwin' ? 'Command+f' : 'Control+f');
 		await expect(noteEditor.editorSearchInput).toBeVisible();
 
 		await noteEditor.editorSearchInput.click();

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -84,7 +84,7 @@ test.describe('markdownEditor', () => {
 		const matches = viewer.locator('mark');
 		await expect(matches).toHaveCount(0);
 
-		await mainWindow.keyboard.press(process.platform === 'darwin' ? 'Command+f' : 'Control+f');
+		await mainWindow.keyboard.press(process.platform === 'darwin' ? 'Meta+f' : 'Control+f');
 		await expect(noteEditor.editorSearchInput).toBeVisible();
 
 		await noteEditor.editorSearchInput.click();

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -85,8 +85,9 @@ test.describe('markdownEditor', () => {
 		await expect(matches).toHaveCount(0);
 
 		await mainWindow.keyboard.press('Control+f');
-		await expect(noteEditor.editorSearchInput).toBeFocused();
+		await expect(noteEditor.editorSearchInput).toBeVisible();
 
+		await noteEditor.editorSearchInput.click();
 		await noteEditor.editorSearchInput.fill('test');
 		await mainWindow.keyboard.press('Enter');
 

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -7,6 +7,9 @@ export default class NoteEditorPage {
 	public readonly noteTitleInput: Locator;
 	public readonly attachFileButton: Locator;
 	public readonly toggleEditorsButton: Locator;
+	public readonly toggleEditorLayoutButton: Locator;
+	public readonly editorSearchInput: Locator;
+	public readonly viewerSearchInput: Locator;
 	private readonly containerLocator: Locator;
 
 	public constructor(private readonly page: Page) {
@@ -16,6 +19,10 @@ export default class NoteEditorPage {
 		this.noteTitleInput = this.containerLocator.locator('.title-input');
 		this.attachFileButton = this.containerLocator.getByRole('button', { name: 'Attach file' });
 		this.toggleEditorsButton = this.containerLocator.getByRole('button', { name: 'Toggle editors' });
+		this.toggleEditorLayoutButton = this.containerLocator.getByRole('button', { name: 'Toggle editor layout' });
+		// The editor and viewer have slightly different search UI
+		this.editorSearchInput = this.containerLocator.getByPlaceholder('Find');
+		this.viewerSearchInput = this.containerLocator.getByPlaceholder('Search...');
 	}
 
 	public toolbarButtonLocator(title: string) {
@@ -26,7 +33,7 @@ export default class NoteEditorPage {
 		// The note viewer can change content when the note re-renders. As such,
 		// a new locator needs to be created after re-renders (and this can't be a
 		// static property).
-		return this.page.frame({ url: /.*note-viewer[/\\]index.html.*/ });
+		return this.page.frameLocator('[src$="note-viewer/index.html"]');
 	}
 
 	public getTinyMCEFrameLocator() {

--- a/packages/editor/CodeMirror/utils/getSearchState.ts
+++ b/packages/editor/CodeMirror/utils/getSearchState.ts
@@ -1,0 +1,17 @@
+import { EditorState } from '@codemirror/state';
+import { SearchState } from '../../types';
+import { getSearchQuery, searchPanelOpen } from '@codemirror/search';
+
+const getSearchState = (state: EditorState) => {
+	const query = getSearchQuery(state);
+	const searchState: SearchState = {
+		searchText: query.search,
+		replaceText: query.replace,
+		useRegex: query.regexp,
+		caseSensitive: query.caseSensitive,
+		dialogVisible: searchPanelOpen(state),
+	};
+	return searchState;
+};
+
+export default getSearchState;

--- a/packages/editor/CodeMirror/utils/searchExtension.ts
+++ b/packages/editor/CodeMirror/utils/searchExtension.ts
@@ -1,0 +1,40 @@
+import { EditorState, Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { EditorSettings, OnEventCallback } from '../../types';
+import getSearchState from './getSearchState';
+import { EditorEventType } from '../../events';
+import { search, searchPanelOpen, setSearchQuery } from '@codemirror/search';
+
+const searchExtension = (onEvent: OnEventCallback, settings: EditorSettings): Extension => {
+	const onSearchDialogUpdate = (state: EditorState) => {
+		const newSearchState = getSearchState(state);
+
+		onEvent({
+			kind: EditorEventType.UpdateSearchDialog,
+			searchState: newSearchState,
+		});
+	};
+
+	return [
+		search(settings.useExternalSearch ? {
+			createPanel(_editor: EditorView) {
+				return {
+					// The actual search dialog is implemented with react native,
+					// use a dummy element.
+					dom: document.createElement('div'),
+					mount() { },
+					destroy() { },
+				};
+			},
+		} : undefined),
+
+		EditorState.transactionExtender.of((tr) => {
+			if (tr.effects.some(e => e.is(setSearchQuery)) || searchPanelOpen(tr.state) !== searchPanelOpen(tr.startState)) {
+				onSearchDialogUpdate(tr.state);
+			}
+			return null;
+		}),
+	];
+};
+
+export default searchExtension;


### PR DESCRIPTION
# Summary

This pull request fixes a Markdown editor [issue originally reported on the Joplin forum](https://discourse.joplinapp.org/t/search-and-auto-quote/39590) &mdash; it was impossible to search a note when the note editor pane was hidden.

# Remaining issues

- It's possible for the Markdown viewer's search panel to be visible in the Rich Text editor. **This is also an issue with the legacy editor prior to this pull request**. To see this:
   1. Open the markdown editor.
   2. Hide the editor such that just the viewer is visible.
   3. Press <kbd>ctrl</kbd>-<kbd>f</kbd> such that the search bar is visible.
   4. Switch to the Rich Text Editor.

# Screen recording

[Screen recording: Searching in the note viewer, then switching to read-only mode.](https://github.com/user-attachments/assets/dfa72b74-6768-4029-b63b-e42f722ac44b)


# Testing plan

**Automated test**: A new Playwright test has been added that verifies:
- It's possible to search (local search) in the new markdown editor.
- The search input remains visible after switching layouts such that the editor is hidden.
- Changing the search in the markdown editor changes the matches in the viewer.
- Changing the search when only the viewer is visible changes the highlighted matches.

**Manual testing (Ubuntu 24.04)**:
1. Create a note containing several instances of the word "test".
6. Search globally for `test`.
7. Open the note created in `1` from the note list.
8. Open local search (<kbd>ctrl</kbd>-<kbd>f</kbd>).
9. Verify that the local search query matches the global search query.
10. Change the local search query. Verify that only the new matches are highlighted in both the viewer and editor.
11. Close the local search panel.
12. Verify that at least one copy of the original global search is highlighted in the viewer.
13. Verify that all copies of the original global search are highlighted in the editor.

**Regression testing: Mobile/web (Firefox)**:
1. Create an empty note with `test... Test.` as its content.
14. Press <kbd>ctrl</kbd>-<kbd>f</kbd>
15. Verify that the search panel is visible.
16. Search for `test`.
17. Click "next".
18. Verify that the selection moves to the next match.
19. Open the advanced search options.
20. Type "testing" in the "replace" input.
21. Click "replace".
22. Verify that the selected match has been replaced with "testing".
23. Click "replace all".
24. Verify that both matches have been replaced.
25. Click '.*' (regex)
26. Replace the text in the find input with `t.*`.
27. Verify that all content is highlighted.
28. Close the search menu by clicking the "x" button.
29. Show the search menu by clicking the "🔍" button.
30. Click on the note editor and press <kbd>ctrl</kbd>-<kbd>f</kbd>.
31. Verify that the search menu is no longer visible.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->