### PR TITLE
Desktop: Accessibility: Fix context menu button doesn't open the note list context menu (regression)

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useRef, useEffect, useCallback } from 'react';
 import { AppState } from '../../app.reducer';
 import BaseModel, { ModelType } from '@joplin/lib/BaseModel';
 import { Props } from './utils/types';
@@ -275,6 +275,12 @@ const NoteList = (props: Props) => {
 		return output;
 	}, [listRenderer.flow]);
 
+	const onContainerContextMenu = useCallback((event: React.MouseEvent) => {
+		const isFromKeyboard = event.button === -1;
+		if (event.isDefaultPrevented() || !isFromKeyboard) return;
+		onItemContextMenu({ itemId: activeNoteId });
+	}, [onItemContextMenu, activeNoteId]);
+
 	return (
 		<div
 			role='listbox'
@@ -293,6 +299,7 @@ const NoteList = (props: Props) => {
 			onKeyDown={onKeyDown}
 			onKeyUp={onKeyUp}
 			onDrop={onDrop}
+			onContextMenu={onContainerContextMenu}
 		>
 			{renderEmptyList()}
 			{renderFiller('top', topFillerStyle)}

--- a/packages/app-desktop/gui/NoteListItem/utils/useOnContextMenu.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useOnContextMenu.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import Folder from '@joplin/lib/models/Folder';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
@@ -5,6 +6,13 @@ import { useCallback } from 'react';
 import { Dispatch } from 'redux';
 import bridge from '../../../services/bridge';
 import NoteListUtils from '../../utils/NoteListUtils';
+
+interface CustomContextMenuEvent {
+	itemId: string;
+	currentTarget?: undefined;
+	preventDefault?: undefined;
+}
+type ContextMenuEvent = React.MouseEvent|CustomContextMenuEvent;
 
 const useOnContextMenu = (
 	selectedNoteIds: string[],
@@ -15,10 +23,14 @@ const useOnContextMenu = (
 	plugins: PluginStates,
 	customCss: string,
 ) => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	return useCallback((event: any) => {
-		const currentNoteId = event.currentTarget.getAttribute('data-id');
+	return useCallback((event: ContextMenuEvent) => {
+		let currentNoteId = event.currentTarget?.getAttribute('data-id');
+		if ('itemId' in event) {
+			currentNoteId = event.itemId;
+		}
+
 		if (!currentNoteId) return;
+		event.preventDefault?.();
 
 		let noteIds = [];
 		if (selectedNoteIds.indexOf(currentNoteId) < 0) {


### PR DESCRIPTION
# Summary

This pull request fixes a regression &mdash; pressing the context menu button (or shift+F10 on Windows) did not show the context menu when the note list was focused.

This issue was introduced with https://github.com/laurent22/joplin/pull/10940, which changed how the note list handles keyboard focus. Rather than focusing the individual note list items, this pull request caused the note list container to have focus. This simplifies focus handling when the selected item is not scrolled into view. However, it means that pressing the context menu button sends `onContextMenu` events to the note list container, rather than the individual note list items.

This pull request fixes the issue by handling keyboard-triggered contextmenu events with a `onContextMenu` event listener on the note list container.

# Testing plan

[Screencast from 2024-10-02 22-53-22.webm](https://github.com/user-attachments/assets/b3ce9163-b96d-4caf-93cf-fa80fe8ca535)


**Windows 11**:
1. Open a notebook with a large number of items.
2. Right-click on the selected item.
3. Verify that a context menu is shown.
4. Right-click on an unselected item.
5. Click "Duplicate".
6. Verify that the note duplicates.
7. Select a different note.
8. Right-click on the selected note.
9. Click "Duplicate".
10. Verify that the selected note has been duplicated.
11. Switch to a notebook with several notes, but not enough to scroll.
12. Right-click below the last notebook.
13. Verify that no context menu is shown.
14. Right-click on the last notebook and verify that this shows a context menu.
15. Focus the note list with the keyboard and press the context menu key (or shift+f10).
16. Verify that a context menu is shown.
17. Move the focus to "duplicate".
18. Press <kbd>enter</kbd>.
19. Verify that the selected note has been duplicated.
20. Select a different note.
21. Open the context menu by pressing the context menu key (or shift+f10).
22. Click "duplicate".
23. Verify that the note selected in step 20 has been duplicated.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->