### PR TITLE
Desktop: Fix ctrl/cmd-n can create new notes while the trash folder is selected

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.ts
@@ -27,6 +27,10 @@ const useKeymap = (editorControl: CodeMirrorControl) => {
 					binding.accelerator, CodeMirrorVersion.CodeMirror6,
 				),
 				run: () => {
+					if (!CommandService.instance().isEnabled(binding.command)) {
+						return false;
+					}
+
 					void CommandService.instance().execute(binding.command);
 					return true;
 				},


### PR DESCRIPTION
# Summary

On desktop, keybindings are registered directly with the editor to allow them to override built-in editor keybindings. Previously, it was possible to run disabled commands when the editor was focused.

This pull request updates the keybinding handler to check whether commands are disabled before running them.

# Testing plan

1. Ensure that 1) the (new) Markdown editor is enabled and 2) there is at least one deleted note.
1. Open a note in the trash folder.
2. Click on the editor.
3. Press <kbd>ctrl</kbd>-<kbd>n</kbd>.
4. Verify that no new note is created.
5. Switch to a different folder.
6. Click on the editor.
7. Press <kbd>ctrl</kbd>-<kbd>n</kbd>.
8. Verify that a note has been created.

This has been tested successfully on Fedora 40.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->