### PR TITLE
Chore: Desktop: Fix automated test that makes assumptions about which plugins are loaded

### DIFF
--- a/packages/app-desktop/integration-tests/models/SettingsScreen.ts
+++ b/packages/app-desktop/integration-tests/models/SettingsScreen.ts
@@ -14,6 +14,10 @@ export default class SettingsScreen {
 		return this.page.getByRole('tab', { name: tabName });
 	}
 
+	public getLastTab() {
+		return this.page.getByRole('tablist').getByRole('tab').last();
+	}
+
 	public async waitFor() {
 		await this.okayButton.waitFor();
 		await this.appearanceTabButton.waitFor();

--- a/packages/app-desktop/integration-tests/settings.spec.ts
+++ b/packages/app-desktop/integration-tests/settings.spec.ts
@@ -75,7 +75,7 @@ test.describe('settings', () => {
 
 		// Pressing Up when the first item is focused should focus the last item
 		await mainWindow.keyboard.press('ArrowUp');
-		await expect(focusedItem).toHaveText('Backup');
+		await expect(settingsScreen.getLastTab()).toBeFocused();
 
 		await mainWindow.keyboard.press('ArrowDown');
 		await mainWindow.keyboard.press('ArrowDown');

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -147,3 +147,4 @@ setsize
 Comprar
 seguidores
 devbox
+tablist


### PR DESCRIPTION
# Summary

This pull request updates a test that was failing in [this pull request](https://github.com/laurent22/joplin/pull/11516). The test previously assumed that the last settings tab is named "Backup". After adding a new default plugin, this will no longer be the case.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->