### PR TITLE
Server: add PUID:PGID envs to server container

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -58,13 +58,11 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 
 FROM node:18-bullseye-slim
 
-ARG user=joplin
-RUN useradd --create-home --shell /bin/bash $user
+# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
+USER node
 
-USER $user
-
-COPY --chown=$user:$user --from=builder /build/packages /home/$user/packages
-COPY --chown=$user:$user --from=builder /usr/bin/tini /usr/local/bin/tini
+COPY --chown=node:node --from=builder /build/packages /app
+COPY --chown=node:node --from=builder /usr/bin/tini /usr/local/bin/tini
 
 ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1
@@ -72,7 +70,7 @@ EXPOSE ${APP_PORT}
 
 # Use Tini to start Joplin Server:
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
-WORKDIR /home/$user/packages/server
+WORKDIR /app/server
 ENTRYPOINT ["tini", "--"]
 CMD ["yarn", "start-prod"]
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -58,21 +58,35 @@ RUN BUILD_SEQUENCIAL=1 yarn install --inline-builds \
 
 FROM node:18-bullseye-slim
 
-# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
-USER node
-
+# Lazy version, https://github.com/tianon/gosu/blob/master/INSTALL.md
+COPY --from=tianon/gosu /gosu /usr/local/bin/
 COPY --chown=node:node --from=builder /build/packages /app
-COPY --chown=node:node --from=builder /usr/bin/tini /usr/local/bin/tini
+COPY --from=builder /usr/bin/tini /usr/local/bin/tini
+# Entry point to check permissions and switch to node:node user 
+COPY --chown=node:node docker/bin/docker-entrypoint.sh /
 
 ENV NODE_ENV=production
 ENV RUNNING_IN_DOCKER=1
+ENV DATA_ROOT=/data
+ENV SRV_ROOT=/app/server
+ENV PM2_HOME=$DATA_ROOT/pm2
+ENV PATH=$PATH:$SRV_ROOT/node_modules/.bin
+
 EXPOSE ${APP_PORT}
+
+RUN chmod ugo+rx,go-w /docker-entrypoint.sh \
+    && mkdir -p $PM2_HOME \
+    && chown node:node -R $DATA_ROOT \
+    # In case custom -u UID:GID arg was specified, these directory should be writable for other users
+    && chmod og+w -R $DATA_ROOT \
+    && chmod og+w $SRV_ROOT
 
 # Use Tini to start Joplin Server:
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
-WORKDIR /app/server
-ENTRYPOINT ["tini", "--"]
-CMD ["yarn", "start-prod"]
+WORKDIR $SRV_ROOT
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["pm2-runtime", "--exp-backoff-restart-delay=1000", "dist/app.js"]
 
 # Build-time metadata
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -3,10 +3,7 @@
 #
 # Update the following fields in the stanza below:
 #
-# POSTGRES_USER
-# POSTGRES_PASSWORD
-# APP_BASE_URL
-#
+# Application Configuration: 
 # APP_BASE_URL: This is the base public URL where the service will be running.
 #	- If Joplin Server needs to be accessible over the internet, configure APP_BASE_URL as follows: https://example.com/joplin. 
 #	- If Joplin Server does not need to be accessible over the internet, set the APP_BASE_URL to your server's hostname. 
@@ -14,6 +11,22 @@
 # APP_PORT: The local port on which the Docker container will listen. 
 #	- This would typically be mapped to port to 443 (TLS) with a reverse proxy.
 #	- If Joplin Server does not need to be accessible over the internet, the port can be mapped to 22300.
+#
+# DataBase configuration:
+# 
+# Using PostgreSQL (recommended):
+# DB_CLIENT=pg
+# POSTGRES_HOST: where is Postgres DB. `db` value in case of compose service.
+# POSTGRES_PORT: The port for Postgres DB. A `5432` should be used in most of cases.
+# POSTGRES_DATABASE: postgres database to store data. A `joplin` value would be a good chose here.
+# POSTGRES_USER: postgres user which has write access to POSTGRES_DATABASE. A `joplin` value would be a good chose here.
+# POSTGRES_PASSWORD: The password for POSTGRES_USER. Please generate your own value here.
+#
+# Using SQLite (not recommended for production, for testing purposes only!)
+# DB_CLIENT=sqlite3
+# SQLITE_DATABASE: location of local DB file. A `/data/db.sqlite` value would be a good chose here.
+#
+
 
 version: '3'
 
