### PR TITLE
Desktop: Fixes #11249: Add sha512sum Checksum Generation for macOS .dmg Builds

### DIFF
--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -80,6 +80,14 @@ jobs:
             echo "Building and publishing desktop application..."
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn dist --mac --arm64
 
+            # Add step to generate sha512sum
+            echo "Generating sha512 checksum for the dmg..."
+            shasum -a 512 dist/*.dmg > dist/joplin.dmg.sha512sum
+
+            # Upload checksum file
+            yarn modifyReleaseAssets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GITHUB_TOKEN"
+            gh release upload "$GIT_TAG_NAME" dist/joplin.dmg.sha512sum
+
             yarn modifyReleaseAssets --repo="$GH_REPO" --tag="$GIT_TAG_NAME" --token="$GITHUB_TOKEN"
           else
             echo "Building but *not* publishing desktop application..."
@@ -92,4 +100,8 @@ jobs:
             npm pkg set 'build.mac.identity'=null --json
 
             PYTHON_PATH=$(which python) USE_HARD_LINKS=false yarn dist  --mac --arm64 --publish=never
+
+            # Add step to generate sha512sum for non-published build
+            echo "Generating sha512 checksum for the dmg..."
+            shasum -a 512 dist/*.dmg > dist/joplin.dmg.sha512sum
           fi


### PR DESCRIPTION
This PR introduces a fix for the macOS build process by adding sha512sum checksum generation for .dmg files. The checksum file ensures cross-platform integrity verification, allowing users on any operating system to validate the downloaded .dmg files.

Fixes #11249

Key Changes:
Generate sha512sum for macOS .dmg Files:

After building the .dmg file, the pipeline now generates a sha512sum checksum for verification purposes.
The checksum is stored as joplin.dmg.sha512sum.
Checksum Upload to Release Assets:

When publishing is enabled, the checksum file is automatically uploaded to the release assets on GitHub alongside the .dmg file.
Support for Non-Published Builds:

The pipeline generates the checksum file even when the build is not published (e.g., in branches or pull requests), though the file is not uploaded to a release.
Reason for the Change:
The current build process relies on platform-specific mechanisms to verify the integrity of macOS .dmg files. This change provides a platform-independent solution by using a sha512sum checksum, improving security and ease of use for all users.
