### PR TITLE
Desktop: Accessibility: Improve note list keyboard and screen reader accessibility

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -460,6 +460,7 @@ packages/app-desktop/gui/style/StyledLink.js
 packages/app-desktop/gui/style/StyledMessage.js
 packages/app-desktop/gui/style/StyledTextInput.js
 packages/app-desktop/gui/utils/NoteListUtils.js
+packages/app-desktop/gui/utils/announceForAccessibility.js
 packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -345,6 +345,7 @@ packages/app-desktop/gui/NoteList/utils/types.js
 packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.js
 packages/app-desktop/gui/NoteList/utils/useDragAndDrop.js
 packages/app-desktop/gui/NoteList/utils/useFocusNote.js
+packages/app-desktop/gui/NoteList/utils/useFocusVisible.js
 packages/app-desktop/gui/NoteList/utils/useItemCss.js
 packages/app-desktop/gui/NoteList/utils/useMoveNote.js
 packages/app-desktop/gui/NoteList/utils/useOnKeyDown.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -472,6 +472,7 @@ packages/app-desktop/integration-tests/markdownEditor.spec.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
+packages/app-desktop/integration-tests/models/NoteList.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -342,6 +342,7 @@ packages/app-desktop/gui/NoteList/commands/focusElementNoteList.js
 packages/app-desktop/gui/NoteList/commands/index.js
 packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.js
 packages/app-desktop/gui/NoteList/utils/types.js
+packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.js
 packages/app-desktop/gui/NoteList/utils/useDragAndDrop.js
 packages/app-desktop/gui/NoteList/utils/useFocusNote.js
 packages/app-desktop/gui/NoteList/utils/useItemCss.js
@@ -364,6 +365,7 @@ packages/app-desktop/gui/NoteListHeader/utils/useContextMenu.js
 packages/app-desktop/gui/NoteListHeader/utils/validateColumns.test.js
 packages/app-desktop/gui/NoteListHeader/utils/validateColumns.js
 packages/app-desktop/gui/NoteListItem/NoteListItem.js
+packages/app-desktop/gui/NoteListItem/utils/getNoteElementIdFromJoplinId.js
 packages/app-desktop/gui/NoteListItem/utils/getNoteTitleHtml.js
 packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.test.js
 packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.js

--- a/.gitignore
+++ b/.gitignore
@@ -319,6 +319,7 @@ packages/app-desktop/gui/NoteList/commands/focusElementNoteList.js
 packages/app-desktop/gui/NoteList/commands/index.js
 packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.js
 packages/app-desktop/gui/NoteList/utils/types.js
+packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.js
 packages/app-desktop/gui/NoteList/utils/useDragAndDrop.js
 packages/app-desktop/gui/NoteList/utils/useFocusNote.js
 packages/app-desktop/gui/NoteList/utils/useItemCss.js
@@ -341,6 +342,7 @@ packages/app-desktop/gui/NoteListHeader/utils/useContextMenu.js
 packages/app-desktop/gui/NoteListHeader/utils/validateColumns.test.js
 packages/app-desktop/gui/NoteListHeader/utils/validateColumns.js
 packages/app-desktop/gui/NoteListItem/NoteListItem.js
+packages/app-desktop/gui/NoteListItem/utils/getNoteElementIdFromJoplinId.js
 packages/app-desktop/gui/NoteListItem/utils/getNoteTitleHtml.js
 packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.test.js
 packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.js

--- a/.gitignore
+++ b/.gitignore
@@ -322,6 +322,7 @@ packages/app-desktop/gui/NoteList/utils/types.js
 packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.js
 packages/app-desktop/gui/NoteList/utils/useDragAndDrop.js
 packages/app-desktop/gui/NoteList/utils/useFocusNote.js
+packages/app-desktop/gui/NoteList/utils/useFocusVisible.js
 packages/app-desktop/gui/NoteList/utils/useItemCss.js
 packages/app-desktop/gui/NoteList/utils/useMoveNote.js
 packages/app-desktop/gui/NoteList/utils/useOnKeyDown.js

--- a/.gitignore
+++ b/.gitignore
@@ -449,6 +449,7 @@ packages/app-desktop/integration-tests/markdownEditor.spec.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js
+packages/app-desktop/integration-tests/models/NoteList.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -437,6 +437,7 @@ packages/app-desktop/gui/style/StyledLink.js
 packages/app-desktop/gui/style/StyledMessage.js
 packages/app-desktop/gui/style/StyledTextInput.js
 packages/app-desktop/gui/utils/NoteListUtils.js
+packages/app-desktop/gui/utils/announceForAccessibility.js
 packages/app-desktop/gui/utils/convertToScreenCoordinates.js
 packages/app-desktop/gui/utils/dragAndDrop.js
 packages/app-desktop/gui/utils/loadScript.js

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -26,6 +26,7 @@ import Folder from '@joplin/lib/models/Folder';
 import { _ } from '@joplin/lib/locale';
 import useActiveDescendantId from './utils/useActiveDescendantId';
 import getNoteElementIdFromJoplinId from '../NoteListItem/utils/getNoteElementIdFromJoplinId';
