### PR TITLE
Android: Fix error logged when opening the note editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -376,16 +376,22 @@ function NoteEditor(props: Props, ref: any) {
 				${shim.injectedJs('codeMirrorBundle')};
 
 				const parentElement = document.getElementsByClassName('CodeMirror')[0];
-				const initialText = ${JSON.stringify(props.initialText)};
-				const settings = ${JSON.stringify(editorSettings)};
+				// On Android, injectJavaScript is run twice -- once before the parent element exists.
+				// To avoid logging unnecessary errors to the console, skip setup in this case:
+				if (parentElement) {
+					const initialText = ${JSON.stringify(props.initialText)};
+					const settings = ${JSON.stringify(editorSettings)};
 
-				window.cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, settings);
+					window.cm = codeMirrorBundle.initCodeMirror(parentElement, initialText, settings);
 
-				${setInitialSelectionJS}
+					${setInitialSelectionJS}
 
-				window.onresize = () => {
-					cm.execCommand('scrollSelectionIntoView');
-				};
+					window.onresize = () => {
+						cm.execCommand('scrollSelectionIntoView');
+					};
+				} else {
+					console.warn('No parent element for the editor found. This may mean that the editor HTML is still loading.');
+				}
 			} catch (e) {
 				window.ReactNativeWebView.postMessage("error:" + e.message + ": " + JSON.stringify(e))
 			}


### PR DESCRIPTION
# Summary

On Android, the `injectedJavaScript` used to initialize the note editor is run multiple times. One of these occurs before the editor DOM has loaded, which results in a "Cannot read property addEventListener of undefined" error.

This pull request prevents this error message from being logged each time the editor is opened.

# Testing plan

**Android 13**:
1. Open the editor
2. Verify that the editor loads
3. Verify that no new errors are logged

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->