### PR TITLE
Mobile: Use fade animation for edit link dialog

### DIFF
--- a/packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx
+++ b/packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx
@@ -132,7 +132,7 @@ const EditLinkDialog = (props: LinkDialogProps) => {
 
 	return (
 		<Modal
-			animationType="slide"
+			animationType="fade"
 			containerStyle={styles.modalContent}
 			transparent={true}
 			visible={props.visible}


### PR DESCRIPTION
# Summary

Replaces the edit link dialog's `slide` animation with a `fade` animation. This change makes the dialog's animation more consistent with other dialogs, many of which also use a `fade` animation.

Previously, the "Edit link" dialog was the only dialog to use a `slide` animation.

# Before/after comparison

| Before | After |
|-------|------|
|  <video src="https://github.com/user-attachments/assets/30ed79e1-2ef3-41ab-97b7-f56c4683ca99" alt="The link dialog slides in from the bottom of the screen, when opening and closing it"></video> |  <video src="https://github.com/user-attachments/assets/97514926-cfcd-499c-abd9-592ecd46d698" alt="The link dialog fades in and out when opening and closing it"></video>  |

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->