### PR TITLE
Chore: Website CI: Do not commit after making changes

### DIFF
--- a/packages/tools/release-website.sh
+++ b/packages/tools/release-website.sh
@@ -93,12 +93,6 @@ else
 	exit 1
 fi
 
+# Note: Do not commit changes to the website -- website updates are handled by the CI
+# script.
 
-cd "$JOPLIN_WEBSITE_ROOT_DIR"
-git add -A
-git commit -m "Updated website
-
-Auto-updated using $SCRIPT_NAME" || true
-
-git pull --rebase
-git push


### PR DESCRIPTION
# Summary

This change removes the `git commit` step in the `website` repository &mdash; if  https://github.com/joplin/website/pull/14 is merged, running `commit` should no longer be necessary.

See https://github.com/joplin/website/pull/14 for details.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->