### PR TITLE
Android: Fixes #11324: Fix sharing to Joplin causes back navigation to get stuck

### DIFF
--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -245,14 +245,14 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 			}
 
 			if (this.state.fromShare) {
-				// effectively the same as NAV_BACK but NAV_BACK causes undesired behaviour in this case:
+				// Note: In the past, NAV_BACK caused undesired behaviour in this case:
 				// - share to Joplin from some other app
 				// - open Joplin and open any note
 				// - go back -- with NAV_BACK this causes the app to exit rather than just showing notes
+				// This no longer seems to happen, but this case should be checked when adjusting navigation
+				// history behavior.
 				this.props.dispatch({
-					type: 'NAV_GO',
-					routeName: 'Notes',
-					folderId: this.state.note.parent_id,
+					type: 'NAV_BACK',
 				});
 
 				ShareExtension.close();

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -107,6 +107,7 @@
     "babel-loader": "9.1.3",
     "babel-plugin-module-resolver": "4.1.0",
     "babel-plugin-react-native-web": "0.19.12",
+    "fast-deep-equal": "3.1.3",
     "fs-extra": "11.2.0",
     "gulp": "4.0.2",
     "jest": "29.7.0",

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -305,8 +305,11 @@ const appReducer = (state = appDefaultState, action: any) => {
 
 				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
 					const previousRoute = navHistory.length && navHistory[navHistory.length - 1];
-					// Don't allow going back to the same screen.
-					if (!previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute)) {
+					const isDifferentRoute = !previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute);
+
+					// Avoid multiple consecutive duplicate screens in the navigation history -- these can make
+					// pressing "back" seem to have no effect.
+					if (isDifferentRoute) {
 						navHistory.push(currentRoute);
 					}
 				}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -360,7 +360,7 @@ const appReducer = (state = appDefaultState, action: any) => {
 				newState.route = action;
 				newState.historyCanGoBack = !!navHistory.length;
 
-				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType, navHistory);
+				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
 			}
 			break;
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -36,6 +36,7 @@ const DropdownAlert = require('react-native-dropdownalert').default;
 const AlarmServiceDriver = require('./services/AlarmServiceDriver').default;
 const SafeAreaView = require('./components/SafeAreaView');
 const { connect, Provider } = require('react-redux');
+import fastDeepEqual = require('fast-deep-equal');
 import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 import BackButtonService from './services/BackButtonService';
 import NavService from '@joplin/lib/services/NavService';
@@ -89,7 +90,6 @@ import JoplinCloudLoginScreen from './components/screens/JoplinCloudLoginScreen'
 
 import SyncTargetNone from '@joplin/lib/SyncTargetNone';
 
-const fastDeepEqual = require('fast-deep-equal');
 
 
 SyncTargetRegistry.addClass(SyncTargetNone);

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -89,6 +89,9 @@ import JoplinCloudLoginScreen from './components/screens/JoplinCloudLoginScreen'
 
 import SyncTargetNone from '@joplin/lib/SyncTargetNone';
 
+const fastDeepEqual = require('fast-deep-equal');
+
+
 SyncTargetRegistry.addClass(SyncTargetNone);
 SyncTargetRegistry.addClass(SyncTargetOneDrive);
 SyncTargetRegistry.addClass(SyncTargetNextcloud);
@@ -301,7 +304,15 @@ const appReducer = (state = appDefaultState, action: any) => {
 				const currentRoute = state.route;
 
 				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
-					navHistory.push(currentRoute);
+					const previousRoute = navHistory.length && navHistory[navHistory.length - 1];
+					// Don't allow going back to the same screen.
+					if (!previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute)) {
+						navHistory.push(currentRoute);
+					}
+				}
+
+				if (action.clearHistory) {
+					navHistory.splice(0, navHistory.length);
 				}
 
 				newState = { ...state };
@@ -349,7 +360,7 @@ const appReducer = (state = appDefaultState, action: any) => {
 				newState.route = action;
 				newState.historyCanGoBack = !!navHistory.length;
 
-				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
+				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType, navHistory);
 			}
 			break;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7507,6 +7507,7 @@ __metadata:
     crypto-browserify: 3.12.0
     deprecated-react-native-prop-types: 5.0.0
     events: 3.3.0
+    fast-deep-equal: 3.1.3
     fs-extra: 11.2.0
     gulp: 4.0.2
     jest: 29.7.0


### PR DESCRIPTION
# Summary

This pull request fixes #11324 by changing how notes are navigated away from when opened from shared data.

Previously, pressing "back" when a note had shared data pushed a new screen (notes list) onto the navigation stack (the notes list), rather than going back. With the changes from #11086, this resulted in a loop:
1. A new note is created from shared data and opened.
2. The back button is pressed: **Navigate to the note list screen** with NAV_GO.
   - The navigation history now contains: `[ note from step 1 ]`.
