### PR TITLE
ci: improve workflow

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           # https://yarnpkg.com/getting-started/install
           corepack enable
-      
+
       # Login to Docker only if we're on a server release tag. If we run this on
       # a pull request it will fail because the PR doesn't have access to
       # secrets
@@ -115,6 +115,7 @@ jobs:
           SERVER_REPOSITORY: joplin/server
           SERVER_TAG_PREFIX: server
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           "${GITHUB_WORKSPACE}/.github/scripts/run_ci.sh"
 
@@ -189,7 +190,7 @@ jobs:
           # Basic test to ensure that the created build is valid. It should exit with
           # code 0  if it works.
           docker run joplin/server:0.0.0-beta node dist/app.js migrate list
- 
+
       - name: Check HTTP request
         run: |
           # Need to pass environment variables:
@@ -201,23 +202,22 @@ jobs:
           # Check if status code is correct
           # if the actual_status DOES NOT include the expected_status
           # it exits the process with code 1
-          
+
           expected_status="HTTP/1.1 200 OK"
           actual_status=$(curl -I -X GET http://localhost:22300/api/ping | head -n 1)
-          if [[ ! "$actual_status" =~ "$expected_status" ]]; then 
+          if [[ ! "$actual_status" =~ "$expected_status" ]]; then
             echo 'Failed while checking the status code after request to /api/ping'
             echo 'expected: ' $expected_status
             echo 'actual:   ' $actual_status
-            exit 1; 
+            exit 1;
           fi
-          
+
           # Check if the body response is correct
           # if the actual_body is different of expected_body exit with code 1
           expected_body='{"status":"ok","message":"Joplin Server is running"}'
           actual_body=$(curl http://localhost:22300/api/ping)
-          
+
           if [[ "$actual_body" != "$expected_body" ]]; then
             echo 'Failed while checking the body response after request to /api/ping'
             exit 1;
           fi
-


### PR DESCRIPTION
1. Run tests, iff the other prerequisites are met
2. In case of a translation PR, skip tests not related to translations (and building the apps)

I've optimized the ci workflow a bit:

First of all the tests were run, even if lints and other prereqs failed. Thus I moved the tests down in the workflow.
There is also no need to run the entire workflow when a translation PR is submitted. The pipelines run for a long time. We can save not only time but CPU cycles in gh actions.