### PR TITLE
Desktop: Fixes #11129: Improve performance by allowing note list background timers to be cancelled

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -374,6 +374,7 @@ packages/app-desktop/gui/NoteListItem/utils/useItemElement.js
 packages/app-desktop/gui/NoteListItem/utils/useItemEventHandlers.js
 packages/app-desktop/gui/NoteListItem/utils/useOnContextMenu.js
 packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.js
+packages/app-desktop/gui/NoteListItem/utils/useRootElement.test.js
 packages/app-desktop/gui/NoteListItem/utils/useRootElement.js
 packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.js
 packages/app-desktop/gui/NotePropertiesDialog.js

--- a/.gitignore
+++ b/.gitignore
@@ -351,6 +351,7 @@ packages/app-desktop/gui/NoteListItem/utils/useItemElement.js
 packages/app-desktop/gui/NoteListItem/utils/useItemEventHandlers.js
 packages/app-desktop/gui/NoteListItem/utils/useOnContextMenu.js
 packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.js
+packages/app-desktop/gui/NoteListItem/utils/useRootElement.test.js
 packages/app-desktop/gui/NoteListItem/utils/useRootElement.js
 packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.js
 packages/app-desktop/gui/NotePropertiesDialog.js

--- a/packages/app-desktop/gui/NoteListItem/utils/useRootElement.test.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRootElement.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useRootElement from './useRootElement';
+
+describe('useRootElement', () => {
+	beforeEach(() => {
+		jest.useFakeTimers({ advanceTimers: true });
+	});
+
+	test('should find an element with a matching ID', async () => {
+		const testElement = document.createElement('div');
+		testElement.id = 'test-element-id';
+		document.body.appendChild(testElement);
+
+		const { result } = renderHook(useRootElement, {
+			initialProps: testElement.id,
+		});
+		await act(async () => {
+			await jest.advanceTimersByTimeAsync(100);
+		});
+		expect(result.current).toBe(testElement);
+
+		testElement.remove();
+	});
+
+	test('should redo the element search when the elementId prop changes', async () => {
+		const testElement = document.createElement('div');
+		document.body.appendChild(testElement);
+
+		const { rerender, result } = renderHook(useRootElement, {
+			initialProps: 'some-id-here',
+		});
+		await jest.advanceTimersByTimeAsync(100);
+		expect(result.current).toBe(null);
+
+		// Searching for another non-existent ID: Should not match
+		rerender('updated-id');
+		await jest.advanceTimersByTimeAsync(100);
+		expect(result.current).toBe(null);
+
+		// Should not match the first element if its ID is set to the original (search
+		// should be cancelled).
+		testElement.id = 'some-id-here';
+		await jest.advanceTimersByTimeAsync(100);
+		expect(result.current).toBe(null);
+
+		// Should match if the element ID changes to the updated ID.
+		await act(async () => {
+			testElement.id = 'updated-id';
+			await jest.advanceTimersByTimeAsync(100);
+		});
+		expect(result.current).toBe(testElement);
+
+		testElement.remove();
+	});
+});

