### PR TITLE
Desktop,Mobile: Fix list renumbering in the Markdown editor resets the first list item number to 1

### DIFF
--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
@@ -38,4 +38,30 @@ describe('renumberSelectedLists', () => {
 			'# End',
 		].join('\n'));
 	});
+
+	it('should preserve the first list number if not 1', async () => {
+		const listText = [
+			'2. This',
+			'4. is',
+			'5. a',
+			'6. test',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			`${listText}\n\n# End`,
+			EditorSelection.range(0, listText.length),
+			['OrderedList', 'ATXHeading1'],
+		);
+
+		editor.dispatch(renumberSelectedLists(editor.state));
+
+		expect(editor.state.doc.toString()).toBe([
+			'2. This',
+			'3. is',
+			'4. a',
+			'5. test',
+			'',
+			'# End',
+		].join('\n'));
+	});
 });

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
@@ -13,6 +13,14 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 	// Re-numbers ordered lists and sublists with numbers on each line in [linesToHandle]
 	const handleLines = (linesToHandle: Line[]) => {
 		const changes: ChangeSpec[] = [];
+		if (linesToHandle.length === 0) {
+			return changes;
+		}
+
+		let firstListNumber = Number(listItemRegex.exec(linesToHandle[0].text)?.[2]);
+		if (!isFinite(firstListNumber) || firstListNumber < 1) {
+			firstListNumber = 1;
+		}
 
 		type ListItemRecord = {
 			nextListNumber: number;
@@ -20,7 +28,7 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 		};
 		const listNumberStack: ListItemRecord[] = [];
 		let currentGroupIndentation = '';
-		let nextListNumber = 1;
+		let nextListNumber = firstListNumber;
 		let prevLineNumber;
 
 		for (const line of linesToHandle) {


### PR DESCRIPTION
# Summary

This pull request fixes a bug [originally reported on the forum](https://discourse.joplinapp.org/t/list-numbering-gets-messed-up-when-i-delete-list-items/41185/3?u=personalizedrefriger).

Markdown lists can start on numbers greater than 1. However, the "indent" button on mobile and <kbd>tab</kbd> on desktop (which renumber list items when indenting a numbered list) reset the first list item to `1`.

## Behavior comparison

Original note:
```
2. This
3. is
4. a
5. test
```

**Old output**: After pressing "indent" for the second item:
```
1. This
	1. is
2. a
3. test
```

**New output**: After pressing "indent" for the second item:
```
2. This
	1. is
3. a
4. test
```

# Testing plan

This pull request includes an automated test.

Additionally, this has been tested with the desktop app by:
1. Creating a note with the following content:
    ```
    2. This
    3. is
    4. a
    4. test
   ```
2. Moving the cursor to the line starting with `3.`.
3. Pressing <kbd>tab</kbd>.
4. Verifying that the note now has the following content:
   ```
   2. This
   	1. is
   3. a
   4. test
   ```
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->