### PR TITLE
Chore: Mobile: Use stronger types in `side-menu` and support FontAwesome icons

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMemo, useEffect, useCallback, useContext } from 'react';
-import { Easing, Animated, TouchableOpacity, Text, StyleSheet, ScrollView, View, Image } from 'react-native';
+import { Easing, Animated, TouchableOpacity, Text, StyleSheet, ScrollView, View, Image, ImageStyle } from 'react-native';
 const { connect } = require('react-redux');
 const IonIcon = require('react-native-vector-icons/Ionicons').default;
 import Icon from './Icon';
@@ -87,6 +87,10 @@ const SideMenuContentComponent = (props: Props) => {
 			textAlign: 'center',
 			textAlignVertical: 'center',
 		};
+		const folderIconBase: ViewStyle&ImageStyle = {
+			marginRight: folderIconRightMargin,
+			width: 27,
+		};
 		const folderButtonStyle: ViewStyle = {
 			...buttonStyle,
 			paddingLeft: 0,
@@ -132,14 +136,17 @@ const SideMenuContentComponent = (props: Props) => {
 			sideButtonText: {
 				...buttonTextStyle,
 			},
-			folderTextIcon: {
+			folderBaseIcon: {
 				...sidebarIconStyle,
-				marginRight: folderIconRightMargin,
-				width: 26,
+				...folderIconBase,
+			},
+			folderEmojiIcon: {
+				...sidebarIconStyle,
+				...folderIconBase,
+				fontSize: theme.fontSize,
 			},
 			folderImageIcon: {
-				marginRight: folderIconRightMargin,
-				width: 27,
+				...folderIconBase,
 				height: 20,
 				resizeMode: 'contain',
 			},
@@ -409,18 +416,18 @@ const SideMenuContentComponent = (props: Props) => {
 			if (folderId === getTrashFolderId()) {
 				folderIcon = getTrashFolderIcon(FolderIconType.FontAwesome);
 			} else if (alwaysShowFolderIcons) {
-				return <IonIcon name="folder-outline" style={styles_.folderTextIcon} />;
+				return <IonIcon name="folder-outline" style={styles_.folderBaseIcon} />;
 			} else {
 				return null;
 			}
 		}
 
 		if (folderIcon.type === FolderIconType.Emoji) {
-			return <Text style={styles_.folderTextIcon}>{folderIcon.emoji}</Text>;
+			return <Text style={styles_.folderEmojiIcon}>{folderIcon.emoji}</Text>;
 		} else if (folderIcon.type === FolderIconType.DataUrl) {
 			return <Image style={styles_.folderImageIcon} source={{ uri: folderIcon.dataUrl }}/>;
 		} else if (folderIcon.type === FolderIconType.FontAwesome) {
-			return <Icon style={styles_.folderTextIcon} name={folderIcon.name} accessibilityLabel={''}/>;
+			return <Icon style={styles_.folderBaseIcon} name={folderIcon.name} accessibilityLabel={''}/>;
 		} else {
 			throw new Error(`Unsupported folder icon type: ${folderIcon.type}`);
 		}

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -39,7 +39,6 @@ interface Props {
 	isOnMobileData: boolean;
 	notesParentType: string;
 	folders: FolderEntity[];
-	opacity: number;
 	profileConfig: ProfileConfig;
 	inboxJopId: string;
 	selectedFolderId: string;
@@ -624,7 +623,7 @@ const SideMenuContentComponent = (props: Props) => {
 
 	return (
 		<View style={style}>
-			<View style={{ flex: 1, opacity: props.opacity }}>
+			<View style={{ flex: 1 }}>
 				<ScrollView scrollsToTop={false} style={styles_.menu}>
 					{items}
 				</ScrollView>

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useMemo, useEffect, useCallback, useContext } from 'react';
 import { Easing, Animated, TouchableOpacity, Text, StyleSheet, ScrollView, View, Image, ImageStyle } from 'react-native';
-const { connect } = require('react-redux');
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 const IonIcon = require('react-native-vector-icons/Ionicons').default;
 import Icon from './Icon';
 import Folder from '@joplin/lib/models/Folder';
@@ -21,21 +22,19 @@ import emptyTrash from '@joplin/lib/services/trash/emptyTrash';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { DialogContext } from './DialogManager';
 import { TextStyle, ViewStyle } from 'react-native';
+import { StateDecryptionWorker, StateResourceFetcher } from '@joplin/lib/reducer';
 const { TouchableRipple } = require('react-native-paper');
 const { substrWithEllipsis } = require('@joplin/lib/string-utils');
 
 interface Props {
 	syncStarted: boolean;
 	themeId: number;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	dispatch: Function;
+	dispatch: Dispatch;
 	collapsedFolderIds: string[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	syncReport: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	decryptionWorker: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	resourceFetcher: any;
+	decryptionWorker: StateDecryptionWorker;
+	resourceFetcher: StateResourceFetcher;
 	syncOnlyOverWifi: boolean;
 	isOnMobileData: boolean;
 	notesParentType: string;
@@ -56,8 +55,7 @@ const syncIconRotation = syncIconRotationValue.interpolate({
 
 const folderIconRightMargin = 10;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-let syncIconAnimation: any;
+let syncIconAnimation: Animated.CompositeAnimation|null = null;
 
 const SideMenuContentComponent = (props: Props) => {
 	const alwaysShowFolderIcons = useMemo(() => Folder.shouldShowFolderIcons(props.folders), [props.folders]);
@@ -414,7 +412,7 @@ const SideMenuContentComponent = (props: Props) => {
 	const renderFolderIcon = (folderId: string, folderIcon: FolderIcon) => {
 		if (!folderIcon) {
 			if (folderId === getTrashFolderId()) {
-				folderIcon = getTrashFolderIcon(FolderIconType.FontAwesome);
+				folderIcon = getTrashFolderIcon(FolderIconType.Emoji);
 			} else if (alwaysShowFolderIcons) {
 				return <IonIcon name="folder-outline" style={styles_.folderBaseIcon} />;
 			} else {
@@ -436,8 +434,7 @@ const SideMenuContentComponent = (props: Props) => {
 	const renderFolderItem = (folder: FolderEntity, hasChildren: boolean, depth: number) => {
 		const theme = themeStyle(props.themeId);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const folderButtonStyle: any = {
+		const folderButtonStyle: ViewStyle = {
 			flex: 1,
 			flexDirection: 'row',
 			flexBasis: 'auto',
@@ -450,8 +447,7 @@ const SideMenuContentComponent = (props: Props) => {
 		if (selected) folderButtonStyle.backgroundColor = theme.selectedColor;
 		folderButtonStyle.paddingLeft = depth * 10 + theme.marginLeft;
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const iconWrapperStyle: any = { paddingLeft: 10, paddingRight: 10 };
+		const iconWrapperStyle: ViewStyle = { paddingLeft: 10, paddingRight: 10 };
 		if (selected) iconWrapperStyle.backgroundColor = theme.selectedColor;
 
 		let iconWrapper = null;
@@ -504,7 +500,6 @@ const SideMenuContentComponent = (props: Props) => {
 		);
 	};
 
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	const renderSidebarButton = (key: string, title: string, iconName: string, onPressHandler: ()=> void = null, selected = false) => {
 		let icon = <IonIcon name={iconName} style={styles_.sidebarIcon} aria-hidden={true} />;
 

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -141,6 +141,7 @@ const SideMenuContentComponent = (props: Props) => {
 			folderEmojiIcon: {
 				...sidebarIconStyle,
 				...folderIconBase,
+				textAlign: undefined,
 				fontSize: theme.fontSize,
 			},
 			folderImageIcon: {

--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -1,13 +1,14 @@
-const React = require('react');
+import * as React from 'react';
 import { useMemo, useEffect, useCallback, useContext } from 'react';
-const { Easing, Animated, TouchableOpacity, Text, StyleSheet, ScrollView, View, Image } = require('react-native');
+import { Easing, Animated, TouchableOpacity, Text, StyleSheet, ScrollView, View, Image } from 'react-native';
 const { connect } = require('react-redux');
-const Icon = require('react-native-vector-icons/Ionicons').default;
+const IonIcon = require('react-native-vector-icons/Ionicons').default;
+import Icon from './Icon';
 import Folder from '@joplin/lib/models/Folder';
 import Synchronizer from '@joplin/lib/Synchronizer';
 import NavService from '@joplin/lib/services/NavService';
 import { _ } from '@joplin/lib/locale';
-import { ThemeStyle, themeStyle } from './global-style';
+import { themeStyle } from './global-style';
 import { buildFolderTree, isFolderSelected, renderFolders } from '@joplin/lib/components/shared/side-menu-shared';
 import { FolderEntity, FolderIcon, FolderIconType } from '@joplin/lib/services/database/types';
 import { AppState } from '../utils/types';
@@ -19,6 +20,7 @@ import restoreItems from '@joplin/lib/services/trash/restoreItems';
 import emptyTrash from '@joplin/lib/services/trash/emptyTrash';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { DialogContext } from './DialogManager';
+import { TextStyle, ViewStyle } from 'react-native';
 const { TouchableRipple } = require('react-native-paper');
 const { substrWithEllipsis } = require('@joplin/lib/string-utils');
 
@@ -63,27 +65,44 @@ const SideMenuContentComponent = (props: Props) => {
 	const styles_ = useMemo(() => {
 		const theme = themeStyle(props.themeId);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const styles: any = {
+		const buttonStyle: ViewStyle = {
+			flex: 1,
+			flexDirection: 'row',
+			flexBasis: 'auto',
+			height: 36,
+			alignItems: 'center',
+			paddingLeft: theme.marginLeft,
+			paddingRight: theme.marginRight,
+		};
+		const buttonTextStyle: TextStyle = {
+			flex: 1,
+			color: theme.color,
+			paddingLeft: 10,
+			fontSize: theme.fontSize,
+		};
+		const sidebarIconStyle: TextStyle = {
+			fontSize: 22,
+			color: theme.color,
+			width: 26,
+			textAlign: 'center',
+			textAlignVertical: 'center',
+		};
+		const folderButtonStyle: ViewStyle = {
+			...buttonStyle,
+			paddingLeft: 0,
+		};
+		const sideButtonStyle: ViewStyle = {
+			...buttonStyle,
+			flex: 0,
+		};
+
+		const styles = StyleSheet.create({
 			menu: {
 				flex: 1,
 				backgroundColor: theme.backgroundColor,
 			},
-			button: {
-				flex: 1,
-				flexDirection: 'row',
-				flexBasis: 'auto',
-				height: 36,
-				alignItems: 'center',
-				paddingLeft: theme.marginLeft,
-				paddingRight: theme.marginRight,
-			},
-			buttonText: {
-				flex: 1,
-				color: theme.color,
-				paddingLeft: 10,
-				fontSize: theme.fontSize,
-			},
+			button: buttonStyle,
+			buttonText: buttonTextStyle,
 			syncStatus: {
 				paddingLeft: theme.marginLeft,
 				paddingRight: theme.marginRight,
@@ -91,31 +110,42 @@ const SideMenuContentComponent = (props: Props) => {
 				fontSize: theme.fontSizeSmaller,
 				flex: 0,
 			},
-			sidebarIcon: {
-				fontSize: 22,
-				color: theme.color,
-				width: 26,
-				textAlign: 'center',
-				textAlignVertical: 'center',
+			sidebarIcon: sidebarIconStyle,
+			folderButton: folderButtonStyle,
+			folderButtonText: {
+				...buttonTextStyle,
+				paddingLeft: 0,
 			},
-		};
+			folderButtonSelected: {
+				...folderButtonStyle,
+				backgroundColor: theme.selectedColor,
+			},
+			folderToggleIcon: {
+				...theme.icon,
+				color: theme.colorFaded,
+				paddingTop: 3,
+			},
+			sideButton: sideButtonStyle,
+			sideButtonSelected: {
+				...sideButtonStyle,
+			},
+			sideButtonText: {
+				...buttonTextStyle,
+			},
+			folderTextIcon: {
+				...sidebarIconStyle,
+				marginRight: folderIconRightMargin,
+				width: 26,
+			},
+			folderImageIcon: {
+				marginRight: folderIconRightMargin,
+				width: 27,
+				height: 20,
+				resizeMode: 'contain',
+			},
+		});
 
-		styles.folderButton = { ...styles.button };
-		styles.folderButton.paddingLeft = 0;
-		styles.folderButtonText = { ...styles.buttonText, paddingLeft: 0 };
-		styles.folderButtonSelected = { ...styles.folderButton };
-		styles.folderButtonSelected.backgroundColor = theme.selectedColor;
-		styles.folderIcon = { ...theme.icon };
-		styles.folderIcon.color = theme.colorFaded; // '#0072d5';
-		styles.folderIcon.paddingTop = 3;
-
-		styles.sideButton = { ...styles.button, flex: 0 };
-		styles.sideButtonSelected = { ...styles.sideButton, backgroundColor: theme.selectedColor };
-		styles.sideButtonText = { ...styles.buttonText };
-
-		styles.emptyFolderIcon = { ...styles.sidebarIcon, marginRight: folderIconRightMargin, width: 26 };
-
-		return StyleSheet.create(styles);
+		return styles;
 	}, [props.themeId]);
 
 	useEffect(() => {
@@ -374,21 +404,23 @@ const SideMenuContentComponent = (props: Props) => {
 		if (actionDone === 'auth') props.dispatch({ type: 'SIDE_MENU_CLOSE' });
 	}, [performSync, props.dispatch]);
 
-	const renderFolderIcon = (folderId: string, theme: ThemeStyle, folderIcon: FolderIcon) => {
+	const renderFolderIcon = (folderId: string, folderIcon: FolderIcon) => {
 		if (!folderIcon) {
 			if (folderId === getTrashFolderId()) {
-				folderIcon = getTrashFolderIcon(FolderIconType.Emoji);
+				folderIcon = getTrashFolderIcon(FolderIconType.FontAwesome);
 			} else if (alwaysShowFolderIcons) {
-				return <Icon name="folder-outline" style={styles_.emptyFolderIcon} />;
+				return <IonIcon name="folder-outline" style={styles_.folderTextIcon} />;
 			} else {
 				return null;
 			}
 		}
 
-		if (folderIcon.type === 1) { // FolderIconType.Emoji
-			return <Text style={{ fontSize: theme.fontSize, marginRight: folderIconRightMargin, width: 27 }}>{folderIcon.emoji}</Text>;
-		} else if (folderIcon.type === 2) { // FolderIconType.DataUrl
-			return <Image style={{ width: 27, height: 20, marginRight: folderIconRightMargin, resizeMode: 'contain' }} source={{ uri: folderIcon.dataUrl }}/>;
+		if (folderIcon.type === FolderIconType.Emoji) {
+			return <Text style={styles_.folderTextIcon}>{folderIcon.emoji}</Text>;
+		} else if (folderIcon.type === FolderIconType.DataUrl) {
+			return <Image style={styles_.folderImageIcon} source={{ uri: folderIcon.dataUrl }}/>;
+		} else if (folderIcon.type === FolderIconType.FontAwesome) {
+			return <Icon style={styles_.folderTextIcon} name={folderIcon.name} accessibilityLabel={''}/>;
 		} else {
 			throw new Error(`Unsupported folder icon type: ${folderIcon.type}`);
 		}
@@ -419,12 +451,11 @@ const SideMenuContentComponent = (props: Props) => {
 
 		const collapsed = props.collapsedFolderIds.indexOf(folder.id) >= 0;
 		const iconName = collapsed ? 'chevron-down' : 'chevron-up';
-		const iconComp = <Icon name={iconName} style={styles_.folderIcon} />;
+		const iconComp = <IonIcon name={iconName} style={styles_.folderToggleIcon} />;
 
 		iconWrapper = !hasChildren ? null : (
 			<TouchableOpacity
 				style={iconWrapperStyle}
-				folderid={folder.id}
 				onPress={() => {
 					if (hasChildren) folder_togglePress(folder);
 				}}
@@ -455,7 +486,7 @@ const SideMenuContentComponent = (props: Props) => {
 					role='button'
 				>
 					<View style={folderButtonStyle}>
-						{renderFolderIcon(folder.id, theme, folderIcon)}
+						{renderFolderIcon(folder.id, folderIcon)}
 						<Text numberOfLines={1} style={styles_.folderButtonText}>
 							{Folder.displayTitle(folder)}
 						</Text>
@@ -467,8 +498,8 @@ const SideMenuContentComponent = (props: Props) => {
 	};
 
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	const renderSidebarButton = (key: string, title: string, iconName: string, onPressHandler: Function = null, selected = false) => {
-		let icon = <Icon name={iconName} style={styles_.sidebarIcon} aria-hidden={true} />;
+	const renderSidebarButton = (key: string, title: string, iconName: string, onPressHandler: ()=> void = null, selected = false) => {
+		let icon = <IonIcon name={iconName} style={styles_.sidebarIcon} aria-hidden={true} />;
 
 		if (key === 'synchronize_button') {
 			icon = <Animated.View style={{ transform: [{ rotate: syncIconRotation }] }}>{icon}</Animated.View>;


### PR DESCRIPTION
# Summary

This pull request refactors `side-menu-content.tsx` in the mobile app to:
1. Use stronger types:
    - For example, `styles_` no longer has type `any`.
2. Support (but, for now, not use) folders with FontAwesome icons (see https://github.com/laurent22/joplin/issues/11202).

# Testing
## Screenshot comparison

**Web/Chromium**:
![screenshot with before and after](https://github.com/user-attachments/assets/adfd2d52-3928-4f43-8b3b-1b5936c003ca)



## Additional manual testing

**Web/Chromium**:
1. Right-click on a notebook and select "edit".
2. Verify that the edit screen is shown.
3. Show the sidebar.
4. Click "All notes".
5. Verify that "All notes" is shown.
6. Click on a notebook.
7. Verify that the notebook is opened.
8. Click "Configuration".
9. Verify that the settings screen is open.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->