### PR TITLE
Desktop, Mobile: Fixes #10891: Markdown editor: Fix toggling bulleted lists when items start with asterisks

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -131,8 +131,8 @@ export const toggleList = (listType: ListType): Command => {
 
 		// RegExps for different list types. The regular expressions MUST
 		// be mutually exclusive.
-		// `(?!\[[ xX]+\]\s?)` means "not followed by [x] or [ ]".
-		const bulletedRegex = /^\s*([-*])(?!\s\[[ xX]+\])\s?/;
+		// `(?!\[[ xX]+\])` means "not followed by [x] or [ ]".
+		const bulletedRegex = /^\s*([-*])\s(?!\[[ xX]+\])/;
 		const checklistRegex = /^\s*[-*]\s\[[ xX]+\]\s?/;
 		const numberedRegex = /^\s*\d+\.\s?/;
 


### PR DESCRIPTION
# Summary

This pull request requires a space after the starting `*` or `-` in a bulleted list. Previously, markup similar to `**test**` was considered a bulleted list item by the list-toggling regular expression.

This should fix #10891.

# Notes

When continuing or creating a new bulleted list with toolbar buttons, a space seems to be automatically added after the leading `-`. As such, it shouldn't be necessary to handle the case where `-` is followed by an end-of-line or end-of-document.

# Testing plan

1. Start the desktop app (CodeMirror 6 markdown editor enabled).
2. Create a new note with the following content:
    ```
    **test**
    test
    *test*
    
    1. This
    2. is
    3. a
    4. test
    
    List:
    - This
    - is
      a
    - test
        - TEST!
    ```
3. Select
    ```
    **test**
    test
    *test*
    ```
4. Click the "toggle bulleted list" button.
5. Verify that the selected items are now in a bulleted list.
6. Click "toggle bulleted list" again.
7. Verify that the bulleted list has been removed.
8. Select the bottommost bulleted list and click "toggle bulleted list".
9. Verify that the bulleted list has been removed.
10. Add a header near the end of the document on a blank line. Press enter.
11. At the end of the document, press "toggle bulleted list".
12. Type.
13. Verify that a single bulleted list item has been added.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->