### PR TITLE
Desktop: Upgrade to Electron 32.2.0

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -452,8 +452,7 @@ export class Bridge {
 		return nativeTheme.shouldUseDarkColors;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	public addEventListener(name: string, fn: Function) {
+	public addEventListener(name: string, fn: ()=> void) {
 		if (name === 'nativeThemeUpdated') {
 			nativeTheme.on('updated', fn);
 		} else {

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -232,7 +232,7 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 				className="noteTextViewer"
 				ref={this.webviewRef_}
 				style={viewerStyle}
-				allow='fullscreen=* autoplay=* local-fonts=* encrypted-media=*'
+				allow='clipboard-write=(self) fullscreen=(self) autoplay=(self) local-fonts=(self) encrypted-media=(self)'
 				allowFullScreen={true}
 				src={`joplin-content://note-viewer/${__dirname}/note-viewer/index.html`}
 			></iframe>

--- a/packages/app-desktop/integration-tests/util/setMessageBoxResponse.ts
+++ b/packages/app-desktop/integration-tests/util/setMessageBoxResponse.ts
@@ -1,9 +1,9 @@
 import { ElectronApplication } from '@playwright/test';
-import { BrowserWindow, MessageBoxOptions } from 'electron';
+import { BaseWindow, MessageBoxOptions } from 'electron';
 
 const setMessageBoxResponse = (electronApp: ElectronApplication, responseMatch: RegExp) => {
 	return electronApp.evaluate(async ({ dialog }, responseMatch) => {
-		type DialogArgsType = [ BrowserWindow, MessageBoxOptions ]|[MessageBoxOptions];
+		type DialogArgsType = [ BaseWindow, MessageBoxOptions ]|[MessageBoxOptions];
 
 		const getMatchingButton = (dialogArgs: DialogArgsType) => {
 			const matchingButton = (options: MessageBoxOptions) => {

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -137,7 +137,7 @@
     "@types/styled-components": "5.1.32",
     "@types/tesseract.js": "2.0.0",
     "axios": "^1.7.7",
-    "electron": "29.4.5",
+    "electron": "32.2.0",
     "electron-builder": "24.13.3",
     "glob": "10.4.5",
     "gulp": "4.0.2",

--- a/packages/app-desktop/tools/electronRebuild.js
+++ b/packages/app-desktop/tools/electronRebuild.js
@@ -25,7 +25,7 @@ async function main() {
 	// wrong one. However it means it will have to be manually upgraded for each
 	// new Electron release. Some ABI map there:
 	// https://github.com/electron/node-abi/tree/master/test
-	const forceAbiArgs = '--force-abi 122';
+	const forceAbiArgs = '--force-abi 128';
 
 	if (isWindows()) {
 		// Cannot run this in parallel, or the 64-bit version might end up

--- a/yarn.lock
+++ b/yarn.lock
@@ -7411,7 +7411,7 @@ __metadata:
     compare-versions: 6.1.0
     countable: 3.0.1
     debounce: 1.2.1
-    electron: 29.4.5
+    electron: 32.2.0
     electron-builder: 24.13.3
     electron-updater: 6.2.1
     electron-window-state: 5.0.3
@@ -21149,16 +21149,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:29.4.5":
-  version: 29.4.5
-  resolution: "electron@npm:29.4.5"
+"electron@npm:32.2.0":
+  version: 32.2.0
+  resolution: "electron@npm:32.2.0"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^20.9.0
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 8c90671ddbde19e3bb4a5e0544e42204b13d1d75f4f96343b400754956a750262c1ad9574f479c0c3b7e90444e675f40a3f61e5374a8bb6f6de45eb6417a7f4f
+  checksum: c8ae07d9cf361b1aa6fd0726d1acb78e47ba8b821f62a007b3c56764861e598428a806ed14e288278f89a013598bde38d24ecccfccd09d26e84f6770d7e7717c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades to Electron 32.2.0.

Potentially related: #11199.

# Relevant breaking changes

- The `permissions-policy` for the note viewer iframe needed to be updated. See [cross-origin iframes now use Permissions Policy to access features](https://www.electronjs.org/docs/latest/breaking-changes#behavior-changed-cross-origin-iframes-now-use-permission-policy-to-access-features)
- TypeScript type changes (see this pull request's diff).

See also https://www.electronjs.org/docs/latest/breaking-changes.

# UI Changes

The Chromium-provided UI for menus has changed on Linux and Windows:
| Before | After |
|---|---|
| ![screenshot: View menu has square corners](https://github.com/user-attachments/assets/165d1aee-93ec-41d7-a6c9-4a90e92f9c6d) | ![screenshot: View menu has rounded corners and slightly larger items](https://github.com/user-attachments/assets/1e3f91ae-3fe2-4aef-ad84-6ef0bfe34749) |
| ![screenshot: Menu has square corners and is roughly the height of the screen (this is the edit menu)](https://github.com/user-attachments/assets/c87e4fd7-b42f-4e27-a335-fbc50f433cf7) | ![screenshot: Menu has rounded corners and doesn't all fit on one screen](https://github.com/user-attachments/assets/14458acd-8d6e-495d-837f-0b51e262eece) |
|**Windows**:<br> ![screenshot: Existing Joplin view menu](https://github.com/user-attachments/assets/b04752ba-8f39-44a6-afdd-33717ae87811) | **Windows**<br> ![screenshot: Joplin view menu, slightly thinner and taller](https://github.com/user-attachments/assets/aec9c444-39a1-41c5-85de-380721c87c86) | 


# Manual testing

**Linux (Fedora 40)**: 
- **Printing**:
   - Ran File > Print and printed to PDF.
   - Attached the resultant PDF to a note and verified that it rendered.
- **Media attachments**:
   - Attached a video and an audio file to a note.
   - Verified that both can play.
   - Verified that the video can fullscreen.
 

**Windows 11**:
- Verified that the automated Playwright tests run successfully (they aren't run on Windows in CI).
- Attached an audio file to a note. Verified that it can play.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->