### PR TITLE
Mobile,Desktop,Cli: Logging: Log less information at level `warn` when a decryption error occurs

### DIFF
--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -254,7 +254,8 @@ export default class DecryptionWorker {
 						}
 
 						if (options.errorHandler === 'log') {
-							this.logger().warn(`DecryptionWorker: error for: ${item.id} (${ItemClass.tableName()})`, error, item);
+							this.logger().warn(`DecryptionWorker: error for: ${item.id} (${ItemClass.tableName()})`, error);
+							this.logger().debug('Item with error:', item);
 						} else {
 							throw error;
 						}


### PR DESCRIPTION
# Summary

For consistency with other data logging code, this pull request moves some log information from level `.warn` to level `.debug`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->