### PR TITLE
Desktop: Resolves: Generate .deb installer for Joplin Desktop

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -118,7 +118,10 @@
         "Icon": "joplin",
         "MimeType": "x-scheme-handler/joplin;"
       },
-      "target": "AppImage"
+      "target": ["AppImage", "deb"],
+      "executableName": "joplin",
+      "maintainer": "Joplin Team <no-reply@joplinapp.org>",
+      "artifactName": "Joplin-${version}.${ext}"
     }
   },
   "homepage": "https://github.com/laurent22/joplin#readme",


### PR DESCRIPTION
# Summary

Creates a .deb installer for Joplin Desktop.

By default, the `electron-builder` will use the package name as the name of the executable, so I add an `executableName` so package can be executed in CLI by running `joplin` instead of `@joplinapp-desktop`, for similar reason I also added the `artifactName`, without it the debian file would end-up on `app-desktop/dist/@joplin/` instead of `app-desktop/dist/`.

<details><summary>Information about the package after installation</summary>
```
js@mint:~/Desktop/joplin/fork/packages/app-desktop/dist$ sudo apt show joplin
Package: joplin
Version: 3.2.4
Status: install ok installed
Priority: optional
Section: default
Maintainer: Joplin Team <no-reply@joplinapp.org>
Installed-Size: 867 MB
Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0
Recommends: libappindicator3-1
Homepage: https://github.com/laurent22/joplin#readme
License: AGPL-3.0-or-later
Vendor: Joplin Team <no-reply@joplinapp.org>
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Joplin for Desktop
```
</details> 

# Testing

1. On a Linux machine
1. Run `yarn dist` on `app-desktop` project
2. After the process is finished there should be one .Appimage and one .deb binary inside the `app-desktop/dist` folder
3. It should be possible to run `sudo dpkg -i Joplin-${version}.deb` to install the package on Debian derivated machines