### PR TITLE
Windows,Linux: Fix keyboard can't add text after certain error/info dialogs are shown

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -1,5 +1,5 @@
 import ElectronAppWrapper from './ElectronAppWrapper';
-import shim from '@joplin/lib/shim';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 import { _, setLocale } from '@joplin/lib/locale';
 import { BrowserWindow, nativeTheme, nativeImage, shell, dialog, MessageBoxSyncOptions, safeStorage } from 'electron';
 import { dirname, toSystemSlashes } from '@joplin/lib/path-utils';
@@ -384,9 +384,14 @@ export class Bridge {
 
 	/* returns the index of the clicked button */
 	public showMessageBox(message: string, options: MessageDialogOptions = {}) {
+		const defaultButtons = [_('OK')];
+		if (options.type !== MessageBoxType.Error && options.type !== MessageBoxType.Info) {
+			defaultButtons.push(_('Cancel'));
+		}
+
 		const result = this.showMessageBox_(this.activeWindow(), { type: 'question',
 			message: message,
-			buttons: [_('OK'), _('Cancel')], ...options });
+			buttons: defaultButtons, ...options });
 
 		return result;
 	}

--- a/packages/app-desktop/commands/copyDevCommand.ts
+++ b/packages/app-desktop/commands/copyDevCommand.ts
@@ -1,5 +1,6 @@
 import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 const app = require('@electron/remote').app;
 const { clipboard } = require('electron');
 
@@ -14,7 +15,7 @@ export const runtime = (): CommandRuntime => {
 			const appPath = app.getPath('exe');
 			const cmd = `${appPath} --env dev`;
 			clipboard.writeText(cmd);
-			alert(`The dev mode command has been copied to clipboard:\n\n${cmd}`);
+			await shim.showMessageBox(`The dev mode command has been copied to clipboard:\n\n${cmd}`, { type: MessageBoxType.Info });
 		},
 	};
 };

--- a/packages/app-desktop/commands/restoreNoteRevision.ts
+++ b/packages/app-desktop/commands/restoreNoteRevision.ts
@@ -1,5 +1,6 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import RevisionService from '@joplin/lib/services/RevisionService';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 
 export const declaration: CommandDeclaration = {
 	name: 'restoreNoteRevision',
@@ -11,9 +12,9 @@ export const runtime = (): CommandRuntime => {
 		execute: async (_context: CommandContext, noteId: string, reverseRevIndex = 0) => {
 			try {
 				const note = await RevisionService.instance().restoreNoteById(noteId, reverseRevIndex);
-				alert(RevisionService.instance().restoreSuccessMessage(note));
+				await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(note), { type: MessageBoxType.Info });
 			} catch (error) {
-				alert(error.message);
+				await shim.showErrorDialog(error.message);
 			}
 		},
 	};

