### PR TITLE
Desktop: Accessibility: Add accessible label to the "remove from share" button

### DIFF
--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -256,6 +256,8 @@ const Button = React.forwardRef((props: Props, ref: any) => {
 			iconOnly={iconOnly}
 			onClick={onClick}
 
+			// When there's no title, the button needs a label. In this case, fall back
+			// to the tooltip.
 			aria-label={props.title ? undefined : props.tooltip}
 			aria-disabled={props.disabled}
 			aria-expanded={props['aria-expanded']}

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -256,6 +256,7 @@ const Button = React.forwardRef((props: Props, ref: any) => {
 			iconOnly={iconOnly}
 			onClick={onClick}
 
+			aria-label={props.title ? undefined : props.tooltip}
 			aria-disabled={props.disabled}
 			aria-expanded={props['aria-expanded']}
 			aria-controls={props['aria-controls']}

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -321,7 +321,13 @@ function ShareFolderDialog(props: Props) {
 				<StyledRecipientName>{shareUser.user.email}</StyledRecipientName>
 				{dropdown}
 				<StyledRecipientStatusIcon title={statusToMessage[shareUser.status]} className={statusToIcon[shareUser.status]}></StyledRecipientStatusIcon>
-				<Button disabled={!enabled} size={ButtonSize.Small} iconName="far fa-times-circle" onClick={() => recipient_delete({ shareUserId: shareUser.id })}/>
+				<Button
+					disabled={!enabled}
+					size={ButtonSize.Small}
+					iconName="far fa-times-circle"
+					onClick={() => recipient_delete({ shareUserId: shareUser.id })}
+					tooltip={_('Remove user from share: %s', shareUser.user.email)}
+				/>
 			</StyledRecipient>
 		);
 	}

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -326,7 +326,7 @@ function ShareFolderDialog(props: Props) {
 					size={ButtonSize.Small}
 					iconName="far fa-times-circle"
 					onClick={() => recipient_delete({ shareUserId: shareUser.id })}
-					tooltip={_('Remove user from share: %s', shareUser.user.email)}
+					tooltip={_('Remove %s from share', shareUser.user.email)}
 				/>
 			</StyledRecipient>
 		);


### PR DESCRIPTION
# Summary

This pull request adds a missing label to the "remove from share" button on the share screen.

# Testing plan

**Fedora 40 (Linux)**:
1. Enable the Orca screen reader.
2. Start Joplin and open the share dialog for an existing share.
3. Move accessibility focus to the "remove" button for a share item.
4. Verify that Orca reads "Remove [[email]] from share" (replacing `[[email]]` with an email).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->