### PR TITLE
Desktop: Windows portable: Fix keychain-backed storage incorrectly enabled

### DIFF
--- a/packages/lib/services/keychain/KeychainService.test.ts
+++ b/packages/lib/services/keychain/KeychainService.test.ts
@@ -134,6 +134,20 @@ describe('KeychainService', () => {
 		expect(Setting.value('keychain.supported')).toBe(0);
 	});
 
+	test('should load settings from a read-only KeychainService if not present in the database', async () => {
+		mockSafeStorage({});
+
+		const service = KeychainService.instance();
+		await service.initialize(makeDrivers());
+		expect(await service.setPassword('setting.encryption.masterPassword', 'keychain password')).toBe(true);
+
+		service.readOnly = true;
+		await service.initialize(makeDrivers());
+		await Setting.load();
+
+		expect(Setting.value('encryption.masterPassword')).toBe('keychain password');
+	});
+
 	test('settings should be saved to database with a read-only keychain', async () => {
 		const safeStorage = mockSafeStorage({});
 

--- a/packages/lib/services/keychain/KeychainService.test.ts
+++ b/packages/lib/services/keychain/KeychainService.test.ts
@@ -13,18 +13,21 @@ interface SafeStorageMockOptions {
 }
 
 const mockSafeStorage = ({ // Safe storage
-	isEncryptionAvailable = jest.fn(() => true),
-	encryptString = jest.fn(async s => (`e:${s}`)),
-	decryptString = jest.fn(async s => s.substring(2)),
+	isEncryptionAvailable = () => true,
+	encryptString = async s => (`e:${s}`),
+	decryptString = async (s) => s.substring(2),
 }: SafeStorageMockOptions) => {
+	const mock = {
+		isEncryptionAvailable: jest.fn(isEncryptionAvailable),
+		encryptString: jest.fn(encryptString),
+		decryptString: jest.fn(decryptString),
+		getSelectedStorageBackend: jest.fn(() => 'mock'),
+	};
 	shim.electronBridge = () => ({
-		safeStorage: {
-			isEncryptionAvailable,
-			encryptString,
-			decryptString,
-			getSelectedStorageBackend: () => 'mock',
-		},
+		safeStorage: mock,
 	});
+
+	return mock;
 };
 
 const mockKeytar = () => {
@@ -51,10 +54,19 @@ const makeDrivers = () => [
 	new KeychainServiceDriverNode(Setting.value('appId'), Setting.value('clientId')),
 ];
 
+const testSaveLoadSecureSetting = async (expectedPassword: string) => {
+	Setting.setValue('encryption.masterPassword', expectedPassword);
+	await Setting.saveAll();
+
+	await Setting.load();
+	expect(Setting.value('encryption.masterPassword')).toBe(expectedPassword);
+};
+
 describe('KeychainService', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(0);
 		await switchClient(0);
+		KeychainService.instance().readOnly = false;
 		Setting.setValue('keychain.supported', 1);
 		shim.electronBridge = null;
 		shim.keytar = null;
@@ -91,16 +103,12 @@ describe('KeychainService', () => {
 		const keytarMock = mockKeytar();
 		await KeychainService.instance().initialize(makeDrivers());
 
-		Setting.setValue('encryption.masterPassword', 'test-password');
-		await Setting.saveAll();
+		await testSaveLoadSecureSetting('test-password');
 		expect(keytarMock.setPassword).toHaveBeenCalledWith(
 			`${Setting.value('appId')}.setting.encryption.masterPassword`,
 			`${Setting.value('clientId')}@joplin`,
 			'test-password',
 		);
-
-		await Setting.load();
-		expect(Setting.value('encryption.masterPassword')).toBe('test-password');
 	});
 
 	test('should re-check for keychain support when a new driver is added', async () => {
@@ -124,5 +132,44 @@ describe('KeychainService', () => {
 		await KeychainService.instance().initialize([]);
 		await KeychainService.instance().detectIfKeychainSupported();
 		expect(Setting.value('keychain.supported')).toBe(0);
+	});
+
+	test('settings should be saved to database with a read-only keychain', async () => {
+		const safeStorage = mockSafeStorage({});
+
+		const service = KeychainService.instance();
+		service.readOnly = true;
+
+		await service.initialize(makeDrivers());
+		await service.detectIfKeychainSupported();
+
+		expect(Setting.value('keychain.supported')).toBe(1);
+		await testSaveLoadSecureSetting('testing...');
+
+		expect(safeStorage.encryptString).not.toHaveBeenCalledWith('testing...');
+	});
+
+	test('loading settings with a read-only keychain should prefer the database', async () => {
+		const safeStorage = mockSafeStorage({});
+
+		const service = KeychainService.instance();
+		await service.initialize(makeDrivers());
+		// Set an initial value
+		expect(await service.setPassword('setting.encryption.masterPassword', 'test keychain password')).toBe(true);
+
+		service.readOnly = true;
+		await service.initialize(makeDrivers());
+
+		safeStorage.encryptString.mockClear();
+
+		Setting.setValue('encryption.masterPassword', 'test database password');
+		await Setting.saveAll();
+
+		await Setting.load();
+		expect(Setting.value('encryption.masterPassword')).toBe('test database password');
+		expect(await service.password('setting.encryption.masterPassword')).toBe('test keychain password');
+
+		// Should not have attempted to encrypt settings in read-only mode.
+		expect(safeStorage.encryptString).not.toHaveBeenCalled();
 	});
 });

--- a/packages/lib/services/keychain/KeychainService.ts
+++ b/packages/lib/services/keychain/KeychainService.ts
@@ -162,7 +162,14 @@ export default class KeychainService extends BaseService {
 		} else {
 			// The supported check requires write access to the keychain -- rely on the more
 			// limited support checks done by each driver.
-			Setting.setValue('keychain.supported', 1);
+			const supported = this.drivers_.length > 0;
+			Setting.setValue('keychain.supported', supported ? 1 : 0);
+
+			if (supported) {
+				logger.info('Starting KeychainService in read-only mode. Keys will be read, but not written.');
+			} else {
+				logger.info('Failed to start in read-only mode -- no supported drivers found.');
+			}
 		}
 		Setting.setValue('keychain.lastAvailableDrivers', this.drivers_.map(driver => driver.driverId));
 	}

--- a/packages/lib/services/keychain/KeychainServiceDriver.node.ts
+++ b/packages/lib/services/keychain/KeychainServiceDriver.node.ts
@@ -5,7 +5,7 @@ export default class KeychainServiceDriver extends KeychainServiceDriverBase {
 	public override readonly driverId: string = 'node-keytar';
 
 	public async supported(): Promise<boolean> {
-		return !!shim.keytar();
+		return !!shim.keytar?.();
 	}
 
 	public async setPassword(name: string, password: string): Promise<boolean> {

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -76,7 +76,7 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 		_('Client ID: %s', Setting.value('clientId')),
 		_('Sync Version: %s', Setting.value('syncVersion')),
 		_('Profile Version: %s', reg.db().version()),
-		_('Keychain Supported: %s', Setting.value('keychain.supported') >= 1 ? _('Yes') : _('No')),
+		_('Keychain Supported: %s', (Setting.value('keychain.supported') >= 1 && !shim.isPortable()) ? _('Yes') : _('No')),
 	];
 
 	if (gitInfo) {

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -76,6 +76,8 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 		_('Client ID: %s', Setting.value('clientId')),
 		_('Sync Version: %s', Setting.value('syncVersion')),
 		_('Profile Version: %s', reg.db().version()),
+		// The portable app temporarily supports read-only keychain access (but disallows
+		// write).
 		_('Keychain Supported: %s', (Setting.value('keychain.supported') >= 1 && !shim.isPortable()) ? _('Yes') : _('No')),
 	];
 


### PR DESCRIPTION
# Summary

This pull request reverts a behavior change from #10535 --- previously, keychain support was disabled in the Windows portable application. After #10535, Electron [safeStorage](https://www.electronjs.org/docs/latest/api/safe-storage#safestorageencryptstringplaintext) is used to encrypt secure settings in the Windows portable app before saving them in Joplin's database. This may break the portability of Joplin Portable.

**Notes**:
- After #10535 secure settings are still stored in Joplin's database (not the system keychain). #10535 encrypted these settings.
- To prevent data loss, this pull request preserves the ability to read `safeStorage`-encrypted settings in the portable app.
- An alternative to this pull request could be to add an "encrypt secure keys" setting only available to users of the portable app that controls whether `safeStorage` can be used.

> [!NOTE]
>
> The new portable app behavior introduced by #10535 may be desired. Consider closing this pull request without merging.

# Testing plan

This pull request includes automated tests that:
- Verify that settings not present in the database are loaded from the `KeychainService`, if available.
- Verify that passwords are saved to the database (without processing by `KeychainService`) when `KeychainService` is read-only.
- In the case where `KeychainService` is read-only, verifies that passwords saved using the default setting storage are preferred to those stored in the keychain.

**Manual testing** (in progress):
1. Build the Windows portable app.
2. Download v3.1.4 of the Windows portable app.
3. Start the just-downloaded version of Joplin.
4. Open the development tools. Run `Setting.value('keychain.supported')` and verify that the output is 1.
5. Enable the backup plugin and restart Joplin.
6. Set the backup password to `testing` and enable password-protected backups.
    - `testing` must be set in both the password and confirm inputs.
7. Save settings and **quit** Joplin.
8. Replace the downloaded `JoplinPortable.exe` with the built `JoplinPortable.exe`.
9. Start the built `JoplinPortable.exe`.
10. Verify that the backup password is still set to `testing` (in settings, using dev tools).
11. Change the backup password to `test` and save.
    - `test` must be set in both the password and confirm inputs.
12. Restart Joplin.
13. Verify that the backup password is still set to `test`.
15. Go to Help > About and verify that keychain support is listed as `No`.
14. Start a development build of Joplin (Windows 11).
15. Go to Help > About and verify that keychain support is listed as `Yes`.
16. Open the development console and run `Setting.setValue('keychain.supported', -1)`.
17. Restart Joplin.
18. Go to Help > About and verify that keychain support is listed as `Yes`.
19. Verify that the development tools contain `tried to set and get password. Result was: mytest`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->