### PR TITLE
Desktop, Mobile: Do not add double newlines around attached files

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -51,6 +51,7 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 				createFileURL: options.createFileURL,
 				resizeLargeImages: Setting.value('imageResizing'),
 				markupLanguage: options.markupLanguage,
+				resourceSuffix: i > 0 ? ' ' : '',
 			});
 
 			if (!newBody) {

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -391,7 +391,13 @@ function shimInit(options: ShimInitOptions = null) {
 	};
 
 	shim.attachFileToNoteBody = async function(noteBody, filePath, position = null, options = null) {
-		options = { createFileURL: false, markupLanguage: 1, ...options };
+		options = {
+			createFileURL: false,
+			markupLanguage: 1,
+			resourcePrefix: '',
+			resourceSuffix: '',
+			...options,
+		};
 
 		const { basename } = require('path');
 		const { escapeTitleText } = require('./markdownUtils').default;
@@ -412,11 +418,11 @@ function shimInit(options: ShimInitOptions = null) {
 		if (noteBody && position) newBody.push(noteBody.substr(0, position));
 
 		if (!options.createFileURL) {
-			newBody.push(Resource.markupTag(resource, options.markupLanguage));
+			newBody.push(options.resourcePrefix + Resource.markupTag(resource, options.markupLanguage) + options.resourceSuffix);
 		} else {
 			const filename = escapeTitleText(basename(filePath)); // to get same filename as standard drag and drop
 			const fileURL = `[${filename}](${toFileProtocolPath(filePath)})`;
-			newBody.push(fileURL);
+			newBody.push(options.resourcePrefix + fileURL + options.resourceSuffix);
 		}
 
 		if (noteBody) newBody.push(noteBody.substr(position));

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -421,7 +421,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 		if (noteBody) newBody.push(noteBody.substr(position));
 
-		return newBody.join('\n\n');
+		return newBody.join('');
 	};
 
 	shim.attachFileToNote = async function(note, filePath, options = {}) {


### PR DESCRIPTION
The two newlines that are added around attached files seem arbitrary and unnecessary. I think I originally added this with the expectation that attached files are on their own lines, but really we can't know how the user wants to present the file.

Rather than nothing as in this pull requests, maybe spaces to separate the attachment from the text would be better? But it still means that user will have to manually delete them if there are already spaces around the file.