### PR TITLE
Desktop: New Markdown editor: Fix horizontal rule button when cursor is not on a new line

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -88,7 +88,7 @@ const useEditorCommands = (props: Props) => {
 					editorRef.current.updateBody(newBody);
 				}
 			},
-			textHorizontalRule: () => editorRef.current.insertText('* * *'),
+			textHorizontalRule: () => editorRef.current.execCommand(EditorCommandType.InsertHorizontalRule),
 			'editor.execCommand': (value: CommandValue) => {
 				if (!('args' in value)) value.args = [];
 

--- a/packages/editor/CodeMirror/editorCommands/editorCommands.ts
+++ b/packages/editor/CodeMirror/editorCommands/editorCommands.ts
@@ -3,6 +3,7 @@ import { EditorCommandType, ListType } from '../../types';
 import { undo, redo, selectAll, indentSelection, cursorDocStart, cursorDocEnd, cursorLineStart, cursorLineEnd, deleteToLineStart, deleteToLineEnd, undoSelection, redoSelection, cursorPageDown, cursorPageUp, cursorCharRight, cursorCharLeft, insertNewlineAndIndent, cursorLineDown, cursorLineUp, toggleComment, deleteLine, moveLineUp, moveLineDown } from '@codemirror/commands';
 import {
 	decreaseIndent, increaseIndent,
+	insertHorizontalRule,
 	toggleBolded, toggleCode,
 	toggleHeaderLevel, toggleItalicized,
 	toggleList, toggleMath,
@@ -41,6 +42,7 @@ const editorCommands: Record<EditorCommandType, EditorCommandFunction> = {
 	[EditorCommandType.ToggleHeading3]: toggleHeaderLevel(3),
 	[EditorCommandType.ToggleHeading4]: toggleHeaderLevel(4),
 	[EditorCommandType.ToggleHeading5]: toggleHeaderLevel(5),
+	[EditorCommandType.InsertHorizontalRule]: insertHorizontalRule,
 
 	[EditorCommandType.ScrollSelectionIntoView]: editor => {
 		editor.dispatch(editor.state.update({

--- a/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
@@ -1,5 +1,6 @@
 import { EditorSelection } from '@codemirror/state';
 import {
+	insertHorizontalRule,
 	insertOrIncreaseIndent,
 	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleMath, updateLink,
 } from './markdownCommands';
@@ -292,6 +293,36 @@ describe('markdownCommands', () => {
 			from: 6,
 			to: 6,
 		});
+	});
+
+	it('insertHorizontalRule should insert a horizontal rule after the current line', async () => {
+		const initialText = 'testing\n\n> this is a test\n> ';
+		const editor = await createTestEditor(
+			initialText,
+			EditorSelection.cursor(0),
+			[],
+		);
+
+		// Add a second selection
+		editor.dispatch({
+			selection: editor.state.selection.addRange(EditorSelection.cursor(initialText.length)),
+		});
+		expect(editor.state.selection.ranges).toHaveLength(2);
+
+		insertHorizontalRule(editor);
+
+		expect(editor.state.doc.toString()).toBe('testing\n* * *\n\n> this is a test\n> * * *');
+		expect(editor.state.selection.ranges).toMatchObject([{
+			from: 'testing\n* * *'.length,
+			empty: true,
+		}, {
+			from: editor.state.doc.length,
+			empty: true,
+		}]);
+
+		insertHorizontalRule(editor);
+
+		expect(editor.state.doc.toString()).toBe('testing\n* * *\n* * *\n\n> this is a test\n> * * *\n> * * *');
 	});
 });
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -401,6 +401,30 @@ export const toggleHeaderLevel = (level: number): Command => {
 	};
 };
 
+export const insertHorizontalRule: Command = (view: EditorView) => {
+	view.dispatch(view.state.changeByRange(selection => {
+		const line = view.state.doc.lineAt(selection.to);
+		const processedLineText = stripBlockquote(line);
+		const inBlockQuote = processedLineText !== line.text;
+		const needsNewLine = processedLineText !== '';
+
+		let prefix = inBlockQuote && needsNewLine ? '> ' : '';
+		if (needsNewLine) {
+			prefix = `\n${prefix}`;
+		}
+		const insert = `${prefix}* * *`;
+
+		return {
+			range: EditorSelection.cursor(line.to + insert.length),
+			changes: {
+				from: line.to,
+				insert,
+			},
+		};
+	}));
+	return true;
+};
+
 // Prepends the given editor's indentUnit to all lines of the current selection
 // and re-numbers modified ordered lists (if any).
 export const increaseIndent: Command = (view: EditorView): boolean => {

--- a/packages/editor/CodeMirror/testUtil/createTestEditor.ts
+++ b/packages/editor/CodeMirror/testUtil/createTestEditor.ts
@@ -26,6 +26,7 @@ const createTestEditor = async (
 			}),
 			indentUnit.of('\t'),
 			EditorState.tabSize.of(4),
+			EditorState.allowMultipleSelections.of(true),
 			extraExtensions,
 		],
 	});

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -30,6 +30,8 @@ export enum EditorCommandType {
 	ToggleHeading4 = 'textHeading4',
 	ToggleHeading5 = 'textHeading5',
 
+	InsertHorizontalRule = 'textHorizontalRule',
+
 	// Find commands
 	ShowSearch = 'find',
 	HideSearch = 'hideSearchDialog',


### PR DESCRIPTION
# Summary

This pull request improves the "insert horizontal rule" command in the new Markdown editor, making its behavior closer to the behavior of the same command in the legacy Markdown editor.

Previously, `insertHorizontalRule` incorrectly inserted `* * *` within a paragraph, rather than starting a new line.

# Screen recording


## Behavior in the legacy Markdown editor

https://github.com/user-attachments/assets/da8d1047-f0e2-4817-9281-80813a0a424e


## Behavior in the new Markdown editor (with this PR)

https://github.com/user-attachments/assets/040167b6-08e6-4061-b24d-583dcd0a7127

<details><summary>Compare with before this PR</summary>

https://github.com/user-attachments/assets/8749fc4b-735d-4ce0-bfc6-07b28172942a


</details>


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->