### PR TITLE
Chore: Web: Fix build fails on Windows

### DIFF
--- a/packages/app-mobile/web/webpack.config.js
+++ b/packages/app-mobile/web/webpack.config.js
@@ -13,8 +13,8 @@ const babelLoaderConfiguration = {
 		path.resolve(appDirectory, 'android'),
 
 		// Compiling these libraries with babel cause build errors.
-		/.*node_modules\/@babel.*/,
-		/.*node_modules\/@sqlite\.org\/.*/,
+		/.*node_modules[/\\]@babel.*/,
+		/.*node_modules[/\\]@sqlite\.org[/\\].*/,
 	],
 
 	use: {


### PR DESCRIPTION
# Summary

This pull request fixes a build issue caused by a regular expression assuming forward slashes in a path.

# Testing plan

On Windows 11:
1. From `packages/app-mobile`, run `yarn serve-web`.
2. Open the web client (`http://localhost:8088`). Verify that the page loads successfully.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->