### PR TITLE
Desktop: Fixes #10737: Fix Fix editing notes in "Conflicts" causes them to temporarily vanish

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/index.ts
@@ -2,6 +2,7 @@ import { FormNote } from './types';
 
 import HtmlToMd from '@joplin/lib/HtmlToMd';
 import Note from '@joplin/lib/models/Note';
+import { NoteEntity } from '@joplin/lib/services/database/types';
 const { MarkupToHtml } = require('@joplin/renderer');
 
 export async function htmlToMarkdown(markupLanguage: number, html: string, originalCss: string): Promise<string> {
@@ -23,8 +24,7 @@ export async function htmlToMarkdown(markupLanguage: number, html: string, origi
 	return newBody;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export async function formNoteToNote(formNote: FormNote): Promise<any> {
+export async function formNoteToNote(formNote: FormNote): Promise<NoteEntity> {
 	return {
 		id: formNote.id,
 		// Should also include parent_id and deleted_time so that the reducer
@@ -32,6 +32,7 @@ export async function formNoteToNote(formNote: FormNote): Promise<any> {
 		// https://discourse.joplinapp.org/t/experimental-wysiwyg-editor-in-joplin/6915/57?u=laurent
 		parent_id: formNote.parent_id,
 		deleted_time: formNote.deleted_time,
+		is_conflict: formNote.is_conflict,
 		title: formNote.title,
 		body: formNote.body,
 	};

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -148,6 +148,7 @@ export interface FormNote {
 	body: string;
 	parent_id: string;
 	is_todo: number;
+	is_conflict?: number;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	bodyEditorContent?: any;
 	markup_language: number;

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -84,6 +84,8 @@ describe('useFormNote', () => {
 	});
 
 
+	// Lacking is_conflict has previously caused UI issues. See https://github.com/laurent22/joplin/pull/10913
+	// for details.
 	it('should preserve value of is_conflict on save', async () => {
 		const testNote = await Note.save({ title: 'Test Note!', is_conflict: 1 });
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.test.ts
@@ -5,6 +5,7 @@ import useFormNote, { HookDependencies } from './useFormNote';
 import shim from '@joplin/lib/shim';
 import Resource from '@joplin/lib/models/Resource';
 import { join } from 'path';
+import { formNoteToNote } from '.';
 
 const defaultFormNoteProps: HookDependencies = {
 	syncStarted: false,
@@ -77,6 +78,37 @@ describe('useFormNote', () => {
 				encryption_applied: 0,
 				title: 'Test Note!',
 			});
+		});
+
+		formNote.unmount();
+	});
+
+
+	it('should preserve value of is_conflict on save', async () => {
+		const testNote = await Note.save({ title: 'Test Note!', is_conflict: 1 });
+
+		const makeFormNoteProps = (): HookDependencies => {
+			return {
+				...defaultFormNoteProps,
+				noteId: testNote.id,
+			};
+		};
+
+		const formNote = renderHook(props => useFormNote(props), {
+			initialProps: makeFormNoteProps(),
+		});
+		await formNote.waitFor(() => {
+			expect(formNote.result.current.formNote).toMatchObject({
+				is_conflict: 1,
+				title: testNote.title,
+			});
+		});
+
+		// Should preserve is_conflict after save.
+		expect(await formNoteToNote(formNote.result.current.formNote)).toMatchObject({
+			is_conflict: 1,
+			deleted_time: 0,
+			title: testNote.title,
 		});
 
 		formNote.unmount();

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -101,6 +101,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 			is_todo: n.is_todo,
 			parent_id: n.parent_id,
 			deleted_time: n.deleted_time,
+			is_conflict: n.is_conflict,
 			bodyWillChangeId: 0,
 			bodyChangeId: 0,
 			markup_language: n.markup_language,

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -123,3 +123,4 @@ Stormlikes
 BYTV
 keyval
 traineddata
+Famegear


### PR DESCRIPTION
# Summary

This pull request fixes an issue where conflict notes would disappear from the note list when edited.

This was caused by `NOTE_UPDATE_ONE` being dispatched with a note entity missing `is_conflict`. As a result, `oldNote.is_conflict && !newNote.is_conflict` was true. This caused the note to be removed from the conflict note list:
https://github.com/laurent22/joplin/blob/88cae93fc49f0cb0ef89c7668187f1daf63fa252/packages/lib/reducer.ts#L972-L976

Fixes #10737.

# Testing plan

1. Open a conflict note in the Markdown editor.
2. Make a small change.
3. Verify that the conflict doesn't disappear.

This has been tested successfully on Fedora 40 (Linux).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->