### PR TITLE
Server: Increase max attempts to retrieve object from S3 before giving up

### DIFF
--- a/packages/server/src/models/items/storage/StorageDriverS3.ts
+++ b/packages/server/src/models/items/storage/StorageDriverS3.ts
@@ -1,5 +1,5 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectsCommand, ObjectIdentifier, HeadObjectCommand } from '@aws-sdk/client-s3';
-import { CustomError, CustomErrorCode, ErrorBadGateway } from '../../../utils/errors';
+import { CustomError, CustomErrorCode, ErrorServiceUnavailable } from '../../../utils/errors';
 import { StorageDriverConfig, StorageDriverType } from '../../../utils/types';
 import StorageDriverBase from './StorageDriverBase';
 
@@ -36,7 +36,6 @@ export default class StorageDriverS3 extends StorageDriverBase {
 		super(id, { type: StorageDriverType.S3, ...config });
 
 		this.client_ = new S3Client({
-			maxAttempts: 5,
 			// We need to set a region. See https://github.com/aws/aws-sdk-js-v3/issues/1845#issuecomment-754832210
 			region: this.config.region,
 			credentials: {
@@ -63,7 +62,7 @@ export default class StorageDriverS3 extends StorageDriverBase {
 
 			return stream2buffer(response.Body);
 		} catch (error) {
-			if (error?.Code === 'InternalError') throw new ErrorBadGateway('Storage driver server returned an internal error. Try again later.');
+			if (error?.Code === 'InternalError') throw new ErrorServiceUnavailable('Storage driver server returned an internal error. Try again later.');
 			if (error?.$metadata?.httpStatusCode === 404) throw new CustomError(`No such item: ${itemId}`, CustomErrorCode.NotFound);
 			error.message = `Could not get item "${itemId}": ${error.message}`;
 			throw error;

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -142,6 +142,15 @@ export class ErrorTooManyRequests extends ApiError {
 	}
 }
 
+export class ErrorBadGateway extends ApiError {
+	public static httpCode = 502;
+
+	public constructor(message = 'Bad Gateway', options: ErrorOptions = null) {
+		super(message, ErrorBadGateway.httpCode, options);
+		Object.setPrototypeOf(this, ErrorBadGateway.prototype);
+	}
+}
+
 export function errorToString(error: Error): string {
 	// const msg: string[] = [];
 	// msg.push(error.message ? error.message : 'Unknown error');

--- a/packages/server/src/utils/errors.ts
+++ b/packages/server/src/utils/errors.ts
@@ -142,12 +142,12 @@ export class ErrorTooManyRequests extends ApiError {
 	}
 }
 
-export class ErrorBadGateway extends ApiError {
-	public static httpCode = 502;
+export class ErrorServiceUnavailable extends ApiError {
+	public static httpCode = 503;
 
 	public constructor(message = 'Bad Gateway', options: ErrorOptions = null) {
-		super(message, ErrorBadGateway.httpCode, options);
-		Object.setPrototypeOf(this, ErrorBadGateway.prototype);
+		super(message, ErrorServiceUnavailable.httpCode, options);
+		Object.setPrototypeOf(this, ErrorServiceUnavailable.prototype);
 	}
 }
 


### PR DESCRIPTION
## Summary

By default, S3Client has a retry strategy with an [exponential backoff that retries for 3 times](https://github.com/aws/aws-sdk-js-v3/blob/84fd78ba51b3362b48ea983c263dd368b88f4287/supplemental-docs/CLIENTS.md#retry-strategy-retrystrategy-retrymode-maxattempts) when encounters a server error.

> `503 Service Unavailable` server error response code indicates that the server is not ready to handle the request.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503

## Testing

I couldn't find a way to test the change, but the change is small enough that it shouldn't matter.