### PR TITLE
Chore: Mobile tests: Fix warning: "A worker process ... has been force exited"

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -70,6 +70,7 @@ describe('PluginStates.installed', () => {
 		for (const pluginId of PluginService.instance().pluginIds) {
 			await act(() => PluginService.instance().unloadPlugin(pluginId));
 		}
+		jest.useRealTimers();
 	});
 
 	it.each([


### PR DESCRIPTION
# Summary

This pull request fixes a warning observed while running `yarn test plugins` in `packages/app-mobile`:
```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```

This seems to be caused by a `shim.setInterval` call in `afterEachCleanup` (called in an `afterEach` in `app-mobile/jest.setup.js`. The `setInterval` failed to run with fake timers.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->