### PR TITLE
Desktop: Accessibility: Improve note title focus handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -297,6 +297,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.js
@@ -844,6 +845,7 @@ packages/editor/CodeMirror/utils/formatting/types.js
 packages/editor/CodeMirror/utils/getSearchState.js
 packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
+packages/editor/CodeMirror/utils/isCursorAtBeginning.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/searchExtension.js
 packages/editor/CodeMirror/utils/setupVim.js

--- a/.gitignore
+++ b/.gitignore
@@ -274,6 +274,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTabIndenter.js
@@ -821,6 +822,7 @@ packages/editor/CodeMirror/utils/formatting/types.js
 packages/editor/CodeMirror/utils/getSearchState.js
 packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
+packages/editor/CodeMirror/utils/isCursorAtBeginning.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/searchExtension.js
 packages/editor/CodeMirror/utils/setupVim.js

--- a/packages/app-desktop/commands/focusElement.ts
+++ b/packages/app-desktop/commands/focusElement.ts
@@ -7,11 +7,11 @@ export const declaration: CommandDeclaration = {
 export const runtime = (): CommandRuntime => {
 	return {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		execute: async (_context: any, target: string) => {
-			if (target === 'noteBody') return CommandService.instance().execute('focusElementNoteBody');
+		execute: async (_context: any, target: string, cursorPosition?: number) => {
+			if (target === 'noteBody') return CommandService.instance().execute('focusElementNoteBody', cursorPosition);
 			if (target === 'noteList') return CommandService.instance().execute('focusElementNoteList');
 			if (target === 'sideBar') return CommandService.instance().execute('focusElementSideBar');
-			if (target === 'noteTitle') return CommandService.instance().execute('focusElementNoteTitle');
+			if (target === 'noteTitle') return CommandService.instance().execute('focusElementNoteTitle', cursorPosition);
 			throw new Error(`Invalid focus target: ${target}`);
 		},
 	};

--- a/packages/app-desktop/commands/focusElement.ts
+++ b/packages/app-desktop/commands/focusElement.ts
@@ -4,14 +4,18 @@ export const declaration: CommandDeclaration = {
 	name: 'focusElement',
 };
 
+export interface FocusElementOptions {
+	moveCursorToStart: boolean;
+}
+
 export const runtime = (): CommandRuntime => {
 	return {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		execute: async (_context: any, target: string, cursorPosition?: number) => {
-			if (target === 'noteBody') return CommandService.instance().execute('focusElementNoteBody', cursorPosition);
+		execute: async (_context: any, target: string, options?: FocusElementOptions) => {
+			if (target === 'noteBody') return CommandService.instance().execute('focusElementNoteBody', options);
 			if (target === 'noteList') return CommandService.instance().execute('focusElementNoteList');
 			if (target === 'sideBar') return CommandService.instance().execute('focusElementSideBar');
-			if (target === 'noteTitle') return CommandService.instance().execute('focusElementNoteTitle', cursorPosition);
+			if (target === 'noteTitle') return CommandService.instance().execute('focusElementNoteTitle', options);
 			throw new Error(`Invalid focus target: ${target}`);
 		},
 	};

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -27,6 +27,7 @@ import useContextMenu from '../utils/useContextMenu';
 import useWebviewIpcMessage from '../utils/useWebviewIpcMessage';
 import Toolbar from '../Toolbar';
 import useEditorSearchHandler from '../utils/useEditorSearchHandler';
+import CommandService from '@joplin/lib/services/CommandService';
 
 const logger = Logger.create('CodeMirror6');
 const logDebug = (message: string) => logger.debug(message);
@@ -354,6 +355,10 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		}
 	}, [editor_scroll, codeMirror_change, props.setLocalSearch, props.setShowLocalSearch]);
 
+	const onSelectPastBeginning = useCallback(() => {
+		void CommandService.instance().execute('focusElement', 'noteTitle');
+	}, []);
+
 	const editorSettings = useMemo((): EditorSettings => {
 		const isHTMLNote = props.contentMarkupLanguage === MarkupToHtml.MARKUP_LANGUAGE_HTML;
 
@@ -403,6 +408,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 					onEvent={onEditorEvent}
 					onLogMessage={logDebug}
 					onEditorPaste={onEditorPaste}
+					onSelectPastBeginning={onSelectPastBeginning}
 					externalSearch={props.searchMarkers}
 					useLocalSearch={props.useLocalSearch}
 				/>

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -9,6 +9,7 @@ import Logger from '@joplin/utils/Logger';
 import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
 import { MarkupLanguage } from '@joplin/renderer';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import { FocusElementOptions } from '../../../../../commands/focusElement';
 
 const logger = Logger.create('CodeMirror 6 commands');
 
@@ -103,11 +104,11 @@ const useEditorCommands = (props: Props) => {
 					logger.warn('CodeMirror execCommand: unsupported command: ', value.name);
 				}
 			},
-			'editor.focus': (cursorLocation?: number) => {
+			'editor.focus': (options?: FocusElementOptions) => {
 				if (props.visiblePanes.indexOf('editor') >= 0) {
 					focus('useEditorCommands::editor.focus', editorRef.current.editor);
-					if (cursorLocation !== undefined) {
-						const selectionCursor = { line: 0, ch: cursorLocation };
+					if (options?.moveCursorToStart) {
+						const selectionCursor = { line: 0, ch: 0 };
 						editorRef.current.setSelection(selectionCursor, selectionCursor);
 					}
 				} else {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -108,8 +108,10 @@ const useEditorCommands = (props: Props) => {
 				if (props.visiblePanes.indexOf('editor') >= 0) {
 					focus('useEditorCommands::editor.focus', editorRef.current.editor);
 					if (options?.moveCursorToStart) {
-						const selectionCursor = { line: 0, ch: 0 };
-						editorRef.current.setSelection(selectionCursor, selectionCursor);
+						editorRef.current.editor.dispatch({
+							selection: { anchor: 0 },
+							scrollIntoView: true,
+						});
 					}
 				} else {
 					// If we just call focus() then the iframe is focused,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -103,9 +103,13 @@ const useEditorCommands = (props: Props) => {
 					logger.warn('CodeMirror execCommand: unsupported command: ', value.name);
 				}
 			},
-			'editor.focus': () => {
+			'editor.focus': (cursorLocation?: number) => {
 				if (props.visiblePanes.indexOf('editor') >= 0) {
 					focus('useEditorCommands::editor.focus', editorRef.current.editor);
+					if (cursorLocation !== undefined) {
+						const selectionCursor = { line: 0, ch: cursorLocation };
+						editorRef.current.setSelection(selectionCursor, selectionCursor);
+					}
 				} else {
 					// If we just call focus() then the iframe is focused,
 					// but not its content, such that scrolling up / down

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -39,6 +39,7 @@ const { clipboard } = require('electron');
 const supportedLocales = require('./supportedLocales');
 import { hasProtocol } from '@joplin/utils/url';
 import useTabIndenter from './utils/useTabIndenter';
+import useKeyboardRefocusHandler from './utils/useKeyboardRefocusHandler';
 
 const logger = Logger.create('TinyMCE');
 
@@ -130,6 +131,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 	usePluginServiceRegistration(ref);
 	useContextMenu(editor, props.plugins, props.dispatch, props.htmlToMarkdown, props.markupToHtml);
 	useTabIndenter(editor);
+	useKeyboardRefocusHandler(editor);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const dispatchDidUpdate = (editor: any) => {
@@ -218,6 +220,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.insertContent(result.html);
 				} else if (cmd.name === 'editor.focus') {
 					focus('TinyMCE::editor.focus', editor);
+					if ((cmd.value ?? null) !== null) {
+						editor.selection.placeCaretAt(0, 0);
+						editor.selection.setCursorLocation(
+							editor.dom.root,
+							cmd.value,
+						);
+					}
 				} else if (cmd.name === 'editor.execCommand') {
 					if (!('ui' in cmd.value)) cmd.value.ui = false;
 					if (!('value' in cmd.value)) cmd.value.value = null;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -220,11 +220,11 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					editor.insertContent(result.html);
 				} else if (cmd.name === 'editor.focus') {
 					focus('TinyMCE::editor.focus', editor);
-					if ((cmd.value ?? null) !== null) {
+					if (cmd.value?.moveCursorToStart) {
 						editor.selection.placeCaretAt(0, 0);
 						editor.selection.setCursorLocation(
 							editor.dom.root,
-							cmd.value,
+							0,
 						);
 					}
 				} else if (cmd.name === 'editor.execCommand') {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.ts
@@ -1,0 +1,43 @@
+import CommandService from '@joplin/lib/services/CommandService';
+import { useEffect } from 'react';
+import type { Editor, EditorEvent } from 'tinymce';
+
+const useKeyboardRefocusHandler = (editor: Editor) => {
+	useEffect(() => {
+		if (!editor) return () => {};
+
+		const isAtBeginningOf = (element: Node, parent: HTMLElement) => {
+			if (!parent.contains(element)) return false;
+
+			while (
+				element &&
+				element.parentNode !== parent &&
+				element.parentNode?.firstChild === element
+			) {
+				element = element.parentNode;
+			}
+
+			return !!element && element.parentNode?.firstChild === element;
+		};
+
+		const eventHandler = (event: EditorEvent<KeyboardEvent>) => {
+			if (!event.isDefaultPrevented() && event.key === 'ArrowUp') {
+				const selection = editor.selection.getRng();
+				if (selection.startOffset === 0 &&
+					selection.collapsed &&
+					isAtBeginningOf(selection.startContainer, editor.dom.getRoot())
+				) {
+					event.preventDefault();
+					void CommandService.instance().execute('focusElement', 'noteTitle');
+				}
+			}
+		};
+
+		editor.on('keydown', eventHandler);
+		return () => {
+			editor.off('keydown', eventHandler);
+		};
+	}, [editor]);
+};
+
+export default useKeyboardRefocusHandler;

--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -84,7 +84,7 @@ export default function NoteTitleBar(props: Props) {
 		if ((event.key === 'ArrowDown' && selectionAtEnd) || event.key === 'Enter') {
 			event.preventDefault();
 			const focusStartOfEditor = event.key === 'ArrowDown';
-			void CommandService.instance().execute('focusElement', 'noteBody', focusStartOfEditor ? 0 : undefined);
+			void CommandService.instance().execute('focusElement', 'noteBody', { moveCursorToStart: focusStartOfEditor });
 		}
 	}, []);
 

--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -83,8 +83,8 @@ export default function NoteTitleBar(props: Props) {
 		const selectionAtEnd = titleElement.selectionEnd === titleElement.value.length;
 		if ((event.key === 'ArrowDown' && selectionAtEnd) || event.key === 'Enter') {
 			event.preventDefault();
-			const focusStartOfEditor = event.key === 'ArrowDown';
-			void CommandService.instance().execute('focusElement', 'noteBody', { moveCursorToStart: focusStartOfEditor });
+			const moveCursorToStart = event.key === 'ArrowDown';
+			void CommandService.instance().execute('focusElement', 'noteBody', { moveCursorToStart });
 		}
 	}, []);
 

--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -78,18 +78,13 @@ function styles_(props: Props) {
 export default function NoteTitleBar(props: Props) {
 	const styles = styles_(props);
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	const onTitleKeydown = useCallback((event: any) => {
-		const keyCode = event.keyCode;
-
-		if (keyCode === 9) { // TAB
+	const onTitleKeydown: React.KeyboardEventHandler<HTMLInputElement> = useCallback((event) => {
+		const titleElement = event.currentTarget;
+		const selectionAtEnd = titleElement.selectionEnd === titleElement.value.length;
+		if ((event.key === 'ArrowDown' && selectionAtEnd) || event.key === 'Enter') {
 			event.preventDefault();
-
-			if (event.shiftKey) {
-				void CommandService.instance().execute('focusElement', 'noteList');
-			} else {
-				void CommandService.instance().execute('focusElement', 'noteBody');
-			}
+			const focusStartOfEditor = event.key === 'ArrowDown';
+			void CommandService.instance().execute('focusElement', 'noteBody', focusStartOfEditor ? 0 : undefined);
 		}
 	}, []);
 

--- a/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts
+++ b/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts
@@ -10,8 +10,8 @@ export const declaration: CommandDeclaration = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export const runtime = (comp: any): CommandRuntime => {
 	return {
-		execute: async () => {
-			comp.editorRef.current.execCommand({ name: 'editor.focus' });
+		execute: async (_context: unknown, cursorLocation?: number) => {
+			comp.editorRef.current.execCommand({ name: 'editor.focus', value: cursorLocation });
 		},
 		enabledCondition: 'oneNoteSelected',
 	};

--- a/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts
+++ b/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts
@@ -1,5 +1,6 @@
 import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
+import { FocusElementOptions } from '../../../commands/focusElement';
 
 export const declaration: CommandDeclaration = {
 	name: 'focusElementNoteBody',
@@ -10,8 +11,8 @@ export const declaration: CommandDeclaration = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export const runtime = (comp: any): CommandRuntime => {
 	return {
-		execute: async (_context: unknown, cursorLocation?: number) => {
-			comp.editorRef.current.execCommand({ name: 'editor.focus', value: cursorLocation });
+		execute: async (_context: unknown, options?: FocusElementOptions) => {
+			comp.editorRef.current.execCommand({ name: 'editor.focus', value: options });
 		},
 		enabledCondition: 'oneNoteSelected',
 	};

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -62,12 +62,19 @@ test.describe('main', () => {
 			'',
 			'Sum: $\\sum_{x=0}^{100} \\tan x$',
 		];
+		let firstLine = true;
 		for (const line of noteText) {
 			if (line) {
-				await mainWindow.keyboard.press('Shift+Tab');
+				if (!firstLine) {
+					// Remove any auto-indentation, but avoid pressing shift-tab at
+					// the beginning of the editor.
+					await mainWindow.keyboard.press('Shift+Tab');
+				}
+
 				await mainWindow.keyboard.type(line);
 			}
 			await mainWindow.keyboard.press('Enter');
+			firstLine = false;
 		}
 
 		// Should render mermaid

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -119,5 +119,29 @@ test.describe('richTextEditor', () => {
 		await editor.toggleEditorsButton.click();
 		await expect(editor.codeMirrorEditor).toHaveText('This is a        test.        Test! Another:        !');
 	});
+
+	test('should be possible to navigate between the note title and rich text editor with enter/down/up keys', async ({ mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('Testing keyboard navigation!');
+
+		const editor = mainScreen.noteEditor;
+		await editor.toggleEditorsButton.click();
+
+		await editor.richTextEditor.waitFor();
+
+		await editor.noteTitleInput.click();
+		await expect(editor.noteTitleInput).toBeFocused();
+
+		await mainWindow.keyboard.press('End');
+		await mainWindow.keyboard.press('ArrowDown');
+		await expect(editor.richTextEditor).toBeFocused();
+
+		await mainWindow.keyboard.press('ArrowUp');
+		await expect(editor.noteTitleInput).toBeFocused();
+
+		await mainWindow.keyboard.press('Enter');
+		await expect(editor.noteTitleInput).not.toBeFocused();
+		await expect(editor.richTextEditor).toBeFocused();
+	});
 });
 

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -31,6 +31,7 @@ import insertLineAfter from './editorCommands/insertLineAfter';
 import handlePasteEvent from './utils/handlePasteEvent';
 import biDirectionalTextExtension from './utils/biDirectionalTextExtension';
 import searchExtension from './utils/searchExtension';
+import isCursorAtBeginning from './utils/isCursorAtBeginning';
 
 const createEditor = (
 	parentElement: HTMLElement, props: EditorProps,
@@ -176,10 +177,26 @@ const createEditor = (
 			return true;
 		}),
 		keyCommand('Tab', insertOrIncreaseIndent, true),
-		keyCommand('Shift-Tab', decreaseIndent, true),
+		keyCommand('Shift-Tab', (view) => {
+			// When at the beginning of the editor, allow shift-tab to act
+			// normally.
+			if (isCursorAtBeginning(view.state)) {
+				return false;
+			}
+
+			return decreaseIndent(view);
+		}, true),
 		keyCommand('Mod-Enter', (_: EditorView) => {
 			insertLineAfter(_);
 			return true;
+		}, true),
+
+		keyCommand('ArrowUp', (view: EditorView) => {
+			if (isCursorAtBeginning(view.state) && props.onSelectPastBeginning) {
+				props.onSelectPastBeginning();
+				return true;
+			}
+			return false;
 		}, true),
 
 		...standardKeymap, ...historyKeymap, ...searchKeymap,

--- a/packages/editor/CodeMirror/utils/isCursorAtBeginning.ts
+++ b/packages/editor/CodeMirror/utils/isCursorAtBeginning.ts
@@ -1,0 +1,8 @@
+import { EditorState } from '@codemirror/state';
+
+const isCursorAtBeginning = (state: EditorState) => {
+	const selection = state.selection;
+	return selection.ranges.length === 1 && selection.main.empty && selection.main.anchor === 0;
+};
+
+export default isCursorAtBeginning;

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -169,6 +169,7 @@ export interface EditorSettings {
 export type LogMessageCallback = (message: string)=> void;
 export type OnEventCallback = (event: EditorEvent)=> void;
 export type PasteFileCallback = (data: File)=> Promise<void>;
+type OnScrollPastBeginningCallback = ()=> void;
 
 export interface EditorProps {
 	settings: EditorSettings;
@@ -176,6 +177,7 @@ export interface EditorProps {
 
 	// If null, paste and drag-and-drop will not work for resources unless handled elsewhere.
 	onPasteFile: PasteFileCallback|null;
+	onSelectPastBeginning?: OnScrollPastBeginningCallback;
 	onEvent: OnEventCallback;
 	onLogMessage: LogMessageCallback;
 }


### PR DESCRIPTION
# Summary

This pull request implements [suggestion 1](https://discourse.joplinapp.org/t/how-should-joplin-handle-tab-key-navigation-keyboard-accessibility/39846) from the ["How should Joplin handle keyboard navigation"](https://discourse.joplinapp.org/t/how-should-joplin-handle-tab-key-navigation-keyboard-accessibility/39846) forum post.

To summarize:
- The custom <kbd>Tab</kbd> keybinding override has been removed.
   - This keybinding override made it very difficult to focus the editor toolbar when navigating with a keyboard.
   - See [WCAG §2.4.3](https://www.w3.org/WAI/WCAG22/quickref/?versions=2.2&showtechniques=212%2C241%2C242%2C243%2C247%2C248%2C251%2C211#focus-order) and (less relevant) [WCAG §2.1.2](https://www.w3.org/WAI/WCAG22/quickref/?versions=2.2&showtechniques=212%2C241%2C242%2C243%2C247%2C248%2C251%2C211#keyboard).
- As a replacement, <kbd>Enter</kbd> and <kbd>ArrowDown</kbd> move the keyboard focus from the title to the editor.
    - <kbd>ArrowDown</kbd> moves the caret to the first line and focuses. <kbd>Enter</kbd> just focuses (& preserves the caret location). 
    - In the legacy Markdown editor, <kbd>ArrowDown</kbd> just focuses (& preserves the caret location).
- <kbd>ArrowUp</kbd> on the first line of the editor moves to the title input.
   - This only applies to the new Markdown editor and the Rich Text Editor.

Related: #10795

# Screen recording

[Screencast from 2024-08-26 15-32-57.webm](https://github.com/user-attachments/assets/c4da9f80-dfa0-4f96-ab63-28a7b90d137e)

# Testing plan

As shown in the screen recording above, this pull request has been tested manually on Fedora 40 (Linux):
1. Switch to the Rich Text Editor and focus the note title.
2. Press the <kbd>Down</kbd> arrow key.
3. Verify that the caret has moved to the first line of the editor.
4. Press the <kbd>Up</kbd> arrow key.
5. Verify that the caret has moved back to the note title.
6. Move the caret to the 2nd or 3rd line.
7. Focus the title.
8. Press <kbd>Enter</kbd>.
9. Verify that the caret has moved to the previously-focused paragraph.
10.  Move the focus to the start of the editor.
11. Press <kbd>Shift</kbd>-<kbd>Tab</kbd>.
12. Verify that the focus has moved to the note toolbar.
13. Switch to the Markdown editor.
14. Focus the note title.
15. Press the <kbd>Down</kbd> arrow key.
16. Verify that the note editor's first line has focus.
17. Press <kbd>Up</kbd>.
18. Verify that the title has focus.
19. Press <kbd>Enter</kbd>.
20. Verify that the editor has focus.
21. Focus a line further from the beginning of the editor.
22. Focus the title input by clicking on it.
23. Press <kbd>Down</kbd>.
24. Type.
25. Verify that focus moved to the start of the editor.

Optional to-do: Add an automated Playwright test for the Markdown editor (currently, one only exists for the Rich Text editor).
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->