### PR TITLE
Mobile,Desktop: Resolves #10856: Allow disabling master keys to improve startup performance

### DIFF
--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -53,6 +53,11 @@ const EncryptionConfigScreen = (props: Props) => {
 	}, [theme]);
 
 	const styles = useMemo(() => {
+		const normalText = {
+			flex: 1,
+			fontSize: theme.fontSize,
+			color: theme.color,
+		};
 		const styles = {
 			titleText: {
 				flex: 1,
@@ -65,11 +70,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				marginBottom: 5,
 				color: theme.color,
 			},
-			normalText: {
-				flex: 1,
-				fontSize: theme.fontSize,
-				color: theme.color,
-			},
+			normalText,
 			normalTextInput: {
 				margin: 10,
 				color: theme.color,
@@ -79,6 +80,9 @@ const EncryptionConfigScreen = (props: Props) => {
 			container: {
 				flex: 1,
 				padding: theme.margin,
+			},
+			passwordInputReplacement: {
+				...normalText, color: theme.colorFaded, fontStyle: 'italic',
 			},
 		};
 
@@ -98,12 +102,14 @@ const EncryptionConfigScreen = (props: Props) => {
 		inputStyle.borderBottomWidth = 1;
 		inputStyle.borderBottomColor = theme.dividerColor;
 
-		const renderPasswordInput = (masterKeyId: string) => {
+		const masterKeyId = mk.id;
+
+		const renderPasswordInput = () => {
 			if (!masterKeyEnabled(mk)) {
-				return <Text style={styles.normalText}>{_('Disabled')}</Text>;
+				return <Text style={styles.passwordInputReplacement}>({_('Disabled')})</Text>;
 			} else if (masterPasswordKeys[masterKeyId] || !passwordChecks['master']) {
 				return (
-					<Text style={{ ...styles.normalText, color: theme.colorFaded, fontStyle: 'italic' }}>({_('Master password')})</Text>
+					<Text style={styles.passwordInputReplacement}>({_('Master password')})</Text>
 				);
 			} else {
 				return (
@@ -118,11 +124,11 @@ const EncryptionConfigScreen = (props: Props) => {
 
 		return (
 			<View key={mk.id}>
-				<Text style={styles.titleText}>{_('Master Key %s', mk.id.substr(0, 6))}</Text>
+				<Text style={styles.titleText}>{_('Master Key %s', masterKeyId.substring(0, 6))}</Text>
 				<Text style={styles.normalText}>{_('Created: %s', time.formatMsToLocal(mk.created_time))}</Text>
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 					<Text style={{ flex: 0, fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{_('Password:')}</Text>
-					{renderPasswordInput(mk.id)}
+					{renderPasswordInput()}
 				</View>
 				<Button onPress={() => onToggleEnabledClick(mk)} title={masterKeyEnabled(mk) ? _('Disable') : _('Enable')}/>
 			</View>

--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -99,7 +99,9 @@ const EncryptionConfigScreen = (props: Props) => {
 		inputStyle.borderBottomColor = theme.dividerColor;
 
 		const renderPasswordInput = (masterKeyId: string) => {
-			if (masterPasswordKeys[masterKeyId] || !passwordChecks['master']) {
+			if (!masterKeyEnabled(mk)) {
+				return <Text style={styles.normalText}>{_('Disabled')}</Text>;
+			} else if (masterPasswordKeys[masterKeyId] || !passwordChecks['master']) {
 				return (
 					<Text style={{ ...styles.normalText, color: theme.colorFaded, fontStyle: 'italic' }}>({_('Master password')})</Text>
 				);

--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -77,12 +77,14 @@ const EncryptionConfigScreen = (props: Props) => {
 				borderWidth: 1,
 				borderColor: theme.dividerColor,
 			},
+			fadedText: {
+				...normalText,
+				color: theme.colorFaded,
+				fontStyle: 'italic',
+			},
 			container: {
 				flex: 1,
 				padding: theme.margin,
-			},
-			passwordInputReplacement: {
-				...normalText, color: theme.colorFaded, fontStyle: 'italic',
 			},
 		};
 
@@ -105,11 +107,9 @@ const EncryptionConfigScreen = (props: Props) => {
 		const masterKeyId = mk.id;
 
 		const renderPasswordInput = () => {
-			if (!masterKeyEnabled(mk)) {
-				return <Text style={styles.passwordInputReplacement}>({_('Disabled')})</Text>;
-			} else if (masterPasswordKeys[masterKeyId] || !passwordChecks['master']) {
+			if (masterPasswordKeys[masterKeyId] || !passwordChecks['master']) {
 				return (
-					<Text style={styles.passwordInputReplacement}>({_('Master password')})</Text>
+					<Text style={styles.fadedText}>({_('Master password')})</Text>
 				);
 			} else {
 				return (
@@ -122,14 +122,22 @@ const EncryptionConfigScreen = (props: Props) => {
 			}
 		};
 
-		return (
-			<View key={mk.id}>
-				<Text style={styles.titleText}>{_('Master Key %s', masterKeyId.substring(0, 6))}</Text>
-				<Text style={styles.normalText}>{_('Created: %s', time.formatMsToLocal(mk.created_time))}</Text>
+		const renderPasswordRow = () => {
+			if (!masterKeyEnabled(mk)) return null;
+
+			return (
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 					<Text style={{ flex: 0, fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{_('Password:')}</Text>
 					{renderPasswordInput()}
 				</View>
+			);
+		};
+
+		return (
+			<View key={mk.id}>
+				<Text style={styles.titleText}>{_('Master Key %s', masterKeyId.substring(0, 6))}</Text>
+				<Text style={styles.normalText}>{_('Created: %s', time.formatMsToLocal(mk.created_time))}</Text>
+				{renderPasswordRow()}
 				<Button onPress={() => onToggleEnabledClick(mk)} title={masterKeyEnabled(mk) ? _('Disable') : _('Enable')}/>
 			</View>
 		);

--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -8,10 +8,10 @@ const { dialogs } = require('../../utils/dialogs.js');
 import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import { _ } from '@joplin/lib/locale';
 import time from '@joplin/lib/time';
-import { decryptedStatText, enableEncryptionConfirmationMessages, onSavePasswordClick, useInputMasterPassword, useInputPasswords, usePasswordChecker, useStats } from '@joplin/lib/components/EncryptionConfigScreen/utils';
+import { decryptedStatText, enableEncryptionConfirmationMessages, onSavePasswordClick, onToggleEnabledClick, useInputMasterPassword, useInputPasswords, usePasswordChecker, useStats } from '@joplin/lib/components/EncryptionConfigScreen/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { State } from '@joplin/lib/reducer';
-import { SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
+import { masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, setupAndDisableEncryption, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
 import { useMemo, useRef, useState } from 'react';
 
@@ -122,6 +122,7 @@ const EncryptionConfigScreen = (props: Props) => {
 					<Text style={{ flex: 0, fontSize: theme.fontSize, marginRight: 10, color: theme.color }}>{_('Password:')}</Text>
 					{renderPasswordInput(mk.id)}
 				</View>
+				<Button onPress={() => onToggleEnabledClick(mk)} title={masterKeyEnabled(mk) ? _('Disable') : _('Enable')}/>
 			</View>
 		);
 	};

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -207,7 +207,10 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 		setTimeLocale(Setting.value('locale'));
 	}
 
-	if ((action.type === 'SETTING_UPDATE_ONE' && (action.key.indexOf('encryption.') === 0)) || (action.type === 'SETTING_UPDATE_ALL')) {
+	// Like the desktop and CLI apps, we run this whenever the sync target properties change.
+	// Previously, this only ran when encryption was enabled/disabled. However, after fetching
+	// a new key, this needs to run.
+	if ((action.type === 'SETTING_UPDATE_ONE' && action.key === 'syncInfoCache') || (action.type === 'SETTING_UPDATE_ALL')) {
 		await loadMasterKeysFromSettings(EncryptionService.instance());
 		void DecryptionWorker.instance().scheduleStart();
 		const loadedMasterKeyIds = EncryptionService.instance().loadedMasterKeyIds();

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -209,8 +209,11 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 
 	// Like the desktop and CLI apps, we run this whenever the sync target properties change.
 	// Previously, this only ran when encryption was enabled/disabled. However, after fetching
-	// a new key, this needs to run.
-	if ((action.type === 'SETTING_UPDATE_ONE' && action.key === 'syncInfoCache') || (action.type === 'SETTING_UPDATE_ALL')) {
+	// a new key, this needs to run and so we run it when the sync target info changes.
+	if (
+		(action.type === 'SETTING_UPDATE_ONE' && ['encryption.passwordCache', 'encryption.masterPassword', 'syncInfoCache'].includes(action.key))
+		|| action.type === 'SETTING_UPDATE_ALL'
+	) {
 		await loadMasterKeysFromSettings(EncryptionService.instance());
 		void DecryptionWorker.instance().scheduleStart();
 		const loadedMasterKeyIds = EncryptionService.instance().loadedMasterKeyIds();

--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -9,10 +9,7 @@ import { masterKeyEnabled, setMasterKeyEnabled } from '../../services/synchroniz
 import MasterKey from '../../models/MasterKey';
 import { reg } from '../../registry';
 import Setting from '../../models/Setting';
-import Logger from '@joplin/utils/Logger';
 const { useCallback, useEffect, useState } = shim.react();
-
-const logger = Logger.create('EncryptionConfigScreen/utils');
 
 type PasswordChecks = Record<string, boolean>;
 
@@ -88,7 +85,6 @@ export const useToggleShowDisabledMasterKeys = () => {
 };
 
 export const onToggleEnabledClick = (mk: MasterKeyEntity) => {
-	logger.info('Toggling master key enabled');
 	setMasterKeyEnabled(mk.id, !masterKeyEnabled(mk));
 };
 

--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -9,7 +9,10 @@ import { masterKeyEnabled, setMasterKeyEnabled } from '../../services/synchroniz
 import MasterKey from '../../models/MasterKey';
 import { reg } from '../../registry';
 import Setting from '../../models/Setting';
+import Logger from '@joplin/utils/Logger';
 const { useCallback, useEffect, useState } = shim.react();
+
+const logger = Logger.create('EncryptionConfigScreen/utils');
 
 type PasswordChecks = Record<string, boolean>;
 
@@ -85,6 +88,7 @@ export const useToggleShowDisabledMasterKeys = () => {
 };
 
 export const onToggleEnabledClick = (mk: MasterKeyEntity) => {
+	logger.info('Toggling master key enabled');
 	setMasterKeyEnabled(mk.id, !masterKeyEnabled(mk));
 };
 

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -15,6 +15,7 @@ import { LoadOptions, SaveOptions } from './utils/types';
 import { State as ShareState } from '../services/share/reducer';
 import { checkIfItemCanBeAddedToFolder, checkIfItemCanBeChanged, checkIfItemsCanBeChanged, needsShareReadOnlyChecks } from './utils/readOnly';
 import { checkObjectHasProperties } from '@joplin/utils/object';
+import EncryptionService from '../services/e2ee/EncryptionService';
 
 const { sprintf } = require('sprintf-js');
 const moment = require('moment');
@@ -47,8 +48,7 @@ export interface EncryptedItemsStats {
 
 export default class BaseItem extends BaseModel {
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public static encryptionService_: any = null;
+	public static encryptionService_: EncryptionService = null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static revisionService_: any = null;
 	public static shareService_: ShareService = null;

--- a/packages/lib/services/e2ee/utils.ts
+++ b/packages/lib/services/e2ee/utils.ts
@@ -142,13 +142,17 @@ export async function loadMasterKeysFromSettings(service: EncryptionService) {
 		const mk = masterKeys[i];
 		if (service.isMasterKeyLoaded(mk)) continue;
 
-		const password = await findMasterKeyPassword(service, mk);
-		if (!password) continue;
+		if (mk.enabled === 0) {
+			await service.disableMasterKey(mk);
+		} else {
+			const password = await findMasterKeyPassword(service, mk);
+			if (!password) continue;
 
-		try {
-			await service.loadMasterKey(mk, password, activeMasterKeyId === mk.id);
-		} catch (error) {
-			logger.warn(`Cannot load master key ${mk.id}. Invalid password?`, error);
+			try {
+				await service.loadMasterKey(mk, password, activeMasterKeyId === mk.id);
+			} catch (error) {
+				logger.warn(`Cannot load master key ${mk.id}. Invalid password?`, error);
+			}
 		}
 	}
 

--- a/packages/lib/services/e2ee/utils.ts
+++ b/packages/lib/services/e2ee/utils.ts
@@ -142,9 +142,7 @@ export async function loadMasterKeysFromSettings(service: EncryptionService) {
 		const mk = masterKeys[i];
 		if (service.isMasterKeyLoaded(mk)) continue;
 
-		if (mk.enabled === 0) {
-			await service.disableMasterKey(mk);
-		} else {
+		if (masterKeyEnabled(mk)) {
 			const password = await findMasterKeyPassword(service, mk);
 			if (!password) continue;
 
@@ -153,6 +151,8 @@ export async function loadMasterKeysFromSettings(service: EncryptionService) {
 			} catch (error) {
 				logger.warn(`Cannot load master key ${mk.id}. Invalid password?`, error);
 			}
+		} else {
+			await service.disableMasterKey(mk);
 		}
 	}
 


### PR DESCRIPTION
# Summary

This pull request:
1. Allows disabling master keys on mobile.
2. Skips decrypting disabled master keys on startup.
   - Previously, all master keys were loaded on startup. This can be slow.
   - This may resolve https://github.com/laurent22/joplin/issues/10856.
3. Reloads master keys on mobile in more cases to match the CLI and desktop app's behavior.
   - This was necessary for clicking "enable" on a master key to cause it to load.

> [!NOTE]
>
> The encryption config screen with many master keys may still be very slow (`usePasswordChecker` seems to check passwords for both enabled and disabled keys). A possible fix [can be found here](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/mobile/fix-encryption-same-but-incorrect-password-2).
>

# Screenshot

![screenshot: Disable/enable buttons are included after master keys](https://github.com/user-attachments/assets/b899d042-3346-4a37-8be2-8f4897155d7a)



# Testing plan

**Web**: 
1. **Setup** (partially done before fixing the issue): Open the web client on two different browsers (Firefox and Chromium). Enable encryption on both (use different master passwords). Connect both to the same Joplin Server account.
2. Sync. For each client, go to settings and verify that two master keys are visible.
3. On Chrome:
   - Disable both.
   - Create a note.
   - Click "sync".
   - Verify that sync fails with an error: "Could not encrypt item [...] master key is disabled": 
     ![screenshot: Encryption error message below the sync icon](https://github.com/user-attachments/assets/eeb58c72-35c5-44c8-9fad-b051e223f7b6)
   - Enable one of the master keys.
   - Click "sync".
   - Verify that sync completes successfully.
4. On Firefox, if not already done, enter the password for the remote master key and click save.
   - **Note**: While testing locally, I then refreshed the page to apply the latest changes made locally.
5. Still on Firefox,
   - Sync.
   - Verify that sync completes successfully.

The above steps were last done on [this commit](https://github.com/laurent22/joplin/pull/10943/commits/e3cae332f66c637e1b92ed4941297a38fe164c59) which is not the latest in this pull request.

**Desktop**:
1. Create a new profile in Joplin desktop.
2. Start a sync with the Joplin Server account used for the web tests above.
3. Verify that, during sync, a "One or more master keys need a password" banner is visible.
4. Click "Set the password".
5. Enter the passwords for the keys.
   - **Existing bug**: Even after entering the correct password, the red borders around password inputs are still visible: ![screenshot: Red borders around some password inputs](https://github.com/user-attachments/assets/d499fae9-af88-4ef9-933f-95d23b8f7f8e)
6. Disable one of the master keys (one that does not have "password" set to "master password").
7. Restart Joplin.
8. Go back to encryption settings. Verify that the just-disabled key is still listed as disabled.
9. Allow sync to finish.


**Android 13**:
1. Connect to the same Joplin Server account used for the web and desktop tests above.
2. Start sync.
3. Verify that a "Press to set the decryption password" banner is visible.
4. Press "Press to set the decryption password".
   - For me, this was done while still syncing.
5. Verify that 3 master keys are listed, each without a password.
6. Enter a password for one of the master keys.
7. Enter a password for one of the other master keys.
8. Verify that the passwords are accepted/listed as saved.
    - I encountered the issue described in [this comment](https://github.com/laurent22/joplin/pull/10943#issuecomment-2319470350) at this point.
9. Disable one of the master keys.
10. Verify that its button's content changes from "DISABLE" to "ENABLE".
11. Close the encryption config screen.
12. Verify that items are decrypting.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->