--- a/packages/app-desktop/gui/ClipperConfigScreen.tsx
+++ b/packages/app-desktop/gui/ClipperConfigScreen.tsx
@@ -9,6 +9,7 @@ import ClipperServer from '@joplin/lib/ClipperServer';
 import Setting from '@joplin/lib/models/Setting';
 import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import { AppState } from '../app.reducer';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 
 class ClipperConfigScreenComponent extends React.Component {
 	public constructor() {
@@ -30,7 +31,7 @@ class ClipperConfigScreenComponent extends React.Component {
 	private copyToken_click() {
 		clipboard.writeText(this.props.apiToken);
 
-		alert(_('Token has been copied to the clipboard!'));
+		void shim.showMessageBox(_('Token has been copied to the clipboard!'), { type: MessageBoxType.Info });
 	}
 
 	private renewToken_click() {

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -19,6 +19,7 @@ import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/conf
 import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 import SettingComponent, { UpdateSettingValueEvent } from './controls/SettingComponent';
+import shim from '@joplin/lib/shim';
 
 
 interface Font {
@@ -144,7 +145,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			screenName = section.name;
 
 			if (this.hasChanges()) {
-				const ok = confirm(_('This will open a new screen. Save your current changes?'));
+				const ok = await shim.showConfirmationDialog(_('This will open a new screen. Save your current changes?'));
 				if (ok) {
 					await shared.saveSettings(this);
 				}

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -3,7 +3,7 @@ import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import { themeStyle } from '@joplin/lib/theme';
 import { _ } from '@joplin/lib/locale';
 import time from '@joplin/lib/time';
-import shim from '@joplin/lib/shim';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 import dialogs from '../dialogs';
 import { decryptedStatText, determineKeyPassword, dontReencryptData, enableEncryptionConfirmationMessages, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
@@ -47,7 +47,7 @@ const EncryptionConfigScreen = (props: Props) => {
 	const onUpgradeMasterKey = useCallback(async (mk: MasterKeyEntity) => {
 		const password = determineKeyPassword(mk.id, masterPasswordKeys, props.masterPassword, props.passwords);
 		const result = await upgradeMasterKey(mk, password);
-		alert(result);
+		await shim.showMessageBox(result, { type: MessageBoxType.Info });
 	}, [props.passwords, masterPasswordKeys, props.masterPassword]);
 
 	const renderNeedUpgradeSection = () => {

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -11,6 +11,7 @@ import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import KvStore from '@joplin/lib/services/KvStore';
 import ShareService from '@joplin/lib/services/share/ShareService';
 import LabelledPasswordInput from '../PasswordInput/LabelledPasswordInput';
+import shim from '@joplin/lib/shim';
 
 interface Props {
 	themeId: number;
@@ -80,7 +81,7 @@ export default function(props: Props) {
 				void reg.waitForSyncFinishedThenSync();
 				onClose();
 			} catch (error) {
-				alert(error.message);
+				void shim.showErrorDialog(error.message);
 			} finally {
 				setUpdatingPassword(false);
 			}

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -17,6 +17,7 @@ const urlUtils = require('@joplin/lib/urlUtils');
 const ReactTooltip = require('react-tooltip');
 const { connect } = require('react-redux');
 import shared from '@joplin/lib/components/shared/note-screen-shared';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 
 interface Props {
 	themeId: number;
@@ -97,7 +98,7 @@ class NoteRevisionViewerComponent extends React.PureComponent<Props, State> {
 		this.setState({ restoring: true });
 		await RevisionService.instance().importRevisionNote(this.state.note);
 		this.setState({ restoring: false });
-		alert(RevisionService.instance().restoreSuccessMessage(this.state.note));
+		await shim.showMessageBox(RevisionService.instance().restoreSuccessMessage(this.state.note), { type: MessageBoxType.Info });
 	}
 
 	private backButton_click() {

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -384,7 +384,9 @@ function ShareFolderDialog(props: Props) {
 
 	async function buttonRow_click(event: ClickEvent) {
 		if (event.buttonName === 'unshare') {
-			if (!confirm(_('Unshare this notebook? The recipients will no longer have access to its content.'))) return;
+			if (!await shim.showConfirmationDialog(_('Unshare this notebook? The recipients will no longer have access to its content.'))) {
+				return;
+			}
 			await ShareService.instance().unshareFolder(props.folderId);
 			void synchronize();
 		}

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -18,6 +18,7 @@ import { connect } from 'react-redux';
 import { reg } from '@joplin/lib/registry';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import { ChangeEvent, Dropdown, DropdownOptions, DropdownVariant } from '../Dropdown/Dropdown';
+import shim from '@joplin/lib/shim';
 
 const logger = Logger.create('ShareFolderDialog');
 
@@ -242,13 +243,13 @@ function ShareFolderDialog(props: Props) {
 	}
 
 	async function recipient_delete(event: RecipientDeleteEvent) {
-		if (!confirm(_('Delete this invitation? The recipient will no longer have access to this shared notebook.'))) return;
+		if (!await shim.showConfirmationDialog(_('Delete this invitation? The recipient will no longer have access to this shared notebook.'))) return;
 
 		try {
 			await ShareService.instance().deleteShareRecipient(event.shareUserId);
 		} catch (error) {
 			logger.error(error);
-			alert(_('The recipient could not be removed from the list. Please try again.\n\nThe error was: "%s"', error.message));
+			await shim.showErrorDialog(_('The recipient could not be removed from the list. Please try again.\n\nThe error was: "%s"', error.message));
 		}
 
 		await ShareService.instance().refreshShareUsers(share.id);
@@ -290,7 +291,7 @@ function ShareFolderDialog(props: Props) {
 			});
 			await ShareService.instance().setPermissions(share.id, shareUserId, permissionsFromString(value));
 		} catch (error) {
-			alert(`Could not set permissions: ${error.message}`);
+			void shim.showErrorDialog(`Could not set permissions: ${error.message}`);
 			logger.error(error);
 		} finally {
 			setRecipientsBeingUpdated(prev => {

--- a/packages/app-desktop/gui/ShareNoteDialog.tsx
+++ b/packages/app-desktop/gui/ShareNoteDialog.tsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { AppState } from '../app.reducer';
 import { getEncryptionEnabled } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
+import shim from '@joplin/lib/shim';
 const { clipboard } = require('electron');
 
 interface Props {
@@ -146,7 +147,7 @@ export function ShareNoteDialog(props: Props) {
 				reg.logger().error('ShareNoteDialog: Cannot publish note:', error);
 
 				setSharesState('idle');
-				alert(JoplinServerApi.connectionErrorMessage(error));
+				void shim.showErrorDialog(JoplinServerApi.connectionErrorMessage(error));
 			}
 
 			break;

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -31,6 +31,7 @@ import HeaderItem from '../listItemComponents/HeaderItem';
 import AllNotesItem from '../listItemComponents/AllNotesItem';
 import ListItemWrapper from '../listItemComponents/ListItemWrapper';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import shim from '@joplin/lib/shim';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -309,7 +310,7 @@ const useOnRenderItem = (props: Props) => {
 			}
 		} catch (error) {
 			logger.error(error);
-			alert(error.message);
+			await shim.showErrorDialog(error.message);
 		}
 	}, []);
 

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts
@@ -2,6 +2,7 @@ import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/
 import { _ } from '@joplin/lib/locale';
 import ShareService from '@joplin/lib/services/share/ShareService';
 import Logger from '@joplin/utils/Logger';
+import shim from '@joplin/lib/shim';
 
 const logger = Logger.create('leaveSharedFolder');
 
@@ -28,7 +29,7 @@ export const runtime = (): CommandRuntime => {
 				await ShareService.instance().leaveSharedFolder(folderId, share.user.id);
 			} catch (error) {
 				logger.error(error);
-				alert(_('Error: %s', error.message));
+				await shim.showErrorDialog(_('Error: %s', error.message));
 			}
 		},
 		enabledCondition: 'joplinServerConnected && folderIsShareRootAndNotOwnedByUser',

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts
@@ -14,7 +14,7 @@ export const declaration: CommandDeclaration = {
 export const runtime = (): CommandRuntime => {
 	return {
 		execute: async (_context: CommandContext, folderId: string = null) => {
-			const answer = confirm(_('This will remove the notebook from your collection and you will no longer have access to its content. Do you wish to continue?'));
+			const answer = await shim.showConfirmationDialog(_('This will remove the notebook from your collection and you will no longer have access to its content. Do you wish to continue?'));
 			if (!answer) return;
 
 			try {

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -337,8 +337,10 @@ export default class Synchronizer {
 		const hasActiveExclusiveLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Exclusive);
 		if (hasActiveExclusiveLock) return 'hasExclusiveLock';
 
-		const hasActiveSyncLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Sync, this.lockClientType(), this.clientId_);
-		if (!hasActiveSyncLock) return 'syncLockGone';
+		if (this.lockHandler().enabled) {
+			const hasActiveSyncLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Sync, this.lockClientType(), this.clientId_);
+			if (!hasActiveSyncLock) return 'syncLockGone';
+		}
 
 		return '';
 	}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -337,10 +337,8 @@ export default class Synchronizer {
 		const hasActiveExclusiveLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Exclusive);
 		if (hasActiveExclusiveLock) return 'hasExclusiveLock';
 
-		if (this.lockHandler().enabled) {
-			const hasActiveSyncLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Sync, this.lockClientType(), this.clientId_);
-			if (!hasActiveSyncLock) return 'syncLockGone';
-		}
+		const hasActiveSyncLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Sync, this.lockClientType(), this.clientId_);
+		if (!hasActiveSyncLock) return 'syncLockGone';
 
 		return '';
 	}


### PR DESCRIPTION
# Summary

This pull request replaces several uses of `alert` in packages/app-desktop with the async `shim.showMessageBox` or `shim.showErrorDialog` equivalents.

This works around [this upstream Electron issue](https://github.com/electron/electron/issues/19977) related to `alert()`.

**Note**: See https://github.com/laurent22/joplin/pull/11241 for a similar change made previously.

# Testing plan

**Fedora Linux**:
1. Click Help > Copy dev mode command to clipboard.
2. Click on the note title input.
3. Type.
4. Verify that the typed text is added to the note title input.
5. Open the webclipper config screen.
6. Click "copy token".
7. Open the "Appearance" tab.
8. Focus the "Editor maximum width" input.
9. Type a number.
10. Verify that the editor maximum width input is updated.
11. Open the note revision viewer.
12. Restore a revision.
13. Verify that it's possible to type text in the title input.
14. Open the encryption config screen.
15. Click "Clear master password".
16. Open the master password dialog.
17. Enter an incorrect password.
18. Click "save".
19. Verify that an error dialog with the message "Master password is not valid. Please try again" and an "OK" button is shown.
20. Enter the correct password and click "save".
21. Disconnect from Joplin Server (e.g. by stopping the Server instance).
22. Right-click on a shared notebook and click "Leave notebook".
23. Click "OK".
24. Verify that it's still possible to edit the note title input.
25. Open settings > appearance.
26. Change a setting.
27. Switch to the "Encryption" tab.
28. In the "This will open a new screen" dialog, click "Ok".
29. Close settings.
30. Verify that it's still possible to edit the note title input.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->