### PR TITLE
Mobile: Center sidebar icons

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -140,7 +140,6 @@ const SideMenuContentComponent = (props: Props) => {
 			folderEmojiIcon: {
 				...sidebarIconStyle,
 				...folderIconBase,
-				textAlign: undefined,
 				fontSize: theme.fontSize,
 			},
 			folderImageIcon: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21308,6 +21308,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "detect-libc@npm:1.0.3"
+  bin:
+    detect-libc: ./bin/detect-libc.js
+  checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.1":
   version: 2.0.1
   resolution: "detect-libc@npm:2.0.1"


### PR DESCRIPTION
# Summary

This pull request centers custom sidebar Emoji icons on mobile. Previously, Emoji icons were left-aligned.

> [!NOTE]
> 
> This pull request includes changes from https://github.com/laurent22/joplin/pull/11298.

# Screenshot

**Web**:
![screenshot: Compares before and after. Before, sidebar icons were left-aligned. After, they are centered.](https://github.com/user-attachments/assets/5d5a12e7-9afd-48a7-89c1-2752e956341f)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->