### PR TITLE
Docs: Fix typo: Change "Thee" to "The"

### DIFF
--- a/readme/apps/to-dos.md
+++ b/readme/apps/to-dos.md
@@ -14,7 +14,7 @@ It's also possible to convert notes to to-dos and to-dos to notes.
 
 **On desktop**, right-click a note, then click "Switch between note and to-do type":
 
-**On mobile**, open a note, open the note action menu (opened by clicking thee "︙" button), and finally click "convert to todo" or "convert to note":
+**On mobile**, open a note, open the note action menu (opened by clicking the "︙" button), and finally click "convert to todo" or "convert to note":
 
 ## Ordering to-dos
 

--- a/readme/dev/spec/web_app.md
+++ b/readme/dev/spec/web_app.md
@@ -6,7 +6,7 @@ This document explains how the Joplin Web App works from a technical perspective
 
 :::
 
-The Joplin Web App is a version of the mobile application that targets web using [`react-native-web`](https://www.npmjs.com/package/react-native-web). See [BUILD.md](../BUILD.md#web) for information about building thee web app.
+The Joplin Web App is a version of the mobile application that targets web using [`react-native-web`](https://www.npmjs.com/package/react-native-web). See [BUILD.md](../BUILD.md#web) for information about building the web app.
 
 
 ## File system


### PR DESCRIPTION
# Summary

Fixes a typo in the documentation &mdash; "the" was written as "thee" in two places.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->