### PR TITLE
Desktop: Fixes #10654: Disable modifying mime property of Resource via API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1208,6 +1208,7 @@ packages/lib/services/rest/routes/master_keys.js
 packages/lib/services/rest/routes/notes.test.js
 packages/lib/services/rest/routes/notes.js
 packages/lib/services/rest/routes/ping.js
+packages/lib/services/rest/routes/resources.test.js
 packages/lib/services/rest/routes/resources.js
 packages/lib/services/rest/routes/revisions.js
 packages/lib/services/rest/routes/search.js

--- a/.gitignore
+++ b/.gitignore
@@ -1185,6 +1185,7 @@ packages/lib/services/rest/routes/master_keys.js
 packages/lib/services/rest/routes/notes.test.js
 packages/lib/services/rest/routes/notes.js
 packages/lib/services/rest/routes/ping.js
+packages/lib/services/rest/routes/resources.test.js
 packages/lib/services/rest/routes/resources.js
 packages/lib/services/rest/routes/revisions.js
 packages/lib/services/rest/routes/search.js

--- a/packages/lib/services/rest/routes/resources.test.ts
+++ b/packages/lib/services/rest/routes/resources.test.ts
@@ -1,0 +1,32 @@
+import { setupDatabaseAndSynchronizer, switchClient } from '../../../testing/test-utils';
+import Api, { RequestMethod } from '../Api';
+
+let api: Api = null;
+
+describe('routes/resources', () => {
+
+	beforeEach(async () => {
+		api = new Api();
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('should not be possible to update mime via PUT', async () => {
+		const originalResource = await api.route(
+			RequestMethod.POST,
+			'resources',
+			null,
+			null,
+			[{ path: './images/SideMenuHeader.png' }],
+		);
+		const resourceModified = await api.route(
+			RequestMethod.PUT,
+			`resources/${originalResource.id}`,
+			null,
+			JSON.stringify({ mime: 'test' }),
+		);
+
+		expect(resourceModified.mime).not.toBe('test');
+		expect(resourceModified.mime).toBe(originalResource.mime);
+	});
+});

--- a/packages/lib/services/rest/routes/resources.ts
+++ b/packages/lib/services/rest/routes/resources.ts
@@ -50,6 +50,16 @@ export default async function(request: Request, id: string = null, link: string 
 	if (request.method === RequestMethod.POST || request.method === RequestMethod.PUT) {
 		const isUpdate = request.method === RequestMethod.PUT;
 
+		// Should not be possible to change the resource mime type
+		// https://github.com/laurent22/joplin/issues/10654
+		if (request.method === RequestMethod.PUT) {
+			if (request.body) {
+				const body = JSON.parse(request.body);
+				delete body.mime;
+				request.body = JSON.stringify(body);
+			}
+		}
+
 		if (!request.files.length) {
 			if (request.method === RequestMethod.PUT) {
 				// In that case, we don't try to update the resource blob, we

--- a/packages/lib/services/rest/routes/resources.ts
+++ b/packages/lib/services/rest/routes/resources.ts
@@ -50,18 +50,15 @@ export default async function(request: Request, id: string = null, link: string 
 	if (request.method === RequestMethod.POST || request.method === RequestMethod.PUT) {
 		const isUpdate = request.method === RequestMethod.PUT;
 
-		// Should not be possible to change the resource mime type
-		// https://github.com/laurent22/joplin/issues/10654
-		if (request.method === RequestMethod.PUT) {
-			if (request.body) {
-				const body = JSON.parse(request.body);
-				delete body.mime;
-				request.body = JSON.stringify(body);
-			}
-		}
-
 		if (!request.files.length) {
 			if (request.method === RequestMethod.PUT) {
+				// Should not be possible to change the resource mime type
+				// https://github.com/laurent22/joplin/issues/10654
+				if (request.body) {
+					const body = JSON.parse(request.body);
+					delete body.mime;
+					request.body = JSON.stringify(body);
+				}
 				// In that case, we don't try to update the resource blob, we
 				// just update the properties.
 				return defaultAction(BaseModel.TYPE_RESOURCE, request, id, link);


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10654

## Description

To fix the issue, I ended up parsing the body, deleting the props and stringifying the body again.

I'm doing this only if the request doesn't have a file because if there is one the `mime` props will be ignored anyway in favour of the one detected.

## Testing

I added an automated test to the API.