### PR TITLE
Desktop: Accessibility: Add ARIA information to the sidebar's notebook and tag list

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -417,6 +417,7 @@ packages/app-desktop/gui/Sidebar/FolderAndTagList.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
+packages/app-desktop/gui/Sidebar/hooks/toggleHeader.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -417,13 +417,13 @@ packages/app-desktop/gui/Sidebar/FolderAndTagList.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
-packages/app-desktop/gui/Sidebar/hooks/toggleHeader.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSelectedSidebarIndex.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarCommandHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.js
+packages/app-desktop/gui/Sidebar/hooks/utils/toggleHeader.js
 packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.js
 packages/app-desktop/gui/Sidebar/listItemComponents/EmptyExpandLink.js
 packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -429,6 +429,7 @@ packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.js
 packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.js
 packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.js
 packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.js
+packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.js
 packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.js
 packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.js
 packages/app-desktop/gui/Sidebar/styles/index.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -419,6 +419,7 @@ packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
+packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSelectedSidebarIndex.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarCommandHandler.js

--- a/.gitignore
+++ b/.gitignore
@@ -394,6 +394,7 @@ packages/app-desktop/gui/Sidebar/FolderAndTagList.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
+packages/app-desktop/gui/Sidebar/hooks/toggleHeader.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js

--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
+packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSelectedSidebarIndex.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarCommandHandler.js

--- a/.gitignore
+++ b/.gitignore
@@ -406,6 +406,7 @@ packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.js
 packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.js
 packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.js
 packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.js
+packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.js
 packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.js
 packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.js
 packages/app-desktop/gui/Sidebar/styles/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -394,13 +394,13 @@ packages/app-desktop/gui/Sidebar/FolderAndTagList.js
 packages/app-desktop/gui/Sidebar/Sidebar.js
 packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.js
 packages/app-desktop/gui/Sidebar/commands/index.js
-packages/app-desktop/gui/Sidebar/hooks/toggleHeader.js
 packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.js
 packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSelectedSidebarIndex.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarCommandHandler.js
 packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.js
+packages/app-desktop/gui/Sidebar/hooks/utils/toggleHeader.js
 packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.js
 packages/app-desktop/gui/Sidebar/listItemComponents/EmptyExpandLink.js
 packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.js

--- a/packages/app-desktop/gui/EmojiBox.tsx
+++ b/packages/app-desktop/gui/EmojiBox.tsx
@@ -44,5 +44,5 @@ export default (props: Props) => {
 		return spanFontSize;
 	}, [props.width, props.height, props.emoji, containerReady, containerRef]);
 
-	return <div className="emoji-box" ref={el => { containerRef.current = el; setContainerReady(true); }} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: props.height, fontSize }}>{props.emoji}</div>;
+	return <div className="emoji-box" role='img' ref={el => { containerRef.current = el; setContainerReady(true); }} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: props.height, fontSize }}>{props.emoji}</div>;
 };

--- a/packages/app-desktop/gui/EmojiBox.tsx
+++ b/packages/app-desktop/gui/EmojiBox.tsx
@@ -44,5 +44,5 @@ export default (props: Props) => {
 		return spanFontSize;
 	}, [props.width, props.height, props.emoji, containerReady, containerRef]);
 
-	return <div className="emoji-box" role='img' ref={el => { containerRef.current = el; setContainerReady(true); }} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: props.height, fontSize }}>{props.emoji}</div>;
+	return <div className="emoji-box" ref={el => { containerRef.current = el; setContainerReady(true); }} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: props.height, fontSize }}>{props.emoji}</div>;
 };

