### PR TITLE
Desktop: Re-enable media with local file URLs in the note viewer

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -127,6 +127,12 @@ class Application extends BaseApplication {
 			bridge().setLocale(Setting.value('locale'));
 		}
 
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'markdown.plugin.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
+			bridge().electronApp().getCustomProtocolHandler().setMediaAccessEnabled(
+				Setting.value('markdown.plugin.fileUrls'),
+			);
+		}
+
 		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'showTrayIcon' || action.type === 'SETTING_UPDATE_ALL') {
 			this.updateTray();
 		}

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -127,9 +127,9 @@ class Application extends BaseApplication {
 			bridge().setLocale(Setting.value('locale'));
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'markdown.plugin.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'renderer.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
 			bridge().electronApp().getCustomProtocolHandler().setMediaAccessEnabled(
-				Setting.value('markdown.plugin.fileUrls'),
+				Setting.value('renderer.fileUrls'),
 			);
 		}
 

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import { reg } from '@joplin/lib/registry';
 import bridge from '../services/bridge';
 import { focus } from '@joplin/lib/utils/focusHandler';
-import { createSecureRandom } from '@joplin/lib/uuid';
-import { AccessController } from '../utils/customProtocols/handleCustomProtocols';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
@@ -32,8 +30,6 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private webviewListeners_: any = null;
 
-	private localMediaAccessController_: AccessController|null = null;
-	private localMediaAccessKey_: string|null = null;
 	private removePluginAssetsCallback_: RemovePluginAssetsCallback|null = null;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -131,8 +127,6 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 		this.domReady_ = false;
 
 		this.removePluginAssetsCallback_?.();
-		this.localMediaAccessController_?.remove();
-		this.localMediaAccessKey_ = null;
 	}
 
 	public focus() {
@@ -222,15 +216,9 @@ export default class NoteTextViewerComponent extends React.Component<Props, any>
 			};
 		}
 
