### PR TITLE
Desktop: Accessibility: Prevent overwrite mode toggle shortcut from conflicting with screen reader shortcuts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -918,6 +918,7 @@ packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
 packages/editor/CodeMirror/utils/isCursorAtBeginning.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
+packages/editor/CodeMirror/utils/keyUpHandlerExtension.js
 packages/editor/CodeMirror/utils/overwriteModeExtension.test.js
 packages/editor/CodeMirror/utils/overwriteModeExtension.js
 packages/editor/CodeMirror/utils/searchExtension.js

--- a/.gitignore
+++ b/.gitignore
@@ -894,6 +894,7 @@ packages/editor/CodeMirror/utils/growSelectionToNode.js
 packages/editor/CodeMirror/utils/handlePasteEvent.js
 packages/editor/CodeMirror/utils/isCursorAtBeginning.js
 packages/editor/CodeMirror/utils/isInSyntaxNode.js
+packages/editor/CodeMirror/utils/keyUpHandlerExtension.js
 packages/editor/CodeMirror/utils/overwriteModeExtension.test.js
 packages/editor/CodeMirror/utils/overwriteModeExtension.js
 packages/editor/CodeMirror/utils/searchExtension.js

--- a/packages/editor/CodeMirror/utils/keyUpHandlerExtension.ts
+++ b/packages/editor/CodeMirror/utils/keyUpHandlerExtension.ts
@@ -1,0 +1,66 @@
+import { EditorView, ViewPlugin } from '@codemirror/view';
+
+interface OnKeyUpEvent {
+	domEvent: KeyboardEvent;
+	view: EditorView;
+	// true if other keys were pressed (and possibly released) during the time
+	// that this key was down (and before it was released).
+	otherKeysWerePressed: boolean;
+}
+
+// Should return true if the event was handled
+type OnKeyUpHandler = (event: OnKeyUpEvent)=> boolean;
+// Should return true if the given event matches the key that should
+// be handled by the extension:
+type IsTargetKeyCallback = (event: KeyboardEvent)=> boolean;
+
+// CodeMirror's built-in keyboard event handlers trigger on key down, rather than on
+// key up. In some cases, it's useful to trigger keyboard shortcuts on key up instead.
+// For example, if a shortcut should only activate if it isn't pressed at the same time
+// as other keys.
+const keyUpHandlerExtension = (isTargetKey: IsTargetKeyCallback, onKeyUp: OnKeyUpHandler) => {
+	return ViewPlugin.fromClass(class {
+		private otherKeysWerePressed = false;
+		private targetKeyDown = false;
+
+		public constructor(private view: EditorView) {
+			view.contentDOM.addEventListener('keydown', this.onKeyDown);
+			view.contentDOM.addEventListener('keyup', this.onKeyUp);
+		}
+
+		public destroy() {
+			this.view?.contentDOM?.removeEventListener('keyup', this.onKeyUp);
+		}
+
+		private onKeyDown = (event: KeyboardEvent) => {
+			if (isTargetKey(event)) {
+				this.targetKeyDown = true;
+			} else if (this.targetKeyDown) {
+				this.otherKeysWerePressed = true;
+			}
+		};
+
+		private onKeyUp = (event: KeyboardEvent) => {
+			if (isTargetKey(event)) {
+				if (this.targetKeyDown && !event.defaultPrevented) {
+					const handled = onKeyUp({
+						domEvent: event,
+						view: this.view,
+						otherKeysWerePressed: this.otherKeysWerePressed,
+					});
+
+					if (handled) {
+						event.preventDefault();
+					}
+				}
+
+				this.targetKeyDown = false;
+				this.otherKeysWerePressed = false;
+			} else if (this.targetKeyDown) {
+				this.otherKeysWerePressed = true;
+			}
+		};
+	});
+};
+
+export default keyUpHandlerExtension;

--- a/packages/editor/CodeMirror/utils/overwriteModeExtension.test.ts
+++ b/packages/editor/CodeMirror/utils/overwriteModeExtension.test.ts
@@ -46,6 +46,17 @@ describe('overwriteModeExtension', () => {
 		expect(editor.state.doc.toString()).toBe('Example!');
 	});
 
