### PR TITLE
Mobile: Fixes #10867: Fix toolbar overflow menu is invisible

### DIFF
--- a/packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownToolbar/Toolbar.tsx
@@ -93,7 +93,7 @@ const Toolbar: React.FC<ToolbarProps> = (props: ToolbarProps) => {
 	);
 
 	const overflow = (
-		<ScrollView style={{ flex: 1 }}>
+		<ScrollView>
 			<ToolbarOverflowRows
 				buttonGroups={props.buttons}
 				styleSheet={props.styleSheet}


### PR DESCRIPTION
# Summary

This pull request reverts a regression introduced by https://github.com/laurent22/joplin/commit/f69dffcf23497361c31b5290ef1152c5609f9b35 &mdash; `flex: 1` was unnecessarily added to the toolbar overflow menu. This caused the overflow menu to collapse to zero height on Android and iOS.

Fixes #10867, #10860.

# Testing plan

1. Start Joplin.
2. Open the note editor.
3. Click "show more actions" (the `...` button in the center of the toolbar).
4. Verify that the actions menu is visible.
5. Close the actions menu by clicking the "x".
6. Open the actions menu by clicking the `...` button.
7. Click the "H5" button.
8. Verify that the current line now starts with `##### `.

This has been tested successfully on:
- [x] Android 13 (tablet)
- [x] Chromium (browser)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->