+import useFocusVisible from './utils/useFocusVisible';
 const { connect } = require('react-redux');
 
 const commands = {
@@ -184,6 +185,8 @@ const NoteList = (props: Props) => {
 	// 	}
 	// }, [makeItemIndexVisible, previousSelectedNoteIds, previousNoteCount, previousVisible, props.selectedNoteIds, props.notes, props.focusedField, props.visible]);
 
+	const { focusVisible, onFocus, onBlur } = useFocusVisible();
+
 	const highlightedWords = useMemo(() => {
 		if (props.notesParentType === 'Search') {
 			const query = BaseModel.byId(props.searches, props.selectedSearchId);
@@ -245,6 +248,7 @@ const NoteList = (props: Props) => {
 					flow={listRenderer.flow}
 					note={note}
 					tabIndex={-1}
+					focusVisible={focusVisible && activeNoteId === note.id}
 					isSelected={isSelected}
 					isWatched={props.watchedNoteFiles.includes(note.id)}
 					listRenderer={listRenderer}
@@ -298,9 +302,10 @@ const NoteList = (props: Props) => {
 			aria-label={_('Notes')}
 			aria-activedescendant={getNoteElementIdFromJoplinId(activeNoteId)}
 			aria-multiselectable={true}
-			// Ensure that the note list can be focused, even if no selected
-			// items are visible.
 			tabIndex={0}
+
+			onFocus={onFocus}
+			onBlur={onBlur}
 
 			className="note-list"
 			style={noteListStyle}

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -183,7 +183,7 @@ const NoteList = (props: Props) => {
 	// 	}
 	// }, [makeItemIndexVisible, previousSelectedNoteIds, previousNoteCount, previousVisible, props.selectedNoteIds, props.notes, props.focusedField, props.visible]);
 
-	const { focusVisible, onFocus, onBlur } = useFocusVisible(listRef, () => {
+	const { focusVisible, onFocus, onBlur, onKeyUp } = useFocusVisible(listRef, () => {
 		focusNote(activeNoteId);
 	});
 
@@ -291,6 +291,7 @@ const NoteList = (props: Props) => {
 			ref={listRef}
 			onScroll={onScroll}
 			onKeyDown={onKeyDown}
+			onKeyUp={onKeyUp}
 			onDrop={onDrop}
 		>
 			{renderEmptyList()}

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -196,12 +196,13 @@ const NoteList = (props: Props) => {
 		return <div key={key} style={style}></div>;
 	};
 
-	let renderedSelectedItem = false;
 	const renderNotes = () => {
-		if (!props.notes.length) return null;
+		let renderedSelectedItem = false;
+		const rows: JSX.Element[] = [];
+
+		if (!props.notes.length) return { notes: rows, renderedSelectedItem };
 
 		const firstRowIndex = Math.floor(startNoteIndex / itemsPerLine);
-		const rows: JSX.Element[] = [];
 		let currentRow: JSX.Element[] = [];
 
 		const finalizeRow = () => {
@@ -264,7 +265,7 @@ const NoteList = (props: Props) => {
 		}
 		finalizeRow();
 
-		return rows;
+		return { notes: rows, renderEmptyList };
 	};
 
 	const topFillerHeight = startLineIndex * itemSize.height;
@@ -295,11 +296,14 @@ const NoteList = (props: Props) => {
 		return output;
 	}, [listRenderer.flow]);
 
+	const { notes, renderedSelectedItem } = renderNotes();
+
 	return (
 		<div
 			role='grid'
 			aria-colcount={itemsPerLine}
 			aria-rowcount={totalLineCount}
+			aria-multiselectable={true}
 			// Ensure that the note list can be focused, even if no selected
 			// items are visible.
 			tabIndex={!renderedSelectedItem ? 0 : undefined}
@@ -313,8 +317,8 @@ const NoteList = (props: Props) => {
 		>
 			{renderEmptyList()}
 			{renderFiller('top', topFillerStyle)}
-			<div className="notes note-list-grid" style={notesStyle}>
-				{renderNotes()}
+			<div className='notes note-list-grid' role='rowgroup' style={notesStyle}>
+				{notes}
 			</div>
 			{renderFiller('bottom', bottomFillerStyle)}
 		</div>

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -205,29 +205,15 @@ const NoteList = (props: Props) => {
 	};
 
 	const renderNotes = () => {
-		let renderedSelectedItem = false;
-		const rows: JSX.Element[] = [];
+		if (!props.notes.length) return [];
 
-		if (!props.notes.length) return { notes: rows, renderedSelectedItem };
-
-		let currentRow: JSX.Element[] = [];
-
-		const finalizeRow = () => {
-			if (currentRow.length === 0) {
-				return;
-			}
-
-			rows.push(...currentRow);
-			currentRow = [];
-		};
+		const output: JSX.Element[] = [];
 
 		for (let i = startNoteIndex; i <= endNoteIndex; i++) {
 			const note = props.notes[i];
-
 			const isSelected = props.selectedNoteIds.includes(note.id);
-			renderedSelectedItem ||= isSelected;
 
-			currentRow.push(
+			output.push(
 				<NoteListItem
 					key={note.id}
 					ref={el => itemRefs.current[note.id] = el}
@@ -254,14 +240,9 @@ const NoteList = (props: Props) => {
 					columns={props.columns}
 				/>,
 			);
-
-			if (currentRow.length >= itemsPerLine) {
-				finalizeRow();
-			}
 		}
-		finalizeRow();
 
-		return { notes: rows, renderEmptyList };
+		return output;
 	};
 
 	const topFillerHeight = startLineIndex * itemSize.height;
@@ -292,8 +273,6 @@ const NoteList = (props: Props) => {
 		return output;
 	}, [listRenderer.flow]);
 
-	const { notes } = renderNotes();
-
 	return (
 		<div
 			role='listbox'
@@ -314,8 +293,8 @@ const NoteList = (props: Props) => {
 		>
 			{renderEmptyList()}
 			{renderFiller('top', topFillerStyle)}
-			<div className='notes note-list-grid' role='presentation' style={notesStyle}>
-				{notes}
+			<div className='notes' role='presentation' style={notesStyle}>
+				{renderNotes()}
 			</div>
 			{renderFiller('bottom', bottomFillerStyle)}
 		</div>

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -24,6 +24,8 @@ import { itemIsInTrash } from '@joplin/lib/services/trash';
 import getEmptyFolderMessage from '@joplin/lib/components/shared/NoteList/getEmptyFolderMessage';
 import Folder from '@joplin/lib/models/Folder';
 import { _ } from '@joplin/lib/locale';
+import useActiveDescendantId from './utils/useActiveDescendantId';
+import getNoteElementIdFromJoplinId from '../NoteListItem/utils/getNoteElementIdFromJoplinId';
 const { connect } = require('react-redux');
 
 const commands = {
@@ -66,7 +68,10 @@ const NoteList = (props: Props) => {
 		props.notes.length,
 	);
 
-	const focusNote = useFocusNote(listRef, itemRefs, props.notes, makeItemIndexVisible);
+	const { activeNoteId, setActiveNoteId } = useActiveDescendantId(props.selectedFolderId, props.selectedNoteIds);
+	const focusNote = useFocusNote(
+		listRef, itemRefs, props.notes, makeItemIndexVisible, setActiveNoteId,
+	);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,
@@ -99,6 +104,7 @@ const NoteList = (props: Props) => {
 	const onNoteClick = useOnNoteClick(props.dispatch, focusNote);
 
 	const onKeyDown = useOnKeyDown(
+		activeNoteId,
 		props.selectedNoteIds,
 		moveNote,
 		makeItemIndexVisible,
@@ -219,7 +225,7 @@ const NoteList = (props: Props) => {
 
 			const isSelected = props.selectedNoteIds.includes(note.id);
 			renderedSelectedItem ||= isSelected;
-			const isFocusable = isSelected;
+			const isFocusable = activeNoteId === note.id;
 
 			currentRow.push(
 				<NoteListItem
@@ -291,7 +297,7 @@ const NoteList = (props: Props) => {
 		<div
 			role='listbox'
 			aria-label={_('Notes')}
-			aria-setsize={notes.length}
+			aria-activedescendant={getNoteElementIdFromJoplinId(activeNoteId)}
 			aria-multiselectable={true}
 			// Ensure that the note list can be focused, even if no selected
 			// items are visible.

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -70,9 +70,7 @@ const NoteList = (props: Props) => {
 	);
 
 	const { activeNoteId, setActiveNoteId } = useActiveDescendantId(props.selectedFolderId, props.selectedNoteIds);
-	const focusNote = useFocusNote(
-		listRef, itemRefs, props.notes, makeItemIndexVisible, setActiveNoteId,
-	);
+	const focusNote = useFocusNote(listRef, props.notes, makeItemIndexVisible, setActiveNoteId);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -23,6 +23,7 @@ import useDragAndDrop from './utils/useDragAndDrop';
 import { itemIsInTrash } from '@joplin/lib/services/trash';
 import getEmptyFolderMessage from '@joplin/lib/components/shared/NoteList/getEmptyFolderMessage';
 import Folder from '@joplin/lib/models/Folder';
+import { _ } from '@joplin/lib/locale';
 const { connect } = require('react-redux');
 
 const commands = {
@@ -202,7 +203,6 @@ const NoteList = (props: Props) => {
 
 		if (!props.notes.length) return { notes: rows, renderedSelectedItem };
 
-		const firstRowIndex = Math.floor(startNoteIndex / itemsPerLine);
 		let currentRow: JSX.Element[] = [];
 
 		const finalizeRow = () => {
@@ -210,18 +210,7 @@ const NoteList = (props: Props) => {
 				return;
 			}
 
-			// Rows are 1-indexed
-			const rowIndex = firstRowIndex + rows.length + 1;
-			rows.push(
-				<div
-					key={`row-${rowIndex}`}
-					role='row'
-					className='row'
-					aria-rowindex={rowIndex}
-				>
-					{currentRow}
-				</div>,
-			);
+			rows.push(...currentRow);
 			currentRow = [];
 		};
 
@@ -300,9 +289,9 @@ const NoteList = (props: Props) => {
 
 	return (
 		<div
-			role='grid'
-			aria-colcount={itemsPerLine}
-			aria-rowcount={totalLineCount}
+			role='listbox'
+			aria-label={_('Notes')}
+			aria-setsize={notes.length}
 			aria-multiselectable={true}
 			// Ensure that the note list can be focused, even if no selected
 			// items are visible.
@@ -317,7 +306,7 @@ const NoteList = (props: Props) => {
 		>
 			{renderEmptyList()}
 			{renderFiller('top', topFillerStyle)}
-			<div className='notes note-list-grid' role='rowgroup' style={notesStyle}>
+			<div className='notes note-list-grid' role='presentation' style={notesStyle}>
 				{notes}
 			</div>
 			{renderFiller('bottom', bottomFillerStyle)}

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -183,7 +183,9 @@ const NoteList = (props: Props) => {
 	// 	}
 	// }, [makeItemIndexVisible, previousSelectedNoteIds, previousNoteCount, previousVisible, props.selectedNoteIds, props.notes, props.focusedField, props.visible]);
 
-	const { focusVisible, onFocus, onBlur } = useFocusVisible();
+	const { focusVisible, onFocus, onBlur } = useFocusVisible(listRef, () => {
+		focusNote(activeNoteId);
+	});
 
 	const highlightedWords = useMemo(() => {
 		if (props.notesParentType === 'Search') {

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -225,7 +225,6 @@ const NoteList = (props: Props) => {
 
 			const isSelected = props.selectedNoteIds.includes(note.id);
 			renderedSelectedItem ||= isSelected;
-			const isFocusable = activeNoteId === note.id;
 
 			currentRow.push(
 				<NoteListItem
@@ -245,7 +244,7 @@ const NoteList = (props: Props) => {
 					isProvisional={props.provisionalNoteIds.includes(note.id)}
 					flow={listRenderer.flow}
 					note={note}
-					tabIndex={isFocusable ? 0 : -1}
+					tabIndex={-1}
 					isSelected={isSelected}
 					isWatched={props.watchedNoteFiles.includes(note.id)}
 					listRenderer={listRenderer}
@@ -291,7 +290,7 @@ const NoteList = (props: Props) => {
 		return output;
 	}, [listRenderer.flow]);
 
-	const { notes, renderedSelectedItem } = renderNotes();
+	const { notes } = renderNotes();
 
 	return (
 		<div
@@ -301,7 +300,7 @@ const NoteList = (props: Props) => {
 			aria-multiselectable={true}
 			// Ensure that the note list can be focused, even if no selected
 			// items are visible.
-			tabIndex={!renderedSelectedItem ? 0 : undefined}
+			tabIndex={0}
 
 			className="note-list"
 			style={noteListStyle}

--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -18,6 +18,12 @@
 		background-color: var(--joplin-background-color);
 		font-family: var(--joplin-font-family);
 	}
+
+	// focus-visible is communicated by displaying the active item in a different style.
+	// As such, an outline is unnecessary.
+	&:focus-visible {
+		outline: unset;
+	}
 }
 
 .note-list-item {

--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -28,7 +28,6 @@
 	border-color: var(--joplin-color);
 	position: relative;
 	box-sizing: border-box;
-	flex-grow: 1;
 
 	> .dragcursor {
 		background-color: var(--joplin-color);

--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -20,13 +20,6 @@
 	}
 }
 
-.note-list-grid {
-	> .row {
-		display: flex;
-		flex-direction: row;
-	}
-}
-
 .note-list-item {
  	display: flex;
 }

--- a/packages/app-desktop/gui/NoteList/style.scss
+++ b/packages/app-desktop/gui/NoteList/style.scss
@@ -20,6 +20,13 @@
 	}
 }
 
+.note-list-grid {
+	> .row {
+		display: flex;
+		flex-direction: row;
+	}
+}
+
 .note-list-item {
  	display: flex;
 }
@@ -28,6 +35,7 @@
 	border-color: var(--joplin-color);
 	position: relative;
 	box-sizing: border-box;
+	flex-grow: 1;
 
 	> .dragcursor {
 		background-color: var(--joplin-color);

--- a/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
@@ -16,21 +16,20 @@ const useActiveDescendantId = (selectedFolderId: string, selectedNoteIds: string
 	useEffect(() => {
 		const previousNoteIds = previousNoteIdsRef.current ?? [];
 
-		// Check for items added
-		for (const id of selectedNoteIds) {
-			if (!previousNoteIds.includes(id)) {
-				setActiveNoteId(id);
-				return;
-			}
-		}
+		setActiveNoteId(current => {
+			if (selectedNoteIds.includes(current)) {
+				return current;
+			} else {
+				// Prefer added items
+				for (const id of selectedNoteIds) {
+					if (!previousNoteIds.includes(id)) {
+						return id;
+					}
+				}
 
-		// Check for items removed
-		for (const id of previousNoteIds) {
-			if (!selectedNoteIds.includes(id)) {
-				setActiveNoteId(id);
-				return;
+				return selectedNoteIds[0] ?? '';
 			}
-		}
+		});
 	}, [selectedNoteIds]);
 
 	return { activeNoteId, setActiveNoteId };

--- a/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useActiveDescendantId.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import usePrevious from '@joplin/lib/hooks/usePrevious';
+
+const useActiveDescendantId = (selectedFolderId: string, selectedNoteIds: string[]) => {
+	const selectedNoteIdsRef = useRef(selectedNoteIds);
+	selectedNoteIdsRef.current = selectedNoteIds;
+
+	const [activeNoteId, setActiveNoteId] = useState('');
+	useEffect(() => {
+		setActiveNoteId(selectedNoteIdsRef.current?.[0] ?? '');
+	}, [selectedFolderId]);
+
+	const previousNoteIdsRef = useRef<string[]>();
+	previousNoteIdsRef.current = usePrevious(selectedNoteIds);
+
+	useEffect(() => {
+		const previousNoteIds = previousNoteIdsRef.current ?? [];
+
+		// Check for items added
+		for (const id of selectedNoteIds) {
+			if (!previousNoteIds.includes(id)) {
+				setActiveNoteId(id);
+				return;
+			}
+		}
+
+		// Check for items removed
+		for (const id of previousNoteIds) {
+			if (!selectedNoteIds.includes(id)) {
+				setActiveNoteId(id);
+				return;
+			}
+		}
+	}, [selectedNoteIds]);
+
+	return { activeNoteId, setActiveNoteId };
+};
+
+export default useActiveDescendantId;

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -22,20 +22,25 @@ const useFocusNote = (
 			setActiveNoteId(noteId);
 		}
 
+		// So that keyboard events can still be handled, we need to ensure that some part
+		// of the note list keeps focus while the note element is loading.
+		focus('useFocusNote', containerRef.current);
+
 		// - We need to focus the item manually otherwise focus might be lost when the
 		//   list is scrolled and items within it are being rebuilt.
 		// - We need to use an interval because when leaving the arrow pressed or scrolling
 		//   offscreen items into view, the rendering of items might lag behind and so the
 		//   ref is not yet available at this point.
 
+		const scrollIntoView = () => {
+			itemRefs.current[noteId].scrollIntoView({ inline: 'nearest', block: 'nearest' });
+		};
+
 		if (!itemRefs.current[noteId]) {
 			const targetIndex = notesRef.current.findIndex(note => note.id === noteId);
 			if (targetIndex > -1) {
 				makeItemIndexVisible(targetIndex);
 			}
-			// So that keyboard events can still be handled, we need to ensure that some part
-			// of the note list keeps focus while the note element is loading.
-			focus('useFocusNote0', containerRef.current);
 
 			if (focusItemIID.current) {
 				shim.clearInterval(focusItemIID.current);
@@ -44,7 +49,7 @@ const useFocusNote = (
 			if (noteId) {
 				focusItemIID.current = shim.setInterval(() => {
 					if (itemRefs.current[noteId]) {
-						focus('useFocusNote1', itemRefs.current[noteId]);
+						scrollIntoView();
 						shim.clearInterval(focusItemIID.current);
 						focusItemIID.current = null;
 					}
@@ -52,7 +57,7 @@ const useFocusNote = (
 			}
 		} else {
 			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
-			focus('useFocusNote2', itemRefs.current[noteId]);
+			scrollIntoView();
 		}
 	}, [containerRef, itemRefs, makeItemIndexVisible, setActiveNoteId]);
 

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -18,8 +18,9 @@ const useFocusNote = (
 			setActiveNoteId(noteId);
 		}
 
-		// So that keyboard events can still be handled, we need to ensure that some part
-		// of the note list keeps focus while the note element is loading.
+		// The note list container should have focus even when a note list item is visibly selected.
+		// The visibly focused item is determined by activeNoteId and is communicated to accessibility
+		// tools using aria- attributes
 		focus('useFocusNote', containerRef.current);
 
 		const targetIndex = notesRef.current.findIndex(note => note.id === noteId);

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -1,19 +1,15 @@
-import shim from '@joplin/lib/shim';
-import { useRef, useCallback, MutableRefObject, RefObject } from 'react';
+import { useRef, useCallback, RefObject } from 'react';
 import { focus } from '@joplin/lib/utils/focusHandler';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
 export type FocusNote = (noteId: string)=> void;
 type ContainerRef = RefObject<HTMLElement>;
-type ItemRefs = MutableRefObject<Record<string, HTMLDivElement>>;
 type OnMakeIndexVisible = (i: number)=> void;
 type OnSetActiveId = (id: string)=> void;
 
 const useFocusNote = (
-	containerRef: ContainerRef, itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible, setActiveNoteId: OnSetActiveId,
+	containerRef: ContainerRef, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible, setActiveNoteId: OnSetActiveId,
 ) => {
-	const focusItemIID = useRef(null);
-
 	const notesRef = useRef(notes);
 	notesRef.current = notes;
 
@@ -26,40 +22,11 @@ const useFocusNote = (
 		// of the note list keeps focus while the note element is loading.
 		focus('useFocusNote', containerRef.current);
 
-		// - We need to focus the item manually otherwise focus might be lost when the
-		//   list is scrolled and items within it are being rebuilt.
-		// - We need to use an interval because when leaving the arrow pressed or scrolling
-		//   offscreen items into view, the rendering of items might lag behind and so the
-		//   ref is not yet available at this point.
-
-		const scrollIntoView = () => {
-			itemRefs.current[noteId].scrollIntoView({ inline: 'nearest', block: 'nearest' });
-		};
-
-		if (!itemRefs.current[noteId]) {
-			const targetIndex = notesRef.current.findIndex(note => note.id === noteId);
-			if (targetIndex > -1) {
-				makeItemIndexVisible(targetIndex);
-			}
-
-			if (focusItemIID.current) {
-				shim.clearInterval(focusItemIID.current);
-			}
-
-			if (noteId) {
-				focusItemIID.current = shim.setInterval(() => {
-					if (itemRefs.current[noteId]) {
-						scrollIntoView();
-						shim.clearInterval(focusItemIID.current);
-						focusItemIID.current = null;
-					}
-				}, 10);
-			}
-		} else {
-			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
-			scrollIntoView();
+		const targetIndex = notesRef.current.findIndex(note => note.id === noteId);
+		if (targetIndex > -1) {
+			makeItemIndexVisible(targetIndex);
 		}
-	}, [containerRef, itemRefs, makeItemIndexVisible, setActiveNoteId]);
+	}, [containerRef, makeItemIndexVisible, setActiveNoteId]);
 
 	return focusNote;
 };

--- a/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusNote.ts
@@ -1,19 +1,21 @@
 import shim from '@joplin/lib/shim';
-import { useRef, useCallback, MutableRefObject } from 'react';
+import { useRef, useCallback, MutableRefObject, RefObject } from 'react';
 import { focus } from '@joplin/lib/utils/focusHandler';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
 export type FocusNote = (noteId: string)=> void;
+type ContainerRef = RefObject<HTMLElement>;
 type ItemRefs = MutableRefObject<Record<string, HTMLDivElement>>;
 type OnMakeIndexVisible = (i: number)=> void;
 
-const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible) => {
+const useFocusNote = (containerRef: ContainerRef, itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisible: OnMakeIndexVisible) => {
 	const focusItemIID = useRef(null);
 
 	const notesRef = useRef(notes);
 	notesRef.current = notes;
 
 	const focusNote: FocusNote = useCallback((noteId: string) => {
+
 		// - We need to focus the item manually otherwise focus might be lost when the
 		//   list is scrolled and items within it are being rebuilt.
 		// - We need to use an interval because when leaving the arrow pressed or scrolling
@@ -25,6 +27,9 @@ const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisi
 			if (targetIndex > -1) {
 				makeItemIndexVisible(targetIndex);
 			}
+			// So that keyboard events can still be handled, we need to ensure that some part
+			// of the note list keeps focus.
+			focus('useFocusNote0', containerRef.current);
 
 			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
 			focusItemIID.current = shim.setInterval(() => {
@@ -38,7 +43,7 @@ const useFocusNote = (itemRefs: ItemRefs, notes: NoteEntity[], makeItemIndexVisi
 			if (focusItemIID.current) shim.clearInterval(focusItemIID.current);
 			focus('useFocusNote2', itemRefs.current[noteId]);
 		}
-	}, [itemRefs, makeItemIndexVisible]);
+	}, [containerRef, itemRefs, makeItemIndexVisible]);
 
 	return focusNote;
 };

--- a/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
@@ -5,16 +5,41 @@ const useFocusVisible = (containerRef: RefObject<HTMLElement>, onFocusEnter: ()=
 
 	const onFocusEnterRef = useRef(onFocusEnter);
 	onFocusEnterRef.current = onFocusEnter;
+	const focusVisibleRef = useRef(focusVisible);
+	focusVisibleRef.current = focusVisible;
 
-	const onFocus = useCallback(() => {
-		if (containerRef.current.matches(':focus-visible')) {
+	const onFocusVisible = useCallback(() => {
+		if (!focusVisibleRef.current) {
 			setFocusVisible(true);
 			onFocusEnterRef.current();
 		}
-	}, [containerRef]);
+	}, []);
+
+	const onFocus = useCallback(() => {
+		if (containerRef.current.matches(':focus-visible')) {
+			onFocusVisible();
+		}
+	}, [containerRef, onFocusVisible]);
+
+	const onKeyUp = useCallback(() => {
+		if (containerRef.current.contains(document.activeElement)) {
+			onFocusVisible();
+		}
+	}, [containerRef, onFocusVisible]);
+
 	const onBlur = useCallback(() => setFocusVisible(false), []);
 
-	return { focusVisible, onFocus, onBlur };
+	return {
+		focusVisible,
+		onFocus,
+
+		// When focus becomes visible due to a key press, but the item was already
+		// focused, no new focus event is emitted and the browser :focus-visible doesn't
+		// change. As such, we need to handle this case ourselves.
+		onKeyUp,
+
+		onBlur,
+	};
 };
 
 export default useFocusVisible;

--- a/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
@@ -1,0 +1,12 @@
+import { useCallback, useState } from 'react';
+
+const useFocusVisible = () => {
+	const [focusVisible, setFocusVisible] = useState(false);
+
+	const onFocus = useCallback(() => setFocusVisible(true), []);
+	const onBlur = useCallback(() => setFocusVisible(false), []);
+
+	return { focusVisible, onFocus, onBlur };
+};
+
+export default useFocusVisible;

--- a/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useFocusVisible.ts
@@ -1,9 +1,17 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef, RefObject } from 'react';
 
-const useFocusVisible = () => {
+const useFocusVisible = (containerRef: RefObject<HTMLElement>, onFocusEnter: ()=> void) => {
 	const [focusVisible, setFocusVisible] = useState(false);
 
-	const onFocus = useCallback(() => setFocusVisible(true), []);
+	const onFocusEnterRef = useRef(onFocusEnter);
+	onFocusEnterRef.current = onFocusEnter;
+
+	const onFocus = useCallback(() => {
+		if (containerRef.current.matches(':focus-visible')) {
+			setFocusVisible(true);
+			onFocusEnterRef.current();
+		}
+	}, [containerRef]);
 	const onBlur = useCallback(() => setFocusVisible(false), []);
 
 	return { focusVisible, onFocus, onBlur };

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -10,6 +10,7 @@ import { ItemFlow } from '@joplin/lib/services/plugins/api/noteListType';
 import { KeyboardEventKey } from '@joplin/lib/dom';
 
 const useOnKeyDown = (
+	activeNoteId: string,
 	selectedNoteIds: string[],
 	moveNote: (direction: number, inc: number)=> void,
 	makeItemIndexVisible: (itemIndex: number)=> void,
@@ -85,7 +86,7 @@ const useOnKeyDown = (
 			}
 			event.preventDefault();
 		} else if (notes.length > 0 && (key === 'ArrowDown' || key === 'ArrowUp' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'PageDown' || key === 'PageUp' || key === 'End' || key === 'Home')) {
-			const noteId = selectedNoteIds[selectedNoteIds.length - 1] ?? notes[0]?.id;
+			const noteId = activeNoteId ?? notes[0]?.id;
 			let noteIndex = BaseModel.modelIndexById(notes, noteId);
 			noteIndex = scrollNoteIndex(visibleItemCount, key, event.ctrlKey, event.metaKey, noteIndex);
 
@@ -164,7 +165,7 @@ const useOnKeyDown = (
 				type: 'NOTE_SELECT_ALL',
 			});
 		}
-	}, [moveNote, focusNote, visibleItemCount, scrollNoteIndex, makeItemIndexVisible, notes, selectedNoteIds, dispatch, flow, itemsPerLine]);
+	}, [moveNote, focusNote, visibleItemCount, scrollNoteIndex, makeItemIndexVisible, notes, selectedNoteIds, activeNoteId, dispatch, flow, itemsPerLine]);
 
 
 	return onKeyDown;

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -84,18 +84,41 @@ const useOnKeyDown = (
 				}
 			}
 			event.preventDefault();
-		} else if (noteIds.length > 0 && (key === 'ArrowDown' || key === 'ArrowUp' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'PageDown' || key === 'PageUp' || key === 'End' || key === 'Home')) {
-			const noteId = noteIds[0];
-			let noteIndex = BaseModel.modelIndexById(notes, noteId);
+		} else if (notes.length > 0 && (key === 'ArrowDown' || key === 'ArrowUp' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'PageDown' || key === 'PageUp' || key === 'End' || key === 'Home')) {
+			// const isDownwardKey = [ 'ArrowDown', 'ArrowRight', 'PageDown', 'End' ].includes(key);
+			// let noteIndex = 0;
+			// for (let i = 0; i < notes.length; i++) {
+			// 	const index = isDownwardKey ? notes.length - 1 - i : i;
+			// 	if (selectedNoteIds.includes(notes[index].id)) {
+			// 		noteIndex = index;
+			// 		break;
+			// 	}
+			// }
 
+			const noteId = selectedNoteIds[selectedNoteIds.length - 1] ?? notes[0]?.id;
+			let noteIndex = BaseModel.modelIndexById(notes, noteId);
 			noteIndex = scrollNoteIndex(visibleItemCount, key, event.ctrlKey, event.metaKey, noteIndex);
 
 			const newSelectedNote = notes[noteIndex];
 
-			dispatch({
-				type: 'NOTE_SELECT',
-				id: newSelectedNote.id,
-			});
+			if (event.shiftKey) {
+				if (selectedNoteIds.includes(newSelectedNote.id)) {
+					dispatch({
+						type: 'NOTE_SELECT_REMOVE',
+						id: noteId,
+					});
+				}
+
+				dispatch({
+					type: 'NOTE_SELECT_ADD',
+					id: newSelectedNote.id,
+				});
+			} else {
+				dispatch({
+					type: 'NOTE_SELECT',
+					id: newSelectedNote.id,
+				});
+			}
 
 			makeItemIndexVisible(noteIndex);
 

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -90,6 +90,7 @@ const useOnKeyDown = (
 		} else if (notes.length > 0 && (key === 'ArrowDown' || key === 'ArrowUp' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'PageDown' || key === 'PageUp' || key === 'End' || key === 'Home')) {
 			const noteId = activeNoteId ?? notes[0]?.id;
 			let noteIndex = BaseModel.modelIndexById(notes, noteId);
+
 			noteIndex = scrollNoteIndex(visibleItemCount, key, event.ctrlKey, event.metaKey, noteIndex);
 
 			const newSelectedNote = notes[noteIndex];
@@ -148,8 +149,8 @@ const useOnKeyDown = (
 
 			dispatch({ type: 'NOTE_SORT' });
 			focusNote(todos[0].id);
-			const oldCompleted = !!todos[0].todo_completed;
-			announceForAccessibility(!oldCompleted ? _('Complete') : _('Incomplete'));
+			const wasCompleted = !!todos[0].todo_completed;
+			announceForAccessibility(!wasCompleted ? _('Complete') : _('Incomplete'));
 		}
 
 		if (key === 'Tab') {

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -136,8 +136,7 @@ const useOnKeyDown = (
 			event.preventDefault();
 
 			const selectedNotes = BaseModel.modelsByIds(notes, noteIds);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const todos = selectedNotes.filter((n: any) => !!n.is_todo);
+			const todos = selectedNotes.filter(n => !!n.is_todo);
 			if (!todos.length) return;
 
 			for (let i = 0; i < todos.length; i++) {
@@ -145,6 +144,7 @@ const useOnKeyDown = (
 				await Note.save(toggledTodo);
 			}
 
+			dispatch({ type: 'NOTE_SORT' });
 			focusNote(todos[0].id);
 		}
 

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -8,6 +8,8 @@ import { Dispatch } from 'redux';
 import { FocusNote } from './useFocusNote';
 import { ItemFlow } from '@joplin/lib/services/plugins/api/noteListType';
 import { KeyboardEventKey } from '@joplin/lib/dom';
+import announceForAccessibility from '../../utils/announceForAccessibility';
+import { _ } from '@joplin/lib/locale';
 
 const useOnKeyDown = (
 	activeNoteId: string,
@@ -146,6 +148,8 @@ const useOnKeyDown = (
 
 			dispatch({ type: 'NOTE_SORT' });
 			focusNote(todos[0].id);
+			const oldCompleted = !!todos[0].todo_completed;
+			announceForAccessibility(!oldCompleted ? _('Complete') : _('Incomplete'));
 		}
 
 		if (key === 'Tab') {

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -85,16 +85,6 @@ const useOnKeyDown = (
 			}
 			event.preventDefault();
 		} else if (notes.length > 0 && (key === 'ArrowDown' || key === 'ArrowUp' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'PageDown' || key === 'PageUp' || key === 'End' || key === 'Home')) {
-			// const isDownwardKey = [ 'ArrowDown', 'ArrowRight', 'PageDown', 'End' ].includes(key);
-			// let noteIndex = 0;
-			// for (let i = 0; i < notes.length; i++) {
-			// 	const index = isDownwardKey ? notes.length - 1 - i : i;
-			// 	if (selectedNoteIds.includes(notes[index].id)) {
-			// 		noteIndex = index;
-			// 		break;
-			// 	}
-			// }
-
 			const noteId = selectedNoteIds[selectedNoteIds.length - 1] ?? notes[0]?.id;
 			let noteIndex = BaseModel.modelIndexById(notes, noteId);
 			noteIndex = scrollNoteIndex(visibleItemCount, key, event.ctrlKey, event.metaKey, noteIndex);

--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -27,9 +27,12 @@ interface NoteItemProps {
 	onDragStart: DragEventHandler;
 	style: CSSProperties;
 	note: NoteEntity;
-	isSelected: boolean;
 	isWatched: boolean;
+
+	isSelected: boolean;
 	tabIndex: number;
+	focusVisible: boolean;
+
 	listRenderer: ListRenderer;
 	columns: NoteListColumns;
 	dispatch: Dispatch;
@@ -72,6 +75,7 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		rootElement,
 		noteId,
 		renderedNote ? renderedNote.html : '',
+		props.focusVisible,
 		props.style,
 		props.itemSize,
 		props.onClick,

--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -157,7 +157,8 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		onDragOver={props.onDragOver}
 
 		aria-selected={props.isSelected}
-		role='gridcell'
+		aria-posinset={1 + props.index}
+		role='option'
 	>
 		<div className="dragcursor" style={dragCursorStyle}></div>
 	</div>;

--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -10,6 +10,7 @@ import Note from '@joplin/lib/models/Note';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import useRenderedNote from './utils/useRenderedNote';
 import { Dispatch } from 'redux';
+import getNoteElementIdFromJoplinId from './utils/getNoteElementIdFromJoplinId';
 
 interface NoteItemProps {
 	dragIndex: number;
@@ -36,7 +37,7 @@ interface NoteItemProps {
 
 const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 	const noteId = props.note.id;
-	const elementId = `list-note-${noteId}`;
+	const elementId = getNoteElementIdFromJoplinId(noteId);
 
 	const onInputChange: OnInputChange = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
 		const getValue = (element: HTMLInputElement) => {
@@ -158,6 +159,7 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 
 		aria-selected={props.isSelected}
 		aria-posinset={1 + props.index}
+		aria-setsize={props.noteCount}
 		role='option'
 	>
 		<div className="dragcursor" style={dragCursorStyle}></div>

--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -156,6 +156,7 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		onDragStart={props.onDragStart}
 		onDragOver={props.onDragOver}
 
+		aria-selected={props.isSelected}
 		role='gridcell'
 	>
 		<div className="dragcursor" style={dragCursorStyle}></div>

--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -28,6 +28,7 @@ interface NoteItemProps {
 	note: NoteEntity;
 	isSelected: boolean;
 	isWatched: boolean;
+	tabIndex: number;
 	listRenderer: ListRenderer;
 	columns: NoteListColumns;
 	dispatch: Dispatch;
@@ -147,13 +148,15 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		id={elementId}
 		ref={ref}
 		draggable={true}
-		tabIndex={0}
+		tabIndex={props.tabIndex}
 		className={className}
 		data-id={noteId}
 		style={{ height: props.itemSize.height }}
 		onContextMenu={props.onContextMenu}
 		onDragStart={props.onDragStart}
 		onDragOver={props.onDragOver}
+
+		role='gridcell'
 	>
 		<div className="dragcursor" style={dragCursorStyle}></div>
 	</div>;

--- a/packages/app-desktop/gui/NoteListItem/utils/getNoteElementIdFromJoplinId.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/getNoteElementIdFromJoplinId.ts
@@ -1,0 +1,4 @@
+
+const getNoteElementIdFromJoplinId = (id: string) => `list-note-${id}`;
+
+export default getNoteElementIdFromJoplinId;

--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
@@ -2,6 +2,7 @@ import { ListRendererDependency } from '@joplin/lib/services/plugins/api/noteLis
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
 import { Size } from '@joplin/utils/types';
 import Note from '@joplin/lib/models/Note';
+import { _ } from '@joplin/lib/locale';
 
 const prepareViewProps = async (
 	dependencies: ListRendererDependency[],
@@ -33,6 +34,12 @@ const prepareViewProps = async (
 			} else if (dep === 'note.folder.title') {
 				if (!output.note.folder) output.note.folder = {};
 				output.note.folder[propName] = folder.title;
+			} else if (dep === 'note.todoStatusText') {
+				let taskStatus = '';
+				if (note.is_todo) {
+					taskStatus = note.todo_completed ? _('Complete to-do') : _('Incomplete to-do');
+				}
+				output.note[propName] = taskStatus;
 			} else {
 				// The notes in the state only contain the properties defined in
 				// Note.previewFields(). It means that if a view request a

--- a/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
@@ -3,8 +3,9 @@ import { Size } from '@joplin/utils/types';
 import { useEffect, useState } from 'react';
 import { ItemFlow } from '@joplin/lib/services/plugins/api/noteListType';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-const useItemElement = (rootElement: HTMLDivElement, noteId: string, noteHtml: string, style: any, itemSize: Size, onClick: React.MouseEventHandler<HTMLDivElement>, flow: ItemFlow) => {
+const useItemElement = (
+	rootElement: HTMLDivElement, noteId: string, noteHtml: string, focusVisible: boolean, style: React.CSSProperties, itemSize: Size, onClick: React.MouseEventHandler<HTMLDivElement>, flow: ItemFlow,
+) => {
 	const [itemElement, setItemElement] = useState<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -31,6 +32,16 @@ const useItemElement = (rootElement: HTMLDivElement, noteId: string, noteHtml: s
 			element.remove();
 		};
 	}, [rootElement, itemSize, noteHtml, noteId, style, onClick, flow]);
+
+	useEffect(() => {
+		if (!itemElement) return;
+
+		if (focusVisible) {
+			itemElement.classList.add('-focus-visible');
+		} else {
+			itemElement.classList.remove('-focus-visible');
+		}
+	}, [focusVisible, itemElement]);
 
 	return itemElement;
 };

--- a/packages/app-desktop/gui/utils/announceForAccessibility.ts
+++ b/packages/app-desktop/gui/utils/announceForAccessibility.ts
@@ -1,0 +1,33 @@
+import shim from '@joplin/lib/shim';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('announceForAccessibility');
+
+const announceForAccessibility = (message: string) => {
+	const id = 'joplin-announce-for-accessibility-live-region';
+	let announcementArea = document.querySelector(`#${id}`);
+
+	if (!announcementArea) {
+		announcementArea = document.createElement('div');
+		announcementArea.ariaLive = 'polite';
+		announcementArea.role = 'status';
+		announcementArea.id = id;
+		announcementArea.classList.add('visually-hidden');
+
+		document.body.appendChild(announcementArea);
+	} else {
+		// Allows messages to be re-announced.
+		announcementArea.textContent = '';
+	}
+
+	// Defer the announcement. Because `aria-live: polite` causes **changes** in
+	// content to be announced, a slight delay is needed when there would otherwise
+	// be no change in content.
+	const announce = () => {
+		logger.debug('Announcing:', message);
+		announcementArea.textContent = message;
+	};
+	shim.setTimeout(announce, 100);
+};
+
+export default announceForAccessibility;

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -24,7 +24,7 @@ test.describe('main', () => {
 		const editor = await mainScreen.createNewNote('Test note');
 
 		// Note list should contain the new note
-		await expect(mainScreen.noteListContainer.getByText('Test note')).toBeVisible();
+		await expect(mainScreen.noteList.getNoteItemByTitle('Test note')).toBeVisible();
 
 		// Focus the editor
 		await editor.codeMirrorEditor.click();

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -15,7 +15,8 @@ test.describe('markdownEditor', () => {
 		await importedFolder.waitFor();
 		await importedFolder.click();
 
-		const importedHtmlFileItem = mainScreen.noteListContainer.getByText('test-html-file-with-image');
+		await mainScreen.noteList.focusContent(electronApp);
+		const importedHtmlFileItem = mainScreen.noteList.getNoteItemByTitle('test-html-file-with-image');
 		await importedHtmlFileItem.click();
 
 		const viewerFrame = mainScreen.noteEditor.getNoteViewerIframe();

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -4,10 +4,11 @@ import activateMainMenuItem from '../util/activateMainMenuItem';
 import Sidebar from './Sidebar';
 import GoToAnything from './GoToAnything';
 import setFilePickerResponse from '../util/setFilePickerResponse';
+import NoteList from './NoteList';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
-	public readonly noteListContainer: Locator;
+	public readonly noteList: NoteList;
 	public readonly sidebar: Sidebar;
 	public readonly dialog: Locator;
 	public readonly noteEditor: NoteEditorScreen;
@@ -15,7 +16,7 @@ export default class MainScreen {
 
 	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
-		this.noteListContainer = page.locator('.rli-noteList');
+		this.noteList = new NoteList(page);
 		this.sidebar = new Sidebar(page, this);
 		this.dialog = page.locator('.dialog-modal-layer');
 		this.noteEditor = new NoteEditorScreen(page);
@@ -24,7 +25,7 @@ export default class MainScreen {
 
 	public async waitFor() {
 		await this.newNoteButton.waitFor();
-		await this.noteListContainer.waitFor();
+		await this.noteList.waitFor();
 	}
 
 	// Follows the steps a user would use to create a new note.

--- a/packages/app-desktop/integration-tests/models/NoteList.ts
+++ b/packages/app-desktop/integration-tests/models/NoteList.ts
@@ -1,0 +1,38 @@
+import activateMainMenuItem from '../util/activateMainMenuItem';
+import { ElectronApplication, Locator, Page, expect } from '@playwright/test';
+
+export default class NoteList {
+	public readonly container: Locator;
+
+	public constructor(page: Page) {
+		this.container = page.locator('.rli-noteList');
+	}
+
+	public waitFor() {
+		return this.container.waitFor();
+	}
+
+	private async sortBy(electronApp: ElectronApplication, sortMethod: string) {
+		const success = await activateMainMenuItem(electronApp, sortMethod, 'Sort notes by');
+		if (!success) {
+			throw new Error(`Unable to find sorting menu item: ${sortMethod}`);
+		}
+	}
+
+	public async sortByTitle(electronApp: ElectronApplication) {
+		return this.sortBy(electronApp, 'Title');
+	}
+
+	public async focusContent(electronApp: ElectronApplication) {
+		await activateMainMenuItem(electronApp, 'Note list', 'Focus');
+	}
+
+	// The resultant locator may fail to resolve if the item is not visible
+	public getNoteItemByTitle(title: string|RegExp) {
+		return this.container.getByRole('option', { name: title });
+	}
+
+	public async expectNoteToBeSelected(title: string|RegExp) {
+		await expect(this.getNoteItemByTitle(title)).toHaveAttribute('aria-selected', 'true');
+	}
+}

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
-import activateMainMenuItem from './util/activateMainMenuItem';
 import setMessageBoxResponse from './util/setMessageBoxResponse';
 
 test.describe('noteList', () => {
-	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow }) => {
+	test('should be possible to edit notes in a different notebook when searching', async ({ mainWindow, electronApp }) => {
 		const mainScreen = new MainScreen(mainWindow);
 		const sidebar = mainScreen.sidebar;
 
@@ -22,7 +21,8 @@ test.describe('noteList', () => {
 
 		// Search for and focus a note different from the folder we were in before searching.
 		await mainScreen.search('/note-1');
-		const note1Result = mainScreen.noteListContainer.getByText('note-1');
+		await mainScreen.noteList.focusContent(electronApp);
+		const note1Result = mainScreen.noteList.getNoteItemByTitle('note-1');
 		await expect(note1Result).toBeAttached();
 		await note1Result.click();
 
@@ -49,9 +49,10 @@ test.describe('noteList', () => {
 		await mainScreen.createNewNote('test note 1');
 		await mainScreen.createNewNote('test note 2');
 
-		await activateMainMenuItem(electronApp, 'Note list', 'Focus');
-		await expect(mainScreen.noteListContainer.getByText('test note 1')).toBeVisible();
-		await expect(mainScreen.noteListContainer.getByText('test note 2')).toBeVisible();
+		const noteList = mainScreen.noteList;
+		await noteList.focusContent(electronApp);
+		await expect(noteList.getNoteItemByTitle('test note 1')).toBeVisible();
+		await expect(noteList.getNoteItemByTitle('test note 2')).toBeVisible();
 
 		await setMessageBoxResponse(electronApp, /^Delete/i);
 
@@ -62,7 +63,7 @@ test.describe('noteList', () => {
 			await mainWindow.keyboard.up('Shift');
 		};
 		await pressShiftDelete();
-		await expect(mainScreen.noteListContainer.getByText('test note 2')).not.toBeVisible();
+		await expect(noteList.getNoteItemByTitle('test note 2')).not.toBeVisible();
 
 		// Should not delete when the editor is focused
 		await mainScreen.noteEditor.focusCodeMirrorEditor();
@@ -71,6 +72,35 @@ test.describe('noteList', () => {
 
 		await folderBHeader.click();
 		await folderAHeader.click();
-		await expect(mainScreen.noteListContainer.getByText('test note 1')).toBeVisible();
+		await expect(noteList.getNoteItemByTitle('test note 1')).toBeVisible();
+	});
+
+	test('arrow keys should navigate the note list', async ({ electronApp, mainWindow }) => {
+		const mainScreen = new MainScreen(mainWindow);
+		const sidebar = mainScreen.sidebar;
+
+		await sidebar.createNewFolder('Folder');
+
+		await mainScreen.createNewNote('note_1');
+		await mainScreen.createNewNote('note_2');
+		await mainScreen.createNewNote('note_3');
+		await mainScreen.createNewNote('note_4');
+
+		const noteList = mainScreen.noteList;
+		await noteList.sortByTitle(electronApp);
+		await noteList.focusContent(electronApp);
+		// The most recently-created note should be visible
+		const note4Item = noteList.getNoteItemByTitle('note_4');
+		await expect(note4Item).toBeVisible();
+		await noteList.expectNoteToBeSelected('note_4');
+
+		await noteList.container.press('ArrowUp');
+		await noteList.expectNoteToBeSelected('note_3');
+
+		await noteList.container.press('ArrowUp');
+		await noteList.expectNoteToBeSelected('note_2');
+
+		await noteList.container.press('ArrowDown');
+		await noteList.expectNoteToBeSelected('note_3');
 	});
 });

--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -8,7 +8,7 @@ test.describe('settings', () => {
 		await mainScreen.waitFor();
 
 		// Sort order buttons should be visible by default
-		const sortOrderLocator = mainScreen.noteListContainer.getByRole('button', { name: 'Toggle sort order' });
+		const sortOrderLocator = mainScreen.noteList.container.getByRole('button', { name: 'Toggle sort order' });
 		await expect(sortOrderLocator).toBeVisible();
 
 		await mainScreen.openSettings(electronApp);

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -249,6 +249,22 @@ p.info-text {
 	color: var(--joplin-color-faded);
 }
 
+// Hides elements, but still exposes them to accessibility tools.
+// Avoids `visibility: hidden` and `display: none`, because this may cause some
+// screen readers to ignore the element.
+// See https://www.w3.org/WAI/tutorials/forms/labels/#hiding-label-text
+.visually-hidden {
+	opacity: 0;
+	z-index: -1;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	overflow: hidden;
+	pointer-events: none;
+	position: absolute;
+}
+
 /* =========================================================================================
 Component-specific classes
 ========================================================================================= */

--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -5,7 +5,7 @@ import time from './time';
 import JoplinDatabase, { TableField } from './JoplinDatabase';
 import { LoadOptions, SaveOptions } from './models/utils/types';
 import ActionLogger, { ItemActionType as ItemActionType } from './utils/ActionLogger';
-import { SqlQuery } from './services/database/types';
+import { BaseItemEntity, SqlQuery } from './services/database/types';
 const Mutex = require('async-mutex').Mutex;
 
 // New code should make use of this enum
@@ -167,8 +167,7 @@ class BaseModel {
 		return -1;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static modelsByIds(items: any[], ids: string[]) {
+	public static modelsByIds<T extends BaseItemEntity>(items: T[], ids: string[]): T[] {
 		const output = [];
 		for (let i = 0; i < items.length; i++) {
 			if (ids.indexOf(items[i].id) >= 0) {

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -58,7 +58,7 @@ const renderer: ListRenderer = {
 			background-color: var(--joplin-selected-color);
 		}
 
-		&:hover, :focus-visible > & > .content {
+		&:hover, &.-focus-visible > .content {
 			background-color: var(--joplin-background-color-hover3);
 		}
 	

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -73,17 +73,6 @@ const renderer: ListRenderer = {
 				display: flex;
 				align-items: center;
 
-				/* See https://www.w3.org/WAI/tutorials/forms/labels/#hiding-label-text */
-				> label {
-					width: 1px;
-					height: 1px;
-					margin: -1px;
-					opacity: 0;
-					padding: 0;
-					position: absolute;
-					overflow: hidden;
-				}
-
 				> input {
 					margin: 0px 10px 1px 0px;
 				}
@@ -145,13 +134,10 @@ const renderer: ListRenderer = {
 		<div class="content {{#item.selected}}-selected{{/item.selected}} {{#note.is_shared}}-shared{{/note.is_shared}} {{#note.todo_completed}}-completed{{/note.todo_completed}} {{#note.isWatched}}-watched{{/note.isWatched}}">
 			{{#note.is_todo}}
 				<div class="checkbox">
-					<label for="todo-checkbox-{{note.id}}">
-						{{note.todoStatusText}}
-					</label>
 					<input
 						data-id="todo-checkbox"
-						id="todo-checkbox-{{note.id}}"
 						type="checkbox"
+						aria-label="{{note.todoStatusText}}"
 						{{#note.todo_completed}}checked="checked"{{/note.todo_completed}}
 					>
 				</div>

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -138,6 +138,7 @@ const renderer: ListRenderer = {
 						data-id="todo-checkbox"
 						type="checkbox"
 						aria-label="{{note.todoStatusText}}"
+						tabindex="-1"
 						{{#note.todo_completed}}checked="checked"{{/note.todo_completed}}
 					>
 				</div>

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -40,6 +40,7 @@ const renderer: ListRenderer = {
 		'note.isWatched',
 		'note.title',
 		'note.todo_completed',
+		'note.todoStatusText',
 	],
 
 	itemCss: // css
@@ -71,6 +72,17 @@ const renderer: ListRenderer = {
 			> .checkbox {
 				display: flex;
 				align-items: center;
+
+				/* See https://www.w3.org/WAI/tutorials/forms/labels/#hiding-label-text */
+				> label {
+					width: 1px;
+					height: 1px;
+					margin: -1px;
+					opacity: 0;
+					padding: 0;
+					position: absolute;
+					overflow: hidden;
+				}
 
 				> input {
 					margin: 0px 10px 1px 0px;
@@ -133,7 +145,15 @@ const renderer: ListRenderer = {
 		<div class="content {{#item.selected}}-selected{{/item.selected}} {{#note.is_shared}}-shared{{/note.is_shared}} {{#note.todo_completed}}-completed{{/note.todo_completed}} {{#note.isWatched}}-watched{{/note.isWatched}}">
 			{{#note.is_todo}}
 				<div class="checkbox">
-					<input data-id="todo-checkbox" type="checkbox" {{#note.todo_completed}}checked="checked"{{/note.todo_completed}}>
+					<label for="todo-checkbox-{{note.id}}">
+						{{note.todoStatusText}}
+					</label>
+					<input
+						data-id="todo-checkbox"
+						id="todo-checkbox-{{note.id}}"
+						type="checkbox"
+						{{#note.todo_completed}}checked="checked"{{/note.todo_completed}}
+					>
 				</div>
 			{{/note.is_todo}}
 			<div class="title" data-id="{{note.id}}">

--- a/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
+++ b/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
@@ -108,7 +108,12 @@ const renderer: ListRenderer = {
 			`
 			{{#note.is_todo}}
 				<div class="checkbox">
-					<input data-id="todo-checkbox" type="checkbox" {{#note.todo_completed}}checked="checked"{{/note.todo_completed}}>
+					<input
+						data-id="todo-checkbox"
+						type="checkbox"
+						aria-label="{{note.todoStatusText}}"
+						tabindex="-1"
+						{{#note.todo_completed}}checked="checked"{{/note.todo_completed}}>
 				</div>
 			{{/note.is_todo}}
 		`,

--- a/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
+++ b/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
@@ -33,10 +33,6 @@ const renderer: ListRenderer = {
 			display: flex;
 			height: 100%;
 
-			&:hover, :focus-visible {
-				background-color: var(--joplin-background-color-hover3);
-			}
-
 			> .item {
 				display: flex;
 				align-items: center;
@@ -82,6 +78,10 @@ const renderer: ListRenderer = {
 
 		> .row.-completed {
 			opacity: 0.5;
+		}
+			
+		> .row:hover, &.-focus-visible > .row {
+			background-color: var(--joplin-background-color-hover3);
 		}
 	`,
 

--- a/packages/lib/services/plugins/api/noteListType.ts
+++ b/packages/lib/services/plugins/api/noteListType.ts
@@ -35,6 +35,10 @@ export type OnClickHandler = (event: OnClickEvent)=> Promise<void>;
  * complemented with special properties such as `note.isWatched`, to know if a note is currently
  * opened in the external editor, and `note.tags` to get the list tags associated with the note.
  *
+ * The `note.todoStatusText` property is a localised description of the to-do status (e.g.
+ * "to-do, incomplete"). If you include an `<input type='checkbox' ... />` for to-do items that would
+ * otherwise be unlabelled, consider adding `note.todoStatusText` as the checkbox's `aria-label`.
+ *
  * ## Item properties
  *
  * The `item.*` properties are specific to the rendered item. The most important being
@@ -49,6 +53,7 @@ export type ListRendererDependency =
 	'note.folder.title' |
 	'note.isWatched' |
 	'note.tags' |
+	'note.todoStatusText' |
 	'note.titleHtml';
 
 export type ListRendererItemValueTemplates = Record<string, string>;

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -130,3 +130,4 @@ Zocial
 agplv
 Famegear
 rcompare
+tabindex


### PR DESCRIPTION
# Summary

This pull request improves the note list's screen reader and keyboard accessibility.

In particular, it,
- Allows selecting multiple notes from just the keyboard (<kbd>Shift</kbd>+arrow keys).
   - Related: [WCAG 2.2: SC 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard).
   - **Note**: This does not fully satisfy WCAG 2.2 § 2.1.1. It's possible to select non-adjacent items with a mouse, but still not possible with a keyboard.
- Adds label information about whether an item is a to-do (and whether it's completed).
- Adds role information to the note list.
   - Previously on Linux with the Orca screen reader, the up/down arrow keys did not change the focused note. Adding role information fixes this issue and makes the screen reader output more informative.
   - Related: [WCAG 2.2: Failure condition 59](https://www.w3.org/WAI/WCAG22/Techniques/failures/F59).

This is related to https://github.com/laurent22/joplin/issues/10795.

# Remaining work

- Currently, the note list overrides <kbd>Tab</kbd> behavior. This breaks (causes <kbd>Tab</kbd> to do nothing) when the note editor isn't visible (e.g. when multiple note items are selected). This prevents certain UI components (e.g. the multiple selection menu) from being reached while navigating with the keyboard.
- Make selection different from focus. See [the keyboard interaction](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/#keyboardinteraction) section of the `listbox` ARIA Practicing Guides page and their [section on focus vs selection](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_vs_selection).
- Document keyboard shortcuts for toggling to-dos?
- Improve accessibility of non-default note lists:
    - The example note list that includes a text input, for example, does not allow editing note titles when navigating with just a keyboard.
- It's currently difficult to determine the number of selected items with just a screen reader.
- With the Orca screen reader, clicking on an item in the note list reads "not selected" after changing the focus.  This does not happen when changing the focus with a keyboard.

# Notes

- This pull request adds the `listbox` role to the note list (see the [WAI ARIA Authoring Guide's Listbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)).
- Prior to [this commit](https://github.com/laurent22/joplin/commit/e7ddcf1c895b19530b880516f08f183f97c0e401), this pull request used the `grid` role for the note list. This change was reverted because it seemed to prevent Windows Narrator from reading the content of the note list. The note list was read correctly with Orca on Linux.
    - It's possible that the `grid` role was incorrectly implemented. 
    - For more-complex note lists, `role=grid` may be a better fit than `role=listbox` &mdash; `grid` should support multiple columns and possibly support focusing elements within a note list item.
    - `role=listbox` seems to fit the default note list renderer.

# Testing plan

**Existing issues**: I've observed at least one issue that seems to have also been present before this pull request:
- While creating a large number of notes in the current folder, it doesn't seem possible to change the focused note by clicking (just with the arrow keys).
- Pressing <kbd>tab</kbd> after selecting multiple items does not move to the selection menu. Instead, it seems to do nothing.

**Linux (with the Orca screen reader running)**:
1. Create several thousand notes.
    - I ran a script similar to the following 2 times total in Joplin's dev tools:
    ```javascript
    for (let i = 0; i < 1000; i++) {
        await Note.save({
            parent_id: '[[notebook ID here]]',
            title: `Test: ${i}`,
            body: `This is a random number: ${Math.floor(Math.random() * 10000)}`
        });
        if (i % 100 === 0) { console.log(i); }
     }
     ```
2. Click on the title input for the current note.
3. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
4. Verify that the note list is focused.
5. Scroll the focused note out of view.
6. Click on the title input.
7. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
8. Verify that the focused note list item has been scrolled into view.
9. Verify that the name of the note is read by the screen reader.
    - For me, the screen reader read `Notes: Multi-select list with 2156 items: Test: 997`, where `Test: 997` is the name of the note.
10. Press the <kbd>Down</kbd> arrow key. Verify that the name of the newly-selected note is read by the screen reader.
    - For me, the screen reader read `Test: 996`. Pressing <kbd>Down</kbd> again reads `Test: 995`.
11. Verify that the focused item is highlighted in blue (in the light theme):
    - ![screenshot: Item test 995 is highlighted in blue](https://github.com/user-attachments/assets/8bf264f6-8283-45ed-a903-1a2c0b371b51)
    - This color is the "focus-visible" color.
12. Press <kbd>Tab</kbd>.
13. Verify that the note title input is focused.
14. Verify that the selected note is highlighted in gray.
15. Click on an item in the note list and move the cursor away from the list.
16. Verify that the item is highlighted in gray:
     ![screenshot: Selected item is highlighted in gray, others have a lighter gray background](https://github.com/user-attachments/assets/a111c65d-4d72-4aa3-8550-052f9556da46)
17. Press the <kbd>Down</kbd> arrow key.
18. Verify that the active item is now highlighted in blue (assumes default light theme).
19. Press <kbd>shift</kbd>-<kbd>down</kbd>.
20. Verify that two notes are selected.
21. Press <kbd>shift</kbd>-<kbd>up</kbd>.
22. Verify that just one note is selected.
23. Press <kbd>shift</kbd>-<kbd>up</kbd>.
24. Verify that two notes are selected.
25. Press <kbd>delete</kbd>
26. Verify that the two notes have been deleted.
27. Press <kbd>ctrl</kbd>-<kbd>a</kbd>.
28. Verify that all notes are selected.
29. Press <kbd>shift</kbd>-<kbd>up</kbd>.
30. Verify that one fewer item is selected.
    - **Note**: Currently, this removes items from the selection near the point where <kbd>ctrl</kbd>-<kbd>a</kbd> was pressed:
    ![screenshot: Item 990 is the only unselected item, has selected items above and below](https://github.com/user-attachments/assets/bc77d15b-7598-4734-b8c0-d3e30e466293)
31. Create a new to-do by clicking "new to-do".
32. Give it a title ("test to-do").
33. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
34. Verify that the note list is selected and that the screen reader reads `Incomplete to-do, test to-do, incomplete to-do checkbox not checked` (after reading information about the note list).
    - On Windows (with Windows Narrator), this message is more verbose (does not repeat "incomplete to-do checkbox not checked").
35. Press <kbd>space</kbd>.
36. Verify that the screen reader reads `Complete to-do, test to-do, complete to-do checkbox checked. Complete.`
    - **Note**: The trailing `Complete` is to support Windows, where "Complete to-do, test to-do, complete to-do checkbox checked" is not read in at least some cases.
37. Press <kbd>space</kbd> again and verify that the to-do is marked as incomplete.
38. Select two to-dos and press <kbd>space</kbd>. Verify that both are marked as complete.
39. Select more notes than are on the screen using <kbd>shift</kbd>-click.
40. Navigate to the trash, select them, right-click, and select "restore".
41. Verify that the notes are restored.
42. Scroll the focused note offscreen.
43. Press <kbd>ctrl</kbd>-<kbd>shift</kbd>-<kbd>l</kbd>.
44. Verify that the focused note is scrolled into view.
45. Switch to the detailed note list view.
46. Click on an item in the list.
47. Verify that the item is marked as selected.
48. Click on a different item.
49. Press <kbd>shift</kbd>-<kbd>up</kbd> 4-6 times.
50. Verify that multiple items are marked as focused:
     ![screenshot: Multiple items marked as focused in detailed/multi-column note list](https://github.com/user-attachments/assets/a19bfd91-a5f9-4c34-bce2-b8d42ca7dafa)



**Note**: This is being edited &mdash; <kbd>ctrl</kbd>-<kbd>enter</kbd> (which opens a pull request) was pressed accidentally.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->