### PR TITLE
Chore: Desktop: Markdown editor panes: Migrate from style properties to SCSS

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useStyles.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useStyles.ts
@@ -23,29 +23,6 @@ const useStyles = (props: NoteBodyEditorProps) => {
 					display: 'flex',
 					flexDirection: 'row',
 				},
-				rowEditorViewer: {
-					position: 'relative',
-					display: 'flex',
-					flexDirection: 'row',
-					flex: 1,
-					paddingTop: 10,
-
-					// Allow the editor container to shrink (allowing the editor to scroll)
-					minHeight: 0,
-				},
-				cellEditor: {
-					position: 'relative',
-					display: 'flex',
-					flex: 1,
-				},
-				cellViewer: {
-					position: 'relative',
-					display: 'flex',
-					flex: 1,
-					borderLeftWidth: 1,
-					borderLeftColor: theme.dividerColor,
-					borderLeftStyle: 'solid',
-				},
 				viewer: {
 					display: 'flex',
 					overflow: 'hidden',

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, useMemo, ForwardedRef, useContext } from 'react';
+import { useState, useEffect, useRef, forwardRef, useCallback, useImperativeHandle, ForwardedRef, useContext } from 'react';
 
 // eslint-disable-next-line no-unused-vars
 import { EditorCommand, MarkupToHtmlOptions, NoteBodyEditorProps, NoteBodyEditorRef } from '../../../utils/types';
@@ -694,25 +694,6 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		showEditorMarkers: true,
 	});
 
-	const cellEditorStyle = useMemo(() => {
-		const output = { ...styles.cellEditor };
-		if (!props.visiblePanes.includes('editor')) {
-			output.display = 'none'; // Seems to work fine since the refactoring
-		}
-
-		return output;
-	}, [styles.cellEditor, props.visiblePanes]);
-
-	const cellViewerStyle = useMemo(() => {
-		const output = { ...styles.cellViewer };
-		if (!props.visiblePanes.includes('viewer')) {
-			output.display = 'none';
-		} else if (!props.visiblePanes.includes('editor')) {
-			output.borderLeftStyle = 'none';
-		}
-		return output;
-	}, [styles.cellViewer, props.visiblePanes]);
-
 	useEffect(() => {
 		if (!editorRef.current) return;
 
@@ -741,7 +722,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		const matchBracesOptions = Setting.value('editor.autoMatchingBraces') ? { override: true, pairs: '``()[]{}\'\'""‘’“”（）《》「」『』【】〔〕〖〗〘〙〚〛' } : false;
 
 		return (
-			<div style={cellEditorStyle}>
+			<div className='editor'>
 				<Editor
 					value={props.content}
 					searchMarkers={props.searchMarkers}
@@ -766,7 +747,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 	function renderViewer() {
 		return (
-			<div style={cellViewerStyle}>
+			<div className='viewer'>
 				<NoteTextViewer
 					ref={webviewRef}
 					themeId={props.themeId}
@@ -779,8 +760,18 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		);
 	}
 
-	const windowId = useContext(WindowIdContext);
+	const editorViewerRow = (
+		<div className={[
+			'note-editor-viewer-row',
+			props.visiblePanes.includes('editor') ? '-show-editor' : '',
+			props.visiblePanes.includes('viewer') ? '-show-viewer' : '',
+		].join(' ')}>
+			{renderEditor()}
+			{renderViewer()}
+		</div>
+	);
 
+	const windowId = useContext(WindowIdContext);
 	return (
 		<ErrorBoundary message="The text editor encountered a fatal error and could not continue. The error might be due to a plugin, so please try to disable some of them and try again.">
 			<div style={styles.root} ref={rootRef}>
@@ -788,10 +779,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 					<Toolbar themeId={props.themeId} windowId={windowId}/>
 					{props.noteToolbar}
 				</div>
-				<div style={styles.rowEditorViewer}>
-					{renderEditor()}
-					{renderViewer()}
-				</div>
+				{editorViewerRow}
 			</div>
 		</ErrorBoundary>
 	);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -301,25 +301,6 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		}
 	}, [renderedBody, webviewReady, getLineScrollPercent, setEditorPercentScroll]);
 
