### PR TITLE
Mobile: Drawing: Fix clicking "cancel" after starting a new drawing in editing mode creates an empty resource

### DIFF
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.test.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.test.ts
@@ -22,6 +22,7 @@ const createEditorWithCallbacks = (callbacks: Partial<ImageEditorCallbacks>) => 
 
 	const allCallbacks: ImageEditorCallbacks = {
 		saveDrawing: () => {},
+		saveThenClose: ()=> {},
 		closeEditor: ()=> {},
 		setImageHasChanges: ()=> {},
 		updateEditorTemplate: ()=> {},

--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
@@ -91,11 +91,15 @@ export const createJsDrawEditor = (
 		}
 	};
 
-	const saveNow = () => {
-		callbacks.saveDrawing(editor.toSVG({
+	const getEditorSVG = () => {
+		return editor.toSVG({
 			// Grow small images to this minimum size
 			minDimension: 50,
-		}), false);
+		});
+	};
+
+	const saveNow = () => {
+		callbacks.saveDrawing(getEditorSVG(), false);
 
 		// The image is now up-to-date with the resource
 		setImageHasChanges(false);
@@ -177,13 +181,7 @@ export const createJsDrawEditor = (
 		},
 		saveNow,
 		saveThenExit: async () => {
-			saveNow();
-
-			// Don't show a confirmation dialog -- it's possible that
-			// the code outside of the WebView still thinks changes haven't
-			// been saved:
-			const showConfirmation = false;
-			callbacks.closeEditor(showConfirmation);
+			callbacks.saveThenClose(getEditorSVG());
 		},
 	};
 

--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/types.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/types.ts
@@ -6,6 +6,7 @@ export interface ImageEditorCallbacks {
 	saveDrawing: SaveDrawingCallback;
 	updateEditorTemplate: UpdateEditorTemplateCallback;
 
+	saveThenClose: (svgData: SVGElement)=> void;
 	closeEditor: (promptIfUnsaved: boolean)=> void;
 	setImageHasChanges: (hasChanges: boolean)=> void;
 }

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -787,7 +787,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 				if (this.editorRef.current) {
 					this.editorRef.current.insertText(newText);
 				} else {
-					logger.error(`Tried to attach resource ${resource.id} to the note when the editor is not visible!`);
+					logger.info(`Tried to attach resource ${resource.id} to the note when the editor is not visible -- updating the note body instead.`);
 				}
 			}
 		} else {
@@ -900,20 +900,12 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 	};
 
 	private drawPicture_onPress = async () => {
-		if (this.state.mode === 'edit') {
-			// Create a new empty drawing and attach it now, before the image editor is opened.
-			// With the present structure of Note.tsx, the we can't use this.editorRef while
-			// the image editor is open, and thus can't attach drawings at the cursor location.
-			const resource = await this.attachNewDrawing('');
-			await this.editDrawing(resource);
-		} else {
-			logger.info('Showing image editor...');
-			this.setState({
-				showImageEditor: true,
-				imageEditorResourceFilepath: null,
-				imageEditorResource: null,
-			});
-		}
+		logger.info('Showing image editor...');
+		this.setState({
+			showImageEditor: true,
+			imageEditorResourceFilepath: null,
+			imageEditorResource: null,
+		});
 	};
 
 	private async editDrawing(item: BaseItem) {


### PR DESCRIPTION
# Summary

This pull request fixes an issue related to [this forum post](https://discourse.joplinapp.org/t/mobile-draw-picture-feature-causes-desktop-sync-error/39963?u=personalizedrefriger). Previously,
1. opening a note in edit mode,
2. clicking "Attach drawing", and
3. clicking "Close"

would attach an empty drawing to the current note, which [may cause sync to fail for some sync targets](https://discourse.joplinapp.org/t/mobile-draw-picture-feature-causes-desktop-sync-error/39963).

# Testing plan

1. Create a new note.
2. Verify that the note editor (and not the viewer) is open.
3. Open the note action menu.
4. Click "Draw picture".
5. Click "Close".
6. Verify that no drawing has been added.
7. Open the note action menu.
8. Click "Draw picture".
9. Draw something.
10. Click "Close".
11. Click "Save changes".
12. Verify that an image has been inserted.
13. Move the cursor to the beginning of the editor.
14. Open the note action menu.
15. Click "Draw picture".
16. Draw something.
17. Click "save".
18. Verify that "save" is greyed out/disabled.
19. Click "Close".
20. Verify that a new drawing has been added to the beginning of the note.
21. Switch to the note viewer.
22. Open the note action menu.
23. Click "Draw picture".
24. Draw something.
25. Click "close".
26. Click "Discard changes".
27. Verify that no new drawing has been attached.
28. Open the note action menu.
29. Click "Draw picture".
30. Draw something.
31. Click "save", then "close".
32. Verify that a new drawing has been added to the end of the note.

This has been tested successfully on:
- An iOS 17 simulator.
- Web (Safari on MacOS).
- Android 13

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->