### PR TITLE
Desktop: Seamless-Updates: updated asset name locally after update call to GitHub API

### DIFF
--- a/packages/app-desktop/tools/githubReleasesUtils.ts
+++ b/packages/app-desktop/tools/githubReleasesUtils.ts
@@ -45,15 +45,20 @@ export const getTargetRelease = async (context: Context, targetTag: string): Pro
 };
 
 // Download a file from Joplin Desktop releases
-export const downloadFile = async (asset: GitHubReleaseAsset, destinationDir: string): Promise<string> => {
+export const downloadFile = async (context: Context, asset: GitHubReleaseAsset, destinationDir: string): Promise<string> => {
 	const downloadPath = path.join(destinationDir, asset.name);
 	if (!fs.existsSync(destinationDir)) {
 		fs.mkdirSync(destinationDir);
 	}
 
 	/* eslint-disable no-console */
-	console.log(`Downloading ${asset.name} to ${downloadPath}`);
-	const response = await fetch(asset.browser_download_url);
+	console.log(`Downloading ${asset.name} from ${asset.url} to ${downloadPath}`);
+	const response = await fetch(asset.url, {
+		headers: {
+			...defaultApiHeaders(context),
+			'Accept': 'application/octet-stream',
+		},
+	});
 	if (!response.ok) {
 		throw new Error(`Failed to download file: Status Code ${response.status}`);
 	}

--- a/packages/app-desktop/tools/modifyReleaseAssets.ts
+++ b/packages/app-desktop/tools/modifyReleaseAssets.ts
@@ -20,6 +20,7 @@ const renameReleaseAssets = async (context: Context, release: GitHubRelease) => 
 			if (asset.name.match(pattern)) {
 				const newName = asset.name.replace(pattern, replacement);
 				await updateReleaseAsset(context, asset.url, newName);
+				asset.name = newName;
 
 				// Only rename a release once.
 				break;

--- a/packages/app-desktop/tools/modifyReleaseAssets.ts
+++ b/packages/app-desktop/tools/modifyReleaseAssets.ts
@@ -35,9 +35,9 @@ const createReleaseAssets = async (context: Context, release: GitHubRelease) => 
 	let zipPath;
 	for (const asset of release.assets) {
 		if (asset.name.endsWith('arm64.zip')) {
-			zipPath = await downloadFile(asset, downloadDir);
+			zipPath = await downloadFile(context, asset, downloadDir);
 		} else if (asset.name.endsWith('arm64.DMG')) {
-			dmgPath = await downloadFile(asset, downloadDir);
+			dmgPath = await downloadFile(context, asset, downloadDir);
 		}
 	}
 


### PR DESCRIPTION
To ensure no differences between the local release object and the release from GitHub Releases, this PR updates the release object locally after the update call to the API. This is a fix for this error:

- `Error: One or both executable files do not exist: undefined, /Users/runner/work/joplin/joplin/packages/app-desktop/downloads/Joplin-3.1.10-arm64.zip`

This time I also tested both functions (for MacOS Intel) to ensure .DMG file is found after renaming. 