### PR TITLE
Desktop: Accessibility: Add "Move to" context menu action for notebooks

### DIFF
--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -36,6 +36,7 @@ export const runtime = (comp: any): CommandRuntime => {
 			const startFolders: any[] = [];
 			const maxDepth = 15;
 
+			// It's okay for folders (but not notes) to have no parent folder:
 			if (allAreFolders) {
 				startFolders.push({
 					key: '',

--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -1,7 +1,13 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
-import Folder from '@joplin/lib/models/Folder';
+import Folder, { FolderEntityWithChildren } from '@joplin/lib/models/Folder';
 import Note from '@joplin/lib/models/Note';
+import BaseItem from '@joplin/lib/models/BaseItem';
+import { ModelType } from '@joplin/lib/BaseModel';
+import Logger from '@joplin/utils/Logger';
+import shim from '@joplin/lib/shim';
+
+const logger = Logger.create('commands/moveToFolder');
 
 export const declaration: CommandDeclaration = {
 	name: 'moveToFolder',
@@ -11,17 +17,35 @@ export const declaration: CommandDeclaration = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export const runtime = (comp: any): CommandRuntime => {
 	return {
-		execute: async (context: CommandContext, noteIds: string[] = null) => {
-			noteIds = noteIds || context.state.selectedNoteIds;
+		execute: async (context: CommandContext, itemIds: string[] = null) => {
+			itemIds = itemIds || context.state.selectedNoteIds;
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const folders: any[] = await Folder.sortFolderTree();
+			let allAreFolders = true;
+			const itemIdToType = new Map<string, ModelType>();
+			for (const id of itemIds) {
+				const item = await BaseItem.loadItemById(id);
+				itemIdToType.set(id, item.type_);
+
+				if (item.type_ !== ModelType.Folder) {
+					allAreFolders = false;
+				}
+			}
+
+			const folders = await Folder.sortFolderTree();
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			const startFolders: any[] = [];
 			const maxDepth = 15;
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const addOptions = (folders: any[], depth: number) => {
+			if (allAreFolders) {
+				startFolders.push({
+					key: '',
+					value: '',
+					label: _('None'),
+					indentDepth: 0,
+				});
+			}
+
+			const addOptions = (folders: FolderEntityWithChildren[], depth: number) => {
 				for (let i = 0; i < folders.length; i++) {
 					const folder = folders[i];
 					startFolders.push({ key: folder.id, value: folder.id, label: folder.title, indentDepth: depth });
@@ -40,8 +64,25 @@ export const runtime = (comp: any): CommandRuntime => {
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 					onClose: async (answer: any) => {
 						if (answer) {
-							for (let i = 0; i < noteIds.length; i++) {
-								await Note.moveToFolder(noteIds[i], answer.value);
+							try {
+								const targetFolderId = answer.value;
+								for (const id of itemIds) {
+									if (id === targetFolderId) {
+										continue;
+									}
+
+									const itemType = itemIdToType.get(id);
+									if (itemType === ModelType.Note) {
+										await Note.moveToFolder(id, targetFolderId);
+									} else if (itemType === ModelType.Folder) {
+										await Folder.moveToFolder(id, targetFolderId);
+									} else {
+										throw new Error(`Cannot move item with type ${itemType}`);
+									}
+								}
+							} catch (error) {
+								logger.error('Error moving items', error);
+								void shim.showMessageBox(`Error: ${error}`);
 							}
 						}
 						comp.setState({ promptOptions: null });

--- a/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
+++ b/packages/app-desktop/gui/MainScreen/commands/moveToFolder.ts
@@ -48,6 +48,12 @@ export const runtime = (comp: any): CommandRuntime => {
 			const addOptions = (folders: FolderEntityWithChildren[], depth: number) => {
 				for (let i = 0; i < folders.length; i++) {
 					const folder = folders[i];
+
+					// Disallow making a folder a subfolder of itself.
+					if (itemIdToType.has(folder.id)) {
+						continue;
+					}
+
 					startFolders.push({ key: folder.id, value: folder.id, label: folder.title, indentDepth: depth });
 					if (folder.children) addOptions(folder.children, (depth + 1) < maxDepth ? depth + 1 : maxDepth);
 				}

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -150,11 +150,14 @@ const useOnRenderItem = (props: Props) => {
 				);
 			}
 
-			if (itemType === BaseModel.TYPE_FOLDER) {
-				menu.append(new MenuItem(menuUtils.commandToStatefulMenuItem('moveToFolder', [itemId])));
-			}
-
 			if (itemType === BaseModel.TYPE_FOLDER && !item.encryption_applied) {
+				menu.append(new MenuItem({
+					...menuUtils.commandToStatefulMenuItem('moveToFolder', [itemId]),
+					// By default, enabled is based on the selected folder. However, the right-click
+					// menu can be shown for unselected folders.
+					enabled: true,
+				}));
+
 				menu.append(new MenuItem(menuUtils.commandToStatefulMenuItem('openFolderDialog', { folderId: itemId })));
 
 				menu.append(new MenuItem({ type: 'separator' }));

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -150,6 +150,10 @@ const useOnRenderItem = (props: Props) => {
 				);
 			}
 
+			if (itemType === BaseModel.TYPE_FOLDER) {
+				menu.append(new MenuItem(menuUtils.commandToStatefulMenuItem('moveToFolder', [itemId])));
+			}
+
 			if (itemType === BaseModel.TYPE_FOLDER && !item.encryption_applied) {
 				menu.append(new MenuItem(menuUtils.commandToStatefulMenuItem('openFolderDialog', { folderId: itemId })));
 


### PR DESCRIPTION
# Summary

This pull request allows changing the parent of a notebook from its context menu. Previously, it seems to have not been possible to change a folder's parent without a mouse.

This pull request modifies the existing `moveToFolder` command &mdash; it now supports changing the parent notebook of **notebooks** in addition to notes.

**Note**: A similar feature was originally requested [on the forum](https://discourse.joplinapp.org/t/move-subnotebook-to-top-level/8927/7?u=personalizedrefriger).

Related to #10795.

# Related WCAG guidelines

- [§2.1.1: Keyboard](https://www.w3.org/WAI/WCAG22/quickref/?versions=2.2&showtechniques=243%2C211#keyboard): "All functionality of the content is operable through a keyboard interface".
   - On my (Linux) computer, this can be done with the "context menu" key or by pressing <kbd>shift</kbd>-<kbd>F10</kbd>. 

# Screenshots

![screenshot: Right-click menu for a notebook includes "Move to notebook"](https://github.com/user-attachments/assets/960b9149-e6fe-4a70-9ab0-3811d2c658ab)
![screenshot: Dialog: Move to notebook: Visible dropdown includes options "None", "Test 2", "Test2", "Test3"](https://github.com/user-attachments/assets/826e5cc5-7fb2-4e63-89f1-ffb9e20067c6)

# Testing plan

**Manual testing** (Fedora 40):
1. Right-click on a subfolder.
2. Click "Move to notebook".
3. Verify that the right-clicked notebook's title is not in the list of possible notebooks.
4. Select "None".
5. Verify that the notebook is now toplevel.
6. Right-click on the folder.
7. Click "Move to notebook".
8. Select an existing folder.
9. Verify that the folder has been added as a subnotebook of the folder selected in step 8.

**Manual regression testing** (Fedora 40):
1. Open the command palette and run `:moveToFolder`.
2. Select a not-currently-selected notebook.
3. Verify that the note has been moved to that notebook.
4. Select multiple notes.
5. Click "Move to notebook".
6. Select a not-currently-selected notebook.
7. Verify that the notes have been moved to that notebook.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->