### PR TITLE
Mobile: Fixes #11539: Fix missing "Insert Time" button

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -754,6 +754,7 @@ packages/app-mobile/components/screens/Note/Note.js
 packages/app-mobile/components/screens/Note/commands/attachFile.js
 packages/app-mobile/components/screens/Note/commands/hideKeyboard.js
 packages/app-mobile/components/screens/Note/commands/index.js
+packages/app-mobile/components/screens/Note/commands/insertDateTime.js
 packages/app-mobile/components/screens/Note/commands/setTags.js
 packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.js
 packages/app-mobile/components/screens/Note/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -730,6 +730,7 @@ packages/app-mobile/components/screens/Note/Note.js
 packages/app-mobile/components/screens/Note/commands/attachFile.js
 packages/app-mobile/components/screens/Note/commands/hideKeyboard.js
 packages/app-mobile/components/screens/Note/commands/index.js
+packages/app-mobile/components/screens/Note/commands/insertDateTime.js
 packages/app-mobile/components/screens/Note/commands/setTags.js
 packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.js
 packages/app-mobile/components/screens/Note/types.js

--- a/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
@@ -23,6 +23,8 @@ const builtInCommandNames = [
 	EditorCommandType.IndentLess,
 	EditorCommandType.IndentMore,
 	'-',
+	'insertDateTime',
+	'-',
 	EditorCommandType.EditLink,
 	'setTags',
 	EditorCommandType.ToggleSearch,

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -69,6 +69,10 @@ const emptyArray: any[] = [];
 
 const logger = Logger.create('screens/Note');
 
+interface InsertTextOptions {
+	newLine?: boolean;
+}
+
 interface Props extends BaseProps {
 	provisionalNoteIds: string[];
 	dispatch: Dispatch;
@@ -721,20 +725,21 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		return await saveOriginalImage();
 	}
 
-	private async insertText(text: string) {
+	private async insertText(text: string, { newLine = false }: InsertTextOptions = {}) {
 		const newNote = { ...this.state.note };
+		const separator = newLine ? '\n' : '';
 
 		if (this.state.mode === 'edit') {
 			let newText = '';
 
 			if (this.selection) {
-				newText = `\n${text}\n`;
+				newText = `${separator}${text}${separator}`;
 				const prefix = newNote.body.substring(0, this.selection.start);
 				const suffix = newNote.body.substring(this.selection.end);
 				newNote.body = `${prefix}${newText}${suffix}`;
 			} else {
-				newText = `\n${text}`;
-				newNote.body = `${newNote.body}\n${newText}`;
+				newText = `${separator}${separator}${text}`;
+				newNote.body = `${newNote.body}${newText}`;
 			}
 
 			if (this.useEditorBeta()) {
@@ -747,7 +752,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				}
 			}
 		} else {
-			newNote.body += `\n${text}`;
+			newNote.body += `${separator}${text}`;
 		}
 
 		this.setState({ note: newNote });
@@ -830,7 +835,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		resource = await Resource.save(resource, { isNew: true });
 
 		const resourceTag = Resource.markupTag(resource);
-		const newNote = await this.insertText(resourceTag);
+		const newNote = await this.insertText(resourceTag, { newLine: true });
 
 		void this.refreshResource(resource, newNote.body);
 
@@ -850,7 +855,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 	private cameraView_onInsertBarcode = (data: string) => {
 		this.setState({ showCamera: false });
-		void this.insertText(data);
+		void this.insertText(data, { newLine: true });
 	};
 
 	private cameraView_onCancel() {

--- a/packages/app-mobile/components/screens/Note/commands/index.ts
+++ b/packages/app-mobile/components/screens/Note/commands/index.ts
@@ -1,12 +1,14 @@
 // AUTO-GENERATED using `gulp buildScriptIndexes`
 import * as attachFile from './attachFile';
 import * as hideKeyboard from './hideKeyboard';
+import * as insertDateTime from './insertDateTime';
 import * as setTags from './setTags';
 import * as toggleVisiblePanes from './toggleVisiblePanes';
 
 const index: any[] = [
 	attachFile,
 	hideKeyboard,
+	insertDateTime,
 	setTags,
 	toggleVisiblePanes,
 ];

--- a/packages/app-mobile/components/screens/Note/commands/insertDateTime.ts
+++ b/packages/app-mobile/components/screens/Note/commands/insertDateTime.ts
@@ -1,0 +1,20 @@
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import { CommandRuntimeProps } from '../types';
+import time from '@joplin/lib/time';
+
+export const declaration: CommandDeclaration = {
+	name: 'insertDateTime',
+	label: () => _('Insert time'),
+	iconName: 'material calendar-plus',
+};
+
+export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
+	return {
+		execute: async (_context: CommandContext) => {
+			props.insertText(time.formatDateToLocal(new Date()));
+		},
+
+		enabledCondition: '!noteIsReadOnly',
+	};
+};


### PR DESCRIPTION
# Summary

This pull request allows adding an "Insert Time" button to the mobile toolbar. This action was (incorrectly) removed in #11472.

Fixes #11539.

> [!NOTE]
>
> At present, the insert time button is included in the toolbar by default.

# Screenshot

![screenshot: An insert time button is included in the toolbar and toolbar settings.](https://github.com/user-attachments/assets/6bd02fca-4d25-4c0e-8a5b-f9ed907d64e2)


# Testing plan

**Web**:
1. Add the "insert time" button to the toolbar.
2. Click the insert time button.
3. Verify that the time/date is added at the cursor location in the editor.
4. Attach a file.
5. Verify that the file is added to the editor surrounded with newlines.
6. Switch to the viewer.
7. Insert a drawing.
8. Verify that the drawing is added to the end of the editor.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->