### PR TITLE
All: Fix `undefined` errors in translations

### DIFF
--- a/packages/tools/locales/zh_CN.po
+++ b/packages/tools/locales/zh_CN.po
@@ -1268,11 +1268,11 @@ msgstr "新建待办事项。"
 
 #: packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx:114
 msgid "Creating new note..."
-msgstr "新建笔记 %s..."
+msgstr "新建笔记..."
 
 #: packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx:114
 msgid "Creating new to-do..."
-msgstr "新建待办 %s..."
+msgstr "新建待办..."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.tsx:29
 msgid "Creating report..."

--- a/packages/tools/locales/zh_TW.po
+++ b/packages/tools/locales/zh_TW.po
@@ -1278,7 +1278,7 @@ msgstr "建立新的待辦事項..."
 
 #: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.tsx:29
 msgid "Creating report..."
-msgstr "正在建立新報告 %s..."
+msgstr "正在建立新報告..."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:41
 msgid "Ctrl-click to open"
@@ -1441,7 +1441,7 @@ msgstr "確定刪除這份邀請嗎？此舉將會使共享對象無法再存取
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:98
 msgid "Delete this profile?"
-msgstr "刪除此設定檔「%s」？"
+msgstr "刪除此設定檔？"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:69
 #: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:207
@@ -5471,7 +5471,7 @@ msgstr ""
 
 #: packages/app-desktop/bridge.ts:417
 msgid "Unknown file type"
-msgstr "未知的檔案類型：%s"
+msgstr "未知的檔案類型"
 
 #: packages/lib/utils/processStartFlags.ts:178
 msgid "Unknown flag: %s"


### PR DESCRIPTION
Some original strings don't have `%s`, but the corresponding translations included it. This mismatch causes the text `undefined` to appear in the UI.

![image](https://github.com/user-attachments/assets/4a5d447b-3fda-42fe-8d65-0e0a8a8d35c4)
![image](https://github.com/user-attachments/assets/f5f760ba-8da0-4085-92ce-8498cb915c6f)
