### PR TITLE
Desktop: Drawing: Fix "insert drawing" button is not disabled in read-only notes (Upgrade Freehand Drawing to v2.14.0)

### DIFF
--- a/packages/default-plugins/pluginRepositories.json
+++ b/packages/default-plugins/pluginRepositories.json
@@ -7,6 +7,6 @@
 	"io.github.personalizedrefrigerator.js-draw": {
 		"cloneUrl": "https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing.git",
 		"branch": "main",
-		"commit": "3e7eac96d10218728120ce81bee2eeffd5f8fdbb"
+		"commit": "9724793b4a6fb83346ff4f7c639af1e352bd7937"
 	}
 }


### PR DESCRIPTION
# Summary

This pull request upgrades the built-in Freehand Drawing plugin to [v2.14.0](https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/releases/tag/v2.14.0). In addition to upgrading `js-draw`, this fixes an issue where the "insert drawing" button was enabled even in read-only notes.

> [!NOTE]
>
> Currently, this targets `release-3.2`.

# Testing plan

1. Run `yarn build` in packages/app-desktop.
2. Start the desktop app.
3. Open a note in the trash folder.
4. Verify that the "insert drawing" button is disabled.
5. Open a note in an editable folder.
6. Verify that the "insert drawing" button is not disabled and can be used to insert a drawing.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->