### PR TITLE
Android: Close voice typing session when closing the editor

### DIFF
--- a/packages/app-mobile/components/voiceTyping/VoiceTypingDialog.tsx
+++ b/packages/app-mobile/components/voiceTyping/VoiceTypingDialog.tsx
@@ -78,6 +78,10 @@ const useWhisper = ({ locale, provider, onSetPreview, onText }: UseVoiceTypingPr
 		setMustDownloadModel(!(await builder.isDownloaded()));
 	}, [builder]);
 
+	useEffect(() => () => {
+		void voiceTypingRef.current?.stop();
+	}, []);
+
 	return [error, mustDownloadModel, voiceTyping];
 };
 

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -75,7 +75,7 @@ class Whisper implements VoiceTypingSession {
 
 	public async stop() {
 		if (this.sessionId === null) {
-			logger.warn('Session already closed.');
+			logger.debug('Session already closed.');
 			return;
 		}
 


### PR DESCRIPTION
# Summary

This pull request closes the voice typing session when closing the editor. Previously, voice typing was only closed when clicking "Done".

# Testing plan

This pull request has been manually tested with the following steps:
1. Start voice typing in a note.
2. Verify that the microphone indicator is shown.
    - On my device, a green dot is shown near the top right corner of the screen.
3. Close the note by clicking the "back" button.
4. Wait 2-3 seconds.
5. Verify that the microphone indicator is no longer visible.
6. Repeat steps 1-5.

This has been tested successfully on an Android 13 tablet.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->