### PR TITLE
All: Fix the error caused by undefined isCodeBlock_ (turndown-plugin-gfm)

### DIFF
--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -179,7 +179,7 @@ const nodeContains = (node, types) => {
 
   for (let i = 0; i < node.childNodes.length; i++) {
     const child = node.childNodes[i];
-    if (types === 'code' && isCodeBlock_(child)) return true;
+    if (types === 'code' && isCodeBlock_ && isCodeBlock_(child)) return true;
     if (types.includes(child.nodeName)) return true;
     if (nodeContains(child, types)) return true;
   }


### PR DESCRIPTION
Fixes #10328

This is a follow-up pull request to another pull request, https://github.com/laurent22/joplin/pull/10931, which was closed due to a build failure caused by the syntax `?.`, introduced in ES 2020.

Instead, I chose a more backward-compatible approach.

----

Unfortunately, I couldn't run `yarn test` because `npm install` failed as shown below. However, the code is simple, and I'm confident it won't cause any issues:

<details>
<summary>The log of `npm install`</summary>

% npm install
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @joplin/app-desktop@3.2.3
npm error Found: react@18.3.1
npm error node_modules/react
npm error   react@"18.3.1" from @joplin/app-desktop@3.2.3
npm error   packages/app-desktop
npm error     @joplin/app-desktop@3.2.3
npm error     node_modules/@joplin/app-desktop
npm error       workspace packages/app-desktop from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm error node_modules/@testing-library/react-hooks
npm error   dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm error   packages/app-desktop
npm error     @joplin/app-desktop@3.2.3
npm error     node_modules/@joplin/app-desktop
npm error       workspace packages/app-desktop from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/manabu/.npm/_logs/2024-12-05T10_28_09_324Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/manabu/.npm/_logs/2024-12-05T10_28_09_324Z-debug-0.log
実行時間: 59.974秒  (起動:1.900秒 処理:7.369秒 CPU15%)
~/workplace/joplin fix-undefined-in-turndown-plugin-gfm [!] is 📦 v(independent) via ⬢ v22.9.0 via myenv took 1m 0s
% npm install --force
npm warn using --force Recommended protections disabled.
npm warn ERESOLVE overriding peer dependency
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: @types/react@18.3.3
npm warn node_modules/@types/react
npm warn   dev @types/react@"18.3.3" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn     @joplin/app-desktop@3.2.3
npm warn     node_modules/@joplin/app-desktop
npm warn   23 more (@joplin/app-mobile, @joplin/editor, @joplin/lib, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional @types/react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn
npm warn Conflicting peer dependency: @types/react@17.0.83
npm warn node_modules/@types/react
npm warn   peerOptional @types/react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn     packages/app-desktop
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: react@18.3.1
npm warn packages/app-desktop/node_modules/react
npm warn   react@"18.3.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn     @joplin/app-desktop@3.2.3
npm warn     node_modules/@joplin/app-desktop
npm warn   3 more (react-dom, react-redux, react-test-renderer)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn
npm warn Conflicting peer dependency: react@17.0.2
npm warn node_modules/react
npm warn   peer react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn     packages/app-desktop
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: react-dom@18.3.1
npm warn packages/app-desktop/node_modules/react-dom
npm warn   react-dom@"18.3.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn     @joplin/app-desktop@3.2.3
npm warn     node_modules/@joplin/app-desktop
npm warn   1 more (react-redux)
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional react-dom@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn
npm warn Conflicting peer dependency: react-dom@17.0.2
npm warn node_modules/react-dom
npm warn   peerOptional react-dom@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn     packages/app-desktop
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: react-test-renderer@18.3.1
npm warn packages/app-desktop/node_modules/react-test-renderer
npm warn   dev react-test-renderer@"18.3.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn     @joplin/app-desktop@3.2.3
npm warn     node_modules/@joplin/app-desktop
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional react-test-renderer@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn
npm warn Conflicting peer dependency: react-test-renderer@17.0.2
npm warn node_modules/react-test-renderer
npm warn   peerOptional react-test-renderer@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/app-desktop/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/app-desktop@3.2.3
npm warn     packages/app-desktop
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @react-native-clipboard/clipboard@1.14.1
npm warn Found: react@18.3.1
npm warn packages/app-mobile/node_modules/react
npm warn   react@"18.3.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   19 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"16.9.0 || 16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0 || 18.2.0" from @react-native-clipboard/clipboard@1.14.1
npm warn packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn   @react-native-clipboard/clipboard@"1.14.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn
npm warn Conflicting peer dependency: react@18.2.0
npm warn node_modules/react
npm warn   peer react@"16.9.0 || 16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0 || 18.2.0" from @react-native-clipboard/clipboard@1.14.1
npm warn   packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn     @react-native-clipboard/clipboard@"1.14.1" from @joplin/app-mobile@3.2.0
npm warn     packages/app-mobile
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @react-native-clipboard/clipboard@1.14.1
npm warn Found: react-native@0.74.1
npm warn packages/app-mobile/node_modules/react-native
npm warn   react-native@"0.74.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   27 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-native@"^0.61.5 || ^0.62.3 || ^0.63.2 || ^0.64.2 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn   @react-native-clipboard/clipboard@"1.14.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn
npm warn Conflicting peer dependency: react-native@0.73.11
npm warn node_modules/react-native
npm warn   peer react-native@"^0.61.5 || ^0.62.3 || ^0.63.2 || ^0.64.2 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn   packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn     @react-native-clipboard/clipboard@"1.14.1" from @joplin/app-mobile@3.2.0
npm warn     packages/app-mobile
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native@0.74.1
npm warn Found: react@18.3.1
npm warn packages/app-mobile/node_modules/react
npm warn   react@"18.3.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   19 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"18.2.0" from react-native@0.74.1
npm warn packages/app-mobile/node_modules/react-native
npm warn   react-native@"0.74.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn   27 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Conflicting peer dependency: react@18.2.0
npm warn node_modules/react
npm warn   peer react@"18.2.0" from react-native@0.74.1
npm warn   packages/app-mobile/node_modules/react-native
npm warn     react-native@"0.74.1" from @joplin/app-mobile@3.2.0
npm warn     packages/app-mobile
npm warn     27 more (@bam.tech/react-native-image-resizer, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native-macos@0.73.35
npm warn Found: react@18.3.1
npm warn packages/app-mobile/node_modules/react
npm warn   react@"18.3.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   19 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"18.2.0" from react-native-macos@0.73.35
npm warn packages/app-mobile/node_modules/react-native-macos
npm warn   peer react-native-macos@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn   packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn   1 more (react-native-localize)
npm warn
npm warn Conflicting peer dependency: react@18.2.0
npm warn node_modules/react
npm warn   peer react@"18.2.0" from react-native-macos@0.73.35
npm warn   packages/app-mobile/node_modules/react-native-macos
npm warn     peer react-native-macos@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn     packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn     1 more (react-native-localize)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native-windows@0.73.21
npm warn Found: react@18.3.1
npm warn packages/app-mobile/node_modules/react
npm warn   react@"18.3.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   19 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"18.2.0" from react-native-windows@0.73.21
npm warn packages/app-mobile/node_modules/react-native-windows
npm warn   peer react-native-windows@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn   packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn   3 more (@react-native-community/datetimepicker, ...)
npm warn
npm warn Conflicting peer dependency: react@18.2.0
npm warn node_modules/react
npm warn   peer react@"18.2.0" from react-native-windows@0.73.21
npm warn   packages/app-mobile/node_modules/react-native-windows
npm warn     peer react-native-windows@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn     packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn     3 more (@react-native-community/datetimepicker, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native-windows@0.73.21
npm warn Found: react-native@0.74.1
npm warn packages/app-mobile/node_modules/react-native
npm warn   react-native@"0.74.1" from @joplin/app-mobile@3.2.0
npm warn   packages/app-mobile
npm warn     @joplin/app-mobile@3.2.0
npm warn     node_modules/@joplin/app-mobile
npm warn   27 more (@bam.tech/react-native-image-resizer, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer react-native@"^0.73.0" from react-native-windows@0.73.21
npm warn packages/app-mobile/node_modules/react-native-windows
npm warn   peer react-native-windows@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn   packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn   3 more (@react-native-community/datetimepicker, ...)
npm warn
npm warn Conflicting peer dependency: react-native@0.73.11
npm warn node_modules/react-native
npm warn   peer react-native@"^0.73.0" from react-native-windows@0.73.21
npm warn   packages/app-mobile/node_modules/react-native-windows
npm warn     peer react-native-windows@"^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0" from @react-native-clipboard/clipboard@1.14.1
npm warn     packages/app-mobile/node_modules/@react-native-clipboard/clipboard
npm warn     3 more (@react-native-community/datetimepicker, ...)
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: @types/react@18.3.3
npm warn node_modules/@types/react
npm warn   dev @types/react@"18.3.3" from @joplin/app-desktop@3.2.3
npm warn   packages/app-desktop
npm warn     @joplin/app-desktop@3.2.3
npm warn     node_modules/@joplin/app-desktop
npm warn   23 more (@joplin/app-mobile, @joplin/editor, @joplin/lib, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional @types/react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/lib/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn   packages/lib
npm warn
npm warn Conflicting peer dependency: @types/react@17.0.83
npm warn node_modules/@types/react
npm warn   peerOptional @types/react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/lib/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn     packages/lib
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: react@18.3.1
npm warn packages/lib/node_modules/react
npm warn   dev react@"18.3.1" from @joplin/lib@3.2.0
npm warn   packages/lib
npm warn     @joplin/lib@3.2.0
npm warn     node_modules/@joplin/lib
npm warn   1 more (react-test-renderer)
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/lib/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn   packages/lib
npm warn
npm warn Conflicting peer dependency: react@17.0.2
npm warn node_modules/react
npm warn   peer react@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/lib/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn     packages/lib
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/react-hooks@8.0.1
npm warn Found: react-test-renderer@18.3.1
npm warn packages/lib/node_modules/react-test-renderer
npm warn   dev react-test-renderer@"18.3.1" from @joplin/lib@3.2.0
npm warn   packages/lib
npm warn     @joplin/lib@3.2.0
npm warn     node_modules/@joplin/lib
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional react-test-renderer@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn packages/lib/node_modules/@testing-library/react-hooks
npm warn   dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn   packages/lib
npm warn
npm warn Conflicting peer dependency: react-test-renderer@17.0.2
npm warn node_modules/react-test-renderer
npm warn   peerOptional react-test-renderer@"^16.9.0 || ^17.0.0" from @testing-library/react-hooks@8.0.1
npm warn   packages/lib/node_modules/@testing-library/react-hooks
npm warn     dev @testing-library/react-hooks@"8.0.1" from @joplin/lib@3.2.0
npm warn     packages/lib
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native@0.70.6
npm warn Found: react@18.3.1
npm warn packages/react-native-alarm-notification/node_modules/react
npm warn   dev react@"18.3.1" from @joplin/react-native-alarm-notification@3.2.0
npm warn   packages/react-native-alarm-notification
npm warn     @joplin/react-native-alarm-notification@3.2.0
npm warn     node_modules/@joplin/react-native-alarm-notification
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"18.1.0" from react-native@0.70.6
npm warn packages/react-native-alarm-notification/node_modules/react-native
npm warn   dev react-native@"0.70.6" from @joplin/react-native-alarm-notification@3.2.0
npm warn   packages/react-native-alarm-notification
npm warn
npm warn Conflicting peer dependency: react@18.1.0
npm warn node_modules/react
npm warn   peer react@"18.1.0" from react-native@0.70.6
npm warn   packages/react-native-alarm-notification/node_modules/react-native
npm warn     dev react-native@"0.70.6" from @joplin/react-native-alarm-notification@3.2.0
npm warn     packages/react-native-alarm-notification
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: react-native@0.70.6
npm warn Found: react@18.3.1
npm warn packages/react-native-saf-x/node_modules/react
npm warn   dev react@"18.3.1" from @joplin/react-native-saf-x@3.2.0
npm warn   packages/react-native-saf-x
npm warn     @joplin/react-native-saf-x@3.2.0
npm warn     node_modules/@joplin/react-native-saf-x
npm warn
npm warn Could not resolve dependency:
npm warn peer react@"18.1.0" from react-native@0.70.6
npm warn packages/react-native-saf-x/node_modules/react-native
npm warn   dev react-native@"0.70.6" from @joplin/react-native-saf-x@3.2.0
npm warn   packages/react-native-saf-x
npm warn
npm warn Conflicting peer dependency: react@18.1.0
npm warn node_modules/react
npm warn   peer react@"18.1.0" from react-native@0.70.6
npm warn   packages/react-native-saf-x/node_modules/react-native
npm warn     dev react-native@"0.70.6" from @joplin/react-native-saf-x@3.2.0
npm warn     packages/react-native-saf-x
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm warn deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm warn deprecated move-concurrently@1.0.1: This package is no longer supported.
npm warn deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm warn deprecated npmlog@5.0.1: This package is no longer supported.
npm warn deprecated @babel/plugin-proposal-numeric-separator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
npm warn deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm warn deprecated @babel/plugin-proposal-nullish-coalescing-operator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated figgy-pudding@3.5.2: This module is no longer supported.
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm warn deprecated har-validator@5.1.5: this library is no longer supported
npm warn deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated copy-concurrently@1.0.5: This package is no longer supported.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated @babel/plugin-proposal-optional-chaining@7.21.0: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
npm warn deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm warn deprecated are-we-there-yet@2.0.0: This package is no longer supported.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm warn deprecated domexception@2.0.1: Use your platform's native DOMException instead
npm warn deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm warn deprecated querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm warn deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
npm warn deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
npm warn deprecated q@1.5.1: You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
npm warn deprecated
npm warn deprecated (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
npm warn deprecated fs-write-stream-atomic@1.0.10: This package is no longer supported.
npm warn deprecated fsevents@1.2.13: Upgrade to fsevents v2 to mitigate potential security issues
npm warn deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm warn deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm warn deprecated gauge@3.0.2: This package is no longer supported.
npm warn deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm warn deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm warn deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm warn deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm warn deprecated eslint@8.57.0: This version is no longer supported. Please see https://eslint.org/version-support for other options.
npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
npm warn deprecated domexception@4.0.0: Use your platform's native DOMException instead
npm warn deprecated uglify-es@3.3.10: support for ECMAScript is superseded by `uglify-js` as of v3.13.0
npm warn deprecated rimraf@2.2.8: Rimraf versions prior to v4 are no longer supported
npm warn deprecated dommatrix@1.0.3: dommatrix is no longer maintained. Please use @thednp/dommatrix.
npm warn deprecated read-package-json@6.0.4: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated acorn-import-assertions@1.9.0: package has been renamed to acorn-import-attributes
npm warn deprecated highlight.js@9.12.0: Version no longer supported. Upgrade to @latest
npm warn deprecated highlight.js@9.12.0: Version no longer supported. Upgrade to @latest
npm warn deprecated trim@0.0.1: Use String.prototype.trim() instead
npm warn deprecated readdir-scoped-modules@1.1.0: This functionality has been moved to @npmcli/fs
npm warn deprecated debuglog@1.0.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated later@1.2.0: Please upgrade to the maintained and new drop-in replacement @breejs/later at https://github.com/breejs/later 🚀 Thanks and happy hacking! 🚀  @niftylettuce
npm warn deprecated uid-number@0.0.6: This package is no longer supported.
npm warn deprecated node-fetch-npm@2.0.4: This module is not used anymore, npm uses minipass-fetch for its fetch implementation now
npm warn deprecated read-package-json@6.0.4: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated mkdirp-promise@5.0.1: This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/gitlab-client@3.15.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/github-client@3.22.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/conventional-commits@3.22.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/resolve-symlink@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npm-lifecycle@3.1.5: The lifecycle script runner used in npm is now @npmcli/run-script. Please use that module moving forward
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/create-symlink@3.16.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated @lerna/npm-run-script@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/timer@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/get-packed@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated read-package-json@2.1.2: This package is no longer supported. Please use @npmcli/package-json instead.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/collect-uncommitted@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @evocateur/libnpmpublish@1.2.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/npm-publish@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/otplease@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated @lerna/pack-directory@3.16.4: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/npm-dist-tag@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/check-working-tree@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/log-packed@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/prerelease-id-from-version@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/package@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated @lerna/get-npm-exec-opts@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @evocateur/libnpmaccess@3.1.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/query-graph@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/filter-packages@3.18.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/profiler@3.20.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/write-log-file@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/project@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/describe-ref@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/output@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated read-package-tree@5.3.1: The functionality that this package provided is now in @npmcli/arborist
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/global-options@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/listable@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/collect-updates@3.20.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/prompt@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/symlink-binary@3.17.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/symlink-dependencies@3.17.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/run-lifecycle@3.16.2: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/pulse-till-done@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/run-topologically@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/rimraf-dir@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated osenv@0.1.5: This package is no longer supported.
npm warn deprecated @lerna/package-graph@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/npm-install@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated @lerna/has-npm-version@3.16.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated @lerna/validation-error@3.13.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/filter-options@3.20.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @evocateur/npm-registry-fetch@4.0.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/command@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/npm-conf@3.16.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/publish@3.22.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/version@3.22.1: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @evocateur/pacote@9.6.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/run@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/info@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/link@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/list@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/init@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/import@3.22.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/exec@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/diff@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn deprecated @lerna/cli@3.18.5: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/changed@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/clean@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/bootstrap@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @lerna/add@3.21.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated boolean@3.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn deprecated @xmldom/xmldom@0.7.13: this version is no longer supported, please update to at least 0.8.*
npm warn deprecated glob@7.1.6: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.1.6: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.1.6: Glob versions prior to v9 are no longer supported
npm warn deprecated @types/jest-expect-message@1.1.0: This is a stub types definition. jest-expect-message provides its own type definitions, so you do not need this installed.
npm warn deprecated @babel/plugin-proposal-optional-catch-binding@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
npm warn deprecated @babel/plugin-proposal-logical-assignment-operators@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
npm warn deprecated @babel/plugin-proposal-async-generator-functions@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
npm warn deprecated @babel/plugin-proposal-object-rest-spread@7.12.1: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
npm warn deprecated @types/pdfjs-dist@2.10.378: This is a stub types definition. pdfjs-dist provides its own type definitions, so you do not need this installed.
npm warn deprecated @types/nanoid@3.0.0: This is a stub types definition. nanoid provides its own type definitions, so you do not need this installed.
npm warn deprecated glob@7.0.6: Glob versions prior to v9 are no longer supported
npm warn deprecated @types/tesseract.js@2.0.0: This is a stub types definition. tesseract.js provides its own type definitions, so you do not need this installed.
npm warn deprecated @joeattardi/emoji-button@4.6.4: Emoji Button is now PicMo! Please install the 'picmo' package, see https://picmojs.com for details
npm warn deprecated gauge@4.0.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
npm warn deprecated npmlog@6.0.2: This package is no longer supported.
npm warn deprecated gauge@4.0.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
npm warn deprecated npmlog@6.0.2: This package is no longer supported.
npm warn deprecated gauge@2.7.4: This package is no longer supported.
npm warn deprecated are-we-there-yet@1.1.7: This package is no longer supported.
npm warn deprecated npmlog@4.1.2: This package is no longer supported.
npm warn cleanup Failed to remove some directories [
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/@joeattardi',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/@joeattardi/emoji-button'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/@joeattardi/emoji-button'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/@joeattardi/emoji-button'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/@joeattardi/emoji-button'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/eslint-plugin-jest',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/eslint-plugin-jest'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/eslint-plugin-jest'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/@mixmark-io',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/@mixmark-io'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/@mixmark-io'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/react-native-rsa-native',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/react-native-rsa-native'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/react-native-rsa-native'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/license-checker-rseidelsohn',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/license-checker-rseidelsohn'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/license-checker-rseidelsohn'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native/ReactAndroid'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native/ReactAndroid'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native/ReactAndroid'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native/ReactAndroid'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native-macos',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native-macos'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/packages/app-mobile/node_modules/react-native-macos'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules/react-native',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules/react-native'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules/react-native'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules/react-native'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/packages/react-native-saf-x/node_modules/react-native'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/@craftzdog',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/@craftzdog/react-native-buffer'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/@craftzdog/react-native-buffer'
npm warn cleanup     }
npm warn cleanup   ],
npm warn cleanup   [
npm warn cleanup     '/Users/manabu/workplace/joplin/node_modules/@craftzdog/react-native-buffer',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/manabu/workplace/joplin/node_modules/@craftzdog/react-native-buffer'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/manabu/workplace/joplin/node_modules/@craftzdog/react-native-buffer'
npm warn cleanup     }
npm warn cleanup   ]
npm warn cleanup ]
npm error code 1
npm error path /Users/manabu/workplace/joplin/node_modules/sharp
npm error command failed
npm error command sh -c node install/check
npm error sharp: Detected globally-installed libvips v8.15.3
npm error sharp: Attempting to build from source via node-gyp
npm error sharp: Found node-addon-api
npm error sharp: Found node-gyp version 9.4.1
npm error sharp: See https://sharp.pixelplumbing.com/install#building-from-source
npm error   CC(target) Release/obj.target/nothing/../../node-addon-api/src/nothing.o
npm error   LIBTOOL-STATIC Release/nothing.a
npm error   TOUCH Release/obj.target/libvips-cpp.stamp
npm error   CXX(target) Release/obj.target/sharp-darwin-arm64/common.o
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@9.4.1
npm error gyp info using node@22.9.0 | darwin | arm64
npm error gyp info chdir src
npm error (node:76535) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
npm error (Use `node --trace-deprecation ...` to show where the warning was created)
npm error gyp info find Python using Python version 3.12.7 found at "/Users/manabu/myenv/bin/python3"
npm error gyp info spawn /Users/manabu/myenv/bin/python3
npm error gyp info spawn args [
npm error gyp info spawn args   '/Users/manabu/workplace/joplin/node_modules/node-gyp/gyp/gyp_main.py',
npm error gyp info spawn args   'binding.gyp',
npm error gyp info spawn args   '-f',
npm error gyp info spawn args   'make',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/Users/manabu/workplace/joplin/node_modules/sharp/src/build/config.gypi',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/Users/manabu/workplace/joplin/node_modules/node-gyp/addon.gypi',
npm error gyp info spawn args   '-I',
npm error gyp info spawn args   '/Users/manabu/Library/Caches/node-gyp/22.9.0/include/node/common.gypi',
npm error gyp info spawn args   '-Dlibrary=shared_library',
npm error gyp info spawn args   '-Dvisibility=default',
npm error gyp info spawn args   '-Dnode_root_dir=/Users/manabu/Library/Caches/node-gyp/22.9.0',
npm error gyp info spawn args   '-Dnode_gyp_dir=/Users/manabu/workplace/joplin/node_modules/node-gyp',
npm error gyp info spawn args   '-Dnode_lib_file=/Users/manabu/Library/Caches/node-gyp/22.9.0/<(target_arch)/node.lib',
npm error gyp info spawn args   '-Dmodule_root_dir=/Users/manabu/workplace/joplin/node_modules/sharp/src',
npm error gyp info spawn args   '-Dnode_engine=v8',
npm error gyp info spawn args   '--depth=.',
npm error gyp info spawn args   '--no-parallel',
npm error gyp info spawn args   '--generator-output',
npm error gyp info spawn args   'build',
npm error gyp info spawn args   '-Goutput_dir=.'
npm error gyp info spawn args ]
npm error <string>:114: SyntaxWarning: invalid escape sequence '\/'
npm error gyp info spawn make
npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm error warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: archive library: Release/nothing.a the table of contents is empty (no object file members in the library define global symbols)
npm error ../common.cc:12:10: fatal error: 'napi.h' file not found
npm error    12 | #include <napi.h>
npm error       |          ^~~~~~~~
npm error 1 error generated.
npm error make: *** [Release/obj.target/sharp-darwin-arm64/common.o] Error 1
npm error gyp ERR! build error
npm error gyp ERR! stack Error: `make` failed with exit code: 2
npm error gyp ERR! stack     at ChildProcess.onExit (/Users/manabu/workplace/joplin/node_modules/node-gyp/lib/build.js:203:23)
npm error gyp ERR! stack     at ChildProcess.emit (node:events:519:28)
npm error gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:293:12)
npm error gyp ERR! System Darwin 24.1.0
npm error gyp ERR! command "/opt/homebrew/Cellar/node/22.9.0_1/bin/node" "/Users/manabu/workplace/joplin/node_modules/.bin/node-gyp" "rebuild" "--directory=src"
npm error gyp ERR! cwd /Users/manabu/workplace/joplin/node_modules/sharp/src
npm error gyp ERR! node -v v22.9.0
npm error gyp ERR! node-gyp -v v9.4.1
npm error gyp ERR! not ok
npm error A complete log of this run can be found in: /Users/manabu/.npm/_logs/2024-12-05T10_29_25_269Z-debug-0.log
</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->