### PR TITLE
Desktop: Encryption screen: Fix "invalid password" border shown for some correct passwords

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -116,7 +116,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				);
 			} else {
 				return (
-					<td style={missingPasswordCellStyle}>
+					<td style={passwordChecks[masterKeyId] ? theme.textStyle : missingPasswordCellStyle}>
 						<input
 							type="password"
 							placeholder={_('Enter password')}


### PR DESCRIPTION
# Summary

This pull request fixes an issue where a red border was incorrectly shown around some correct passwords:

**Before**:
![screenshot: Encryption key has a valid checkmark, but a red border](https://github.com/user-attachments/assets/a15483cc-3150-498f-9a57-529a59a7e9e9)

**After**:
![screenshot: Encryption key has a valid checkmark and no red border](https://github.com/user-attachments/assets/d7efe8f0-d324-40ad-9f99-9bae3af19bb5)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->