### PR TITLE
Desktop: Remove Math Mode from the list of plugins incompatible with the new editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
@@ -38,7 +38,6 @@ const incompatiblePluginIds = [
 	'ylc395.noteLinkSystem',
 	'outline',
 	'joplin.plugin.cmoptions',
-	'plugin.calebjohn.MathMode',
 	'com.ckant.joplin-plugin-better-code-blocks',
 	// cSpell:enable
 ];


### PR DESCRIPTION
# Summary

The Math Mode plugin [now supports CodeMirror 6](https://discourse.joplinapp.org/t/plugin-math-mode/13254/30?u=personalizedrefriger) (as of v0.7.0).

This pull request removes `'plugin.calebjohn.MathMode'` from the list of plugins incompatible with CodeMirror 6.


# Testing plan

1. Start Joplin (before compiling the changed files from this PR to JavaScript).
2. Install the Math Mode plugin and restart.
3. Verify that an incompatibility warning is shown for the Math Mode plugin
4. Quit Joplin
5. Run `yarn tsc` from `packages/app-desktop`.
6. Start Joplin
7. Verify that the incompatibility warning is no longer shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->