### PR TITLE
Desktop: Fixes #11457: Fix crash on startup if old read-only items are in the trash

### DIFF
--- a/packages/lib/services/trash/permanentlyDeleteOldItems.ts
+++ b/packages/lib/services/trash/permanentlyDeleteOldItems.ts
@@ -4,8 +4,43 @@ import Setting from '../../models/Setting';
 import Note from '../../models/Note';
 import { Day, Hour } from '@joplin/utils/time';
 import shim from '../../shim';
+import { itemIsReadOnlySync } from '../../models/utils/readOnly';
+import BaseItem from '../../models/BaseItem';
+import { ModelType } from '../../BaseModel';
+import ItemChange from '../../models/ItemChange';
 
 const logger = Logger.create('permanentlyDeleteOldData');
+
+const readOnlyItemsRemoved = async (itemIds: string[], itemType: ModelType) => {
+	const result = [];
+	for (const id of itemIds) {
+		const item = await BaseItem.loadItem(itemType, id);
+
+		// Only do the share-related read-only checks. If other checks are done,
+		// readOnly will always be true because the item is in the trash.
+		const shareChecksOnly = true;
+		const readOnly = itemIsReadOnlySync(
+			itemType,
+			ItemChange.SOURCE_UNSPECIFIED,
+			item,
+			Setting.value('sync.userId'),
+			BaseItem.syncShareCache,
+			shareChecksOnly,
+		);
+		if (!readOnly) {
+			result.push(id);
+		}
+	}
+	return result;
+};
+
+const itemsToDelete = async (ttl: number|null = null) => {
+	const result = await Folder.trashItemsOlderThan(ttl);
+	const folderIds = await readOnlyItemsRemoved(result.folderIds, ModelType.Folder);
+	const noteIds = await readOnlyItemsRemoved(result.noteIds, ModelType.Note);
+
+	return { folderIds, noteIds };
+};
 
 const permanentlyDeleteOldItems = async (ttl: number = null) => {
 	ttl = ttl === null ? Setting.value('trash.ttlDays') * Day : ttl;
@@ -17,13 +52,13 @@ const permanentlyDeleteOldItems = async (ttl: number = null) => {
 		return;
 	}
 
-	const result = await Folder.trashItemsOlderThan(ttl);
-	logger.info('Items to permanently delete:', result);
+	const toDelete = await itemsToDelete(ttl);
+	logger.info('Items to permanently delete:', toDelete);
 
-	await Note.batchDelete(result.noteIds, { sourceDescription: 'permanentlyDeleteOldItems' });
+	await Note.batchDelete(toDelete.noteIds, { sourceDescription: 'permanentlyDeleteOldItems' });
 
 	// We only auto-delete folders if they are empty.
-	for (const folderId of result.folderIds) {
+	for (const folderId of toDelete.folderIds) {
 		const noteIds = await Folder.noteIds(folderId, { includeDeleted: true });
 		if (!noteIds.length) {
 			logger.info(`Deleting empty folder: ${folderId}`);


### PR DESCRIPTION
# Summary

This pull request should fix #11457.

Previously, the trash auto-deletion logic attempted to delete items in the trash even if part of a read-only share. This caused a crash on startup when deleting old items.

> [!IMPORTANT]
>
> Although this issue doesn't seem to be a recent regression, this pull request targets `release-3.1` &mdash; this issue is preventing [at least one user](https://discourse.joplinapp.org/t/2024-12-01-fatal-error-on-windows/42249/2) from starting Joplin.

# Testing plan

This pull request includes an automated test, but has not been tested manually.

I have verified that, if the changes to `permanentlyDeleteItems.ts` are **reverted**, then the test fails with:
```
    Cannot change or delete a read-only item: a85b609b6eef4914833c381e0d393a89
```