### PR TITLE
Cli: Fixes #10992: Disable deprecation warning when running Joplin from CLI

### DIFF
--- a/packages/app-cli/app/main.js
+++ b/packages/app-cli/app/main.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S NODE_OPTIONS=--no-deprecation node
 
 // Use njstrace to find out what Node.js might be spending time on
 // var njstrace = require('njstrace').inject();


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10992

# Summary

The change is to add a flag to the shebang line that should hide all warning when the `main.js` file is run directly (aka `$: ./main.js`), but it shouldn't affect when running in dev mode (`yarn start`).

I took more time to fix this than it was probably necessary because at first I was testing the modification running `node ./build/main.js version` which ignored the shebang line.

The depreciation warning started to appear when running the CLI with Node.js version >21 where `punycode` std lib is being deprecated but it is still used by a lot of our dependencies.

# Testing

- Open `packages/app-cli`
- Run `yarn build`
- Run `./build/main.js version`
- It should printout the app-cli version without showing the deprecation warning

Dev environment should still print the warning:

- Run `yarn start version` on `packages/app-cli`
- It should printout the app-cli but also the deprecation warning