### PR TITLE
Desktop: Fixes #11335: Markdown editor: Auto-close backticks

### DIFF
--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -29,7 +29,7 @@ const configFromSettings = (settings: EditorSettings) => {
 					],
 					codeLanguages: lookUpLanguage,
 				}),
-				markdownLanguage.data.of({ closeBrackets: openingBrackets }),
+				markdownLanguage.data.of({ closeBrackets: { brackets: openingBrackets } }),
 			];
 		} else if (language === EditorLanguageType.Html) {
 			return html();


### PR DESCRIPTION
# Summary

This commit auto-matches "\`" characters. Previously, `closeBrackets` was specified incorrectly (wrong type), which seems to have prevented bracket matching from taking place.

This change affects both mobile and desktop.

Fixes #11335.

> [!NOTE]
>
> This pull request targets `release-3.1`.
>
> On mobile, "auto-match brackets" is [always disabled](https://github.com/laurent22/joplin/blob/4a88d6ff7aef1bf9bc5240e72120e0183ed92c16/packages/app-mobile/components/NoteEditor/NoteEditor.tsx#L346). As such, this pull request should only affect desktop.
>

# Testing plan

**Web**:
1. Open a note.
2. Select text.
3. Press <kbd>`</kbd>
4. Verify that the text has been **replaced** with \`
    - On mobile/web, automatch brackets is disabled.
5. Press <kbd>(</kbd>
6. Verify that no closing `)` is added.

**Desktop**:
1. Select text in a note.
2. Press <kbd>`</kbd>.
3. Verify that the text is surrounded by `\``s.
4. On a new line, press <kbd>(</kbd>.
5. Verify that a closing `)` is added.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->