### PR TITLE
Desktop: Fix error when a note has no history

### DIFF
--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -61,7 +61,7 @@ const useNoteContent = (
 
 	useQueuedAsyncEffect(async () => {
 		const noteBody = note?.body ?? _('This note has no history');
-		const markupLanguage = note.markup_language ?? MarkupLanguage.Markdown;
+		const markupLanguage = note?.markup_language ?? MarkupLanguage.Markdown;
 		const result = await markupToHtml(markupLanguage, noteBody, {
 			resources: await shared.attachedResources(noteBody),
 			whiteBackgroundNoteRendering: markupLanguage === MarkupLanguage.Html,


### PR DESCRIPTION
# Summary

This pull request fixes an error that was logged to the console when viewing a note with no history in the note viewer. This is a regression, caused by a missing `null` check.

This was originally reported on [the forum](https://discourse.joplinapp.org/t/whats-new-in-joplin-3-2/43101/9?u=personalizedrefriger).


# Testing plan

1. Create a new note.
2. Open its note history.
3. Verify that the history panel reads "This note has no history".
4. Repeat step 2 for a note with history.
5. Verify that revisions are shown in the dropdown.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->