### PR TITLE
Desktop: Security: Fix title rendering in GotoAnything search results

### DIFF
--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -23,6 +23,7 @@ import Resource from '@joplin/lib/models/Resource';
 import { NoteEntity, ResourceEntity } from '@joplin/lib/services/database/types';
 import Dialog from '../gui/Dialog';
 import AsyncActionQueue from '@joplin/lib/AsyncActionQueue';
+import { htmlentities } from '@joplin/utils/html';
 
 const logger = Logger.create('GotoAnything');
 
@@ -555,7 +556,7 @@ class DialogComponent extends React.PureComponent<Props, State> {
 		};
 
 		const titleHtml = item.fragments
-			? `<span style="font-weight: bold; color: ${theme.color};">${item.title}</span>`
+			? `<span style="font-weight: bold; color: ${theme.color};">${htmlentities(item.title)}</span>`
 			: wrapKeywordMatches(item.title);
 
 		const fragmentsHtml = !item.fragments ? null : wrapKeywordMatches(item.fragments);


### PR DESCRIPTION
# Summary

Fixes note title rendering in the GotoAnything dialog in certain edge-cases.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->