### PR TITLE
Mobile: Fixes #11455: Clicking on an external note link from within a note logs an error

### DIFF
--- a/packages/app-mobile/commands/openItem.ts
+++ b/packages/app-mobile/commands/openItem.ts
@@ -8,6 +8,7 @@ import BaseItem from '@joplin/lib/models/BaseItem';
 import { BaseItemEntity } from '@joplin/lib/services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import showResource from './util/showResource';
+import { isCallbackUrl, parseCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 
 const logger = Logger.create('openItemCommand');
 
@@ -15,39 +16,48 @@ export const declaration: CommandDeclaration = {
 	name: 'openItem',
 };
 
+const openItemById = async (itemId: string, hash?: string) => {
+	logger.info(`Navigating to item ${itemId}`);
+	const item: BaseItemEntity = await BaseItem.loadItemById(itemId);
+
+	if (item.type_ === ModelType.Note) {
+		await goToNote(itemId, hash);
+	} else if (item.type_ === ModelType.Resource) {
+		await showResource(item);
+	} else {
+		throw new Error(`Unsupported item type for links: ${item.type_}`);
+	}
+};
+
 export const runtime = (): CommandRuntime => {
 	return {
 		execute: async (_context: CommandContext, link: string) => {
 			if (!link) throw new Error('Link cannot be empty');
 
-			let isInvalid = false;
+			try {
+				if (link.startsWith('joplin://') || link.startsWith(':/')) {
+					const parsedResourceUrl = parseResourceUrl(link);
+					const parsedCallbackUrl = isCallbackUrl(link) ? parseCallbackUrl(link) : null;
 
-			if (link.startsWith('joplin://') || link.startsWith(':/')) {
-				const parsedUrl = parseResourceUrl(link);
-				if (parsedUrl) {
-					const { itemId, hash } = parsedUrl;
-
-					logger.info(`Navigating to item ${itemId}`);
-					const item: BaseItemEntity = await BaseItem.loadItemById(itemId);
-					if (item.type_ === ModelType.Note) {
-						await goToNote(itemId, hash);
-					} else if (item.type_ === ModelType.Resource) {
-						await showResource(item);
+					if (parsedResourceUrl) {
+						const { itemId, hash } = parsedResourceUrl;
+						await openItemById(itemId, hash);
+					} else if (parsedCallbackUrl) {
+						const id = parsedCallbackUrl.params.id;
+						if (!id) {
+							throw new Error('Missing item ID');
+						}
+						await openItemById(id);
 					} else {
-						logger.error('Unsupported item type for links:', item.type_);
-						isInvalid = true;
+						throw new Error('Unsupported link format.');
 					}
+				} else if (urlProtocol(link)) {
+					shim.openUrl(link);
 				} else {
-					isInvalid = true;
+					throw new Error('Unsupported protocol');
 				}
-			} else if (urlProtocol(link)) {
-				shim.openUrl(link);
-			} else {
-				isInvalid = true;
-			}
-
-			if (isInvalid) {
-				const errorMessage = _('Unsupported link or message: %s', link);
+			} catch (error) {
+				const errorMessage = _('Unsupported link or message: %s.\nError: %s', link, error);
 				logger.error(errorMessage);
 				await shim.showErrorDialog(errorMessage);
 			}

--- a/packages/app-mobile/commands/openItem.ts
+++ b/packages/app-mobile/commands/openItem.ts
@@ -20,6 +20,8 @@ export const runtime = (): CommandRuntime => {
 		execute: async (_context: CommandContext, link: string) => {
 			if (!link) throw new Error('Link cannot be empty');
 
+			let isInvalid = false;
+
 			if (link.startsWith('joplin://') || link.startsWith(':/')) {
 				const parsedUrl = parseResourceUrl(link);
 				if (parsedUrl) {
@@ -33,13 +35,18 @@ export const runtime = (): CommandRuntime => {
 						await showResource(item);
 					} else {
 						logger.error('Unsupported item type for links:', item.type_);
+						isInvalid = true;
 					}
 				} else {
-					logger.error(`Invalid Joplin link: ${link}`);
+					isInvalid = true;
 				}
 			} else if (urlProtocol(link)) {
 				shim.openUrl(link);
 			} else {
+				isInvalid = true;
+			}
+
+			if (isInvalid) {
 				const errorMessage = _('Unsupported link or message: %s', link);
 				logger.error(errorMessage);
 				await shim.showErrorDialog(errorMessage);


### PR DESCRIPTION
# Summary

This pull request adds support for external links to the `openItem` command on mobile.

Fixes #11455.

**Note**: [The relevant GitHub issue](https://github.com/laurent22/joplin/issues/11455) marks this as a regression from v3.0.7:
> This behavior differs from version 3.0.7, where both types of internal note links worked properly within notes. In earlier versions before 3.0.7, these links did not work inside notes, but an error window was displayed, providing feedback to the user.

The link handling logic in `Note.tsx` was replaced with a call to `openItem` in Joplin 3.0.1 [in this commit](https://github.com/laurent22/joplin/commit/f69dffcf23497361c31b5290ef1152c5609f9b35#diff-bae26a183bc9c96ac2dc7ada643bf5c06a8363be9dba3fca6f2ee0259661aecbR271). Joplin external links were likely supported implicitly by the `Linking.openURL` line (using the system handler).

# Testing plan

1. Start the web app (tested in Chromium 131)
2. Copy the internal link to a note.
3. Open another note.
4. Paste the internal link.
5. Paste the internal link again.
6. Convert the second internal link to an x-callback-url.

At this point, the note should have content similar to the following:
```markdown
[Test](:/0e340025a2f14f59a2fcecb9d69f6183)
[Test](joplin://x-callback-url/openNote?id=0e340025a2f14f59a2fcecb9d69f6183)
```

7. Click the external link.
8. Verify that the linked note opens.
9. Click the internal link.
10. Verify that the linked note opens.
11. Add a drawing.
12. Convert the drawing to an internal resource link.
13. Click the link.
14. Verify that the drawing opens in a new window (in the browser's SVG viewer).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->