### PR TITLE
Mobile: Accessibility: Improve note selection screen reader accessibility

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -819,6 +819,7 @@ packages/app-mobile/utils/fs-driver/testUtil/createFilesFromPathRecord.js
 packages/app-mobile/utils/fs-driver/testUtil/verifyDirectoryMatches.js
 packages/app-mobile/utils/getPackageInfo.js
 packages/app-mobile/utils/getVersionInfoText.js
+packages/app-mobile/utils/hooks/useOnLongPressProps.js
 packages/app-mobile/utils/hooks/useReduceMotionEnabled.js
 packages/app-mobile/utils/image/fileToImage.web.js
 packages/app-mobile/utils/image/getImageDimensions.js

--- a/.gitignore
+++ b/.gitignore
@@ -795,6 +795,7 @@ packages/app-mobile/utils/fs-driver/testUtil/createFilesFromPathRecord.js
 packages/app-mobile/utils/fs-driver/testUtil/verifyDirectoryMatches.js
 packages/app-mobile/utils/getPackageInfo.js
 packages/app-mobile/utils/getVersionInfoText.js
+packages/app-mobile/utils/hooks/useOnLongPressProps.js
 packages/app-mobile/utils/hooks/useReduceMotionEnabled.js
 packages/app-mobile/utils/image/fileToImage.web.js
 packages/app-mobile/utils/image/getImageDimensions.js

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { PureComponent } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
-import { Text, TouchableOpacity, View, StyleSheet, TextStyle, ViewStyle } from 'react-native';
+import { Text, View, StyleSheet, TextStyle, ViewStyle, AccessibilityInfo, TouchableOpacity } from 'react-native';
 import Checkbox from './Checkbox';
 import Note from '@joplin/lib/models/Note';
 import time from '@joplin/lib/time';
@@ -10,6 +10,7 @@ import { _ } from '@joplin/lib/locale';
 import { AppState } from '../utils/types';
 import { Dispatch } from 'redux';
 import { NoteEntity } from '@joplin/lib/services/database/types';
