### PR TITLE
Desktop: Accessibility: Add accessibility information to the warning banner

### DIFF
--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -580,7 +580,14 @@ class MainScreenComponent extends React.Component<Props, State> {
 
 		return (
 			<div style={styles.messageBox}>
-				<span style={theme.textStyle} role='alert'>{msg}</span>
+				<span
+					style={theme.textStyle}
+					role='alert'
+					// role='alert' has an implicit aria-live='assertive', which tells screen readers that changes
+					// to the warning's content should be announced as soon as possible. However, since it's generally
+					// okay for announcements related to these notifications to be delayed, use aria-live='polite'.
+					aria-live='polite'
+				>{msg}</span>
 			</div>
 		);
 	}

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -579,8 +579,8 @@ class MainScreenComponent extends React.Component<Props, State> {
 		}
 
 		return (
-			<div style={styles.messageBox}>
-				<span style={theme.textStyle}>{msg}</span>
+			<div style={styles.messageBox} role='region' aria-label={_('Warnings')}>
+				<span style={theme.textStyle} role='alert'>{msg}</span>
 			</div>
 		);
 	}

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -579,7 +579,7 @@ class MainScreenComponent extends React.Component<Props, State> {
 		}
 
 		return (
-			<div style={styles.messageBox} role='region' aria-label={_('Warnings')}>
+			<div style={styles.messageBox}>
 				<span style={theme.textStyle} role='alert'>{msg}</span>
 			</div>
 		);


### PR DESCRIPTION
# Summary

This pull request marks the warning banner content as an [`alert`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role).
   - This causes the banner's content to be announced by screen readers when added to the document or changed.
   - At least with the Orca screen reader, this also allows jumping to the banner with a keyboard shortcut.

Related to https://github.com/laurent22/joplin/issues/10795.

# Testing plan

**Fedora 41 (Orca)**:
1. **Setup**: Switch to a Joplin profile with a "one or more master keys needs a password" warning message, enable the Orca screen reader.
2. Press <kbd>d</kbd>.
3. Verify that the screen reader focus jumps to the alert from step 1.
4. Press <kbd>tab</kbd>.
5. Verify that the screen reader focus jumps to the "set the password" link.
6. Open settings (<kbd>ctrl</kbd>-<kbd>,</kbd>).
7. Close settings.
8. Verify that the screen reader reads the "missing password" warning.

<details><summary>Screen reader transcript</summary>

```Joplin  left paren(DEV  dash-  slash home slash self slash  dot config slash joplindev dash-desktop right paren) frame
d
notification.
One or more master keys need a password.
Set the password link
tab
Set the password link
left control
,
Joplin  left paren(DEV  dash-  slash home slash self slash  dot config slash joplindev dash-desktop right paren)  dash- Options
Joplin document web
m
General page tab.
m
navigation
Back button
space
Joplin  left paren(DEV  dash-  slash home slash self slash  dot config slash joplindev dash-desktop right paren)
Joplin document web
One or more master keys need a password.
 Set the password
Set the password
```
</details>
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->