### PR TITLE
Desktop: Resolves  #11478 - Bold or italic text in markdown viewer

### DIFF
--- a/packages/utils/markdown.ts
+++ b/packages/utils/markdown.ts
@@ -40,6 +40,8 @@ export const extractUrls = (md: string): Link[] => {
 				};
 			} else if (token.type === 'link_close') {
 				if (!currentLink) throw new Error('Found a link_close without a link_open');
+				// Render the collected title content to process Markdown (supports bold, italic, etc.)
+				currentLink.title = markdownIt.renderInline(currentLink.title);
 				output.push(currentLink);
 				currentLink = null;
 			} else if (token.children && token.children.length) {
@@ -57,9 +59,10 @@ export const extractUrls = (md: string): Link[] => {
 	const htmlAnchorRegex = /<a[\s\S]*?href=["'](.*?)["'][\s\S]*?>(.*?)<\/a>/ig;
 	let result;
 	while ((result = htmlAnchorRegex.exec(md)) !== null) {
+		// Render the content inside HTML anchor tags to process Markdown (e.g., italic, bold)
 		output.push({
 			url: result[1],
-			title: result[2],
+			title: markdownIt.renderInline(result[2]),
 		});
 	}
 


### PR DESCRIPTION
…matting in markdown viewer

Fixes the issue with bold and italic text in markdown viewer which is addressed in the issue #11478

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->