### PR TITLE
Mobile: Fixes #11384: Fix switching notes then unloading app causes blank screen

### DIFF
--- a/packages/app-mobile/commands/util/goToNote.ts
+++ b/packages/app-mobile/commands/util/goToNote.ts
@@ -2,8 +2,7 @@ import Note from '@joplin/lib/models/Note';
 import NavService from '@joplin/lib/services/NavService';
 
 const goToNote = async (id: string, hash?: string) => {
-	const note = await Note.load(id);
-	if (!note) {
+	if (!(await Note.load(id))) {
 		throw new Error(`No note with id ${id}`);
 	}
 

--- a/packages/app-mobile/commands/util/goToNote.ts
+++ b/packages/app-mobile/commands/util/goToNote.ts
@@ -10,7 +10,6 @@ const goToNote = async (id: string, hash?: string) => {
 	return NavService.go('Note', {
 		noteId: id,
 		noteHash: hash,
-		folderId: note.parent_id,
 	});
 };
 

--- a/packages/app-mobile/commands/util/goToNote.ts
+++ b/packages/app-mobile/commands/util/goToNote.ts
@@ -2,13 +2,15 @@ import Note from '@joplin/lib/models/Note';
 import NavService from '@joplin/lib/services/NavService';
 
 const goToNote = async (id: string, hash?: string) => {
-	if (!(await Note.load(id))) {
+	const note = await Note.load(id);
+	if (!note) {
 		throw new Error(`No note with id ${id}`);
 	}
 
 	return NavService.go('Note', {
 		noteId: id,
 		noteHash: hash,
+		folderId: note.parent_id,
 	});
 };
 

--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -37,7 +37,8 @@ const PADDING_V = 10;
 type OnPressCallback=()=> void;
 
 export interface FolderPickerOptions {
-	enabled: boolean;
+	visible: boolean;
+	disabled?: boolean;
 	selectedFolderId?: string;
 	onValueChange?: OnValueChangedListener;
 	mustSelect?: boolean;
@@ -517,10 +518,12 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 			});
 		}
 
-		const createTitleComponent = (disabled: boolean, hideableAfterTitleComponents: ReactElement) => {
+		const createTitleComponent = (hideableAfterTitleComponents: ReactElement) => {
 			const folderPickerOptions = this.props.folderPickerOptions;
 
-			if (folderPickerOptions && folderPickerOptions.enabled) {
+			if (folderPickerOptions && folderPickerOptions.visible) {
+				const hasSelectedNotes = this.props.selectedNoteIds.length > 0;
+				const disabled = this.props.folderPickerOptions.disabled ?? !hasSelectedNotes;
 				return (
 					<FolderPicker
 						themeId={themeId}
@@ -599,7 +602,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 			{betaIconComp}
 		</>;
 
-		const titleComp = createTitleComponent(headerItemDisabled, hideableRightComponents);
+		const titleComp = createTitleComponent(hideableRightComponents);
 
 		const contextMenuStyle: ViewStyle = {
 			paddingTop: PADDING_V,

--- a/packages/app-mobile/components/screens/Note.tsx
+++ b/packages/app-mobile/components/screens/Note.tsx
@@ -50,7 +50,7 @@ import { isSupportedLanguage } from '../../services/voiceTyping/vosk';
 import { ChangeEvent as EditorChangeEvent, SelectionRangeChangeEvent, UndoRedoDepthChangeEvent } from '@joplin/editor/events';
 import { join } from 'path';
 import { Dispatch } from 'redux';
-import { RefObject } from 'react';
+import { RefObject, useRef } from 'react';
 import { SelectionRange } from '../NoteEditor/types';
 import { getNoteCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import { AppState } from '../../utils/types';
@@ -1372,7 +1372,8 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 
 	public folderPickerOptions() {
 		const options = {
-			enabled: !this.state.readOnly,
+			visible: !this.state.readOnly,
+			disabled: false,
 			selectedFolderId: this.state.folder ? this.state.folder.id : null,
 			onValueChange: this.folderPickerOptions_valueChanged,
 		};
@@ -1380,7 +1381,7 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 		if (
 			this.folderPickerOptions_
 			&& options.selectedFolderId === this.folderPickerOptions_.selectedFolderId
-			&& options.enabled === this.folderPickerOptions_.enabled
+			&& options.visible === this.folderPickerOptions_.visible
 		) {
 			return this.folderPickerOptions_;
 		}
@@ -1639,8 +1640,18 @@ class NoteScreenComponent extends BaseScreenComponent<Props, State> implements B
 // which can cause some bugs where previously set state to another note would interfere
 // how the new note should be rendered
 const NoteScreenWrapper = (props: Props) => {
+	const lastNonNullNoteIdRef = useRef(props.noteId);
+	if (props.noteId) {
+		lastNonNullNoteIdRef.current = props.noteId;
+	}
+
+	// This keeps the current note open even if it's no longer present in selectedNoteIds.
+	// This might happen, for example, if the selected note is moved to an unselected
+	// folder.
+	const noteId = lastNonNullNoteIdRef.current;
+
 	return (
-		<NoteScreenComponent key={props.noteId} {...props} />
+		<NoteScreenComponent key={noteId} {...props} noteId={noteId} />
 	);
 };
 

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -166,7 +166,7 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 			parentId: parent.id,
 		});
 
-		if (source === props.notesSource && false) return;
+		if (source === props.notesSource) return;
 		// For now, search refresh is handled by the search screen.
 		if (props.notesParentType === 'Search') return;
 

--- a/packages/app-mobile/components/screens/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes.tsx
@@ -166,7 +166,7 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 			parentId: parent.id,
 		});
 
-		if (source === props.notesSource) return;
+		if (source === props.notesSource && false) return;
 		// For now, search refresh is handled by the search screen.
 		if (props.notesParentType === 'Search') return;
 
@@ -222,11 +222,11 @@ class NotesScreenComponent extends BaseScreenComponent<Props, State> {
 
 	public folderPickerOptions() {
 		const options = {
-			enabled: this.props.noteSelectionEnabled,
+			visible: this.props.noteSelectionEnabled,
 			mustSelect: true,
 		};
 
-		if (this.folderPickerOptions_ && options.enabled === this.folderPickerOptions_.enabled) return this.folderPickerOptions_;
+		if (this.folderPickerOptions_ && options.visible === this.folderPickerOptions_.visible) return this.folderPickerOptions_;
 
 		this.folderPickerOptions_ = options;
 		return this.folderPickerOptions_;

--- a/packages/app-mobile/components/screens/SearchScreen/index.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/index.tsx
@@ -85,7 +85,7 @@ const SearchScreenComponent: React.FC<Props> = props => {
 			<ScreenHeader
 				title={_('Search')}
 				folderPickerOptions={{
-					enabled: props.noteSelectionEnabled,
+					visible: props.noteSelectionEnabled,
 					mustSelect: true,
 				}}
 				showSideMenuButton={false}


### PR DESCRIPTION
# Summary

This pull request updates `Note.tsx` to:
1. Continue displaying the previous note even if `selectedNoteIds` is empty.
2. Not disable the folder picker if `selectedNoteIds` is empty.

Fixes #11384.

> [!NOTE]
>
> This pull request targets `release-3.1`.

## Explanation

After following a link or changing the parent folder of the open note, `state.selectedNoteIds` can contain notes from different (unselected) folders. When `refreshNotes` is called, it removes notes from `selectedNoteIds` if they are not in the selected notebook/tag/smart filter. This causes `selectedNoteIds` to be set to `[]` when `refreshNotes` is called after moving the open note to a different folder or following a link to a note in a different folder.

# Testing plan

**Android 13**:
1. Create two notes in different notebooks.
2. Add a link from one note to the other.
3. Open the note with the link from the notes list.
4. Follow the link.
5. Turn the device off.
6. Turn the device back on.
7. Verify that the note is still open.
8. Verify that the "select folder" dropdown is not disabled.
9. Change the note's parent folder using the "select folder" dropdown.
10. Press the back button.
11. Verify that the note from step 3 is open.
12. Press the back button.
13. Verify that both notes are visible in the notes list.
14. Select both notes.
15. Using the "move to notebook..." dropdown, move both notes to a different notebook.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->