### PR TITLE
Desktop: Fixes #10560: Fix table column and rows not being resizable on RTE

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -655,7 +655,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
-				table_resize_bars: false,
 				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `${bridge().vendorDir()}/lib/tinymce/langs/${language}`,
 				toolbar: toolbar.join(' '),
 				localization_function: _,


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10560
Related to [Desktop: Fixes #10562: Preserve table customization made on RTE](https://github.com/laurent22/joplin/pull/10927)

# Summary

This property was set to be disabled. I'm not sure exactly why without this property sometimes it was possible to change the column/rows, but with this change, it seems to be **always** possible.

On the other PR related to changes made to the RTE table I also added some additional logic to preserve the table if its style property for width or height are different. I think this code looks a little ugly:
https://github.com/laurent22/joplin/pull/10927/commits/a39644672fe0f82b366907f3083e844148603878

The problem is that the only way to know if the table was resized is to check its columns and rows and compare the values between them, but it seems like it could be problematic

# Testing

I couldn't think of a way of adding automated testing to this change.

But a way to reproduce the previous behavior is to:

- Switch to RTE
- Create a new note
- Create a table 2x2
- Write "a" in the top left corner
- Switch to Markdown
- Switch to RTE
- Before this PR, it shouldn't be possible to resize columns or rows, now it is