### PR TITLE
Desktop: Fixes #11274: Fix content dropped into the Markdown editor is missing a cursor preview or dropped at the wrong location

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -39,18 +39,21 @@ const useEditorCommands = (props: Props) => {
 
 		return {
 			dropItems: async (cmd: DropCommandValue) => {
+				let pos = cmd.pos && editorRef.current.editor.posAtCoords({ x: cmd.pos.clientX, y: cmd.pos.clientY });
 				if (cmd.type === 'notes') {
 					const text = cmd.markdownTags.join('\n');
-
-					const pos = cmd.pos && editorRef.current.editor.posAtCoords({ x: cmd.pos.clientX, y: cmd.pos.clientY });
 					if ((pos ?? null) !== null) {
 						editorRef.current.select(pos, pos);
 					}
 
 					editorRef.current.insertText(text, UserEventSource.Drop);
 				} else if (cmd.type === 'files') {
-					const pos = props.selectionRange.from;
-					const newBody = await commandAttachFileToBody(props.editorContent, cmd.paths, { createFileURL: !!cmd.createFileURL, position: pos, markupLanguage: props.contentMarkupLanguage });
+					pos ??= props.selectionRange.from;
+					const newBody = await commandAttachFileToBody(props.editorContent, cmd.paths, {
+						createFileURL: !!cmd.createFileURL,
+						position: pos,
+						markupLanguage: props.contentMarkupLanguage,
+					});
 					editorRef.current.updateBody(newBody);
 				} else {
 					logger.warn('CodeMirror: unsupported drop item: ', cmd);

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -252,3 +252,16 @@ export interface CommandValue {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	value?: any; // For TinyMCE only
 }
+
+export type DropCommandValue = {
+	type: 'notes';
+	pos: {
+		clientX: number;
+		clientY: number;
+	}|undefined;
+	markdownTags: string[];
+}|{
+	type: 'files';
+	paths: string[];
+	createFileURL: boolean;
+};

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -253,15 +253,18 @@ export interface CommandValue {
 	value?: any; // For TinyMCE only
 }
 
-export type DropCommandValue = {
-	type: 'notes';
+type DropCommandBase = {
 	pos: {
 		clientX: number;
 		clientY: number;
 	}|undefined;
+};
+
+export type DropCommandValue = ({
+	type: 'notes';
 	markdownTags: string[];
 }|{
 	type: 'files';
 	paths: string[];
 	createFileURL: boolean;
-};
+}) & DropCommandBase;

--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import Note from '@joplin/lib/models/Note';
 import { DragEvent as ReactDragEvent } from 'react';
+import { DropCommandValue } from './types';
 
 interface HookDependencies {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -29,12 +30,18 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 					noteMarkdownTags.push(Note.markdownTag(note));
 				}
 
+				const props: DropCommandValue = {
+					type: 'notes',
+					pos: {
+						clientX: event.clientX,
+						clientY: event.clientY,
+					},
+					markdownTags: noteMarkdownTags,
+				};
+
 				editorRef.current.execCommand({
 					name: 'dropItems',
-					value: {
-						type: 'notes',
-						markdownTags: noteMarkdownTags,
-					},
+					value: props,
 				});
 			};
 			void dropNotes();
@@ -51,13 +58,15 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 				paths.push(file.path);
 			}
 
+			const props: DropCommandValue = {
+				type: 'files',
+				paths: paths,
+				createFileURL: createFileURL,
+			};
+
 			editorRef.current.execCommand({
 				name: 'dropItems',
-				value: {
-					type: 'files',
-					paths: paths,
-					createFileURL: createFileURL,
-				},
+				value: props,
 			});
 			return true;
 		}

--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -20,6 +20,11 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 		const dt = event.dataTransfer;
 		const createFileURL = event.altKey;
 
+		const eventPosition = {
+			clientX: event.clientX,
+			clientY: event.clientY,
+		};
+
 		if (dt.types.indexOf('text/x-jop-note-ids') >= 0) {
 			const noteIds = JSON.parse(dt.getData('text/x-jop-note-ids'));
 
@@ -32,10 +37,7 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 
 				const props: DropCommandValue = {
 					type: 'notes',
-					pos: {
-						clientX: event.clientX,
-						clientY: event.clientY,
-					},
+					pos: eventPosition,
 					markdownTags: noteMarkdownTags,
 				};
 
@@ -60,6 +62,7 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 
 			const props: DropCommandValue = {
 				type: 'files',
+				pos: eventPosition,
 				paths: paths,
 				createFileURL: createFileURL,
 			};

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -6,6 +6,7 @@ import { classHighlighter } from '@lezer/highlight';
 
 import {
 	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command, rectangularSelection,
+	dropCursor,
 } from '@codemirror/view';
 import { history, undoDepth, redoDepth, standardKeymap } from '@codemirror/commands';
 
@@ -253,6 +254,8 @@ const createEditor = (
 
 				// Apply styles to entire lines (block-display decorations)
 				decoratorExtension,
+				dropCursor(),
+
 				biDirectionalTextExtension,
 
 				// Adds additional CSS classes to tokens (the default CSS classes are

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -90,6 +90,7 @@ export interface ContentScriptData {
 // Intended to correspond with https://codemirror.net/docs/ref/#state.Transaction%5EuserEvent
 export enum UserEventSource {
 	Paste = 'input.paste',
+	Drop = 'input.drop',
 }
 
 export interface EditorControl {


### PR DESCRIPTION
# Summary

This pull request:
1. resolves #11274
2. resolves a similar (but not identical) issue reported [on the forum](https://discourse.joplinapp.org/t/drag-and-drop-text-cursor/41568).

In particular:
1. In-editor content was dropped at the correct location, but no preview cursor was shown.
2. Notes were dropped at the last editor cursor location.

> [!NOTE]
>
> This pull request targets `release-3.1`.

# Screen recording

[Screencast from 2024-10-29 15-54-21.webm](https://github.com/user-attachments/assets/cd015504-be27-4519-b430-64d180c0c0e5)


# Manual testing plan

**MacOS (Sequoia)**: (MacOS testing done before rebasing on release-3.1).
1. Drag a note from the note list over the editor.
2. Verify that a preview cursor is visible.
3. Drop the note at a location distinct from the current editor cursor.
4. Verify that the note is dropped at that position.

**Fedora 41**:
1. Open Chromium.
   - Files from Firefox and the Files app often fail to drop into Joplin. This is the case with both with the new and legacy editors. Drag and drop from Chromium's "Downloads" list seems to work consistently.
2. Download 2-3 images (2 PNGs, 1 SVG).
3. Drop a PNG from the downloads list into Joplin's Markdown editor.
4. Verify that the image drops successfully.
5. Drop the SVG from the downloads list into a different location in Joplin's Markdown editor.
7. Verify that the image is dropped at the mouse's last location.
8. Drop a note from the note list into the editor.
9. Verify that a note link is added at the mouse's last location.
10. Select text in the editor.
11. Drag and drop the text to a different part of the editor.
12. Verify that the text is moved.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->