### PR TITLE
Desktop: Fixes #11226: Fix reordering notes in custom sort order when some notes are deleted

### DIFF
--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -1030,6 +1030,7 @@ export default class Note extends BaseItem {
 					FROM notes
 					WHERE
 						is_conflict = 0
+						AND deleted_time = 0
 						${showCompletedTodos ? '' : 'AND todo_completed = 0'}
 					AND parent_id = ?
 				`;

--- a/packages/lib/models/Note_CustomSortOrder.test.js
+++ b/packages/lib/models/Note_CustomSortOrder.test.js
@@ -282,4 +282,34 @@ describe('models/Note_CustomSortOrder', () => {
 		expect(resortedNotes3[5].id).toBe(resortedNotes2[5].id);
 	}));
 
+	it('should account for items in the trash', async () => {
+		const folder1 = await Folder.save({});
+
+		const notes = [];
+		notes.push(await Note.save({ order: 1003, parent_id: folder1.id, deleted_time: 1 })); await time.msleep(2);
+		notes.push(await Note.save({ order: 1002, parent_id: folder1.id })); await time.msleep(2);
+		notes.push(await Note.save({ order: 1001, parent_id: folder1.id })); await time.msleep(2);
+		notes.push(await Note.save({ order: 1000, parent_id: folder1.id })); await time.msleep(2);
+
+		const sortedNoteIds = async () => {
+			const notes = await Note.previews(folder1.id, {
+				fields: ['id', 'order', 'user_created_time', 'is_todo', 'todo_completed'],
+				order: Note.customOrderByColumns(),
+			});
+			return notes.map(note => note.id);
+		};
+
+		// Should sort items correctly initially, with deleted items omitted
+		expect(await sortedNoteIds()).toEqual([
+			notes[1].id, notes[2].id, notes[3].id,
+		]);
+
+		// Move a note to the end
+		await Note.insertNotesAt(folder1.id, [notes[1].id], 3, true, true);
+
+		// Should correctly reorder notes
+		expect(await sortedNoteIds()).toEqual([
+			notes[2].id, notes[3].id, notes[1].id,
+		]);
+	});
 });


### PR DESCRIPTION
# Summary

Previously, reordering notes with a custom sort order enabled didn't work with some notes deleted to the trash folder.

This pull request should fix #11226.

# Testing plan

This pull request includes an automated test.

Additionally, this pull request has been tested manually by:
1. Opening an existing folder with custom sort order enabled.
2. Moving most notes in the folder to the trash.
3. Adding a new note.
4. Dragging the note to the first location in the note list.
5. Dragging the note to the last location in the note list.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->