-	const cellEditorStyle = useMemo(() => {
-		const output = { ...styles.cellEditor };
-		if (!props.visiblePanes.includes('editor')) {
-			output.display = 'none'; // Seems to work fine since the refactoring
-		}
-
-		return output;
-	}, [styles.cellEditor, props.visiblePanes]);
-
-	const cellViewerStyle = useMemo(() => {
-		const output = { ...styles.cellViewer };
-		if (!props.visiblePanes.includes('viewer')) {
-			output.display = 'none';
-		} else if (!props.visiblePanes.includes('editor')) {
-			output.borderLeftStyle = 'none';
-		}
-		return output;
-	}, [styles.cellViewer, props.visiblePanes]);
-
 	useRefocusOnVisiblePaneChange({ editorRef, webviewRef, visiblePanes: props.visiblePanes });
 
 	useEditorSearchHandler({
@@ -406,7 +387,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 	const renderEditor = () => {
 		return (
-			<div style={cellEditorStyle}>
+			<div className='editor'>
 				<Editor
 					style={styles.editor}
 					initialText={props.content}
@@ -427,7 +408,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 
 	const renderViewer = () => {
 		return (
-			<div style={cellViewerStyle}>
+			<div className='viewer'>
 				<NoteTextViewer
 					ref={webviewRef}
 					themeId={props.themeId}
@@ -440,8 +421,18 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		);
 	};
 
-	const windowId = useContext(WindowIdContext);
+	const editorViewerRow = (
+		<div className={[
+			'note-editor-viewer-row',
+			props.visiblePanes.includes('editor') ? '-show-editor' : '',
+			props.visiblePanes.includes('viewer') ? '-show-viewer' : '',
+		].join(' ')}>
+			{renderEditor()}
+			{renderViewer()}
+		</div>
+	);
 
+	const windowId = useContext(WindowIdContext);
 	return (
 		<ErrorBoundary message="The text editor encountered a fatal error and could not continue. The error might be due to a plugin, so please try to disable some of them and try again.">
 			<div style={styles.root} ref={rootRef}>
@@ -449,10 +440,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 					<Toolbar themeId={props.themeId} windowId={windowId}/>
 					{props.noteToolbar}
 				</div>
-				<div style={styles.rowEditorViewer}>
-					{renderEditor()}
-					{renderViewer()}
-				</div>
+				{editorViewerRow}
 			</div>
 		</ErrorBoundary>
 	);

--- a/packages/app-desktop/gui/NoteEditor/style.scss
+++ b/packages/app-desktop/gui/NoteEditor/style.scss
@@ -4,3 +4,4 @@
 @use "./styles/note-title-info-group.scss";
 @use "./styles/note-title-wrapper.scss";
 @use "./styles/note-editor-wrapper.scss";
+@use "./styles/note-editor-viewer-row.scss";

--- a/packages/app-desktop/gui/NoteEditor/styles/note-editor-viewer-row.scss
+++ b/packages/app-desktop/gui/NoteEditor/styles/note-editor-viewer-row.scss
@@ -1,0 +1,37 @@
+
+.note-editor-viewer-row {
+	position: relative;
+	display: flex;
+	flex-direction: row;
+	flex: 1;
+	padding-top: 10px;
+
+	// Allow the editor container to shrink (allowing the editor to scroll)
+	min-height: 0;
+
+	> .editor, > .viewer {
+		position: relative;
+		display: flex;
+		flex: 1;
+	}
+
+	> .viewer {
+		border-left-width: 1px;
+		border-left-color: var(--joplin-divider-color);
+		border-left-style: solid;
+	}
+
+	&:not(.-show-viewer) > .viewer {
+		display: none;
+	}
+
+	&:not(.-show-editor) {
+		> .editor {
+			display: none;
+		}
+
+		> .viewer {
+			border-left: none;
+		}
+	}
+}


### PR DESCRIPTION
# Summary

This pull request migrates part of the Markdown editor's styling from `style=`-based styling to SCSS.

**Motivation**: This is motivated in part by the [complicated styling used here](https://discourse.joplinapp.org/t/the-style-in-userchrome-css-stopped-working-as-it-should/41978/2) to style Joplin's editor/viewer panes. Such style sheets are likely to be fragile to changes to the app's HTML structure in the future. 

# Screenshots

## CodeMirror 6-based editor

![Screenshot: editor and viewer side-by-side](https://github.com/user-attachments/assets/ecab2286-0e59-4323-94cb-bca327272b88)
![Screenshot: editor only](https://github.com/user-attachments/assets/2f59657e-8feb-49c4-8a33-7f192b73cc0a)
![Screenshot: viewer only](https://github.com/user-attachments/assets/dda19dbc-bb68-4335-8436-dd78c0ef1ef3)

## Legacy editor (CodeMirror 5-based)

![Screenshot editor and viewer side-by-side](https://github.com/user-attachments/assets/71ecf94e-cf9e-4b07-82e8-614192ae5009)
![Screenshot editor only](https://github.com/user-attachments/assets/7943d11f-fcb3-4e01-b13e-ea02b720ad5c)
![Screenshot viewer only](https://github.com/user-attachments/assets/534d3f8d-4442-438f-8891-674311119767)

