### PR TITLE
Desktop: Accessibility: Improve sidebar content contrast

### DIFF
--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -61,7 +61,12 @@ export const StyledListItemAnchor = styled.a`
 	text-decoration: none;
 	color: ${(props: StyleProps) => listItemTextColor(props)};
 	cursor: default;
-	opacity: ${(props: StyleProps) => props.selected || props.shareId ? 1 : 0.8};
+	opacity: ${(props: StyleProps) => {
+		// So that the conflicts folder and shared folders have sufficient contrast,
+		// use an opacity of 1 even when unselected.
+		const needsHigherContrast = props.isConflictFolder || props.isSpecialItem;
+		return (props.selected || props.shareId || needsHigherContrast) ? 1 : 0.8;
+	}};
 	white-space: nowrap;
 	display: flex;
 	flex: 1;

--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -55,10 +55,6 @@ test.describe('wcag', () => {
 
 		await mainScreen.createNewNote('Test');
 
-		// For now, activate all notes to make it active. When inactive, it causes a contrast warning.
-		// This seems to be allowed under WCAG 2.2 SC 1.4.3 under the "Incidental" exception.
-		await mainScreen.sidebar.allNotes.click();
-
 		// Ensure that `:hover` styling is consistent between tests:
 		await mainScreen.noteEditor.noteTitleInput.hover();
 

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -215,7 +215,7 @@ export function extraStyles(theme: Theme) {
 		...fontSizes,
 		selectedDividerColor: Color(theme.dividerColor).darken(0.2).hex(),
 		iconColor,
-		colorFaded2: Color(theme.color2).alpha(0.5).rgb(),
+		colorFaded2: Color(theme.color2).alpha(0.52).rgb(),
 		colorHover2: Color(theme.color2).alpha(0.7).rgb(),
 		colorActive2: Color(theme.color2).alpha(0.9).rgb(),
 

--- a/packages/lib/themes/light.ts
+++ b/packages/lib/themes/light.ts
@@ -24,7 +24,7 @@ const theme: Theme = {
 	backgroundColor2: '#313640',
 	color2: '#ffffff',
 	selectedColor2: '#131313',
-	colorError2: '#ff6c6c',
+	colorError2: '#ff7070',
 	colorWarn2: '#ffcb81',
 	colorWarn3: '#ff7626',
 


### PR DESCRIPTION
# Summary

This pull request improves the contrast of the "Conflicts" and "All notes" items in the sidebar.


# Related WCAG 2.2 guideline

[WCAG 2.2 SC 1.4.3](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html):
<blockquote>

The visual presentation of [text](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html#dfn-text) and [images of text](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html#dfn-image-of-text) has a [contrast ratio](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html#dfn-contrast-ratio) of at least 4.5:1, except for the following:

[ [...exceptions omitted...] ](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
</blockquote>

# Screenshot comparison

| Theme | Before | After |
|--------|--------|--------|
| Light | ![screenshot: sidebar in light theme has a gray background, two normal notebooks, a conflicts notebook (red), and an "all notes" notebook.](https://github.com/user-attachments/assets/1c3f6007-d938-4a7d-9e79-2c4adde576a7) | ![screenshot: before, except text color for all notes and conflicts is slightly lighter](https://github.com/user-attachments/assets/a8209fe7-012f-4b62-b4fd-73a88b4595ae) |
| Dark | ![screenshot: sidebar in dark theme has a dark gray background](https://github.com/user-attachments/assets/4bbd984e-3155-427b-b567-c56f1f1171f9) | ![screenshot: sidebar in dark theme has a dark gray background, slightly lighter than the before](https://github.com/user-attachments/assets/66c149e0-0de3-4c40-ac27-700530185179) |

**Contrast ratio comparison** (light mode): Before this change, the "Conflicts" sidebar item had contrast [3.32:1](https://webaim.org/resources/contrastchecker/?fcolor=FF6C6Ccc&bcolor=313640) when unselected and the "All notes" sidebar item had contrast 3.35:1. After this change, the conflicts folder has contrast ratio [4.5:1](https://webaim.org/resources/contrastchecker/?fcolor=FF7070&bcolor=313640) and the all notes item has contrast ratio [4.56:1](https://webaim.org/resources/contrastchecker/?fcolor=FF7070&bcolor=313640).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->