### PR TITLE
Desktop: Fix editor/viewer loses focus when visible panels are changed with ctrl-l

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -287,6 +287,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -264,6 +264,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -28,7 +28,7 @@ import useWebviewIpcMessage from '../utils/useWebviewIpcMessage';
 import Toolbar from '../Toolbar';
 import useEditorSearchHandler from '../utils/useEditorSearchHandler';
 import CommandService from '@joplin/lib/services/CommandService';
-import { focus } from '@joplin/lib/utils/focusHandler';
+import useRefocusOnVisiblePaneChange from './utils/useRefocusOnVisiblePaneChange';
 
 const logger = Logger.create('CodeMirror6');
 const logDebug = (message: string) => logger.debug(message);
@@ -319,25 +319,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		return output;
 	}, [styles.cellViewer, props.visiblePanes]);
 
-	const lastVisiblePanes = useRef(props.visiblePanes);
-	useEffect(() => {
-		const editorHasFocus = editorRef.current?.cm6?.dom?.contains(document.activeElement);
-		const viewerHasFocus = document.activeElement?.tagName === 'IFRAME';
-
-		const lastHadViewer = lastVisiblePanes.current.includes('viewer');
-		const hasViewer = props.visiblePanes.includes('viewer');
-		const lastHadEditor = lastVisiblePanes.current.includes('editor');
-		const hasEditor = props.visiblePanes.includes('editor');
-		if (lastHadViewer !== hasViewer && !hasViewer && viewerHasFocus) {
-			focus('CodeMirror/refocusEditor', editorRef.current);
-		}
-
-		if (lastHadEditor !== hasEditor && !hasEditor && editorHasFocus) {
-			focus('CodeMirror/refocusViewer', webviewRef.current);
-		}
-
-		lastVisiblePanes.current = props.visiblePanes;
-	}, [props.visiblePanes]);
+	useRefocusOnVisiblePaneChange({ editorRef, webviewRef, visiblePanes: props.visiblePanes });
 
 	useEditorSearchHandler({
 		setLocalSearchResultCount: props.setLocalSearchResultCount,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.ts
@@ -1,0 +1,44 @@
+import { RefObject, useRef, useEffect } from 'react';
+import { focus } from '@joplin/lib/utils/focusHandler';
+import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
+import NoteTextViewer from '../../../../../NoteTextViewer';
+
+interface Props {
+	editorRef: RefObject<CodeMirrorControl>;
+	webviewRef: RefObject<NoteTextViewer>;
+	visiblePanes: string[];
+}
+
+const useRefocusOnVisiblePaneChange = ({ editorRef, webviewRef, visiblePanes }: Props) => {
+	const lastVisiblePanes = useRef(visiblePanes);
+	useEffect(() => {
+		const editorHasFocus = editorRef.current?.cm6?.dom?.contains(document.activeElement);
+		const viewerHasFocus = webviewRef.current?.hasFocus();
+
+		const lastHadViewer = lastVisiblePanes.current.includes('viewer');
+		const hasViewer = visiblePanes.includes('viewer');
+		const lastHadEditor = lastVisiblePanes.current.includes('editor');
+		const hasEditor = visiblePanes.includes('editor');
+
+		const viewerJustHidden = lastHadViewer && !hasViewer;
+		if (viewerJustHidden && viewerHasFocus) {
+			focus('CodeMirror/refocusEditor1', editorRef.current);
+		}
+
+		// Jump focus to the editor just after showing it -- this assumes that the user
+		// shows the editor to start editing the note.
+		const editorJustShown = !lastHadEditor && hasEditor;
+		if (editorJustShown && viewerHasFocus) {
+			focus('CodeMirror/refocusEditor2', editorRef.current);
+		}
+
+		const editorJustHidden = lastHadEditor && !hasEditor;
+		if (editorJustHidden && editorHasFocus) {
+			focus('CodeMirror/refocusViewer', webviewRef.current);
+		}
+
+		lastVisiblePanes.current = visiblePanes;
+	}, [visiblePanes, editorRef, webviewRef]);
+};
+
+export default useRefocusOnVisiblePaneChange;

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -2,6 +2,7 @@ import PostMessageService, { MessageResponse, ResponderComponentType } from '@jo
 import * as React from 'react';
 import { reg } from '@joplin/lib/registry';
 import bridge from '../services/bridge';
+import { focus } from '@joplin/lib/utils/focusHandler';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
@@ -129,9 +130,12 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 
 	public focus() {
 		if (this.webviewRef_.current) {
-			// Note: Calling .focus on this.webviewRef.current seems to focus the viewer
-			// iframe. However, when this is done, it isn't scrollable with the arrow keys.
-			// To allow arrow-key scrolling, focus is done from within the iframe:
+			// Calling focus on webviewRef_ seems necessary to mark the iframe as focused
+			// during automated testing.
+			focus('NoteTextViewer::focus', this.webviewRef_.current);
+
+			// Calling .focus on this.webviewRef.current isn't sufficient.
+			// To allow arrow-key scrolling, focus must also be set within the iframe:
 			this.send('focus');
 		}
 	}

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -2,7 +2,6 @@ import PostMessageService, { MessageResponse, ResponderComponentType } from '@jo
 import * as React from 'react';
 import { reg } from '@joplin/lib/registry';
 import bridge from '../services/bridge';
-import { focus } from '@joplin/lib/utils/focusHandler';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
@@ -130,7 +129,9 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 
 	public focus() {
 		if (this.webviewRef_.current) {
-			focus('NoteTextViewer::focus', this.webviewRef_.current);
+			// Note: Calling .focus on this.webviewRef.current seems to focus the viewer
+			// iframe. However, when this is done, it isn't scrollable with the arrow keys.
+			// To allow arrow-key scrolling, focus is done from within the iframe:
 			this.send('focus');
 		}
 	}

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -132,6 +132,7 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 	public focus() {
 		if (this.webviewRef_.current) {
 			focus('NoteTextViewer::focus', this.webviewRef_.current);
+			this.send('focus');
 		}
 	}
 

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -130,8 +130,9 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 
 	public focus() {
 		if (this.webviewRef_.current) {
-			// Calling focus on webviewRef_ seems necessary to mark the iframe as focused
-			// during automated testing.
+			// Calling focus on webviewRef_ seems to be necessary when NoteTextViewer.focus
+			// is called outside of a user event (e.g. in a setTimeout) or during automated
+			// tests:
 			focus('NoteTextViewer::focus', this.webviewRef_.current);
 
 			// Calling .focus on this.webviewRef.current isn't sufficient.

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -26,8 +26,7 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 
 	private initialized_ = false;
 	private domReady_ = false;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private webviewRef_: any;
+	private webviewRef_: React.RefObject<HTMLIFrameElement>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private webviewListeners_: any = null;
 	private removePluginAssetsCallback_: RemovePluginAssetsCallback|null = null;
@@ -134,6 +133,10 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 			focus('NoteTextViewer::focus', this.webviewRef_.current);
 			this.send('focus');
 		}
+	}
+
+	public hasFocus() {
+		return this.webviewRef_.current?.contains(document.activeElement);
 	}
 
 	public tryInit() {

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -36,7 +36,7 @@ test.describe('main', () => {
 		await mainWindow.keyboard.type('New note content!');
 
 		// Should render
-		const viewerFrame = editor.getNoteViewerIframe();
+		const viewerFrame = editor.getNoteViewerFrameLocator();
 		await expect(viewerFrame.locator('h1')).toHaveText('Test note!');
 	});
 
@@ -78,7 +78,7 @@ test.describe('main', () => {
 		}
 
 		// Should render mermaid
-		const viewerFrame = editor.getNoteViewerIframe();
+		const viewerFrame = editor.getNoteViewerFrameLocator();
 		await expect(
 			viewerFrame.locator('pre.mermaid text', { hasText: testCommitId }),
 		).toBeVisible();
@@ -115,7 +115,7 @@ test.describe('main', () => {
 		await setMessageBoxResponse(electronApp, /^No/i);
 		await editor.attachFileButton.click();
 
-		const viewerFrame = editor.getNoteViewerIframe();
+		const viewerFrame = editor.getNoteViewerFrameLocator();
 		const renderedImage = viewerFrame.getByAltText(filename);
 
 		const fullSize = await getImageSourceSize(renderedImage);

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -25,7 +25,7 @@ test.describe('markdownEditor', () => {
 			await importedHtmlFileItem.click({ timeout: 300 });
 		}).toPass();
 
-		const viewerFrame = mainScreen.noteEditor.getNoteViewerIframe();
+		const viewerFrame = mainScreen.noteEditor.getNoteViewerFrameLocator();
 		// Should render headers
 		await expect(viewerFrame.locator('h1')).toHaveText('Test HTML file!');
 
@@ -45,7 +45,7 @@ test.describe('markdownEditor', () => {
 		await setFilePickerResponse(electronApp, [join(__dirname, 'resources', 'small-pdf.pdf')]);
 		await editor.attachFileButton.click();
 
-		const viewerFrame = mainScreen.noteEditor.getNoteViewerIframe();
+		const viewerFrame = mainScreen.noteEditor.getNoteViewerFrameLocator();
 		const pdfLink = viewerFrame.getByText('small-pdf.pdf');
 		await expect(pdfLink).toBeVisible();
 
@@ -107,7 +107,7 @@ test.describe('markdownEditor', () => {
 		await setFilePickerResponse(electronApp, [join(__dirname, 'resources', 'video.mp4')]);
 		await editor.attachFileButton.click();
 
-		const videoLocator = editor.getNoteViewerIframe().locator('video');
+		const videoLocator = editor.getNoteViewerFrameLocator().locator('video');
 		const expectVideoToRender = async () => {
 			await expect(videoLocator).toBeSeekableMediaElement(6.9, 7);
 		};
@@ -173,7 +173,7 @@ test.describe('markdownEditor', () => {
 		await mainWindow.keyboard.press('Enter');
 		await mainWindow.keyboard.type('This is a test of search. `Test inline code`');
 
-		const viewer = noteEditor.getNoteViewerIframe();
+		const viewer = noteEditor.getNoteViewerFrameLocator();
 		await expect(viewer.locator('h1')).toHaveText('Testing');
 
 		const matches = viewer.locator('mark');

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -3,6 +3,7 @@ import { Locator, Page } from '@playwright/test';
 
 export default class NoteEditorPage {
 	public readonly codeMirrorEditor: Locator;
+	public readonly noteViewerContainer: Locator;
 	public readonly richTextEditor: Locator;
 	public readonly noteTitleInput: Locator;
 	public readonly attachFileButton: Locator;
@@ -12,7 +13,7 @@ export default class NoteEditorPage {
 	public readonly viewerSearchInput: Locator;
 	private readonly containerLocator: Locator;
 
-	public constructor(private readonly page: Page) {
+	public constructor(page: Page) {
 		this.containerLocator = page.locator('.rli-editor');
 		this.codeMirrorEditor = this.containerLocator.locator('.cm-editor');
 		this.richTextEditor = this.containerLocator.locator('iframe[title="Rich Text Area"]');
@@ -20,6 +21,7 @@ export default class NoteEditorPage {
 		this.attachFileButton = this.containerLocator.getByRole('button', { name: 'Attach file' });
 		this.toggleEditorsButton = this.containerLocator.getByRole('button', { name: 'Toggle editors' });
 		this.toggleEditorLayoutButton = this.containerLocator.getByRole('button', { name: 'Toggle editor layout' });
+		this.noteViewerContainer = this.containerLocator.locator('iframe[src$="note-viewer/index.html"]');
 		// The editor and viewer have slightly different search UI
 		this.editorSearchInput = this.containerLocator.getByPlaceholder('Find');
 		this.viewerSearchInput = this.containerLocator.getByPlaceholder('Search...');
@@ -33,7 +35,7 @@ export default class NoteEditorPage {
 		// The note viewer can change content when the note re-renders. As such,
 		// a new locator needs to be created after re-renders (and this can't be a
 		// static property).
-		return this.page.frameLocator('[src$="note-viewer/index.html"]');
+		return this.noteViewerContainer.frameLocator('iframe');
 	}
 
 	public getTinyMCEFrameLocator() {

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -31,11 +31,11 @@ export default class NoteEditorPage {
 		return this.containerLocator.getByRole('button', { name: title });
 	}
 
-	public getNoteViewerIframe() {
+	public getNoteViewerFrameLocator() {
 		// The note viewer can change content when the note re-renders. As such,
 		// a new locator needs to be created after re-renders (and this can't be a
 		// static property).
-		return this.noteViewerContainer.frameLocator('iframe');
+		return this.noteViewerContainer.frameLocator(':scope');
 	}
 
 	public getTinyMCEFrameLocator() {

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -32,7 +32,7 @@ test.describe('noteList', () => {
 		await mainWindow.keyboard.type('[Testing...](http://example.com/)');
 
 		// Wait to render
-		await expect(editor.getNoteViewerIframe().locator('a', { hasText: 'Testing...' })).toBeVisible();
+		await expect(editor.getNoteViewerFrameLocator().locator('a', { hasText: 'Testing...' })).toBeVisible();
 
 		// Updating the title should force the sidebar to update sooner
 		await expect(editor.noteTitleInput).toHaveValue('note-1');

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -18,7 +18,7 @@ test.describe('richTextEditor', () => {
 		await editor.attachFileButton.click();
 
 		// Wait to render
-		const viewerFrame = editor.getNoteViewerIframe();
+		const viewerFrame = editor.getNoteViewerFrameLocator();
 		await viewerFrame.locator('a[data-from-md]').waitFor();
 
 		// Should have an attached resource


### PR DESCRIPTION
# Summary

This pull request fixes an issue [originally reported on the forum](https://discourse.joplinapp.org/t/how-should-joplin-handle-tab-key-navigation-keyboard-accessibility/39846/2) &mdash; focusing the editor, then pressing <kbd>ctrl</kbd>-<kbd>l</kbd> to cycle through the different editor/viewer layouts causes focus to be lost.

This pull request causes the `toggleEditorLayout` command to refocus the editor or viewer such that the note editor retains focus on layout change. In particular,
- If the editor has focus and is hidden, focus moves to the viewer.
- If the editor is shown and the viewer had focus, moves focus to the editor.
- If neither the editor nor the viewer has focus, the focus is not changed.
   - This might happen if, for example, the user activated the "change editor layout button" with a keyboard.


# Testing plan

This pull request includes an automated test. It has also been tested manually on Fedora 40 using the following steps:
1. Focus the note editor.
2. Press <kbd>ctrl</kbd>-<kbd>l</kbd>. Verify that the viewer is hidden.
3. Verify that the note editor still has focus.
4. Press <kbd>ctrl</kbd>-<kbd>l</kbd>. Verify that only the viewer is visible.
5. Verify that the note viewer has focus (that arrow keys scroll the note viewer).
6. Press <kbd>ctrl</kbd>-<kbd>l</kbd>.
7. Verify that the note editor has focus.
8. Focus the title, then navigate to the "toggle editor layout" button with the tab and arrow keys.
9. Press <kbd>enter</kbd>.
10. Verify that the visible panes changed, but the "toggle editor layout" button still has focus.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->