### PR TITLE
Desktop: Seamless-Updates: triggering updates

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -332,6 +332,10 @@ export default class ElectronAppWrapper {
 			this.updaterService_.updateApp();
 		});
 
+		ipcMain.on('check-for-updates', () => {
+			void this.updaterService_.checkForUpdates(true);
+		});
+
 		// Let us register listeners on the window, so we can update the state
 		// automatically (the listeners will be removed when the window is closed)
 		// and restore the maximized or full screen state
@@ -470,7 +474,7 @@ export default class ElectronAppWrapper {
 	}
 
 	// Electron's autoUpdater has to be init from the main process
-	public async initializeAutoUpdaterService(logger: LoggerWrapper, devMode: boolean, includePreReleases: boolean) {
+	public initializeAutoUpdaterService(logger: LoggerWrapper, devMode: boolean, includePreReleases: boolean) {
 		if (shim.isWindows() || shim.isMac()) {
 			if (!this.updaterService_) {
 				this.updaterService_ = new AutoUpdaterService(this.win_, logger, devMode, includePreReleases);
@@ -482,7 +486,7 @@ export default class ElectronAppWrapper {
 	private startPeriodicUpdateCheck = (updateInterval: number = defaultUpdateInterval): void => {
 		this.stopPeriodicUpdateCheck();
 		this.updatePollInterval_ = setInterval(() => {
-			void this.updaterService_.checkForUpdates();
+			void this.updaterService_.checkForUpdates(false);
 		}, updateInterval);
 		setTimeout(this.updaterService_.checkForUpdates, initialUpdateStartup);
 	};

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -495,6 +495,7 @@ export default class ElectronAppWrapper {
 		if (this.updatePollInterval_) {
 			clearInterval(this.updatePollInterval_);
 			this.updatePollInterval_ = null;
+			this.updaterService_ = null;
 		}
 	};
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -404,9 +404,9 @@ class Application extends BaseApplication {
 		eventManager.on(EventName.ResourceChange, handleResourceChange);
 	}
 
-	private async setupAutoUpdaterService() {
+	private setupAutoUpdaterService() {
 		if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) {
-			await bridge().electronApp().initializeAutoUpdaterService(
+			bridge().electronApp().initializeAutoUpdaterService(
 				Logger.create('AutoUpdaterService'),
 				Setting.value('env') === 'dev',
 				Setting.value('autoUpdate.includePreReleases'),
@@ -448,6 +448,8 @@ class Application extends BaseApplication {
 
 		// Loads app-wide styles. (Markdown preview-specific styles loaded in app.js)
 		await injectCustomStyles('appStyles', Setting.customCssFilePath(Setting.customCssFilenames.JOPLIN_APP));
+
+		this.setupAutoUpdaterService();
 
 		AlarmService.setDriver(new AlarmServiceDriverNode({ appName: packageInfo.build.appId }));
 		AlarmService.setLogger(reg.logger());
@@ -697,8 +699,6 @@ class Application extends BaseApplication {
 		eventManager.on(EventName.NoteResourceIndexed, async () => {
 			SearchEngine.instance().scheduleSyncTables();
 		});
-
-		await this.setupAutoUpdaterService();
 
 		// setTimeout(() => {
 		// 	void populateDatabase(reg.db(), {

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -26,6 +26,7 @@ import PluginService, { PluginSettings } from '@joplin/lib/services/plugins/Plug
 import { getListRendererById, getListRendererIds } from '@joplin/lib/services/noteList/renderers';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import { EventName } from '@joplin/lib/eventManager';
+import { ipcRenderer } from 'electron';
 const packageInfo: PackageInfo = require('../packageInfo.js');
 const { clipboard } = require('electron');
 const Menu = bridge().Menu;
@@ -575,7 +576,12 @@ function useMenu(props: Props) {
 			toolsItems.push(SpellCheckerService.instance().spellCheckerConfigMenuItem(props['spellChecker.languages'], props['spellChecker.enabled']));
 
 			function _checkForUpdates() {
-				void checkForUpdates(false, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+				if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) {
+					ipcRenderer.send('check-for-updates');
+				} else {
+					void checkForUpdates(false, bridge().window(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+				}
+
 			}
 
 			function _showAbout() {

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -5,7 +5,7 @@ import NotyfContext from '../NotyfContext';
 import { UpdateInfo } from 'electron-updater';
 import { ipcRenderer, IpcRendererEvent } from 'electron';
 import { AutoUpdaterEvents } from '../../services/autoUpdater/AutoUpdaterService';
-import { NotyfNotification } from 'notyf';
+import { NotyfEvent, NotyfNotification } from 'notyf';
 import { _ } from '@joplin/lib/locale';
 import { htmlentities } from '@joplin/utils/html';
 import shim from '@joplin/lib/shim';
@@ -16,6 +16,7 @@ interface UpdateNotificationProps {
 
 export enum UpdateNotificationEvents {
 	ApplyUpdate = 'apply-update',
+	UpdateNotAvailable = 'update-not-available',
 	Dismiss = 'dismiss-update-notification',
 }
 
@@ -84,19 +85,53 @@ const UpdateNotification = ({ themeId }: UpdateNotificationProps) => {
 		});
 
 		notificationRef.current = notification;
+
+		notification.on(NotyfEvent.Dismiss, () => {
+			notificationRef.current = null;
+		});
+	}, [notyf, theme]);
+
+	const handleUpdateNotAvailable = useCallback(() => {
+		if (notificationRef.current) return;
+
+		const noUpdateMessageHtml = htmlentities(_('No updates available'));
+
+		const messageHtml = `
+			<div class="update-notification" style="color: ${theme.color2};">
+				${noUpdateMessageHtml}
+			</div>
+		`;
+
+		const notification: NotyfNotification = notyf.open({
+			type: 'success',
+			message: messageHtml,
+			position: {
+				x: 'right',
+				y: 'bottom',
+			},
+			duration: 5000,
+		});
+
+		notification.on(NotyfEvent.Dismiss, () => {
+			notificationRef.current = null;
+		});
+
+		notificationRef.current = notification;
 	}, [notyf, theme]);
 
 	useEffect(() => {
 		ipcRenderer.on(AutoUpdaterEvents.UpdateDownloaded, handleUpdateDownloaded);
+		ipcRenderer.on(AutoUpdaterEvents.UpdateNotAvailable, handleUpdateNotAvailable);
 		document.addEventListener(UpdateNotificationEvents.ApplyUpdate, handleApplyUpdate);
 		document.addEventListener(UpdateNotificationEvents.Dismiss, handleDismissNotification);
 
 		return () => {
 			ipcRenderer.removeListener(AutoUpdaterEvents.UpdateDownloaded, handleUpdateDownloaded);
+			ipcRenderer.removeListener(AutoUpdaterEvents.UpdateNotAvailable, handleUpdateNotAvailable);
 			document.removeEventListener(UpdateNotificationEvents.ApplyUpdate, handleApplyUpdate);
 			document.removeEventListener(UpdateNotificationEvents.Dismiss, handleDismissNotification);
 		};
-	}, [handleApplyUpdate, handleDismissNotification, handleUpdateDownloaded]);
+	}, [handleApplyUpdate, handleDismissNotification, handleUpdateDownloaded, handleUpdateNotAvailable]);
 
 
 	return (

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -85,10 +85,6 @@ const UpdateNotification = ({ themeId }: UpdateNotificationProps) => {
 		});
 
 		notificationRef.current = notification;
-
-		notification.on(NotyfEvent.Dismiss, () => {
-			notificationRef.current = null;
-		});
 	}, [notyf, theme]);
 
 	const handleUpdateNotAvailable = useCallback(() => {
@@ -129,7 +125,6 @@ const UpdateNotification = ({ themeId }: UpdateNotificationProps) => {
 			ipcRenderer.removeListener(AutoUpdaterEvents.UpdateDownloaded, handleUpdateDownloaded);
 			ipcRenderer.removeListener(AutoUpdaterEvents.UpdateNotAvailable, handleUpdateNotAvailable);
 			document.removeEventListener(UpdateNotificationEvents.ApplyUpdate, handleApplyUpdate);
-			document.removeEventListener(UpdateNotificationEvents.Dismiss, handleDismissNotification);
 		};
 	}, [handleApplyUpdate, handleDismissNotification, handleUpdateDownloaded, handleUpdateNotAvailable]);
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1127,7 +1127,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		},
 
 
-		autoUpdateEnabled: { value: true, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: platform !== 'linux', appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
+		autoUpdateEnabled: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: false, appTypes: [AppType.Desktop], label: () => _('Automatically check for updates') },
 		'autoUpdate.includePreReleases': { value: false, type: SettingItemType.Bool, section: 'application', storage: SettingStorage.File, isGlobal: true, public: true, appTypes: [AppType.Desktop], label: () => _('Get pre-releases when checking for updates'), description: () => _('See the pre-release page for more details: %s', 'https://joplinapp.org/help/about/prereleases') },
 
 		'autoUploadCrashDumps': {


### PR DESCRIPTION
This PR triggers the updates.

- Automatic check:
  - if an update is available, show a notification:
![image](https://github.com/user-attachments/assets/38fff2e1-c90a-4fe6-b705-321667838328)
  - if an update is not available, do nothing
- Manual check (from toolbar choose Help > check for updates):
  - if an update is available, show the same notification
  - if not, the user is notified that no updates are available:
![image](https://github.com/user-attachments/assets/e5885e22-1914-4513-a300-cd01df4f4fad)

If the user chooses to update later, then the updates will not be triggered (not even if the app is closed). If the user chooses to restart now, a new version is installed (the old one is automatically deleted).
