### PR TITLE
Desktop: Fixes #11382: Rich Text Editor: Fix resized images in lists break sub-list items

### DIFF
--- a/packages/app-cli/tests/html_to_md/image_preserve_size_in_lists.html
+++ b/packages/app-cli/tests/html_to_md/image_preserve_size_in_lists.html
@@ -1,0 +1,33 @@
+<ul>
+	<li>
+		<img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"/>
+		<ul>
+			<li>HTML images just before a sublist should have a closing &lt;img&gt; tag added.</li>
+			<li>Otherwise, when rendered to Markdown again, the subsequent list items will be rendered as HTML.</li>
+		</ul>
+	</li>
+	<li>
+		<img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"/>
+		<br/>
+		<strong>A closing tag is also necessary if the image is followed by content on a new line.</strong>
+	</li>
+	<li>
+		<img src=":/0123456789abcdef0123456789abcdef"/>
+		<ul>
+			<li>Similar logic isn't necessary for images converted to Markdown.</li>
+		</ul>
+	</li>
+	<li>
+		<img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"/>
+	</li>
+	<li>It also isn't necessary if the next item is at the same level as the image...</li>
+	<li>
+		...or if the image has text just before it.
+		<img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"/>
+		<ul>
+			<li>
+				See <a href="https://github.com/laurent22/joplin/issues/11382">this issue</a> for details.
+			</li>
+		</ul>
+	</li>
+</ul>

--- a/packages/app-cli/tests/html_to_md/image_preserve_size_in_lists.md
+++ b/packages/app-cli/tests/html_to_md/image_preserve_size_in_lists.md
@@ -1,0 +1,11 @@
+- <img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"></img>
+    - HTML images just before a sublist should have a closing &lt;img&gt; tag added.
+    - Otherwise, when rendered to Markdown again, the subsequent list items will be rendered as HTML.
+- <img src=":/0123456789abcdef0123456789abcdef" width="10" height="11"></img>  
+    **A closing tag is also necessary if the image is followed by content on a new line.**
+- ![](:/0123456789abcdef0123456789abcdef)
+    - Similar logic isn't necessary for images converted to Markdown.
+- <img src=":/0123456789abcdef0123456789abcdef" width="10" height="11">
+- It also isn't necessary if the next item is at the same level as the image...
+- ...or if the image has text just before it. <img src=":/0123456789abcdef0123456789abcdef" width="10" height="11">
+    - See [this issue](https://github.com/laurent22/joplin/issues/11382) for details.

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -561,7 +561,37 @@ function imageMarkdownFromNode(node, options = null) {
   }, options);
 
   if (options.preserveImageTagsWithSize && (node.getAttribute('width') || node.getAttribute('height'))) {
-    return node.outerHTML;
+    let html = node.outerHTML;
+
+    const needsClosingTag = () => {
+      const parent = node.parentElement;
+      if (!parent || parent.nodeName !== 'LI') return false;
+      const hasClosingTag = html.match(/<\/[a-z]+\/>$/ig);
+      if (hasClosingTag) {
+        return false;
+      }
+
+      // A closing tag is only necessary when the image would be in a list item
+      // by itself, and the next item is a list.
+      const allChildren = [...parent.childNodes];
+      const nonEmptyChildren = allChildren.filter(item => {
+        return item.nodeName !== '#text' || item.textContent.trim() !== '';
+      });
+
+      const imageIndex = nonEmptyChildren.indexOf(node);
+      const hasNextSibling = imageIndex + 1 < nonEmptyChildren.length;
+      const nextSiblingName = hasNextSibling ? (
+        nonEmptyChildren[imageIndex + 1].nodeName
+      ) : null;
+
+      const nextSiblingIsNewLine = nextSiblingName === 'UL' || nextSiblingName === 'OL' || nextSiblingName === 'BR';
+      return imageIndex === 0 && nextSiblingIsNewLine;
+    };
+
+    if (needsClosingTag()) {
+      html = html.replace(/[/]?>$/, `></${node.nodeName.toLowerCase()}>`);
+    }
+    return html;
   }
 
   return imageMarkdownFromAttributes({

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -563,6 +563,8 @@ function imageMarkdownFromNode(node, options = null) {
   if (options.preserveImageTagsWithSize && (node.getAttribute('width') || node.getAttribute('height'))) {
     let html = node.outerHTML;
 
+    // To prevent markup immediately after the image from being interpreted as HTML, a closing tag
+    // is sometimes necessary.
     const needsClosingTag = () => {
       const parent = node.parentElement;
       if (!parent || parent.nodeName !== 'LI') return false;

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -573,10 +573,11 @@ function imageMarkdownFromNode(node, options = null) {
         return false;
       }
 
-      // A closing tag is only necessary when the image would be in a list item
-      // by itself, and the next item is a list.
       const allChildren = [...parent.childNodes];
       const nonEmptyChildren = allChildren.filter(item => {
+        // Even if surrounded by #text nodes that only contain whitespace, Markdown after
+        // an <img> can still be incorrectly interpreted as HTML. Only non-empty #texts seem
+        // to prevent this.
         return item.nodeName !== '#text' || item.textContent.trim() !== '';
       });
 


### PR DESCRIPTION
# Summary

This pull request fixes #11382 by adding a closing `</img>` tag to HTML images in some cases.

# Testing plan

This pull request includes an automated test. It has also been tested manually by:
1. Creating a Markdown note with the following content:
	```markdown
	- <img src=":/7e6a92008e2d4f7bb0fcb3e631b8b50e" width="128"></img>
		- is
		- a
		- test
	```
2. Switching to the Rich Text Editor.
3. Adding a list item with content.
4. Switching back to the Markdown editor.
5. Verifying that the sublist is still present.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->