### PR TITLE
Desktop: Open more target="_blank" links in a browser

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -241,6 +241,20 @@ export default class ElectronAppWrapper {
 			}
 		});
 
+		// Override calls to window.open and links with target="_blank": Open most in a browser instead
+		// of Electron:
+		this.win_.webContents.setWindowOpenHandler((event) => {
+			const url = new URL(event.url);
+
+			if (event.url === 'about:blank') {
+				// Script-controlled pages: Used by certain plugins
+				return { action: 'allow' };
+			} else if (['http:', 'https:'].includes(url.protocol)) {
+				void bridge().openExternal(event.url);
+			}
+			return { action: 'deny' };
+		});
+
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.win_.on('close', (event: any) => {
 			// If it's on macOS, the app is completely closed only if the user chooses to close the app (willQuitApp_ will be true)

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -5,7 +5,7 @@ import type ShimType from '@joplin/lib/shim';
 const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 
-import { BrowserWindow, Tray, screen } from 'electron';
+import { BrowserWindow, Tray, WebContents, screen } from 'electron';
 import bridge from './bridge';
 const url = require('url');
 const path = require('path');
@@ -232,28 +232,35 @@ export default class ElectronAppWrapper {
 			}, 3000);
 		}
 
-		// will-frame-navigate is fired by clicking on a link within the BrowserWindow.
-		this.win_.webContents.on('will-frame-navigate', event => {
-			// If the link changes the URL of the browser window,
-			if (event.isMainFrame) {
-				event.preventDefault();
-				void bridge().openExternal(event.url);
-			}
-		});
+		const addWindowEventHandlers = (webContents: WebContents) => {
+			// will-frame-navigate is fired by clicking on a link within the BrowserWindow.
+			webContents.on('will-frame-navigate', event => {
+				// If the link changes the URL of the browser window,
+				if (event.isMainFrame) {
+					event.preventDefault();
+					void bridge().openExternal(event.url);
+				}
+			});
 
-		// Override calls to window.open and links with target="_blank": Open most in a browser instead
-		// of Electron:
-		this.win_.webContents.setWindowOpenHandler((event) => {
-			const url = new URL(event.url);
+			// Override calls to window.open and links with target="_blank": Open most in a browser instead
+			// of Electron:
+			webContents.setWindowOpenHandler((event) => {
+				if (event.url === 'about:blank') {
+					// Script-controlled pages: Used for opening notes in new windows
+					return {
+						action: 'allow',
+					};
+				} else if (event.url.match(/^https?:\/\//)) {
+					void bridge().openExternal(event.url);
+				}
+				return { action: 'deny' };
+			});
 
-			if (event.url === 'about:blank') {
-				// Script-controlled pages: Used by certain plugins
-				return { action: 'allow' };
-			} else if (['http:', 'https:'].includes(url.protocol)) {
-				void bridge().openExternal(event.url);
-			}
-			return { action: 'deny' };
-		});
+			webContents.on('did-create-window', (event) => {
+				addWindowEventHandlers(event.webContents);
+			});
+		};
+		addWindowEventHandlers(this.win_.webContents);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.win_.on('close', (event: any) => {

--- a/packages/app-desktop/integration-tests/main.spec.ts
+++ b/packages/app-desktop/integration-tests/main.spec.ts
@@ -136,50 +136,55 @@ test.describe('main', () => {
 		expect(fullSize[0] / resizedSize[0]).toBeCloseTo(fullSize[1] / resizedSize[1]);
 	});
 
-	test('clicking on an external link should try to launch a browser', async ({ electronApp, mainWindow }) => {
-		const mainScreen = new MainScreen(mainWindow);
-		await mainScreen.waitFor();
+	for (const target of ['', '_blank']) {
+		test(`clicking on an external link with target=${JSON.stringify(target)} should try to launch a browser`, async ({ electronApp, mainWindow }) => {
+			const mainScreen = new MainScreen(mainWindow);
+			await mainScreen.waitFor();
 
-		// Mock openExternal
-		const nextExternalUrlPromise = electronApp.evaluate(({ shell }) => {
-			return new Promise<string>(resolve => {
-				const openExternal = async (url: string) => {
-					resolve(url);
-				};
-				shell.openExternal = openExternal;
+			// Mock openExternal
+			const nextExternalUrlPromise = electronApp.evaluate(({ shell }) => {
+				return new Promise<string>(resolve => {
+					const openExternal = async (url: string) => {
+						resolve(url);
+					};
+					shell.openExternal = openExternal;
+				});
 			});
+
+			// Create a test link
+			const testLinkTitle = 'This is a test link!';
+			const linkHref = 'https://joplinapp.org/';
+
+			await mainWindow.evaluate(({ testLinkTitle, linkHref, target }) => {
+				const testLink = document.createElement('a');
+				testLink.textContent = testLinkTitle;
+				testLink.onclick = () => {
+					// We need to navigate by setting location.href -- clicking on a link
+					// directly within the main window (i.e. not in a PDF viewer) doesn't
+					// navigate.
+					location.href = linkHref;
+				};
+				testLink.href = '#';
+
+				// Display on top of everything
+				testLink.style.zIndex = '99999';
+				testLink.style.position = 'fixed';
+				testLink.style.top = '0';
+				testLink.style.left = '0';
+				if (target) {
+					testLink.target = target;
+				}
+
+				document.body.appendChild(testLink);
+			}, { testLinkTitle, linkHref, target });
+
+			const testLink = mainWindow.getByText(testLinkTitle);
+			await expect(testLink).toBeVisible();
+			await testLink.click({ noWaitAfter: true });
+
+			expect(await nextExternalUrlPromise).toBe(linkHref);
 		});
-
-		// Create a test link
-		const testLinkTitle = 'This is a test link!';
-		const linkHref = 'https://joplinapp.org/';
-
-		await mainWindow.evaluate(({ testLinkTitle, linkHref }) => {
-			const testLink = document.createElement('a');
-			testLink.textContent = testLinkTitle;
-			testLink.onclick = () => {
-				// We need to navigate by setting location.href -- clicking on a link
-				// directly within the main window (i.e. not in a PDF viewer) doesn't
-				// navigate.
-				location.href = linkHref;
-			};
-			testLink.href = '#';
-
-			// Display on top of everything
-			testLink.style.zIndex = '99999';
-			testLink.style.position = 'fixed';
-			testLink.style.top = '0';
-			testLink.style.left = '0';
-
-			document.body.appendChild(testLink);
-		}, { testLinkTitle, linkHref });
-
-		const testLink = mainWindow.getByText(testLinkTitle);
-		await expect(testLink).toBeVisible();
-		await testLink.click({ noWaitAfter: true });
-
-		expect(await nextExternalUrlPromise).toBe(linkHref);
-	});
+	}
 
 	test('should start in safe mode if profile-dir/force-safe-mode-on-next-start exists', async ({ profileDirectory }) => {
 		await writeFile(join(profileDirectory, 'force-safe-mode-on-next-start'), 'true', 'utf8');


### PR DESCRIPTION
# Summary

This pull request improves how `target="_blank"` links are handled if they aren't first processed by Joplin's renderer (e.g. links added by a plugin or added as the result of a bug).

> [!NOTE]
>
> This pull request targets `release-3.1`.

# Testing plan

This pull request contains an automated Playwright test that:
1. Adds a `target="_blank"` link to the document.
2. Clicks it.
3. Verifies that the APIs to open a browser with the link are called.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->