+import useOnLongPressProps from '../utils/hooks/useOnLongPressProps';
 
 interface Props {
 	dispatch: Dispatch;
@@ -19,42 +20,51 @@ interface Props {
 	selectedNoteIds: string[];
 }
 
-interface State {}
 
-type Styles = Record<string, TextStyle|ViewStyle>;
+const useStyles = (themeId: number) => {
+	return useMemo(() => {
+		const theme = themeStyle(themeId);
 
-class NoteItemComponent extends PureComponent<Props, State> {
-	private styles_: Record<string, Styles> = {};
-	public constructor(props: Props) {
-		super(props);
-	}
+		const listItem: ViewStyle = {
+			flexDirection: 'row',
+			// height: 40,
+			borderBottomWidth: 1,
+			borderBottomColor: theme.dividerColor,
+			alignItems: 'flex-start',
+			paddingLeft: theme.marginLeft,
+			paddingRight: theme.marginRight,
+			paddingTop: theme.itemMarginTop,
+			paddingBottom: theme.itemMarginBottom,
+			// backgroundColor: theme.backgroundColor,
+		};
 
-	private styles() {
-		const theme = themeStyle(this.props.themeId);
-		if (this.styles_[this.props.themeId]) return this.styles_[this.props.themeId];
-		this.styles_ = {};
+		const listItemWithCheckbox = { ...listItem };
+		delete listItemWithCheckbox.paddingTop;
+		delete listItemWithCheckbox.paddingBottom;
+		delete listItemWithCheckbox.paddingLeft;
 
-		const styles: Record<string, TextStyle|ViewStyle> = {
-			listItem: {
-				flexDirection: 'row',
-				// height: 40,
-				borderBottomWidth: 1,
-				borderBottomColor: theme.dividerColor,
-				alignItems: 'flex-start',
-				paddingLeft: theme.marginLeft,
-				paddingRight: theme.marginRight,
-				paddingTop: theme.itemMarginTop,
-				paddingBottom: theme.itemMarginBottom,
-				// backgroundColor: theme.backgroundColor,
-			},
-			listItemText: {
-				flex: 1,
-				color: theme.color,
-				fontSize: theme.fontSize,
-			},
-			selectionWrapper: {
-				backgroundColor: theme.backgroundColor,
-			},
+		const listItemText: TextStyle = {
+			flex: 1,
+			color: theme.color,
+			fontSize: theme.fontSize,
+		};
+
+		const listItemTextWithCheckbox = { ...listItemText };
+		listItemTextWithCheckbox.marginTop = theme.itemMarginTop - 1;
+		listItemTextWithCheckbox.marginBottom = listItem.paddingBottom;
+
+		const selectionWrapper: ViewStyle = { };
+
+		const selectionWrapperSelected = { ...selectionWrapper };
+		selectionWrapperSelected.backgroundColor = theme.selectedColor;
+
+		return StyleSheet.create({
+			listItem,
+			listItemText,
+			selectionWrapper,
+			listItemWithCheckbox,
+			listItemTextWithCheckbox,
+			selectionWrapperSelected,
 			checkboxStyle: {
 				color: theme.color,
 				paddingRight: 10,
@@ -66,103 +76,105 @@ class NoteItemComponent extends PureComponent<Props, State> {
 				opacity: 0.4,
 			},
 			uncheckedOpacityStyle: { },
-		};
+		});
+	}, [themeId]);
+};
 
-		styles.listItemWithCheckbox = { ...styles.listItem };
-		delete styles.listItemWithCheckbox.paddingTop;
-		delete styles.listItemWithCheckbox.paddingBottom;
-		delete styles.listItemWithCheckbox.paddingLeft;
+const NoteItemComponent: React.FC<Props> = memo(props => {
+	const styles = useStyles(props.themeId);
 
-		styles.listItemTextWithCheckbox = { ...styles.listItemText };
-		styles.listItemTextWithCheckbox.marginTop = theme.itemMarginTop - 1;
-		styles.listItemTextWithCheckbox.marginBottom = styles.listItem.paddingBottom;
-
-		styles.selectionWrapperSelected = { ...styles.selectionWrapper };
-		styles.selectionWrapperSelected.backgroundColor = theme.selectedColor;
-
-		this.styles_[this.props.themeId] = StyleSheet.create(styles);
-		return this.styles_[this.props.themeId];
-	}
-
-	private todoCheckbox_change = async (checked: boolean) => {
-		if (!this.props.note) return;
+	const todoCheckbox_change = useCallback(async (checked: boolean) => {
+		if (!props.note) return;
 
 		const newNote = {
-			id: this.props.note.id,
+			id: props.note.id,
 			todo_completed: checked ? time.unixMs() : 0,
 		};
 		await Note.save(newNote);
 
-		this.props.dispatch({ type: 'NOTE_SORT' });
-	};
+		props.dispatch({ type: 'NOTE_SORT' });
+	}, [props.note, props.dispatch]);
 
-	private onPress = () => {
-		if (!this.props.note) return;
-		if (this.props.note.encryption_applied) return;
+	const onPress = useCallback(() => {
+		if (!props.note) return;
+		if (props.note.encryption_applied) return;
 
-		if (this.props.noteSelectionEnabled) {
-			this.props.dispatch({
+		if (props.noteSelectionEnabled) {
+			props.dispatch({
 				type: 'NOTE_SELECTION_TOGGLE',
-				id: this.props.note.id,
+				id: props.note.id,
 			});
 		} else {
-			this.props.dispatch({
+			props.dispatch({
 				type: 'NAV_GO',
 				routeName: 'Note',
-				noteId: this.props.note.id,
+				noteId: props.note.id,
 			});
 		}
-	};
+	}, [props.note, props.noteSelectionEnabled, props.dispatch]);
 
-	private onLongPress = () => {
-		if (!this.props.note) return;
+	const onLongPress = useCallback(() => {
+		if (!props.note) return;
 
-		this.props.dispatch({
-			type: this.props.noteSelectionEnabled ? 'NOTE_SELECTION_TOGGLE' : 'NOTE_SELECTION_START',
-			id: this.props.note.id,
+		if (!props.noteSelectionEnabled) {
+			AccessibilityInfo.announceForAccessibility(_('Entering selection mode'));
+		}
+
+		props.dispatch({
+			type: props.noteSelectionEnabled ? 'NOTE_SELECTION_TOGGLE' : 'NOTE_SELECTION_START',
+			id: props.note.id,
 		});
+	}, [props.dispatch, props.note, props.noteSelectionEnabled]);
+
+	const onLongPressProps = useOnLongPressProps(onLongPress);
+
+	const note = props.note ?? {};
+	const isTodo = !!Number(note.is_todo);
+	const checkboxChecked = !!Number(note.todo_completed);
+
+	const checkboxStyle = styles.checkboxStyle;
+	const listItemStyle = isTodo ? styles.listItemWithCheckbox : styles.listItem;
+	const listItemTextStyle = isTodo ? styles.listItemTextWithCheckbox : styles.listItemText;
+	const opacityStyle = isTodo && checkboxChecked ? styles.checkedOpacityStyle : styles.uncheckedOpacityStyle;
+	const isSelected = props.noteSelectionEnabled && props.selectedNoteIds.includes(note.id);
+
+	const selectionWrapperStyle = isSelected ? styles.selectionWrapperSelected : styles.selectionWrapper;
+
+	const noteTitle = Note.displayTitle(note);
+
+	const contextMenuProps = {
+		// Web only.
+		onContextMenu: onLongPressProps.onContextMenu,
 	};
-
-	public render() {
-		const note = this.props.note ? this.props.note : {};
-		const isTodo = !!Number(note.is_todo);
-		const checkboxChecked = !!Number(note.todo_completed);
-
-		const checkboxStyle = this.styles().checkboxStyle;
-		const listItemStyle = isTodo ? this.styles().listItemWithCheckbox : this.styles().listItem;
-		const listItemTextStyle = isTodo ? this.styles().listItemTextWithCheckbox : this.styles().listItemText;
-		const opacityStyle = isTodo && checkboxChecked ? this.styles().checkedOpacityStyle : this.styles().uncheckedOpacityStyle;
-		const isSelected = this.props.noteSelectionEnabled && this.props.selectedNoteIds.indexOf(note.id) >= 0;
-
-		const selectionWrapperStyle = isSelected ? this.styles().selectionWrapperSelected : this.styles().selectionWrapper;
-
-		const noteTitle = Note.displayTitle(note);
-
-		return (
+	return (
+		<View
+			// context menu listeners need to be added to a parent view of the
+			// TouchableOpacity -- on web, TouchableOpacity registers a custom
+			// onContextMenu handler that can't be overridden.
+			{...contextMenuProps}
+		>
 			<TouchableOpacity
-				onPress={this.onPress}
-				onLongPress={this.onLongPress}
 				activeOpacity={0.5}
-				accessibilityHint={_('Opens note')}
+				onPress={onPress}
 				accessibilityRole='button'
+				accessibilityHint={props.noteSelectionEnabled ? '' : _('Opens note')}
+				aria-pressed={props.noteSelectionEnabled ? isSelected : undefined}
+				accessibilityState={{ selected: isSelected }}
+				{...onLongPressProps}
 			>
-				<View style={selectionWrapperStyle}>
-					<View style={opacityStyle}>
-						<View style={listItemStyle}>
-							{isTodo ? <Checkbox
-								style={checkboxStyle}
-								checked={checkboxChecked}
-								onChange={this.todoCheckbox_change}
-								accessibilityLabel={_('to-do: %s', noteTitle)}
-							/> : null }
-							<Text style={listItemTextStyle}>{noteTitle}</Text>
-						</View>
-					</View>
+				<View style={[selectionWrapperStyle, opacityStyle, listItemStyle]}>
+					{isTodo ? <Checkbox
+						style={checkboxStyle}
+						checked={checkboxChecked}
+						onChange={todoCheckbox_change}
+						accessibilityLabel={_('to-do: %s', noteTitle)}
+					/> : null }
+					<Text style={listItemTextStyle}>{noteTitle}</Text>
 				</View>
 			</TouchableOpacity>
-		);
-	}
-}
+		</View>
+	);
+});
 
 export default connect((state: AppState) => {
 	return {

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -126,7 +126,6 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 		});
 	}, [props.dispatch, props.note, props.noteSelectionEnabled]);
 
-	const onLongPressProps = useOnLongPressProps(onLongPress);
 
 	const note = props.note ?? {};
 	const isTodo = !!Number(note.is_todo);
@@ -141,6 +140,9 @@ const NoteItemComponent: React.FC<Props> = memo(props => {
 	const selectionWrapperStyle = isSelected ? styles.selectionWrapperSelected : styles.selectionWrapper;
 
 	const noteTitle = Note.displayTitle(note);
+
+	const selectDeselectLabel = isSelected ? _('Deselect') : _('Select');
+	const onLongPressProps = useOnLongPressProps({ onLongPress, actionDescription: selectDeselectLabel });
 
 	const contextMenuProps = {
 		// Web only.

--- a/packages/app-mobile/utils/hooks/useOnLongPressProps.ts
+++ b/packages/app-mobile/utils/hooks/useOnLongPressProps.ts
@@ -1,12 +1,20 @@
 import { useMemo } from 'react';
 import { AccessibilityActionEvent, NativeSyntheticEvent } from 'react-native';
 
+interface Props {
+	onLongPress: ()=> void;
+	// Read by accessibility tools on iOS/Android when describing
+	// the long press action. For example, TalkBack might read
+	// "Double-tap to activate. Double-tap and hold to [[longPressLabel]]".
+	actionDescription: string;
+}
+
 // Allows adding an onLongPress listener in a more accessible way.
 // In particular:
 // - For keyboard accessibility (web only) adds an onContextMenu listener.
 // - Adds a longpress accessibility action. This causes TalkBack to announce that
 //   a longpress accessibility action is available.
-const useOnLongPressProps = (onLongPress: ()=> void) => {
+const useOnLongPressProps = ({ onLongPress, actionDescription }: Props) => {
 	return useMemo(() => {
 		if (!onLongPress) return {};
 
@@ -17,7 +25,7 @@ const useOnLongPressProps = (onLongPress: ()=> void) => {
 			},
 			onLongPress,
 			accessibilityActions: [
-				{ name: 'longpress', label: 'Long press' },
+				{ name: 'longpress', label: actionDescription },
 			],
 			onAccessibilityAction: (event: AccessibilityActionEvent)=>{
 				if (event.nativeEvent.actionName === 'longpress') {
@@ -25,7 +33,7 @@ const useOnLongPressProps = (onLongPress: ()=> void) => {
 				}
 			},
 		};
-	}, [onLongPress]);
+	}, [onLongPress, actionDescription]);
 };
 
 export default useOnLongPressProps;

--- a/packages/app-mobile/utils/hooks/useOnLongPressProps.ts
+++ b/packages/app-mobile/utils/hooks/useOnLongPressProps.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { AccessibilityActionEvent, NativeSyntheticEvent } from 'react-native';
+
+// Allows adding an onLongPress listener in a more accessible way.
+// In particular:
+// - For keyboard accessibility (web only) adds an onContextMenu listener.
+// - Adds a longpress accessibility action. This causes TalkBack to announce that
+//   a longpress accessibility action is available.
+const useOnLongPressProps = (onLongPress: ()=> void) => {
+	return useMemo(() => {
+		if (!onLongPress) return {};
+
+		return {
+			onContextMenu: (event: NativeSyntheticEvent<unknown>) => {
+				event.preventDefault();
+				onLongPress();
+			},
+			onLongPress,
+			accessibilityActions: [
+				{ name: 'longpress', label: 'Long press' },
+			],
+			onAccessibilityAction: (event: AccessibilityActionEvent)=>{
+				if (event.nativeEvent.actionName === 'longpress') {
+					onLongPress();
+				}
+			},
+		};
+	}, [onLongPress]);
+};
+
+export default useOnLongPressProps;


### PR DESCRIPTION
# Summary

This pull request improves the screen reader accessibility (and, on web, keyboard accessibility) of managing note selection from the note list. This is done by:
- (Android, iOS) Exposing the long-press note list item action to accessibility tools.
    - (Android) Previously, TalkBack didn't announce that it was possible to double-tap and hold to enter selection mode. With this change, after describing a note list item, TalkBack reads, `Double-tap to activate. Double-tap and hold to Select`. Alternatively, if the item is already selected, TalkBack reads `Double-tap to activate. Double-tap and hold to Deselect`.
- (Android, iOS, Web) When in selection mode, provides information about whether a note list item is selected.
    - On web, this is done with [`aria-pressed`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed).
    - On Android/iOS, this is done with `accessibilityState={{ selected: ... }}`.
- (Web) Makes it possible to enter selection mode with a keyboard by pressing the context menu key.
- (Web) Makes it possible to enter selection mode with a pointer device by right-clicking.

Much of the long-press accessibility logic is implemented in `packages/app-mobile/utils/hooks/useOnLongPressProps.ts`. To use this hook, `NoteItem` was converted from a class component to a function component.

Related to #10795.
**Edit**: Related to https://github.com/laurent22/joplin/issues/11661.

# Remaining issues

**iOS and Android**:
- The screen reader doesn't read "not selected" (or similar) when in selection mode and an item is not selected.
   - Currently, if selected, the button is described as `selected`. However, when unselected, its selection state isn't mentioned.

**iOS (simulator)**:
- After selecting a note, the "select/deselect" accessibility action is still described as `select`, when it should be described as `deselect`.
    - On Android, it is described as `deselect`.
- After selecting/deselecting an item, VoiceOver doesn't read the new state.
    - On Android, after changing the selection state of a note, TalkBack reads "selected" or "unselected".


# Testing plan

**Android 13**:
1. Open the note list screen (for a folder).
2. Move accessibility focus to the first button in the list.
3. Verify that after describing the button, TalkBack reads `Double-tap to activate., Double-tap and hold to Select.`
4. Double-tap and hold.
5. Verify that TalkBack reads the note's title, then "selected".
6. Move accessibility focus to the next item.
7. Double-tap.
8. Verify that TalkBack reads the note's title, followed by "selected".
9. Verify that the note is selected.


**Web (Chromium 130)**:
1. Open the note list.
2. Right-click on a note.
3. Verify that the note is selected and that the selection menu is visible.
4. Move keyboard focus to the note from step 2 in the note list.
5. Press the context menu button.
6. Verify that Joplin exits selection mode.

**iOS 18 (simulator)**:
1. Open a note list with 2 notes.
1. Enable MacOS VoiceOver
2. Move VoiceOver focus to the simulator's content.
3. Move accessibility focus to the first note.
4. Verify that VoiceOver describes the button and offers a selection action.
   - For me, after moving focus to a note button labelled `Test`, VoiceOver reads `Test, button`, then `actions available, Opens note, You are currently on a button. To click this button, press Control-Option-Space.  To Select, press Control-Option-Command-Space first to bring up the action menu.
5. Bring up the action menu.
6. Select "select".
7. Verify that the note is selected.
8. Move focus to the next item.
9. Move focus to the previous item.
10. Verify that VoiceOver reads the note item as selected.
    - For me, VoiceOver reads `Test, selected, button.`

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->