### PR TITLE
Desktop: Linux: Move keychain support behind an off-by-default feature flag

### DIFF
--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1576,6 +1576,20 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'featureFlag.linuxKeychain': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: true,
+			storage: SettingStorage.File,
+			appTypes: [AppType.Desktop],
+			label: () => 'Enable keychain support',
+			description: () => 'This is an experimental setting to enable keychain support on Linux',
+			show: () => shim.isLinux(),
+			section: 'general',
+			isGlobal: true,
+			advanced: true,
+		},
+
 
 		// 'featureFlag.syncAccurateTimestamps': {
 		// 	value: false,

--- a/packages/lib/services/SettingUtils.ts
+++ b/packages/lib/services/SettingUtils.ts
@@ -34,6 +34,13 @@ export async function loadKeychainServiceAndSettings(keychainServiceDrivers: Key
 	Setting.setKeychainService(KeychainService.instance());
 	await Setting.load();
 
+	// Using Linux with the keychain has been observed to cause all secure settings to be lost
+	// on Fedora 40 + GNOME. (This may have been related to running multiple Joplin instances).
+	// For now, make saving to the keychain opt-in until more feedback is received.
+	if (shim.isLinux() && !Setting.value('featureFlag.linuxKeychain')) {
+		KeychainService.instance().readOnly = true;
+	}
+
 	// This is part of the migration to the new sync target info. It needs to be
 	// set as early as possible since it's used to tell if E2EE is enabled, it
 	// contains the master keys, etc. Once it has been set, it becomes a noop

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -1,8 +1,12 @@
+import Logger from '@joplin/utils/Logger';
 import { _ } from './locale';
 import Setting from './models/Setting';
 import { reg } from './registry';
+import KeychainService from './services/keychain/KeychainService';
 import { Plugins } from './services/plugins/PluginService';
 import shim from './shim';
+
+const logger = Logger.create('versionInfo');
 
 export interface PackageInfo {
 	name: string;
@@ -70,6 +74,13 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 		copyrightText.replace('YYYY', `${now.getFullYear()}`),
 	];
 
+	let keychainSupported = false;
+	try {
+		keychainSupported = Setting.value('keychain.supported') >= 1 && !KeychainService.instance().readOnly;
+	} catch (error) {
+		logger.error('Failed to determine if keychain is supported', error);
+	}
+
 	const body = [
 		_('%s %s (%s, %s)', p.name, p.version, Setting.value('env'), shim.platformName()),
 		'',
@@ -78,7 +89,7 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 		_('Profile Version: %s', reg.db().version()),
 		// The portable app temporarily supports read-only keychain access (but disallows
 		// write).
-		_('Keychain Supported: %s', (Setting.value('keychain.supported') >= 1 && !shim.isPortable()) ? _('Yes') : _('No')),
+		_('Keychain Supported: %s', keychainSupported ? _('Yes') : _('No')),
 	];
 
 	if (gitInfo) {

--- a/packages/lib/versionInfo.ts
+++ b/packages/lib/versionInfo.ts
@@ -76,6 +76,7 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 
 	let keychainSupported = false;
 	try {
+		// To allow old keys to be read, certain apps allow read-only keychain access:
 		keychainSupported = Setting.value('keychain.supported') >= 1 && !KeychainService.instance().readOnly;
 	} catch (error) {
 		logger.error('Failed to determine if keychain is supported', error);
@@ -87,8 +88,6 @@ export default function versionInfo(packageInfo: PackageInfo, plugins: Plugins) 
 		_('Client ID: %s', Setting.value('clientId')),
 		_('Sync Version: %s', Setting.value('syncVersion')),
 		_('Profile Version: %s', reg.db().version()),
-		// The portable app temporarily supports read-only keychain access (but disallows
-		// write).
 		_('Keychain Supported: %s', keychainSupported ? _('Yes') : _('No')),
 	];
 


### PR DESCRIPTION
# Summary

This pull request is in response to a failure to decrypt saved keychain secrets on Fedora 40. It makes the following changes:
- Makes the keychain read-only just after loading settings UNLESS the user has opted in to keychain support through a feature flag.
- Updates versionInfo to not display Yes for "Keychain supported" if the keychain is in read-only mode.

With the keychain in read-only mode, new secrets will be saved **as they were before the 3.1 pre-release** (see https://github.com/laurent22/joplin/pull/10535) but old secrets can still be read from the `KeychainService`.



# Testing plan


## Linux + Fedora 40

1. Build a release version of Joplin and start it.
2. Verify that Help > About Joplin shows "Keychain Supported" as "No".
3. Trigger a settings save (e.g. change the editor layout).
4. Verify that `encryption.` passwords are stored in the `settings` table in the database.
5. Go to settings > general and check "enable keychain support".
6. Restart Joplin.
7. Verify that Help > About Joplin shows "Keychain Supported" as "Yes".
8. Verify that `encryption.` passwords are no longer present in the `settings` table in the database.
9. Verify that `encryption.` passwords are now present (encrypted) in the `key_value` table in the database.

## Windows 11

1. Start Joplin in dev mode.
2. Open Help> About
3. Verify that "Keychain Supported" is listed as "Yes".
4. Under settings > general, verify that the "Enable keychain support" setting is not visible.
5. Enable encryption and enter an encryption password.
6. Restart Joplin.
7. Verify that the keychain password is still saved.
8. Start an existing install of Joplin.
9. Enable E2EE if not already enabled and enter a password.
10. Quit Joplin.
11. Build a release version of Joplin and install it.
12. Launch Joplin.
13. Verify that the master password is still saved.
14. Quit Joplin and launch `JoplinPortable.exe` 
15. Verify that under Help > About Joplin, "Keychain Supported" is listed as "No".


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->