+	test('should be disabled by pressing <escape>', async () => {
+		const editor = await createEditor('Test!', true);
+
+		expect(overwriteModeEnabled(editor)).toBe(true);
+		pressReleaseKey(editor, { key: 'Escape', code: 'Escape' });
+		expect(overwriteModeEnabled(editor)).toBe(false);
+		// Escape should not re-enable the extension
+		pressReleaseKey(editor, { key: 'Escape', code: 'Escape' });
+		expect(overwriteModeEnabled(editor)).toBe(false);
+	});
+
 	test('<insert> should not toggle overwrite mode if other keys are pressed', async () => {
 		// On Linux, the Orca screen reader's default "do screen reader action" key is
 		// <insert>. To avoid toggling insert mode when users perform screen reader actions,

--- a/packages/editor/CodeMirror/utils/overwriteModeExtension.test.ts
+++ b/packages/editor/CodeMirror/utils/overwriteModeExtension.test.ts
@@ -1,6 +1,6 @@
 import { EditorSelection } from '@codemirror/state';
 import createTestEditor from '../testUtil/createTestEditor';
-import overwriteModeExtension, { toggleOverwrite } from './overwriteModeExtension';
+import overwriteModeExtension, { overwriteModeEnabled, toggleOverwrite } from './overwriteModeExtension';
 import typeText from '../testUtil/typeText';
 import pressReleaseKey from '../testUtil/pressReleaseKey';
 
@@ -36,12 +36,32 @@ describe('overwriteModeExtension', () => {
 		const editor = await createEditor('Test!');
 
 		pressReleaseKey(editor, { key: 'Insert', code: 'Insert' });
+		expect(overwriteModeEnabled(editor)).toBe(true);
+
 		typeText(editor, 'Exam');
 		expect(editor.state.doc.toString()).toBe('Exam!');
 
 		pressReleaseKey(editor, { key: 'Insert', code: 'Insert' });
 		typeText(editor, 'ple');
 		expect(editor.state.doc.toString()).toBe('Example!');
+	});
+
+	test('<insert> should not toggle overwrite mode if other keys are pressed', async () => {
+		// On Linux, the Orca screen reader's default "do screen reader action" key is
+		// <insert>. To avoid toggling insert mode when users perform screen reader actions,
+		// pressing <insert> should only toggle insert mode in certain cases.
+		const editor = await createEditor('Test');
+		const insertKey = { code: 'Insert', key: 'Insert ' };
+
+		editor.contentDOM.dispatchEvent(new KeyboardEvent('keydown', insertKey));
+		expect(overwriteModeEnabled(editor)).toBe(false);
+
+		// Pressing & releasing the space key should prevent insert mode from being enabled
+		pressReleaseKey(editor, { code: 'Space', key: 'Space' });
+
+		editor.contentDOM.dispatchEvent(new KeyboardEvent('keyup', insertKey));
+
+		expect(overwriteModeEnabled(editor)).toBe(false);
 	});
 
 	test('should insert text if the cursor is at the end of a line', async () => {

--- a/packages/editor/CodeMirror/utils/overwriteModeExtension.ts
+++ b/packages/editor/CodeMirror/utils/overwriteModeExtension.ts
@@ -1,4 +1,4 @@
-import { EditorView } from '@codemirror/view';
+import { EditorView, keymap } from '@codemirror/view';
 import { StateField, Facet, StateEffect } from '@codemirror/state';
 import keyUpHandlerExtension from './keyUpHandlerExtension';
 
@@ -81,6 +81,20 @@ const setOverwriteModeEnabled = (enabled: boolean, view: EditorView) => {
 
 const overwriteModeExtension = [
 	overwriteModeState,
+	keymap.of([
+		{
+			// The <escape> keyboard shortcut may be more easily discoverable for users
+			// who enter overwrite mode unintentionally.
+			key: 'Escape',
+			run: (view) => {
+				if (overwriteModeEnabled(view)) {
+					setOverwriteModeEnabled(false, view);
+					return true;
+				}
+				return false;
+			},
+		},
+	]),
 	keyUpHandlerExtension(
 		(event) => (
 			event.code === 'Insert' && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey


### PR DESCRIPTION
# Summary

On Linux, the Orca screen reader's default modifier key is <kbd>insert</kbd>. Before this pull request, pressing <kbd>insert</kbd> as part of a screen reader shortcut (e.g. <kbd>insert</kbd>-<kbd>h</kbd>), entered overwrite mode.

This pull request:
- Prevents <kbd>insert</kbd> from entering overwrite mode if another key was pressed before releasing <kbd>insert</kbd>.
- To allow this check to work, enters/exits insert mode on keyup rather than on keydown.
   - A custom `keyUpHandler` CodeMirror extension was created to allow this.

# Testing plan

This pull request adds a new `overwriteModeExtension` automated test that verifies that the following process does not enable insert mode:
1. Pressing <kbd>insert</kbd>.
2. Pressing and releasing some other key.
3. Releasing <kbd>insert</kbd>.

Additionally, on Fedora 41:
1. Enable the Orca screen reader.
2. Open Joplin and open a note in the Markdown editor.
3. Press <kbd>insert</kbd>.
    - With Orca enabled (at least with my desktop environment), the `onkeyup` event handler is not invoked when the user releases <kbd>insert</kbd> (though the `onkeydown` handler is on key down). With Orca disabled, both `onkeydown` and `onkeyup` are received.
4. Verify that insert mode has not been enabled.
5. Press <kbd>insert</kbd> twice quickly.
6. Verify that overwrite mode is enabled.
7. Press <kbd>escape</kbd>.
8. Verify that overwrite mode is disabled.
9. Disable Orca and restart Joplin.
10. Open a note.
11. Press <kbd>insert</kbd>.
12. Verify that overwrite mode is enabled.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->