### PR TITLE
Chore: Remove unused function in string-utils.ts

### DIFF
--- a/packages/lib/string-utils.ts
+++ b/packages/lib/string-utils.ts
@@ -100,25 +100,6 @@ export function removeDiacritics(str: string) {
 	return str;
 }
 
-export function escapeFilename(s: string, maxLength = 32) {
-	let output = removeDiacritics(s);
-	output = output.replace('\n\r', ' ');
-	output = output.replace('\r\n', ' ');
-	output = output.replace('\r', ' ');
-	output = output.replace('\n', ' ');
-	output = output.replace('\t', ' ');
-	output = output.replace('\0', '');
-
-	const unsafe = '/\\:*"\'?<>|'; // In Windows
-	for (let i = 0; i < unsafe.length; i++) {
-		output = output.replace(unsafe[i], '_');
-	}
-
-	if (output.toLowerCase() === 'nul') output = 'n_l'; // For Windows...
-
-	return output.substr(0, maxLength);
-}
-
 export function wrap(text: string, indent: string, width: number) {
 	const wrap_ = require('word-wrap');
 


### PR DESCRIPTION
# Summary

This pull request removes the unused `escapeFilename` function from `string-utils.ts`.

**Note**: `escapeFilename` has bugs and lacks automated tests.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->