### PR TITLE
Mac: Fixes #10921: Markdown editor: Fix custom arrow-key shortcuts fail to register

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/normalizeAccelerator.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/normalizeAccelerator.test.ts
@@ -6,7 +6,7 @@ describe('normalizeAccelerator', () => {
 		['Z', { v6: 'z', v5: 'Z' }],
 		['Alt+A', { v6: 'Alt-a', v5: 'Alt-A' }],
 		['Shift+A', { v6: 'Shift-a', v5: 'Shift-A' }],
-		['Shift+Up', { v6: 'Shift-Up', v5: 'Shift-Up' }],
+		['Shift+Up', { v6: 'Shift-ArrowUp', v5: 'Shift-Up' }],
 	])(
 		'should convert single-letter key names to lowercase for CM6, keep case unchanged for CM5 (%j)',
 		(original, expected) => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/normalizeAccelerator.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/normalizeAccelerator.ts
@@ -12,11 +12,17 @@ const normalizeAccelerator = (accelerator: string, editorVersion: CodeMirrorVers
 	const parts = command.split(/-(?!$)/);
 	let name = parts[parts.length - 1];
 
-	// In CodeMirror 6, an uppercase single-letter key name makes the editor
-	// require the shift key to activate the shortcut. If a key name like `Up`,
-	// however, `.toLowerCase` breaks the shortcut.
-	if (editorVersion === CodeMirrorVersion.CodeMirror6 && name.length === 1) {
-		name = name.toLowerCase();
+	if (editorVersion === CodeMirrorVersion.CodeMirror6) {
+		// In CodeMirror 6, an uppercase single-letter key name makes the editor
+		// require the shift key to activate the shortcut. If a key name like `Up`,
+		// however, `.toLowerCase` breaks the shortcut.
+		if (name.length === 1) {
+			name = name.toLowerCase();
+		}
+
+		if (['Up', 'Down', 'Left', 'Right'].includes(name)) {
+			name = `Arrow${name}`;
+		}
 	}
 
 	let alt, ctrl, shift, cmd;


### PR DESCRIPTION
# Summary

On Mac, it seems necessary for CodeMirror 6 arrow-key shortcut keys to start with `Arrow` (as opposed to just `Left`). This pull request prepends `Arrow` to `Left`, `Right`, `Up` and `Down` key names when converting Joplin to CodeMirror 6 shortcuts.

This only seems to have been an issue on MacOS.

Fixes #10921.

# Notes

- The [documentation for `KeyBinding`](https://codemirror.net/docs/ref/#view.KeyBinding) states "Key identifiers are based 
on the strings that can appear in [KeyEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)."
- The arrow-key values for `KeyEvent.key` [seem to be](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#navigation_keys) `ArrowLeft`, `ArrowRight`, `ArrowUp`, and `ArrowDown`. 

# Testing

1. Set the "Back" shortcut to <kbd>cmd</kbd>-<kbd>left</kbd> (<kbd>ctrl</kbd>-<kbd>left</kbd> when testing on Linux).
2. Set the "Forward" shortcut to <kbd>option</kbd>-<kbd>right</kbd>  (<kbd>alt</kbd>-<kbd>right</kbd> when testing on Linux).
3. Restart Joplin.
4. Open the Markdown editor (if not open already)
5. Open one note.
6. Open a different note.
7. Press <kbd>cmd</kbd>-<kbd>left</kbd> (<kbd>ctrl</kbd>-<kbd>left</kbd> when testing on Linux). Verify that the previous note is now open.
8. Press <kbd>cmd</kbd>-<kbd>right</kbd>  (<kbd>alt</kbd>-<kbd>right</kbd> when testing on Linux). Verify that the note opened in step 6 is again open.

This has been tested successfully on Fedora 40 and, with a similar set of steps, MacOS Sonoma.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->