### PR TITLE
Desktop: Fix HTML parsing bug

### DIFF
--- a/packages/app-cli/tests/md_to_html/sanitize_20.html
+++ b/packages/app-cli/tests/md_to_html/sanitize_20.html
@@ -1,0 +1,2 @@
+<div class="jop-noMdConv">
+&lt;.a

--- a/packages/app-cli/tests/md_to_html/sanitize_20.md
+++ b/packages/app-cli/tests/md_to_html/sanitize_20.md
@@ -1,0 +1,2 @@
+<div>
+<.a<iframe src="http://example.com/" >

--- a/packages/fork-htmlparser2/README.md
+++ b/packages/fork-htmlparser2/README.md
@@ -54,6 +54,8 @@ index 44b4371..bcd7cc2 100644
          if (this._cbs.onend)
 ```
 
+To fix an HTML parsing issue (tags were allowed to start with non-alphanumeric characters), [this upstream commit](https://github.com/fb55/htmlparser2/commit/bc010de9df09f2d730a69734e05e5175ea8bd2d7) has also been applied.
+
 * * *
 
 # htmlparser2

--- a/packages/fork-htmlparser2/src/Tokenizer.ts
+++ b/packages/fork-htmlparser2/src/Tokenizer.ts
@@ -32,6 +32,7 @@ const enum State {
     //comments
     BeforeComment,
     InComment,
+    InSpecialComment,
     AfterComment1,
     AfterComment2,
 
@@ -85,6 +86,10 @@ const enum Special {
 
 function whitespace(c: string): boolean {
     return c === " " || c === "\n" || c === "\t" || c === "\f" || c === "\r";
+}
+
+function isASCIIAlpha(c: string): boolean {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
 interface Callbacks {
@@ -282,6 +287,8 @@ export default class Tokenizer {
         } else if (c === "?") {
             this._state = State.InProcessingInstruction;
             this._sectionStart = this._index + 1;
+        } else if (!isASCIIAlpha(c)) {
+            this._state = State.Text;
         } else {
             this._state =
                 !this._xmlMode && (c === "s" || c === "S")
@@ -309,6 +316,9 @@ export default class Tokenizer {
                 this._state = State.Text;
                 this._index--;
             }
+        } else if (!isASCIIAlpha(c)) {
+            this._state = State.InSpecialComment;
+            this._sectionStart = this._index;
         } else {
             this._state = State.InClosingTagName;
             this._sectionStart = this._index;
@@ -453,6 +463,15 @@ export default class Tokenizer {
     }
     _stateInComment(c: string) {
         if (c === "-") this._state = State.AfterComment1;
+    }
+    _stateInSpecialComment(c: string) {
+        if (c === ">") {
+            this._cbs.oncomment(
+                this._buffer.substring(this._sectionStart, this._index)
+            );
+            this._state = State.Text;
+            this._sectionStart = this._index + 1;
+        }
     }
     _stateAfterComment1(c: string) {
         if (c === "-") {
@@ -702,6 +721,8 @@ export default class Tokenizer {
                 this._stateInAttributeName(c);
             } else if (this._state === State.InComment) {
                 this._stateInComment(c);
+            } else if (this._state === State.InSpecialComment) {
+                this._stateInSpecialComment(c);
             } else if (this._state === State.BeforeAttributeName) {
                 this._stateBeforeAttributeName(c);
             } else if (this._state === State.InTagName) {

--- a/packages/fork-htmlparser2/src/__fixtures__/Events/34-not-alpha-tags.json
+++ b/packages/fork-htmlparser2/src/__fixtures__/Events/34-not-alpha-tags.json
@@ -1,0 +1,12 @@
+{
+  "name": "tag names are not ASCII alpha",
+  "options": {
+      "parser": {}
+  },
+  "html": "<12>text</12>",
+  "expected": [
+      { "event": "text", "data": ["<12>text"] },
+      { "event": "comment", "data": ["12"] },
+      { "event": "commentend", "data": [] }
+  ]
+}


### PR DESCRIPTION
# Summary

Applies an upstream patch to fix an issue where `<.a>` was recognised as a tag (this seems to be correct for XHTML, but not HTML).

# Testing

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->