### PR TITLE
Mobile: Fixes #11130: Fix regression: Search screen not hidden when cached for search result navigation

### DIFF
--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -30,6 +30,7 @@ export type ThemeStyle = BaseTheme & typeof baseStyle & {
 	headerStyle: TextStyle;
 	headerWrapperStyle: ViewStyle;
 	rootStyle: ViewStyle;
+	hiddenRootStyle: ViewStyle;
 	keyboardAppearance: 'light'|'dark';
 };
 
@@ -87,6 +88,11 @@ function extraStyles(theme: BaseTheme) {
 		backgroundColor: theme.backgroundColor,
 	};
 
+	const hiddenRootStyle: ViewStyle = {
+		...rootStyle,
+		flex: 0.001, // This is a bit of a hack but it seems to work fine - it makes the component invisible but without unmounting it
+	};
+
 	return {
 		marginRight: baseStyle.margin,
 		marginLeft: baseStyle.margin,
@@ -101,6 +107,7 @@ function extraStyles(theme: BaseTheme) {
 		headerStyle,
 		headerWrapperStyle,
 		rootStyle,
+		hiddenRootStyle,
 
 		keyboardAppearance: theme.appearance,
 		color5: theme.color5 ?? theme.backgroundColor4,

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -234,14 +234,7 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 		const parent = this.parentItem();
 		const theme = themeStyle(this.props.themeId);
 
-		const rootStyle = {
-			flex: 1,
-			backgroundColor: theme.backgroundColor,
-		};
-
-		if (!this.props.visible) {
-			rootStyle.flex = 0.001; // This is a bit of a hack but it seems to work fine - it makes the component invisible but without unmounting it
-		}
+		const rootStyle = this.props.visible ? theme.rootStyle : theme.hiddenRootStyle;
 
 		const title = parent ? parent.title : null;
 		if (!parent) {

--- a/packages/app-mobile/components/screens/SearchScreen/index.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/index.tsx
@@ -10,6 +10,7 @@ import { Dispatch } from 'redux';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import IconButton from '../../IconButton';
 import SearchResults from './SearchResults';
+import AccessibleView from '../../accessibility/AccessibleView';
 
 interface Props {
 	themeId: number;
@@ -21,7 +22,7 @@ interface Props {
 	ftsEnabled: number;
 }
 
-const useStyles = (theme: ThemeStyle) => {
+const useStyles = (theme: ThemeStyle, visible: boolean) => {
 	return useMemo(() => {
 		return StyleSheet.create({
 			body: {
@@ -46,13 +47,19 @@ const useStyles = (theme: ThemeStyle) => {
 				paddingRight: theme.marginRight,
 				backgroundColor: theme.backgroundColor,
 			},
+			rootStyle: {
+				...theme.rootStyle,
+
+				// TODO: Improve. This hides the component without unmounting it.
+				flex: !visible ? 0.001 : 1,
+			},
 		});
-	}, [theme]);
+	}, [theme, visible]);
 };
 
 const SearchScreenComponent: React.FC<Props> = props => {
 	const theme = themeStyle(props.themeId);
-	const styles = useStyles(theme);
+	const styles = useStyles(theme, props.visible);
 
 	const [query, setQuery] = useState(props.query);
 
@@ -79,7 +86,7 @@ const SearchScreenComponent: React.FC<Props> = props => {
 	}, [props.dispatch]);
 
 	return (
-		<View style={theme.rootStyle}>
+		<AccessibleView style={styles.rootStyle} inert={!props.visible}>
 			<ScreenHeader
 				title={_('Search')}
 				folderPickerOptions={{
@@ -115,7 +122,7 @@ const SearchScreenComponent: React.FC<Props> = props => {
 					onHighlightedWordsChange={onHighlightedWordsChange}
 				/>
 			</View>
-		</View>
+		</AccessibleView>
 	);
 };
 

--- a/packages/app-mobile/components/screens/SearchScreen/index.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/index.tsx
@@ -47,12 +47,7 @@ const useStyles = (theme: ThemeStyle, visible: boolean) => {
 				paddingRight: theme.marginRight,
 				backgroundColor: theme.backgroundColor,
 			},
-			rootStyle: {
-				...theme.rootStyle,
-
-				// TODO: Improve. This hides the component without unmounting it.
-				flex: !visible ? 0.001 : 1,
-			},
+			rootStyle: visible ? theme.rootStyle : theme.hiddenRootStyle,
 		});
 	}, [theme, visible]);
 };


### PR DESCRIPTION
# Summary

This pull request fixes a regression related to refactoring done in a recent [pull request](https://github.com/laurent22/joplin/pull/11104) &mdash; the search results screen was not hidden when its `visible` prop was set to `false`. This happened after clicking on a search result and resulted in a split layout.

This pull request  copies the approach used by `screens/Notes.tsx` &mdash; styling the search screen with `flex: 0.001` when marked with `visible: false` and setting `inert={true}` to prevent accessibility navigation. This is similar to the [logic used prior to the refactoring](https://github.com/laurent22/joplin/blob/598677b2072ab0648c7702f1d27c1e5ca3d628d3/packages/app-mobile/components/screens/search.tsx#L163).

Fixes #11130.
**Edit**: Related to https://github.com/laurent22/joplin/issues/11661.

# Screen recordings

## Android + TalkBack


[search-bugfix.webm](https://github.com/user-attachments/assets/d7e82aec-342a-47e5-8ea6-8827f323a15a)


Shows:
1. Opening search with an existing query.
2. Activating a search result.
    - The search screen is correctly hidden.
3. Clicking back navigates back to the search result screen.
4. Activating another search result.
    - The search screen is correctly hidden.
5. TalkBack focus is moved from the title to the edit button.

## Web + Chromium

[Screencast from 2024-09-26 15-47-55.webm](https://github.com/user-attachments/assets/a5d2a782-a232-4046-bc08-93ba2381c0f4)

Shows:
1. Opening search with an existing query.
2. Activating a search result.
3. Navigating to a different note from the result.
4. Pressing the back arrow.
    - Navigates back to the first note.
5. Pressing the back arrow.
    - Navigates back to the search screen.
6. Opening a different search result.
7. Pressing the back arrow.
    - Navigates back to the search screen.
8. Pressing the back arrow.
    - Navigates back to the note list.






<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->