### PR TITLE
Mobile: Toolbar: Show only half of last button to indicate scroll

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -618,6 +618,7 @@ packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromSta
 packages/app-mobile/components/EditorToolbar/utils/isSelected.js
 packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.js
 packages/app-mobile/components/EditorToolbar/utils/toolbarButtonsFromState.js
+packages/app-mobile/components/EditorToolbar/utils/useButtonSize.js
 packages/app-mobile/components/ExtendedWebView/index.jest.js
 packages/app-mobile/components/ExtendedWebView/index.js
 packages/app-mobile/components/ExtendedWebView/index.web.js

--- a/.gitignore
+++ b/.gitignore
@@ -593,6 +593,7 @@ packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromSta
 packages/app-mobile/components/EditorToolbar/utils/isSelected.js
 packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.js
 packages/app-mobile/components/EditorToolbar/utils/toolbarButtonsFromState.js
+packages/app-mobile/components/EditorToolbar/utils/useButtonSize.js
 packages/app-mobile/components/ExtendedWebView/index.jest.js
 packages/app-mobile/components/ExtendedWebView/index.js
 packages/app-mobile/components/ExtendedWebView/index.web.js

--- a/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
+++ b/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
@@ -47,7 +47,7 @@ const useButtonGap = (buttonCount: number) => {
 	return { onContainerLayout, buttonGap };
 };
 
-const useStyles = (themeId: number, buttonGap: number) => {
+const useStyles = (themeId: number) => {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		return StyleSheet.create({
@@ -57,7 +57,6 @@ const useStyles = (themeId: number, buttonGap: number) => {
 			},
 			contentContainer: {
 				flexGrow: 1,
-				gap: buttonGap,
 				paddingVertical: 0,
 				flexDirection: 'row',
 			},
@@ -65,7 +64,7 @@ const useStyles = (themeId: number, buttonGap: number) => {
 				flexGrow: 1,
 			},
 		});
-	}, [themeId, buttonGap]);
+	}, [themeId]);
 };
 
 type SetSettingsVisible = React.Dispatch<React.SetStateAction<boolean>>;
