### PR TITLE
Mobile,Desktop,Cli: Fixes #10896: Fix "Enable auto-updates" enabled by default and visible on unsupported platforms

### DIFF
--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1557,6 +1557,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			type: SettingItemType.Bool,
 			public: true,
 			storage: SettingStorage.File,
+			appTypes: [AppType.Desktop],
 			label: () => 'Enable auto-updates',
 			description: () => 'Enable this feature to receive notifications about updates and install them instead of manually downloading them. Restart app to start receiving auto-updates.',
 			section: 'application',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1553,13 +1553,14 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		},
 
 		'featureFlag.autoUpdaterServiceEnabled': {
-			value: true,
+			value: false,
 			type: SettingItemType.Bool,
 			public: true,
 			storage: SettingStorage.File,
 			appTypes: [AppType.Desktop],
 			label: () => 'Enable auto-updates',
 			description: () => 'Enable this feature to receive notifications about updates and install them instead of manually downloading them. Restart app to start receiving auto-updates.',
+			show: () => shim.isWindows() || shim.isMac(),
 			section: 'application',
 			isGlobal: true,
 		},


### PR DESCRIPTION
# Summary

This pull request fixes #10896 -- "enable auto-updates" (which only applies to desktop) was visible in mobile settings (and also likely in CLI).

# Testing plan

1. Start Joplin (Web)
2. Open "Configuration"
3. Verify that the "Application" tab is not visible.
4. Search for "updates".
5. Verify that the "enable auto-updates" setting is not visible.

---

1. Start Joplin (desktop, Windows).
2. Open settings.
3. Open the "Application" tab.
4. Verify that the "Enable auto-updates" setting is visible.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->