### PR TITLE
Server: use node:18 (bookworm) instead node:18-bullseye

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,11 +2,11 @@
 # Build stage
 # =============================================================================
 
-FROM node:18-bullseye AS builder
+FROM node:18 AS builder
 
 RUN apt-get update \
     && apt-get install -y \
-    python tini \
+    python3 tini \
     && rm -rf /var/lib/apt/lists/*
 
 # Enables Yarn
@@ -56,7 +56,7 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 # from a smaller base image.
 # =============================================================================
 
-FROM node:18-bullseye-slim
+FROM node:18-slim
 
 ARG user=joplin
 RUN useradd --create-home --shell /bin/bash $user


### PR DESCRIPTION
Joplin server is built on Bullseye based images. This Debian distributive has "old stable" status and related docker images have significantly bigger amount of vulnerabilities (the both full and slim images, please see a dockerhub statistic for more details).

The proposed version do not use explicit distro name in image tag which allow to using latest stable distro automatically. 

As bonus, looks like bookworm slim image has slightly smaller size.
