### PR TITLE
Mobile: Fixes #11197: Fix search result note hidden after powering on device

### DIFF
--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -167,6 +167,9 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 		});
 
 		if (source === props.notesSource) return;
+		// TODO: For now, search refresh is handled by the search screen. In the future,
+		// this should be refactored to use the same logic as desktop and CLI.
+		if (props.notesParentType === 'Search') return;
 
 		let notes: NoteEntity[] = [];
 		if (props.notesParentType === 'Folder') {

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -167,8 +167,7 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 		});
 
 		if (source === props.notesSource) return;
-		// TODO: For now, search refresh is handled by the search screen. In the future,
-		// this should be refactored to use the same logic as desktop and CLI.
+		// For now, search refresh is handled by the search screen.
 		if (props.notesParentType === 'Search') return;
 
 		let notes: NoteEntity[] = [];

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -308,6 +308,10 @@ const appReducer = (state = appDefaultState, action: any) => {
 
 				newState.selectedNoteHash = '';
 
+				if (action.routeName === 'Search') {
+					newState.notesParentType = 'Search';
+				}
+
 				if ('noteId' in action) {
 					newState.selectedNoteIds = action.noteId ? [action.noteId] : [];
 				}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -348,6 +348,8 @@ const appReducer = (state = appDefaultState, action: any) => {
 
 				newState.route = action;
 				newState.historyCanGoBack = !!navHistory.length;
+
+				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
 			}
 			break;
 


### PR DESCRIPTION
# Summary

This pull request fixes an issue where actions that caused `refreshNotes` to be called caused notes opened from a search to vanish.

Fixes #11197

> [!NOTE]
>
> This pull request targets `release-3.1`.

# Explanation

Previously, after:
1. searching, then
2. opening a search result,

the app state had `notesParentType` set to `Folder`.

As such, when `refreshNotes` was called,
1. `state.notes` was refreshed and
2. [the reducer removed items from `selectedNoteIds`](https://github.com/laurent22/joplin/blob/a62e35c123d7e6be517d51895ffdb97f2743bc2e/packages/lib/reducer.ts#L511) that were not in `selectedFolderId`.

This then caused the note screen's [`noteId` prop to be set to `null`](https://github.com/laurent22/joplin/blob/a62e35c123d7e6be517d51895ffdb97f2743bc2e/packages/app-mobile/components/screens/Note.tsx#L1659), which then caused the note screen to display an empty note.

This pull request sets `notesParentType` to `Search` when the search screen is opened, which prevents `refreshNotes` from updating `state.notes` while viewing a search result.

> [!NOTE]
>
> Currently, the mobile and desktop apps use different logic for managing search state. A better solution might be to update the mobile app to use the same `reducer` logic as the desktop and CLI apps. Such a solution, however, may require significant mobile app refactoring.

# Testing plan

**Android API 35 emulator**:
1. Ensure that at least two notebooks exist, both with notes.
2. Open one of the two notebooks.
3. Search for a note in the other notebook.
4. Open the note in the other notebook from the search screen.
5. Turn off the emulator (using the power button).
6. Turn on the emulator.
7. Verify that the note is still open.
8. Press the back button.
9. Press the back button.
10. Search for "navigated to route" in the console with the emulator's logs.
11. Verify that the last 4 lines containing "Navigated to route" are:
    ````
    root: Navigated to route: Search with notesParentType: Search
    root: Navigated to route: Note with notesParentType: Search
    root: Navigated to route: Search with notesParentType: Search
    root: Navigated to route: Notes with notesParentType: Folder
    ````
12. Re-open the search screen.
13. Open a note with a link.
14. Click the link.
15. Turn off the emulator (using the power button).
16. Turn on the emulator (using the power button).
17. Verify that the note opened in step 14 is still visible.
18. Press the back button.
19. Press the back button.
20. Press the back button.
21. Verify that the notes screen is open.
22. Verify that the last line containing "Navigated to route" in the log is:
    ```
    root: Navigated to route: Notes with notesParentType: Folder
    ```
23. Open "All Notes".
24. Search and open a search result.
25. Turn off the emulator and turn it back on again.
26. Verify that the note is still open.
27. Press the back button.
28. Press the back button.
29. Verify that "All notes" is open.
30. Verify that the last line containing "Navigated to route" in the log is:
    ```
    root: Navigated to route: Notes with notesParentType: SmartFilter
    ```
31. **Regression testing/tags**: Navigate to the "Tags" screen and open a tag.
32. Open a note associated with the tag.
33. Add a new tag to the note.
34. Close the tag dialog.
35. Remove the original tag.
36. Close the tag dialog.
37. Verify that the note is still open.
38. Press the back button.
39. Verify that the note is no longer included in the tag list.
40. **Regression testing/deletions**: Open a folder.
41. Open a note in the folder.
42. Delete the note from the note actions menu.
43. Verify that the note is closed and the note's parent folder is opened.
44. Open the trash folder.
45. Open the note in the trash folder.
46. Permanently delete the note.
47. Verify that the note is closed and the trash folder is opened.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->