### PR TITLE
Desktop: Improve Markdown viewer link handling

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -733,6 +733,13 @@
 		}));
 
 		document.addEventListener('click', webviewLib.logEnabledEventHandler(e => {
+			// Links should all have custom click handlers. Allowing Electron to load custom links
+			// can cause security issues, particularly if these links have the same domain as the
+			// top-level page.
+			if (e.target.hasAttribute('href')) {
+				e.preventDefault();
+			}
+
 			document.querySelectorAll('.media-pdf').forEach(element => {
 				if(!!element.contentWindow){
 					element.contentWindow.postMessage({


### PR DESCRIPTION
# Summary

Fixes an issue where links could be opened by Electron, rather than Joplin's custom link handler, from the Markdown viewer.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->