### PR TITLE
Mobile: Accessibility: Mark note properties buttons as buttons

### DIFF
--- a/packages/app-mobile/components/SideMenuContentNote.tsx
+++ b/packages/app-mobile/components/SideMenuContentNote.tsx
@@ -91,7 +91,11 @@ const SideMenuContentNoteComponent: React.FC<Props> = props => {
 		if (!onPressHandler) return content;
 
 		return (
-			<TouchableOpacity key={key} onPress={onPressHandler}>
+			<TouchableOpacity
+				key={key}
+				onPress={onPressHandler}
+				accessibilityRole='button'
+			>
 				{content}
 			</TouchableOpacity>
 		);


### PR DESCRIPTION
# Summary

This pull request causes TalkBack to read the "View on map" button as a button.

Related to #10795.

# Before/after comparison

**Android 13** (TalkBack):
- **Before**: When focusing the "View on map" button, TalkBack reads `View on map. Double-tap to activate`.
- **After**: When focusing the "View on map" button, TalkBack reads `View on map, Button. Double-tap to activate`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->