### PR TITLE
Desktop: Fixes #11443: Accessibility: Do not override focus order when pressing tab/shift-tab on the note list

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -85,7 +85,7 @@ export default function NoteTitleBar(props: Props) {
 	const onTitleKeydown: React.KeyboardEventHandler<HTMLInputElement> = useCallback((event) => {
 		const titleElement = event.currentTarget;
 		const selectionAtEnd = titleElement.selectionEnd === titleElement.value.length;
-		if ((event.key === 'ArrowDown' && selectionAtEnd) || event.key === 'Enter') {
+		if ((event.key === 'ArrowDown' && selectionAtEnd) || (event.key === 'Enter' && !event.shiftKey)) {
 			event.preventDefault();
 			const moveCursorToStart = event.key === 'ArrowDown';
 			void CommandService.instance().execute('focusElement', 'noteBody', { moveCursorToStart });

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -153,11 +153,6 @@ const useOnKeyDown = (
 			announceForAccessibility(!wasCompleted ? _('Complete') : _('Incomplete'));
 		}
 
-		if (key === 'Tab' && event.shiftKey) {
-			event.preventDefault();
-			void CommandService.instance().execute('focusElement', 'sideBar');
-		}
-
 		if (key.toUpperCase() === 'A' && (event.ctrlKey || event.metaKey)) {
 			event.preventDefault();
 

--- a/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts
@@ -153,6 +153,17 @@ const useOnKeyDown = (
 			announceForAccessibility(!wasCompleted ? _('Complete') : _('Incomplete'));
 		}
 
+		// Check for isDefaultPrevented to allow plugins to call .preventDefault
+		if (key === 'Enter' && !event.isDefaultPrevented()) {
+			event.preventDefault();
+
+			if (event.shiftKey) {
+				void CommandService.instance().execute('focusElement', 'sideBar');
+			} else {
+				void CommandService.instance().execute('focusElement', 'noteTitle');
+			}
+		}
+
 		if (key.toUpperCase() === 'A' && (event.ctrlKey || event.metaKey)) {
 			event.preventDefault();
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -54,14 +54,10 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {
 			indexChange = 1;
-		} else if (event.code === 'Tab') {
+		} else if (event.code === 'Tab' && event.shiftKey) {
 			event.preventDefault();
 
-			if (event.shiftKey) {
-				void CommandService.instance().execute('focusElement', 'noteBody');
-			} else {
-				void CommandService.instance().execute('focusElement', 'noteList');
-			}
+			void CommandService.instance().execute('focusElement', 'noteBody');
 		}
 
 		if (indexChange !== 0) {

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -58,6 +58,9 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			event.preventDefault();
 
 			void CommandService.instance().execute('focusElement', 'noteBody');
+		} else if (event.code === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			void CommandService.instance().execute('focusElement', 'noteList');
 		}
 
 		if (indexChange !== 0) {


### PR DESCRIPTION
# Summary

Fixes #11443. Related to #10795.

Before this pull request, Joplin overrode the default focus order when:
- Pressing <kbd>tab</kbd> from the notebook list (skipping sync, new note, new to-do, search, sort by, etc.).
- Pressing <kbd>shift</kbd>-<kbd>tab</kbd> from the note list (skipping sort by, search, new to-do, etc.).

This pull request removes the above two overrides, making it easier for screen reader/keyboard only users to access the note list controls and the sync button.

## Replacement shortcuts

To preserve ability to navigate quickly between the notes list and sidebar, new shortcuts have been added:
- Pressing <kbd>enter</kbd> from the **notebook list**: Navigates to the note list.
- Pressing <kbd>shift</kbd>-<kbd>enter</kbd> from the **note list**: Navigates to the notebook list.

Also, for consistency,
- Pressing <kbd>enter</kbd> from the **note list**: Navigates to the title of the currently open note (if any).

## Additional notes

- <kbd>Enter</kbd> was selected, in part, because it's similar to what's done in VSCode when the file tree is focused. When I 1) focus the file tree and 2) press enter, VSCode jumps focus to the editor (skipping focusable elements in between). 
- Currently (before this PR), checkboxes are toggled in the note list by pressing <kbd>space</kbd> (and not <kbd>enter</kbd>). (Though perhaps they should be toggled by <kbd>enter</kbd>?)

# Testing plan


<details><summary>Manual testing -- Fedora 41</summary>

1. Start Joplin (with a notebook and note open).
2. Focus the note list.
3. Press <kbd>tab</kbd>.
4. Verify that "Synchronize" is selected.
5. Press <kbd>tab</kbd>.
6. Verify that the "new note" button is selected.
7. Press <kbd>tab</kbd>.
8. Verify that the "new to-do" button is selected.
9. Press <kbd>tab</kbd>.
10. Verify that the search field is selected.
11. Press <kbd>tab</kbd>.
12. Verify that the search button is selected.
13. Press <kbd>tab</kbd>.
14. Verify that the "toggle sort order field" button is selected.
15. Verify that the "reverse sort order" button is selected.
16. Press <kbd>tab</kbd>.
17. Verify that an item in the note list is selected.
18. Press <kbd>tab</kbd>.
19. Verify that the title input for the currently open note is focused.
20. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
21. Verify that the note list is focused.
22. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
23. Verify that the "reverse sort order" button is focused.
24. Press <kbd>tab</kbd>.
    - This should focus the note list.
25. Press <kbd>shift</kbd>-<kbd>enter</kbd>.
26. Verify that the notebook list has focus.
27. Press <kbd>enter</kbd>.
28. Verify that the note list has focus.
29. Press <kbd>enter</kbd>.
30. Verify that the note title input has focus.

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->