### PR TITLE
Doc: Add Backblaze to S3 Providers

### DIFF
--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -131,3 +131,4 @@ agplv
 Famegear
 rcompare
 tabindex
+Backblaze

--- a/readme/apps/sync/s3.md
+++ b/readme/apps/sync/s3.md
@@ -1,6 +1,6 @@
 # S3 synchronisation
 
-As of Joplin 2.x.x, Joplin supports multiple S3 providers. We expose some options that will need to be configured depending on your provider of choice. We have tested with UpCloud, AWS, Linode, Scaleway, and Backblaze. Others should work as well.
+As of Joplin 2.x.x, Joplin supports multiple S3 providers. We expose some options that will need to be configured depending on your provider of choice. See below for the providers that have been tested and confirmed to work.
 
 In the **desktop application** or **mobile application**, select "S3 (Beta)" as the synchronisation target in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md).
 

--- a/readme/apps/sync/s3.md
+++ b/readme/apps/sync/s3.md
@@ -1,6 +1,6 @@
 # S3 synchronisation
 
-As of Joplin 2.x.x, Joplin supports multiple S3 providers. We expose some options that will need to be configured depending on your provider of choice. We have tested with UpCloud, AWS, and Linode. others should work as well.
+As of Joplin 2.x.x, Joplin supports multiple S3 providers. We expose some options that will need to be configured depending on your provider of choice. We have tested with UpCloud, AWS, Linode, Scaleway, and Backblaze. Others should work as well.
 
 In the **desktop application** or **mobile application**, select "S3 (Beta)" as the synchronisation target in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md).
 
@@ -49,11 +49,16 @@ If you provide a configuration and you receive "success!" on the "check config" 
 - Region: required
 - Force Path Style: unchecked
 
+## Backblaze
+- URL: `https://s3.<region>.backblazeb2.com` (This is the endpoint URL provided by Backblaze B2)
+- Region: required (Copied from the provided endpoint URL. Example: `us-east-001`)
+- Force Path Style: unchecked
+
 ## Linode
 - URL: `https://<region>.linodeobjects.com` (region is in the URL provided by Linode; this URL is also the same as the URL provided by Linode with the bucket name removed)
 - Region: Anything you want to type, can't be left empty
 - Force Path Style: unchecked
-- 
+
 ## Scaleway
 - URL: `https://s3.<region>.scw.cloud` (The region is the same as the bucket's region. You could just copy your bucket endpoint in the bucket settings tab, then remove the bucket name from it.)
 - Region: required (example: `fr-par`)


### PR DESCRIPTION
Add [Backblaze](https://www.backblaze.com/cloud-storage) as a documented S3 sync provider.

I currently use this and have encountered no problems.