-		if (!this.localMediaAccessKey_) {
-			this.localMediaAccessController_?.remove();
-			this.localMediaAccessKey_ = createSecureRandom();
-			this.localMediaAccessController_ = protocolHandler.allowMediaAccessWithKey(this.localMediaAccessKey_);
-		}
-
 		this.send('setHtml', html, {
 			...options,
-			mediaAccessKey: this.localMediaAccessKey_,
+			mediaAccessKey: protocolHandler.getMediaAccessKey(),
 		});
 	}
 

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -378,6 +378,8 @@
 		}
 
 		const rewriteFileUrls = (accessKey) => {
+			if (!accessKey) return;
+
 			// To allow accessing local files from the viewer's non-file URL, file:// URLs are re-written
 			// to joplin-content:// URLs:
 			const mediaElements = document.querySelectorAll('video[src], audio[src], source[src], img[src]');

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -400,7 +400,9 @@
 
 			contentElement.innerHTML = html;
 
-			rewriteFileUrls(event.options.mediaAccessKey);
+			if (html.includes('file://')) {
+				rewriteFileUrls(event.options.mediaAccessKey);
+			}
 
 			scrollmap.create(event.options.markupLineCount);
 			if (typeof event.options.percent !== 'number') {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -377,13 +377,14 @@
 			contentElement.scrollTop = scrollTop;
 		}
 
-		const rewriteFileUrls = () => {
+		const rewriteFileUrls = (accessKey) => {
 			// To allow accessing local files from the viewer's non-file URL, file:// URLs are re-written
 			// to joplin-content:// URLs:
 			const mediaElements = document.querySelectorAll('video[src], audio[src], source[src], img[src]');
 			for (const element of mediaElements) {
 				if (element.src?.startsWith('file:')) {
-					element.src = element.src.replace(/^file:\/\//, 'joplin-content://file-media/')
+					const newUrl = element.src.replace(/^file:\/\//, 'joplin-content://file-media/');
+					element.src = `${newUrl}?access-key=${accessKey}`;
 				}
 			}
 		};
@@ -399,7 +400,7 @@
 
 			contentElement.innerHTML = html;
 
-			rewriteFileUrls();
+			rewriteFileUrls(event.options.mediaAccessKey);
 
 			scrollmap.create(event.options.markupLineCount);
 			if (typeof event.options.percent !== 'number') {

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -377,6 +377,17 @@
 			contentElement.scrollTop = scrollTop;
 		}
 
+		const rewriteFileUrls = () => {
+			// To allow accessing local files from the viewer's non-file URL, file:// URLs are re-written
+			// to joplin-content:// URLs:
+			const mediaElements = document.querySelectorAll('video[src], audio[src], source[src], img[src]');
+			for (const element of mediaElements) {
+				if (element.src?.startsWith('file:')) {
+					element.src = element.src.replace(/^file:\/\//, 'joplin-content://file-media/')
+				}
+			}
+		};
+
 		ipc.setHtml = (event) => {
 			const html = event.html;
 
@@ -387,6 +398,8 @@
 			alreadyAllImagesLoaded = false;
 
 			contentElement.innerHTML = html;
+
+			rewriteFileUrls();
 
 			scrollmap.create(event.options.markupLineCount);
 			if (typeof event.options.percent !== 'number') {

--- a/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
@@ -135,8 +135,10 @@ const handleCustomProtocols = (logger: LoggerWrapper): CustomProtocolHandler => 
 		debug: () => {},
 	};
 
+	// Allow-listed files/directories for joplin-content://note-viewer/
 	const readableDirectories: string[] = [];
 	const readableFiles = new Map<string, number>();
+	// Access keys for joplin-content://file-media/
 	const allowedMediaAccessKeys = new Set<string>();
 
 	// See also the protocol.handle example: https://www.electronjs.org/docs/latest/api/protocol#protocolhandlescheme-handler

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -926,6 +926,18 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'markdown.plugin.insert': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable ++insert++ syntax')}${wysiwygYes}` },
 		'markdown.plugin.multitable': { storage: SettingStorage.File, isGlobal: true, value: false, type: SettingItemType.Bool, section: 'markdownPlugins', public: true, appTypes: [AppType.Mobile, AppType.Desktop], label: () => `${_('Enable multimarkdown table extension')}${wysiwygNo}` },
 
+		// For now, applies only to the Markdown viewer
+		'renderer.fileUrls': {
+			storage: SettingStorage.File,
+			isGlobal: true,
+			value: false,
+			type: SettingItemType.Bool,
+			section: 'markdownPlugins',
+			public: true,
+			appTypes: [AppType.Desktop],
+			label: () => `${_('Enable file:// URLs for images and videos')}${wysiwygYes}`,
+		},
+
 		// Tray icon (called AppIndicator) doesn't work in Ubuntu
 		// http://www.webupd8.org/2017/04/fix-appindicator-not-working-for.html
 		// Might be fixed in Electron 18.x but no non-beta release yet. So for now

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -132,3 +132,4 @@ Famegear
 rcompare
 tabindex
 Backblaze
+nosniff

--- a/readme/dev/spec/note_viewer_isolation.md
+++ b/readme/dev/spec/note_viewer_isolation.md
@@ -31,7 +31,7 @@ Here's an example:
 - Joplin checks to make sure the `joplin-content://` protocol has access to `/home/user/.config/joplin-desktop/path/here.css`. If it does, it fetches and returns the file.
 
 
-## `joplin-content://` only has access to specific directories
+## `joplin-content://note-viewer/` only has access to specific directories
 
 When `handleCustomProtocols` creates a handler for the `joplin-content://` protocol, it returns an object that allows certain directories to be marked as readable.
 
@@ -41,6 +41,13 @@ By default, the list of readable directories includes:
 - The resource directory
 - The profile directory
 
+## `joplin-content://file-media/` can only load specific file types
+
+To allow images and videos with `file://` URLs, Joplin maps `file://` URIs to `joplin-content://file-media/`. The `file-media/` host has the following restrictions:
+- Only files with certain extensions/content-types can be loaded.
+   - For example, `text/html` is disallowed but `image/png` is allowed.
+- A valid `?access-key=<...>` parameter must be provided with the request.
+   - A new access key is created for each render and old access keys are revoked.
 
 ## Why not the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) property?
 


### PR DESCRIPTION
# Summary

Rendering media with local file URLs in the note viewer was originally disabled in https://github.com/laurent22/joplin/pull/10678. This pull request re-enables it by mapping `file://` URLs to `joplin-content://` URLs **if enabled in settings**.

See https://discourse.joplinapp.org/t/not-allowed-to-load-local-resource/41500.

# Testing plan

**Linux (Fedora 40)**:
1. Create files `/home/self/Videos/test.mp4` and `/home/self/Pictures/test.jpg`.
2. Create a new note with the following content:
    ```markdown
    <video src="file:///home/self/Videos/test.mp4" controls></video>
    <img src="file:///home/self/Pictures/test.jpg"/> 
    <video controls>
	<source src="file:///home/self/Videos/test.mp4" controls></source>
    </video>
    ```
3. Verify that both videos and the image render in the Markdown viewer.
4. Open an existing note with an audio attachment (resource).
5. Verify that the embedded audio can still play.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->