### PR TITLE
Mobile: Resolves #11486: Add an accordion for disabled master keys on encryption screen

### DIFF
--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -85,7 +85,7 @@ const EncryptionConfigScreen = (props: Props) => {
 
 	const decryptedItemsInfo = props.encryptionEnabled ? <Text style={styles.normalText}>{decryptedStatText(stats)}</Text> : null;
 
-	const renderMasterKey = (_num: number, mk: MasterKeyEntity) => {
+	const renderMasterKey = (mk: MasterKeyEntity) => {
 		const theme = themeStyle(props.themeId);
 
 		const password = inputPasswords[mk.id] ? inputPasswords[mk.id] : '';

--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -287,18 +287,16 @@ const EncryptionConfigScreen = (props: Props) => {
 		<View style={rootStyle}>
 			<ScreenHeader title={_('Encryption Config')} />
 			<ScrollView style={styles.container}>
-				{
-					<View style={{ backgroundColor: theme.warningBackgroundColor, paddingTop: 5, paddingBottom: 5, paddingLeft: 10, paddingRight: 10 }}>
-						<Text>{_('For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:')}</Text>
-						<TouchableOpacity
-							onPress={() => {
-								Linking.openURL('https://joplinapp.org/help/apps/sync/e2ee');
-							}}
-						>
-							<Text>https://joplinapp.org/help/apps/sync/e2ee</Text>
-						</TouchableOpacity>
-					</View>
-				}
+				<View style={{ backgroundColor: theme.warningBackgroundColor, paddingTop: 5, paddingBottom: 5, paddingLeft: 10, paddingRight: 10 }}>
+					<Text>{_('For more information about End-To-End Encryption (E2EE) and advice on how to enable it please check the documentation:')}</Text>
+					<TouchableOpacity
+						onPress={() => {
+							Linking.openURL('https://joplinapp.org/help/apps/sync/e2ee');
+						}}
+					>
+						<Text>https://joplinapp.org/help/apps/sync/e2ee</Text>
+					</TouchableOpacity>
+				</View>
 
 				<Text style={styles.titleText}>{_('Status')}</Text>
 				<Text style={styles.normalText}>{_('Encryption is: %s', props.encryptionEnabled ? _('Enabled') : _('Disabled'))}</Text>


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/11486

# Summary

Mobile didn't had any differentiation between encryption keys that are enabled or disabled, I added an accordion from `react-native-paper` to hide the ones that are disabled.

To use `react-native-paper` Accordion I had to make some changes to the layout so it would all be aligned. I opted to a quick modification instead of refactoring all the page.

<details><summary>Images</summary>

![2024-12-17_11-34](https://github.com/user-attachments/assets/22dba523-8589-4520-ac29-86cfe20fba1e)

![2024-12-17_11-33](https://github.com/user-attachments/assets/9c415bc6-24dd-4932-9e0a-5760ab35dc9e)

</details> 

# Testing

1. I opened the application on web
2. Put a breakpoint where `Setting` is available
3. Got `Setting.value('syncInfoCache')` and modified to include more `masterKeys` values
4. Made some of these keys disabled by setting `enabled: 0`
5. Updated the Settings by setting the new syncInfoCache with `Setting.setValue`
6. Observed if the interface was working properly