### PR TITLE
Mobile,Desktop: Fixes #10914: Fix BMP image rendering in the Markdown viewer

### DIFF
--- a/packages/lib/models/utils/resourceUtils.ts
+++ b/packages/lib/models/utils/resourceUtils.ts
@@ -38,6 +38,6 @@ export const resourceUrlToId = (url: string) => {
 };
 
 export const isSupportedImageMimeType = (type: string) => {
-	const imageMimeTypes = ['image/jpg', 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif'];
+	const imageMimeTypes = ['image/jpg', 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/webp', 'image/avif', 'image/bmp'];
 	return imageMimeTypes.indexOf(type.toLowerCase()) >= 0;
 };


### PR DESCRIPTION
# Summary

This pull request adds `image/bmp` to the list of supported resource formats.

**Note**: The Rich Text Editor replaces resource URLs before checking whether an image is in a supported format (`replaceResourceInternalToExternalLinks` is true), so this only affects the Markdown editor.

This pull request fixes #10914.

**Note**: I have observed the original issue on both desktop and web.

# Testing plan

1. Create a new note and attach a BMP image.
2. Verify that the BMP image renders in the Markdown viewer.

This has been tested successfully on Linux (Fedora 40) and web (Chromium).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->