### PR TITLE
Add Devbox+DirEnv integration to simplify build tool setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.4/.schema/devbox.schema.json",
+  "packages": {
+    "cocoapods": {
+      "version":   "latest",
+      "platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "yarn": "latest",
+    "vips.dev": {
+      "platforms": ["aarch64-darwin"],
+    },
+    "nodejs":     "latest",
+    "pkg-config": "latest",
+    "pixman":     "latest",
+    "cairo.dev":  "",
+    "pango.dev":  "",
+    "darwin.apple_sdk.frameworks.Foundation": { // satisfies missing CoreText/CoreText.h
+      // https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/darwin/apple-sdk/default.nix
+      "version":   "",
+      "platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "python": "latest",
+    "bat":    "latest",
+    "electron": {
+      "version":            "latest",
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "git": "latest",
+  },
+  "shell": {
+    "init_hook": [
+      "export COLOR_BLACK='\\e[0;30m' COLOR_GRAY='\\e[1;30m' COLOR_RED='\\e[0;31m' COLOR_LIGHT_RED='\\e[1;31m' COLOR_GREEN='\\e[0;32m' COLOR_LIGHT_GREEN='\\e[1;32m' COLOR_BROWN='\\e[0;33m' COLOR_YELLOW='\\e[1;33m' COLOR_BLUE='\\e[0;34m' COLOR_LIGHT_BLUE='\\e[1;34m' COLOR_PURPLE='\\e[0;35m' COLOR_LIGHT_PURPLE='\\e[1;35m' COLOR_CYAN='\\e[0;36m'; export COLOR_LIGHT_CYAN='\\e[1;36m'; export COLOR_LIGHT_GRAY='\\e[0;37m'; export COLOR_WHITE='\\e[1;37m'",
+      ". $VENV_DIR/bin/activate",
+      "pip -q install -U pip setuptools wheel", // Newer Pythons are missing distutils
+      "echo -e \"${COLOR_LIGHT_PURPLE}Build ${COLOR_LIGHT_BLUE}Joplin${COLOR_LIGHT_PURPLE}: ${COLOR_LIGHT_GREEN}yarn install ${COLOR_GRAY}\"",
+      "echo -e \"${COLOR_LIGHT_PURPLE}Run ${COLOR_LIGHT_BLUE}Joplin Desktop${COLOR_LIGHT_PURPLE}: ${COLOR_LIGHT_GREEN}cd packages/app-desktop && ${COLOR_YELLOW}$(grep -q '^ID=nixos$' /etc/os-release 2>/dev/null && echo 'ELECTRON_OVERRIDE_DIST_PATH=$(dirname $(which electron)) ')${COLOR_LIGHT_GREEN}yarn start ${COLOR_GRAY}\"",
+      "echo -e \"${COLOR_LIGHT_PURPLE}Run ${COLOR_LIGHT_BLUE}Joplin CLI${COLOR_LIGHT_PURPLE}: ${COLOR_LIGHT_GREEN}cd packages/app-cli && yarn start ${COLOR_GRAY}\"",
+      "echo -e \"${COLOR_LIGHT_PURPLE}Read ${COLOR_LIGHT_BLUE}Full Build Instructions${COLOR_LIGHT_PURPLE}: ${COLOR_LIGHT_GREEN}bat readme/dev/BUILD.md ${COLOR_GRAY}\"",
+    ],
+  },
+}

--- a/readme/dev/BUILD.md
+++ b/readme/dev/BUILD.md
@@ -18,23 +18,15 @@ There are also a few forks of existing packages under the "fork-*" name.
 
 ## Required dependencies
 
-- Install Node 18+. On Windows, also install the build tools - https://nodejs.org/en/
-  - [Enable Yarn](https://yarnpkg.com/getting-started/install): `corepack enable`
-- macOS: Install Cocoapods - `brew install cocoapods`. Apple Silicon [may require libvips](https://github.com/laurent22/joplin/pull/5966#issuecomment-1007158597) - `brew install vips`.
-- Linux: Install dependencies - `sudo apt install build-essential libnss3 libsecret-1-dev python rsync libgbm-dev libatk-bridge2.0-0 libgtk-3.0 libasound2`
+All of the required dependencies are listed within the [devbox.json](../../devbox.json) file in the project root. You can either manually install them based on that list, or you can automatically install them on Linux or MacOS by using:
 
-If using the `onenote-converter` you will require Rust:
-- Install Rust 1.80+. Follow the instructions on [Rust toolchain website](https://rustup.rs/)
-
-All of the required dependencies to build Joplin are listed within the `devbox.json` file in the project root; you can also automatically install them and start a development environment on any distribution of Linux or MacOS by using:
 ```sh
 devbox shell
 ```
 
-If you don't already devbox, it can be installed using:
-```sh
-curl -fsSL https://get.jetify.com/devbox | bash
-```
+If you don't already have devbox, please [follow these instructions](https://www.jetify.com/docs/devbox/quickstart/).
+
+If working on the `onenote-converter` packages you will need to install the [Rust toolchain](https://rustup.rs/).
 
 ## Building
 

--- a/readme/dev/BUILD.md
+++ b/readme/dev/BUILD.md
@@ -26,6 +26,16 @@ There are also a few forks of existing packages under the "fork-*" name.
 If using the `onenote-converter` you will require Rust:
 - Install Rust 1.80+. Follow the instructions on [Rust toolchain website](https://rustup.rs/)
 
+All of the required dependencies to build Joplin are listed within the `devbox.json` file in the project root; you can also automatically install them and start a development environment on any distribution of Linux or MacOS by using:
+```sh
+devbox shell
+```
+
+If you don't already devbox, it can be installed using:
+```sh
+curl -fsSL https://get.jetify.com/devbox | bash
+```
+
 ## Building
 
 Make sure the path to the project directory does not contain spaces or the build may fail.


### PR DESCRIPTION
[Devbox](https://github.com/jetify-com/devbox) is a tool that codifies and satisfies OS-specific dependencies using [Nix](https://nixos.org/); [DirEnv](https://direnv.net/) auto-loads `devbox` when entering a directory (must run `direnv allow` once to prevent hacks).

When devbox+direnv are enabled together, the user need only checkout the repo and change into the directory and a full build environment will be automatically downloaded & configured.

This devbox.json has successfully built and run Joplin Desktop & CLI on MacOS (Apple Silicon) and Linux (NixOS); it should also work on any Linux distro including WSL.

## MacOS / Apple Silicon
<img alt="Joplin-Devbox-OSX" src="https://github.com/user-attachments/assets/996c5247-db7c-4d7c-ad80-55b8528ceea3">

## Linux / X86-64
![image](https://github.com/user-attachments/assets/545f0fde-be37-4001-8dd8-faf87ac19724)
(Electron override message appears only on NixOS where it is required)

## Setting Up Devbox + DirEnv (this a one-time setup for all projects using devbox configurations)

There are a number of ways to setup devbox+direnv, the general requirements are:
1. Install [DirEnv](https://direnv.net/docs/installation.html) + [Devbox](https://www.jetify.com/docs/devbox/installing_devbox/) + [Nix](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#determinate-nix-installer) (devbox will install nix, if not present)
   - These can be installed via package manager or direct download or after installing nix via `nix profile install nixpkgs#{direnv,devbox}`
2. Add direnv hooks to your shell `~/.bash_profile` or `~/.zshrc` (i.e. append `direnv hook bash` or `direnv hook zsh`) and source or restart your shell. 