@@ -94,13 +93,14 @@ const EditorToolbar: React.FC<Props> = props => {
 	// Include setting button in the count
 	const buttonCount = buttonInfos.length + 1;
 	const { buttonGap, onContainerLayout } = useButtonGap(buttonCount);
-	const styles = useStyles(props.themeId, buttonGap);
+	const styles = useStyles(props.themeId);
 
 	const renderButton = (info: ToolbarButtonInfo) => {
 		return <ToolbarButton
 			key={`command-${info.name}`}
 			buttonInfo={info}
 			themeId={props.themeId}
+			extraPadding={buttonGap}
 			selected={isSelected(info.name, props.editorState)}
 		/>;
 	};
@@ -122,6 +122,7 @@ const EditorToolbar: React.FC<Props> = props => {
 	const settingsButtonInfo = useSettingButtonInfo(setSettingsVisible);
 	const settingsButton = <ToolbarButton
 		buttonInfo={settingsButtonInfo}
+		extraPadding={buttonGap}
 		themeId={props.themeId}
 	/>;
 

--- a/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
+++ b/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
@@ -20,7 +20,7 @@ interface Props {
 	editorState: EditorState;
 }
 
-const useButtonGap = (buttonCount: number) => {
+const useButtonPadding = (buttonCount: number) => {
 	const { buttonSize } = useButtonSize();
 	const [containerWidth, setContainerWidth] = useState(0);
 
@@ -28,7 +28,7 @@ const useButtonGap = (buttonCount: number) => {
 		setContainerWidth(event.nativeEvent.layout.width);
 	}, []);
 
-	const buttonGap = useMemo(() => {
+	const buttonPadding = useMemo(() => {
 		if (buttonCount <= 1) return 0;
 		// Number of offscreen buttons -- round up because we can't have negative padding
 		const overflowButtonCount = Math.max(0, Math.ceil((buttonCount * buttonSize - containerWidth) / buttonSize));
@@ -39,12 +39,12 @@ const useButtonGap = (buttonCount: number) => {
 		const targetContentWidth = containerWidth + buttonSize / 2;
 		const actualContentWidth = visibleButtonCount * buttonSize;
 		const widthDifference = targetContentWidth - actualContentWidth;
-		// Gaps are only present between buttons
-		const gapCount = visibleButtonCount - 1;
+		// Only half of the gap for the rightmost visible button is on the screen
+		const gapCount = visibleButtonCount - 1 / 2;
 		return widthDifference / gapCount;
 	}, [containerWidth, buttonCount, buttonSize]);
 
-	return { onContainerLayout, buttonGap };
+	return { onContainerLayout, buttonPadding };
 };
 
 const useStyles = (themeId: number) => {
@@ -92,7 +92,7 @@ const EditorToolbar: React.FC<Props> = props => {
 
 	// Include setting button in the count
 	const buttonCount = buttonInfos.length + 1;
-	const { buttonGap, onContainerLayout } = useButtonGap(buttonCount);
+	const { buttonPadding, onContainerLayout } = useButtonPadding(buttonCount);
 	const styles = useStyles(props.themeId);
 
 	const renderButton = (info: ToolbarButtonInfo) => {
@@ -100,7 +100,7 @@ const EditorToolbar: React.FC<Props> = props => {
 			key={`command-${info.name}`}
 			buttonInfo={info}
 			themeId={props.themeId}
-			extraPadding={buttonGap}
+			extraPadding={buttonPadding}
 			selected={isSelected(info.name, props.editorState)}
 		/>;
 	};
@@ -122,7 +122,7 @@ const EditorToolbar: React.FC<Props> = props => {
 	const settingsButtonInfo = useSettingButtonInfo(setSettingsVisible);
 	const settingsButton = <ToolbarButton
 		buttonInfo={settingsButtonInfo}
-		extraPadding={buttonGap}
+		extraPadding={buttonPadding}
 		themeId={props.themeId}
 	/>;
 

--- a/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
+++ b/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
@@ -91,6 +91,7 @@ const EditorToolbar: React.FC<Props> = props => {
 		}
 	}
 
+	// Include setting button in the count
 	const buttonCount = buttonInfos.length + 1;
 	const { buttonGap, onContainerLayout } = useButtonGap(buttonCount);
 	const styles = useStyles(props.themeId, buttonGap);

--- a/packages/app-mobile/components/EditorToolbar/ToolbarButton.tsx
+++ b/packages/app-mobile/components/EditorToolbar/ToolbarButton.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { ToolbarButtonInfo } from '@joplin/lib/services/commands/ToolbarButtonUtils';
 import IconButton from '../IconButton';
 import { memo, useMemo } from 'react';
-import { StyleSheet, useWindowDimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { themeStyle } from '../global-style';
+import useButtonSize from './utils/useButtonSize';
 
 interface Props {
 	themeId: number;
@@ -12,27 +13,25 @@ interface Props {
 }
 
 const useStyles = (themeId: number, selected: boolean, enabled: boolean) => {
-	const { fontScale } = useWindowDimensions();
+	const { buttonSize, iconSize } = useButtonSize();
 
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		return StyleSheet.create({
 			icon: {
 				color: theme.color,
-				fontSize: 22 * fontScale,
+				fontSize: iconSize,
 			},
 			button: {
-				// Scaling the button width/height by the device font scale causes the button to scale
-				// with the user's device font size.
-				width: 48 * fontScale,
-				height: 48 * fontScale,
+				width: buttonSize,
+				height: buttonSize,
 				justifyContent: 'center',
 				alignItems: 'center',
 				backgroundColor: selected ? theme.backgroundColorHover3 : theme.backgroundColor3,
 				opacity: enabled ? 1 : theme.disabledOpacity,
 			},
 		});
-	}, [themeId, selected, enabled, fontScale]);
+	}, [themeId, selected, enabled, buttonSize, iconSize]);
 };
 
 const ToolbarButton: React.FC<Props> = memo(({ themeId, buttonInfo, selected }) => {

--- a/packages/app-mobile/components/EditorToolbar/ToolbarButton.tsx
+++ b/packages/app-mobile/components/EditorToolbar/ToolbarButton.tsx
@@ -8,11 +8,12 @@ import useButtonSize from './utils/useButtonSize';
 
 interface Props {
 	themeId: number;
+	extraPadding: number;
 	buttonInfo: ToolbarButtonInfo;
 	selected?: boolean;
 }
 
-const useStyles = (themeId: number, selected: boolean, enabled: boolean) => {
+const useStyles = (themeId: number, selected: boolean, enabled: boolean, extraPadding: number) => {
 	const { buttonSize, iconSize } = useButtonSize();
 
 	return useMemo(() => {
@@ -23,7 +24,7 @@ const useStyles = (themeId: number, selected: boolean, enabled: boolean) => {
 				fontSize: iconSize,
 			},
 			button: {
-				width: buttonSize,
+				width: buttonSize + extraPadding,
 				height: buttonSize,
 				justifyContent: 'center',
 				alignItems: 'center',
@@ -31,11 +32,11 @@ const useStyles = (themeId: number, selected: boolean, enabled: boolean) => {
 				opacity: enabled ? 1 : theme.disabledOpacity,
 			},
 		});
-	}, [themeId, selected, enabled, buttonSize, iconSize]);
+	}, [themeId, selected, enabled, buttonSize, iconSize, extraPadding]);
 };
 
-const ToolbarButton: React.FC<Props> = memo(({ themeId, buttonInfo, selected }) => {
-	const styles = useStyles(themeId, selected, buttonInfo.enabled);
+const ToolbarButton: React.FC<Props> = memo(({ themeId, buttonInfo, selected, extraPadding }) => {
+	const styles = useStyles(themeId, selected, buttonInfo.enabled, extraPadding);
 	const isToggleButton = selected !== undefined;
 
 	return <IconButton

--- a/packages/app-mobile/components/EditorToolbar/utils/useButtonSize.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/useButtonSize.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
+
+const useButtonSize = () => {
+	const { fontScale } = useWindowDimensions();
+
+	return useMemo(() => {
+		return {
+			// Scaling the button width/height by the device font scale causes the button to scale
+			// with the user's device font size.
+			buttonSize: 48 * fontScale,
+			iconSize: 22 * fontScale,
+		};
+	}, [fontScale]);
+};
+
+export default useButtonSize;


### PR DESCRIPTION
# Summary

This pull request adjusts the size of buttons in the mobile toolbar to indicate scrollability.

# Screen recording

The below screencast demonstrates resizing the web app window and the toolbar adjusting the size of buttons such that the rightmost button is only half shown.

[Screencast from 2025-02-03 18-28-31.webm](https://github.com/user-attachments/assets/ed46dcc6-67c0-4073-8179-35f990207868)



# Testing plan

1. Start with a small-width window and gradually increase the window size.
   - On Android 13, this required multiple steps, as the app content only resizes after resizing is finished..
2. Verify that after each resize, the rightmost button is either cut in half, or is the settings button (in which case, all buttons are visible).

At present, this has been tested manually on Android 13 and web (in Chromium 131), but not on iOS.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->