### PR TITLE
Mobile: Fixes #11183: Fix new note/edit buttons only work if pressed quickly

### DIFF
--- a/packages/app-mobile/components/buttons/FloatingActionButton.tsx
+++ b/packages/app-mobile/components/buttons/FloatingActionButton.tsx
@@ -100,6 +100,9 @@ const FloatingActionButton = (props: ActionButtonProps) => {
 		onStateChange={onMenuToggled}
 		actions={actions}
 		onPress={props.mainButton?.onPress ?? defaultOnPress}
+		// The long press delay is too short by default (and we don't use the long press event). See https://github.com/laurent22/joplin/issues/11183.
+		// Increase to a large value:
+		delayLongPress={10_000}
 		visible={true}
 	/>;
 	const mainMenu = isWeb ? (


### PR DESCRIPTION
# Summary

This pull request fixes #11183 by increasing the long press delay to 10s. Joplin currently doesn't use the long press event, so it should be safe to set this to a large value.

**Note**: A built version of this pull request has been deployed to https://personalizedrefrigerator.github.io/joplin/web-client/ .

# Testing plan

**Android 13**:
1. Open a folder.
2. Quickly tap the "+" button.
3. Verify that this opens the "new to-do"/"new note" menu.
4. Tap and hold the "x" button for roughly 2s.
5. Verify that the menu closes when the gesture ends.
6. Tap and hold the "+" button for roughly 2s.
7. Verify that the "new note"/"new to-do" menu opens.
8. Tap and hold "new note" for roughly 1s.
9. Verify that a new note is opened in the editor.
10. Enter a title and open the note viewer.
11. Tap and hold the edit button for roughly 4s.
12. Verify that releasing the button switches to edit mode.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->