### PR TITLE
Desktop: Fixes #11408: Correct file path of OneNote converter on release build

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -61,7 +61,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		const outputDirectory2 = join(tempOutputDirectory, baseFolder);
 
 		const notebookFiles = zip.getEntries().filter(e => e.name !== '.onetoc2' && e.name !== 'OneNote_RecycleBin.onetoc2');
-		const { oneNoteConverter } = shim.requireDynamic('../../../onenote-converter/pkg/onenote_converter');
+		const { oneNoteConverter } = shim.requireDynamic('../../node_modules/@joplin/onenote-converter/pkg/onenote_converter');
 
 		logger.info('Extracting OneNote to HTML');
 		for (const notebookFile of notebookFiles) {

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -61,7 +61,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		const outputDirectory2 = join(tempOutputDirectory, baseFolder);
 
 		const notebookFiles = zip.getEntries().filter(e => e.name !== '.onetoc2' && e.name !== 'OneNote_RecycleBin.onetoc2');
-		const { oneNoteConverter } = shim.requireDynamic('../../node_modules/@joplin/onenote-converter/pkg/onenote_converter');
+		const { oneNoteConverter } = shim.requireDynamic('@joplin/onenote-converter');
 
 		logger.info('Extracting OneNote to HTML');
 		for (const notebookFile of notebookFiles) {

--- a/packages/onenote-converter/package.json
+++ b/packages/onenote-converter/package.json
@@ -10,13 +10,7 @@
     "type": "git",
     "url": "https://github.com/laurent22/joplin"
   },
-  "files": [
-    "./pkg/onenote_converter_bg.wasm",
-    "./pkg/onenote_converter.js",
-    "./pkg/onenote_converter.d.ts"
-  ],
   "main": "./pkg/onenote_converter.js",
-  "types": "./pkg/onenote_converter.d.ts",
   "scripts": {
     "build": "node ./build.js --profile=release",
     "buildDev": "node ./build.js --profile=dev"


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11408

# Summary

When we added `onenote-converter` to `3.2.3` I end-up forgetting to test the release build.

Testing it I found out that the `requireDynamic` call that we have on `InteropService_Importe_OneNote` was pointing it out to a file that doesn't exist on the release build.

The file doesn't exist there because the path that was being used is from the file to `packages/onenote-converter`, instead of pointing it out to the module inside lib `lib/node_modules/@joplin/onenote-convert`.

# Testing

## Testing on dev

1. Run `git clean -dfx` in the root directory of Joplin
2. Run `yarn`
3. Run `cd packages/onenote-converter && IS_CONTINUOUS_INTEGRATION=1 yarn build` 
4. Run `cd ../app-desktop && yarn start`
5. File -> Import -> ZIP - OneNote Importer
6. Select any ZIP file
7. The error reported in the issue shouldn't be present

## Testing on release

1. Run `git clean -dfx` in the root directory of Joplin
2. Run `yarn`
3. Run `cd packages/onenote-converter && IS_CONTINUOUS_INTEGRATION=1 yarn build` 
4. Run `cd ../app-desktop && yarn dist`
5. Run `dist/Joplin-3.2.3.AppImage`
6. File -> Import -> ZIP - OneNote Importer
7. Select any ZIP file
8. The error reported in the issue shouldn't be present
