### PR TITLE
Desktop: Accessibility: Add label to the delete buttons of the Note Attachments

### DIFF
--- a/packages/app-desktop/gui/ResourceScreen.tsx
+++ b/packages/app-desktop/gui/ResourceScreen.tsx
@@ -116,7 +116,7 @@ const ResourceTableComp = (props: ResourceTable) => {
 			<tbody>
 				{filteredResources.map((resource: InnerResource, index: number) =>
 					<tr key={index}>
-						<td style={titleCellStyle} className="titleCell">
+						<td id={`title-${resource.id}`} style={titleCellStyle} className="titleCell">
 							<a
 								style={{ color: theme.urlColor }}
 								href="#"
@@ -126,7 +126,14 @@ const ResourceTableComp = (props: ResourceTable) => {
 						<td style={cellStyle} className="dataCell">{prettyBytes(resource.size)}</td>
 						<td style={cellStyle} className="dataCell">{resource.id}</td>
 						<td style={cellStyle} className="dataCell">
-							<button style={theme.buttonStyle} onClick={() => props.onResourceDelete(resource)}>{_('Delete')}</button>
+							<button
+								id={`delete-${resource.id}`}
+								aria-labelledby={`delete-${resource.id} title-${resource.id}`}
+								style={theme.buttonStyle}
+								onClick={() => props.onResourceDelete(resource)}
+							>
+								{_('Delete')}
+							</button>
 						</td>
 					</tr>,
 				)}


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/10795

# Summary

Adding `aria-labelledby` to delete buttons inside of the note attachments table. This should help users that use screen readers to navigate the page and identify to which attachment each delete button referes to.

See also: https://stackoverflow.com/a/72232641/19037121

# WCAG guidelines

Guideline: [3.3.2 Labels or Instructions](https://www.w3.org/TR/WCAG22/#labels-or-instructions)
Technique: [ARIA19 Technique "Using aria-labelledby to concatenate a label from several text nodes"](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA9.html)

# Testing 

1. Add a note attachment
2. Open Note Attachment screen
3. Navigate to the button
4. Screen reader should read "delete {{attachment name}} button"
