### PR TITLE
Mobile: Fixes #11325: Fix error on creating new notes if the user is a share recipient

### DIFF
--- a/packages/lib/models/Note.test.ts
+++ b/packages/lib/models/Note.test.ts
@@ -387,7 +387,7 @@ describe('models/Note', () => {
 		expect(conflictedNote.conflict_original_id).toBe(origNote.id);
 		expect(conflictedNote.parent_id).toBe(folder.id);
 		expect(conflictedNote.is_shared).toBeUndefined();
-		expect(conflictedNote.share_id).toBeUndefined();
+		expect(conflictedNote.share_id).toBe('');
 	});
 
 	it('should copy conflicted note to target folder and cancel conflict', (async () => {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -828,6 +828,12 @@ export default class Note extends BaseItem {
 		void ItemChange.add(BaseModel.TYPE_NOTE, savedNote.id, isNew ? ItemChange.TYPE_CREATE : ItemChange.TYPE_UPDATE, changeSource, beforeNoteJson);
 
 		if (dispatchUpdateAction) {
+			// The UI requires share_id -- if a new note, it will always be the empty string in the database
+			// until processed by the share service. At present, loading savedNote from the database in this case
+			// breaks tests.
+			if (!('share_id' in savedNote) && isNew) {
+				savedNote.share_id = '';
+			}
 			// Ensures that any note added to the state has all the required
 			// properties for the UI to work.
 			if (!('deleted_time' in savedNote) || !('share_id' in savedNote)) {
@@ -913,7 +919,9 @@ export default class Note extends BaseItem {
 
 			for (let i = 0; i < processIds.length; i++) {
 				const id = processIds[i];
-				void ItemChange.add(BaseModel.TYPE_NOTE, id, changeType, changeSource, beforeChangeItems[id]);
+				void ItemChange.add(BaseModel.TYPE_NOTE, id, changeType, {
+					changeSource, beforeChangeItemJson: beforeChangeItems[id],
+				});
 
 				this.dispatch({
 					type: 'NOTE_DELETE',

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -830,7 +830,7 @@ export default class Note extends BaseItem {
 		if (dispatchUpdateAction) {
 			// Ensures that any note added to the state has all the required
 			// properties for the UI to work.
-			if (!('deleted_time' in savedNote)) {
+			if (!('deleted_time' in savedNote) || !('share_id' in savedNote)) {
 				const fields = removeElement(unique(this.previewFields().concat(Object.keys(savedNote))), 'type_');
 				savedNote = await this.load(savedNote.id, {
 					fields,

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -919,9 +919,7 @@ export default class Note extends BaseItem {
 
 			for (let i = 0; i < processIds.length; i++) {
 				const id = processIds[i];
-				void ItemChange.add(BaseModel.TYPE_NOTE, id, changeType, {
-					changeSource, beforeChangeItemJson: beforeChangeItems[id],
-				});
+				void ItemChange.add(BaseModel.TYPE_NOTE, id, changeType, changeSource, beforeChangeItems[id]);
 
 				this.dispatch({
 					type: 'NOTE_DELETE',


### PR DESCRIPTION
# Summary

This pull request fixes #11325 &mdash; a failing assertion prevented users from creating new notes in certain conditions.

> [!NOTE]
>
> This may also fix similar issues on desktop and CLI. Although I have not experienced #11325 on either of these platforms, for me, notes in a share created with "can view" **seem to be editable** (suggesting another issue).
>
> Depending on whether this issue can happen on desktop and CLI, it may make sense to title this pull request `Mobile,Desktop,Cli: Fixes #11325: ...`.

> [!NOTE]
>
> This currently targets `release-3.1`. I'm in the process of checking whether this issue also happens with the `release-3.0` branch.
> **Update**: This does seem to be a regression. I'm currently doing a `git bisect` to determine the first problematic commit.
> **Update 2**: According to a `git bisect`, this was caused by [220f8678](https://github.com/laurent22/joplin/commit/220f867814b5e43ed9735d748f7c899e55e353b5). In particular, this seems to be caused by adding a call to `commandService.isEnabled` while `state.notes` includes a note that lacks a `share_id`. Because it was possible for `commandService.isEnabled` to be called if certain plugins were installed **before** https://github.com/laurent22/joplin/commit/220f867814b5e43ed9735d748f7c899e55e353b5, I suspect that a version of this bug existed in `release-3.0` (but only with certain plugins installed).

# Testing plan

1. Start Joplin with a profile that was previously experiencing #11325.
2. Create a new note from the "+" button.
3. Verify that the note is created successfully.
4. Unapply the change made by this pull request.
5. Press the "+" button, then "new note".
6. Verify that Joplin shows an error message (if in dev mode, in release mode, a blank screen should be visible).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->