### PR TITLE
Desktop: Fixes #11179: Fixed tags with same special unicode characters not matching

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -212,4 +212,15 @@ describe('models/Tag', () => {
 		expect(commonTagIds.includes(tagc.id)).toBe(true);
 	});
 
+	it('should allow finding tags even with special Unicode characters', async () => {
+		const note1 = await Note.save({});
+		// cSpell:disable
+		await Tag.setNoteTagsByTitles(note1.id, ['Ökonomie']);
+
+		const tag1 = await Tag.loadByTitle('Ökonomie');
+		const tag2 = await Tag.loadByTitle('ökonomie');
+		// cSpell:enable
+
+		expect(tag1).toStrictEqual(tag2);
+	});
 });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -172,7 +172,9 @@ export default class Tag extends BaseItem {
 	}
 
 	public static async loadByTitle(title: string): Promise<TagEntity> {
-		return this.loadByField('title', title, { caseInsensitive: true });
+		// Case insensitive doesn't work with especial Unicode characters like Ö
+		const lowercaseTitle = title.toLowerCase();
+		return this.loadByField('title', lowercaseTitle, { caseInsensitive: true });
 	}
 
 	public static async addNoteTagByTitle(noteId: string, tagTitle: string) {


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11179

# Summary

The issue happens because SQLite case-insensitive search doesn't work with all Unicode characters, I tried to remedy this by lowercasing the title before the search, since all tags seems to be stored as lowercase this should prevent the issue in the future, but I also spend some time looking for a way to make this work on SQLite.

To fix this problem with the case-sensitive search on SQLITE we could look into adding an extension like: 
https://github.com/nalgeon/sqlean/blob/main/docs/text.md

## Description

The issue would happen when the user tried to import two notes with the same tag `Ökonomie`. 

When Joplin creates the tag it would turn into `ökonomie`, but when the second note tried to find the tag `Ökonomie`  it wouldn't find **because SQLite case-insensitive search doesn't support the `Ö`/`ö` character**.

I added a fix where I lowercase the title because doing the search by title and it should fix it for most cases.

## Proper fix


# Testing

1. Download https://github.com/user-attachments/files/17265549/example_tag_umlaut.zip
2. Import content as "MD + Front Matter (Directory)"
3. Before this PR the import process would crash because `Ökonomie` tag already existed
4. After this PR it should import both notes with the tag `ökonomie`
