### PR TITLE
Mobile: Resolves #11202: Use a FontAwesome icon for the trash folder

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -411,7 +411,7 @@ const SideMenuContentComponent = (props: Props) => {
 	const renderFolderIcon = (folderId: string, folderIcon: FolderIcon) => {
 		if (!folderIcon) {
 			if (folderId === getTrashFolderId()) {
-				folderIcon = getTrashFolderIcon(FolderIconType.Emoji);
+				folderIcon = getTrashFolderIcon(FolderIconType.FontAwesome);
 			} else if (alwaysShowFolderIcons) {
 				return <IonIcon name="folder-outline" style={styles_.folderBaseIcon} />;
 			} else {


### PR DESCRIPTION
# Summary

This pull request resolves #11202 by using a FontAwesome icon for the trash notebook (as is done on desktop).

# Screenshot

**Web (Chrome)**:

![screenshot: Trash folder uses a FontAwesome icon](https://github.com/user-attachments/assets/7eb8d6f0-208b-4ecd-b966-40c363375d8d)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->