### PR TITLE
Desktop: Update plugin compatibility layer to allow more legacy plugins (e.g. Markdown Prettier) to run

### DIFF
--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -426,6 +426,12 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		);
 	}
 
+	public getDoc() {
+		// [this] has several of the methods available on a CodeMirror 5 document.
+		// For some plugins, this is sufficient.
+		return this;
+	}
+
 	public static commands = (() => {
 		const commands: Record<string, CodeMirror5Command> = {
 			...BaseCodeMirror5Emulation.commands,

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -427,8 +427,8 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 	}
 
 	public getDoc() {
-		// [this] has several of the methods available on a CodeMirror 5 document.
-		// For some plugins, this is sufficient.
+		// The emulation layer has several of the methods available on a CodeMirror 5 document.
+		// For some plugins, `this` is sufficient.
 		return this;
 	}
 


### PR DESCRIPTION
# Summary

This pull request adds `.getDoc` to the CodeMirror 5 emulation layer, which [is required](https://github.com/shufo/joplin-plugin-markdown-prettier/blob/0484a5b183d6f53159dcda70bfdbf8ca0a10df36/src/formatter.ts#L13) by the `markdown-prettier` plugin.

# Testing plan

1. Add `markdown-prettier` as a development plugin.
    - **Note**: Locally, I tested with a version that uses a newer version of prettier and Joplin plugin template.
2. Restart Joplin.
3. Click the "format" button.
4. Verify that the note is formatted
5. Install Rich Markdown (regression testing).
6. Restart Joplin.
7. Enable focus mode.
8. Verify that non-active lines are still faded.

This has been tested successfully on Fedora 40.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->