### PR TITLE
Desktop: Fix secondary windows not removed from state if closed while focused

### DIFF
--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -3,6 +3,7 @@ import reducer, { defaultState, defaultWindowId, MAX_HISTORY, State } from './re
 import { BaseItemEntity, FolderEntity, NoteEntity, TagEntity } from './services/database/types';
 import Note from './models/Note';
 import BaseModel from './BaseModel';
+import Folder from './models/Folder';
 // const { ALL_NOTES_FILTER_ID } = require('./reserved-ids');
 
 function initTestState(folders: FolderEntity[], selectedFolderIndex: number, notes: NoteEntity[], selectedNoteIndexes: number[], tags: TagEntity[] = null, selectedTagIndex: number = null) {
@@ -813,5 +814,36 @@ describe('reducer', () => {
 			});
 			checkCurrentState(windowId);
 		}
+	});
+
+	test('closing the focused window should set the focus to a different window', async () => {
+		const folder = await Folder.save({ title: 'Test' });
+		const notes = await createNTestNotes(3, folder);
+		let state = initTestState([folder], 0, notes, [0]);
+
+		const secondaryWindowId = 'window1';
+		state = createBackgroundWindow(state, secondaryWindowId, notes[2], notes);
+
+		state = reducer(state, {
+			type: 'WINDOW_FOCUS',
+			windowId: secondaryWindowId,
+		});
+
+		expect(state.windowId).toBe(secondaryWindowId);
+		expect(state.selectedNoteIds).toEqual([notes[2].id]);
+
+
+		// Closing the focused window should set focus to the other window
+		state = reducer(state, {
+			type: 'WINDOW_CLOSE',
+			windowId: secondaryWindowId,
+		});
+
+		// There should be no background windows
+		expect(state.backgroundWindows).toEqual({});
+
+		// The other window should be focused
+		expect(state.windowId).toBe(defaultWindowId);
+		expect(state.selectedNoteIds).toEqual([notes[0].id]);
 	});
 });


### PR DESCRIPTION
# Summary

Fixes an issue where secondary windows weren't removed from the app state when closed (unless not focused). As a result, the React components were never unmounted.

Partially fixes #11739. With this change, the "ResizeObserver" warnings no longer seem to be infinite (they stop [after up to two seconds](https://github.com/laurent22/joplin/blob/9b825782531d66190b84e8d24bf8bea1c16ca2de/packages/app-desktop/gui/NewWindowOrIFrame.tsx#L52)).

# Testing plan

This pull request includes an automated test. Limited manual testing (closing secondary windows) has also been done.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->