### PR TITLE
Desktop: Resolves #5762: Rich Text Editor: Add eight spaces when pressing tab

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -299,6 +299,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useWebViewApi.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js

--- a/.gitignore
+++ b/.gitignore
@@ -276,6 +276,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useWebViewApi.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -38,6 +38,7 @@ const md5 = require('md5');
 const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 import { hasProtocol } from '@joplin/utils/url';
+import useTabIndenter from './utils/useTabIndenter';
 
 const logger = Logger.create('TinyMCE');
 
@@ -128,6 +129,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 	usePluginServiceRegistration(ref);
 	useContextMenu(editor, props.plugins, props.dispatch, props.htmlToMarkdown, props.markupToHtml);
+	useTabIndenter(editor);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const dispatchDidUpdate = (editor: any) => {
@@ -629,6 +631,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				icons_url: 'gui/NoteEditor/NoteBody/TinyMCE/icons.js',
 				plugins: 'noneditable link joplinLists hr searchreplace codesample table',
 				noneditable_noneditable_class: 'joplin-editable', // Can be a regex too
+				iframe_aria_text: _('Rich Text editor. Press Escape then Tab to escape focus.'),
 
 				// #p: Pad empty paragraphs with &nbsp; to prevent them from being removed.
 				// *[*]: Allow all elements and attributes -- we already filter in sanitize_html

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.ts
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import type { Editor, EditorEvent } from 'tinymce';
+
+const useTabIndenter = (editor: Editor) => {
+	useEffect(() => {
+		if (!editor) return () => {};
+
+		const canChangeIndentation = () => {
+			const selectionElement = editor.selection.getNode();
+			return !selectionElement.closest('li, table') && !editor.readonly;
+		};
+
+		const tabStringLengthChars = 8;
+		let tabString = '';
+		for (let i = 0; i < tabStringLengthChars; i++) {
+			tabString += '&nbsp;';
+		}
+
+		let lastKeyWasEscape = false;
+
+		const eventHandler = (event: EditorEvent<KeyboardEvent>) => {
+			if (!event.isDefaultPrevented() && event.key === 'Tab' && canChangeIndentation() && !lastKeyWasEscape) {
+				if (!event.shiftKey) {
+					editor.execCommand('mceInsertContent', false, tabString);
+					event.preventDefault();
+				} else {
+					const selectionRange = editor.selection.getRng();
+					if (selectionRange.collapsed) {
+						let rangeStart = selectionRange.startOffset;
+						let testRange = selectionRange.cloneRange();
+						while (rangeStart >= 0) {
+							rangeStart--;
+
+							const lastRange = testRange.cloneRange();
+							testRange.setStart(testRange.startContainer, Math.max(rangeStart, 0));
+							const rangeContent = testRange.toString();
+							if (!rangeContent.match(/^\s*$/) || rangeContent.length > tabStringLengthChars) {
+								testRange = lastRange;
+								break;
+							}
+						}
+
+						if (testRange.toString().match(/\s+/)) {
+							editor.selection.setRng(testRange);
+							editor.execCommand('Delete', false);
+							event.preventDefault();
+						}
+					}
+				}
+			} else if (event.key === 'Escape' && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey) {
+				// For accessibility, let Escape followed by tab escape the focus trap.
+				lastKeyWasEscape = true;
+			} else if (event.key !== 'Shift') { // Allows Esc->Shift+Tab to escape the focus trap.
+				lastKeyWasEscape = false;
+			}
+		};
+
+		editor.on('keydown', eventHandler);
+		return () => {
+			editor.off('keydown', eventHandler);
+		};
+	}, [editor]);
+};
+
+export default useTabIndenter;

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -82,5 +82,42 @@ test.describe('richTextEditor', () => {
 		expect(await openPathResult).toContain(basename(pathToAttach));
 	});
 
+	test('pressing Tab should indent', async ({ mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('Testing tabs!');
+		const editor = mainScreen.noteEditor;
+
+		await editor.toggleEditorsButton.click();
+		await editor.richTextEditor.click();
+
+		await mainWindow.keyboard.type('This is a');
+		// Tab should add spaces
+		await mainWindow.keyboard.press('Tab');
+		await mainWindow.keyboard.type('test.');
+
+		// Shift-tab should remove spaces
+		await mainWindow.keyboard.press('Tab');
+		await mainWindow.keyboard.press('Tab');
+		await mainWindow.keyboard.press('Shift+Tab');
+		await mainWindow.keyboard.type('Test!');
+
+		// Escape then tab should move focus
+		await mainWindow.keyboard.press('Escape');
+		await expect(editor.richTextEditor).toBeFocused();
+		await mainWindow.keyboard.press('Tab');
+		await expect(editor.richTextEditor).not.toBeFocused();
+
+		// After re-focusing the editor, Tab should indent again.
+		await mainWindow.keyboard.press('Shift+Tab');
+		await expect(editor.richTextEditor).toBeFocused();
+		await mainWindow.keyboard.type(' Another:');
+		await mainWindow.keyboard.press('Tab');
+		await mainWindow.keyboard.type('!');
+
+		// After switching back to the Markdown editor,
+		await expect(editor.toggleEditorsButton).not.toBeDisabled();
+		await editor.toggleEditorsButton.click();
+		await expect(editor.codeMirrorEditor).toHaveText('This is a        test.        Test! Another:        !');
+	});
 });
 


### PR DESCRIPTION
# Summary

This pull request adds the folllowing keyboard shortcuts to the Rich Text Editor:
1. <kbd>Tab</kbd>: Adds eight nonbreaking spaces before the cursor.
    - **Adds before the cursor**: This is similar to how LibreOffice Writer handles the tab key &mdash; a tab character is inserted just before the cursor.
    - If in a list or table, the previous navigation/indentation behavior is preserved.
2. <kbd>Shift-Tab</kbd>: Deletes up to eight spaces before the cursor.
    - If in a list or table, the previous navigation/indentation behavior is preserved.
3. <kbd>Escape</kbd>, then <kbd>Tab</kbd>: Moves focus to the first item out of the Rich Text Editor. (Accessibility).
4. <kbd>Escape</kbd>, then <kbd>Shift</kbd>-<kbd>tab</kbd>: Moves focus to the first item before the Rich Text Editor.

**Why (nonbreaking) spaces?**
1. Logic already exists to convert repeated nonbreaking spaces to Markdown.
2. Tab characters [are treated as collapsible whitespace by default in HTML](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#spaces).

Resolves #5762.

# Screen recording

[Screen recording: Shows indentation by pressing tab in paragraphs, headers. Shows standard indentation in lists and navigation in tables.](https://github.com/user-attachments/assets/5222814e-8dc5-4ca2-9288-cb9d04f02ac3)


# Testing

This pull request includes an automated Playwright test that verifies 1) <kbd>Tab</kbd> adds spaces in a paragraph, 2) <kbd>shift</kbd>-<kbd>Tab</kbd> removes spaces before the cursor, 3) <kbd>Escape</kbd>, then <kbd>Tab</kbd> moves the focus.

See the screen recording for manual testing information.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->