### PR TITLE
Desktop,Mobile: Accessibility: Improve contrast of faded URLs in Markdown editor

### DIFF
--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -198,7 +198,7 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 
 		// Override the default URL style when the URL is within a link
 		'& .tok-url.tok-link, & .tok-link.tok-meta, & .tok-link.tok-string': {
-			opacity: 0.66,
+			opacity: 0.661,
 		},
 
 		// Applying font size changes with CSS rather than the theme below works

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -198,7 +198,7 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 
 		// Override the default URL style when the URL is within a link
 		'& .tok-url.tok-link, & .tok-link.tok-meta, & .tok-link.tok-string': {
-			opacity: 0.6,
+			opacity: 0.66,
 		},
 
 		// Applying font size changes with CSS rather than the theme below works


### PR DESCRIPTION
# Summary

This pull request increases the contrast of URLs for links in the Markdown editor from [3.81:1](https://webaim.org/resources/contrastchecker/?fcolor=00337799&bcolor=FFFFFF) to [4.53:1](https://webaim.org/resources/contrastchecker/?fcolor=003377a9&bcolor=FFFFFF) in the default light theme.

See [WCAG 2.2 SC 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum).

# Screenshots

| Before | After |
|---|---|
| ![screenshot: URL is slightly lighter](https://github.com/user-attachments/assets/6b97324a-a434-4dbc-9b89-6356078850ff) | ![screenshot: URL is slightly darker](https://github.com/user-attachments/assets/573b66e6-b2c0-492f-bb43-1b9710943dfb) |


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->