### PR TITLE
Server: Add arm64 support for Joplin Server

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -74,7 +74,7 @@ jobs:
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64, linux/arm64
-          load: true
+          # load: true works only with amd64
           push: true
       - name: Validate build
         env:

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-20.04]
     env:
       VERSION: 0.0.0-beta
-      IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -53,7 +53,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.IMAGE }}
+          images: |
+            ${{ env.IMAGE }}
+            ghcr.io/${{ env.IMAGE }}
           tags: |
             type=ref,event=tag
             type=raw,value=${{ env.VERSION }}

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -2,7 +2,7 @@ name: Joplin Continuous Integration
 on: [push, pull_request]
 jobs:
   pre_job:
-    if: github.repository == 'laurent22/joplin'
+    # if: github.repository == 'laurent22/joplin'
     # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
     # https://github.com/actions/runner-images/issues/6709
     runs-on: ubuntu-20.04
@@ -14,151 +14,11 @@ jobs:
         with:
           concurrent_skipping: 'same_content_newer'
 
-  Main:
-    needs: pre_job
-    # We always process server or desktop release tags, because they also publish the release
-    if: github.repository == 'laurent22/joplin' && (needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/server-v') || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
-        # https://github.com/actions/runner-images/issues/6709
-        os: [macos-12, ubuntu-20.04, windows-2019]
-    steps:
-
-      # Trying to fix random networking issues on Windows
-      # https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable TCP/UDP offload on Windows
-        if: runner.os == 'Windows'
-        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
-
-      - name: Disable TCP/UDP offload on Linux
-        if: runner.os == 'Linux'
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Disable TCP/UDP offload on macOS
-        if: runner.os == 'macOS'
-        run: |
-          sudo sysctl -w net.link.generic.system.hwcksum_tx=0
-          sudo sysctl -w net.link.generic.system.hwcksum_rx=0
-
-      # Silence apt-get update errors (for example when a module doesn't
-      # exist) since otherwise it will make the whole build fails, even though
-      # it might work without update. libsecret-1-dev is required for keytar -
-      # https://github.com/atom/node-keytar
-
-      - name: Install Linux dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update || true
-          sudo apt-get install -y gettext
-          sudo apt-get install -y libsecret-1-dev
-          sudo apt-get install -y translate-toolkit
-          sudo apt-get install -y rsync
-          # Provides a virtual display on Linux. Used for Playwright integration
-          # testing.
-          sudo apt-get install -y xvfb
-
-      - name: Install macOs dependencies
-        if: runner.os == 'macOS'
-        run: |
-          # Required for building the canvas package
-          brew install pango
-
-      - name: Install Docker Engine
-        # if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/server-v')
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y apt-transport-https
-          sudo apt-get install -y ca-certificates
-          sudo apt-get install -y curl
-          sudo apt-get install -y gnupg
-          sudo apt-get install -y lsb-release
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo \
-              "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-              $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update || true
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-
-      - uses: actions/checkout@v4
-      - uses: olegtarasov/get-tag@v2.1.3
-      - uses: actions/setup-node@v4
-        with:
-          # We need to pin the version to 18.15, because 18.16+ fails with this error:
-          # https://github.com/facebook/react-native/issues/36440
-          node-version: '18.15.0'
-          cache: 'yarn'
-
-      - name: Install Yarn
-        run: |
-          # https://yarnpkg.com/getting-started/install
-          corepack enable
-      
-      # Login to Docker only if we're on a server release tag. If we run this on
-      # a pull request it will fail because the PR doesn't have access to
-      # secrets
-      - uses: docker/login-action@v3
-        if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/server-v')
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # macos-latest ships with Python 3.12 by default, but this removes a
-      # utility that's used by electron-builder (distutils) so we need to pin
-      # Python to an earlier version.
-      # Fixes error `ModuleNotFoundError: No module named 'distutils'`
-      # Ref: https://github.com/nodejs/node-gyp/issues/2869
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Run tests, build and publish Linux and macOS apps
-        if: runner.os == 'Linux' || runner.os == 'macOs'
-        env:
-          APPLE_ASC_PROVIDER: ${{ secrets.APPLE_ASC_PROVIDER }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          IS_CONTINUOUS_INTEGRATION: 1
-          BUILD_SEQUENCIAL: 1
-          SERVER_REPOSITORY: joplin/server
-          SERVER_TAG_PREFIX: server
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-        run: |
-          "${GITHUB_WORKSPACE}/.github/scripts/run_ci.sh"
-
-      - name: Build and publish Windows app
-        if: runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/v')
-        env:
-          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          IS_CONTINUOUS_INTEGRATION: 1
-          BUILD_SEQUENCIAL: 1
-        # To ensure that the operations stop on failure, all commands
-        # should be on one line with "&&" in between.
-        run: |
-          yarn install && cd packages/app-desktop && yarn dist
-
-      # Build and package the Windows app, without publishing it, just to
-      # verify that the build process hasn't been broken.
-      - name: Build Windows app (no publishing)
-        if: runner.os == 'Windows' && !startsWith(github.ref, 'refs/tags/v')
-        env:
-          IS_CONTINUOUS_INTEGRATION: 1
-          BUILD_SEQUENCIAL: 1
-          SERVER_REPOSITORY: joplin/server
-          SERVER_TAG_PREFIX: server
-        run: |
-          yarn install && cd packages/app-desktop && yarn dist --publish=never
+  # Removed for testing
 
   ServerDockerImage:
     needs: pre_job
-    if: github.repository == 'laurent22/joplin' && needs.pre_job.outputs.should_skip != 'true'
+    # if: github.repository == 'laurent22/joplin' && needs.pre_job.outputs.should_skip != 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -180,6 +40,12 @@ jobs:
           # https://yarnpkg.com/getting-started/install
           corepack enable
           yarn install
+      - name: Log in to GitHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -53,9 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: |
-            ${{ env.IMAGE }}
-            ghcr.io/${{ env.IMAGE }}
+          images: ghcr.io/${{ env.IMAGE }}
           tags: |
             type=ref,event=tag
             type=raw,value=${{ env.VERSION }}
@@ -74,12 +72,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64
           push: true
-      - name: Run Docker Image
+      - name: Validate build
         env:
           BUILD_SEQUENCIAL: 1
         run: |
-          yarn buildServerDocker --tag-name server-v0.0.0 --repository joplin/server --dry-run
-
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
           docker run ${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js migrate list
@@ -87,7 +83,7 @@ jobs:
       - name: Check HTTP request
         run: |
           # Need to pass environment variables:
-          docker run -p 22300:22300 j${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js --env dev &
+          docker run -p 22300:22300 ${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js --env dev &
 
           # Wait for server to start
           sleep 30

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-20.04]
     env:
       VERSION: 0.0.0-beta
-      IMAGE: joplin
+      IMAGE: ghcr.io/maresmar/joplin
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -54,7 +54,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/maresmar/${{ env.IMAGE }}
+            ${{ env.IMAGE }}
           tags: |
             type=ref,event=tag
             type=raw,value=${{ env.VERSION }}
@@ -72,6 +72,7 @@ jobs:
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64
+          load: true
           push: true
       - name: Validate build
         env:

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -80,8 +80,8 @@ jobs:
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64 ${{ env.PUBLISH == 'true' && ', linux/arm64' || '' }} # Build arm only when publishing
-          load: ${{ !env.PUBLISH }} # Push image to local regirstry
-          push: ${{ env.PUBLISH }} # Push image to remote registry
+          load: ${{ env.PUBLISH == 'false' }} # Push image to local regirstry, doesn't work with two platform builds
+          push: ${{ env.PUBLISH == 'true' }} # Push image to remote registry
       - name: Validate build
         env:
           BUILD_SEQUENCIAL: 1

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-20.04]
     env:
       VERSION: 0.0.0-beta
-      IMAGE: ${{ github.repository }}
+      IMAGE: joplin
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -53,7 +53,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/${{ env.IMAGE }}
+          images: |
+            ${{ env.IMAGE }}
+            ghcr.io/maresmar/${{ env.IMAGE }}
           tags: |
             type=ref,event=tag
             type=raw,value=${{ env.VERSION }}

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -45,12 +45,6 @@ jobs:
           # https://yarnpkg.com/getting-started/install
           corepack enable
           yarn install
-      - name: Log in to GitHub container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build args
         run: |
           echo DATE=`date -u +'%FT%T.%2NZ'` >> $GITHUB_ENV
@@ -70,6 +64,12 @@ jobs:
             type=semver,pattern={{version}},value=v${{ env.VERSION }}
             type=semver,pattern={{major}}.{{minor}},value=v${{ env.VERSION }}
             type=semver,pattern={{major}},value=v${{ env.VERSION }}
+      - name: Log in to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -30,7 +30,7 @@ jobs:
       IMAGE: ghcr.io/maresmar/joplin
     steps:
       - name: Clenup runner space # based on https://github.com/orgs/community/discussions/25678
-        run: rm -rf /opt/hostedtoolcache/Java* /opt/hostedtoolcache/Python /opt/hostedtoolcache/PyPy
+        run: rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Java* /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go 
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -26,8 +26,8 @@ jobs:
         # https://github.com/actions/runner-images/issues/6709
         os: [ubuntu-20.04]
     env:
-      VERSION: 0.0.0-beta
-      IMAGE: ghcr.io/maresmar/joplin
+      PUBLISH: ${{ startsWith(github.ref, 'refs/tags/server-v') }}
+      IMAGE: ghcr.io/${{ github.repository }}
     steps:
       - name: Clenup runner space # based on https://github.com/orgs/community/discussions/25678
         run: rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Java* /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go 
@@ -51,6 +51,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build args
+        run: |
+          echo DATE=`date -u +'%FT%T.%2NZ'` >> $GITHUB_ENV
+          echo REV=`git rev-parse --short HEAD` >> $GITHUB_ENV
+          if [[ "${{ env.PUBLISH }}" == "true" ]]; then
+            echo VERSION=${GITHUB_REF##*/server-v} >> $GITHUB_ENV
+          else
+            echo VERSION=0.0.0-beta >> $GITHUB_ENV
+          fi
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
@@ -58,12 +67,9 @@ jobs:
           images: |
             ${{ env.IMAGE }}
           tags: |
-            type=ref,event=tag
-            type=raw,value=${{ env.VERSION }}
-      - name: Build args
-        run: |
-          echo DATE=`date -u +'%FT%T.%2NZ'` >> $GITHUB_ENV
-          echo REV=`git rev-parse --short HEAD` >> $GITHUB_ENV
+            type=semver,pattern={{version}},value=v${{ env.VERSION }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ env.VERSION }}
+            type=semver,pattern={{major}},value=v${{ env.VERSION }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
@@ -73,9 +79,9 @@ jobs:
             REVISION=${{ env.REV }}
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64, linux/arm64
-          # load: true works only with amd64
-          push: true
+          platforms: linux/amd64 ${{ env.PUBLISH && ', linux/arm64' || '' }} # Build arm only when publishing
+          load: ${{ !env.PUBLISH }} # Push image to local regirstry
+          push: ${{ env.PUBLISH }} # Push image to remote registry
       - name: Validate build
         env:
           BUILD_SEQUENCIAL: 1

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -29,6 +29,8 @@ jobs:
       VERSION: 0.0.0-beta
       IMAGE: ghcr.io/maresmar/joplin
     steps:
+      - name: Clenup runner space # based on https://github.com/orgs/community/discussions/25678
+        run: rm -rf /opt/hostedtoolcache/Java* /opt/hostedtoolcache/Python /opt/hostedtoolcache/PyPy
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -166,39 +166,48 @@ jobs:
         # https://github.com/actions/runner-images/issues/6709
         os: [ubuntu-20.04]
     steps:
-
-      - name: Install Docker Engine
-        run: |
-          sudo apt-get install -y apt-transport-https
-          sudo apt-get install -y ca-certificates
-          sudo apt-get install -y curl
-          sudo apt-get install -y gnupg
-          sudo apt-get install -y lsb-release
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo \
-              "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-              $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update || true
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-
       - uses: actions/checkout@v4
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'yarn'
-
-      - name: Install Yarn
+      - name: Install Yarn 
         run: |
           # https://yarnpkg.com/getting-started/install
           corepack enable
-
-      - name: Build Docker Image
+          yarn install
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=server-v0.0.0
+      - name: Build args
+        run: |
+          echo DATE=`date -u +'%FT%T.%2NZ'` >> $GITHUB_ENV
+          echo REV=`git rev-parse --short HEAD` >> $GITHUB_ENV
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile.server 
+          build-args: |
+            BUILD_DATE=${{ env.DATE }}
+            REVISION=${{ env.REV }}
+            VERSION=0.0.0-beta
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          push: true
+      - name: Run Docker Image
         env:
           BUILD_SEQUENCIAL: 1
         run: |
-          yarn install
-          yarn buildServerDocker --tag-name server-v0.0.0 --repository joplin/server
+          yarn buildServerDocker --tag-name server-v0.0.0 --repository joplin/server --dry-run
 
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -33,9 +33,9 @@ jobs:
         run: rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Java* /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go 
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -46,7 +46,7 @@ jobs:
           corepack enable
           yarn install
       - name: Log in to GitHub container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
           fi
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMAGE }}
@@ -71,7 +71,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=v${{ env.VERSION }}
             type=semver,pattern={{major}},value=v${{ env.VERSION }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: Dockerfile.server 
           build-args: |

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -79,7 +79,7 @@ jobs:
             REVISION=${{ env.REV }}
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64 ${{ env.PUBLISH && ', linux/arm64' || '' }} # Build arm only when publishing
+          platforms: linux/amd64 ${{ env.PUBLISH == 'true' && ', linux/arm64' || '' }} # Build arm only when publishing
           load: ${{ !env.PUBLISH }} # Push image to local regirstry
           push: ${{ env.PUBLISH }} # Push image to remote registry
       - name: Validate build

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -73,7 +73,7 @@ jobs:
             REVISION=${{ env.REV }}
             VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           load: true
           push: true
       - name: Validate build
@@ -82,7 +82,6 @@ jobs:
         run: |
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
-          docker images
           docker run ${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js migrate list
  
       - name: Check HTTP request

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -2,7 +2,7 @@ name: Joplin Continuous Integration
 on: [push, pull_request]
 jobs:
   pre_job:
-    # if: github.repository == 'laurent22/joplin'
+    if: github.repository == 'laurent22/joplin'
     # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
     # https://github.com/actions/runner-images/issues/6709
     runs-on: ubuntu-20.04
@@ -14,11 +14,127 @@ jobs:
         with:
           concurrent_skipping: 'same_content_newer'
 
-  # Removed for testing
+  Main:
+    needs: pre_job
+    # We always process server or desktop release tags, because they also publish the release
+    if: github.repository == 'laurent22/joplin' && (needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
+        # https://github.com/actions/runner-images/issues/6709
+        os: [macos-12, ubuntu-20.04, windows-2019]
+    steps:
+
+      # Trying to fix random networking issues on Windows
+      # https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable TCP/UDP offload on Windows
+        if: runner.os == 'Windows'
+        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
+
+      - name: Disable TCP/UDP offload on Linux
+        if: runner.os == 'Linux'
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Disable TCP/UDP offload on macOS
+        if: runner.os == 'macOS'
+        run: |
+          sudo sysctl -w net.link.generic.system.hwcksum_tx=0
+          sudo sysctl -w net.link.generic.system.hwcksum_rx=0
+
+      # Silence apt-get update errors (for example when a module doesn't
+      # exist) since otherwise it will make the whole build fails, even though
+      # it might work without update. libsecret-1-dev is required for keytar -
+      # https://github.com/atom/node-keytar
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y gettext
+          sudo apt-get install -y libsecret-1-dev
+          sudo apt-get install -y translate-toolkit
+          sudo apt-get install -y rsync
+          # Provides a virtual display on Linux. Used for Playwright integration
+          # testing.
+          sudo apt-get install -y xvfb
+
+      - name: Install macOs dependencies
+        if: runner.os == 'macOS'
+        run: |
+          # Required for building the canvas package
+          brew install pango
+
+      - uses: actions/checkout@v4
+      - uses: olegtarasov/get-tag@v2.1.3
+      - uses: actions/setup-node@v4
+        with:
+          # We need to pin the version to 18.15, because 18.16+ fails with this error:
+          # https://github.com/facebook/react-native/issues/36440
+          node-version: '18.15.0'
+          cache: 'yarn'
+
+      - name: Install Yarn
+        run: |
+          # https://yarnpkg.com/getting-started/install
+          corepack enable
+      
+
+      # macos-latest ships with Python 3.12 by default, but this removes a
+      # utility that's used by electron-builder (distutils) so we need to pin
+      # Python to an earlier version.
+      # Fixes error `ModuleNotFoundError: No module named 'distutils'`
+      # Ref: https://github.com/nodejs/node-gyp/issues/2869
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run tests, build and publish Linux and macOS apps
+        if: runner.os == 'Linux' || runner.os == 'macOs'
+        env:
+          APPLE_ASC_PROVIDER: ${{ secrets.APPLE_ASC_PROVIDER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          IS_CONTINUOUS_INTEGRATION: 1
+          BUILD_SEQUENCIAL: 1
+          SERVER_REPOSITORY: joplin/server
+          SERVER_TAG_PREFIX: server
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/run_ci.sh"
+
+      - name: Build and publish Windows app
+        if: runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          IS_CONTINUOUS_INTEGRATION: 1
+          BUILD_SEQUENCIAL: 1
+        # To ensure that the operations stop on failure, all commands
+        # should be on one line with "&&" in between.
+        run: |
+          yarn install && cd packages/app-desktop && yarn dist
+
+      # Build and package the Windows app, without publishing it, just to
+      # verify that the build process hasn't been broken.
+      - name: Build Windows app (no publishing)
+        if: runner.os == 'Windows' && !startsWith(github.ref, 'refs/tags/v')
+        env:
+          IS_CONTINUOUS_INTEGRATION: 1
+          BUILD_SEQUENCIAL: 1
+          SERVER_REPOSITORY: joplin/server
+          SERVER_TAG_PREFIX: server
+        run: |
+          yarn install && cd packages/app-desktop && yarn dist --publish=never
 
   ServerDockerImage:
     needs: pre_job
-    # if: github.repository == 'laurent22/joplin' && needs.pre_job.outputs.should_skip != 'true'
+    if: github.repository == 'laurent22/joplin' && (needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/server-v'))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,7 +143,7 @@ jobs:
         os: [ubuntu-20.04]
     env:
       PUBLISH: ${{ startsWith(github.ref, 'refs/tags/server-v') }}
-      IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE: joplin/server
     steps:
       - name: Clenup runner space # based on https://github.com/orgs/community/discussions/25678
         run: rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/Java* /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/Python /opt/hostedtoolcache/Ruby /opt/hostedtoolcache/go 
@@ -64,12 +180,14 @@ jobs:
             type=semver,pattern={{version}},value=v${{ env.VERSION }}
             type=semver,pattern={{major}}.{{minor}},value=v${{ env.VERSION }}
             type=semver,pattern={{major}},value=v${{ env.VERSION }}
-      - name: Log in to GitHub container registry
-        uses: docker/login-action@v3
+      # Login to Docker only if we're on a server release tag. If we run this on
+      # a pull request it will fail because the PR doesn't have access to
+      # secrets
+      - uses: docker/login-action@v3
+        if: runner.os == 'Linux' && startsWith(github.ref, 'refs/tags/server-v')
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -25,6 +25,9 @@ jobs:
         # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
         # https://github.com/actions/runner-images/issues/6709
         os: [ubuntu-20.04]
+    env:
+      VERSION: 0.0.0-beta
+      IMAGE: ghcr.io/${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -50,10 +53,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=tag
-            type=raw,value=server-v0.0.0
+            type=raw,value=${{ env.VERSION }}
       - name: Build args
         run: |
           echo DATE=`date -u +'%FT%T.%2NZ'` >> $GITHUB_ENV
@@ -65,7 +68,7 @@ jobs:
           build-args: |
             BUILD_DATE=${{ env.DATE }}
             REVISION=${{ env.REV }}
-            VERSION=0.0.0-beta
+            VERSION=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64
           push: true
@@ -77,12 +80,12 @@ jobs:
 
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
-          docker run joplin/server:0.0.0-beta node dist/app.js migrate list
+          docker run ${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js migrate list
  
       - name: Check HTTP request
         run: |
           # Need to pass environment variables:
-          docker run -p 22300:22300 joplin/server:0.0.0-beta node dist/app.js --env dev &
+          docker run -p 22300:22300 j${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js --env dev &
 
           # Wait for server to start
           sleep 30

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
+          docker images
           docker run ${{ env.IMAGE }}:${{ env.VERSION }} node dist/app.js migrate list
  
       - name: Check HTTP request

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -54,7 +54,6 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ${{ env.IMAGE }}
             ghcr.io/maresmar/${{ env.IMAGE }}
           tags: |
             type=ref,event=tag

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -9,7 +9,7 @@ RUN apt-get update \
     python tini libcairo2-dev libpango1.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Enables Yarn  
+# Enables Yarn
 RUN corepack enable
 
 WORKDIR /build

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -6,10 +6,10 @@ FROM node:18-bullseye AS builder
 
 RUN apt-get update \
     && apt-get install -y \
-    python tini \
+    python tini libcairo2-dev libpango1.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Enables Yarn
+# Enables Yarn  
 RUN corepack enable
 
 WORKDIR /build


### PR DESCRIPTION
# Summary

This pull request introduces ARM64 container pipeline for Joplin Server and adds the necessary dependencies for ARM64. I have successfully tested and used the image created in my repository on my Raspberry Pi 5.

I have changed `ServerDockerImage` to build the container using Docker buildx (based on the `buildServerDocker.js` script) and I have changed `Main` to not been called for Joplin Server tags. I did all changes trying to maximize mimicking of the existing workflow.

# Execution scenarios

- `ServerDockerImage` is invoked from pull request or branch push 
   - The action builds the AMD64 container, pushes it to the local container store, and runs existing tests in `ServerDockerImage`.
   - Tested successfully in my repository https://github.com/maresmar/joplin/actions/runs/10404305701
- `ServerDockerImage` is invoked from `server-v1.2.3` tag
   - The action builds both AMD64 and ARM64 containers, pushes these containers to Docker Hub, and uses the AMD64 container for existing tests in `ServerDockerImage`
   - Tested successfully in my repository https://github.com/maresmar/joplin/actions/runs/10400289242
   - Target containers from my reposiotry https://github.com/maresmar/joplin/pkgs/container/joplin/258405651?tag=3.0.2

# Possible limitations

- I didn't test the AMD64 container locally, but the existing tests are passing. 
- I was unable to test Docker Hub push and impact of `skip-duplicate-actions`
- The `buildServerDocker.js` could be probably removed and `run_ci.sh` could be simplified, but I wasn't sure if you want to keep an local push script.
- Docker tag is created from git tag, so to create `1.2.3-beta` the git tag has to be `server-v1.2.3-beta`.
- Building both ARM64 and AMD64 containers took 1 hour and 40 minutes in my repository.
