### PR TITLE
Server: Fixes #10532: Fix PostgreSQL version check failing on Windows Server because wrong regex

### DIFF
--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -1,0 +1,46 @@
+import { DbConnection, versionCheck } from './db';
+import { } from './env';
+import { DatabaseConfigClient } from './utils/types';
+
+describe('db', () => {
+
+	const mockedDb = (version: string, client: DatabaseConfigClient = DatabaseConfigClient.PostgreSQL) => {
+		return {
+			select: () => {
+				return {
+					first: () => ({
+						version,
+					}),
+				};
+			}
+			,
+			raw: () => '',
+			client: {
+				config: { client },
+			},
+		} as unknown as DbConnection;
+	};
+
+	it.each(
+		[
+			'PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit',
+			'PostgreSQL 16.3, compiled by Visual C++ build 1938, 64-bit"',
+		],
+	)('should handle versionCheck on all known string versions', async (versionDescription: string) => {
+
+		expect(versionCheck(mockedDb(versionDescription))).resolves.toBe(undefined);
+	});
+
+	it.each([
+		'PostgreSQL 11.16 (Debian 11.16-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit',
+	])('should throw because it is a outdated version', async (versionDescription: string) => {
+
+		expect(async () => versionCheck(mockedDb(versionDescription))).rejects.toThrow(`Postgres version not supported: ${versionDescription}. Min required version is: 12.0`);
+	});
+
+	it('should not check version if client is not SQLite', async () => {
+		const sqliteDb = mockedDb('invalid version', DatabaseConfigClient.SQLite);
+
+		expect(async () => versionCheck(sqliteDb)).resolves.toBe(undefined);
+	});
+});

