### PR TITLE
Chore: Reduce mobile note screen test flakiness

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -139,6 +139,7 @@ const MenuComponent: React.FC<Props> = props => {
 					style={styles.menuContentScroller}
 					aria-modal={true}
 					accessibilityViewIsModal={true}
+					testID={`menu-content-${refocusCounter ? 'refocusing' : ''}`}
 				>{menuOptionComponents}</ScrollView>
 			</MenuOptions>
 		</Menu>

--- a/packages/app-mobile/components/screens/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note.test.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
 import { describe, it, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, screen, userEvent } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, userEvent, waitFor } from '@testing-library/react-native';
 import '@testing-library/jest-native/extend-expect';
 import { Provider } from 'react-redux';
 
 import NoteScreen from './Note';
 import { MenuProvider } from 'react-native-popup-menu';
-import { setupDatabaseAndSynchronizer, switchClient, simulateReadOnlyShareEnv, waitFor } from '@joplin/lib/testing/test-utils';
+import { setupDatabaseAndSynchronizer, switchClient, simulateReadOnlyShareEnv, runWithFakeTimers } from '@joplin/lib/testing/test-utils';
+import { waitFor as waitForWithRealTimers } from '@joplin/lib/testing/test-utils';
 import Note from '@joplin/lib/models/Note';
 import { AppState } from '../../utils/types';
 import { Store } from 'redux';
