### PR TITLE
Desktop: Seamless-Updates: used url instead of browser url and added api heade…

### DIFF
--- a/packages/app-desktop/tools/githubReleasesUtils.ts
+++ b/packages/app-desktop/tools/githubReleasesUtils.ts
@@ -45,15 +45,20 @@ export const getTargetRelease = async (context: Context, targetTag: string): Pro
 };
 
 // Download a file from Joplin Desktop releases
-export const downloadFile = async (asset: GitHubReleaseAsset, destinationDir: string): Promise<string> => {
+export const downloadFile = async (context: Context, asset: GitHubReleaseAsset, destinationDir: string): Promise<string> => {
 	const downloadPath = path.join(destinationDir, asset.name);
 	if (!fs.existsSync(destinationDir)) {
 		fs.mkdirSync(destinationDir);
 	}
 
 	/* eslint-disable no-console */
-	console.log(`Downloading ${asset.name} to ${downloadPath}`);
-	const response = await fetch(asset.browser_download_url);
+	console.log(`Downloading ${asset.name} from ${asset.url} to ${downloadPath}`);
+	const response = await fetch(asset.url, {
+		headers: {
+			...defaultApiHeaders(context),
+			'Accept': 'application/octet-stream',
+		},
+	});
 	if (!response.ok) {
 		throw new Error(`Failed to download file: Status Code ${response.status}`);
 	}

--- a/packages/app-desktop/tools/modifyReleaseAssets.ts
+++ b/packages/app-desktop/tools/modifyReleaseAssets.ts
@@ -35,9 +35,9 @@ const createReleaseAssets = async (context: Context, release: GitHubRelease) => 
 	let zipPath;
 	for (const asset of release.assets) {
 		if (asset.name.endsWith('arm64.zip')) {
-			zipPath = await downloadFile(asset, downloadDir);
+			zipPath = await downloadFile(context, asset, downloadDir);
 		} else if (asset.name.endsWith('arm64.DMG')) {
-			dmgPath = await downloadFile(asset, downloadDir);
+			dmgPath = await downloadFile(context, asset, downloadDir);
 		}
 	}
 


### PR DESCRIPTION
This PR replaces the property `browser_download_url` in favor of `url` while also adding headers to the fetch request. This PR is trying to solve the error thrown by the [the last PR](https://github.com/laurent22/joplin/pull/11042):
- `Error: Failed to download file: Status Code 404`

[This](https://stackoverflow.com/questions/66551931/download-github-release-by-url-is-giving-404-not-found) is the solution I found on StackOverflow