### PR TITLE
Mobile: Accessibility: Search screen: Hide the progress bar from accessibility tools when invisible

### DIFF
--- a/packages/app-mobile/components/screens/SearchScreen/SearchResults.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchResults.tsx
@@ -100,10 +100,11 @@ const SearchResults: React.FC<Props> = props => {
 	// Don't show the progress bar immediately, only show if the search
 	// is taking some time.
 	const longRunning = useIsLongRunning(isPending);
+	const progressVisible = longRunning;
 
 	// To have the correct height on web, the progress bar needs to be wrapped:
-	const progressBar = <View>
-		<ProgressBar indeterminate={true} visible={longRunning}/>
+	const progressBar = <View aria-hidden={!progressVisible}>
+		<ProgressBar indeterminate={true} visible={progressVisible}/>
 	</View>;
 
 	return (


### PR DESCRIPTION
# Summary

This pull request fixes an issue where TalkBack on Android read "Progress Bar, Double-tap to activate" as the next item in the focus order after "Clear, Button", **even if the progress bar is invisible**.

Related to #10795.

# Testing plan

**Android 13**:
1. Enable TalkBack
2. Open the search screen.
3. Enter a search that produces results.
4. Move to the next item until "Clear, Button" is focused.
5. Move to the next item.
6. Verify that TalkBack reads a search result.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->