### PR TITLE
Desktop: Improve KaTeX error handling

### DIFF
--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -352,4 +352,12 @@ describe('MdToHtml', () => {
 		expect(html).toContain('Inline</span>');
 		expect(html).toContain('Block</span>');
 	});
+
+	it('should sanitize KaTeX errors', async () => {
+		const markdown = '$\\a<svg>$';
+		const renderResult = await newTestMdToHtml().render(markdown, null, { bodyOnly: true });
+
+		// Should not contain the HTML in unsanitized form
+		expect(renderResult.html).not.toContain('<svg>');
+	});
 });

--- a/packages/renderer/MdToHtml/rules/katex.ts
+++ b/packages/renderer/MdToHtml/rules/katex.ts
@@ -310,12 +310,6 @@ function renderToStringWithCache(latex: string, katexOptions: any) {
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-function renderKatexError(latex: string, error: any): string {
-	console.error('Katex error for:', latex, error);
-	return `<div class="inline-code">${error.message}</div>`;
-}
-
 export default {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	plugin: function(markdownIt: any, options: RuleOptions) {
@@ -329,6 +323,10 @@ export default {
 		katexOptions.macros = options.context.userData.__katex.macros;
 		katexOptions.trust = true;
 
+		const renderKatexError = (error: Error): string => {
+			return `<div class="inline-code">${markdownIt.utils.escapeHtml(error.message)}</div>`;
+		};
+
 		// set KaTeX as the renderer for markdown-it-simplemath
 		const katexInline = function(latex: string) {
 			katexOptions.displayMode = false;
@@ -336,7 +334,7 @@ export default {
 			try {
 				outputHtml = renderToStringWithCache(latex, katexOptions);
 			} catch (error) {
-				outputHtml = renderKatexError(latex, error);
+				outputHtml = renderKatexError(error);
 			}
 			return `<span class="joplin-editable"><span class="joplin-source" data-joplin-language="katex" data-joplin-source-open="$" data-joplin-source-close="$">${markdownIt.utils.escapeHtml(latex)}</span>${outputHtml}</span>`;
 		};
@@ -353,7 +351,7 @@ export default {
 			try {
 				outputHtml = renderToStringWithCache(latex, katexOptions);
 			} catch (error) {
-				outputHtml = renderKatexError(latex, error);
+				outputHtml = renderKatexError(error);
 			}
 
 			return `<div class="joplin-editable"><pre class="joplin-source" data-joplin-language="katex" data-joplin-source-open="$$&#10;" data-joplin-source-close="&#10;$$&#10;">${markdownIt.utils.escapeHtml(latex)}</pre>${outputHtml}</div>`;


### PR DESCRIPTION
# Summary

Adds a missing `markdownIt.utils.escapeHtml` to the KaTeX error output generator.

> [!NOTE]
>
> This pull request targets `release-3.1`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->