### PR TITLE
Desktop: Resolves #11710: Plugins: Mark the LanguageTool Integration plugin as incompatible

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
@@ -38,6 +38,7 @@ const incompatiblePluginIds = [
 	'ylc395.noteLinkSystem',
 	'outline',
 	'joplin.plugin.cmoptions',
+	'com.asdibiase.joplin-languagetool',
 	// cSpell:enable
 ];
 


### PR DESCRIPTION
# Summary

The [LanguageTool Integration plugin causes crashes](https://github.com/tito21/joplin-langugetool/issues/8) with the v6 CodeMirror editor. This pull request marks it as only compatible with the legacy editor.

This may resolve #11710.

See https://github.com/tito21/joplin-langugetool/issues/8.

> [!IMPORTANT]
>
> This pull request targets `release-3.2`. If no change for v3.2 is desired, please close this pull request &mdash; https://github.com/laurent22/joplin/pull/11714 may resolve the issue for v3.3.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->