--- a/packages/app-desktop/gui/NoteListItem/utils/useRootElement.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRootElement.ts
@@ -6,7 +6,7 @@ const useRootElement = (elementId: string) => {
 	const [rootElement, setRootElement] = useState<HTMLDivElement>(null);
 
 	useAsyncEffect(async (event) => {
-		const element = await waitForElement(document, elementId);
+		const element = await waitForElement(document, elementId, event);
 		if (event.cancelled) return;
 		setRootElement(element);
 	}, [document, elementId]);

--- a/packages/app-desktop/jest.setup.js
+++ b/packages/app-desktop/jest.setup.js
@@ -24,9 +24,9 @@ jest.mock('@electron/remote', () => {
 
 // Import after mocking problematic libraries
 const { afterEachCleanUp, afterAllCleanUp } = require('@joplin/lib/testing/test-utils.js');
+const React = require('react');
 
-
-shimInit({ nodeSqlite: sqlite3 });
+shimInit({ nodeSqlite: sqlite3, React });
 
 afterEach(async () => {
 	await afterEachCleanUp();

--- a/packages/lib/dom.ts
+++ b/packages/lib/dom.ts
@@ -7,13 +7,15 @@ export const isInsideContainer = (node: any, className: string): boolean => {
 	return false;
 };
 
+interface CancelEvent { cancelled: boolean }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export const waitForElement = async (parent: any, id: string): Promise<any> => {
+export const waitForElement = async (parent: any, id: string, cancelEvent?: CancelEvent): Promise<any> => {
 	return new Promise((resolve, reject) => {
 		const iid = setInterval(() => {
 			try {
 				const element = parent.getElementById(id);
-				if (element) {
+				if (element || cancelEvent?.cancelled) {
 					clearInterval(iid);
 					resolve(element);
 				}


### PR DESCRIPTION
# Summary

This pull request cancels note list `waitForElement` intervals when note list items unmount. This should fix #11129.

# Testing plan

## With this PR

This pull request includes automated regression tests. At present, they **do not** verify that the background `waitForElement` interval stops. However, they do verify:
- `useRootElement` (the hook that wraps `waitForElement`) can find an element if it already exists in the DOM.
- `useRootElement` re-searches for an element if the `elementId` it's given changes (tests the case that no result is initially found).

Additionally, manual testing has been done (on Fedora 40):
1. Open the Electron dev tools and modify `packages/lib/dom.js`.
   <details><summary>diff</summary>
    
   ```diff
   diff --git a/dom.js b/dom-updated.js
   index e807b93..c9dfc91 100644
   --- a/dom.js
   +++ b/dom-updated.js
   @@ -22,6 +22,7 @@ const isInsideContainer = (node, className) => {
    exports.isInsideContainer = isInsideContainer;
    const waitForElement = (parent, id, cancelEvent) => __awaiter(void 0, void 0, void 0, function* () {
        return new Promise((resolve, reject) => {
   +        var start = Date.now()
            const iid = setInterval(() => {
                try {
                    const element = parent.getElementById(id);
   @@ -29,6 +30,7 @@ const waitForElement = (parent, id, cancelEvent) => __awaiter(void 0, void 0, vo
                        clearInterval(iid);
                        resolve(element);
                    }
   +                if (Date.now() - start > 1000) console.warn('long!')
                }
                catch (error) {
                    clearInterval(iid);
   ```
   </details>
3. Press <kbd>ctrl</kbd>-<kbd>s</kbd> to apply the changes.
4. Clear the console with `console.clear()`
5. Scroll quickly through a long note list (style: detailed)
6. Repeat step 4 for style: compact.
7. Verify that no `long!` warnings are present in the console.

## Comparison with before this PR

I then **compared with a version of Joplin from before this change**:
1. Open a copy of Joplin from before this change (v3.1.16).
10. Apply a the change from the previous testing steps to `packages/lib/dom.js` through the Electron dev tools.
    <details><summary>diff</summary>
    
    ```diff
    diff --git a/dom.js b/dom-updated.js
    index f229e6f..71486bf 100644
    --- a/dom.js
    +++ b/dom-updated.js
    @@ -23,6 +23,7 @@ exports.isInsideContainer = isInsideContainer;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
     const waitForElement = (parent, id) => __awaiter(void 0, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {
    +        var start = Date.now()
             const iid = setInterval(() => {
                 try {
                     const element = parent.getElementById(id);
    @@ -30,6 +31,7 @@ const waitForElement = (parent, id) => __awaiter(void 0, void 0, void 0, functio
                         clearInterval(iid);
                         resolve(element);
                     }
    +                if (Date.now() - start > 1000) console.warn('long!')
                 }
                 catch (error) {
                     clearInterval(iid);
    ```
    </details>
11. Press <kbd>ctrl</kbd>-<kbd>s</kbd> to apply changes.
12. Scroll quickly through a long note list.
13. Verify that a large number of `long!` messages are logged and that the number of such log statements is increasing rapidly:
       ![screenshot: Chrome dev tools with many `long!` log messages](https://github.com/user-attachments/assets/f73c36d0-cd25-4312-b89a-f44a0d35d199)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->