### PR TITLE
Chore: Plugin repo CLI: Only match packages with the joplin-plugin keyword

### DIFF
--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -245,7 +245,7 @@ async function commandBuild(args: CommandBuildArgs) {
 
 	chdir(previousDir);
 
-	const searchResults = (await execCommand('npm search joplin-plugin --searchlimit 5000 --json', { showStdout: false, showStderr: false })).trim();
+	const searchResults = (await execCommand('npm search keywords:joplin-plugin --searchlimit 5000 --json', { showStdout: false, showStderr: false })).trim();
 	const npmPackages = pluginInfoFromSearchResults(JSON.parse(searchResults));
 
 	for (const npmPackage of npmPackages) {


### PR DESCRIPTION
# Summary

Currently, the plugin repo CLI identifies Joplin plugins using `npm search joplin-plugin --searchlimit 5000 --json`. The maximum `searchlimit`, however seems to be 250 (perhaps as a result of the [API](https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md#get-v1search)).

The search results returned by `npm search joplin-plugin ...` currently include packages that are not Joplin plugins (e.g. `clean-webpack-plugin`). As such, limiting the search query to exclude packages that aren't tagged with `joplin-plugin` should allow more plugins to be identified.

This pull request may fix [this issue reported on the forum](https://discourse.joplinapp.org/t/plugin-update-not-appearing-in-the-plugin-repository/42950).

# Testing

I've verified that running `npm search keywords:joplin-plugin --searchlimit 5000 --json` from the command line returns search results containing `joplin-plugin`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->