### PR TITLE
Desktop: Fix #11409: Fix the "Go to Anything" search

### DIFF
--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -377,7 +377,7 @@ class DialogComponent extends React.PureComponent<Props, State> {
 						.map(r => ({ ...r, title: notesById[r.id].title }));
 
 					const normalizedKeywords = (await this.keywords(searchQuery)).map(
-						({ valueRegex }: ComplexTerm) => new RegExp(removeDiacritics(valueRegex), 'ig'),
+						({ value }: ComplexTerm) => new RegExp(removeDiacritics(value), 'ig'),
 					);
 
 					for (let i = 0; i < results.length; i++) {

--- a/packages/lib/services/search/gotoAnythingStyleQuery.test.ts
+++ b/packages/lib/services/search/gotoAnythingStyleQuery.test.ts
@@ -8,6 +8,7 @@ describe('search/gotoAnythingStyleQuery', () => {
 			['hello welc', 'hello* welc*'],
 			['joplin://x-callback-url/openNote?id=3600e074af0e4b06aeb0ae76d3d96af7', 'joplin://x-callback-url/openNote?id=3600e074af0e4b06aeb0ae76d3d96af7'],
 			['3600e074af0e4b06aeb0ae76d3d96af7', '3600e074af0e4b06aeb0ae76d3d96af7*'],
+			['id:3600e074af0e4b06aeb0ae76d3d96af7', 'id:3600e074af0e4b06aeb0ae76d3d96af7'],
 			['', ''],
 		];
 

--- a/packages/lib/services/search/gotoAnythingStyleQuery.test.ts
+++ b/packages/lib/services/search/gotoAnythingStyleQuery.test.ts
@@ -7,7 +7,7 @@ describe('search/gotoAnythingStyleQuery', () => {
 			['hello', 'hello*'],
 			['hello welc', 'hello* welc*'],
 			['joplin://x-callback-url/openNote?id=3600e074af0e4b06aeb0ae76d3d96af7', 'joplin://x-callback-url/openNote?id=3600e074af0e4b06aeb0ae76d3d96af7'],
-			['3600e074af0e4b06aeb0ae76d3d96af7', '3600e074af0e4b06aeb0ae76d3d96af7'],
+			['3600e074af0e4b06aeb0ae76d3d96af7', '3600e074af0e4b06aeb0ae76d3d96af7*'],
 			['', ''],
 		];
 

--- a/packages/lib/services/search/gotoAnythingStyleQuery.ts
+++ b/packages/lib/services/search/gotoAnythingStyleQuery.ts
@@ -1,10 +1,9 @@
 import { isCallbackUrl } from '../../callbackUrlUtils';
-import isItemId from '../../models/utils/isItemId';
 
 export default (query: string) => {
 	if (!query) return '';
 
-	if (isItemId(query) || isCallbackUrl(query)) return query;
+	if (isCallbackUrl(query)) return query;
 
 	const output = [];
 	const splitted = query.split(' ');

--- a/packages/lib/services/search/gotoAnythingStyleQuery.ts
+++ b/packages/lib/services/search/gotoAnythingStyleQuery.ts
@@ -1,9 +1,10 @@
 import { isCallbackUrl } from '../../callbackUrlUtils';
+import isItemId from '../../models/utils/isItemId';
 
 export default (query: string) => {
 	if (!query) return '';
 
-	if (isCallbackUrl(query)) return query;
+	if ((query.startsWith('id:') && isItemId(query.substring(3))) || isCallbackUrl(query)) return query;
 
 	const output = [];
 	const splitted = query.split(' ');


### PR DESCRIPTION
**Close #11409**

## Summary

When using exactly 32 characters to search, the input may match the ID regex. However, upon reviewing the `notes_fts` table in the database (where the search is performed), I noticed that the `id` field is not indexed. As a result, I removed the ID match check to resolve the issue.