### PR TITLE
Desktop: Accessibility: Improve "change application layout" screen keyboard accessibility

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -355,6 +355,7 @@ packages/app-desktop/gui/PasswordInput/types.js
 packages/app-desktop/gui/PdfViewer.js
 packages/app-desktop/gui/PluginNotification/PluginNotification.js
 packages/app-desktop/gui/PromptDialog.js
+packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.js
 packages/app-desktop/gui/ResizableLayout/MoveButtons.js
 packages/app-desktop/gui/ResizableLayout/ResizableLayout.js
 packages/app-desktop/gui/ResizableLayout/utils/findItemByKey.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -501,6 +501,7 @@ packages/app-desktop/gulpfile.js
 packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js
+packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -510,6 +510,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/pluginApi.spec.js
+packages/app-desktop/integration-tests/resizableLayout.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
 packages/app-desktop/integration-tests/settings.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -485,6 +485,7 @@ packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/pluginApi.spec.js
+packages/app-desktop/integration-tests/resizableLayout.spec.js
 packages/app-desktop/integration-tests/richTextEditor.spec.js
 packages/app-desktop/integration-tests/settings.spec.js
 packages/app-desktop/integration-tests/sidebar.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -476,6 +476,7 @@ packages/app-desktop/gulpfile.js
 packages/app-desktop/integration-tests/goToAnything.spec.js
 packages/app-desktop/integration-tests/main.spec.js
 packages/app-desktop/integration-tests/markdownEditor.spec.js
+packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.js
 packages/app-desktop/integration-tests/models/GoToAnything.js
 packages/app-desktop/integration-tests/models/MainScreen.js
 packages/app-desktop/integration-tests/models/NoteEditorScreen.js

--- a/.gitignore
+++ b/.gitignore
@@ -330,6 +330,7 @@ packages/app-desktop/gui/PasswordInput/types.js
 packages/app-desktop/gui/PdfViewer.js
 packages/app-desktop/gui/PluginNotification/PluginNotification.js
 packages/app-desktop/gui/PromptDialog.js
+packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.js
 packages/app-desktop/gui/ResizableLayout/MoveButtons.js
 packages/app-desktop/gui/ResizableLayout/ResizableLayout.js
 packages/app-desktop/gui/ResizableLayout/utils/findItemByKey.js

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -30,6 +30,7 @@ interface Props {
 	iconAnimation?: string;
 	tooltip?: string;
 	disabled?: boolean;
+	autoFocus?: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied;
 	style?: any;
 	size?: ButtonSize;
@@ -253,6 +254,7 @@ const Button = React.forwardRef((props: Props, ref: any) => {
 			size={props.size}
 			style={props.style}
 			disabled={props.disabled}
+			autoFocus={props.autoFocus}
 			title={props.tooltip}
 			className={props.className}
 			iconOnly={iconOnly}

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -18,29 +18,24 @@ export enum ButtonSize {
 	Normal = 2,
 }
 
-interface Props {
+type BaseButtonProps = Omit<
+React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
+'onClick'
+>;
+interface Props extends BaseButtonProps {
 	title?: string;
 	iconName?: string;
 	level?: ButtonLevel;
 	iconLabel?: string;
-	className?: string;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onClick?: Function;
+	onClick?: ()=> void;
 	color?: string;
 	iconAnimation?: string;
 	tooltip?: string;
 	disabled?: boolean;
-	autoFocus?: boolean;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied;
-	style?: any;
 	size?: ButtonSize;
 	isSquare?: boolean;
 	iconOnly?: boolean;
 	fontSize?: number;
-
-	'aria-controls'?: string;
-	'aria-describedby'?: string;
-	'aria-expanded'?: string;
 }
 
 const StyledTitle = styled.span`
@@ -217,56 +212,52 @@ function buttonClass(level: ButtonLevel) {
 	return StyledButtonSecondary;
 }
 
+const Button = React.forwardRef(({
+	iconName, iconLabel, iconAnimation, color, title, level, fontSize, isSquare, tooltip, disabled, onClick: propsOnClick, ...unusedProps
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied;
-const Button = React.forwardRef((props: Props, ref: any) => {
-	const iconOnly = props.iconName && !props.title;
+}: Props, ref: any) => {
+	const iconOnly = iconName && !title;
 
-	const StyledButton = buttonClass(props.level);
+	const StyledButton = buttonClass(level);
 
 	function renderIcon() {
-		if (!props.iconName) return null;
+		if (!iconName) return null;
 		return <StyledIcon
-			aria-label={props.iconLabel ?? undefined}
-			aria-hidden={!props.iconLabel}
-			animation={props.iconAnimation}
+			aria-label={iconLabel ?? undefined}
+			aria-hidden={!iconLabel}
+			animation={iconAnimation}
 			mr={iconOnly ? '0' : '6px'}
-			color={props.color}
-			className={props.iconName}
+			color={color}
+			className={iconName}
 			role='img'
 		/>;
 	}
 
 	function renderTitle() {
-		if (!props.title) return null;
-		return <StyledTitle color={props.color}>{props.title}</StyledTitle>;
+		if (!title) return null;
+		return <StyledTitle color={color}>{title}</StyledTitle>;
 	}
 
 	function onClick() {
-		if (props.disabled) return;
-		props.onClick();
+		if (disabled) return;
+		propsOnClick();
 	}
 
 	return (
 		<StyledButton
 			ref={ref}
-			fontSize={props.fontSize}
-			isSquare={props.isSquare}
-			size={props.size}
-			style={props.style}
-			disabled={props.disabled}
-			autoFocus={props.autoFocus}
-			title={props.tooltip}
-			className={props.className}
+			fontSize={fontSize}
+			isSquare={isSquare}
+			disabled={disabled}
+			title={tooltip}
 			iconOnly={iconOnly}
 			onClick={onClick}
 
 			// When there's no title, the button needs a label. In this case, fall back
 			// to the tooltip.
-			aria-label={props.title ? undefined : props.tooltip}
-			aria-disabled={props.disabled}
-			aria-expanded={props['aria-expanded']}
-			aria-controls={props['aria-controls']}
-			aria-describedby={props['aria-describedby']}
+			aria-label={title ? undefined : tooltip}
+			aria-disabled={disabled}
+			{...unusedProps}
 		>
 			{renderIcon()}
 			{renderTitle()}

--- a/packages/app-desktop/gui/Button/Button.tsx
+++ b/packages/app-desktop/gui/Button/Button.tsx
@@ -18,11 +18,8 @@ export enum ButtonSize {
 	Normal = 2,
 }
 
-type BaseButtonProps = Omit<
-React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-'onClick'
->;
-interface Props extends BaseButtonProps {
+type ReactButtonProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+interface Props extends Omit<ReactButtonProps, 'onClick'> {
 	title?: string;
 	iconName?: string;
 	level?: ButtonLevel;

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -43,6 +43,7 @@ import UpdateNotification from './UpdateNotification/UpdateNotification';
 import NoteEditor from './NoteEditor/NoteEditor';
 import PluginNotification from './PluginNotification/PluginNotification';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
+import PluginService from '@joplin/lib/services/plugins/PluginService';
 
 const ipcRenderer = require('electron').ipcRenderer;
 
@@ -119,6 +120,18 @@ const defaultLayout: LayoutItem = {
 		{ key: 'noteList', width: 250 },
 		{ key: 'editor' },
 	],
+};
+
+const layoutKeyToLabel = (key: string, plugins: PluginStates) => {
+	if (key === 'sideBar') return _('Sidebar');
+	if (key === 'noteList') return _('Note list');
+	if (key === 'editor') return _('Editor');
+
+	const viewInfo = pluginUtils.viewInfoByViewId(plugins, key);
+	if (viewInfo) {
+		return PluginService.instance().safePluginNameById(viewInfo.plugin.id);
+	}
+	return key;
 };
 
 class MainScreenComponent extends React.Component<Props, State> {
@@ -728,6 +741,10 @@ class MainScreenComponent extends React.Component<Props, State> {
 		);
 	}
 
+	private layoutKeyToLabel = (key: string) => {
+		return layoutKeyToLabel(key, this.props.plugins);
+	};
+
 	public render() {
 		const theme = themeStyle(this.props.themeId);
 		const style = {
@@ -746,6 +763,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				onResize={this.resizableLayout_resize}
 				onMoveButtonClick={this.resizableLayout_moveButtonClick}
 				renderItem={this.resizableLayout_renderItem}
+				layoutKeyToLabel={this.layoutKeyToLabel}
 				moveMode={this.props.layoutMoveMode}
 				moveModeMessage={_('Use the arrows to move the layout items. Press "Escape" to exit.')}
 			/>

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -741,8 +741,8 @@ class MainScreenComponent extends React.Component<Props, State> {
 		);
 	}
 
-	private layoutKeyToLabel = (key: string) => {
-		return layoutKeyToLabel(key, this.props.plugins);
+	private layoutKeyToLabel = (key: string, row: number, column: number) => {
+		return `${layoutKeyToLabel(key, this.props.plugins)} (${row}, ${column})`;
 	};
 
 	public render() {
@@ -763,7 +763,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				onResize={this.resizableLayout_resize}
 				onMoveButtonClick={this.resizableLayout_moveButtonClick}
 				renderItem={this.resizableLayout_renderItem}
-				layoutKeyToLabel={this.layoutKeyToLabel}
+				layoutLabel={this.layoutKeyToLabel}
 				moveMode={this.props.layoutMoveMode}
 				moveModeMessage={_('Use the arrows to move the layout items. Press "Escape" to exit.')}
 			/>

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -741,8 +741,8 @@ class MainScreenComponent extends React.Component<Props, State> {
 		);
 	}
 
-	private layoutKeyToLabel = (key: string, row: number, column: number) => {
-		return `${layoutKeyToLabel(key, this.props.plugins)} (${row}, ${column})`;
+	private layoutKeyToLabel = (key: string) => {
+		return layoutKeyToLabel(key, this.props.plugins);
 	};
 
 	public render() {
@@ -763,7 +763,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 				onResize={this.resizableLayout_resize}
 				onMoveButtonClick={this.resizableLayout_moveButtonClick}
 				renderItem={this.resizableLayout_renderItem}
-				layoutLabel={this.layoutKeyToLabel}
+				layoutKeyToLabel={this.layoutKeyToLabel}
 				moveMode={this.props.layoutMoveMode}
 				moveModeMessage={_('Use the arrows to move the layout items. Press "Escape" to exit.')}
 			/>

--- a/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Resizable, ResizeCallback, ResizeStartCallback, Size } from 're-resizable';
+import { LayoutItem } from './utils/types';
+import { itemMinHeight, itemMinWidth, itemSize, LayoutItemSizes } from './utils/useLayoutItemSizes';
+
+interface Props {
+	item: LayoutItem;
+	parent: LayoutItem|null;
+	sizes: LayoutItemSizes;
+	resizedItemMaxSize: Size|null;
+	onResizeStart: ResizeStartCallback;
+	onResize: ResizeCallback;
+	onResizeStop: ResizeCallback;
+	children: React.ReactNode;
+	isLastChild: boolean;
+	visible: boolean;
+}
+
+const LayoutItemContainer: React.FC<Props> = ({
+	item, visible, parent, sizes, resizedItemMaxSize, onResize, onResizeStart, onResizeStop, children, isLastChild,
+}) => {
+	const style: React.CSSProperties = {
+		display: visible ? 'flex' : 'none',
+		flexDirection: item.direction,
+	};
+
+	const size: Size = itemSize(item, parent, sizes, true);
+
+	const className = `resizableLayoutItem rli-${item.key}`;
+	if (item.resizableRight || item.resizableBottom) {
+		const enable = {
+			top: false,
+			right: !!item.resizableRight && !isLastChild,
+			bottom: !!item.resizableBottom && !isLastChild,
+			left: false,
+			topRight: false,
+			bottomRight: false,
+			bottomLeft: false,
+			topLeft: false,
+		};
+
+		return (
+			<Resizable
+				key={item.key}
+				className={className}
+				style={style}
+				size={size}
+				onResizeStart={onResizeStart}
+				onResize={onResize}
+				onResizeStop={onResizeStop}
+				enable={enable}
+				minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
+				minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}
+				maxWidth={resizedItemMaxSize?.width}
+				maxHeight={resizedItemMaxSize?.height}
+			>
+				{children}
+			</Resizable>
+		);
+	} else {
+		return (
+			<div key={item.key} className={className} style={{ ...style, ...size }}>
+				{children}
+			</div>
+		);
+	}
+};
+
+export default LayoutItemContainer;

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import Button, { ButtonLevel } from '../Button/Button';
 import { MoveDirection } from './utils/movements';
 import styled from 'styled-components';
+import { _ } from '@joplin/lib/locale';
 
 const StyledRoot = styled.div`
 	display: flex;
@@ -53,11 +54,21 @@ export default function MoveButtons(props: Props) {
 		throw new Error('Unreachable');
 	}
 
+	const iconLabel = (dir: MoveDirection) => {
+		if (dir === MoveDirection.Up) return _('Move up');
+		if (dir === MoveDirection.Down) return _('Move down');
+		if (dir === MoveDirection.Left) return _('Move left');
+		if (dir === MoveDirection.Right) return _('Move right');
+		const unreachable: never = dir;
+		throw new Error(`Invalid direction: ${unreachable}`);
+	};
+
 	function renderButton(dir: MoveDirection) {
 		return <ArrowButton
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
+			iconLabel={iconLabel(dir)}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}
@@ -69,7 +80,7 @@ export default function MoveButtons(props: Props) {
 			</ButtonRow>
 			<ButtonRow>
 				{renderButton(MoveDirection.Left)}
-				<EmptyButton iconName="fas fa-arrow-down" disabled={true}/>
+				<EmptyButton iconName="fas fa-arrow-down" aria-hidden={true} disabled={true}/>
 				{renderButton(MoveDirection.Right)}
 			</ButtonRow>
 			<ButtonRow>

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -13,12 +13,8 @@ const StyledRoot = styled.div`
 	border-radius: 5px;
 
 	> .label {
-		text-align: center;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-
-		font-weight: bold;
-		padding-top: 4px;
+		// Used only for accessibility tools
+		display: none;
 	}
 `;
 

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -76,8 +76,7 @@ export default function MoveButtons(props: Props) {
 		throw new Error(`Invalid direction: ${unreachable}`);
 	};
 
-	const baseId = useId();
-	const descriptionId = `${baseId}-description`;
+	const descriptionId = useId();
 
 	const buttonKey = (dir: MoveDirection) => `${props.itemKey}-${dir}`;
 	const autoFocusDirection = (() => {
@@ -102,17 +101,13 @@ export default function MoveButtons(props: Props) {
 	})();
 
 	function renderButton(dir: MoveDirection) {
-		const buttonId = `${baseId}-button-${dir}`;
 		return <ArrowButton
-			id={buttonId}
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
-			aria-labelledby={`${buttonId} ${descriptionId}`}
-			// Use 'true' as a string to use the browser's default autoFocus behavior
-			// (rather than the Electron behavior).
-			autoFocus={autoFocusDirection === dir ? 'true' : undefined}
+			aria-describedby={descriptionId}
+			autoFocus={autoFocusDirection === dir}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}
@@ -130,11 +125,7 @@ export default function MoveButtons(props: Props) {
 			<ButtonRow>
 				{renderButton(MoveDirection.Down)}
 			</ButtonRow>
-			<div
-				className='label'
-				aria-live={autoFocusDirection ? 'polite' : null}
-				id={descriptionId}
-			>{props.itemLabel}</div>
+			<div className='label' id={descriptionId}>{props.itemLabel}</div>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -11,6 +11,15 @@ const StyledRoot = styled.div`
 	padding: 5px;
 	background-color: ${props => props.theme.backgroundColor};
 	border-radius: 5px;
+
+	> .label {
+		text-align: center;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		font-weight: bold;
+		padding-top: 4px;
+	}
 `;
 
 const ButtonRow = styled.div`
@@ -90,7 +99,7 @@ export default function MoveButtons(props: Props) {
 			<ButtonRow>
 				{renderButton(MoveDirection.Down)}
 			</ButtonRow>
-			<span id={descriptionId}>{props.itemLabel}</span>
+			<div className='label' id={descriptionId}>{props.itemLabel}</div>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useId } from 'react';
 import Button, { ButtonLevel } from '../Button/Button';
 import { MoveDirection } from './utils/movements';
 import styled from 'styled-components';
@@ -35,6 +35,7 @@ export interface MoveButtonClickEvent {
 interface Props {
 	onClick(event: MoveButtonClickEvent): void;
 	itemKey: string;
+	itemLabel: string;
 	canMoveLeft: boolean;
 	canMoveRight: boolean;
 	canMoveUp: boolean;
@@ -63,12 +64,15 @@ export default function MoveButtons(props: Props) {
 		throw new Error(`Invalid direction: ${unreachable}`);
 	};
 
+	const descriptionId = useId();
+
 	function renderButton(dir: MoveDirection) {
 		return <ArrowButton
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
+			aria-describedby={descriptionId}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}
@@ -86,6 +90,7 @@ export default function MoveButtons(props: Props) {
 			<ButtonRow>
 				{renderButton(MoveDirection.Down)}
 			</ButtonRow>
+			<span id={descriptionId}>{props.itemLabel}</span>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -53,7 +53,8 @@ interface Props {
 	canMoveUp: boolean;
 	canMoveDown: boolean;
 
-	// A buttonKey to auto-focus
+	// A buttonKey to auto-focus. As one of the move buttons can change the app's layout,
+	// it's important to refocus the last-clicked button.
 	autoFocusKey: ButtonKey|null;
 }
 
@@ -81,15 +82,36 @@ export default function MoveButtons(props: Props) {
 
 	const descriptionId = useId();
 
+	const buttonKey = (dir: MoveDirection) => `${props.itemKey}-${dir}`;
+	const autoFocusDirection = (() => {
+		if (!props.autoFocusKey) return undefined;
+
+		const buttonDirections = [MoveDirection.Up, MoveDirection.Down, MoveDirection.Left, MoveDirection.Right];
+		const autoFocusDirection = buttonDirections.find(
+			direction => buttonKey(direction) === props.autoFocusKey,
+		);
+
+		if (!autoFocusDirection) {
+			return null;
+		}
+
+		const autoFocusDirectionEnabled = autoFocusDirection && canMove(autoFocusDirection);
+		if (autoFocusDirectionEnabled) {
+			return autoFocusDirection;
+		} else {
+			// Select an enabled direction instead
+			return buttonDirections.find(dir => canMove(dir));
+		}
+	})();
+
 	function renderButton(dir: MoveDirection) {
-		const key = `${props.itemKey}-${dir}`;
 		return <ArrowButton
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
 			aria-describedby={descriptionId}
-			autoFocus={key === props.autoFocusKey}
+			autoFocus={autoFocusDirection === dir}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -36,9 +36,12 @@ const ArrowButton = styled(Button)`
 	opacity: ${props => props.disabled ? 0.2 : 1};
 `;
 
+type ButtonKey = string;
+
 export interface MoveButtonClickEvent {
 	direction: MoveDirection;
 	itemKey: string;
+	buttonKey: ButtonKey;
 }
 
 interface Props {
@@ -49,11 +52,14 @@ interface Props {
 	canMoveRight: boolean;
 	canMoveUp: boolean;
 	canMoveDown: boolean;
+
+	// A buttonKey to auto-focus
+	autoFocusKey: ButtonKey|null;
 }
 
 export default function MoveButtons(props: Props) {
 	const onButtonClick = useCallback((direction: MoveDirection) => {
-		props.onClick({ direction, itemKey: props.itemKey });
+		props.onClick({ direction, itemKey: props.itemKey, buttonKey: `${props.itemKey}-${direction}` });
 	}, [props.onClick, props.itemKey]);
 
 	function canMove(dir: MoveDirection) {
@@ -76,12 +82,14 @@ export default function MoveButtons(props: Props) {
 	const descriptionId = useId();
 
 	function renderButton(dir: MoveDirection) {
+		const key = `${props.itemKey}-${dir}`;
 		return <ArrowButton
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
 			aria-describedby={descriptionId}
+			autoFocus={key === props.autoFocusKey}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -76,7 +76,8 @@ export default function MoveButtons(props: Props) {
 		throw new Error(`Invalid direction: ${unreachable}`);
 	};
 
-	const descriptionId = useId();
+	const baseId = useId();
+	const descriptionId = `${baseId}-description`;
 
 	const buttonKey = (dir: MoveDirection) => `${props.itemKey}-${dir}`;
 	const autoFocusDirection = (() => {
@@ -101,13 +102,17 @@ export default function MoveButtons(props: Props) {
 	})();
 
 	function renderButton(dir: MoveDirection) {
+		const buttonId = `${baseId}-button-${dir}`;
 		return <ArrowButton
+			id={buttonId}
 			disabled={!canMove(dir)}
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
-			aria-describedby={descriptionId}
-			autoFocus={autoFocusDirection === dir}
+			aria-labelledby={`${buttonId} ${descriptionId}`}
+			// Use 'true' as a string to use the browser's default autoFocus behavior
+			// (rather than the Electron behavior).
+			autoFocus={autoFocusDirection === dir ? 'true' : undefined}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}
@@ -125,7 +130,11 @@ export default function MoveButtons(props: Props) {
 			<ButtonRow>
 				{renderButton(MoveDirection.Down)}
 			</ButtonRow>
-			<div className='label' id={descriptionId}>{props.itemLabel}</div>
+			<div
+				className='label'
+				aria-live={autoFocusDirection ? 'polite' : null}
+				id={descriptionId}
+			>{props.itemLabel}</div>
 		</StyledRoot>
 	);
 }

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -49,8 +49,9 @@ interface Props {
 	canMoveUp: boolean;
 	canMoveDown: boolean;
 
-	// A buttonKey to auto-focus. As one of the move buttons can change the app's layout,
-	// it's important to refocus the last-clicked button.
+	// Specifies which button to auto-focus (if any). Clicking a "Move ..." button changes the app's layout. By default, this
+	// causes focus to jump to the start of the move dialog. Providing the key of the last-clicked button allows focus
+	// to be restored after changing the app layout:
 	autoFocusKey: ButtonKey|null;
 }
 

--- a/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx
@@ -106,14 +106,13 @@ export default function MoveButtons(props: Props) {
 			level={ButtonLevel.Primary}
 			iconName={`fas fa-arrow-${dir}`}
 			iconLabel={iconLabel(dir)}
-			aria-describedby={descriptionId}
 			autoFocus={autoFocusDirection === dir}
 			onClick={() => onButtonClick(dir)}
 		/>;
 	}
 
 	return (
-		<StyledRoot>
+		<StyledRoot role='group' aria-labelledby={descriptionId}>
 			<ButtonRow>
 				{renderButton(MoveDirection.Up)}
 			</ButtonRow>

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -4,7 +4,7 @@ import useWindowResizeEvent from './utils/useWindowResizeEvent';
 import setLayoutItemProps from './utils/setLayoutItemProps';
 import useLayoutItemSizes, { LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem, itemMinWidth, itemMinHeight } from './utils/useLayoutItemSizes';
 import validateLayout from './utils/validateLayout';
-import { Size, LayoutItem, LayoutItemDirection } from './utils/types';
+import { Size, LayoutItem } from './utils/types';
 import { canMove, MoveDirection } from './utils/movements';
 import MoveButtons, { MoveButtonClickEvent } from './MoveButtons';
 import { StyledWrapperRoot, StyledMoveOverlay, MoveModeRootMessage } from './utils/style';
@@ -18,7 +18,7 @@ interface OnResizeEvent {
 
 interface Props {
 	layout: LayoutItem;
-	layoutLabel: (itemKey: string, rowIndex: number, colIndex: number)=> string;
+	layoutKeyToLabel: (key: string)=> string;
 	onResize(event: OnResizeEvent): void;
 	width?: number;
 	height?: number;
@@ -96,19 +96,14 @@ function ResizableLayout(props: Props) {
 		props.onMoveButtonClick(event);
 	}, [props.onMoveButtonClick]);
 
-	type ItemPosition = {
-		rowIndex: number;
-		colIndex: number;
-	};
-
-	const renderMoveControls = (item: LayoutItem, parent: LayoutItem | null, size: Size, { rowIndex, colIndex }: ItemPosition) => {
+	const renderMoveControls = (item: LayoutItem, parent: LayoutItem | null, size: Size) => {
 		return (
 			<StyledWrapperRoot key={item.key} size={size}>
 				<StyledMoveOverlay>
 					<MoveButtons
 						autoFocusKey={lastUsedMoveButtonKey.current}
 						itemKey={item.key}
-						itemLabel={props.layoutLabel(item.key, rowIndex, colIndex)}
+						itemLabel={props.layoutKeyToLabel(item.key)}
 						onClick={onMoveButtonClick}
 						canMoveLeft={canMove(MoveDirection.Left, item, parent)}
 						canMoveRight={canMove(MoveDirection.Right, item, parent)}
@@ -129,7 +124,7 @@ function ResizableLayout(props: Props) {
 	}
 
 	function renderLayoutItem(
-		item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isVisible: boolean, isLastChild: boolean, onlyMoveControls: boolean, position: ItemPosition,
+		item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, isVisible: boolean, isLastChild: boolean, onlyMoveControls: boolean,
 	): React.ReactNode {
 		function onResizeStart() {
 			setResizedItem({
@@ -180,25 +175,14 @@ function ResizableLayout(props: Props) {
 				visible: isVisible,
 			});
 
-			const wrapper = onlyMoveControls ? renderMoveControls(item, parent, size, position) : renderItemWrapper(comp, item, size);
+			const wrapper = onlyMoveControls ? renderMoveControls(item, parent, size) : renderItemWrapper(comp, item, size);
 			return renderContainer(item, parent, sizes, resizedItemMaxSize, onResizeStart, onResize, onResizeStop, [wrapper], isLastChild, props.moveMode);
 		} else {
 			const childrenComponents = [];
 			for (let i = 0; i < item.children.length; i++) {
 				const child = item.children[i];
 				childrenComponents.push(
-					renderLayoutItem(
-						child,
-						item,
-						sizes,
-						isVisible && itemVisible(child, props.moveMode),
-						i === item.children.length - 1,
-						onlyMoveControls,
-						{
-							rowIndex: position.rowIndex + (item.direction === LayoutItemDirection.Row ? i : 0),
-							colIndex: position.colIndex + (item.direction === LayoutItemDirection.Column ? i : 0),
-						},
-					),
+					renderLayoutItem(child, item, sizes, isVisible && itemVisible(child, props.moveMode), i === item.children.length - 1, onlyMoveControls),
 				);
 			}
 
@@ -214,7 +198,7 @@ function ResizableLayout(props: Props) {
 	const sizes = useLayoutItemSizes(props.layout, props.moveMode);
 
 	const renderRoot = (moveControlsOnly: boolean) => {
-		return renderLayoutItem(props.layout, null, sizes, itemVisible(props.layout, props.moveMode), true, moveControlsOnly, { rowIndex: 0, colIndex: 0 });
+		return renderLayoutItem(props.layout, null, sizes, itemVisible(props.layout, props.moveMode), true, moveControlsOnly);
 	};
 
 	function renderMoveModeBox() {

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import useWindowResizeEvent from './utils/useWindowResizeEvent';
 import setLayoutItemProps from './utils/setLayoutItemProps';
 import useLayoutItemSizes, { LayoutItemSizes, itemSize, calculateMaxSizeAvailableForItem, itemMinWidth, itemMinHeight } from './utils/useLayoutItemSizes';
@@ -89,15 +89,22 @@ function ResizableLayout(props: Props) {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const [resizedItem, setResizedItem] = useState<any>(null);
+	const lastUsedMoveButtonKey = useRef<string|null>(null);
+
+	const onMoveButtonClick = useCallback((event: MoveButtonClickEvent) => {
+		lastUsedMoveButtonKey.current = event.buttonKey;
+		props.onMoveButtonClick(event);
+	}, [props.onMoveButtonClick]);
 
 	const renderMoveControls = (item: LayoutItem, parent: LayoutItem | null, size: Size) => {
 		return (
 			<StyledWrapperRoot key={item.key} size={size}>
 				<StyledMoveOverlay>
 					<MoveButtons
+						autoFocusKey={lastUsedMoveButtonKey.current}
 						itemKey={item.key}
 						itemLabel={props.layoutKeyToLabel(item.key)}
-						onClick={props.onMoveButtonClick}
+						onClick={onMoveButtonClick}
 						canMoveLeft={canMove(MoveDirection.Left, item, parent)}
 						canMoveRight={canMove(MoveDirection.Right, item, parent)}
 						canMoveUp={canMove(MoveDirection.Up, item, parent)}

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -167,7 +167,7 @@ function ResizableLayout(props: Props) {
 
 	function renderMoveModeBox() {
 		return <div>
-			<Dialog contentFillsScreen={true} className='resizable-panels-move-dialog'>
+			<Dialog contentFillsScreen={true} className='change-app-layout-dialog'>
 				<MoveModeRootMessage>{props.moveModeMessage}</MoveModeRootMessage>
 				{renderRoot(true)}
 			</Dialog>

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -8,7 +8,7 @@ import { Size, LayoutItem } from './utils/types';
 import { canMove, MoveDirection } from './utils/movements';
 import MoveButtons, { MoveButtonClickEvent } from './MoveButtons';
 import { StyledWrapperRoot, StyledMoveOverlay, MoveModeRootWrapper, MoveModeRootMessage } from './utils/style';
-import { Resizable } from 're-resizable';
+import { Resizable, ResizeCallback, ResizeStartCallback } from 're-resizable';
 const EventEmitter = require('events');
 
 interface OnResizeEvent {
@@ -34,7 +34,7 @@ function itemVisible(item: LayoutItem, moveMode: boolean) {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, resizedItemMaxSize: Size | null, onResizeStart: Function, onResize: Function, onResizeStop: Function, children: any[], isLastChild: boolean, moveMode: boolean): any {
+function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: LayoutItemSizes, resizedItemMaxSize: Size | null, onResizeStart: ResizeStartCallback, onResize: ResizeCallback, onResizeStop: ResizeCallback, children: any[], isLastChild: boolean, moveMode: boolean): any {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const style: any = {
 		display: itemVisible(item, moveMode) ? 'flex' : 'none',
@@ -62,12 +62,9 @@ function renderContainer(item: LayoutItem, parent: LayoutItem | null, sizes: Lay
 				className={className}
 				style={style}
 				size={size}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				onResizeStart={onResizeStart as any}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				onResize={onResize as any}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-				onResizeStop={onResizeStop as any}
+				onResizeStart={onResizeStart}
+				onResize={onResize}
+				onResizeStop={onResizeStop}
 				enable={enable}
 				minWidth={'minWidth' in item ? item.minWidth : itemMinWidth}
 				minHeight={'minHeight' in item ? item.minHeight : itemMinHeight}

--- a/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
+++ b/packages/app-desktop/gui/ResizableLayout/ResizableLayout.tsx
@@ -123,7 +123,7 @@ function ResizableLayout(props: Props) {
 		const resizedItemMaxSize = resizedItem && item.key === resizedItem.key ? resizedItem.maxSize : null;
 		const visible = itemVisible(item, props.moveMode);
 		const itemContainerProps = {
-			item, parent, sizes, resizedItemMaxSize, onResizeStart, onResizeStop, onResize, isLastChild, visible,
+			key: item.key, item, parent, sizes, resizedItemMaxSize, onResizeStart, onResizeStop, onResize, isLastChild, visible,
 		};
 		if (!item.children) {
 			const size = itemSize(item, parent, sizes, false);

--- a/packages/app-desktop/gui/ResizableLayout/utils/style.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/style.ts
@@ -29,11 +29,11 @@ export const StyledMoveOverlay = styled.div`
 `;
 
 export const MoveModeRootMessage = styled.h1`
-	position:absolute;
+	position: absolute;
 	bottom: 10px;
+	font-size: 1em;
 
 	z-index:200;
 	background-color: ${props => props.theme.backgroundColor};
 	padding: 10px;
-	border-radius: 5px;
 `;

--- a/packages/app-desktop/gui/ResizableLayout/utils/style.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/style.ts
@@ -28,18 +28,12 @@ export const StyledMoveOverlay = styled.div`
 	height: 100%;
 `;
 
-export const MoveModeRootWrapper = styled.div`
-	position:relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-`;
-
-export const MoveModeRootMessage = styled.div`
+export const MoveModeRootMessage = styled.h1`
 	position:absolute;
 	bottom: 10px;
+
 	z-index:200;
 	background-color: ${props => props.theme.backgroundColor};
 	padding: 10px;
-	border-radius: 5;
+	border-radius: 5px;
 `;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts
@@ -1,6 +1,6 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
-import dialogs from '../../dialogs';
+import shim from '@joplin/lib/shim';
 
 export const declaration: CommandDeclaration = {
 	name: 'resetLayout',
@@ -12,7 +12,7 @@ export const runtime = (): CommandRuntime => {
 		execute: async (context: CommandContext) => {
 
 			const message = _('Are you sure you want to return to the default layout? The current layout configuration will be lost.');
-			const isConfirmed = await dialogs.confirm(message);
+			const isConfirmed = await shim.showConfirmationDialog(message);
 
 			if (!isConfirmed) return;
 

--- a/packages/app-desktop/gui/styles/change-app-layout-dialog.scss
+++ b/packages/app-desktop/gui/styles/change-app-layout-dialog.scss
@@ -1,4 +1,4 @@
-.resizable-panels-move-dialog {
+.change-app-layout-dialog {
 	padding: 0;
 
 	> .content {

--- a/packages/app-desktop/gui/styles/dialog-modal-layer.scss
+++ b/packages/app-desktop/gui/styles/dialog-modal-layer.scss
@@ -32,13 +32,16 @@
 	}
 
 	&.-fullscreen {
+		max-width: 100vw;
+		max-height: 100vh;
+
 		&::backdrop {
 			background-color: var(--joplin-background-color);
 		}
 
 		> .content {
-			width: calc(100% - 20px);
-			padding: 10px;
+			margin: 0;
+			padding: 0;
 			border-radius: 0;
 			box-shadow: none;
 			background-color: transparent;

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -11,4 +11,4 @@
 @use './dialog-anchor-node.scss';
 @use './note-editor-wrapper.scss';
 @use './text-input.scss';
-@use './resizable-panels-move-dialog.scss';
+@use './change-app-layout-dialog.scss';

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -11,3 +11,4 @@
 @use './dialog-anchor-node.scss';
 @use './note-editor-wrapper.scss';
 @use './text-input.scss';
+@use './resizable-panels-move-dialog.scss';

--- a/packages/app-desktop/gui/styles/resizable-panels-move-dialog.scss
+++ b/packages/app-desktop/gui/styles/resizable-panels-move-dialog.scss
@@ -1,0 +1,7 @@
+.resizable-panels-move-dialog {
+	padding: 0;
+
+	&::backdrop {
+		background-color: transparent !important;
+	}
+}

--- a/packages/app-desktop/gui/styles/resizable-panels-move-dialog.scss
+++ b/packages/app-desktop/gui/styles/resizable-panels-move-dialog.scss
@@ -1,6 +1,13 @@
 .resizable-panels-move-dialog {
 	padding: 0;
 
+	> .content {
+		position:relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
 	&::backdrop {
 		background-color: transparent !important;
 	}

--- a/packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.ts
+++ b/packages/app-desktop/integration-tests/models/ChangeAppLayoutScreen.ts
@@ -1,0 +1,23 @@
+
+import { ElectronApplication, Locator, Page } from '@playwright/test';
+import MainScreen from './MainScreen';
+import activateMainMenuItem from '../util/activateMainMenuItem';
+
+export default class ChangeAppLayoutScreen {
+	public readonly containerLocator: Locator;
+
+	public constructor(page: Page, private readonly mainScreen: MainScreen) {
+		this.containerLocator = page.locator('.change-app-layout-dialog[open]');
+	}
+
+	public async open(electronApp: ElectronApplication) {
+		await this.mainScreen.waitFor();
+		await activateMainMenuItem(electronApp, 'Change application layout');
+
+		return this.waitFor();
+	}
+
+	public async waitFor() {
+		await this.containerLocator.waitFor();
+	}
+}

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -6,6 +6,7 @@ import GoToAnything from './GoToAnything';
 import setFilePickerResponse from '../util/setFilePickerResponse';
 import NoteList from './NoteList';
 import { expect } from '../util/test';
+import ChangeAppLayoutScreen from './ChangeAppLayoutScreen';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
@@ -14,6 +15,7 @@ export default class MainScreen {
 	public readonly dialog: Locator;
 	public readonly noteEditor: NoteEditorScreen;
 	public readonly goToAnything: GoToAnything;
+	public readonly changeLayoutScreen: ChangeAppLayoutScreen;
 
 	public constructor(private page: Page) {
 		this.newNoteButton = page.locator('.new-note-button');
@@ -22,6 +24,7 @@ export default class MainScreen {
 		this.dialog = page.locator('.dialog-modal-layer');
 		this.noteEditor = new NoteEditorScreen(page);
 		this.goToAnything = new GoToAnything(page, this);
+		this.changeLayoutScreen = new ChangeAppLayoutScreen(page, this);
 	}
 
 	public async setup() {

--- a/packages/app-desktop/integration-tests/resizableLayout.spec.ts
+++ b/packages/app-desktop/integration-tests/resizableLayout.spec.ts
@@ -1,0 +1,22 @@
+
+import { test, expect } from './util/test';
+import MainScreen from './models/MainScreen';
+
+test.describe('resizableLayout', () => {
+	test('right/left buttons should retain keyboard focus after use', async ({ electronApp, mainWindow }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		const changeLayoutScreen = mainScreen.changeLayoutScreen;
+		await changeLayoutScreen.open(electronApp);
+
+		const moveSidebarControls = changeLayoutScreen.containerLocator.getByRole('group', { name: 'Sidebar' });
+		const moveSidebarRight = moveSidebarControls.getByRole('button', { name: 'Move right' });
+
+		await expect(moveSidebarRight).not.toBeDisabled();
+
+		// Should refocus (or keep focused) after clicking
+		await moveSidebarRight.click();
+		await expect(moveSidebarRight).toBeFocused();
+		await moveSidebarRight.click();
+		await expect(moveSidebarRight).toBeFocused();
+	});
+});

--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -67,5 +67,11 @@ test.describe('wcag', () => {
 
 		await expectNoViolations(mainWindow);
 	});
+
+	test('should not detect significant issues in the change app layout screen', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.changeLayoutScreen.open(electronApp);
+		await expectNoViolations(mainWindow);
+	});
 });
 

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -203,6 +203,14 @@ export default class PluginService extends BaseService {
 		return this.plugins_[id];
 	}
 
+	public safePluginNameById(id: string) {
+		if (!this.plugins_[id]) {
+			return id;
+		}
+
+		return this.pluginById(id).manifest?.name ?? 'Unknown';
+	}
+
 	public viewControllerByViewId(id: string): ViewController|null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);


### PR DESCRIPTION
# Summary

This pull request improves the accessibility of the "change application layout" screen. In particular, it,
1. **Keyboard**: Prevents keyboard focus from being on the content behind the "change application layout" screen. (See [SC 2.4.3: Focus order](https://www.w3.org/TR/WCAG22/#focus-order)).
    - Previously, it was difficult to move keyboard focus to the move buttons in the "change application layout" screen. Focus would instead remain in the content behind the screen.
    - This is fixed by displaying the move/resize controls (when open) in a [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog), which causes Electron to prevent keyboard focus from interacting with content behind the "change application layout" screen while open.
2. **Labels**: Adds labels to the "move" buttons. (See [SC 1.1.1: Non-text content](https://www.w3.org/TR/WCAG22/#non-text-content)).
   - Buttons now describe the move action (e.g. "move left") and are in a [group](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria) labelled with what they move (e.g. "editor").
3. **Labels**: Marks the "use arrows to move..." header as a header. (See [SC 4.1.2: Name, role, value](https://www.w3.org/TR/WCAG22/#name-role-value)).

**Note**: This pull request refactors parts of `ResizableLayout` to improve type safety.

Related to #10795.

# To-do

**For this pull request**:
- [x] **Bug**: Currently activating "move" buttons with the keyboard causes focus to be lost (jumps to the start of the dialog).
   - See [WCAG 2.2 F85/focus jumps to the beginning of the document](https://www.w3.org/WAI/WCAG22/Techniques/failures/F85#examples).
- [x] **Styles**: Improve styling of new section labels (e.g. hide them when not using a screen reader).

**For a follow-up pull request**:
- [ ] **Bug**: On very small screens, the header can overlap with the "move layout item" buttons.
    - Not a regression, this can be done in a separate PR.
- [ ] **Screen reader**: After clicking a button, no information about the new screen layout is given.
    - Also not a regression, this can be done in a separate PR. Related WCAG 2.2 guidelines: [SC 4.1.3 (status messages)](https://www.w3.org/TR/WCAG22/#status-messages).

# Testing plan

This pull request adds automated end-to-end tests that verify: 1) the change layout screen opens and passes the automated accessibility scanner and 2) clicking "move right" for the sidebar keeps the "move right" button focused.

**Manual testing** (Fedora 41):
1. Enable the screen reader (Orca).
2. Start Joplin.
3. Activate "Change application layout" from the "View" menu.
4. Verify that Joplin, after reading the window title, reads `Use the arrows to move the layout items. Press "Escape" to exit.` then `Sidebar panel, Move right button`.
5. Activate "Reset application layout" from the "View" menu.
6. Click "OK".
7. Press <kbd>tab</kbd>.
8. Verify that Orca reads `Note list panel, move left button`.
9. Press <kbd>enter</kbd>.
10. Verify that the panel is moved left.
    - **Note**: The change in layout is currently not announced. See the to-do section.
11. Verify that the "move left" button still has focus.
12. Press <kbd>enter</kbd>.
13. Verify that the note list panel is now on the far left side of the screen.
14. Verify that the "move right" button now has focus.
15. Press <kbd>escape</kbd>.
16. Verify that the "change application layout" dialog is no longer visible.
17. Using the mouse, increase the size of the note list panel.
18. Verify that the note list panel size is larger.
19. Using the "View" menu, reset the application layout.
20. Verify that the layout has been reset.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->