### PR TITLE
CLI: Fixes #11577: Revert deprecation warning suppression

### DIFF
--- a/packages/app-cli/app/main.js
+++ b/packages/app-cli/app/main.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S NODE_OPTIONS=--no-deprecation node
+#!/usr/bin/env node
 
 // Use njstrace to find out what Node.js might be spending time on
 // var njstrace = require('njstrace').inject();


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11577

# Summary

The `-S` option required to make the environment variable work on the shebang line is not supported on BusyBox systems (e.g.: Alpine), making Joplin CLI stop working on these systems.

Instead of finding a workaround, we opt to revert the last change.
