### PR TITLE
Desktop: Fixes #10887: Prevent disabling of textbox inputs after entering an incorrect password

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -206,7 +206,7 @@ const EncryptionConfigScreen = (props: Props) => {
 
 		if (hasMasterPassword && newEnabled) {
 			if (!(await masterPasswordIsValid(newPassword))) {
-				alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
+				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
 				return;
 			}
 		}


### PR DESCRIPTION
On Joplin desktop (tested on Windows), when you use the enable encryption setting after a master password has been set, if you enter an incorrect password, then textbox inputs across the whole application are disabled as a result. This persists until minimising or restarting Joplin, or switching between different windows. This may be related to opening a standard alert dialog while a smalltalk prompt is active, as changing the validation error to use a smalltalk alert seems to fix the issue. Note that there is a slight change in behaviour in that the initial smalltalk prompt is closed when the validation error appears, but this shouldn't really be a big deal from a user perspective.

Video showing the current behaviour:
https://github.com/user-attachments/assets/6fabc55a-ae4b-47ce-b076-7f5181993130

Video showing the new behaviour:
https://github.com/user-attachments/assets/5580f810-e91d-4f55-9da7-e160ed77940e

This fixes https://github.com/laurent22/joplin/issues/10887
