### PR TITLE
Desktop: Fix crash when closing a secondary window with the Rich Text Editor open

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1400,8 +1400,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			const ownerDocument = editorRef.current.getContainer().ownerDocument;
 			const parentWindow = ownerDocument.defaultView;
 
-			// As of TinyMCE 6, calling .remove after the parent window is closed
-			// throws an Error. Since closing the window also removes the editor,
+			// Calling .remove after the parent window is closed throws an Error
+			// related to DOM API access. Since closing the window also removes the editor,
 			// it shouldn't be necessary to call .remove in this case:
 			if (parentWindow) {
 				editorRef.current.remove();

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1395,7 +1395,17 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 
 	useEffect(() => {
 		return () => {
-			if (editorRef.current) editorRef.current.remove();
+			if (!editorRef.current) return;
+
+			const ownerDocument = editorRef.current.getContainer().ownerDocument;
+			const parentWindow = ownerDocument.defaultView;
+
+			// As of TinyMCE 6, calling .remove after the parent window is closed
+			// throws an Error. Since closing the window also removes the editor,
+			// it shouldn't be necessary to call .remove in this case:
+			if (parentWindow) {
+				editorRef.current.remove();
+			}
 		};
 	}, []);
 


### PR DESCRIPTION
# Summary

This pull request fixes a "Joplin encountered a fatal error and could not continue" screen caused by calling `.remove()` on a TinyMCE editor after its parent window has been closed. With this change, `.remove` is not called on an editor with no parent window.

> [!NOTE]
>
> The issue does not seem to be present in Joplin v3.2. The issue doesn't seem related to the Electron or TinyMCE upgrades — it's still present after downgrading to TinyMCE v5 and Electron v32. **Edit**: Based on a `git bisect`, the does seem related to the commit that upgraded from TinyMCE v5 to v6. I suspect that the issue is related to one of the changes made to the editor setup to prepare for TinyMCE v6.

## Error message

```
Joplin encountered a fatal error and could not continue.

To report the error, please copy the *entire content* of this page and post it on Joplin forum or GitHub.

If the error persists you may try to [restart in safe mode](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/desktop/fix-crash-on-close-secondary-window?expand=1#), which will temporarily disable all plugins.

Message
Failed to execute 'acceptNode' on 'NodeFilter': The provided callback is no longer runnable.
```

# Testing plan

1. Switch to the Rich Text Editor.
2. Open a note in a new window.
3. Close the new window.
4. Verify that Joplin's main window doesn't show an error screen.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->