### PR TITLE
Desktop: Fix PDF export fails with error

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts
@@ -4,14 +4,14 @@ import InteropServiceHelper from '../../../InteropServiceHelper';
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
 import bridge from '../../../services/bridge';
+import { WindowControl } from '../utils/useWindowControl';
 
 export const declaration: CommandDeclaration = {
 	name: 'exportPdf',
 	label: () => `PDF - ${_('PDF File')}`,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export const runtime = (comp: any): CommandRuntime => {
+export const runtime = (comp: WindowControl): CommandRuntime => {
 	return {
 		execute: async (context: CommandContext, noteIds: string[] = null) => {
 			try {
@@ -53,7 +53,7 @@ export const runtime = (comp: any): CommandRuntime => {
 						pdfPath = await shim.fsDriver().findUniqueFilename(`${path}/${n}`);
 					}
 
-					await comp.printTo_('pdf', { path: pdfPath, noteId: note.id });
+					await comp.printTo('pdf', { path: pdfPath, noteId: note.id });
 				}
 			} catch (error) {
 				console.error(error);


### PR DESCRIPTION
# Summary

This pull request fixes a regression in v3.2.1 &mdash; the `exportPdf` command fails with an error. The issue was [originally reported on the Joplin forum](https://discourse.joplinapp.org/t/comp-printto-is-not-a-function-error-message/41944).

The bug was introduced in https://github.com/laurent22/joplin/pull/11181, when `printTo_` was renamed to `printTo`, as it was no longer a private method of a class.

# Testing plan

1. Open a note.
2. Open the go to anything dialog.
3. Run `:exportPdf`.
4. Save the PDF to a file.
5. Attach the PDF to a note.
6. Verify that it renders.

This has been tested successfully on Fedora 41.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->