### PR TITLE
Desktop: Fixes #11640: Pressing Shift+Tab when focus is on notebook list would jump straight to editor

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -54,10 +54,6 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {
 			indexChange = 1;
-		} else if (event.code === 'Tab' && event.shiftKey) {
-			event.preventDefault();
-
-			void CommandService.instance().execute('focusElement', 'noteBody');
 		} else if (event.code === 'Enter' && !event.shiftKey) {
 			event.preventDefault();
 			void CommandService.instance().execute('focusElement', 'noteList');


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11640

# Summary

According to the [WCAG 2.4.3 guideline](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html) the order of navigation of elements should be predictable, so we should avoid programmatically choosing which element should be focused when navigating with `Tab` and `Shift+Tab`

# Testing

1. Open editor
2. Add focus to the notebook list
3. Press `Shift+Tab`
4. Focus should go to `Add new Notebook` button