### PR TITLE
Mobile: Fixes #11276: Fix new note button is pushed offscreen on certain Android devices

### DIFF
--- a/packages/app-mobile/components/buttons/FloatingActionButton.tsx
+++ b/packages/app-mobile/components/buttons/FloatingActionButton.tsx
@@ -71,12 +71,17 @@ const FloatingActionButton = (props: ActionButtonProps) => {
 	// is disabled.
 	//
 	// See https://github.com/callstack/react-native-paper/issues/4064
+	// May be possible to remove if https://github.com/callstack/react-native-paper/pull/4514
+	// is merged.
 	const adjustMargins = !open && shim.mobilePlatform() === 'android';
 	const marginStyles = useMemo((): ViewStyle => {
 		if (!adjustMargins) {
 			return {};
 		}
 
+		// Internally, React Native Paper uses absolute positioning to make its
+		// (usually invisible) view fill the screen. Setting top and left to
+		// undefined causes the view to take up only part of the screen.
 		return {
 			top: undefined,
 			left: undefined,

--- a/packages/app-mobile/components/buttons/FloatingActionButton.tsx
+++ b/packages/app-mobile/components/buttons/FloatingActionButton.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { FAB, Portal } from 'react-native-paper';
 import { _ } from '@joplin/lib/locale';
 import { Dispatch } from 'redux';
-import { Platform, useWindowDimensions, View } from 'react-native';
+import { Platform, View, ViewStyle } from 'react-native';
 import shim from '@joplin/lib/shim';
 import AccessibleWebMenu from '../accessibility/AccessibleModalMenu';
 const Icon = require('react-native-vector-icons/Ionicons').default;
@@ -71,10 +71,17 @@ const FloatingActionButton = (props: ActionButtonProps) => {
 	// is disabled.
 	//
 	// See https://github.com/callstack/react-native-paper/issues/4064
-	const windowSize = useWindowDimensions();
 	const adjustMargins = !open && shim.mobilePlatform() === 'android';
-	const marginTop = adjustMargins ? Math.max(0, windowSize.height - 140) : undefined;
-	const marginStart = adjustMargins ? Math.max(0, windowSize.width - 200) : undefined;
+	const marginStyles = useMemo((): ViewStyle => {
+		if (!adjustMargins) {
+			return {};
+		}
+
+		return {
+			top: undefined,
+			left: undefined,
+		};
+	}, [adjustMargins]);
 
 	const label = props.mainButton?.label ?? _('Add new');
 
@@ -92,7 +99,7 @@ const FloatingActionButton = (props: ActionButtonProps) => {
 	const menuContent = <FAB.Group
 		open={open}
 		accessibilityLabel={label}
-		style={{ marginStart, marginTop }}
+		style={marginStyles}
 		icon={ open ? openIcon : closedIcon }
 		fabStyle={{
 			backgroundColor: props.mainButton?.color ?? 'rgba(231,76,60,1)',


### PR DESCRIPTION
# Summary

This pull request fixes a regression &mdash; on certain Android devices, the "+" button for creating new notes was pushed partially or completely offscreen. This seems to have been introduced in Joplin v3.0.1 by https://github.com/laurent22/joplin/pull/10123.

Fixes #11276.
Fixes #11315.

> [!NOTE]
>
> Currently, this pull request targets `release-3.1`.

## Details

React Native Paper's `<FAB.Group>` renders an invisible `<View>` that covers most/all of Joplin's UI. This view is present even when the `FAB.Group` is collapsed.

To allow users to continue to interact with the application while the view is visible, `react-native-paper` uses [`pointerEvents={'box-none'}`](https://github.com/callstack/react-native-paper/blob/9162a1fdf4e97c0669de8a8fa2057d8cfbe2e728/src/components/FAB/FABGroup.tsx#L345) when the FAB.Group is collapsed. Unfortunately, [this breaks TalkBack on Android's "tap to navigate" feature](https://github.com/callstack/react-native-paper/issues/4064), which significantly impacts users that rely on TalkBack to use the app.

Starting from Joplin v3.0.1, the `<View>` added by React Native is made smaller by adding margins above and to the left. These margins are determined by the screen size and an offset. Even with this solution, a small portion of the screen still blocks TalkBack's tap-to-navigate. As reported in #11276, this workaround also pushed the new note/new to-do buttons offscren.

This commit changes how the FAB.Group's invisible `<View>` is resized. Previously it was done with margins. Now, it's done with the top/left absolute positioning properties.

**Note**: If [this upstream pull request](https://github.com/callstack/react-native-paper/pull/4514) is merged, it should be possible to remove the workaround entirely.

# Screen recording

# Testing plan

## TalkBack regression testing

**Android 13**:
1. Verify that the new note menu can be opened and closed by clicking on the "+" button.
2. Enable TalkBack.
3. Tap the "new note" button.
4. Verify that it receives focus.
5. Tap on a note in the note list (far away from the "+" button).
6. Verify that it receives focus.
7. Open the note.
8. Verify that the edit button can be focused by Talkback.
9. Verify that tapping on the titlebar focuses it.
10. Focus the edit button, then double-tap.
11. Verify that edit mode is open.


[screen recording, roughly demonstrates testing plan below](https://github.com/user-attachments/assets/d4c98eaf-8f30-4a3b-9a44-4c23f5728269)

**Note**: Observe that the "New note" and "New to-do" buttons can be focused by TalkBack even when the menu is collapsed. See [this upstream pull request](https://github.com/callstack/react-native-paper/pull/4498) for a possible fix.

## Verifying that the new note button isn't pushed offscreen

**Android 14 emulator in 3-button navigation mode**:
1. Open the notes list in portrait mode (such that the three navigation buttons are at the bottom of the screen).
2. Verify that the new note button is completely on-screen.

> [!NOTE]
>
> On the Android 14 emulator, before this PR, the "+" button was not completely pushed offscreen (about 3/4ths of the button visible).