### PR TITLE
Mobile,Desktop: Fixes #11135: Fix incorrect list switching behavior

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -232,4 +232,19 @@ describe('markdownCommands.toggleList', () => {
 		);
 		expect(editor.state.selection.main.from).toBe(preSubListText.length);
 	});
+
+	it('should not treat a list of IP addresses as a numbered list', async () => {
+		const initialDocText = '192.168.1.1. This\n127.0.0.1. is\n0.0.0.0. a list';
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			[],
+		);
+
+		toggleList(ListType.UnorderedList)(editor);
+		expect(editor.state.doc.toString()).toBe(
+			'- 192.168.1.1. This\n- 127.0.0.1. is\n- 0.0.0.0. a list',
+		);
+	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -132,9 +132,9 @@ export const toggleList = (listType: ListType): Command => {
 		// RegExps for different list types. The regular expressions MUST
 		// be mutually exclusive.
 		// `(?!\[[ xX]+\])` means "not followed by [x] or [ ]".
-		const bulletedRegex = /^\s*([-*])\s(?!\[[ xX]+\])/;
-		const checklistRegex = /^\s*[-*]\s\[[ xX]+\]\s?/;
-		const numberedRegex = /^\s*\d+\.\s?/;
+		const bulletedRegex = /^\s*([-*])\s(?!\[[ xX]+\]\s)/;
+		const checklistRegex = /^\s*[-*]\s\[[ xX]+\]\s/;
+		const numberedRegex = /^\s*\d+\.\s/;
 
 		const listRegexes: Record<ListType, RegExp> = {
 			[ListType.OrderedList]: numberedRegex,


### PR DESCRIPTION
# Summary

This pull request fixes incorrect regular expressions for numbered lists and checklists.

Previously, the numbered and checklist regular expressions did not require a space after the first number (so "1.a" would be considered a list item).

Fixes #11135.

# Screen recording

[Screencast from 2024-09-27 12-23-17.webm](https://github.com/user-attachments/assets/70f2790f-e766-441f-afec-f61f7a62d36e)


# Possible future improvements

1. Use CodeMirror's syntax tree to determine whether a list type is already selected, rather than using a custom regular expression.
    - This may lead to more fragile tests &mdash; in the past there have been random CI failures due to the CodeMirror syntax tree not being present.
2. Don't try to remove a list if: 1) the user has selected text and 2) the text seems to be only part of a larger list.

# Testing plan

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->