3. The Android back button is pressed: Navigate to the previous item in the navigation history.
   - The navigation history now contains: `[ ]`.
4. The back button is pressed: Navigate to the note list screen.
   - The navigation history now contains: `[ note from step 1 ]`.
5. ... repeat ...

Previously, navigating to the notes list with NAV_GO was done to work around a bug:
https://github.com/laurent22/joplin/blob/598677b2072ab0648c7702f1d27c1e5ca3d628d3/packages/app-mobile/components/screens/Note.tsx#L249-L256

With #11086 and the changes discussed in "Other changes", this no longer seems to be an issue. As such, `NAV_BACK` can be used instead of `NAV_GO`. Switching to `NAV_BACK` prevents the loop outlined above.

# Other changes

- In addition to switching to `NAV_BACK`, some other changes were necessary:
    - **Route equivalence check**: Preventing multiple consecutive identical routes from appearing in the navigation history prevents the note list from appearing twice in the navigation history.
        - Before this change, after opening Joplin by creating a note from shared data, the navigation history might look like this:
            - `[ note list, note list, note from share ]`
       - After this change, `note list` is no longer duplicated in the shared data. As a result, the navigation history only has one copy of the note list: `[note list, note from share]`.
       - The original issue may be caused by `shareHandler`'s navigation to the folder that will contain the new note happening roughly at the same time as the app's initial `NAV_GO`.
   - **Clearing navigation history**: If Joplin is already open when a share is received, it's necessary to clear the existing navigation history. This, for example, prevents Joplin from navigating to the config screen (or other items in the old navigation history), before returning to the application that shared the data.

# Testing

## Manual testing plan

### iOS/regression testing

> [!NOTE]
>
> To run the share extension on an iOS simulator, I needed to switch from a non-deprecated version of `openURL` (otherwise the URL refused to open). I'm including the patch below:
> <details><summary>patch</summary>
>
> `openURL` now requires `options` and `completionHandler` arguments:
>
> ```diff
> diff --git a/packages/app-mobile/ios/ShareExtension/Source/ShareExtension/ShareViewController.m b/packages/app-mobile/ios/ShareExtension/Source/ShareExtension/ShareViewController.m
> index 3e1c230ae..3ed421ad0 100644
> --- a/packages/app-mobile/ios/ShareExtension/Source/ShareExtension/ShareViewController.m
> +++ b/packages/app-mobile/ios/ShareExtension/Source/ShareExtension/ShareViewController.m
> @@ -132,7 +132,15 @@ - (void)launchMainApp {
>   UIResponder* responder = self;
>   while (responder != nil) {
>     if ([responder respondsToSelector:selector]) {
> -      [responder performSelector:selector withObject:[NSURL URLWithString:ShareExtensionShareURL]];
> +      UIApplication *app = (UIApplication*) responder;
> +      NSURL *url = [NSURL URLWithString:ShareExtensionShareURL];
> +      [app openURL:url options:@{} completionHandler:^(BOOL success) {
> +        if (success) {
> +          NSLog(@"Opened URL successfully!");
> +        } else {
> +          NSLog(@"Failed to open URL.");
> +        }
> +      }];
>        break;
>      }
> ```
>
> </details>
>
> Note that I'm able to receive shared data on my non-simulator iOS device (Joplin from TestFlight) without issue.

**iOS 18/simulator**:
1. (With Joplin already running) Start the share extension. Select the "Photos" app as the source application when prompted by XCode.
2. Open a photo.
3. Click share.
4. Select Joplin from the share menu.
5. If the "resize" popup is visible, click "yes".
6. Open the editor.
7. Close the editor with the back arrow.
8. Press the back button.
9. Verify that the note list is visible.
10. Repeat steps 2-5.
11. Move the note to a different folder.
12. Press the back arrow. 
13. Verify that **the folder the note was originally created in** is visible.

### Android 


1. With Joplin open in the background, open a website and share it with Joplin.
    - I tested sharing from the Firefox web browser.
2. Press the back button.
3. Verify that the note list is visible.
4. Press the device's back button.
5. Verify that the web browser is shown.
6. Open Joplin from the recent apps screen.
7. Open a note.
8. Switch back to the web browser.
9. Share the same website with Joplin again.
10. Verify that a note with a link to the website is created.
11. Press the back button twice.
12. Verify that the web browser is visible.
13. Close Joplin.
14. Share the website again.
15. Verify that Joplin opens and a note with the website URL is visible.
16. Press the back button twice.
17. Verify that the web browser is visible.
18. Switch back to Joplin from the recent apps list.
19. Open a note.
20. Press the back button twice.
21. Verify that the web browser is visible.


[screen recording: Shows sharing from Firefox to Joplin when 1) Joplin is closed 2) Joplin is open](https://github.com/user-attachments/assets/e15591f0-ede6-441b-a31d-90d31c52842c)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->