### PR TITLE
Documentation: Fixed two broken links in rest_api.md

### DIFF
--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -136,9 +136,9 @@ Call **GET /ping** to check if the service is available. It should return "Jopli
 
 ## Searching
 
-Call **GET /search?query=YOUR_QUERY** to search for notes. This end-point supports the `field` parameter which is recommended to use so that you only get the data that you need. The query syntax is as described in the main documentation: https://joplinapp.org/help/#searching
+Call **GET /search?query=YOUR_QUERY** to search for notes. This end-point supports the `field` parameter which is recommended to use so that you only get the data that you need. The query syntax is as described in the main documentation: https://joplinapp.org/help/apps/search
 
-To retrieve non-notes items, such as notebooks or tags, add a `type` parameter and set it to the required [item type name](#item-type-id). In that case, full text search will not be used - instead it will be a simple case-insensitive search. You can also use `*` as a wildcard. This is convenient for example to retrieve notebooks or tags by title.
+To retrieve non-notes items, such as notebooks or tags, add a `type` parameter and set it to the required [item type name](#item-type-ids). In that case, full text search will not be used - instead it will be a simple case-insensitive search. You can also use `*` as a wildcard. This is convenient for example to retrieve notebooks or tags by title.
 
 For example, to retrieve the notebook named `recipes`: **GET /search?query=recipes&type=folder**
 


### PR DESCRIPTION
Fixed two broken hyperlinks in the `Searching` section of `Joplin Data API` documentation.
