### PR TITLE
Chore: Fix compilation errors due to test resources with .ts extensions

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -1,9 +1,10 @@
 import Note from '@joplin/lib/models/Note';
-import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+import { setupDatabaseAndSynchronizer, supportDir, switchClient } from '@joplin/lib/testing/test-utils';
 import { act, renderHook } from '@testing-library/react-hooks';
 import useFormNote, { HookDependencies } from './useFormNote';
 import shim from '@joplin/lib/shim';
 import Resource from '@joplin/lib/models/Resource';
+import { join } from 'path';
 
 const defaultFormNoteProps: HookDependencies = {
 	syncStarted: false,
@@ -115,7 +116,7 @@ describe('useFormNote', () => {
 
 	test('should refresh resource infos when changed outside the editor', async () => {
 		let note = await Note.save({});
-		note = await shim.attachFileToNote(note, __filename);
+		note = await shim.attachFileToNote(note, join(supportDir, 'sample.txt'));
 		const resourceIds = Note.linkedItemIds(note.body);
 		const resource = await Resource.load(resourceIds[0]);
 
@@ -141,12 +142,12 @@ describe('useFormNote', () => {
 		});
 
 		await act(async () => {
-			await Resource.save({ ...resource, filename: 'test.ts' });
+			await Resource.save({ ...resource, filename: 'test.txt' });
 		});
 		await formNote.waitFor(() => {
 			const resourceInfo = formNote.result.current.resourceInfos[resource.id];
 			expect(resourceInfo.item).toMatchObject({
-				id: resource.id, filename: 'test.ts',
+				id: resource.id, filename: 'test.txt',
 			});
 		});
 

--- a/packages/app-desktop/integration-tests/resources/test-file.txt
+++ b/packages/app-desktop/integration-tests/resources/test-file.txt
@@ -1,0 +1,1 @@
+This is a test.

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
 import setFilePickerResponse from './util/setFilePickerResponse';
 import waitForNextOpenPath from './util/waitForNextOpenPath';
-import { basename } from 'path';
+import { basename, join } from 'path';
 
 test.describe('richTextEditor', () => {
 	test('HTML links should be preserved when editing a note', async ({ electronApp, mainWindow }) => {
@@ -58,7 +58,7 @@ test.describe('richTextEditor', () => {
 		await editor.focusCodeMirrorEditor();
 
 		// Attach this file to the note (create a resource ID)
-		const pathToAttach = __filename;
+		const pathToAttach = join(__dirname, 'resources', 'test-file.txt');
 		await setFilePickerResponse(electronApp, [pathToAttach]);
 		await editor.attachFileButton.click();
 


### PR DESCRIPTION
# Summary

Previously, it was possible for temporary test data folders to cause compilation errors due to the use of `.ts` files as test resources. This pull request migrates these tests to `.txt` files.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->