### PR TITLE
Desktop: Resolves #11654: Add scrollbar to Note Revision to allow usage on zoomed interface

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -59,7 +59,6 @@ import PluginService from '@joplin/lib/services/plugins/PluginService';
 import WebviewController from '@joplin/lib/services/plugins/WebviewController';
 import AsyncActionQueue, { IntervalType } from '@joplin/lib/AsyncActionQueue';
 import useResourceUnwatcher from './utils/useResourceUnwatcher';
-import Dialog from '../Dialog';
 
 const debounce = require('debounce');
 
@@ -540,13 +539,12 @@ function NoteEditorContent(props: NoteEditorProps) {
 			verticalAlign: 'top',
 			boxSizing: 'border-box',
 			flex: 1,
-			height: '95%',
 		};
 
 		return (
-			<Dialog contentStyle={revStyle}>
+			<div style={revStyle} ref={containerRef}>
 				<NoteRevisionViewer customCss={props.customCss} noteId={formNote.id} onBack={noteRevisionViewer_onBack} />
-			</Dialog>
+			</div>
 		);
 	}
 

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -539,6 +539,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 			verticalAlign: 'top',
 			boxSizing: 'border-box',
 			flex: 1,
+			overflowX: 'scroll',
 		};
 
 		return (

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -59,6 +59,7 @@ import PluginService from '@joplin/lib/services/plugins/PluginService';
 import WebviewController from '@joplin/lib/services/plugins/WebviewController';
 import AsyncActionQueue, { IntervalType } from '@joplin/lib/AsyncActionQueue';
 import useResourceUnwatcher from './utils/useResourceUnwatcher';
+import Dialog from '../Dialog';
 
 const debounce = require('debounce');
 
@@ -539,12 +540,13 @@ function NoteEditorContent(props: NoteEditorProps) {
 			verticalAlign: 'top',
 			boxSizing: 'border-box',
 			flex: 1,
+			height: '95%',
 		};
 
 		return (
-			<div style={revStyle} ref={containerRef}>
+			<Dialog contentStyle={revStyle}>
 				<NoteRevisionViewer customCss={props.customCss} noteId={formNote.id} onBack={noteRevisionViewer_onBack} />
-			</div>
+			</Dialog>
 		);
 	}
 


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/11654

# Summary

Add a scrollbar to Note Revision to make it work on zoomed-in screens.

<details><summary>Screenshot</summary>

![2025-01-20_15-35](https://github.com/user-attachments/assets/584127d5-60f1-40c4-bc69-1d9ea98b40dd)


</details> 

# Testing

1. Open Desktop
2. Open Note -> Note properties -> Previous versions of this note 