@@ -27,8 +40,8 @@ services:
         restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            - POSTGRES_USER=${POSTGRES_USER}
-            - POSTGRES_DB=${POSTGRES_DATABASE}
+            - POSTGRES_USER=${POSTGRES_USER:-joplin}
+            - POSTGRES_DB=${POSTGRES_DATABASE:-joplin}
     app:
         image: joplin/server:latest
         depends_on:
@@ -41,7 +54,7 @@ services:
             - APP_BASE_URL=${APP_BASE_URL}
             - DB_CLIENT=pg
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            - POSTGRES_DATABASE=${POSTGRES_DATABASE}
-            - POSTGRES_USER=${POSTGRES_USER}
-            - POSTGRES_PORT=${POSTGRES_PORT}
-            - POSTGRES_HOST=db
+            - POSTGRES_DATABASE=${POSTGRES_DATABASE:-joplin}
+            - POSTGRES_USER=${POSTGRES_USER:-joplin}
+            - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+            - POSTGRES_HOST=${POSTGRES_HOST:-db}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -11,6 +11,8 @@
 # APP_PORT: The local port on which the Docker container will listen. 
 #	- This would typically be mapped to port to 443 (TLS) with a reverse proxy.
 #	- If Joplin Server does not need to be accessible over the internet, the port can be mapped to 22300.
+# PUID: an optional parameter to specify UID for internal user. `1000` is default value. Right now may be used for beta images only!
+# PGID: an optional parameter to specify UID for internal user. `1000` is default value. Right now may be used for beta images only!
 #
 # DataBase configuration:
 # 
@@ -58,3 +60,5 @@ services:
             - POSTGRES_USER=${POSTGRES_USER:-joplin}
             - POSTGRES_PORT=${POSTGRES_PORT:-5432}
             - POSTGRES_HOST=${POSTGRES_HOST:-db}
+            - PUID=${PUID:-1000}
+            - PGID=${PGID:-1000}

--- a/docker/bin/docker-entrypoint.sh
+++ b/docker/bin/docker-entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+# Take care about zombies
+set -- tini -- "$@"
+
+# user:group from host docker env.A 0:0 by default or result of -u UID:GID
+SRC_UID=$(id -u)
+SRC_GID=$(id -g)
+
+# user:group of build in `node`` user
+ORIGIN_NODE_UID=$(id -u node)
+ORIGIN_NODE_GID=$(id -g node)
+
+
+PUID=${PUID:-$ORIGIN_NODE_UID} # Use the environment variable value or default (1000) if variable is not set.
+PGID=${PGID:-$ORIGIN_NODE_GID} # Use the environment variable value or default (1000) if variable is not set.
+
+
+if [ "$PUID" != "$ORIGIN_NODE_UID" -o "$PGID" != "$ORIGIN_NODE_GID" ]; then
+
+    printf "PUID and PGID envs were specified: %s:%s \n" "$PUID" "$PGID"
+  
+    if [ "$SRC_UID" = "0" ]; then
+        # Adjusting node user
+        groupmod -o -g "$PGID" node # Modify the group id.
+        usermod -o -u "$PUID" node # Modify the user id.
+
+        # fix data dirs permissions
+        printf "Adjusting file permissions for the new node UID:GID...\n"
+        # Changing $SRV_ROOT recursivelly takes too long. The same may be about $DATA_ROOT
+        chown node:node $SRV_ROOT
+        chown node:node $DATA_ROOT
+        chown node:node $DATA_ROOT/*
+        chown node:node -R $PM2_HOME
+    else
+        printf "WARNING: PUID/PGID envs were specified together with custom -u UID:GID argument.\n"
+        printf "This may lead to unexpected problems with file permissions.\n"
+    fi
+fi
+
+
+if [ "$SRC_UID" = "0" ]; then
+    printf "Switching to node user (%s:%s)... \n" "$PUID" "$PGID"
+
+    # Drop from root to node user 
+    set -- gosu node:node "$@"
+fi
+
+printf "Command to be executed: 'exec %s'. Good luck.\n" "$*"
+
+exec "$@"


### PR DESCRIPTION
The fix of a few issue with around rootless image:

1. Fix file and dirs permissions for run with non default uid/gid user
2. add `PUID` and `PGID` to explicitly specify IDs for internal user
3. add possibility to specify custom user:group (`-u uid:gid` arg) 
4. split data from data/dynamic_created_content from source code
