### PR TITLE
Chore: Refactor linkReplacement to use a different destructuring pattern

### DIFF
--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -114,10 +114,19 @@ export default function(href: string, {
 
 	let resourceFullPath = resource && ResourceModel?.fullPath ? ResourceModel.fullPath(resource) : null;
 
-	const customResourceUrl = resourceId ? itemIdToUrl?.(resourceId) : null;
-	if (customResourceUrl) {
-		attrHtml.push(`href='${htmlentities(customResourceUrl)}'`);
-		resourceFullPath = customResourceUrl;
+	// Handle overrides
+	let addedHrefAttr = false;
+	if (resourceId && itemIdToUrl) {
+		const url = itemIdToUrl(resourceId);
+		if (url !== null) {
+			attrHtml.push(`href='${htmlentities(url)}'`);
+			resourceFullPath = url;
+			addedHrefAttr = true;
+		}
+	}
+
+	if (addedHrefAttr) {
+		// Done -- the HREF has already bee set.
 	} else if (plainResourceRendering || linkRenderingType === LinkRenderingType.HrefHandler) {
 		icon = '';
 		attrHtml.push(`href='${htmlentities(href)}'`);


### PR DESCRIPTION
# Summary

This pull request is a follow-up to [this review comment](https://github.com/laurent22/joplin/pull/11022#discussion_r1754868456) &mdash; it causes `linkReplacement.ts` to use object destructuring to set default properties, rather than object assignment.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->