--- a/packages/server/src/db.test.ts
+++ b/packages/server/src/db.test.ts
@@ -26,21 +26,21 @@ describe('db', () => {
 			'PostgreSQL 15.3 (Debian 15.3-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit',
 			'PostgreSQL 16.3, compiled by Visual C++ build 1938, 64-bit"',
 		],
-	)('should handle versionCheck on all known string versions', async (versionDescription: string) => {
+	)('should handle versionCheck on all known string versions', (versionDescription: string) => {
 
 		expect(versionCheck(mockedDb(versionDescription))).resolves.toBe(undefined);
 	});
 
 	it.each([
 		'PostgreSQL 11.16 (Debian 11.16-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit',
-	])('should throw because it is a outdated version', async (versionDescription: string) => {
+	])('should throw because it is a outdated version', (versionDescription: string) => {
 
-		expect(async () => versionCheck(mockedDb(versionDescription))).rejects.toThrow(`Postgres version not supported: ${versionDescription}. Min required version is: 12.0`);
+		expect(versionCheck(mockedDb(versionDescription))).rejects.toThrow(`Postgres version not supported: ${versionDescription}. Min required version is: 12.0`);
 	});
 
-	it('should not check version if client is not SQLite', async () => {
+	it('should not check version if client is not SQLite', () => {
 		const sqliteDb = mockedDb('invalid version', DatabaseConfigClient.SQLite);
 
-		expect(async () => versionCheck(sqliteDb)).resolves.toBe(undefined);
+		expect(versionCheck(sqliteDb)).resolves.toBe(undefined);
 	});
 });

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -4,6 +4,7 @@ import * as pathUtils from 'path';
 import time from '@joplin/lib/time';
 import Logger from '@joplin/utils/Logger';
 import { databaseSchema } from './services/database/types';
+import { compareVersions } from 'compare-versions';
 import { copyFile } from 'fs-extra';
 
 // Make sure bigInteger values are numbers and not strings
@@ -450,17 +451,23 @@ export function isUniqueConstraintError(error: any): boolean {
 	return false;
 }
 
+const parsePostgresVersionString = (versionString: string) => {
+	// PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
+	const matches = versionString.match('PostgreSQL (.*?) ');
+	if (!matches || matches.length !== 2) throw new Error(`Cannot parse Postgres version string: ${versionString}`);
+	return matches[1];
+};
+
 export const versionCheck = async (db: DbConnection) => {
 	if (isPostgres(db)) {
 		// We only support Postgres v12+
 		// https://github.com/laurent22/joplin/issues/9695
 		// https://www.postgresql.org/docs/current/rules-materializedviews.html
-		const minPostgresVersion = 120000;
-		const result = await db.raw('SHOW server_version_num');
-		if (result && result.rows && result.rows[0].server_version_num) {
-			const serverVersionNum = parseInt(result.rows[0].server_version_num, 10);
-			if (Number.isNaN(serverVersionNum)) throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result.rows)}`);
-			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
+		const minPostgresVersion = '12.0';
+		const result = await db.select(db.raw('version()')).first();
+		if (result && result.version) {
+			const version = parsePostgresVersionString(result.version);
+			if (compareVersions(version, minPostgresVersion) < 0) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
 		} else {
 			throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result)}`);
 		}

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -453,7 +453,7 @@ export function isUniqueConstraintError(error: any): boolean {
 
 const parsePostgresVersionString = (versionString: string) => {
 	// PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
-	const matches = versionString.match('PostgreSQL (.*?)[, ]');
+	const matches = versionString.match(/PostgreSQL ([0-9.]+)/);
 	if (!matches || matches.length !== 2) throw new Error(`Cannot parse Postgres version string: ${versionString}`);
 	return matches[1];
 };

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -4,7 +4,6 @@ import * as pathUtils from 'path';
 import time from '@joplin/lib/time';
 import Logger from '@joplin/utils/Logger';
 import { databaseSchema } from './services/database/types';
-import { compareVersions } from 'compare-versions';
 import { copyFile } from 'fs-extra';
 
 // Make sure bigInteger values are numbers and not strings
@@ -451,23 +450,17 @@ export function isUniqueConstraintError(error: any): boolean {
 	return false;
 }
 
-const parsePostgresVersionString = (versionString: string) => {
-	// PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
-	const matches = versionString.match('PostgreSQL (.*?) ');
-	if (!matches || matches.length !== 2) throw new Error(`Cannot parse Postgres version string: ${versionString}`);
-	return matches[1];
-};
-
 export const versionCheck = async (db: DbConnection) => {
 	if (isPostgres(db)) {
 		// We only support Postgres v12+
 		// https://github.com/laurent22/joplin/issues/9695
 		// https://www.postgresql.org/docs/current/rules-materializedviews.html
-		const minPostgresVersion = '12.0';
-		const result = await db.select(db.raw('version()')).first();
-		if (result && result.version) {
-			const version = parsePostgresVersionString(result.version);
-			if (compareVersions(version, minPostgresVersion) < 0) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
+		const minPostgresVersion = 120000;
+		const result = await db.raw('SHOW server_version_num');
+		if (result && result.rows && result.rows[0].server_version_num) {
+			const serverVersionNum = parseInt(result.rows[0].server_version_num, 10);
+			if (Number.isNaN(serverVersionNum)) throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result.rows)}`);
+			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
 		} else {
 			throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result)}`);
 		}

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -453,7 +453,7 @@ export function isUniqueConstraintError(error: any): boolean {
 
 const parsePostgresVersionString = (versionString: string) => {
 	// PostgreSQL 16.1 (Debian 16.1-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
-	const matches = versionString.match('PostgreSQL (.*?) ');
+	const matches = versionString.match('PostgreSQL (.*?)[, ]');
 	if (!matches || matches.length !== 2) throw new Error(`Cannot parse Postgres version string: ${versionString}`);
 	return matches[1];
 };

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -460,7 +460,7 @@ export const versionCheck = async (db: DbConnection) => {
 		if (result && result.rows && result.rows[0].server_version_num) {
 			const serverVersionNum = parseInt(result.rows[0].server_version_num, 10);
 			if (Number.isNaN(serverVersionNum)) throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result.rows)}`);
-			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
+			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${serverVersionNum}. Min required version is: ${minPostgresVersion}`);
 		} else {
 			throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result)}`);
 		}

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -460,7 +460,7 @@ export const versionCheck = async (db: DbConnection) => {
 		if (result && result.rows && result.rows[0].server_version_num) {
 			const serverVersionNum = parseInt(result.rows[0].server_version_num, 10);
 			if (Number.isNaN(serverVersionNum)) throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result.rows)}`);
-			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${serverVersionNum}. Min required version is: ${minPostgresVersion}`);
+			if (minPostgresVersion > serverVersionNum) throw new Error(`Postgres version not supported: ${result.version}. Min required version is: ${minPostgresVersion}`);
 		} else {
 			throw new Error(`Could not fetch Postgres version info. Got: ${JSON.stringify(result)}`);
 		}


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10532

# Summary

A user reported an error when trying to run Joplin Server on a Windows Server machine because the Regex used to get the PostgreSQL version didn't work there.

I went over PostgreSQL documentation and found a better way to check the database version:

> Software developers should use server_version_num (available since 8.2) or [PQserverVersion](https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQSERVERVERSION) instead of parsing the text version.

https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION

Although the `server_version_num` should be a number, a `parseInt` call is required because the value returned by knex is a string.

# Testing

The user reported the error on Windows Server, but I can't test it on this environment.

To test the change, I ran Joplin Sever with a PostgreSQL 15.3 docker image (worked) and with the 11.16 version (error was thrown as expected).

I'm not sure if there is a way to add automated tests to this change.