### PR TITLE
Desktop: Accessibility: Rich Text Editor: Make it possible to edit code blocks with just the keyboard

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -256,6 +256,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js

--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/shouldPasteResources.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useKeyboardRefocusHandler.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/openEditDialog.ts
@@ -1,7 +1,9 @@
 import { _ } from '@joplin/lib/locale';
 import { MarkupToHtml } from '@joplin/renderer';
-import { TinyMceEditorEvents } from './types';
+import { DispatchDidUpdateCallback, TinyMceEditorEvents } from './types';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import { RefObject } from 'react';
+import { MarkupToHtmlHandler } from '../../../utils/types';
 const taboverride = require('taboverride');
 
 interface SourceInfo {
@@ -81,8 +83,13 @@ function editableInnerHtml(html: string): string {
 	return editable[0].innerHTML;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-export default function openEditDialog(editor: any, markupToHtml: any, dispatchDidUpdate: Function, editable: any) {
+export default function openEditDialog(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
+	editor: any,
+	markupToHtml: RefObject<MarkupToHtmlHandler>,
+	dispatchDidUpdate: DispatchDidUpdateCallback,
+	editable: Element,
+) {
 	const source = editable ? findBlockSource(editable) : newBlockSource();
 
 	editor.windowManager.open({

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/types.ts
@@ -1,3 +1,5 @@
+import type { Editor } from 'tinymce';
+
 // eslint-disable-next-line import/prefer-default-export
 export enum TinyMceEditorEvents {
 	KeyUp = 'keyup',
@@ -14,3 +16,5 @@ export enum TinyMceEditorEvents {
 	ExecCommand = 'ExecCommand',
 	SetAttrib = 'SetAttrib',
 }
+
+export type DispatchDidUpdateCallback = (editor: Editor)=> void;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.ts
@@ -1,0 +1,58 @@
+import { RefObject, useEffect } from 'react';
+import type { Editor } from 'tinymce';
+import openEditDialog from './openEditDialog';
+import { DispatchDidUpdateCallback, TinyMceEditorEvents } from './types';
+import { MarkupToHtmlHandler } from '../../../utils/types';
+
+interface Props {
+	editor: Editor;
+	markupToHtml: RefObject<MarkupToHtmlHandler>;
+	dispatchDidUpdate: DispatchDidUpdateCallback;
+}
+
+const findEditableContainer = (node: Element) => {
+	return node?.closest('.joplin-editable');
+};
+
+const useEmbeddedContentEditor = ({
+	editor, markupToHtml, dispatchDidUpdate,
+}: Props) => {
+	useEffect(() => {
+		if (!editor) return () => {};
+
+		const openInEditor = (element: Node) => {
+			if (element.nodeName.startsWith('#')) { // e.g. '#text'
+				element = element.parentElement;
+			}
+
+			const editable = findEditableContainer(element as Element);
+			if (editable) {
+				openEditDialog(editor, markupToHtml, dispatchDidUpdate, editable);
+				return true;
+			}
+			return false;
+		};
+
+		const dblClickHandler = (event: Event) => {
+			openInEditor(event.target as Node);
+		};
+
+		const keyDownHandler = (event: KeyboardEvent) => {
+			const hasModifiers = event.shiftKey || event.altKey || event.ctrlKey || event.metaKey;
+			if (event.code === 'Enter' && !event.isComposing && !hasModifiers) {
+				if (openInEditor(editor.selection.getNode())) {
+					event.preventDefault();
+				}
+			}
+		};
+
+		editor.on(TinyMceEditorEvents.KeyDown, keyDownHandler);
+		editor.on('DblClick', dblClickHandler);
+		return () => {
+			editor.off(TinyMceEditorEvents.KeyDown, keyDownHandler);
+			editor.off('DblClick', dblClickHandler);
+		};
+	}, [editor, markupToHtml, dispatchDidUpdate]);
+};
+
+export default useEmbeddedContentEditor;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEmbeddedContentEditor.ts
@@ -20,7 +20,7 @@ const useEmbeddedContentEditor = ({
 	useEffect(() => {
 		if (!editor) return () => {};
 
-		const openInEditor = (element: Node) => {
+		const openIfEditableBlock = (element: Node) => {
 			if (element.nodeName.startsWith('#')) { // e.g. '#text'
 				element = element.parentElement;
 			}
@@ -34,13 +34,13 @@ const useEmbeddedContentEditor = ({
 		};
 
 		const dblClickHandler = (event: Event) => {
-			openInEditor(event.target as Node);
+			openIfEditableBlock(event.target as Node);
 		};
 
 		const keyDownHandler = (event: KeyboardEvent) => {
 			const hasModifiers = event.shiftKey || event.altKey || event.ctrlKey || event.metaKey;
 			if (event.code === 'Enter' && !event.isComposing && !hasModifiers) {
-				if (openInEditor(editor.selection.getNode())) {
+				if (openIfEditableBlock(editor.selection.getNode())) {
 					event.preventDefault();
 				}
 			}


### PR DESCRIPTION
# Summary

If a code block is selected, this pull request makes pressing <kbd>enter</kbd> with no modifiers open the code editor. Previously, it was necessary to double-click code blocks to edit them.

**Related WCAG guideline**: [WCAG 2.2, SC 2.1.1: Keyboard](https://www.w3.org/TR/WCAG22/#keyboard-accessible).

See https://github.com/laurent22/joplin/issues/10795.

## Related tasks

- Screen reader doesn't read anything when code blocks are selected in the Rich Text Editor.
- The textarea for the code block body is unlabelled.

# Testing

1. Create a new note (in the Rich Text Editor).
2. Title the note "Test note"
3. Move focus to the Rich Text Editor body by pressing <kbd>tab</kbd>.
4. Focus the toolbar by pressing <kbd>alt</kbd>-<kbd>F10</kbd>.
5. Move focus to the "Block Code" toolbar button.
6. Activate it.
7. Enter `javascript` for the language name and `function test() {}` for the code block content.
8. Press <kbd>ctrl</kbd>-<kbd>enter</kbd> (submits the dialog).
9. Move focus to before the code block and type something.
10. Using the arrow keys, move focus to the code block.
   - **Note**: The screen reader doesn't read anything when the code block is selected.
11. Press <kbd>enter</kbd>.
12. Verify that this opens the edit dialog.

<details><summary>Text-to-speech log</summary>

```
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode
up
main content Note
Creating new note...
 entry.
left shift
T
Note title
e
s
t
space
n
o
t
e
tab
en button Spell checker.
tab
Back button
Browse mode
tab
Toggle external editing button
tab
Toggle editors toggle button not pressed Switch to the Markdown Editor.
tab
document web
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode
left shift
F10
frame
menu.
escape
Joplin  left paren left paren(DEV  dash dash-  slash home slash self slash  dot config slash joplindev dash dash-desktop slash profile dash dash-yo35nu8f right paren right paren) frame
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode
left alt
F10
Bold toggle button not pressed
tab
Insert slash edit link toggle button not pressed
right
Inline Code toggle button not pressed
right
Code Block button
return
Edit Language
Language entry.
j
a
v
a
s
c
r
i
p
t
tab
f
u
n
c
t
i
o
n
space
t
e
s
t
left shift
(
)
space
left shift
{
}
return
left control
return
document web
Browse mode
function test  left paren left paren(   right paren right paren) left brace right brace
selected
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode
left
 line feed 
left shift
T
e
s
t
left shift
:
right
 line feed 
right
right
 line feed 
left
left
 line feed 
left shift
right
left
blank
right
 line feed 
right
return
Edit Languagejavascript function test left paren left paren( right paren right paren)  left brace  right brace 
Language entry javascript.
misspelled
escape
document web
Browse mode
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode
left
 line feed 
up
Test colon colon:
down
function test  left paren left paren(   right paren right paren) left brace right brace
right
return
Edit Languagejavascript function test left paren left paren( right paren right paren)  left brace  right brace 
Language entry javascript.
misspelled
escape
document web
Browse mode
Rich Text editor.
 Press Escape then Tab to escape focus.
Focus mode

```

</details>

Later, after closing the edit dialog, it has been verified that double-clicking on a code block still opens it in edit mode.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->