### PR TITLE
Desktop: Accessibility: Make click outside of dialog content be cancellable 

### DIFF
--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -82,7 +82,7 @@ const useClickedOutsideContent = (dialogElement: HTMLDialogElement|null) => {
 			}
 		};
 		const mouseUpListener = (event: MouseEvent) => {
-			if (!mouseDownOutsideContent) return;
+			if (!mouseDownOutsideContent.current) return;
 			if (mouseDownOutsideContent.current && event.target === dialogElement) {
 				setClickedOutsideContent(true);
 				mouseDownOutsideContent.current = false;

--- a/packages/app-desktop/gui/Dialog.tsx
+++ b/packages/app-desktop/gui/Dialog.tsx
@@ -63,7 +63,7 @@ const Dialog: React.FC<Props> = props => {
 	</div>;
 };
 
-const useDialogDIsmissed = (dialogElement: HTMLDialogElement|null) => {
+const useDialogDismissed = (dialogElement: HTMLDialogElement|null) => {
 	const [mouseDownOutsideContent, setMouseDownOutsideContent] = useState(false);
 	const [clickedOutsideOfContent, setClickedOutsideOfContent] = useState(false);
 
@@ -96,7 +96,7 @@ const useDialogElement = (containerDocument: Document, onCancel: undefined|OnCan
 	const onCancelRef = useRef(onCancel);
 	onCancelRef.current = onCancel;
 
-	const dialogDismissed = useDialogDIsmissed(dialogElement);
+	const dialogDismissed = useDialogDismissed(dialogElement);
 
 	useEffect(() => {
 		if (dialogDismissed) {


### PR DESCRIPTION
Related to https://github.com/laurent22/joplin/issues/10795

# Summary

It should be possible to cancel the action of clicking in the dimmed background. Before this PR it was only possible by moving the pointer outside of Joplin window.

I change this behaviour by keeping track of the mouseup and mousedown event, dismissing only if the click action is finished in the dimmed background and not inside the content of the dialog.

# WCAG

Guideline: [2.5.2 Pointer Cancellation](https://www.w3.org/WAI/WCAG22/quickref/#pointer-cancellation)
Technique: [Using native controls to ensure functionality is triggered on the up-event.](https://www.w3.org/WAI/WCAG22/Techniques/general/G212.html)

# Testing


## Test 1

1. Open Note Properties
2. Press click in the dimmed area
3. Let go inside the Note Properties content
4. Dialog should NOT be dismissed

## Test 2

1. Open Note Properties
2. Press click in the dimmed area
3. Let go outside the dimmed area
4. Dialog should be dismissed

## Test 3

1. Open Note Properties
2. Press click over the content of the Dialog
3. Select content with the mouse (see image below)
4. Let go outside of the content
5. DIalog should NOT be dismissed

![image](https://github.com/user-attachments/assets/a459b456-6e30-4034-98f1-156c8ddc71aa)

## Test 4

1. Open Note Properties
2. Press click over the Ok button
3. Let go outside the Ok button
4. No action should take place

## Test 5

1. Open Note Properties
2. Press click on the dimmed area
3. Let go over Ok button
4. No action should take place


## Test 6

1. Open Change Application Layout
2. Press click anywhere
3. Nothing should happen
4. Press Esc
5. Change application Layout should be removed