### PR TITLE
Desktop: Accessibility: Make Markdown toolbar scrollable when low on space

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.tsx
@@ -33,6 +33,7 @@ function Toolbar(props: ToolbarProps) {
 	return (
 		<ToolbarBase
 			style={styles.root}
+			scrollable={true}
 			items={props.toolbarButtonInfos}
 			disabled={!!props.disabled}
 			aria-label={_('Editor actions')}

--- a/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
+++ b/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
@@ -35,6 +35,7 @@ function NoteToolbar(props: NoteToolbarProps) {
 	return (
 		<ToolbarBase
 			style={styles.root}
+			scrollable={false}
 			items={props.toolbarButtonInfos}
 			disabled={props.disabled}
 			aria-label={_('Note')}

--- a/packages/app-desktop/gui/ToolbarBase.tsx
+++ b/packages/app-desktop/gui/ToolbarBase.tsx
@@ -10,6 +10,7 @@ import { focus } from '@joplin/lib/utils/focusHandler';
 
 interface Props {
 	themeId: number;
+	scrollable: boolean;
 	style: React.CSSProperties;
 	items: ToolbarItem[];
 	disabled: boolean;
@@ -177,7 +178,7 @@ const ToolbarBaseComponent: React.FC<Props> = props => {
 	return (
 		<div
 			ref={containerRef}
-			className='editor-toolbar'
+			className={`editor-toolbar ${props.scrollable ? '-scrollable' : ''}`}
 			style={props.style}
 
 			role='toolbar'
@@ -191,7 +192,8 @@ const ToolbarBaseComponent: React.FC<Props> = props => {
 			<div className='group'>
 				{centerItemComps}
 			</div>
-			<div className='group -right'>
+			<div className='spacer' />
+			<div className='group'>
 				{rightItemComps}
 			</div>
 		</div>

--- a/packages/app-desktop/gui/styles/editor-toolbar.scss
+++ b/packages/app-desktop/gui/styles/editor-toolbar.scss
@@ -7,15 +7,21 @@
 	padding: var(--joplin-toolbar-padding);
 	padding-right: var(--joplin-main-padding);
 
+	&.-scrollable {
+		overflow-x: auto;
+	}
+
 	> .group {
 		display: flex;
 		flex-direction: row;
 		box-sizing: border-box;
-		min-width: 0;
 
-		&.-right {
-			flex: 1;
-			justify-content: flex-end;
-		}
+		min-width: 0;
+		flex-shrink: 0;
+	}
+
+	> .spacer {
+		flex-grow: 1;
+		min-width: 7px;
 	}
 }


### PR DESCRIPTION
# Summary

This pull request makes the Markdown toolbar scrollable when content would otherwise be offscreen.

## Screenshots

**A window with width of 256px**:
![screenshot: A scrollbar is shown below the Markdown toolbar in a very small Joplin window](https://github.com/user-attachments/assets/b5a6afc2-0157-4f8d-aaeb-2450661db683)


**A larger window**:
![screenshot: No scrollbar is visible](https://github.com/user-attachments/assets/16807254-865d-4b60-9874-64e9902fb3a6)


## Relevant accessibility guidelines

From [WCAG 2.2 SC 1.4.10](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html) (emphasis added):
> Content can be presented **without loss of information or functionality**, and without requiring scrolling in two dimensions for:
>
> -   Vertical scrolling content at a width equivalent to 320 [CSS pixels](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#dfn-css-pixel);
> -   Horizontal scrolling content at a height equivalent to 256 [CSS pixels](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#dfn-css-pixel).
>
> Except for parts of the content which require two-dimensional layout for usage or meaning.

Previously, functionality could be lost when displaying the note editor with a width of 320 CSS pixels, even with the sidebar and notes list hidden. This pull request allows users to continue to access items in the Markdown toolbar even on a small screen width.

# Testing plan

1. Start Joplin.
2. Hide the sidebar and notes list.
3. Make Joplin's Window have a width of at most 320 CSS pixels.
4. Verify that a scrollbar is shown beneath the Markdown toolbar.
5. Drag the scrollbar to the right.
6. Click "toggle editors".
7. Verify that the Rich Text editor is visible.
8. Switch back to the Markdown editor.
9. Click the "insert drawing" button in the toolbar.
10. Verify that the drawing dialog is shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->