### PR TITLE
Desktop: Accessibility: Fix multi-note selection menu not tab-focusable

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { _ } from '@joplin/lib/locale';
 import CommandService from '@joplin/lib/services/CommandService';
-import { ChangeEvent, useCallback } from 'react';
+import { ChangeEvent, useCallback, useRef } from 'react';
 import NoteToolbar from '../../NoteToolbar/NoteToolbar';
 import { buildStyle } from '@joplin/lib/theme';
 import time from '@joplin/lib/time';
@@ -75,6 +75,33 @@ function styles_(props: Props) {
 	});
 }
 
+const useReselectHandlers = () => {
+	const lastTitleFocus = useRef([0, 0]);
+	const lastTitleValue = useRef('');
+
+	const onTitleBlur: React.FocusEventHandler<HTMLInputElement> = useCallback((event) => {
+		const titleElement = event.currentTarget;
+		lastTitleFocus.current = [titleElement.selectionStart, titleElement.selectionEnd];
+		lastTitleValue.current = titleElement.value;
+	}, []);
+
+	const onTitleFocus: React.FocusEventHandler<HTMLInputElement> = useCallback((event) => {
+		const titleElement = event.currentTarget;
+		// By default, focusing the note title bar can cause its content to become selected. We override
+		// this with a more reasonable default:
+		if (titleElement.selectionStart === 0 && titleElement.selectionEnd === titleElement.value.length) {
+			if (lastTitleValue.current !== titleElement.value) {
+				titleElement.selectionStart = titleElement.value.length;
+			} else {
+				titleElement.selectionStart = lastTitleFocus.current[0];
+				titleElement.selectionEnd = lastTitleFocus.current[1];
+			}
+		}
+	}, []);
+
+	return { onTitleBlur, onTitleFocus };
+};
+
 export default function NoteTitleBar(props: Props) {
 	const styles = styles_(props);
 
@@ -87,6 +114,8 @@ export default function NoteTitleBar(props: Props) {
 			void CommandService.instance().execute('focusElement', 'noteBody', { moveCursorToStart });
 		}
 	}, []);
+
+	const { onTitleFocus, onTitleBlur } = useReselectHandlers();
 
 	function renderTitleBarDate() {
 		return <span className="updated-time-label" style={styles.titleDate}>{time.formatMsToLocal(props.noteUserUpdatedTime)}</span>;
@@ -111,6 +140,8 @@ export default function NoteTitleBar(props: Props) {
 				readOnly={props.disabled}
 				onChange={props.onTitleChange}
 				onKeyDown={onTitleKeydown}
+				onFocus={onTitleFocus}
+				onBlur={onTitleBlur}
 				value={props.noteTitle}
 			/>
 			<InfoGroup>

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -153,14 +153,9 @@ const useOnKeyDown = (
 			announceForAccessibility(!wasCompleted ? _('Complete') : _('Incomplete'));
 		}
 
-		if (key === 'Tab') {
+		if (key === 'Tab' && event.shiftKey) {
 			event.preventDefault();
-
-			if (event.shiftKey) {
-				void CommandService.instance().execute('focusElement', 'sideBar');
-			} else {
-				void CommandService.instance().execute('focusElement', 'noteTitle');
-			}
+			void CommandService.instance().execute('focusElement', 'sideBar');
 		}
 
 		if (key.toUpperCase() === 'A' && (event.ctrlKey || event.metaKey)) {


### PR DESCRIPTION
# Summary

This pull request fixes an accessibility bug &mdash; previously, selecting multiple notes in the sidebar, then pressing <kbd>tab</kbd> had no effect (despite the presence of a menu).

This issue is fixed by removing an unnecessary tab override. Previously, pressing <kbd>tab</kbd> from the note list 1) prevented the default browser handling of the <kbd>tab</kbd> key and 2) tried to focus the note title input regardless of whether it was visible. 

# Notes

- To avoid a regression, additional focus/blur selection logic is added. Without it, refocusing the title input with the tab key would select the title input's content, rather than restore the cursor location.
- For now, the <kbd>shift</kbd>-<kbd>tab</kbd> override remains.

# Testing plan

1. Ensure that several to-dos and notes are visible in the note list.
2. Focus a note in the note list.
3. Press <kbd>tab</kbd>.
4. Verify that the note title has focus and that the cursor is at the end of the input.
5. Focus the note list by pressing <kbd>shift</kbd>-<kbd>tab</kbd>.
6. Select multiple notes using <kbd>shift</kbd> and the arrow keys.
7. Verify that the note selection menu is visible.
8. Press <kbd>tab</kbd>.
9. Verify that the note selection menu has focus.
10. Select just one note.
11. Press <kbd>tab</kbd>.
12. Verify that the note title is focused. Select the first letter.
13. Press <kbd>shift</kbd>-<kbd>tab</kbd>, then <kbd>tab</kbd>.
14. Verify that focus is restored to the first character.

This has been tested successfully on MacOS Sonoma.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->