### PR TITLE
Desktop,Mobile,Cli: Fixes #10608: WebDAV synchronisation not working because of URL encoding differences

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -948,6 +948,7 @@ packages/lib/eventManager.js
 packages/lib/file-api-driver-joplinServer.js
 packages/lib/file-api-driver-local.js
 packages/lib/file-api-driver-memory.js
+packages/lib/file-api-driver-webdav.test.js
 packages/lib/file-api-driver.test.js
 packages/lib/file-api.test.js
 packages/lib/file-api.js

--- a/.gitignore
+++ b/.gitignore
@@ -925,6 +925,7 @@ packages/lib/eventManager.js
 packages/lib/file-api-driver-joplinServer.js
 packages/lib/file-api-driver-local.js
 packages/lib/file-api-driver-memory.js
+packages/lib/file-api-driver-webdav.test.js
 packages/lib/file-api-driver.test.js
 packages/lib/file-api.test.js
 packages/lib/file-api.js

--- a/packages/lib/file-api-driver-webdav.js
+++ b/packages/lib/file-api-driver-webdav.js
@@ -107,6 +107,8 @@ class FileApiDriverWebDav {
 			output = href.substr(baseUrl.length);
 		} else if (href.indexOf(relativeBaseUrl) === 0) {
 			output = href.substr(relativeBaseUrl.length);
+		} else if (decodeURIComponent(href).indexOf(decodeURIComponent(relativeBaseUrl)) === 0) {
+			output = decodeURIComponent(href).substring(decodeURIComponent(relativeBaseUrl).length);
 		} else {
 			throw new Error(`href ${href} not in baseUrl ${baseUrl} nor relativeBaseUrl ${relativeBaseUrl}`);
 		}

--- a/packages/lib/file-api-driver-webdav.test.ts
+++ b/packages/lib/file-api-driver-webdav.test.ts
@@ -1,0 +1,29 @@
+const { FileApiDriverWebDav } = require('./file-api-driver-webdav');
+
+describe('file-api-driver-webdav', () => {
+
+	it.each([
+		[
+			'/remote.php/dav/files/user@mail.com/Joplin/',
+			'/remote.php/dav/files/user%40mail.com/Joplin',
+			'',
+		],
+		[
+			'/remote.php/dav/files/user@mail.com/Joplin/.lock',
+			'/remote.php/dav/files/user%40mail.com/Joplin',
+			'.lock',
+		],
+		[
+			'/remote.php/dav/files/user@mail.com/joplin%20files/locks/',
+			'/remote.php/dav/files/user%40mail.com/joplin files',
+			'locks',
+		],
+	])('should return relative path even if encoding is different', (async (href: string, relativePath: string, result: string) => {
+		const driver = new FileApiDriverWebDav();
+
+		const baseUrl = 'https://use07.thegood.cloud/remote.php/dav/files/user%40mail.com/Joplin';
+
+		expect(driver.hrefToRelativePath_(href, baseUrl, relativePath)).toBe(result);
+	}));
+
+});


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/10608

# Summary

When using the WebDAV sync target the items data returned by the server doesn't encode URI elements of email (see test example at `user@mail.com`), but it will encode URI folders with spaces (`joplin files` turns into `joplin%20files`).


When using the WebDAV sync target, synchronisation can fail because of the difference between the encodings of the data returned by the WebDAV API (in this case specific to the `d:href` property) and the `relativeBaseUrl` property. 

Differences that I noticed:
- `d:href` does not encode `@` but `relativeBaseUrl` does
- `relativeBaseUrl` does not encode whitespace while `d:href` does

I think the best solution for this would be to fix this encoding difference before it reaches the `hrefToRelativePath_` function (where this PR is fixing the issue) but since it is near the feature freeze I thought that the simplesest solution would be better.

# Testing

I added automated tests to the  `hrefToRelativePath_` function on `file-api-driver-webdav.test.ts`.

To create the tests I made some real world testing described bellow:

1 - Created a `Joplin` folder on my base WebDAV server
2 - Added WebDav as my sync target, my sync target URL has my `user@mail.com` address on it
3 - Created some notebooks and notes and tried to synch
4 - Found the error reported in the issue because `@` on email address is encoded to `%40` on `relativeBaseUrl` value, but the `d:href` property with the relative path to the file doesn't encode it

Other test case:

1 - Created a `joplin files` folder on my base WebDAV server
2 - Added WebDav as my sync target, my sync target URL has my `user@mail.com` address on it
3 - Created some notebooks and notes and tried to synch
4 - Now I found that `d:href` encodes whites spaces while `relativeBaseUrl` does not