--- a/packages/app-desktop/gui/FolderIconBox.tsx
+++ b/packages/app-desktop/gui/FolderIconBox.tsx
@@ -17,7 +17,7 @@ export default function(props: Props) {
 	} else if (folderIcon.type === FolderIconType.DataUrl) {
 		return <img style={{ width, height, opacity }} src={folderIcon.dataUrl} />;
 	} else if (folderIcon.type === FolderIconType.FontAwesome) {
-		return <i style={{ fontSize: 18, width, opacity }} className={folderIcon.name}></i>;
+		return <i style={{ fontSize: 18, width, opacity }} className={folderIcon.name} role='img'></i>;
 	} else {
 		throw new Error(`Unsupported folder icon type: ${folderIcon.type}`);
 	}

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -14,6 +14,7 @@ interface Props<ItemType> {
 	id?: string;
 	role?: string;
 	'aria-label'?: string;
+	tabIndex?: number;
 }
 
 interface State {
@@ -177,6 +178,7 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 				role={this.props.role}
 				aria-label={this.props['aria-label']}
 				aria-setsize={items.length}
+				tabIndex={this.props.tabIndex}
 
 				onScroll={this.onScroll}
 				onKeyDown={this.onKeyDown}

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -5,18 +5,21 @@ interface Props<ItemType> {
 	style: React.CSSProperties & { height: number };
 	itemHeight: number;
 	items: ItemType[];
+
 	disabled?: boolean;
-	onKeyDown?: KeyboardEventHandler<HTMLElement>;
-	itemRenderer: (item: ItemType, index: number)=> React.JSX.Element;
 	className?: string;
+
+	itemRenderer: (item: ItemType, index: number)=> React.JSX.Element;
+	renderContentWrapper?: (listItems: React.ReactNode[])=> React.ReactNode;
+	onKeyDown?: KeyboardEventHandler<HTMLElement>;
 	onItemDrop?: DragEventHandler<HTMLElement>;
+
 	selectedIndex?: number;
 	alwaysRenderSelection?: boolean;
 
 	id?: string;
 	role?: string;
 	'aria-label'?: string;
-	tabIndex?: number;
 }
 
 interface State {
@@ -198,6 +201,7 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 		const classes = ['item-list'];
 		if (this.props.className) classes.push(this.props.className);
 
+		const wrapContent = this.props.renderContentWrapper ?? ((children) => <>{children}</>);
 		return (
 			<div
 				ref={this.listRef}
@@ -208,13 +212,12 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 				role={this.props.role}
 				aria-label={this.props['aria-label']}
 				aria-setsize={items.length}
-				tabIndex={this.props.tabIndex}
 
 				onScroll={this.onScroll}
 				onKeyDown={this.onKeyDown}
 				onDrop={this.onDrop}
 			>
-				{itemComps}
+				{wrapContent(itemComps)}
 			</div>
 		);
 	}

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -163,8 +163,8 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 
 		if (this.props.alwaysRenderSelection && isFinite(this.props.selectedIndex)) {
 			const selectionVisible = this.props.selectedIndex >= this.state.topItemIndex && this.props.selectedIndex <= this.state.bottomItemIndex;
-
-			if (!selectionVisible) {
+			const isValidSelection = this.props.selectedIndex >= 0 && this.props.selectedIndex < items.length;
+			if (!selectionVisible && isValidSelection) {
 				renderableBlocks.push({ from: this.props.selectedIndex, to: this.props.selectedIndex });
 			}
 		}

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -39,12 +39,12 @@ const FolderAndTagList: React.FC<Props> = props => {
 		listItems: listItems,
 	});
 
-	const [selectedListElement, setSelectedListElement] = useState<HTMLElement|null>(null);
+	const listContainerRef = useRef<HTMLDivElement|null>(null);
 	const onRenderItem = useOnRenderItem({
 		...props,
 		selectedIndex,
-		onSelectedElementShown: setSelectedListElement,
 		listItems,
+		containerRef: listContainerRef,
 	});
 
 	const onKeyEventHandler = useOnSidebarKeyDownHandler({
@@ -56,11 +56,12 @@ const FolderAndTagList: React.FC<Props> = props => {
 	});
 
 	const itemListRef = useRef<ItemList<ListItem>>();
-	const { focusSidebar } = useFocusHandler({ itemListRef, selectedListElement, selectedIndex, listItems });
+	const { focusSidebar } = useFocusHandler({ itemListRef, selectedIndex, listItems });
 
 	useSidebarCommandHandler({ focusSidebar });
 
 	const [itemListContainer, setItemListContainer] = useState<HTMLDivElement|null>(null);
+	listContainerRef.current = itemListContainer;
 	const listHeight = useElementHeight(itemListContainer);
 	const listStyle = useMemo(() => ({ height: listHeight }), [listHeight]);
 

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -80,6 +80,9 @@ const FolderAndTagList: React.FC<Props> = props => {
 				tabIndex={0}
 				role='tree'
 
+				selectedIndex={selectedIndex}
+				alwaysRenderSelection={true}
+
 				itemHeight={30}
 			/>
 		</div>

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -44,6 +44,7 @@ const FolderAndTagList: React.FC<Props> = props => {
 		...props,
 		selectedIndex,
 		onSelectedElementShown: setSelectedListElement,
+		listItems,
 	});
 
 	const onKeyEventHandler = useOnSidebarKeyDownHandler({
@@ -75,6 +76,8 @@ const FolderAndTagList: React.FC<Props> = props => {
 				items={listItems}
 				itemRenderer={onRenderItem}
 				onKeyDown={onKeyEventHandler}
+				tabIndex={0}
+				role='tree'
 
 				itemHeight={30}
 			/>

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -14,6 +14,7 @@ import useFocusHandler from './hooks/useFocusHandler';
 import useOnRenderItem from './hooks/useOnRenderItem';
 import { ListItem } from './types';
 import useSidebarCommandHandler from './hooks/useSidebarCommandHandler';
+import useOnRenderListWrapper from './hooks/useOnRenderListWrapper';
 
 interface Props {
 	dispatch: Dispatch;
@@ -65,6 +66,8 @@ const FolderAndTagList: React.FC<Props> = props => {
 	const listHeight = useElementHeight(itemListContainer);
 	const listStyle = useMemo(() => ({ height: listHeight }), [listHeight]);
 
+	const onRenderContentWrapper = useOnRenderListWrapper({ selectedIndex, onKeyDown: onKeyEventHandler });
+
 	return (
 		<div
 			className='folder-and-tag-list'
@@ -74,12 +77,10 @@ const FolderAndTagList: React.FC<Props> = props => {
 				className='items'
 				ref={itemListRef}
 				style={listStyle}
+
 				items={listItems}
 				itemRenderer={onRenderItem}
-				onKeyDown={onKeyEventHandler}
-				// Allow focusing the item list when there is no selection
-				tabIndex={0}
-				role='tree'
+				renderContentWrapper={onRenderContentWrapper}
 
 				// The selected item is the only item with tabindex=0. Always render it
 				// to allow the item list to be focused.

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -77,11 +77,14 @@ const FolderAndTagList: React.FC<Props> = props => {
 				items={listItems}
 				itemRenderer={onRenderItem}
 				onKeyDown={onKeyEventHandler}
+				// Allow focusing the item list when there is no selection
 				tabIndex={0}
 				role='tree'
 
-				selectedIndex={selectedIndex}
+				// The selected item is the only item with tabindex=0. Always render it
+				// to allow the item list to be focused.
 				alwaysRenderSelection={true}
+				selectedIndex={selectedIndex}
 
 				itemHeight={30}
 			/>

--- a/packages/app-desktop/gui/Sidebar/hooks/toggleHeader.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/toggleHeader.ts
@@ -1,0 +1,10 @@
+import Setting from '@joplin/lib/models/Setting';
+import { HeaderId } from '../types';
+
+const toggleHeader = (headerId: HeaderId) => {
+	const settingKey = headerId === HeaderId.TagHeader ? 'tagHeaderIsExpanded' : 'folderHeaderIsExpanded';
+	const current = Setting.value(settingKey);
+	Setting.setValue(settingKey, !current);
+};
+
+export default toggleHeader;

--- a/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
@@ -5,7 +5,6 @@ import { focus } from '@joplin/lib/utils/focusHandler';
 
 interface Props {
 	itemListRef: RefObject<ItemList<ListItem>>;
-	selectedListElement: HTMLElement|null;
 	selectedIndex: number;
 	listItems: ListItem[];
 }
@@ -46,16 +45,23 @@ const useScrollToSelectionHandler = (
 };
 
 const useFocusHandler = (props: Props) => {
-	const { itemListRef, selectedListElement, selectedIndex, listItems } = props;
+	const { itemListRef, selectedIndex, listItems } = props;
 
 	useScrollToSelectionHandler(itemListRef, listItems, selectedIndex);
 
 	const focusSidebar = useCallback(() => {
-		if (!selectedListElement || !itemListRef.current.isIndexVisible(selectedIndex)) {
+		if (!itemListRef.current.isIndexVisible(selectedIndex)) {
 			itemListRef.current.makeItemIndexVisible(selectedIndex);
 		}
-		focus('FolderAndTagList/useFocusHandler/focusSidebar', itemListRef.current.container);
-	}, [selectedListElement, selectedIndex, itemListRef]);
+
+		// Select the focusable item, if it's visible
+		const selectableItem = itemListRef.current.container.querySelector('[role="treeitem"][tabindex="0"]');
+		if (selectableItem) {
+			focus('FolderAndTagList/focusSidebarItem', selectableItem);
+		} else {
+			focus('FolderAndTagList/focusSidebarContainer', itemListRef.current.container);
+		}
+	}, [selectedIndex, itemListRef]);
 
 	return { focusSidebar };
 };

--- a/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
@@ -54,12 +54,13 @@ const useFocusHandler = (props: Props) => {
 			itemListRef.current.makeItemIndexVisible(selectedIndex);
 		}
 
-		// Select the focusable item, if it's visible
-		const selectableItem = itemListRef.current.container.querySelector('[role="treeitem"][tabindex="0"]');
-		if (selectableItem) {
-			focus('FolderAndTagList/focusSidebarItem', selectableItem);
-		} else {
-			focus('FolderAndTagList/focusSidebarContainer', itemListRef.current.container);
+		const focusableItem = itemListRef.current.container.querySelector('[role="treeitem"][tabindex="0"]');
+		const focusableContainer = itemListRef.current.container.querySelector('[role="tree"][tabindex="0"]');
+		if (focusableItem) {
+			focus('FolderAndTagList/focusSidebarItem', focusableItem);
+		} else if (focusableContainer) {
+			// Handles the case where no items in the tree can be focused.
+			focus('FolderAndTagList/focusSidebarTree', focusableContainer);
 		}
 	}, [selectedIndex, itemListRef]);
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -53,8 +53,10 @@ type ItemContextMenuListener = MouseEventHandler<HTMLElement>;
 
 const menuUtils = new MenuUtils(CommandService.instance());
 
-const focusListItem = (item: HTMLElement) => {
-	focus('useOnRenderItem', item);
+const focusListItem = (item: HTMLElement|null) => {
+	if (item) {
+		focus('useOnRenderItem', item);
+	}
 };
 
 const noFocusListItem = () => {};

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -55,7 +55,10 @@ const menuUtils = new MenuUtils(CommandService.instance());
 
 const focusListItem = (item: HTMLElement|null) => {
 	if (item) {
-		focus('useOnRenderItem', item);
+		// Avoid scrolling to the selected item when refocusing the note list. Such a refocus
+		// can happen if the note list rerenders and the selection is scrolled out of view and
+		// can cause scroll to change unexpectedly.
+		focus('useOnRenderItem', item, { preventScroll: true });
 	}
 };
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -419,6 +419,7 @@ const useOnRenderItem = (props: Props) => {
 				<ListItemWrapper
 					key={item.key}
 					containerRef={anchorRef}
+					depth={0}
 					selected={selected}
 					itemIndex={index}
 					itemCount={itemCount}

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -428,6 +428,7 @@ const useOnRenderItem = (props: Props) => {
 					selected={selected}
 					itemIndex={index}
 					itemCount={itemCount}
+					highlightOnHover={false}
 					className='sidebar-spacer-item'
 				>
 					<div aria-label={_('Spacer')}></div>

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import { _ } from '@joplin/lib/locale';
+import CommandService from '@joplin/lib/services/CommandService';
+
+interface Props {
+	selectedIndex: number;
+	onKeyDown: React.KeyboardEventHandler;
+}
+
+const onAddFolderButtonClick = () => {
+	void CommandService.instance().execute('newFolder');
+};
+
+const NewFolderButton = () => {
+	// To allow it to be accessed by accessibility tools, the new folder button
+	// is not included in the portion of the list with role='tree'.
+	return <button onClick={onAddFolderButtonClick} className='new-folder-button'>
+		<i
+			aria-label={_('New notebook')}
+			role='img'
+			className='fas fa-plus'
+		/>
+	</button>;
+};
+
+const useOnRenderListWrapper = ({ selectedIndex, onKeyDown }: Props) => {
+	return useCallback((listItems: React.ReactNode[]) => {
+		const listHasValidSelection = selectedIndex >= 0;
+		const allowContainerFocus = !listHasValidSelection;
+		return <>
+			<NewFolderButton/>
+			<div
+				role='tree'
+				className='sidebar-list-items-wrapper'
+				aria-setsize={listItems.length}
+				tabIndex={allowContainerFocus ? 0 : undefined}
+				onKeyDown={onKeyDown}
+			>
+				{...listItems}
+			</div>
+		</>;
+	}, [selectedIndex, onKeyDown]);
+};
+
+export default useOnRenderListWrapper;

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -29,6 +29,8 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 
 	return useCallback<KeyboardEventHandler<HTMLElement>>((event) => {
 		const selectedItem = listItems[selectedIndex];
+		let indexChange = 0;
+
 		if (selectedItem?.kind === ListItemType.Folder && isToggleShortcut(event.code, selectedItem, collapsedFolderIds)) {
 			event.preventDefault();
 
@@ -36,18 +38,13 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 				type: 'FOLDER_TOGGLE',
 				id: selectedItem.folder.id,
 			});
-		}
-
-		if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') { // ctrl+a or cmd+a
+		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') { // ctrl+a or cmd+a
 			event.preventDefault();
-		}
-
-		let indexChange = 0;
-		if (event.code === 'ArrowUp') {
+		} else if (event.code === 'ArrowUp') {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {
 			indexChange = 1;
-		} else if (event.code === 'Tab') {
+		} else if (event.code === 'ArrowRight') {
 			event.preventDefault();
 
 			if (event.shiftKey) {

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -44,7 +44,7 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {
 			indexChange = 1;
-		} else if (event.code === 'ArrowRight') {
+		} else if (event.code === 'Tab') {
 			event.preventDefault();
 
 			if (event.shiftKey) {

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -2,7 +2,7 @@ import { Dispatch } from 'redux';
 import { ListItem, ListItemType, SetSelectedIndexCallback } from '../types';
 import { KeyboardEventHandler, useCallback } from 'react';
 import CommandService from '@joplin/lib/services/CommandService';
-import toggleHeader from './toggleHeader';
+import toggleHeader from './utils/toggleHeader';
 
 interface Props {
 	dispatch: Dispatch;

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -1,7 +1,8 @@
 import { Dispatch } from 'redux';
-import { FolderListItem, ListItem, ListItemType, SetSelectedIndexCallback } from '../types';
+import { ListItem, ListItemType, SetSelectedIndexCallback } from '../types';
 import { KeyboardEventHandler, useCallback } from 'react';
 import CommandService from '@joplin/lib/services/CommandService';
+import toggleHeader from './toggleHeader';
 
 interface Props {
 	dispatch: Dispatch;
@@ -12,15 +13,20 @@ interface Props {
 }
 
 
-const isToggleShortcut = (keyCode: string, selectedItem: FolderListItem, collapsedFolderIds: string[]) => {
+const isToggleShortcut = (keyCode: string, selectedItem: ListItem, collapsedFolderIds: string[]) => {
+	if (selectedItem.kind !== ListItemType.Header && selectedItem.kind !== ListItemType.Folder) {
+		return false;
+	}
+
 	if (!['Space', 'ArrowLeft', 'ArrowRight'].includes(keyCode)) {
 		return false;
 	}
+
 	if (keyCode === 'Space') {
 		return true;
 	}
 
-	const isCollapsed = collapsedFolderIds.includes(selectedItem.folder.id);
+	const isCollapsed = 'expanded' in selectedItem ? !selectedItem.expanded : collapsedFolderIds.includes(selectedItem.folder.id);
 	return (keyCode === 'ArrowRight') === isCollapsed;
 };
 
@@ -31,13 +37,17 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 		const selectedItem = listItems[selectedIndex];
 		let indexChange = 0;
 
-		if (selectedItem?.kind === ListItemType.Folder && isToggleShortcut(event.code, selectedItem, collapsedFolderIds)) {
+		if (selectedItem && isToggleShortcut(event.code, selectedItem, collapsedFolderIds)) {
 			event.preventDefault();
 
-			dispatch({
-				type: 'FOLDER_TOGGLE',
-				id: selectedItem.folder.id,
-			});
+			if (selectedItem.kind === ListItemType.Folder) {
+				dispatch({
+					type: 'FOLDER_TOGGLE',
+					id: selectedItem.folder.id,
+				});
+			} else if (selectedItem.kind === ListItemType.Header) {
+				toggleHeader(selectedItem.id);
+			}
 		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') { // ctrl+a or cmd+a
 			event.preventDefault();
 		} else if (event.code === 'ArrowUp') {

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -4,7 +4,7 @@ import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/data
 import { buildFolderTree, renderFolders, renderTags } from '@joplin/lib/components/shared/side-menu-shared';
 import { _ } from '@joplin/lib/locale';
 import CommandService from '@joplin/lib/services/CommandService';
-import Setting from '@joplin/lib/models/Setting';
+import toggleHeader from './toggleHeader';
 
 interface Props {
 	tags: TagsWithNoteCountEntity[];
@@ -16,12 +16,6 @@ interface Props {
 
 const onAddFolderButtonClick = () => {
 	void CommandService.instance().execute('newFolder');
-};
-
-const onHeaderClick = (headerId: HeaderId) => {
-	const settingKey = headerId === HeaderId.TagHeader ? 'tagHeaderIsExpanded' : 'folderHeaderIsExpanded';
-	const current = Setting.value(settingKey);
-	Setting.setValue(settingKey, !current);
 };
 
 const useSidebarListData = (props: Props): ListItem[] => {
@@ -60,9 +54,10 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			kind: ListItemType.Header,
 			label: _('Notebooks'),
 			iconName: 'icon-notebooks',
+			expanded: props.folderHeaderIsExpanded,
 			id: HeaderId.FolderHeader,
 			key: HeaderId.FolderHeader,
-			onClick: onHeaderClick,
+			onClick: toggleHeader,
 			onPlusButtonClick: onAddFolderButtonClick,
 			extraProps: {
 				['data-folder-id']: '',
@@ -79,9 +74,10 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			kind: ListItemType.Header,
 			label: _('Tags'),
 			iconName: 'icon-tags',
+			expanded: props.tagHeaderIsExpanded,
 			id: HeaderId.TagHeader,
 			key: HeaderId.TagHeader,
-			onClick: onHeaderClick,
+			onClick: toggleHeader,
 			onPlusButtonClick: null,
 			extraProps: { },
 			supportsFolderDrop: false,

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -4,7 +4,7 @@ import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/data
 import { buildFolderTree, renderFolders, renderTags } from '@joplin/lib/components/shared/side-menu-shared';
 import { _ } from '@joplin/lib/locale';
 import CommandService from '@joplin/lib/services/CommandService';
-import toggleHeader from './toggleHeader';
+import toggleHeader from './utils/toggleHeader';
 
 interface Props {
 	tags: TagsWithNoteCountEntity[];

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -3,7 +3,6 @@ import { FolderListItem, HeaderId, HeaderListItem, ListItem, ListItemType, TagLi
 import { FolderEntity, TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
 import { buildFolderTree, renderFolders, renderTags } from '@joplin/lib/components/shared/side-menu-shared';
 import { _ } from '@joplin/lib/locale';
-import CommandService from '@joplin/lib/services/CommandService';
 import toggleHeader from './utils/toggleHeader';
 
 interface Props {
@@ -13,10 +12,6 @@ interface Props {
 	folderHeaderIsExpanded: boolean;
 	tagHeaderIsExpanded: boolean;
 }
-
-const onAddFolderButtonClick = () => {
-	void CommandService.instance().execute('newFolder');
-};
 
 const useSidebarListData = (props: Props): ListItem[] => {
 	const tagItems = useMemo(() => {
@@ -58,7 +53,6 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			id: HeaderId.FolderHeader,
 			key: HeaderId.FolderHeader,
 			onClick: toggleHeader,
-			onPlusButtonClick: onAddFolderButtonClick,
 			extraProps: {
 				['data-folder-id']: '',
 			},
@@ -78,7 +72,6 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			id: HeaderId.TagHeader,
 			key: HeaderId.TagHeader,
 			onClick: toggleHeader,
-			onPlusButtonClick: null,
 			extraProps: { },
 			supportsFolderDrop: false,
 		};

--- a/packages/app-desktop/gui/Sidebar/hooks/utils/toggleHeader.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/utils/toggleHeader.ts
@@ -1,5 +1,5 @@
 import Setting from '@joplin/lib/models/Setting';
-import { HeaderId } from '../types';
+import { HeaderId } from '../../types';
 
 const toggleHeader = (headerId: HeaderId) => {
 	const settingKey = headerId === HeaderId.TagHeader ? 'tagHeaderIsExpanded' : 'folderHeaderIsExpanded';

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -55,6 +55,7 @@ const AllNotesItem: React.FC<Props> = props => {
 			selected={props.selected}
 			depth={1}
 			className={'list-item-container list-item-depth-0 all-notes'}
+			highlightOnHover={true}
 			itemIndex={props.index}
 			itemCount={props.itemCount}
 		>

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -59,7 +59,7 @@ const AllNotesItem: React.FC<Props> = props => {
 			itemCount={props.itemCount}
 		>
 			<EmptyExpandLink/>
-			<StyledAllNotesIcon className="icon-notes"/>
+			<StyledAllNotesIcon aria-label='' role='img' className='icon-notes'/>
 			<StyledListItemAnchor
 				className="list-item"
 				isSpecialItem={true}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -10,7 +10,7 @@ import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSort
 import { _ } from '@joplin/lib/locale';
 import { connect } from 'react-redux';
 import EmptyExpandLink from './EmptyExpandLink';
-import ListItemWrapper from './ListItemWrapper';
+import ListItemWrapper, { ListItemRef } from './ListItemWrapper';
 const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 
 const Menu = bridge().Menu;
@@ -18,6 +18,7 @@ const MenuItem = bridge().MenuItem;
 
 interface Props {
 	dispatch: Dispatch;
+	anchorRef: ListItemRef;
 	selected: boolean;
 	index: number;
 	itemCount: number;
@@ -49,6 +50,7 @@ const AllNotesItem: React.FC<Props> = props => {
 
 	return (
 		<ListItemWrapper
+			containerRef={props.anchorRef}
 			key="allNotesHeader"
 			selected={props.selected}
 			className={'list-item-container list-item-depth-0 all-notes'}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyledAllNotesIcon, StyledListItem, StyledListItemAnchor } from '../styles';
+import { StyledAllNotesIcon, StyledListItemAnchor } from '../styles';
 import { useCallback } from 'react';
 import { Dispatch } from 'redux';
 import bridge from '../../../services/bridge';
@@ -10,6 +10,7 @@ import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSort
 import { _ } from '@joplin/lib/locale';
 import { connect } from 'react-redux';
 import EmptyExpandLink from './EmptyExpandLink';
+import ListItemWrapper from './ListItemWrapper';
 const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 
 const Menu = bridge().Menu;
@@ -18,7 +19,8 @@ const MenuItem = bridge().MenuItem;
 interface Props {
 	dispatch: Dispatch;
 	selected: boolean;
-	anchorRef: React.Ref<HTMLAnchorElement>;
+	index: number;
+	itemCount: number;
 }
 
 const menuUtils = new MenuUtils(CommandService.instance());
@@ -46,21 +48,25 @@ const AllNotesItem: React.FC<Props> = props => {
 	}, []);
 
 	return (
-		<StyledListItem key="allNotesHeader" selected={props.selected} className={'list-item-container list-item-depth-0 all-notes'} isSpecialItem={true}>
+		<ListItemWrapper
+			key="allNotesHeader"
+			selected={props.selected}
+			className={'list-item-container list-item-depth-0 all-notes'}
+			itemIndex={props.index}
+			itemCount={props.itemCount}
+		>
 			<EmptyExpandLink/>
 			<StyledAllNotesIcon className="icon-notes"/>
 			<StyledListItemAnchor
-				ref={props.anchorRef}
 				className="list-item"
 				isSpecialItem={true}
-				href="#"
 				selected={props.selected}
 				onClick={onAllNotesClick_}
 				onContextMenu={toggleAllNotesContextMenu}
 			>
 				{_('All notes')}
 			</StyledListItemAnchor>
-		</StyledListItem>
+		</ListItemWrapper>
 	);
 };
 

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -53,6 +53,7 @@ const AllNotesItem: React.FC<Props> = props => {
 			containerRef={props.anchorRef}
 			key="allNotesHeader"
 			selected={props.selected}
+			depth={1}
 			className={'list-item-container list-item-depth-0 all-notes'}
 			itemIndex={props.index}
 			itemCount={props.itemCount}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/EmptyExpandLink.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/EmptyExpandLink.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import ExpandIcon from './ExpandIcon';
 
 interface Props {
+	className?: string;
 }
 
-const EmptyExpandLink: React.FC<Props> = _props => {
-	return <a className='sidebar-expand-link'><ExpandIcon isVisible={false} isExpanded={false}/></a>;
+const EmptyExpandLink: React.FC<Props> = props => {
+	return <a className={`sidebar-expand-link ${props.className ?? ''}`}><ExpandIcon isVisible={false} isExpanded={false}/></a>;
 };
 
 export default EmptyExpandLink;

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
@@ -25,10 +25,10 @@ const ExpandIcon: React.FC<ExpandIconProps> = props => {
 		if (props.isExpanded) {
 			return _('Expanded, press space to collapse.');
 		}
-		return _('Collapse, press space to expand.');
+		return _('Collapsed, press space to expand.');
 	};
 	const label = getLabel();
-	return <i className={classNames.join(' ')} title={label} aria-label={label} role='img'></i>;
+	return <i className={classNames.join(' ')} aria-label={label} role='img'></i>;
 };
 
 export default ExpandIcon;

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
@@ -23,11 +23,12 @@ const ExpandIcon: React.FC<ExpandIconProps> = props => {
 			return undefined;
 		}
 		if (props.isExpanded) {
-			return _('Collapse %s', props.targetTitle);
+			return _('Expanded, press space to collapse.');
 		}
-		return _('Expand %s', props.targetTitle);
+		return _('Collapse, press space to expand.');
 	};
-	return <i className={classNames.join(' ')} title={getLabel()} role='img'></i>;
+	const label = getLabel();
+	return <i className={classNames.join(' ')} title={label} aria-label={label} role='img'></i>;
 };
 
 export default ExpandIcon;

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx
@@ -27,7 +27,7 @@ const ExpandIcon: React.FC<ExpandIconProps> = props => {
 		}
 		return _('Expand %s', props.targetTitle);
 	};
-	return <i className={classNames.join(' ')} aria-label={getLabel()}></i>;
+	return <i className={classNames.join(' ')} title={getLabel()} role='img'></i>;
 };
 
 export default ExpandIcon;

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
@@ -13,7 +13,7 @@ interface ExpandLinkProps {
 
 const ExpandLink: React.FC<ExpandLinkProps> = props => {
 	return props.hasChildren ? (
-		<a className='sidebar-expand-link' href="#" data-folder-id={props.folderId} onClick={props.onClick}>
+		<a className='sidebar-expand-link' data-folder-id={props.folderId} onClick={props.onClick}>
 			<ExpandIcon isVisible={true} isExpanded={props.isExpanded} targetTitle={props.folderTitle}/>
 		</a>
 	) : (

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
@@ -14,8 +14,7 @@ interface ExpandLinkProps {
 
 const ExpandLink: React.FC<ExpandLinkProps> = props => {
 	return props.hasChildren ? (
-		// The expand/collapse information is conveyed through ARIA.
-		<a className={`sidebar-expand-link ${props.className}`} data-folder-id={props.folderId} onClick={props.onClick} aria-label=''>
+		<a className={`sidebar-expand-link ${props.className}`} data-folder-id={props.folderId} onClick={props.onClick} role='button'>
 			<ExpandIcon isVisible={true} isExpanded={props.isExpanded} targetTitle={props.folderTitle}/>
 		</a>
 	) : (

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
@@ -8,17 +8,18 @@ interface ExpandLinkProps {
 	folderTitle: string;
 	hasChildren: boolean;
 	isExpanded: boolean;
+	className: string;
 	onClick: MouseEventHandler<HTMLElement>;
 }
 
 const ExpandLink: React.FC<ExpandLinkProps> = props => {
 	return props.hasChildren ? (
 		// The expand/collapse information is conveyed through ARIA.
-		<a className='sidebar-expand-link' data-folder-id={props.folderId} onClick={props.onClick} aria-label=''>
+		<a className={`sidebar-expand-link ${props.className}`} data-folder-id={props.folderId} onClick={props.onClick} aria-label=''>
 			<ExpandIcon isVisible={true} isExpanded={props.isExpanded} targetTitle={props.folderTitle}/>
 		</a>
 	) : (
-		<EmptyExpandLink/>
+		<EmptyExpandLink className={props.className}/>
 	);
 };
 

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ExpandLink.tsx
@@ -13,7 +13,8 @@ interface ExpandLinkProps {
 
 const ExpandLink: React.FC<ExpandLinkProps> = props => {
 	return props.hasChildren ? (
-		<a className='sidebar-expand-link' data-folder-id={props.folderId} onClick={props.onClick}>
+		// The expand/collapse information is conveyed through ARIA.
+		<a className='sidebar-expand-link' data-folder-id={props.folderId} onClick={props.onClick} aria-label=''>
 			<ExpandIcon isVisible={true} isExpanded={props.isExpanded} targetTitle={props.folderTitle}/>
 		</a>
 	) : (

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -10,7 +10,7 @@ import Folder from '@joplin/lib/models/Folder';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { _ } from '@joplin/lib/locale';
 import NoteCount from './NoteCount';
-import ListItemWrapper from './ListItemWrapper';
+import ListItemWrapper, { ListItemRef } from './ListItemWrapper';
 
 const renderFolderIcon = (folderIcon: FolderIcon) => {
 	if (!folderIcon) {
@@ -27,6 +27,7 @@ const renderFolderIcon = (folderIcon: FolderIcon) => {
 };
 
 interface FolderItemProps {
+	anchorRef: ListItemRef;
 	hasChildren: boolean;
 	showFolderIcon: boolean;
 	isExpanded: boolean;
@@ -67,11 +68,12 @@ function FolderItem(props: FolderItemProps) {
 
 	return (
 		<ListItemWrapper
+			containerRef={props.anchorRef}
 			depth={depth}
 			selected={selected}
 			itemIndex={props.index}
 			itemCount={props.itemCount}
-			aria-expanded={hasChildren ? props.isExpanded : undefined}
+			expanded={hasChildren ? props.isExpanded : undefined}
 			className={`list-item-container list-item-depth-${depth} ${selected ? 'selected' : ''}`}
 			onDragStart={onFolderDragStart_}
 			onDragOver={onFolderDragOver_}
@@ -79,7 +81,7 @@ function FolderItem(props: FolderItemProps) {
 			draggable={draggable}
 			data-folder-id={folderId}
 		>
-			<ExpandLink hasChildren={hasChildren} folderTitle={folderTitle} folderId={folderId} onClick={onFolderToggleClick_} isExpanded={isExpanded}/>
+			<ExpandLink aria-label='' hasChildren={hasChildren} folderTitle={folderTitle} folderId={folderId} onClick={onFolderToggleClick_} isExpanded={isExpanded}/>
 			<StyledListItemAnchor
 				className="list-item"
 				isConflictFolder={folderId === Folder.conflictFolderId()}
@@ -90,7 +92,7 @@ function FolderItem(props: FolderItemProps) {
 				onContextMenu={itemContextMenu}
 				data-folder-id={folderId}
 				onDoubleClick={onFolderToggleClick_}
-			
+
 				onClick={() => {
 					folderItem_click(folderId);
 				}}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -100,6 +100,8 @@ function FolderItem(props: FolderItemProps) {
 				{shareIcon} <NoteCount count={noteCount}/>
 			</StyledListItemAnchor>
 			<ExpandLink
+				// The ExpandLink is included after the title so that the screen reader reads the
+				// title first.
 				className='toggle'
 				hasChildren={hasChildren}
 				folderTitle={folderTitle}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -76,6 +76,7 @@ function FolderItem(props: FolderItemProps) {
 			itemCount={props.itemCount}
 			expanded={hasChildren ? props.isExpanded : undefined}
 			className={`list-item-container list-item-depth-${depth} ${selected ? 'selected' : ''}`}
+			highlightOnHover={true}
 			onDragStart={onFolderDragStart_}
 			onDragOver={onFolderDragOver_}
 			onDrop={onFolderDrop_}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -85,7 +85,6 @@ function FolderItem(props: FolderItemProps) {
 			data-id={folderId}
 			data-type={ModelType.Folder}
 		>
-			<ExpandLink aria-label='' hasChildren={hasChildren} folderTitle={folderTitle} folderId={folderId} onClick={onFolderToggleClick_} isExpanded={isExpanded}/>
 			<StyledListItemAnchor
 				className="list-item"
 				isConflictFolder={folderId === Folder.conflictFolderId()}
@@ -100,6 +99,14 @@ function FolderItem(props: FolderItemProps) {
 				{doRenderFolderIcon()}<StyledSpanFix className="title">{folderTitle}</StyledSpanFix>
 				{shareIcon} <NoteCount count={noteCount}/>
 			</StyledListItemAnchor>
+			<ExpandLink
+				className='toggle'
+				hasChildren={hasChildren}
+				folderTitle={folderTitle}
+				folderId={folderId}
+				onClick={onFolderToggleClick_}
+				isExpanded={isExpanded}
+			/>
 		</ListItemWrapper>
 	);
 }

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -69,7 +69,8 @@ function FolderItem(props: FolderItemProps) {
 	return (
 		<ListItemWrapper
 			containerRef={props.anchorRef}
-			depth={depth}
+			// Folders are contained within the "Notebooks" section (which has depth 0):
+			depth={depth + 1}
 			selected={selected}
 			itemIndex={props.index}
 			itemCount={props.itemCount}
@@ -78,8 +79,11 @@ function FolderItem(props: FolderItemProps) {
 			onDragStart={onFolderDragStart_}
 			onDragOver={onFolderDragOver_}
 			onDrop={onFolderDrop_}
+			onContextMenu={itemContextMenu}
 			draggable={draggable}
 			data-folder-id={folderId}
+			data-id={folderId}
+			data-type={ModelType.Folder}
 		>
 			<ExpandLink aria-label='' hasChildren={hasChildren} folderTitle={folderTitle} folderId={folderId} onClick={onFolderToggleClick_} isExpanded={isExpanded}/>
 			<StyledListItemAnchor
@@ -87,10 +91,6 @@ function FolderItem(props: FolderItemProps) {
 				isConflictFolder={folderId === Folder.conflictFolderId()}
 				selected={selected}
 				shareId={shareId}
-				data-id={folderId}
-				data-type={ModelType.Folder}
-				onContextMenu={itemContextMenu}
-				data-folder-id={folderId}
 				onDoubleClick={onFolderToggleClick_}
 
 				onClick={() => {

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { FolderIcon, FolderIconType } from '@joplin/lib/services/database/types';
 import ExpandLink from './ExpandLink';
-import { StyledListItem, StyledListItemAnchor, StyledShareIcon, StyledSpanFix } from '../styles';
+import { StyledListItemAnchor, StyledShareIcon, StyledSpanFix } from '../styles';
 import { ItemClickListener, ItemContextMenuListener, ItemDragListener } from '../types';
 import FolderIconBox from '../../FolderIconBox';
 import { getTrashFolderIcon, getTrashFolderId } from '@joplin/lib/services/trash';
@@ -10,6 +10,7 @@ import Folder from '@joplin/lib/models/Folder';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { _ } from '@joplin/lib/locale';
 import NoteCount from './NoteCount';
+import ListItemWrapper from './ListItemWrapper';
 
 const renderFolderIcon = (folderIcon: FolderIcon) => {
 	if (!folderIcon) {
@@ -43,7 +44,9 @@ interface FolderItemProps {
 	onFolderToggleClick_: ItemClickListener;
 	shareId: string;
 	selected: boolean;
-	anchorRef: React.Ref<HTMLElement>;
+
+	index: number;
+	itemCount: number;
 }
 
 function FolderItem(props: FolderItemProps) {
@@ -63,29 +66,39 @@ function FolderItem(props: FolderItemProps) {
 	};
 
 	return (
-		<StyledListItem depth={depth} selected={selected} className={`list-item-container list-item-depth-${depth} ${selected ? 'selected' : ''}`} onDragStart={onFolderDragStart_} onDragOver={onFolderDragOver_} onDrop={onFolderDrop_} draggable={draggable} data-folder-id={folderId}>
+		<ListItemWrapper
+			depth={depth}
+			selected={selected}
+			itemIndex={props.index}
+			itemCount={props.itemCount}
+			aria-expanded={hasChildren ? props.isExpanded : undefined}
+			className={`list-item-container list-item-depth-${depth} ${selected ? 'selected' : ''}`}
+			onDragStart={onFolderDragStart_}
+			onDragOver={onFolderDragOver_}
+			onDrop={onFolderDrop_}
+			draggable={draggable}
+			data-folder-id={folderId}
+		>
 			<ExpandLink hasChildren={hasChildren} folderTitle={folderTitle} folderId={folderId} onClick={onFolderToggleClick_} isExpanded={isExpanded}/>
 			<StyledListItemAnchor
-				ref={props.anchorRef}
 				className="list-item"
 				isConflictFolder={folderId === Folder.conflictFolderId()}
-				href="#"
 				selected={selected}
-				aria-selected={selected}
 				shareId={shareId}
 				data-id={folderId}
 				data-type={ModelType.Folder}
 				onContextMenu={itemContextMenu}
 				data-folder-id={folderId}
+				onDoubleClick={onFolderToggleClick_}
+			
 				onClick={() => {
 					folderItem_click(folderId);
 				}}
-				onDoubleClick={onFolderToggleClick_}
 			>
 				{doRenderFolderIcon()}<StyledSpanFix className="title">{folderTitle}</StyledSpanFix>
 				{shareIcon} <NoteCount count={noteCount}/>
 			</StyledListItemAnchor>
-		</StyledListItem>
+		</ListItemWrapper>
 	);
 }
 

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -59,14 +59,14 @@ const HeaderItem: React.FC<Props> = props => {
 			selected={props.isSelected}
 			itemIndex={props.index}
 			itemCount={props.itemCount}
+			expanded={props.item.expanded}
+			onContextMenu={onContextMenu}
+			depth={0}
 			className='sidebar-header-container'
 			{...item.extraProps}
 			onDrop={props.onDrop}
 		>
-			<StyledHeader
-				onContextMenu={onContextMenu}
-				onClick={onClick}
-			>
+			<StyledHeader onClick={onClick}>
 				<StyledHeaderIcon aria-label='' className={item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { useCallback } from 'react';
-import { ButtonLevel } from '../../Button/Button';
-import { StyledAddButton, StyledHeader, StyledHeaderIcon, StyledHeaderLabel } from '../styles';
+import { StyledHeader, StyledHeaderIcon, StyledHeaderLabel } from '../styles';
 import { HeaderId, HeaderListItem } from '../types';
-import { _ } from '@joplin/lib/locale';
 import bridge from '../../../services/bridge';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -46,13 +44,6 @@ const HeaderItem: React.FC<Props> = props => {
 		}
 	}, [itemId]);
 
-	const addButton = <StyledAddButton
-		iconLabel={_('New')}
-		onClick={item.onPlusButtonClick}
-		iconName='fas fa-plus'
-		level={ButtonLevel.SidebarSecondary}
-	/>;
-
 	return (
 		<ListItemWrapper
 			containerRef={props.anchorRef}
@@ -71,7 +62,6 @@ const HeaderItem: React.FC<Props> = props => {
 				<StyledHeaderIcon aria-label='' role='img' className={item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>
-			{ item.onPlusButtonClick && addButton }
 		</ListItemWrapper>
 	);
 };

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -7,6 +7,7 @@ import { _ } from '@joplin/lib/locale';
 import bridge from '../../../services/bridge';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
+import ListItemWrapper from './ListItemWrapper';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -15,8 +16,10 @@ const menuUtils = new MenuUtils(CommandService.instance());
 
 interface Props {
 	item: HeaderListItem;
+	isSelected: boolean;
 	onDrop: React.DragEventHandler|null;
-	anchorRef: React.Ref<HTMLElement>;
+	index: number;
+	itemCount: number;
 }
 
 const HeaderItem: React.FC<Props> = props => {
@@ -50,7 +53,10 @@ const HeaderItem: React.FC<Props> = props => {
 	/>;
 
 	return (
-		<div
+		<ListItemWrapper
+			selected={props.isSelected}
+			itemIndex={props.index}
+			itemCount={props.itemCount}
 			className='sidebar-header-container'
 			{...item.extraProps}
 			onDrop={props.onDrop}
@@ -58,14 +64,12 @@ const HeaderItem: React.FC<Props> = props => {
 			<StyledHeader
 				onContextMenu={onContextMenu}
 				onClick={onClick}
-				tabIndex={0}
-				ref={props.anchorRef}
 			>
 				<StyledHeaderIcon aria-label='' className={item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>
 			{ item.onPlusButtonClick && addButton }
-		</div>
+		</ListItemWrapper>
 	);
 };
 

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -67,7 +67,7 @@ const HeaderItem: React.FC<Props> = props => {
 			onDrop={props.onDrop}
 		>
 			<StyledHeader onClick={onClick}>
-				<StyledHeaderIcon aria-label='' className={item.iconName}/>
+				<StyledHeaderIcon aria-label='' role='img' className={item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>
 			{ item.onPlusButtonClick && addButton }

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -7,7 +7,7 @@ import { _ } from '@joplin/lib/locale';
 import bridge from '../../../services/bridge';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
-import ListItemWrapper from './ListItemWrapper';
+import ListItemWrapper, { ListItemRef } from './ListItemWrapper';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -15,6 +15,7 @@ const menuUtils = new MenuUtils(CommandService.instance());
 
 
 interface Props {
+	anchorRef: ListItemRef;
 	item: HeaderListItem;
 	isSelected: boolean;
 	onDrop: React.DragEventHandler|null;
@@ -54,6 +55,7 @@ const HeaderItem: React.FC<Props> = props => {
 
 	return (
 		<ListItemWrapper
+			containerRef={props.anchorRef}
 			selected={props.isSelected}
 			itemIndex={props.index}
 			itemCount={props.itemCount}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -62,6 +62,7 @@ const HeaderItem: React.FC<Props> = props => {
 			expanded={props.item.expanded}
 			onContextMenu={onContextMenu}
 			depth={0}
+			highlightOnHover={false}
 			className='sidebar-header-container'
 			{...item.extraProps}
 			onDrop={props.onDrop}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { _ } from '@joplin/lib/locale';
+import { useMemo } from 'react';
+
+interface Props {
+	selected: boolean;
+	itemIndex: number;
+	itemCount: number;
+	depth?: number;
+	className?: string;
+	children: (React.ReactNode[])|React.ReactNode;
+
+	onDrag?: React.DragEventHandler;
+	onDragStart?: React.DragEventHandler;
+	onDragOver?: React.DragEventHandler;
+	onDrop?: React.DragEventHandler;
+	draggable?: boolean;
+}
+
+const ListItemWrapper: React.FC<Props> = props => {
+	const style = useMemo(() => {
+		return {
+			'--depth': props.depth,
+		} as React.CSSProperties;
+	}, [props.depth]);
+	
+	return (
+		<div
+			aria-posinset={props.itemIndex + 1}
+			aria-setsize={props.itemCount}
+			aria-selected={props.selected}
+			aria-level={props.depth}
+			// Focus is handled directly by the item list
+			tabIndex={-1}
+			onDrag={props.onDrag}
+			onDragStart={props.onDragStart}
+			onDragOver={props.onDragOver}
+			onDrop={props.onDrop}
+			draggable={props.draggable}
+			role='treeitem'
+			className={`list-item-wrapper ${props.selected ? '-selected' : ''} ${props.className ?? ''}`}
+			style={style}
+		>
+			{props.children}
+		</div>
+	);
+};
+
+export default ListItemWrapper;

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
-import { _ } from '@joplin/lib/locale';
 import { useMemo } from 'react';
 
+export type ListItemRef = React.Ref<HTMLDivElement>;
+
 interface Props {
+	containerRef: ListItemRef;
 	selected: boolean;
 	itemIndex: number;
 	itemCount: number;
+	expanded?: boolean|undefined;
 	depth?: number;
 	className?: string;
 	children: (React.ReactNode[])|React.ReactNode;
@@ -15,6 +18,7 @@ interface Props {
 	onDragOver?: React.DragEventHandler;
 	onDrop?: React.DragEventHandler;
 	draggable?: boolean;
+	'data-folder-id'?: string;
 }
 
 const ListItemWrapper: React.FC<Props> = props => {
@@ -23,15 +27,17 @@ const ListItemWrapper: React.FC<Props> = props => {
 			'--depth': props.depth,
 		} as React.CSSProperties;
 	}, [props.depth]);
-	
+
 	return (
 		<div
+			ref={props.containerRef}
 			aria-posinset={props.itemIndex + 1}
 			aria-setsize={props.itemCount}
 			aria-selected={props.selected}
-			aria-level={props.depth}
-			// Focus is handled directly by the item list
-			tabIndex={-1}
+			aria-expanded={props.expanded}
+			// aria-level is 1-based, where depth is zero-based
+			aria-level={props.depth + 1}
+			tabIndex={props.selected ? 0 : -1}
 			onDrag={props.onDrag}
 			onDragStart={props.onDragStart}
 			onDragOver={props.onDragOver}
@@ -40,6 +46,7 @@ const ListItemWrapper: React.FC<Props> = props => {
 			role='treeitem'
 			className={`list-item-wrapper ${props.selected ? '-selected' : ''} ${props.className ?? ''}`}
 			style={style}
+			data-folder-id={props['data-folder-id']}
 		>
 			{props.children}
 		</div>

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -1,3 +1,4 @@
+import { ModelType } from '@joplin/lib/BaseModel';
 import * as React from 'react';
 import { useMemo } from 'react';
 
@@ -9,16 +10,19 @@ interface Props {
 	itemIndex: number;
 	itemCount: number;
 	expanded?: boolean|undefined;
-	depth?: number;
+	depth: number;
 	className?: string;
 	children: (React.ReactNode[])|React.ReactNode;
 
+	onContextMenu?: React.MouseEventHandler;
 	onDrag?: React.DragEventHandler;
 	onDragStart?: React.DragEventHandler;
 	onDragOver?: React.DragEventHandler;
 	onDrop?: React.DragEventHandler;
 	draggable?: boolean;
 	'data-folder-id'?: string;
+	'data-id'?: string;
+	'data-type'?: ModelType;
 }
 
 const ListItemWrapper: React.FC<Props> = props => {
@@ -38,15 +42,20 @@ const ListItemWrapper: React.FC<Props> = props => {
 			// aria-level is 1-based, where depth is zero-based
 			aria-level={props.depth + 1}
 			tabIndex={props.selected ? 0 : -1}
+
+			onContextMenu={props.onContextMenu}
 			onDrag={props.onDrag}
 			onDragStart={props.onDragStart}
 			onDragOver={props.onDragOver}
 			onDrop={props.onDrop}
 			draggable={props.draggable}
+
 			role='treeitem'
 			className={`list-item-wrapper ${props.selected ? '-selected' : ''} ${props.className ?? ''}`}
 			style={style}
 			data-folder-id={props['data-folder-id']}
+			data-id={props['data-id']}
+			data-type={props['data-type']}
 		>
 			{props.children}
 		</div>

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -12,6 +12,7 @@ interface Props {
 	expanded?: boolean|undefined;
 	depth: number;
 	className?: string;
+	highlightOnHover: boolean;
 	children: (React.ReactNode[])|React.ReactNode;
 
 	onContextMenu?: React.MouseEventHandler;
@@ -51,7 +52,7 @@ const ListItemWrapper: React.FC<Props> = props => {
 			draggable={props.draggable}
 
 			role='treeitem'
-			className={`list-item-wrapper ${props.selected ? '-selected' : ''} ${props.className ?? ''}`}
+			className={`list-item-wrapper ${props.highlightOnHover ? '-highlight-on-hover' : ''} ${props.selected ? '-selected' : ''} ${props.className ?? ''}`}
 			style={style}
 			data-folder-id={props['data-folder-id']}
 			data-id={props['data-id']}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
@@ -7,11 +7,12 @@ import BaseModel from '@joplin/lib/BaseModel';
 import NoteCount from './NoteCount';
 import Tag from '@joplin/lib/models/Tag';
 import EmptyExpandLink from './EmptyExpandLink';
-import ListItemWrapper from './ListItemWrapper';
+import ListItemWrapper, { ListItemRef } from './ListItemWrapper';
 
 export type TagLinkClickEvent = { tag: TagsWithNoteCountEntity|undefined };
 
 interface Props {
+	anchorRef: ListItemRef;
 	selected: boolean;
 	tag: TagsWithNoteCountEntity;
 	onTagDrop: React.DragEventHandler<HTMLElement>;
@@ -37,6 +38,7 @@ const TagItem = (props: Props) => {
 
 	return (
 		<ListItemWrapper
+			containerRef={props.anchorRef}
 			selected={selected}
 			className={`list-item-container ${selected ? 'selected' : ''}`}
 			onDrop={props.onTagDrop}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
@@ -40,6 +40,7 @@ const TagItem = (props: Props) => {
 		<ListItemWrapper
 			containerRef={props.anchorRef}
 			selected={selected}
+			depth={1}
 			className={`list-item-container ${selected ? 'selected' : ''}`}
 			onDrop={props.onTagDrop}
 			data-tag-id={tag.id}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
@@ -42,6 +42,7 @@ const TagItem = (props: Props) => {
 			selected={selected}
 			depth={1}
 			className={`list-item-container ${selected ? 'selected' : ''}`}
+			highlightOnHover={true}
 			onDrop={props.onTagDrop}
 			data-tag-id={tag.id}
 			aria-selected={selected}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/TagItem.tsx
@@ -1,22 +1,25 @@
 import Setting from '@joplin/lib/models/Setting';
 import * as React from 'react';
 import { useCallback } from 'react';
-import { StyledListItem, StyledListItemAnchor, StyledSpanFix } from '../styles';
+import { StyledListItemAnchor, StyledSpanFix } from '../styles';
 import { TagsWithNoteCountEntity } from '@joplin/lib/services/database/types';
 import BaseModel from '@joplin/lib/BaseModel';
 import NoteCount from './NoteCount';
 import Tag from '@joplin/lib/models/Tag';
 import EmptyExpandLink from './EmptyExpandLink';
+import ListItemWrapper from './ListItemWrapper';
 
 export type TagLinkClickEvent = { tag: TagsWithNoteCountEntity|undefined };
 
 interface Props {
 	selected: boolean;
-	anchorRef: React.Ref<HTMLElement>;
 	tag: TagsWithNoteCountEntity;
 	onTagDrop: React.DragEventHandler<HTMLElement>;
 	onContextMenu: React.MouseEventHandler<HTMLElement>;
 	onClick: (event: TagLinkClickEvent)=> void;
+
+	itemCount: number;
+	index: number;
 }
 
 const TagItem = (props: Props) => {
@@ -33,18 +36,18 @@ const TagItem = (props: Props) => {
 	}, [props.onClick, tag]);
 
 	return (
-		<StyledListItem
+		<ListItemWrapper
 			selected={selected}
 			className={`list-item-container ${selected ? 'selected' : ''}`}
 			onDrop={props.onTagDrop}
 			data-tag-id={tag.id}
 			aria-selected={selected}
+			itemIndex={props.index}
+			itemCount={props.itemCount}
 		>
 			<EmptyExpandLink/>
 			<StyledListItemAnchor
-				ref={props.anchorRef}
 				className="list-item"
-				href="#"
 				selected={selected}
 				data-id={tag.id}
 				data-type={BaseModel.TYPE_TAG}
@@ -54,7 +57,7 @@ const TagItem = (props: Props) => {
 				<StyledSpanFix className="tag-label">{Tag.displayTitle(tag)}</StyledSpanFix>
 				{noteCount}
 			</StyledListItemAnchor>
-		</StyledListItem>
+		</ListItemWrapper>
 	);
 };
 

--- a/packages/app-desktop/gui/Sidebar/style.scss
+++ b/packages/app-desktop/gui/Sidebar/style.scss
@@ -1,4 +1,5 @@
 @use 'styles/folder-and-tag-list.scss';
+@use 'styles/list-item-wrapper.scss';
 @use 'styles/note-count-label.scss';
 @use 'styles/sidebar-expand-icon.scss';
 @use 'styles/sidebar-expand-link.scss';

--- a/packages/app-desktop/gui/Sidebar/style.scss
+++ b/packages/app-desktop/gui/Sidebar/style.scss
@@ -5,3 +5,4 @@
 @use 'styles/sidebar-expand-link.scss';
 @use 'styles/sidebar-header-container.scss';
 @use 'styles/sidebar-spacer-item.scss';
+@use 'styles/new-folder-button.scss';

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -49,22 +49,6 @@ export const StyledHeaderLabel = styled.span`
 	font-weight: bold;
 `;
 
-export const StyledListItem = styled.div`
-	box-sizing: border-box;
-	height: 30px;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	padding-left: ${(props: StyleProps) => props.theme.mainPadding + ('depth' in props ? props.depth : 0) * 16}px;
-	background: ${(props: StyleProps) => props.selected ? props.theme.selectedColor2 : 'none'};
-	/*text-transform: ${(props: StyleProps) => props.isSpecialItem ? 'uppercase' : 'none'};*/
-	transition: 0.1s;
-
-	&:hover {
-		background-color: ${(props: StyleProps) => props.theme.backgroundColorHover2};
-	}
-`;
-
 function listItemTextColor(props: StyleProps) {
 	if (props.isConflictFolder) return props.theme.colorError2;
 	if (props.isSpecialItem) return props.theme.colorFaded2;

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -9,6 +9,12 @@
 	background: none;
 	transition: 0.1s;
 
+	// Show the toggle button first, even if it's markup is included later for a better screen reader
+	// experience.
+	> .toggle {
+		order: -1;
+	}
+
 	&.-selected {
 		background: var(--joplin-selected-color2);
 	}

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -1,0 +1,19 @@
+
+.list-item-wrapper {
+	box-sizing: border-box;
+	height: 30px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding-left: calc(var(--joplin-main-padding) + calc(var(--depth) * 16px));
+	background: none;
+	transition: 0.1s;
+
+	&.-selected {
+		background: var(--joplin-selected-color2);
+	}
+
+	&:hover {
+		background-color: var(--joplin-background-color-hover2);
+	}
+}

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding-left: calc(var(--joplin-main-padding) + calc(var(--depth) * 16px));
+	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 16px);
 	background: none;
 	transition: 0.1s;
 

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -19,7 +19,7 @@
 		background: var(--joplin-selected-color2);
 	}
 
-	&:hover {
+	&.-highlight-on-hover:hover {
 		background-color: var(--joplin-background-color-hover2);
 	}
 }

--- a/packages/app-desktop/gui/Sidebar/styles/new-folder-button.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/new-folder-button.scss
@@ -1,0 +1,25 @@
+
+.new-folder-button {
+	position: absolute;
+	top: 0;
+	inset-inline-end: 0;
+
+	padding-inline-end: 15px;
+	padding-top: 4px;
+	height: 30px;
+	border: none;
+
+	background-color: transparent;
+	font-size: var(--joplin-toolbar-icon-size);
+	color: var(--joplin-color2);
+
+	&:hover {
+		color: var(--joplin-color-hover2);
+		background: none;
+	}
+
+	&:active {
+		color: var(--joplin-color-active2);
+		background: none;
+	}
+}

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-expand-link.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-expand-link.scss
@@ -5,6 +5,7 @@
 	opacity: 0.8;
 	text-decoration: none;
 	padding-right: 8px;
+	text-align: center;
 	display: flex;
 	align-items: center;
 	width: 16px;

--- a/packages/app-desktop/gui/Sidebar/types.ts
+++ b/packages/app-desktop/gui/Sidebar/types.ts
@@ -21,6 +21,7 @@ interface BaseListItem {
 export interface HeaderListItem extends BaseListItem {
 	kind: ListItemType.Header;
 	label: string;
+	expanded: boolean;
 	iconName: string;
 	id: HeaderId;
 	onClick: ((headerId: HeaderId, event: ReactMouseEvent<HTMLElement>)=> void)|null;

--- a/packages/app-desktop/gui/Sidebar/types.ts
+++ b/packages/app-desktop/gui/Sidebar/types.ts
@@ -25,7 +25,6 @@ export interface HeaderListItem extends BaseListItem {
 	iconName: string;
 	id: HeaderId;
 	onClick: ((headerId: HeaderId, event: ReactMouseEvent<HTMLElement>)=> void)|null;
-	onPlusButtonClick: MouseEventHandler<HTMLElement>|null;
 	extraProps: Record<string, string>;
 	supportsFolderDrop: boolean;
 }

--- a/packages/app-desktop/integration-tests/models/Sidebar.ts
+++ b/packages/app-desktop/integration-tests/models/Sidebar.ts
@@ -19,7 +19,7 @@ export default class Sidebar {
 		const submitButton = this.mainScreen.dialog.getByRole('button', { name: 'OK' });
 		await submitButton.click();
 
-		return this.container.getByText(title);
+		return this.container.getByRole('treeitem', { name: title });
 	}
 
 	private async sortBy(electronApp: ElectronApplication, option: string) {

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -59,14 +59,14 @@ test.describe('sidebar', () => {
 		await childFolderHeader.dragTo(parentFolderHeader);
 
 		// Verify that it's now a child folder -- expand and collapse the parent
-		const collapseButton = sidebar.container.getByRole('link', { name: 'Collapse Parent folder' });
+		const collapseButton = sidebar.container.getByTitle('Collapse Parent folder');
 		await expect(collapseButton).toBeVisible();
 		await collapseButton.click();
 
 		// Should be collapsed
 		await expect(childFolderHeader).not.toBeAttached();
 
-		const expandButton = sidebar.container.getByRole('link', { name: 'Expand Parent folder' });
+		const expandButton = sidebar.container.getByTitle('Expand Parent folder');
 		await expandButton.click();
 
 		// Should be possible to move back to the root

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -56,24 +56,24 @@ test.describe('sidebar', () => {
 
 		await sidebar.forceUpdateSorting(electronApp);
 
+		await expect(childFolderHeader).toBeVisible();
 		await childFolderHeader.dragTo(parentFolderHeader);
 
 		// Verify that it's now a child folder -- expand and collapse the parent
-		const collapseButton = sidebar.container.getByTitle('Collapse Parent folder');
-		await expect(collapseButton).toBeVisible();
-		await collapseButton.click();
+		await expect(parentFolderHeader).toHaveJSProperty('ariaExpanded', 'true');
+		const toggleButton = parentFolderHeader.getByRole('button', { name: /^(Expand|Collapse)/ });
+		await toggleButton.click();
 
 		// Should be collapsed
 		await expect(childFolderHeader).not.toBeAttached();
+		await expect(parentFolderHeader).toHaveJSProperty('ariaExpanded', 'false');
 
-		const expandButton = sidebar.container.getByTitle('Expand Parent folder');
-		await expandButton.click();
+		await toggleButton.click();
 
 		// Should be possible to move back to the root
 		const rootFolderHeader = sidebar.container.getByText('Notebooks');
 		await childFolderHeader.dragTo(rootFolderHeader);
-		await expect(collapseButton).not.toBeVisible();
-		await expect(expandButton).not.toBeVisible();
+		await expect(toggleButton).not.toBeVisible();
 	});
 
 	test('all notes section should list all notes', async ({ electronApp, mainWindow }) => {

--- a/packages/lib/utils/focusHandler.ts
+++ b/packages/lib/utils/focusHandler.ts
@@ -12,12 +12,16 @@ enum ToggleFocusAction {
 	Blur = 'blur',
 }
 
+interface FocusOptions {
+	preventScroll: boolean;
+}
+
 interface FocusableElement {
-	focus: ()=> void;
+	focus: (options?: FocusOptions)=> void;
 	blur: ()=> void;
 }
 
-const toggleFocus = (source: string, element: FocusableElement, action: ToggleFocusAction) => {
+const toggleFocus = (source: string, element: FocusableElement, action: ToggleFocusAction, options: FocusOptions|null) => {
 	if (!element) {
 		logger.warn(`Tried action "${action}" on an undefined element: ${source}`);
 		return;
@@ -29,15 +33,19 @@ const toggleFocus = (source: string, element: FocusableElement, action: ToggleFo
 	}
 
 	logger.debug(`Action "${action}" from "${source}"`);
-	element[action]();
+	if (options) {
+		element[action](options);
+	} else {
+		element[action]();
+	}
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export const focus = (source: string, element: any) => {
-	toggleFocus(source, element, ToggleFocusAction.Focus);
+export const focus = (source: string, element: any, options: FocusOptions|null = null) => {
+	toggleFocus(source, element, ToggleFocusAction.Focus, options);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export const blur = (source: string, element: any) => {
-	toggleFocus(source, element, ToggleFocusAction.Blur);
+	toggleFocus(source, element, ToggleFocusAction.Blur, null);
 };

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -132,3 +132,4 @@ Famegear
 rcompare
 tabindex
 Backblaze
+treeitem


### PR DESCRIPTION
# Summary

This pull request:

-   **Main goal**: Adds appropriate aria information to the sidebar (see [WCAG SC 1.3.1](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships), [WCAG SC 1.3.6](https://www.w3.org/WAI/WCAG22/Understanding/identify-purpose)):
    -   [role=tree](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role) is used for the sidebar tag+notebook container.
    -  [role=treeitem](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/treeitem_role) is used for individual items in the tree.
    - [aria-level](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) is used to convey notebook depth. The NOTEBOOKS heading has `aria-level=1`, a toplevel notebook has `aria-level=2`, a notebook with one parent notebook has `aria-level=3`.
     -  Among other things, this causes NVDA, VoiceOver, and Orca to announce the depth of a notebook.

Additionally:

-   **Keyboard accessibility**: Makes it possible to expand/collapse the "TAGS"/"NOTEBOOKS" headings with the keyboard.
     -  See [WCAG SC 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard).
-   **Side-effect of refactoring**: Fixes an issue where the :focusElementSidebar command did nothing if both "NOTEBOOKS" and "TAGS" were collapsed.
-   **Side-effect of refactoring**: Provides screen readers with information about the currently selected item in the sidebar, even if offscreen.
-   **Side-effect of refactoring:** Fixes an issue where the "NOTEBOOKS" and "TAGS" headers were slightly taller than expected by the note list container.

## Remaining issues & future work

-   Skip spacer items when navigating with the keyboard.
-   Fix "NOTEBOOKS" must be reselected after toggling it.
-   Remove tab override on the sidebar and note list.
-   (Optional) Improve focus-visible styling.

# Testing plan

1.   Enable the screen reader.
2.   Focus "All Notes"
3.   Press the down arrow until the last notebook has focus.
4.   Move focus to a notebook that has subnotebooks. Expand it if it isn't already expanded.
5.   Toggle the notebook using space.
6.   Toggle the notebook using the arrow keys.
7.   Focus the "NOTEBOOKS" header.
8. Hide, then show, all notebooks by pressing space.
9.   Hide, then show, all tags using the left/right arrow keys.
10.   Move focus to the "NOTEBOOKS" header.
11.   Open the context menu and create a new notebook using the context menu key.
12.   Make one notebook a subnotebook of another using the context menu key.
13.   Disable the screen reader.
14.   Drag a note from one notebook to another. Verify that the note is moved.

## Screen recording comparison: NVDA + Windows



[Screencast: Shows the above steps](https://github.com/user-attachments/assets/67d457ef-44ac-43ba-a8cf-7e62a61633fa)

<details><summary>Compare with before</summary>

Note: Previously, NVDA interacted with the note list in [browse mode](https://www.nvaccess.org/files/nvda/documentation/userGuide.html#BrowseMode), due to its lack of a role. As such, NVDA handles the focus, rather than Joplin.

[Screencast: Shows the above steps done with a version of Joplin from before this pull request](https://github.com/user-attachments/assets/9164f6be-efa6-4036-835d-c16ac49fc6ec)

</details>