### PR TITLE
Desktop: Fixes #11624: Fix double-click to collapse notebooks

### DIFF
--- a/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx
@@ -91,6 +91,7 @@ function FolderItem(props: FolderItemProps) {
 				isConflictFolder={folderId === Folder.conflictFolderId()}
 				selected={selected}
 				shareId={shareId}
+				data-folder-id={folderId}
 				onDoubleClick={onFolderToggleClick_}
 
 				onClick={() => {

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -101,4 +101,24 @@ test.describe('sidebar', () => {
 		await expect(mainWindow.getByText('Another note in Folder A')).toBeAttached();
 		await expect(mainWindow.getByText('A note in Folder B')).toBeAttached();
 	});
+
+	test('double-clicking should collapse/expand folders in the sidebar', async ({ mainWindow }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		const sidebar = mainScreen.sidebar;
+
+		const testFolderA = await sidebar.createNewFolder('Folder A');
+		const testFolderB = await sidebar.createNewFolder('Folder B');
+
+		await testFolderB.dragTo(testFolderA);
+
+		await expect(testFolderB).toBeVisible();
+
+		// Collapse
+		await testFolderA.dblclick();
+		await expect(testFolderB).not.toBeVisible();
+
+		// Expand
+		await testFolderA.dblclick();
+		await expect(testFolderB).toBeVisible();
+	});
 });

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -109,6 +109,7 @@ test.describe('sidebar', () => {
 		const testFolderA = await sidebar.createNewFolder('Folder A');
 		const testFolderB = await sidebar.createNewFolder('Folder B');
 
+		// Convert folder B to a subfolder
 		await testFolderB.dragTo(testFolderA);
 
 		await expect(testFolderB).toBeVisible();


### PR DESCRIPTION
# Summary

This pull request fixes #11624 &mdash; double-click to toggle folders wasn't working.

This was caused in [this commit](https://github.com/laurent22/joplin/commit/38be0e81a9669dad1dc71e54a88426f997d6fdcd#diff-4536825df8e337f089acd473e10e3004758b37c70d38bea318ea6f87c9541d8cR85) when `data-folder-id` and several event handlers were moved to a parent element.

> [!IMPORTANT]
>
> This pull request currently targets the `dev` branch, though perhaps it should target `release-3.2`.

# Testing

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->