### PR TITLE
Desktop: Remove Better Code Blocks from the list of plugins incompatible with the new editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
@@ -38,7 +38,6 @@ const incompatiblePluginIds = [
 	'ylc395.noteLinkSystem',
 	'outline',
 	'joplin.plugin.cmoptions',
-	'com.ckant.joplin-plugin-better-code-blocks',
 	// cSpell:enable
 ];
 


### PR DESCRIPTION
# Summary

The Better Code Blocks plugin [now supports CodeMirror 6](https://discourse.joplinapp.org/t/plugin-better-code-blocks/32613/14?u=ckant) (as of v2.0.0).

This pull request removes `'com.ckant.joplin-plugin-better-code-blocks` from the list of plugins incompatible with CodeMirror 6.
# Testing plan

    1. Start Joplin (before compiling the changed files from this PR to JavaScript).

    2. Install the Better Code Blocks plugin and restart.

    3. Verify that an incompatibility warning is shown for the Better Code Blocks plugin

    4. Quit Joplin

    5. Run `yarn tsc` from `packages/app-desktop`.

    6. Start Joplin

    7. Verify that the incompatibility warning is no longer shown.

---

Same as #11143 which removed the Math Mode plugin