### PR TITLE
Desktop: Fixes #11444: Allow zooming in/out in secondary windows

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -99,6 +99,11 @@ export default class ElectronAppWrapper {
 		return null;
 	}
 
+	public allAppWindows() {
+		const allWindowIds = [...this.secondaryWindows_.keys(), defaultWindowId];
+		return allWindowIds.map(id => this.windowById(id));
+	}
+
 	public env() {
 		return this.env_;
 	}
@@ -357,6 +362,9 @@ export default class ElectronAppWrapper {
 			const window = BrowserWindow.fromWebContents(event.sender);
 			const electronWindowId = window?.id;
 			this.secondaryWindows_.set(windowId, { electronId: electronWindowId });
+
+			// Match the main window's zoom:
+			window.webContents.setZoomFactor(this.mainWindow().webContents.getZoomFactor());
 
 			window.once('close', () => {
 				this.secondaryWindows_.delete(windowId);

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -29,7 +29,7 @@ import { reg } from '@joplin/lib/registry';
 const packageInfo: PackageInfo = require('./packageInfo.js');
 import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import ClipperServer from '@joplin/lib/ClipperServer';
-import { ipcRenderer, webFrame } from 'electron';
+import { ipcRenderer } from 'electron';
 const Menu = bridge().Menu;
 const PluginManager = require('@joplin/lib/services/PluginManager');
 import RevisionService from '@joplin/lib/services/RevisionService';
@@ -133,29 +133,33 @@ class Application extends BaseApplication {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	protected async generalMiddleware(store: any, next: any, action: any) {
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'locale' || action.type === 'SETTING_UPDATE_ALL') {
+		const isSettingUpdate = (key: string) => {
+			return action.type === 'SETTING_UPDATE_ONE' && action.key === key || action.type === 'SETTING_UPDATE_ALL';
+		};
+
+		if (isSettingUpdate('locale')) {
 			this.updateLanguage();
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'renderer.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
+		if (isSettingUpdate('renderer.fileUrls')) {
 			bridge().electronApp().getCustomProtocolHandler().setMediaAccessEnabled(
 				Setting.value('renderer.fileUrls'),
 			);
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'showTrayIcon' || action.type === 'SETTING_UPDATE_ALL') {
+		if (isSettingUpdate('showTrayIcon')) {
 			this.updateTray();
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'ocr.enabled' || action.type === 'SETTING_UPDATE_ALL') {
+		if (isSettingUpdate('ocr.enabled')) {
 			void this.setupOcrService();
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'windowContentZoomFactor' || action.type === 'SETTING_UPDATE_ALL') {
-			webFrame.setZoomFactor(Setting.value('windowContentZoomFactor') / 100);
+		if (isSettingUpdate('windowContentZoomFactor')) {
+			bridge().setZoomFactor(Setting.value('windowContentZoomFactor') / 100);
 		}
 
-		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'linking.extraAllowedExtensions' || action.type === 'SETTING_UPDATE_ALL') {
+		if (isSettingUpdate('linking.extraAllowedExtensions')) {
 			bridge().extraAllowedOpenExtensions = Setting.value('linking.extraAllowedExtensions');
 		}
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -133,33 +133,29 @@ class Application extends BaseApplication {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	protected async generalMiddleware(store: any, next: any, action: any) {
-		const isSettingUpdate = (key: string) => {
-			return action.type === 'SETTING_UPDATE_ONE' && action.key === key || action.type === 'SETTING_UPDATE_ALL';
-		};
-
-		if (isSettingUpdate('locale')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'locale' || action.type === 'SETTING_UPDATE_ALL') {
 			this.updateLanguage();
 		}
 
-		if (isSettingUpdate('renderer.fileUrls')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'renderer.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
 			bridge().electronApp().getCustomProtocolHandler().setMediaAccessEnabled(
 				Setting.value('renderer.fileUrls'),
 			);
 		}
 
-		if (isSettingUpdate('showTrayIcon')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'showTrayIcon' || action.type === 'SETTING_UPDATE_ALL') {
 			this.updateTray();
 		}
 
-		if (isSettingUpdate('ocr.enabled')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'ocr.enabled' || action.type === 'SETTING_UPDATE_ALL') {
 			void this.setupOcrService();
 		}
 
-		if (isSettingUpdate('windowContentZoomFactor')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'windowContentZoomFactor' || action.type === 'SETTING_UPDATE_ALL') {
 			bridge().setZoomFactor(Setting.value('windowContentZoomFactor') / 100);
 		}
 
-		if (isSettingUpdate('linking.extraAllowedExtensions')) {
+		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'linking.extraAllowedExtensions' || action.type === 'SETTING_UPDATE_ALL') {
 			bridge().extraAllowedOpenExtensions = Setting.value('linking.extraAllowedExtensions');
 		}
 

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -285,6 +285,13 @@ export class Bridge {
 		this.switchToWindow(defaultWindowId);
 	}
 
+	// zoom should be in the range [0..1]
+	public setZoomFactor(zoom: number) {
+		for (const window of this.electronWrapper_.allAppWindows()) {
+			window.webContents.setZoomFactor(zoom);
+		}
+	}
+
 	public showItemInFolder(fullPath: string) {
 		return require('electron').shell.showItemInFolder(toSystemSlashes(fullPath));
 	}


### PR DESCRIPTION
# Summary

This pull request:
- Applies the zoom level setting to all windows when zooming in/out.
- On creation, initializes secondary windows with the same zoom level as the main window.
When the zoom level changes, this pull request

Fixes #11444.

# Testing plan

This pull request has been tested manually by:
1. Starting Joplin.
2. Opening a note in a new window.
3. Pressing <kbd>ctrl</kbd>-<kbd>+</kbd> in the secondary window.
4. Verifying that both the secondary and main windows zoom in.
5. Opening a different note in a new window.
7. Pressing <kbd>ctrl</kbd>-<kbd>0</kbd>.
8. Verifying that all windows zoom out.

This has been tested successfully on Fedora (Linux) 41.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->