### PR TITLE
Chore: Disable flaky end-to-end PDF link test

### DIFF
--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -78,24 +78,6 @@ test.describe('markdownEditor', () => {
 		await mainScreen.noteEditor.toggleEditorsButton.click();
 
 		await expectToBeRendered();
-
-		// Clicking on the PDF link should attempt to open it in a viewer
-		await expect(pdfLink).toBeVisible();
-
-		const nextOpenFilePromise = electronApp.evaluate(({ shell }) => {
-			return new Promise<string>(resolve => {
-				const openPath = async (url: string) => {
-					resolve(url);
-					return '';
-				};
-				shell.openPath = openPath;
-			});
-		});
-		await pdfLink.click();
-		expect(await nextOpenFilePromise).toMatch(/\.pdf$/);
-
-		// Should not have rendered something else in the viewer frame
-		await expectToBeRendered();
 	});
 
 	test('preview pane should render video attachments', async ({ mainWindow, electronApp }) => {


### PR DESCRIPTION
# Summary

This pull request removes part of the `preview pane should render PDFs` test that has failed several times in CI.

**What it tested**:
- Verified that clicking on the link above a PDF attachment attempted to open the PDF in an external viewer.

**How it failed**:
- Sometimes, the `nextOpenFilePromise` would never resolve. I suspect that this was due to a race condition &mdash; the result from `nextOpenFilePromise` isn't `await`ed until after clicking the PDF link. As such, it may have been possible for the `nextOpenFilePromise` to start listening for a file open just **after** the PDF link was clicked.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->