### PR TITLE
Chore: Desktop: Add extra check to try to prevent duplicate setting key warning

### DIFF
--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -544,20 +544,6 @@ class Setting extends BaseModel {
 		this.cache_ = [];
 		const rows: CacheItem[] = await this.modelSelectAll('SELECT * FROM settings');
 
-		this.cache_ = [];
-
-		const pushItemsToCache = (items: CacheItem[]) => {
-			for (let i = 0; i < items.length; i++) {
-				const c = items[i];
-
-				if (!this.keyExists(c.key)) continue;
-
-				c.value = this.formatValue(c.key, c.value);
-				c.value = this.filterValue(c.key, c.value);
-
-				this.cache_.push(c);
-			}
-		};
 
 		// Keys in the database takes precedence over keys in the keychain because
 		// they are more likely to be up to date (saving to keychain can fail, but
@@ -597,6 +583,25 @@ class Setting extends BaseModel {
 				});
 			}
 		}
+
+
+		this.cache_ = [];
+		const cachedKeys = new Set();
+		const pushItemsToCache = (items: CacheItem[]) => {
+			for (let i = 0; i < items.length; i++) {
+				const c = items[i];
+
+				// Avoid duplicating keys -- doing so causes save issues.
+				if (cachedKeys.has(c.key)) continue;
+				if (!this.keyExists(c.key)) continue;
+
+				c.value = this.formatValue(c.key, c.value);
+				c.value = this.filterValue(c.key, c.value);
+
+				cachedKeys.add(c.key);
+				this.cache_.push(c);
+			}
+		};
 
 		pushItemsToCache(rows);
 		pushItemsToCache(secureItems);


### PR DESCRIPTION
# Summary

This pull request may fix a "duplicate key" error while saving settings. In particular, this should fix the error if it's caused by settings being saved to multiple locations (e.g. database and file or database and keychain).

**Note**: I haven't been able to reproduce this error consistently. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->