### PR TITLE
Desktop: Resolves #11575: Remove "URI malformed" alert

### DIFF
--- a/packages/app-cli/tests/support/test_notes/md/sample-malformed-uri.md
+++ b/packages/app-cli/tests/support/test_notes/md/sample-malformed-uri.md
@@ -1,0 +1,1 @@
+![malformed link](https://malformed_uri/%E0%A4%A.jpg)

--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -195,4 +195,13 @@ describe('InteropService_Importer_Md', () => {
 		// The invalid image is imported as-is
 		expect(resource.title).toBe('invalid-image.jpg');
 	});
+
+	it('should not fail to import file that contains a malformed URI', async () => {
+		// The first implicit test is that the below call doesn't throw due to the malformed URI
+		const note = await importNote(`${supportDir}/test_notes/md/sample-malformed-uri.md`);
+		const itemIds = Note.linkedItemIds(note.body);
+		expect(itemIds.length).toBe(0);
+		// The malformed link is imported as-is
+		expect(note.body).toContain('![malformed link](https://malformed_uri/%E0%A4%A.jpg)');
+	});
 });

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -16,7 +16,7 @@ import { isDataUrl } from '@joplin/utils/url';
 import { stripBom } from '../../string-utils';
 import Logger from '@joplin/utils/Logger';
 
-const logger = Logger.create('command-sync');
+const logger = Logger.create('InteropService_Importer_Md');
 
 export default class InteropService_Importer_Md extends InteropService_Importer_Base {
 	protected importedNotes: Record<string, NoteEntity> = {};

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -118,7 +118,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				link = decodeURI(encodedLink);
 			} catch (error) {
 				// If the URI cannot be decoded, leave it as it is.
-				logger.warn('Failed to decode URI, skipped:', error);
+				logger.info('Failed to decode URI, skipped:', error);
 				continue;
 			}
 

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -14,9 +14,6 @@ const { pregQuote } = require('../../string-utils-common');
 import { MarkupToHtml } from '@joplin/renderer';
 import { isDataUrl } from '@joplin/utils/url';
 import { stripBom } from '../../string-utils';
-import Logger from '@joplin/utils/Logger';
-
-const logger = Logger.create('InteropService_Importer_Md');
 
 export default class InteropService_Importer_Md extends InteropService_Importer_Base {
 	protected importedNotes: Record<string, NoteEntity> = {};
@@ -118,7 +115,6 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				link = decodeURI(encodedLink);
 			} catch (error) {
 				// If the URI cannot be decoded, leave it as it is.
-				logger.info('Failed to decode URI, skipped:', error);
 				continue;
 			}
 


### PR DESCRIPTION
Resolves #11575

The "URI malformed" alert is triggered here.

https://github.com/laurent22/joplin/blob/2b43a9a4d667fe6b81bc97b66e0b3700688ec3cf/packages/lib/services/interop/InteropService_Importer_Md.ts#L113

The "malformed" link is less likely to be a Resource URI, so we can leave it as it is. I add the `catch` statement to prevent the alert dialog ~~and log it as a warning~~.