### PR TITLE
Desktop: Accessibility: Fix unlabelled toolbar button in the Rich Text Editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
@@ -67,6 +67,7 @@ export default function(editor: any) {
 
 	editor.ui.registry.addGroupToolbarButton('formattingExtras', {
 		icon: 'image-options',
+		tooltip: _('Formatting'),
 		items: items.join(' '),
 	});
 }


### PR DESCRIPTION
# Summary

This pull request fixes a missing label in the TinyMCE toolbar.

## Related WCAG guidelines

Among other requirements, [WCAG 2.2 SC 1.1.1](https://www.w3.org/TR/WCAG22/#non-text-content) states,
> If non-text content is a control or accepts user input, then it has a [name](https://www.w3.org/TR/WCAG22/#dfn-name) that describes its purpose.


# Testing plan

**Linux**:
1. Ensure that <kbd>alt</kbd>-<kbd>F10</kbd> isn't a shortcut handled by the OS.
1. Enable the Orca screen reader.
2. Open the Rich Text Editor.
3. Press <kbd>alt</kbd>-<kbd>F10</kbd>.
4. Verify that Orca reads "Bold, togglebutton not pressed".
5. Press the right arrow key repeatedly until Orca reads "Formatting, collapsed, button, opens menu".
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->