### PR TITLE
Mobile: Accessibility: Improve note list accessibility

### DIFF
--- a/packages/app-mobile/components/Checkbox.tsx
+++ b/packages/app-mobile/components/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { TouchableHighlight, StyleSheet, TextStyle } from 'react-native';
-const Icon = require('react-native-vector-icons/Ionicons').default;
+import Icon from './Icon';
 
 interface Props {
 	checked: boolean;
@@ -44,7 +44,7 @@ const Checkbox: React.FC<Props> = props => {
 		});
 	}, [props.onChange]);
 
-	const iconName = checked ? 'checkbox-outline' : 'square-outline';
+	const iconName = checked ? 'ionicon checkbox-outline' : 'ionicon square-outline';
 	const styles = useStyles(props.style, props.iconStyle);
 
 	const accessibilityState = useMemo(() => ({
@@ -58,8 +58,10 @@ const Checkbox: React.FC<Props> = props => {
 			accessibilityRole="checkbox"
 			accessibilityState={accessibilityState}
 			accessibilityLabel={props.accessibilityLabel ?? ''}
+			// Web requires aria-checked
+			aria-checked={checked}
 		>
-			<Icon name={iconName} style={styles.icon} />
+			<Icon name={iconName} style={styles.icon} accessibilityLabel={null} />
 		</TouchableHighlight>
 	);
 };

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -139,7 +139,13 @@ class NoteItemComponent extends PureComponent<Props, State> {
 		const noteTitle = Note.displayTitle(note);
 
 		return (
-			<TouchableOpacity onPress={this.onPress} onLongPress={this.onLongPress} activeOpacity={0.5}>
+			<TouchableOpacity
+				onPress={this.onPress}
+				onLongPress={this.onLongPress}
+				activeOpacity={0.5}
+				accessibilityHint={_('Opens note')}
+				accessibilityRole='button'
+			>
 				<View style={selectionWrapperStyle}>
 					<View style={opacityStyle}>
 						<View style={listItemStyle}>


### PR DESCRIPTION
# Summary

This pull request improves the accessibility of the mobile app's note list by:
- Hiding the checkbox icon from accessibility tools.
    - It uses `react-native-vector-icons`, which uses an icon font. Previously, accessibility tools would attempt to read the checkbox icon as a character (unpronounceable with my current TalkBack settings).
- Marking note buttons as buttons.
- Adding `aria-checked` to checkboxes (for web).
    - `react-native-web` seems to require `aria-checked` for accessibility tools to read a checked checkbox as checked.
    - React Native Android seems to require `accessibilityState={{ checked: true }}`  for a checked checkbox to be read as checked.
- Adding `accessibilityHint` to note list buttons to describe the effect of clicking one of the buttons.

Related to https://github.com/laurent22/joplin/issues/10795.
**Edit**: Related to https://github.com/laurent22/joplin/issues/11661.

## Known unresolved issues

- **iOS**: Tasks can't be toggled from the note list with VoiceOver (it's necessary to open the note).
    - This is because the `<Checkbox>` is contained within a `<TouchableOpacity>`. VoiceOver only makes the parent `TouchableOpacity` focusable.

# Testing plan

**Android 13**:
1. Setup: Open/create a notebook with the following notes/tasks:
    - Note: `Example`
    - Note: `Test`
    - Task (complete): `Test`
2. Enable the screen reader and move accessibility focus to `Example`.
3. Verify that TalkBack reads `Example, Button, Opens note`
4. Move accessibility focus to the next item (swipe right).
5. Verify that TalkBack reads `Test, Button, Opens note`.
6. Wait 1-2 seconds.
7. Verify that TalkBack reads `Double-tap to activate`.
8. Move accessibility focus to the next item (swipe right).
9. Verify that TalkBack reads `Test, Button, Opens note`.
    - **Optional**: Perhaps this should read "Opens to-do" for tasks?
10. Move accessibility focus to the next item.
11. Verify that TalkBack reads `checked, to-do: Test, checkbox`.
12. Wait 1-2 seconds.
13. Verify that TalkBack reads `Double-tap to toggle`.
14. Double-tap.
15. Verify that TalkBack reads `Not checked`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->