### PR TITLE
Desktop: Accessibility: Replacing library used for datetime with native input element

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { _ } from '@joplin/lib/locale';
 import { themeStyle } from '@joplin/lib/theme';
-import time from '@joplin/lib/time';
-const Datetime = require('react-datetime').default;
 import CreatableSelect from 'react-select/creatable';
 import Select from 'react-select';
 import makeAnimated from 'react-select/animated';
 import { focus } from '@joplin/lib/utils/focusHandler';
 import Dialog from './Dialog';
+import { ChangeEvent } from 'react';
+import { formatDateTimeLocalToMs, isValidDate } from '@joplin/utils/time';
 
 interface Props {
 	themeId: number;
@@ -204,16 +204,14 @@ export default class PromptDialog extends React.Component<Props, any> {
 			if (this.props.onClose) {
 				let outputAnswer = this.state.answer;
 				if (this.props.inputType === 'datetime') {
-					// outputAnswer = anythingToDate(outputAnswer);
-					outputAnswer = time.anythingToDateTime(outputAnswer);
+					outputAnswer = isValidDate(outputAnswer) ? formatDateTimeLocalToMs(outputAnswer) : null;
 				}
 				this.props.onClose(accept ? outputAnswer : null, buttonType);
 			}
 			this.setState({ visible: false, answer: '' });
 		};
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const onChange = (event: any) => {
+		const onChange = (event: ChangeEvent<HTMLInputElement>) => {
 			this.setState({ answer: event.target.value });
 		};
 
@@ -225,11 +223,6 @@ export default class PromptDialog extends React.Component<Props, any> {
 		// 	m = moment(o, time.dateFormat());
 		// 	return m.isValid() ? m.toDate() : null;
 		// }
-
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const onDateTimeChange = (momentObject: any) => {
-			this.setState({ answer: momentObject });
-		};
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const onSelectChange = (newValue: any) => {
@@ -258,8 +251,13 @@ export default class PromptDialog extends React.Component<Props, any> {
 		let inputComp = null;
 
 		if (this.props.inputType === 'datetime') {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			inputComp = <Datetime className="datetime-picker" value={this.state.answer} inputProps={{ style: styles.input }} dateFormat={time.dateFormat()} timeFormat={time.timeFormat()} onChange={(momentObject: any) => onDateTimeChange(momentObject)} />;
+			inputComp = <input
+				defaultValue={this.state.answer}
+				onChange={onChange}
+				type="datetime-local"
+				className='datetime-picker'
+				style={styles.input}
+			/>;
 		} else if (this.props.inputType === 'tags') {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			inputComp = <CreatableSelect className="tag-selector" onMenuOpen={this.select_menuOpen} onMenuClose={this.select_menuClose} styles={styles.select} theme={styles.selectTheme} ref={this.answerInput_} value={this.state.answer} placeholder="" components={makeAnimated()} isMulti={true} isClearable={false} backspaceRemovesValue={true} options={this.props.autocomplete} onChange={onSelectChange} onKeyDown={(event: any) => onKeyDown(event)} />;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.ts
@@ -4,6 +4,7 @@ import { _ } from '@joplin/lib/locale';
 import { stateUtils } from '@joplin/lib/reducer';
 import Note from '@joplin/lib/models/Note';
 import time from '@joplin/lib/time';
+import { formatMsToDateTimeLocal } from '@joplin/utils/time';
 import { NoteEntity } from '@joplin/lib/services/database/types';
 
 export const declaration: CommandDeclaration = {
@@ -29,7 +30,7 @@ export const runtime = (comp: any): CommandRuntime => {
 					label: _('Set alarm:'),
 					inputType: 'datetime',
 					buttons: ['ok', 'cancel', 'clear'],
-					value: note.todo_due ? new Date(note.todo_due) : defaultDate,
+					value: note.todo_due ? formatMsToDateTimeLocal(note.todo_due) : formatMsToDateTimeLocal(defaultDate.getTime()),
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 					onClose: async (answer: any, buttonType: string) => {
 						let newNote: NoteEntity = null;
@@ -42,7 +43,7 @@ export const runtime = (comp: any): CommandRuntime => {
 						} else if (answer !== null) {
 							newNote = {
 								id: note.id,
-								todo_due: answer.getTime(),
+								todo_due: answer,
 							};
 						}
 

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -193,7 +193,6 @@
     "pretty-bytes": "5.6.0",
     "re-resizable": "6.9.17",
     "react": "18.3.1",
-    "react-datetime": "3.2.0",
     "react-dom": "18.3.1",
     "react-redux": "8.1.3",
     "react-select": "5.8.0",

--- a/packages/app-desktop/style.scss
+++ b/packages/app-desktop/style.scss
@@ -24,7 +24,6 @@
 // See https://sasscss.org/documentation/at-rules/import#plain-css-imports.
 @import url('style/icons/style.css');
 @import url('vendor/lib/@fortawesome/fontawesome-free/css/all.min.css');
-@import url('vendor/lib/react-datetime/css/react-datetime.css');
 @import url('vendor/lib/smalltalk/css/smalltalk.css');
 @import url('vendor/lib/roboto-fontface/css/roboto/roboto-fontface.css');
 @import url('vendor/lib/codemirror/lib/codemirror.css');

--- a/packages/app-desktop/tools/copyApplicationAssets.js
+++ b/packages/app-desktop/tools/copyApplicationAssets.js
@@ -85,7 +85,6 @@ async function main() {
 		'codemirror/addon/dialog/dialog.css',
 		'codemirror/lib/codemirror.css',
 		'mark.js/dist/mark.min.js',
-		'react-datetime/css/react-datetime.css',
 		'roboto-fontface/css/roboto/roboto-fontface.css',
 		'smalltalk/css/smalltalk.css',
 		'smalltalk/dist/smalltalk.min.js',

--- a/packages/utils/time.ts
+++ b/packages/utils/time.ts
@@ -145,3 +145,15 @@ export const formatMsToLocal = (ms: number, format: string|null = null) => {
 	if (format === null) format = dateTimeFormat();
 	return dayjs(ms).format(format);
 };
+
+export const formatMsToDateTimeLocal = (ms: number) => {
+	return formatMsToLocal(ms, 'YYYY-MM-DDTHH:mm');
+};
+
+export const isValidDate = (anything: string) => {
+	return dayjs(anything).isValid();
+};
+
+export const formatDateTimeLocalToMs = (anything: string) => {
+	return dayjs(anything).unix() * 1000;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8324,7 +8324,6 @@ __metadata:
     pretty-bytes: 5.6.0
     re-resizable: 6.9.17
     react: 18.3.1
-    react-datetime: 3.2.0
     react-dom: 18.3.1
     react-redux: 8.1.3
     react-select: 5.8.0
@@ -39081,7 +39080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.7, prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -39573,18 +39572,6 @@ __metadata:
     lodash.flow: ^3.3.0
     pure-color: ^1.2.0
   checksum: 00a12dddafc8a9025cca933b0dcb65fca41c81fa176d1fc3a6a9d0242127042e2c0a604f4c724a3254dd2c6aeb5ef55095522ff22f5462e419641c1341a658e4
-  languageName: node
-  linkType: hard
-
-"react-datetime@npm:3.2.0":
-  version: 3.2.0
-  resolution: "react-datetime@npm:3.2.0"
-  dependencies:
-    prop-types: ^15.5.7
-  peerDependencies:
-    moment: ^2.16.0
-    react: ^16.5.0 || ^17.0.0 || ^18.0.0
-  checksum: c3407beb64f44cd5944252bee1c4565fc138e3f1e81d8e4fd00d2aeac564a18848ee9af5f51fbbb39bba588f8c2d659570384af1ce8378d4e0049a6bdb083655
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/10795

Related to task:

- Switch to a date picker that doesn't use type=text for setting note alarms (perhaps use <input type=datetime-local>).

# Summary

Related to the guideline [1.3.5](https://www.w3.org/WAI/WCAG22/quickref/#identify-input-purpose), we are replacing the `react-datetime` library that doesn't offer accessibility support with the general `<input type="datetime-local"`.

One of the downsides is that the date/time format selected by the user is impossible to set on, so it is possible that this behavior will happen (compare the date format between the two images):

<details><summary>Images</summary>

![2025-01-25_14-34](https://github.com/user-attachments/assets/c6e6e1a1-ea46-48d2-a1db-dee8ec8b6518)

![2025-01-25_14-34_1](https://github.com/user-attachments/assets/95ab0351-06a8-4b7e-9aad-c6a09f4637e0)

</details> 

Changing the input format is impossible since it is associated with the user locale.

# Testing

To test the change I:

- Tested the Set alarm date picker
- Tested changing the note properties for created and updated time on `Note Properties` dialog 


### Testing Set alarm

1. Created a To-do note
2. Click `Set Alarm` option on the note header
3. Modify the date and time and Click `Ok`
4. Verify that the alarm date and time was updated correctly
5. Try to Open the `Set Alarm` again and verify that the date is set to the latest value

## Testing Note Properties

1. Open `Note Properties` dialog
2. Try to modify the `Updated` or `Created` field
3. The calendar should be open as it was the current behaviour
4. It should be possible to set the date and press `Esc` to cancel saving the new value
5. It should be possible to set the date and press `Enter` to save the new value
6. Closing and opening `Note Properties` should show the new value