### PR TITLE
Chore: Desktop: Wait for plugins to load before running certain plugin-related tests

### DIFF
--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -3,9 +3,10 @@ import MainScreen from './models/MainScreen';
 import SettingsScreen from './models/SettingsScreen';
 
 test.describe('settings', () => {
-	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {
+	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow, startupPluginsLoaded }) => {
 		const mainScreen = new MainScreen(mainWindow);
 		await mainScreen.waitFor();
+		await startupPluginsLoaded;
 
 		// Sort order buttons should be visible by default
 		const sortOrderLocator = mainScreen.noteList.sortOrderButton;

--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -3,10 +3,9 @@ import MainScreen from './models/MainScreen';
 import SettingsScreen from './models/SettingsScreen';
 
 test.describe('settings', () => {
-	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow, startupPluginsLoaded }) => {
+	test('should be possible to remove sort order buttons in settings', async ({ electronApp, mainWindow }) => {
 		const mainScreen = new MainScreen(mainWindow);
 		await mainScreen.waitFor();
-		await startupPluginsLoaded;
 
 		// Sort order buttons should be visible by default
 		const sortOrderLocator = mainScreen.noteList.sortOrderButton;
@@ -52,8 +51,10 @@ test.describe('settings', () => {
 		await expect(mainScreen.dialog).toBeVisible();
 	});
 
-	test('should be possible to navigate settings screen tabs with the arrow keys', async ({ electronApp, mainWindow }) => {
+	test('should be possible to navigate settings screen tabs with the arrow keys', async ({ electronApp, mainWindow, startupPluginsLoaded }) => {
 		const mainScreen = new MainScreen(mainWindow);
+		await startupPluginsLoaded;
+
 		await mainScreen.waitFor();
 		await mainScreen.openSettings(electronApp);
 


### PR DESCRIPTION
# Summary

This pull request waits for startup plugins to load before running certain Playwright tests that depend on plugins. This should reduce test flakyness.

**Notes**: 
- `settings > should be possible to navigate settings screen tabs with the arrow keys` sometimes failed because it expected the backup plugin to have a tab in settings, but that plugin hadn't loaded yet.
- `pluginApi.spec.ts` tests similarly didn't wait for startup plugins to load, which may also cause test failures. 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->