### PR TITLE
Desktop: Resolves #11279: Remove left/right edge margin around editor content when disabled in settings

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -378,6 +378,8 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			katexEnabled: Setting.value('markdown.plugin.katex'),
 			themeData: {
 				...styles.globalTheme,
+				marginLeft: 0,
+				marginRight: 0,
 				monospaceFont: Setting.value('style.editor.monospaceFontFamily'),
 			},
 			automatchBraces: Setting.value('editor.autoMatchingBraces'),

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -79,6 +79,10 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 	// be at least this specific.
 	const selectionBackgroundSelector = '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground';
 
+	// Matches the editor only when there are no gutters (e.g. line numbers) added by
+	// plugins
+	const editorNoGuttersSelector = '&:not(:has(> .cm-scroller > .cm-gutters))';
+
 	const baseHeadingStyle = {
 		fontWeight: 'bold',
 		fontFamily: theme.fontFamily,
@@ -178,6 +182,12 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			// Center
 			marginLeft: 'auto',
 			marginRight: 'auto',
+		} : undefined,
+
+		// Allows editor content to be left-aligned with the toolbar on desktop.
+		// See https://github.com/laurent22/joplin/issues/11279
+		[`${editorNoGuttersSelector} .cm-line`]: theme.isDesktop ? {
+			paddingLeft: 0,
 		} : undefined,
 
 		// Override the default URL style when the URL is within a link


### PR DESCRIPTION
# Summary

This pull request resolves #11279 by:
1. Removing left and right margins from the editor.
2. Removing CodeMirror's `2px` left-edge padding **unless the editor has a gutter**.
    - Gutters include line numbers, fold/unfold markers, and certain types of other content added by plugins.
    - Without the "unless the editor has a gutter" exception, gutters leave no space between the note text and the gutter's content:<br/> ![screenshot: Line number gutter is touching editor content](https://github.com/user-attachments/assets/bb1e0626-b04a-450c-a5e4-5e2edcc02aaa)<br/>Gutters can be added by plugins with, for example, the CodeMirror [lineNumbers](https://codemirror.net/docs/ref/#view.lineNumbers) extension.


# Screenshot comparison

**Note**: Desktop screenshots are from Fedora 41/Linux.
**Note**: Web screenshots are from Chromium 130 on Fedora 41.

| Description | Before | After |
|---|---|---|
| Desktop: No plugins | ![image](https://github.com/user-attachments/assets/c7c75718-8c4a-4a5e-b392-8902e99f0052) | ![editor text now is left-aligned with the toolbar](https://github.com/user-attachments/assets/7ac7fdc6-14e7-4e92-b002-a235470770fd) |
| Desktop: Small editor maximum width | ![image](https://github.com/user-attachments/assets/6ad61df2-24d1-4753-b173-07cdfe0f6097) | ![appears roughly identical to before](https://github.com/user-attachments/assets/cabe366e-9d80-492d-ae7c-b174d0663f45) |
| Desktop: Plugin that adds line numbers | ![image](https://github.com/user-attachments/assets/84a2f6f7-b855-46ff-9514-a192400ae293)| ![similar to before, but less horizontal space between line numbers and editor content](https://github.com/user-attachments/assets/23763e88-7009-46e6-b6c7-fbfaaf030819) |
| Web: No plugins | ![image](https://github.com/user-attachments/assets/483cc104-a884-476a-a8c6-d6de1b05591f) | ![roughly identical to before](https://github.com/user-attachments/assets/af76f301-4ecc-4394-96a6-dcee91479b0c) |
| Web: With a plugin that adds line numbers | ![image](https://github.com/user-attachments/assets/69b765f6-878b-4a88-a443-d69eb5dd6db9) | ![roughly identical to before](https://github.com/user-attachments/assets/54e561c3-05ff-461a-b3cf-ec02ed2c10d4)  |
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->