### PR TITLE
Mobile: Accessibility: Describe the notebook dropdown for accessibility tools

### DIFF
--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -65,6 +65,7 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 	return (
 		<Dropdown
 			items={titlePickerItems(!!mustSelect)}
+			accessibilityHint={_('Selects a notebook')}
 			disabled={disabled}
 			labelTransform="trim"
 			selectedValue={selectedFolderId || ''}


### PR DESCRIPTION
# Summary

This pull request adds an `accessibilityHint` to the "move to notebook" dropdown.

**Before/after comparison** (Android 13/TalkBack):
- **Before**: Before this pull request, TalkBack might read `Notebook title, button, Opens dropdown` (for some "Notebook title").
- **After**: With this pull request, TalkBack reads `Notebook title, button, Selects a notebook Opens dropdown` (for some "Notebook title").

Related to #10795.

> [!NOTE]
>
> Currently, `<Dropdown>` doesn't add punctuation when [concatenating hint text](https://github.com/laurent22/joplin/blob/f382ab3d13b860335790eba9dffdd70bda72e2ab/packages/app-mobile/components/Dropdown.tsx#L215). It may make sense to change this in a follow-up pull request.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->