### PR TITLE
Desktop: Fix dropping files into the editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import Note from '@joplin/lib/models/Note';
 import { DragEvent as ReactDragEvent } from 'react';
 import { DropCommandValue } from './types';
+import { webUtils } from 'electron';
 
 interface HookDependencies {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -56,8 +57,9 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 			const paths = [];
 			for (let i = 0; i < files.length; i++) {
 				const file = files[i];
-				if (!file.path) continue;
-				paths.push(file.path);
+				const path = webUtils.getPathForFile(file);
+				if (!path) continue;
+				paths.push(path);
 			}
 
 			const props: DropCommandValue = {


### PR DESCRIPTION
# Summary

This pull request fixes a regression in v3.2.1 -- it wasn't possible to drop files into the Markdown or Rich Text editors.

# Testing plan

**Fedora 41**:
1. Open Chromium and Joplin.
2. Open Chromium's downloads page.
3. Drag an image file from Chromium's downloads into Joplin's Markdown editor.
4. Verify that the image is inserted into the note as a resource.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->