### PR TITLE
Mobile: Accessibility: Fix screen reader is unable to scroll settings tab list

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector/index.tsx
@@ -98,7 +98,6 @@ const SectionSelector: FunctionComponent<Props> = props => {
 	return (
 		<View style={containerStyle}>
 			<FlatList
-				role='tablist'
 				ref={setFlatListRef}
 				data={sections}
 				renderItem={onRenderButton}


### PR DESCRIPTION
# Summary

With the `tablist` role, TalkBack is unable to scroll the list of settings sections on Android. This pull request removes `role=tablist` from the tab container, which seems to allow TalkBack to scroll to reach offscreen section tabs.

Related to #10795.
**Edit**: Related to https://github.com/laurent22/joplin/issues/11661.

# Testing plan

**Android 13** (TalkBack enabled):
1. Resize the Joplin window such that the tab list in configuration scrolls.
2. Open settings and move TalkBack focus to the tab list.
3. Move TalkBack to the next item.
4. Repeat step 3 until TalkBack reaches the last tab item.
5. Verify that TalkBack was able to focus the last item in the tab list.
6. Double-tap.
7. Verify that the tab is selected.
   - For me, TalkBack reads "More information. Donate, website. Selected". Moving to the next item focuses items in the "More information" section.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->