### PR TITLE
Desktop: Accessibility: Fix incorrect note viewer accessibility label

### DIFF
--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -225,7 +225,6 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 			style={viewerStyle}
 			allow='clipboard-write=(self) fullscreen=(self) autoplay=(self) local-fonts=(self) encrypted-media=(self)'
 			allowFullScreen={true}
-			role='region'
 			aria-label={_('Note viewer')}
 			src={`joplin-content://note-viewer/${__dirname}/note-viewer/index.html`}
 		></iframe>

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -225,7 +225,8 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 			style={viewerStyle}
 			allow='clipboard-write=(self) fullscreen=(self) autoplay=(self) local-fonts=(self) encrypted-media=(self)'
 			allowFullScreen={true}
-			aria-label={_('Note editor')}
+			role='region'
+			aria-label={_('Note viewer')}
 			src={`joplin-content://note-viewer/${__dirname}/note-viewer/index.html`}
 		></iframe>
 	);


### PR DESCRIPTION
# Summary

This pull request fixes the `aria-label` given to the note viewer. Previously, it was incorrect.

Related #10795.

# WCAG guidelines

- **Fixing the label**: This change is related to the ["Headings and Labels Describe Topic or Purpose" (WCAG 2.2. SC 2.4.6)](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) guideline.

# Testing

## Windows: NVDA screen reader

1. Open Joplin, focus the note editor.
2. Press <kbd>esc</kbd> to move to browse mode.
3. Press <kbd>m</kbd>.
4. Verify that the screen reader focus is on the note viewer.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->