### PR TITLE
Desktop: Accessibility: Improve text read by screen readers when focusing the note viewer

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -369,7 +369,7 @@
 		ipc.focus = (event) => {
 			const dummyID = 'joplin-content-focus-dummy';
 			if (! document.getElementById(dummyID)) {
-				const focusDummy = '<div style="width: 0; height: 0; overflow: hidden"><a id="' + dummyID + '" href="#">focus dummy</a></div>';
+				const focusDummy = '<div style="width: 0; height: 0; overflow: hidden"><a id="' + dummyID + '" href="#">Note viewer top</a></div>';
 				contentElement.insertAdjacentHTML("afterbegin", focusDummy);
 			}
 			const scrollTop = contentElement.scrollTop;


### PR DESCRIPTION
# Summary

This pull request changes the label of the link used to focus the note editor from `focus dummy` to `Note viewer top`. This link is sometimes read by a screen reader. In this case, the text, `focus dummy`, might be confusing.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->