### PR TITLE
Desktop: Custom CSS: Add cm-listItem class to lines with list items, don't add region start/end markers for items that are always single-line

### DIFF
--- a/packages/editor/CodeMirror/markdown/decoratorExtension.ts
+++ b/packages/editor/CodeMirror/markdown/decoratorExtension.ts
@@ -84,6 +84,14 @@ const tableDelimiterDecoration = Decoration.line({
 	attributes: { class: 'cm-tableDelimiter' },
 });
 
+const orderedListDecoration = Decoration.line({
+	attributes: { class: 'cm-orderedList' },
+});
+
+const unorderedListDecoration = Decoration.line({
+	attributes: { class: 'cm-unorderedList' },
+});
+
 const listItemDecoration = Decoration.line({
 	attributes: { class: 'cm-listItem' },
 });
@@ -101,6 +109,10 @@ const nodeNameToLineDecoration: Record<string, Decoration> = {
 	'CodeBlock': codeBlockDecoration,
 	'BlockMath': mathBlockDecoration,
 	'Blockquote': blockQuoteDecoration,
+	'OrderedList': orderedListDecoration,
+	'BulletList': unorderedListDecoration,
+
+	'ListItem': listItemDecoration,
 
 	'SetextHeading1': header1LineDecoration,
 	'ATXHeading1': header1LineDecoration,
@@ -114,8 +126,6 @@ const nodeNameToLineDecoration: Record<string, Decoration> = {
 	'TableHeader': tableHeaderDecoration,
 	'TableDelimiter': tableDelimiterDecoration,
 	'TableRow': tableBodyDecoration,
-
-	'ListItem': listItemDecoration,
 };
 
 const nodeNameToMarkDecoration: Record<string, Decoration> = {
@@ -133,6 +143,8 @@ const multilineNodes = {
 	'CodeBlock': true,
 	'BlockMath': true,
 	'Blockquote': true,
+	'OrderedList': true,
+	'BulletList': true,
 };
 
 type DecorationDescription = { pos: number; length: number; decoration: Decoration };

--- a/packages/editor/CodeMirror/markdown/decoratorExtension.ts
+++ b/packages/editor/CodeMirror/markdown/decoratorExtension.ts
@@ -84,6 +84,10 @@ const tableDelimiterDecoration = Decoration.line({
 	attributes: { class: 'cm-tableDelimiter' },
 });
 
+const listItemDecoration = Decoration.line({
+	attributes: { class: 'cm-listItem' },
+});
+
 const horizontalRuleDecoration = Decoration.mark({
 	attributes: { class: 'cm-hr' },
 });
@@ -110,6 +114,8 @@ const nodeNameToLineDecoration: Record<string, Decoration> = {
 	'TableHeader': tableHeaderDecoration,
 	'TableDelimiter': tableDelimiterDecoration,
 	'TableRow': tableBodyDecoration,
+
+	'ListItem': listItemDecoration,
 };
 
 const nodeNameToMarkDecoration: Record<string, Decoration> = {
@@ -122,6 +128,12 @@ const nodeNameToMarkDecoration: Record<string, Decoration> = {
 	'TaskMarker': taskMarkerDecoration,
 };
 
+const multilineNodes = {
+	'FencedCode': true,
+	'CodeBlock': true,
+	'BlockMath': true,
+	'Blockquote': true,
+};
 
 type DecorationDescription = { pos: number; length: number; decoration: Decoration };
 
@@ -179,8 +191,8 @@ const computeDecorations = (view: EditorView) => {
 					addDecorationToRange(viewFrom, viewTo, decoration);
 				}
 
-				// Only block decorations will have differing first and last lines
-				if (blockDecorated) {
+				// Only certain block decorations will have differing first and last lines
+				if (blockDecorated && multilineNodes.hasOwnProperty(node.name)) {
 					// Allow different styles for the first, last lines in a block.
 					if (viewFrom === node.from) {
 						addDecorationToLines(viewFrom, viewFrom, regionStartDecoration);


### PR DESCRIPTION
# Summary

The goal of this pull request is to simplify custom styling of the CodeMirror 6-based editor:
- With the legacy CodeMirror 5 editor, it was possible to style list items. With CodeMirror 6, this is only possible by referring to internal class names.
- The CodeMirror 6-based editor was adding unnecessary `cm-regionFirstLine` and `cm-regionLastLine` classes to regions that are **always single-line**.
    - This could complicate styling if headers or other affected items were present in a multi-line region (e.g. a blockquote).

> [!NOTE]
>
> This currently targets `release-3.1`. Previously, certain list-specific custom styles were impossible (or very difficult) to migrate from CodeMirror 5 to CodeMirror 6.
>

# Screenshot

![screenshot: Shows headers 1 and 2, a monospaced table, numbered and unordered lists open in Joplin with the dev tools visible](https://github.com/user-attachments/assets/ef99b8fe-f6d0-4cb1-9a53-f845f8ac4c1d)
![screenshot: Same as previous screenshot, but in dark mode and with a code block also visible](https://github.com/user-attachments/assets/65d5c3ea-b81f-4343-bd91-0e6f3066e908)


# CSS comparison



<table><thead><th>Before</th><th>After</th></thead>
<tbody>
<tr><td>Header 1</td><td>

`class="cm-h1 cm-headerLine cm-header cm-regionFirstLine cm-regionLastLine cm-line"`

</td><td>


`class="cm-h1 cm-headerLine cm-header cm-line"`

</td>
</tr>

<tr><td>Block math</td><td>

- First line:
    - `class="cm-mathBlock cm-regionFirstLine cm-line"`
- Middle lines:
    - `class="cm-mathBlock cm-line"`
- Last line:
    - `class="cm-mathBlock cm-regionLastLine cm-line"`

</td><td>

- First line:
    - `class="cm-mathBlock cm-regionFirstLine cm-line"`
- Middle lines:
    - `class="cm-mathBlock cm-line"`
- Last line:
    - `class="cm-mathBlock cm-regionLastLine cm-line"`

</td>
</tr>
<tr><td>Single-level ordered list</td><td>

- First line:
    - `class="cm-line"`
- Middle lines:
    - `class="cm-line"`
- Last line:
    - `class="cm-line"`

</td><td>

- First line:
    - `class="cm-orderedList cm-regionFirstLine cm-listItem cm-line"`
- Middle lines:
    - `class="cm-orderedList cm-listItem cm-line"`
- Last line:
    - `class="cm-orderedList cm-regionLastLine cm-listItem cm-line"`

</td>
</tr>
<tr><td>Single-level unordered list (bullet list/task list)</td><td>

- First line:
    - `class="cm-line"`
- Middle lines:
    - `class="cm-line"`
- Last line:
    - `class="cm-line"`

</td><td>

- First line:
    - `class="cm-unorderedList cm-regionFirstLine cm-listItem cm-line"`
- Middle lines:
    - `class="cm-unorderedList cm-listItem cm-line"`
- Last line:
    - `class="cm-unorderedList cm-regionLastLine cm-listItem cm-line"`

</td>
</tr>
</tbody>
</table>

**Note**: This pull request does not make it possible to consistently style even/odd list items differently (without a plugin).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->