### PR TITLE
Desktop: Fixes #11313: Don't completely left-align the editor with the toolbar

### DIFF
--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -79,6 +79,10 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 	// be at least this specific.
 	const selectionBackgroundSelector = '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground';
 
+	// Matches the editor only when there are no gutters (e.g. line numbers) added by
+	// plugins
+	const editorNoGuttersSelector = '&:not(:has(> .cm-scroller > .cm-gutters))';
+
 	const baseHeadingStyle = {
 		fontWeight: 'bold',
 		fontFamily: theme.fontFamily,
@@ -178,6 +182,13 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			// Center
 			marginLeft: 'auto',
 			marginRight: 'auto',
+		} : undefined,
+
+		// Allows editor content to be left-aligned with the toolbar on desktop.
+		// See https://github.com/laurent22/joplin/issues/11279
+		[`${editorNoGuttersSelector} .cm-line`]: theme.isDesktop ? {
+			// Note: This cannot be zero:
+			paddingLeft: '1px',
 		} : undefined,
 
 		// Override the default URL style when the URL is within a link

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -79,10 +79,6 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 	// be at least this specific.
 	const selectionBackgroundSelector = '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground';
 
-	// Matches the editor only when there are no gutters (e.g. line numbers) added by
-	// plugins
-	const editorNoGuttersSelector = '&:not(:has(> .cm-scroller > .cm-gutters))';
-
 	const baseHeadingStyle = {
 		fontWeight: 'bold',
 		fontFamily: theme.fontFamily,
@@ -182,12 +178,6 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			// Center
 			marginLeft: 'auto',
 			marginRight: 'auto',
-		} : undefined,
-
-		// Allows editor content to be left-aligned with the toolbar on desktop.
-		// See https://github.com/laurent22/joplin/issues/11279
-		[`${editorNoGuttersSelector} .cm-line`]: theme.isDesktop ? {
-			paddingLeft: 0,
 		} : undefined,
 
 		// Override the default URL style when the URL is within a link


### PR DESCRIPTION
# Summary

This pull request adjusts the fix for https://github.com/laurent22/joplin/issues/11279 &mdash; completely removing left-edge padding from the editor caused the cursor to be invisible when at the start of the line.

Fixes #11313.

> [!NOTE]
>
> This pull request targets release-3.1

> [!NOTE]
>
> **Until this is merged, a temporary workaround might be:** In settings > appearance, set "editor maximum width" to a number smaller than the Markdown editor's width.

# Screen recordings

1. Dark mode, multiple cursors at the beginning and end of lines

    [Screencast from 2024-11-05 08-32-57.webm](https://github.com/user-attachments/assets/5845fce8-cf34-4db7-b6ab-f010aa10f611)

2. Switching from dark mode to light mode, single cursor at the beginning of a line
  
  [Screencast from 2024-11-05 08-36-28.webm](https://github.com/user-attachments/assets/71e5149d-937c-498b-a3be-5c9d64cfb886)

# Screenshots

**Note**: All screenshots are from Fedora 41 Linux/GNOME.

## Cursor at the beginning of a line in a code block

![screenshot: Cursor at the beginning of a code block line](https://github.com/user-attachments/assets/43a8833e-3418-49e7-a597-1a3cf9d4b710)

## Cursor at the beginning of a paragraph line

![screenshot: Cursor at the beginning of a paragraph line](https://github.com/user-attachments/assets/dee118a4-a0aa-40a0-a420-139fabbcef79)

## Cursor at the end of a paragraph

![screenshot: Shows the cursor at the end of a paragraph](https://github.com/user-attachments/assets/26f4b552-e413-4d01-ac85-73b99a062cce)






<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->