### PR TITLE
Chore: Windows: Fix building the desktop app clears the list of supported Rich Text Editor locales

### DIFF
--- a/packages/app-desktop/tools/copyApplicationAssets.js
+++ b/packages/app-desktop/tools/copyApplicationAssets.js
@@ -2,7 +2,6 @@ const { writeFile, copy, mkdirp, remove } = require('fs-extra');
 const glob = require('glob');
 const { resolve, basename } = require('path');
 const { dirname } = require('@joplin/tools/gulp/utils');
-const { toForwardSlashes } = require('@joplin/utils/path');
 
 const rootDir = resolve(__dirname, '../../..');
 const nodeModulesDir = resolve(__dirname, '../node_modules');
@@ -146,10 +145,8 @@ async function main() {
 		await withRetry(() => copy(sourceFile, destFile, { overwrite: true }));
 	}
 
-	// glob requires forward slashes, even on Windows.
-	const supportedLocales = glob.sync(`${toForwardSlashes(langSourceDir)}/*.js`).map(s => {
-		s = basename(s);
-		s = s.split('.');
+	const supportedLocales = glob.sync(`${langSourceDir}/*.js`).map(s => {
+		s = basename(s).split('.');
 		return s[0];
 	});
 

--- a/packages/app-desktop/tools/copyApplicationAssets.js
+++ b/packages/app-desktop/tools/copyApplicationAssets.js
@@ -1,7 +1,8 @@
 const { writeFile, copy, mkdirp, remove } = require('fs-extra');
 const glob = require('glob');
-const { resolve } = require('path');
+const { resolve, basename } = require('path');
 const { dirname } = require('@joplin/tools/gulp/utils');
+const { toForwardSlashes } = require('@joplin/utils/path');
 
 const rootDir = resolve(__dirname, '../../..');
 const nodeModulesDir = resolve(__dirname, '../node_modules');
@@ -145,9 +146,9 @@ async function main() {
 		await withRetry(() => copy(sourceFile, destFile, { overwrite: true }));
 	}
 
-	const supportedLocales = glob.sync(`${langSourceDir}/*.js`).map(s => {
-		s = s.split('/');
-		s = s[s.length - 1];
+	// glob requires forward slashes, even on Windows.
+	const supportedLocales = glob.sync(`${toForwardSlashes(langSourceDir)}/*.js`).map(s => {
+		s = basename(s);
 		s = s.split('.');
 		return s[0];
 	});


### PR DESCRIPTION
# Summary

This pull request fixes a bug in `copyApplicationAssets.js` &mdash; its filename extraction logic was incompatible with Windows. This pull request switches to the NodeJS built-in `basename` function.

# Testing plan

1. Run `yarn build` in `packages/app-desktop`.
2. Verify that no changes have been made to `supportedLocales.js`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->