### PR TITLE
Desktop: Seamless-Updates: added debugging logs for createReleaseAssets

### DIFF
--- a/packages/app-desktop/tools/modifyReleaseAssets.ts
+++ b/packages/app-desktop/tools/modifyReleaseAssets.ts
@@ -42,6 +42,14 @@ const createReleaseAssets = async (context: Context, release: GitHubRelease) => 
 		}
 	}
 
+	if (zipPath === undefined || dmgPath === undefined) {
+		const formattedAssets = release.assets.map(asset => ({
+			name: asset.name,
+			url: asset.url,
+		}));
+		throw new Error(`Zip path: ${zipPath} and/or dmg path: ${dmgPath} are not defined. Logging assets of release: ${JSON.stringify(formattedAssets, null, 2)}`);
+	}
+
 	const info: GenerateInfo = {
 		version: release.tag_name.slice(1),
 		dmgPath: dmgPath,


### PR DESCRIPTION
This PR added extra logging for createReleaseAssets to see where this error comes from:
- `One or both executable files do not exist`