### PR TITLE
iOS: Fix sidemenu can't be interacted with using VoiceOver

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -602,8 +602,8 @@ const SideMenuContentComponent = (props: Props) => {
 
 			// Accessibility, keyboard, and touch hidden.
 			inert={isHidden}
-			refocusCounter={isHidden ? undefined : 1}
 		>
+			<AccessibleView refocusCounter={isHidden ? undefined : 1} />
 			<View style={{ flex: 1, opacity: props.opacity }}>
 				<ScrollView scrollsToTop={false} style={styles_.menu}>
 					{items}


### PR DESCRIPTION
# Summary

This pull request fixes an iOS-specific regression from https://github.com/laurent22/joplin/commit/f69dffcf23497361c31b5290ef1152c5609f9b35 &mdash; the content of the side menu could not be interacted with using VoiceOver.

# Testing plan

**iOS 17 simulator**:
1. Open the side menu (using VoiceOver).
2. Navigate to "Configuration".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->