### PR TITLE
Mobile: Plugin API: Implement the `toggleVisiblePanes` command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -757,6 +757,7 @@ packages/app-mobile/components/screens/Note/commands/attachFile.js
 packages/app-mobile/components/screens/Note/commands/hideKeyboard.js
 packages/app-mobile/components/screens/Note/commands/index.js
 packages/app-mobile/components/screens/Note/commands/setTags.js
+packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.js
 packages/app-mobile/components/screens/Note/types.js
 packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes.js

--- a/.gitignore
+++ b/.gitignore
@@ -733,6 +733,7 @@ packages/app-mobile/components/screens/Note/commands/attachFile.js
 packages/app-mobile/components/screens/Note/commands/hideKeyboard.js
 packages/app-mobile/components/screens/Note/commands/index.js
 packages/app-mobile/components/screens/Note/commands/setTags.js
+packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.js
 packages/app-mobile/components/screens/Note/types.js
 packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes.js

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -60,7 +60,7 @@ import getImageDimensions from '../../../utils/image/getImageDimensions';
 import resizeImage from '../../../utils/image/resizeImage';
 import { CameraResult } from '../../CameraView/types';
 import { DialogContext, DialogControl } from '../../DialogManager';
-import { CommandRuntimeProps, PickerResponse } from './types';
+import { CommandRuntimeProps, EditorMode, PickerResponse } from './types';
 import commands from './commands';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -91,7 +91,7 @@ interface ComponentProps extends Props {
 
 interface State {
 	note: NoteEntity;
-	mode: 'view'|'edit';
+	mode: EditorMode;
 	readOnly: boolean;
 	folder: FolderEntity|null;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -339,6 +339,10 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					if (!this.state.note || !this.state.note.id) return;
 
 					this.setState({ noteTagDialogShown: visible });
+				},
+				getMode: () => this.state.mode,
+				setMode: (mode: 'view'|'edit') => {
+					this.setState({ mode });
 				},
 			},
 			commands,

--- a/packages/app-mobile/components/screens/Note/commands/index.ts
+++ b/packages/app-mobile/components/screens/Note/commands/index.ts
@@ -2,11 +2,13 @@
 import * as attachFile from './attachFile';
 import * as hideKeyboard from './hideKeyboard';
 import * as setTags from './setTags';
+import * as toggleVisiblePanes from './toggleVisiblePanes';
 
 const index: any[] = [
 	attachFile,
 	hideKeyboard,
 	setTags,
+	toggleVisiblePanes,
 ];
 
 export default index;

--- a/packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.ts
+++ b/packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.ts
@@ -1,0 +1,18 @@
+import { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
+import { CommandRuntimeProps } from '../types';
+
+export const declaration: CommandDeclaration = {
+	// For compatibility with the desktop app, this command is called "toggleVisiblePanes".
+	name: 'toggleVisiblePanes',
+	label: () => 'Start/stop editing',
+};
+
+export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
+	return {
+		execute: async (_context: CommandContext) => {
+			// For now, the only two "panes" on mobile are view and edit.
+			const newMode = props.getMode() === 'edit' ? 'view' : 'edit';
+			props.setMode(newMode);
+		},
+	};
+};

--- a/packages/app-mobile/components/screens/Note/types.ts
+++ b/packages/app-mobile/components/screens/Note/types.ts
@@ -7,10 +7,15 @@ export interface PickerResponse {
 	fileName?: string;
 }
 
+export type EditorMode = 'view'|'edit';
+
 export interface CommandRuntimeProps {
 	attachFile(pickerResponse: PickerResponse, fileType: string): Promise<ResourceEntity|null>;
 	hideKeyboard(): void;
 	insertText(text: string): void;
+
+	getMode(): EditorMode;
+	setMode(mode: EditorMode): void;
 	setCameraVisible(visible: boolean): void;
 	setTagDialogVisible(visible: boolean): void;
 	dialogs: DialogControl;


### PR DESCRIPTION
# Summary

This pull request adds a `toggleVisiblePanes` note screen command to the mobile app. This feature was requested [on the forum](https://discourse.joplinapp.org/t/mobile-plugins-api-togglevisiblepanes-fr/42254).

# Testing plan

This pull request includes an automated test. Additionally, it has been tested manually by:
1. Starting the Joplin web app with a plugin installed.
2. Opening the note viewer.
3. Inspecting the plugin background frame in the browser development tools.
4. Running `joplin.commands.execute('toggleVisiblePanes')`.
5. Verifying that this opens the editor.
6. Running `joplin.commands.execute('toggleVisiblePanes')`.
7. Verifying that this re-opens the note viewer (and closes the editor).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->