### PR TITLE
Chore: Desktop: Retry creating new notes in automated tests

### DIFF
--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -33,12 +33,14 @@ export default class MainScreen {
 	public async createNewNote(title: string) {
 		await this.waitFor();
 
+		// Create the new note. Retry this -- creating new notes can sometimes fail if done just after
+		// application startup.
 		await expect.poll(async () => {
 			await this.newNoteButton.click();
-			await expect(this.noteEditor.noteTitleInput).toHaveValue('');
-			await expect(this.noteEditor.noteTitleInput).toHaveJSProperty('placeholder', 'Creating new note...');
+			await expect(this.noteEditor.noteTitleInput).toHaveValue('', { timeout: 4_000 });
+			await expect(this.noteEditor.noteTitleInput).toHaveJSProperty('placeholder', 'Creating new note...', { timeout: 4_000 });
 			return true;
-		}).toBe(true);
+		}, { timeout: 10_000 }).toBe(true);
 
 		// Fill the title
 		await this.noteEditor.noteTitleInput.click();

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -33,9 +33,12 @@ export default class MainScreen {
 	public async createNewNote(title: string) {
 		await this.waitFor();
 
-		await this.newNoteButton.click();
-		await expect(this.noteEditor.noteTitleInput).toHaveValue('');
-		await expect(this.noteEditor.noteTitleInput).toHaveJSProperty('placeholder', 'Creating new note...');
+		await expect.poll(async () => {
+			await this.newNoteButton.click();
+			await expect(this.noteEditor.noteTitleInput).toHaveValue('');
+			await expect(this.noteEditor.noteTitleInput).toHaveJSProperty('placeholder', 'Creating new note...');
+			return true;
+		}).toBe(true);
 
 		// Fill the title
 		await this.noteEditor.noteTitleInput.click();


### PR DESCRIPTION
# Summary

This pull request attempts to address certain automated test failures related to creating new notes in the desktop app. In particular, it allows new note creation to be retried if clicking the new note button fails to create a new note.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->