### PR TITLE
Desktop: Reduce application size

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -41,9 +41,6 @@
       "build/tesseract.js-core/**",
       "build/7zip/**"
     ],
-    "files": [
-      "!./integration-tests/**"
-    ],
     "afterAllArtifactBuild": "./afterAllArtifactBuild.js",
     "asar": true,
     "asarUnpack": "./node_modules/node-notifier/vendor/**",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -42,9 +42,6 @@
       "build/7zip/**"
     ],
     "files": [
-      "!**/node_modules/mermaid/**",
-      "!**/node_modules/cytoscape-fcose/demo/**",
-      "!node_modules/@fortawesome/**",
       "!./integration-tests/**"
     ],
     "afterAllArtifactBuild": "./afterAllArtifactBuild.js",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -41,6 +41,12 @@
       "build/tesseract.js-core/**",
       "build/7zip/**"
     ],
+    "files": [
+      "!**/node_modules/mermaid/**",
+      "!**/node_modules/cytoscape-fcose/demo/**",
+      "!node_modules/@fortawesome/**",
+      "!./integration-tests/**"
+    ],
     "afterAllArtifactBuild": "./afterAllArtifactBuild.js",
     "asar": true,
     "asarUnpack": "./node_modules/node-notifier/vendor/**",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -18,12 +18,15 @@
   },
   "author": "",
   "license": "AGPL-3.0-or-later",
+
+  "//": "Mermaid is bundled by buildAssets.js -- using it as an unbundled dependency significantly increases app size.",
   "devDependencies": {
     "@types/jest": "29.5.12",
     "@types/markdown-it": "13.0.9",
     "@types/node": "18.19.50",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
+    "mermaid": "11.4.0",
     "ts-jest": "29.1.5",
     "typescript": "5.4.5"
   },
@@ -50,8 +53,7 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "2.0.0",
     "markdown-it-toc-done-right": "4.2.0",
-    "md5": "2.3.0",
-    "mermaid": "11.4.0"
+    "md5": "2.3.0"
   },
   "gitHead": "05a29b450962bf05a8642bbd39446a1f679a96ba"
 }


### PR DESCRIPTION
# Summary

This pull request is a follow-up to @pedr's work on [decreasing the application build size](https://github.com/laurent22/joplin/pull/11412).

This pull request moves  `mermaid` from a runtime dependency to a dev dependency of the renderer package. This decreases the locally-built `AppImage` size from from 285.9 MB to 228.6 MB.

At present, `mermaid` is bundled into an asset file **and only used from this asset file**. As such, the `mermaid` package in `node_modules` is unused at runtime. This is the case on both mobile and desktop.

# Testing plan

1. Build an `.AppImage` using `yarn dist`.
2. Start the `.AppImage`.
3. Add a `mermaid` graph.
4. Verify that the graph renders in the note viewer.
    - I tested with a `gitGraph`:  
      ![screenshot: gitGraph rendered in the Markdown viewer and editor](https://github.com/user-attachments/assets/f701a5a7-1ff8-46d6-966d-5b81014d2a32)
5. Switch to the Rich Text Editor and verify that the graph still renders.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->