### PR TITLE
Mobile,Desktop: Fix unable to change incorrect decryption password if the same as the master password

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -917,6 +917,7 @@ packages/lib/commands/historyForward.js
 packages/lib/commands/index.js
 packages/lib/commands/openMasterPasswordDialog.js
 packages/lib/commands/synchronize.js
+packages/lib/components/EncryptionConfigScreen/utils.test.js
 packages/lib/components/EncryptionConfigScreen/utils.js
 packages/lib/components/shared/NoteList/getEmptyFolderMessage.js
 packages/lib/components/shared/config/config-shared.js

--- a/.gitignore
+++ b/.gitignore
@@ -894,6 +894,7 @@ packages/lib/commands/historyForward.js
 packages/lib/commands/index.js
 packages/lib/commands/openMasterPasswordDialog.js
 packages/lib/commands/synchronize.js
+packages/lib/components/EncryptionConfigScreen/utils.test.js
 packages/lib/components/EncryptionConfigScreen/utils.js
 packages/lib/components/shared/NoteList/getEmptyFolderMessage.js
 packages/lib/components/shared/config/config-shared.js

--- a/packages/lib/components/EncryptionConfigScreen/utils.test.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.test.ts
@@ -1,0 +1,88 @@
+import MasterKey from '../../models/MasterKey';
+import EncryptionService, { EncryptionMethod } from '../../services/e2ee/EncryptionService';
+import { MasterKeyEntity } from '../../services/e2ee/types';
+import { setEncryptionEnabled } from '../../services/synchronizer/syncInfoUtils';
+import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import { usePasswordChecker } from './utils';
+import { renderHook } from '@testing-library/react-hooks';
+
+interface WrappedPasswordCheckerProps {
+	masterKeys: MasterKeyEntity[];
+	activeMasterKeyId: string;
+	masterPassword: string;
+	passwords: Record<string, string>;
+}
+
+const useWrappedPasswordChecker = ({
+	masterKeys = [],
+	activeMasterKeyId = '',
+	masterPassword = '',
+	passwords = {},
+}: WrappedPasswordCheckerProps) => usePasswordChecker(
+	masterKeys,
+	activeMasterKeyId,
+	masterPassword,
+	passwords,
+);
+
+describe('EncryptionConfigScreen/utils', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(0);
+		await switchClient(0);
+		setEncryptionEnabled(true);
+	});
+
+	test('should not mark keys as master password keys if the master password is incorrect for that key', async () => {
+		const makeMasterKey = async (password: string) => {
+			const result = await EncryptionService.instance().generateMasterKey(password, {
+				encryptionMethod: EncryptionMethod.SJCL4,
+			});
+			return await MasterKey.save(result);
+		};
+
+		const activeMasterKey = await makeMasterKey('master-password');
+		const secondaryMasterKey = await makeMasterKey('some other password');
+		const masterKeys = [
+			activeMasterKey,
+			secondaryMasterKey,
+		];
+
+		const initialProps = {
+			masterKeys,
+			activeMasterKeyId: activeMasterKey.id,
+			masterPassword: 'master-password',
+			passwords: {
+				[activeMasterKey.id]: 'master-password',
+				[secondaryMasterKey.id]: 'some other password',
+			},
+		};
+		const hook = renderHook(useWrappedPasswordChecker, {
+			initialProps,
+		});
+
+		// Different password from the master password should cause the secondary key
+		// to be marked as not using the master password.
+		await hook.waitFor(() => {
+			expect(hook.result.current.masterPasswordKeys).toMatchObject({
+				[activeMasterKey.id]: true,
+				[secondaryMasterKey.id]: false,
+			});
+		});
+
+		// Same password as the master password but fails to decrypt: Should not be marked
+		// as using the master password.
+		hook.rerender({
+			...initialProps,
+			passwords: {
+				...initialProps.passwords,
+				[secondaryMasterKey.id]: 'primary',
+			},
+		});
+		await hook.waitFor(() => {
+			expect(hook.result.current.masterPasswordKeys).toMatchObject({
+				[activeMasterKey.id]: true,
+				[secondaryMasterKey.id]: false,
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Summary

This pull request fixes an issue where a "Press to set the decryption password" banner could be visible, but the user was unable to input a correct password for a key:
![screenshot: Before vs after](https://github.com/user-attachments/assets/81ed5e59-6bb2-44e0-acf2-018caba6f706)

# Testing plan

This pull request includes an automated test that verifies that entering an incorrect password for a key **that is the same as the master password** does not mark the key as a `masterPasswordKey` (a key that can be decrypted with the master password).


In addition,
- **On desktop**:
    1. Change the password for a secondary encryption key (with a password different from the `masterPassword`) to the master password.
    2. Verify that the password input is still visible and that the valid column has an "x".
- **On Android**:
    1. In an environment where a master key has an incorrect password set that is the same as the `masterPassword`, open the "Encryption Config" screen.
    2. Verify that a password input is visible for the key with an incorrect password.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->