### PR TITLE
Chore: Desktop: Fix SCSS compilation warning

### DIFF
--- a/packages/app-desktop/gui/styles/toolbar-button.scss
+++ b/packages/app-desktop/gui/styles/toolbar-button.scss
@@ -10,15 +10,6 @@
 	width: var(--joplin-toolbar-height);
 	max-width: var(--joplin-toolbar-height);
 
-	&.-has-title {
-		width: auto;
-		max-width: unset;
-	}
-
-	&:disabled {
-		opacity: 0.3;
-	}
-
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -33,6 +24,14 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 
+	&.-has-title {
+		width: auto;
+		max-width: unset;
+	}
+
+	&:disabled {
+		opacity: 0.3;
+	}
 
 	&:not(:disabled) {
 		&:hover, &:focus-visible {


### PR DESCRIPTION
# Summary

This pull request fixes the following warning, which was previously printed when running `yarn start` in `packages/app-desktop`:
````
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
18  │ ┌     &:disabled {
19  │ │         opacity: 0.3;
20  │ │     }
    │ └─── nested rule
... │
22  │       display: flex;
    │       ^^^^^^^^^^^^^ declaration
    ╵
    app-desktop/gui/styles/toolbar-button.scss 22:2  @use
    app-desktop/gui/styles/index.scss 7:1            @use
    app-desktop/style.scss 16:1                      root stylesheet

````

<details><summary>Show warnings for other lines (same file)</summary>

```

Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
18  │ ┌     &:disabled {
19  │ │         opacity: 0.3;
20  │ │     }
    │ └─── nested rule
... │
23  │       align-items: center;
    │       ^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    app-desktop/gui/styles/toolbar-button.scss 23:2  @use
    app-desktop/gui/styles/index.scss 7:1            @use
    app-desktop/style.scss 16:1                      root stylesheet

Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
18  │ ┌     &:disabled {
19  │ │         opacity: 0.3;
20  │ │     }
    │ └─── nested rule
... │
24  │       justify-content: center;
    │       ^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    app-desktop/gui/styles/toolbar-button.scss 24:2  @use
    app-desktop/gui/styles/index.scss 7:1            @use
    app-desktop/style.scss 16:1                      root stylesheet

Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
18  │ ┌     &:disabled {
19  │ │         opacity: 0.3;
20  │ │     }
    │ └─── nested rule
... │
25  │       cursor: default;
    │       ^^^^^^^^^^^^^^^ declaration
    ╵
    app-desktop/gui/styles/toolbar-button.scss 25:2  @use
    app-desktop/gui/styles/index.scss 7:1            @use
    app-desktop/style.scss 16:1                      root stylesheet

Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
18  │ ┌     &:disabled {
19  │ │         opacity: 0.3;
20  │ │     }
    │ └─── nested rule
... │
26  │       border-radius: 3px;
    │       ^^^^^^^^^^^^^^^^^^ declaration
    ╵
    app-desktop/gui/styles/toolbar-button.scss 26:2  @use
    app-desktop/gui/styles/index.scss 7:1            @use
    app-desktop/style.scss 16:1                      root stylesheet

Warning: 8 repetitive deprecation warnings omitted.
```

</details>

# Screenshot comparison

| Before | After |
|---|---|
| ![screenshot: Shows a note with a (Markdown) toolbar](https://github.com/user-attachments/assets/f25f5659-2562-489a-a054-2e5cb0782410)|  ![screenshot: Shows a note with a toolbar. Appears roughly identical to the before screenshot](https://github.com/user-attachments/assets/e5211194-9797-4755-9b76-5cf739014967) |

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->