### PR TITLE
Mobile: Fix homescreen new-note shortcuts are re-applied after switching notes

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -36,9 +36,10 @@ interface WrapperProps {
 
 let store: Store<AppState>;
 
+const mockNavigation = { state: { } };
 const WrappedNoteScreen: React.FC<WrapperProps> = _props => {
 	return <TestProviderStack store={store}>
-		<NoteScreen />
+		<NoteScreen navigation={mockNavigation}/>
 	</TestProviderStack>;
 };
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -73,8 +73,16 @@ interface InsertTextOptions {
 	newLine?: boolean;
 }
 
+interface NoteNavigation {
+	// Arguments passed to the NAV_GO action
+	state: {
+		newNoteAttachFileAction?: AttachFileAction;
+	};
+}
+
 interface Props extends BaseProps {
 	provisionalNoteIds: string[];
+	navigation: NoteNavigation;
 	dispatch: Dispatch;
 	noteId: string;
 	useEditorBeta: boolean;
@@ -89,7 +97,6 @@ interface Props extends BaseProps {
 	highlightedWords: string[];
 	noteHash: string;
 	toolbarEnabled: boolean;
-	newNoteAttachFileAction: AttachFileAction;
 }
 
 interface ComponentProps extends Props {
@@ -531,13 +538,14 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		// been granted, the popup will open anyway.
 		void this.requestGeoLocationPermissions();
 
-		if (this.props.newNoteAttachFileAction) {
+		const action = this.props.navigation.state?.newNoteAttachFileAction;
+		if (action) {
 			setTimeout(async () => {
-				if (this.props.newNoteAttachFileAction === AttachFileAction.AttachDrawing) {
+				if (action === AttachFileAction.AttachDrawing) {
 					await this.drawPicture_onPress();
 				} else {
 					const options: AttachFileOptions = {
-						action: this.props.newNoteAttachFileAction,
+						action: action,
 					};
 					await CommandService.instance().execute('attachFile', '', options);
 				}
@@ -1632,7 +1640,6 @@ const NoteScreen = connect((state: AppState) => {
 	return {
 		noteId: state.selectedNoteIds.length ? state.selectedNoteIds[0] : null,
 		noteHash: state.selectedNoteHash,
-		newNoteAttachFileAction: state.newNoteAttachFileAction,
 		itemType: state.selectedItemType,
 		folders: state.folders,
 		searchQuery: state.searchQuery,

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -354,10 +354,6 @@ const appReducer = (state = appDefaultState, action: any) => {
 					newState.selectedNoteHash = action.noteHash;
 				}
 
-				if ('newNoteAttachFileAction' in action) {
-					newState.newNoteAttachFileAction = action.newNoteAttachFileAction;
-				}
-
 				if ('sharedData' in action) {
 					newState.sharedData = action.sharedData;
 				} else {

--- a/packages/app-mobile/utils/appDefaultState.ts
+++ b/packages/app-mobile/utils/appDefaultState.ts
@@ -16,7 +16,6 @@ const appDefaultState: AppState = {
 	isOnMobileData: false,
 	disableSideMenuGestures: false,
 	showPanelsDialog: false,
-	newNoteAttachFileAction: null,
 	...defaultState,
 
 	// On mobile, it's possible to select notes that aren't in the selected folder/tag/etc.

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -1,5 +1,4 @@
 import { State } from '@joplin/lib/reducer';
-import { AttachFileAction } from '../components/screens/Note/commands/attachFile';
 
 export interface AppState extends State {
 	showPanelsDialog: boolean;
@@ -11,6 +10,4 @@ export interface AppState extends State {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	noteSideMenuOptions: any;
 	disableSideMenuGestures: boolean;
-
-	newNoteAttachFileAction: AttachFileAction | null;
 }


### PR DESCRIPTION
# Summary

This pull request fixes an attachment issue. This issue was previously observed when:
1. Click one of the "New photo" or "New attachment" homescreen shortcuts.
2. Dismiss the attachment/camera screen.
3. Open the notes list.
4. Switch to an existing note.
5. Observe that Joplin shows the GUI for attaching a photo or attachment to the existing note.

This issue was originally observed while working with the `newNote` command's `attachFileAction` argument.


# Testing plan

**On Android 13**:
1. Click the "New photo" homescreen shortcut.
2. Dismiss the camera screen.
3. Close the note.
4. Switch to a different, existing note.
5. Verify that the camera screen is not shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->