### PR TITLE
Mobile: Resolves #10824: Allow adjusting the default note viewer font size

### DIFF
--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.test.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.test.tsx
@@ -43,6 +43,7 @@ const WrappedNoteViewer: React.FC<WrapperProps> = (
 		<NoteBodyViewer
 			themeId={Setting.THEME_LIGHT}
 			style={emptyObject}
+			fontSize={12}
 			noteBody={noteBody}
 			noteMarkupLanguage={MarkupLanguage.Markdown}
 			highlightedKeywords={highlightedKeywords}

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -19,6 +19,7 @@ import { MarkupLanguage } from '@joplin/renderer';
 interface Props {
 	themeId: number;
 	style: ViewStyle;
+	fontSize: number;
 	noteBody: string;
 	noteMarkupLanguage: MarkupLanguage;
 	highlightedKeywords: string[];
@@ -80,6 +81,7 @@ export default function NoteBodyViewer(props: Props) {
 
 	useRerenderHandler({
 		renderer,
+		fontSize: props.fontSize,
 		noteBody: props.noteBody,
 		noteMarkupLanguage: props.noteMarkupLanguage,
 		themeId: props.themeId,

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
@@ -150,8 +150,8 @@ const useRerenderHandler = (props: Props) => {
 			theme: JSON.stringify({
 				bodyPaddingTop: '0.8em',
 				bodyPaddingBottom: props.paddingBottom,
-
 				...theme,
+
 				noteViewerFontSize: props.fontSize,
 			}),
 			codeTheme: theme.codeThemeCss,

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
@@ -25,6 +25,7 @@ interface Props {
 	noteBody: string;
 	noteMarkupLanguage: MarkupLanguage;
 	themeId: number;
+	fontSize: number;
 
 	highlightedKeywords: string[];
 	noteResources: Record<string, ResourceInfo>;
@@ -82,7 +83,7 @@ const useRerenderHandler = (props: Props) => {
 	const effectDependencies = [
 		props.noteBody, props.noteMarkupLanguage, props.renderer, props.highlightedKeywords,
 		props.noteHash, props.noteResources, props.themeId, props.paddingBottom, lastResourceLoadCounter,
-		createEditPopupSyntax, destroyEditPopupSyntax, pluginSettingKeys,
+		createEditPopupSyntax, destroyEditPopupSyntax, pluginSettingKeys, props.fontSize,
 	];
 	const previousDeps = usePrevious(effectDependencies, []);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -151,6 +152,7 @@ const useRerenderHandler = (props: Props) => {
 				bodyPaddingBottom: props.paddingBottom,
 
 				...theme,
+				noteViewerFontSize: props.fontSize,
 			}),
 			codeTheme: theme.codeThemeCss,
 

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -9,7 +9,6 @@ const baseStyle = {
 	appearance: 'light',
 	fontSize: 16,
 	fontSizeLarge: 20,
-	noteViewerFontSize: 16,
 	margin: 15, // No text and no interactive component should be within this margin
 	itemMarginTop: 10,
 	itemMarginBottom: 10,

--- a/packages/app-mobile/components/global-style.ts
+++ b/packages/app-mobile/components/global-style.ts
@@ -15,6 +15,8 @@ const baseStyle = {
 	fontSizeSmaller: 14,
 	disabledOpacity: 0.2,
 	lineHeight: '1.6em',
+	// The default, may be overridden in settings:
+	noteViewerFontSize: 16,
 };
 
 export type ThemeStyle = BaseTheme & typeof baseStyle & {

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -82,6 +82,7 @@ interface Props extends BaseProps {
 	themeId: number;
 	editorFontSize: number;
 	editorFont: number; // e.g. Setting.FONT_MENLO
+	viewerFontSize: number;
 	showSideMenu: boolean;
 	searchQuery: string;
 	ftsEnabled: number;
@@ -1459,6 +1460,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						noteResources={this.state.noteResources}
 						highlightedKeywords={keywords}
 						themeId={this.props.themeId}
+						fontSize={this.props.viewerFontSize}
 						noteHash={this.props.noteHash}
 						onCheckboxChange={this.onBodyViewerCheckboxChange}
 						onMarkForDownload={this.onMarkForDownload}
@@ -1637,6 +1639,7 @@ const NoteScreen = connect((state: AppState) => {
 		themeId: state.settings.theme,
 		editorFont: state.settings['style.editor.fontFamily'] as number,
 		editorFontSize: state.settings['style.editor.fontSize'],
+		viewerFontSize: state.settings['style.viewer.fontSize'],
 		toolbarEnabled: state.settings['editor.mobile.toolbarEnabled'],
 		ftsEnabled: state.settings['db.ftsEnabled'],
 		sharedData: state.sharedData,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1120,6 +1120,20 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 
 		'style.editor.contentMaxWidth': { value: 0, type: SettingItemType.Int, public: true, storage: SettingStorage.File, isGlobal: true, appTypes: [AppType.Desktop], section: 'appearance', label: () => _('Editor maximum width'), description: () => _('Set it to 0 to make it take the complete available space. Recommended width is 600.') },
 
+		'style.viewer.fontSize': {
+			value: 16,
+			type: SettingItemType.Int,
+			public: true,
+			storage: SettingStorage.File,
+			isGlobal: true,
+			appTypes: [AppType.Mobile],
+			section: 'appearance',
+			label: () => _('Viewer font size'),
+			minimum: 4,
+			maximum: 50,
+			step: 1,
+		},
+
 		'ui.layout': { value: {}, type: SettingItemType.Object, storage: SettingStorage.File, isGlobal: true, public: false, appTypes: [AppType.Desktop] },
 
 		'ui.lastSelectedPluginPanel': {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1057,6 +1057,20 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		// Deprecated in favour of windowContentZoomFactor
 		'style.zoom': { value: 100, type: SettingItemType.Int, public: false, storage: SettingStorage.File, isGlobal: true, appTypes: [AppType.Desktop], section: 'appearance', label: () => '', minimum: 50, maximum: 500, step: 10 },
 
+		'style.viewer.fontSize': {
+			value: 16,
+			type: SettingItemType.Int,
+			public: true,
+			storage: SettingStorage.File,
+			isGlobal: true,
+			appTypes: [AppType.Mobile],
+			section: 'appearance',
+			label: () => _('Viewer font size'),
+			minimum: 4,
+			maximum: 50,
+			step: 1,
+		},
+
 		'style.editor.fontSize': {
 			value: 15,
 			type: SettingItemType.Int,
@@ -1125,20 +1139,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		},
 
 		'style.editor.contentMaxWidth': { value: 0, type: SettingItemType.Int, public: true, storage: SettingStorage.File, isGlobal: true, appTypes: [AppType.Desktop], section: 'appearance', label: () => _('Editor maximum width'), description: () => _('Set it to 0 to make it take the complete available space. Recommended width is 600.') },
-
-		'style.viewer.fontSize': {
-			value: 16,
-			type: SettingItemType.Int,
-			public: true,
-			storage: SettingStorage.File,
-			isGlobal: true,
-			appTypes: [AppType.Mobile],
-			section: 'appearance',
-			label: () => _('Viewer font size'),
-			minimum: 4,
-			maximum: 50,
-			step: 1,
-		},
 
 		'style.scrollbarSize': {
 			value: ScrollbarSize.Small,


### PR DESCRIPTION
# Summary

**Goal**: Allow users to adjust the note viewer font size independently of the main app font size.

This is a frequently-requested feature that may improve the usability of Joplin's note viewer ([relevant forum post 1](https://discourse.joplinapp.org/t/joplin-android-app-cannot-adjust-the-default-font-size-of-the-note-reading-page/39581), [relevant forum post 2](https://discourse.joplinapp.org/t/better-reading-experience-especially-on-android/39318)).

Resolves #10824.

## Related accessibility guidelines

This change is related to [WCAG 2.2 SC 1.4.4](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html). However, this change **is likely not needed to satisfy** [WCAG 2.2 SC 1.4.4](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html), since it's already possible to resize Joplin's UI from Android/iOS system settings.

[WCAG 2.2 SC 1.4.4](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html) states:
> The intent of this Success Criterion is to ensure that visually rendered text, including controls and labels using text, can be made larger so that it can be read more easily by people with milder visual impairments, without requiring the use of assistive technology (such as a screen magnifier). Users may benefit from scaling all content on the Web page, but text is most critical. 
>
> The scaling of content is primarily a user agent responsibility. User agents that satisfy [UAAG 1.0 Checkpoint 4.1](https://www.w3.org/TR/WAI-USERAGENT/guidelines.html#tech-configure-text-scale) allow users to configure text scale through a number of mechanisms - including zoom (of the entire page's content), magnification, text-only resizing, and allowing the user to configure a size for rendered text. The author's responsibility is to create Web content that does not prevent the user agent from scaling the content effectively.

**Note**: Although it should already possible to change the default viewer font size by adjusting the global system text scale, the viewer font size cannot be adjusted independently from the rest of the system. This pull request allows changing the viewer font size independently from the overall UI font size.

# Screenshots

**The font size setting**:

![screenshot: viewer font size setting is included in the "appearance" tab, just above "editor font size"](https://github.com/user-attachments/assets/c763c45b-ba22-4fb3-b7bf-8f513572bb0c)

**Font size = 16** (default):
![screenshot: A note with normal text size](https://github.com/user-attachments/assets/300ba565-deaf-46c5-9c26-d410e7016e02)

**Font size = 32** (200%):
![screenshot: A note with large text size](https://github.com/user-attachments/assets/af6c9698-cd16-4f8b-b120-72b7dd9fc498)

# Testing plan

This pull request has been tested by:
1. Starting the app.
2. Verifying that after opening a note, the text size appears roughly the normal size.
    - The note should contain math, inline and block code.
3. Doubling the font size in settings > appearance.
4. Saving.
5. Opening a note.
6. Verifying that the font size has been roughly doubled.

This has been tested successfully on Android 13 and web (in Chromium 131).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->