### PR TITLE
Desktop: Fixes #10561: Table options not visible on dark theme

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -421,6 +421,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				background-color: ${theme.backgroundColor3};
 			}
 
+			.tox .tox-checkbox__icons .tox-checkbox-icon__unchecked svg {
+				fill: ${theme.color};
+			}
+
 			.tox .tox-collection--list .tox-collection__item--active {
 				color: ${theme.backgroundColor};
 			}

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -411,6 +411,16 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				color: ${theme.color};
 			}
 
+			.tox .tox-dialog__body-nav-item {
+				color: ${theme.color};
+			}
+
+			.tox .tox-dialog__body-nav-item[aria-selected=true] {
+				color: ${theme.color3};
+				border-color: ${theme.color3};
+				background-color: ${theme.backgroundColor3};
+			}
+
 			.tox .tox-collection--list .tox-collection__item--active {
 				color: ${theme.backgroundColor};
 			}


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10561

# Summary

I wasn't sure what colours I should pick from the theme, but I chose these ones because they are readable on all themes that Joplin have by default.

I also added a `background-color` since by default TinyMCE also has, but I don't think it makes a lot of difference here

I also added the theme colour to the checkbox to make it visible:

<details><summary>Screenshots</summary>

![2024-09-12_21-24](https://github.com/user-attachments/assets/9bc3c154-cb97-4611-b878-efa529c5ae9c)
![2024-09-12_21-23](https://github.com/user-attachments/assets/b63de766-5c1e-459a-be89-1836b99a7462)
![2024-09-12_21-19_1](https://github.com/user-attachments/assets/ce594f1e-0f59-44b8-b751-9724edb8a8e7)

</details> 