### PR TITLE
Chore: Disable flaky test: Disable Rich Text Editor case of the `editor.setText` command test

### DIFF
--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -3,31 +3,24 @@ import { test } from './util/test';
 import MainScreen from './models/MainScreen';
 
 test.describe('pluginApi', () => {
-	for (const richTextEditor of [false, true]) {
-		test(`the editor.setText command should update the current note (use RTE: ${richTextEditor})`, async ({ startAppWithPlugins }) => {
-			const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/execCommand.js']);
-			const mainScreen = new MainScreen(mainWindow);
-			await mainScreen.createNewNote('First note');
-			const editor = mainScreen.noteEditor;
+	test('the editor.setText command should update the current note (use RTE: false)', async ({ startAppWithPlugins }) => {
+		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/execCommand.js']);
+		const mainScreen = new MainScreen(mainWindow);
+		await mainScreen.createNewNote('First note');
+		const editor = mainScreen.noteEditor;
 
-			await editor.focusCodeMirrorEditor();
-			await mainWindow.keyboard.type('This content should be overwritten.');
+		await editor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('This content should be overwritten.');
 
-			if (richTextEditor) {
-				await editor.toggleEditorsButton.click();
-				await editor.richTextEditor.click();
-			}
+		await editor.expectToHaveText('This content should be overwritten.');
+		await mainScreen.goToAnything.runCommand(app, 'testUpdateEditorText');
+		await editor.expectToHaveText('PASS');
 
-			await editor.expectToHaveText('This content should be overwritten.');
-			await mainScreen.goToAnything.runCommand(app, 'testUpdateEditorText');
-			await editor.expectToHaveText('PASS');
+		// Should still have the same text after switching notes:
+		await mainScreen.createNewNote('Second note');
+		await editor.goBack();
 
-			// Should still have the same text after switching notes:
-			await mainScreen.createNewNote('Second note');
-			await editor.goBack();
-
-			await editor.expectToHaveText('PASS');
-		});
-	}
+		await editor.expectToHaveText('PASS');
+	});
 });
 


### PR DESCRIPTION
# Summary

This disables the Rich Text Editor variant of the `editor.setText` command test, which has failed frequently in CI.

See https://github.com/laurent22/joplin/actions/runs/11672227647/job/32500411318#step:14:1222

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->