### PR TITLE
Chore: Mobile: Improve `Notes` screen type safety

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -36,6 +36,13 @@ const PADDING_V = 10;
 
 type OnPressCallback=()=> void;
 
+export interface FolderPickerOptions {
+	enabled: boolean;
+	selectedFolderId?: string;
+	onValueChange?: OnValueChangedListener;
+	mustSelect?: boolean;
+}
+
 interface ScreenHeaderProps {
 	selectedNoteIds: string[];
 	selectedFolderId: string;
@@ -49,12 +56,7 @@ interface ScreenHeaderProps {
 	menuOptions: MenuOptionType[];
 	title?: string|null;
 	folders: FolderEntity[];
-	folderPickerOptions?: {
-		enabled: boolean;
-		selectedFolderId?: string;
-		onValueChange?: OnValueChangedListener;
-		mustSelect?: boolean;
-	};
+	folderPickerOptions?: FolderPickerOptions;
 	plugins: PluginStates;
 
 	dispatch: Dispatch;

--- a/packages/app-mobile/components/app-nav.tsx
+++ b/packages/app-mobile/components/app-nav.tsx
@@ -115,7 +115,7 @@ class AppNavComponent extends Component<Props, State> {
 				behavior={Platform.OS === 'ios' ? 'padding' : null}
 				style={style}
 			>
-				<NotesScreen visible={notesScreenVisible} navigation={{ state: route }} />
+				<NotesScreen visible={notesScreenVisible} />
 				{searchScreenLoaded && <SearchScreen visible={searchScreenVisible} navigation={{ state: route }} />}
 				{!notesScreenVisible && !searchScreenVisible && <Screen navigation={{ state: route }} themeId={this.props.themeId} dispatch={this.props.dispatch} />}
 				<View style={{ height: this.state.autoCompletionBarExtraHeight }} />

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -148,7 +148,7 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 		}
 	}
 
-	public async refreshNotes(props: Props = null) {
+	public async refreshNotes(props: Props|null = null) {
 		if (props === null) props = this.props;
 
 		const options = {

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -1,86 +1,117 @@
-const React = require('react');
-import { AppState as RNAppState, View, StyleSheet, NativeEventSubscription } from 'react-native';
+import * as React from 'react';
+import { AppState as RNAppState, View, StyleSheet, NativeEventSubscription, ViewStyle, TextStyle } from 'react-native';
 import { stateUtils } from '@joplin/lib/reducer';
 import { connect } from 'react-redux';
 import NoteList from '../NoteList';
 import Folder from '@joplin/lib/models/Folder';
 import Tag from '@joplin/lib/models/Tag';
-import Note from '@joplin/lib/models/Note';
+import Note, { PreviewsOrder } from '@joplin/lib/models/Note';
 import Setting from '@joplin/lib/models/Setting';
 import { themeStyle } from '../global-style';
-import { ScreenHeader } from '../ScreenHeader';
+import { FolderPickerOptions, ScreenHeader } from '../ScreenHeader';
 import { _ } from '@joplin/lib/locale';
 import ActionButton from '../buttons/FloatingActionButton';
 const { dialogs } = require('../../utils/dialogs.js');
 const DialogBox = require('react-native-dialogbox').default;
-const { BaseScreenComponent } = require('../base-screen');
+import { BaseScreenComponent } from '../base-screen';
 const { BackButtonService } = require('../../services/back-button.js');
 import { AppState } from '../../utils/types';
-import { NoteEntity } from '@joplin/lib/services/database/types';
+import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
 import { itemIsInTrash } from '@joplin/lib/services/trash';
 import AccessibleView from '../accessibility/AccessibleView';
+import { Dispatch } from 'redux';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-class NotesScreenComponent extends BaseScreenComponent<any> {
+interface Props {
+	dispatch: Dispatch;
+
+	themeId: number;
+	visible: boolean;
+
+	folders: FolderEntity[];
+	tags: TagEntity[];
+	notesSource: string;
+	notesOrder: PreviewsOrder[];
+	uncompletedTodosOnTop: boolean;
+	showCompletedTodos: boolean;
+	noteSelectionEnabled: boolean;
+
+	activeFolderId: string;
+	selectedFolderId: string;
+	selectedTagId: string;
+	selectedSmartFilterId: string;
+	notesParentType: string;
+}
+
+interface State {
+
+}
+
+type Styles = Record<string, ViewStyle|TextStyle>;
+
+class NotesScreenComponent extends BaseScreenComponent<Props, State> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code from before rule was applied
+	private dialogbox: any;
 
 	private onAppStateChangeSub_: NativeEventSubscription = null;
+	private styles_: Record<number, Styles> = {};
+	private folderPickerOptions_: FolderPickerOptions;
 
-	public constructor() {
-		super();
-
-		this.onAppStateChange_ = async () => {
-			// Force an update to the notes list when app state changes
-			const newProps = { ...this.props };
-			newProps.notesSource = '';
-			await this.refreshNotes(newProps);
-		};
-
-		this.sortButton_press = async () => {
-			const buttons = [];
-			const sortNoteOptions = Setting.enumOptions('notes.sortOrder.field');
-
-			const makeCheckboxText = function(selected: boolean, sign: string, label: string) {
-				const s = sign === 'tick' ? '✓' : '⬤';
-				return (selected ? `${s} ` : '') + label;
-			};
-
-			for (const field in sortNoteOptions) {
-				if (!sortNoteOptions.hasOwnProperty(field)) continue;
-				buttons.push({
-					text: makeCheckboxText(Setting.value('notes.sortOrder.field') === field, 'bullet', sortNoteOptions[field]),
-					id: { name: 'notes.sortOrder.field', value: field },
-				});
-			}
-
-			buttons.push({
-				text: makeCheckboxText(Setting.value('notes.sortOrder.reverse'), 'tick', `[ ${Setting.settingMetadata('notes.sortOrder.reverse').label()} ]`),
-				id: { name: 'notes.sortOrder.reverse', value: !Setting.value('notes.sortOrder.reverse') },
-			});
-
-			buttons.push({
-				text: makeCheckboxText(Setting.value('uncompletedTodosOnTop'), 'tick', `[ ${Setting.settingMetadata('uncompletedTodosOnTop').label()} ]`),
-				id: { name: 'uncompletedTodosOnTop', value: !Setting.value('uncompletedTodosOnTop') },
-			});
-
-			buttons.push({
-				text: makeCheckboxText(Setting.value('showCompletedTodos'), 'tick', `[ ${Setting.settingMetadata('showCompletedTodos').label()} ]`),
-				id: { name: 'showCompletedTodos', value: !Setting.value('showCompletedTodos') },
-			});
-
-			const r = await dialogs.pop(this, Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
-			if (!r) return;
-
-			Setting.setValue(r.name, r.value);
-		};
-
-		this.backHandler = () => {
-			if (this.dialogbox && this.dialogbox.state && this.dialogbox.state.isVisible) {
-				this.dialogbox.close();
-				return true;
-			}
-			return false;
-		};
+	public constructor(props: Props) {
+		super(props);
 	}
+
+	private onAppStateChange_ = async () => {
+		// Force an update to the notes list when app state changes
+		const newProps = { ...this.props };
+		newProps.notesSource = '';
+		await this.refreshNotes(newProps);
+	};
+
+	private sortButton_press = async () => {
+		const buttons = [];
+		const sortNoteOptions = Setting.enumOptions('notes.sortOrder.field');
+
+		const makeCheckboxText = function(selected: boolean, sign: string, label: string) {
+			const s = sign === 'tick' ? '✓' : '⬤';
+			return (selected ? `${s} ` : '') + label;
+		};
+
+		for (const field in sortNoteOptions) {
+			if (!sortNoteOptions.hasOwnProperty(field)) continue;
+			buttons.push({
+				text: makeCheckboxText(Setting.value('notes.sortOrder.field') === field, 'bullet', sortNoteOptions[field]),
+				id: { name: 'notes.sortOrder.field', value: field },
+			});
+		}
+
+		buttons.push({
+			text: makeCheckboxText(Setting.value('notes.sortOrder.reverse'), 'tick', `[ ${Setting.settingMetadata('notes.sortOrder.reverse').label()} ]`),
+			id: { name: 'notes.sortOrder.reverse', value: !Setting.value('notes.sortOrder.reverse') },
+		});
+
+		buttons.push({
+			text: makeCheckboxText(Setting.value('uncompletedTodosOnTop'), 'tick', `[ ${Setting.settingMetadata('uncompletedTodosOnTop').label()} ]`),
+			id: { name: 'uncompletedTodosOnTop', value: !Setting.value('uncompletedTodosOnTop') },
+		});
+
+		buttons.push({
+			text: makeCheckboxText(Setting.value('showCompletedTodos'), 'tick', `[ ${Setting.settingMetadata('showCompletedTodos').label()} ]`),
+			id: { name: 'showCompletedTodos', value: !Setting.value('showCompletedTodos') },
+		});
+
+		const r = await dialogs.pop(this, Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
+		if (!r) return;
+
+		Setting.setValue(r.name, r.value);
+	};
+
+	private backHandler = () => {
+		if (this.dialogbox && this.dialogbox.state && this.dialogbox.state.isVisible) {
+			this.dialogbox.close();
+			return true;
+		}
+		return false;
+	};
 
 	public styles() {
 		if (!this.styles_) this.styles_ = {};
@@ -111,15 +142,13 @@ class NotesScreenComponent extends BaseScreenComponent<any> {
 		BackButtonService.removeHandler(this.backHandler);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public async componentDidUpdate(prevProps: any) {
+	public async componentDidUpdate(prevProps: Props) {
 		if (prevProps.notesOrder !== this.props.notesOrder || prevProps.selectedFolderId !== this.props.selectedFolderId || prevProps.selectedTagId !== this.props.selectedTagId || prevProps.selectedSmartFilterId !== this.props.selectedSmartFilterId || prevProps.notesParentType !== this.props.notesParentType || prevProps.uncompletedTodosOnTop !== this.props.uncompletedTodosOnTop || prevProps.showCompletedTodos !== this.props.showCompletedTodos) {
 			await this.refreshNotes(this.props);
 		}
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public async refreshNotes(props: any = null) {
+	public async refreshNotes(props: Props = null) {
 		if (props === null) props = this.props;
 
 		const options = {
@@ -172,8 +201,7 @@ class NotesScreenComponent extends BaseScreenComponent<any> {
 		}
 	};
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public parentItem(props: any = null) {
+	public parentItem(props: Props|null = null) {
 		if (!props) props = this.props;
 
 		let output = null;
@@ -305,8 +333,6 @@ const NotesScreen = connect((state: AppState) => {
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		notesOrder: stateUtils.notesOrder(state.settings),
 	};
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-})(NotesScreenComponent as any);
+})(NotesScreenComponent);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export default NotesScreen as any;
+export default NotesScreen;

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -24,11 +24,13 @@ const { isImageMimeType } = require('../resourceUtils');
 const { MarkupToHtml } = require('@joplin/renderer');
 const { ALL_NOTES_FILTER_ID } = require('../reserved-ids');
 
+export interface PreviewsOrder {
+	by: string;
+	dir: string;
+}
+
 interface PreviewsOptions {
-	order?: {
-		by: string;
-		dir: string;
-	}[];
+	order?: PreviewsOrder[];
 	conditions?: string[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	conditionsParams?: any[];


### PR DESCRIPTION
# Summary

This pull request removes several explicit `any` types in `app-mobile/components/screens/Notes.tsx`.

**Note**:
- A large portion of the lines shown in the diff are due to an indentation change &mdash; several class callback definitions were moved out of the constructor.

# Testing plan

**Android 13**:
1. Open a folder.
2. Click the "sort by" button.
3. Change from "Title" to "Updated date".
4. Wait for the list to update.
5. Verify that the list order has changed.
6. Click "sort by".
7. Toggle "reverse sort order".
8. Wait for the note list to update.
9. Verify that the note list order has changed.
10. Add a new tag to a note.
11. Open the tag.
12. Verify that the note is shown in the note screen.
13. Create a new note with the "+" button.
14. Title the note "Test".
15. Press "back".
16. Verify that the note is shown in the note list.
   - Interestingly, the note is not assigned the tag and disappears after switching to a folder, then back to the tag. This, however, seems to have been an issue before this pull request.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->