### PR TITLE
Desktop: Accessibility: Mark secondary screen navigation bars as navigation regions

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
@@ -17,7 +17,7 @@ interface Props {
 	onApplyClick?: Function;
 }
 
-export const StyledRoot = styled.div`
+const StyledRoot = styled.nav`
 	display: flex;
 	align-items: center;
 	padding: 10px;
@@ -40,7 +40,7 @@ export default function ButtonBar(props: Props) {
 	}
 
 	return (
-		<StyledRoot role='navigation'>
+		<StyledRoot>
 			<Button
 				onClick={props.onCancelClick}
 				level={ButtonLevel.Secondary}

--- a/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
@@ -40,7 +40,7 @@ export default function ButtonBar(props: Props) {
 	}
 
 	return (
-		<StyledRoot>
+		<StyledRoot role='navigation'>
 			<Button
 				onClick={props.onCancelClick}
 				level={ButtonLevel.Secondary}


### PR DESCRIPTION
# Summary

This pull request marks the navigation bar (with "back", "OK", etc. buttons) with `role=navigation`. This makes it easier to jump to the navigation bar when using a screen reader.


## Related WCAG guidelines

This change is related to [WCAG 2.2 SC 1.3.1](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html). This success criterion lists ["using ARIA landmarks to identify regions of a page"](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11) as a related technique.

# Testing plan

1. Enable the Orca screen reader.
2. Open the note attachments page.
3. Press <kbd>m</kbd>.
4. Verify that Orca reads "navigation, back button".


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->