### PR TITLE
Chore: Mobile tests: Hide debug logging

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useOnMessage.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import shared from '@joplin/lib/components/shared/note-screen-shared';
+import Logger from '@joplin/utils/Logger';
 
 export type HandleMessageCallback = (message: string)=> void;
 export type OnMarkForDownloadCallback = (resource: { resourceId: string })=> void;
@@ -11,6 +12,8 @@ interface MessageCallbacks {
 	onRequestEditResource?: HandleMessageCallback;
 	onCheckboxChange: HandleMessageCallback;
 }
+
+const logger = Logger.create('useOnMessage');
 
 export default function useOnMessage(
 	noteBody: string,
@@ -29,10 +32,10 @@ export default function useOnMessage(
 	return useCallback((msg: string) => {
 		const isScrollMessage = msg.startsWith('onscroll:');
 
-		// Scroll messages are very frequent so we avoid logging them.
+		// Scroll messages are very frequent so we avoid logging them, even
+		// in debug mode
 		if (!isScrollMessage) {
-			// eslint-disable-next-line no-console
-			console.info('Got IPC message: ', msg);
+			logger.debug('Got IPC message: ', msg);
 		}
 
 		if (msg.indexOf('checkboxclick:') === 0) {


### PR DESCRIPTION
# Summary

This pull request converts a `console.info` call to a `logger.debug` call.

This pull request uses `logger.debug` instead of `logger.info` to avoid a (small) behavior change &mdash; previously, these messages would not be saved to the mobile log in release mode.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->