### PR TITLE
Android: Fix clicking "Draw picture" results in blank screen with very old WebView versions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -641,6 +641,7 @@ packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/applyTemplateToEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.test.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.js
+packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/polyfills.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/startAutosaveLoop.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/types.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/watchEditorForTemplateChanges.js

--- a/.gitignore
+++ b/.gitignore
@@ -616,6 +616,7 @@ packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/applyTemplateToEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.test.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.js
+packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/polyfills.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/startAutosaveLoop.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/types.js
 packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/watchEditorForTemplateChanges.js

--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/createJsDrawEditor.ts
@@ -7,6 +7,8 @@ import watchEditorForTemplateChanges from './watchEditorForTemplateChanges';
 import { ImageEditorCallbacks, ImageEditorControl, LocalizedStrings } from './types';
 import startAutosaveLoop from './startAutosaveLoop';
 import WebViewToRNMessenger from '../../../../utils/ipc/WebViewToRNMessenger';
+import './polyfills';
+
 
 const restoreToolbarState = (toolbar: AbstractToolbar, state: string) => {
 	if (state) {

--- a/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/polyfills.ts
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/js-draw/polyfills.ts
@@ -1,0 +1,11 @@
+// .replaceChildren is not supported in Chromium 83, which is the default for Android 11
+// (unless auto-updated from the Google Play store).
+HTMLElement.prototype.replaceChildren ??= function(this: HTMLElement, ...nodes: Node[]) {
+	while (this.children.length) {
+		this.children[0].remove();
+	}
+
+	for (const node of nodes) {
+		this.appendChild(node);
+	}
+};

--- a/packages/app-mobile/tools/buildInjectedJs/BundledFile.ts
+++ b/packages/app-mobile/tools/buildInjectedJs/BundledFile.ts
@@ -58,18 +58,18 @@ export default class BundledFile {
 							// Some libraries don't work with older browsers/WebViews.
 							// Because Babel transpilation can be slow, we only transpile
 							// these libraries.
-							// For now, it's just Replit's CodeMirror-vim library. This library
-							// uses `a?.b` syntax, which seems to be unsupported in iOS 12 Safari.
-							const moduleNeedsTranspilation = !!(/.*node_modules.*replit.*\.[mc]?js$/.exec(value));
+							const moduleNeedsTranspilation = !!(
+								// Replit's CodeMirror-vim library uses a?.b syntax which seems to be unsupported in iOS 12 Safari.
+								/.*node_modules.*replit.*\.[mc]?js$/.exec(value) ||
+								// js-draw uses a ??= b syntax, which is unsupported in old Android WebView versions
+								/.*node_modules.*js-draw.*\.[mc]?js$/.exec(value)
+							);
 
 							if (isModuleFile && !moduleNeedsTranspilation) {
 								return false;
 							}
 
 							const isJsFile = !!(/\.[cm]?js$/.exec(value));
-							if (isJsFile) {
-								console.log('Compiling with Babel:', value);
-							}
 							return isJsFile;
 						},
 						use: {


### PR DESCRIPTION
# Summary

Android 11 ships with a WebView based on Chromium 83. This commit:
1. adds `js-draw` to the list of packages that need to be transpiled with `babel` before creating injectedJs
2. adds a polyfill for `HTMLElement.replaceChildren`.

**Note**: Some devices upgrade the system WebView version (e.g. through the Google PlayStore). As such, before this pull request, the "Draw picture" feature may work correctly on many Android 11 and older devices.


# Testing plan

1. Create an Android 11 emulator (choose the system image without access to the Play Store).
2. Run Joplin.
3. Create a new note.
4. Click "Draw picture".
5. Draw something.
6. Click "save".
7. Verify that the drawing is added to the note.
8. Click the edit button for the drawing.
9. Verify that the drawing is opened in the image editor.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->