@@ -61,18 +62,14 @@ const getNoteEditorControl = async () => {
 };
 
 const waitForNoteToMatch = async (noteId: string, note: Partial<NoteEntity>) => {
-	await act(() => waitFor(async () => {
+	await act(() => waitForWithRealTimers(async () => {
 		const loadedNote = await Note.load(noteId);
 		expect(loadedNote).toMatchObject(note);
 	}));
 };
 
-const openNewNote = async (noteProperties: NoteEntity) => {
-	const note = await Note.save({
-		parent_id: (await Folder.defaultFolder()).id,
-		...noteProperties,
-	});
-
+const openExistingNote = async (noteId: string) => {
+	const note = await Note.load(noteId);
 	const displayParentId = getDisplayParentId(note, await Folder.load(note.parent_id));
 
 	store.dispatch({
@@ -85,7 +82,15 @@ const openNewNote = async (noteProperties: NoteEntity) => {
 		id: note.id,
 		folderId: displayParentId,
 	});
+};
 
+const openNewNote = async (noteProperties: NoteEntity) => {
+	const note = await Note.save({
+		parent_id: (await Folder.defaultFolder()).id,
+		...noteProperties,
+	});
+
+	await openExistingNote(note.id);
 	await waitForNoteToMatch(note.id, { parent_id: note.parent_id, title: note.title, body: note.body });
 
 	return note.id;
@@ -106,20 +111,31 @@ const openNoteActionsMenu = async () => {
 		cursor = cursor.parent;
 	}
 
-	await userEvent.press(actionMenuButton);
+	// Wrap in act(...) -- this tells the test library that component state is intended to update (prevents
+	// warnings).
+	await act(async () => {
+		await runWithFakeTimers(async () => {
+			await userEvent.press(actionMenuButton);
+		});
+
+		// State can update until the menu content is marked as in the process of refocusing (part of the
+		// menu transition).
+		await waitFor(async () => {
+			expect(await screen.findByTestId('menu-content-refocusing')).toBeVisible();
+		});
+	});
 };
 
 const openEditor = async () => {
 	const editButton = await screen.findByLabelText('Edit');
-	await userEvent.press(editButton);
+
+	fireEvent.press(editButton);
+	await waitFor(() => {
+		expect(screen.queryByLabelText('Edit')).toBeNull();
+	});
 };
 
 describe('screens/Note', () => {
-	beforeAll(() => {
-		// advanceTimers: Needed by internal note save logic
-		jest.useFakeTimers({ advanceTimers: true });
-	});
-
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(0);
 		await switchClient(0);
@@ -160,20 +176,23 @@ describe('screens/Note', () => {
 
 		await waitForNoteToMatch(noteId, { title: 'New title', body: 'Unchanged body' });
 
-		let expectedTitle = 'New title';
-		for (let i = 0; i <= 10; i++) {
-			for (const chunk of ['!', ' test', '!!!', ' Testing']) {
-				jest.advanceTimersByTime(i % 5);
-				await user.type(titleInput, chunk);
-				expectedTitle += chunk;
+		// Use fake timers to allow advancing timers without pausing the test
+		await runWithFakeTimers(async () => {
+			let expectedTitle = 'New title';
+			for (let i = 0; i <= 10; i++) {
+				for (const chunk of ['!', ' test', '!!!', ' Testing']) {
+					jest.advanceTimersByTime(i % 5);
+					await user.type(titleInput, chunk);
+					expectedTitle += chunk;
 
-				// Don't verify after each input event -- this allows the save action queue to fill.
-				if (i % 4 === 0) {
-					await waitForNoteToMatch(noteId, { title: expectedTitle });
+					// Don't verify after each input event -- this allows the save action queue to fill.
+					if (i % 4 === 0) {
+						await waitForNoteToMatch(noteId, { title: expectedTitle });
+					}
 				}
+				await waitForNoteToMatch(noteId, { title: expectedTitle });
 			}
-			await waitForNoteToMatch(noteId, { title: expectedTitle });
-		}
+		});
 	});
 
 	it('changing the note body in the editor should update the note\'s body', async () => {
@@ -181,27 +200,27 @@ describe('screens/Note', () => {
 		const noteId = await openNewNote({ title: 'Unchanged title', body: defaultBody });
 
 		const noteScreen = render(<WrappedNoteScreen />);
+		await act(async () => await runWithFakeTimers(async () => {
+			await openEditor();
+			const editor = await getNoteEditorControl();
+			editor.select(defaultBody.length, defaultBody.length);
 
-		await openEditor();
-		const editor = await getNoteEditorControl();
-		editor.select(defaultBody.length, defaultBody.length);
+			editor.insertText(' Testing!!!');
+			await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!!' });
 
-		editor.insertText(' Testing!!!');
-		await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!!' });
+			editor.insertText(' This is a test.');
+			await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!! This is a test.' });
 
-		editor.insertText(' This is a test.');
-		await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!! This is a test.' });
+			// should also save changes made shortly before unmounting
+			editor.insertText(' Test!');
 
-		// should also save changes made shortly before unmounting
-		editor.insertText(' Test!');
+			// TODO: Decreasing this below 100 causes the test to fail.
+			//       See issue #11125.
+			await jest.advanceTimersByTimeAsync(450);
 
-		// TODO: Decreasing this below 100 causes the test to fail.
-		//       See issue #11125.
-		await jest.advanceTimersByTimeAsync(150);
-
-		noteScreen.unmount();
-		await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!! This is a test. Test!' });
-
+			noteScreen.unmount();
+			await waitForNoteToMatch(noteId, { body: 'Change me! Testing!!! This is a test. Test!' });
+		}));
 	});
 
 	it('pressing "delete" should move the note to the trash', async () => {
@@ -212,9 +231,9 @@ describe('screens/Note', () => {
 		const deleteButton = await screen.findByText('Delete');
 		fireEvent.press(deleteButton);
 
-		await act(() => waitFor(async () => {
+		await waitFor(async () => {
 			expect((await Note.load(noteId)).deleted_time).toBeGreaterThan(0);
-		}));
+		});
 	});
 
 	it('pressing "delete permanently" should permanently delete a note', async () => {
@@ -229,9 +248,9 @@ describe('screens/Note', () => {
 		const deleteButton = await screen.findByText('Permanently delete note');
 		fireEvent.press(deleteButton);
 
-		await act(() => waitFor(async () => {
+		await waitFor(async () => {
 			expect(await Note.load(noteId)).toBeUndefined();
-		}));
+		});
 		expect(shim.showMessageBox).toHaveBeenCalled();
 	});
 

--- a/packages/app-mobile/components/screens/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note.test.tsx
@@ -68,8 +68,11 @@ const waitForNoteToMatch = async (noteId: string, note: Partial<NoteEntity>) => 
 	}));
 };
 
-const openExistingNote = async (noteId: string) => {
-	const note = await Note.load(noteId);
+const openNewNote = async (noteProperties: NoteEntity) => {
+	const note = await Note.save({
+		parent_id: (await Folder.defaultFolder()).id,
+		...noteProperties,
+	});
 	const displayParentId = getDisplayParentId(note, await Folder.load(note.parent_id));
 
 	store.dispatch({
@@ -82,15 +85,7 @@ const openExistingNote = async (noteId: string) => {
 		id: note.id,
 		folderId: displayParentId,
 	});
-};
 
-const openNewNote = async (noteProperties: NoteEntity) => {
-	const note = await Note.save({
-		parent_id: (await Folder.defaultFolder()).id,
-		...noteProperties,
-	});
-
-	await openExistingNote(note.id);
 	await waitForNoteToMatch(note.id, { parent_id: note.parent_id, title: note.title, body: note.body });
 
 	return note.id;

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1125,7 +1125,8 @@ export const runWithFakeTimers = async (callback: ()=> Promise<void>) => {
 		throw new Error('Fake timers are only supported in jest.');
 	}
 
-	jest.useFakeTimers();
+	// advanceTimers: Needed by Joplin's database driver
+	jest.useFakeTimers({ advanceTimers: true });
 
 	// The shim.setTimeout and similar functions need to be changed to
 	// use fake timers.


### PR DESCRIPTION
# Summary

This pull request attempts to fix CI failures related to recent changes to mobile tests. These failures seem related to the recent switch to fake timers in `screens/Note.test.tsx`. This pull request attempts to enable fake timers only for the parts of the tests that relate to performance, while preventing test warnings that were previously resolved by switching to fake timers.


## Notes

- When state changes aren't wrapped in `act` (or `waitFor`, or certain `react-native-testing-library` queries) during testing, `react-test-renderer` (used by `react-native-testing-library`) produces a warning. Several added `waitFor`s and `act`s are intended to prevent warnings related to background state changes.
   - One example of this is the check that the menu component has finished moving focus to itself before continuing &mdash; the focus change is caused by a delayed state change.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->