### PR TITLE
Desktop: Fixes #11662: Prevent the default note title from being "&nbsp;"

### DIFF
--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -216,12 +216,19 @@ const markdownUtils = {
 
 	titleFromBody(body: string) {
 		if (!body) return '';
+		const spaceEntities = /&nbsp;/g;
+		body = body.replace(spaceEntities, ' ');
+		const lines = body.trim().split('\n');
+		const title = lines[0].trim();
+
 		const mdLinkRegex = /!?\[([^\]]+?)\]\(.+?\)/g;
 		const emptyMdLinkRegex = /!?\[\]\((.+?)\)/g;
 		const filterRegex = /^[# \n\t*`-]*/;
-		const lines = body.trim().split('\n');
-		const title = lines[0].trim();
-		return title.replace(filterRegex, '').replace(mdLinkRegex, '$1').replace(emptyMdLinkRegex, '$1').substring(0, 80);
+		return title
+			.replace(filterRegex, '')
+			.replace(mdLinkRegex, '$1')
+			.replace(emptyMdLinkRegex, '$1')
+			.substring(0, 80);
 	},
 };
 

--- a/packages/lib/markdownUtils2.test.ts
+++ b/packages/lib/markdownUtils2.test.ts
@@ -106,23 +106,17 @@ describe('markdownUtils', () => {
 		}
 	}));
 
-	it('replace markdown link with description', (async () => {
-
-		const testCases = [
-			['Test case [one](link)', 'Test case one'],
-			['Test case ![two](imagelink)', 'Test case two'],
-			['**# -Test case three', 'Test case three'],
-			['This is a looooooong tiiitlllle with moore thaaaaaaan eighty characters and a [link](linkurl) at the end', 'This is a looooooong tiiitlllle with moore thaaaaaaan eighty characters and a li'],
-			['', ''],
-			['These are [link1](one), [link2](two) and ![link3](three)', 'These are link1, link2 and link3'],
-			['No description link to [](https://joplinapp.org)', 'No description link to https://joplinapp.org'],
-		];
-
-		for (let i = 0; i < testCases.length; i++) {
-			const md = testCases[i][0];
-			const expected = testCases[i][1];
-			expect(markdownUtils.titleFromBody(md)).toBe(expected);
-		}
-	}));
+	it.each([
+		['Test case [one](link)', 'Test case one'],
+		['Test case ![two](imagelink)', 'Test case two'],
+		['**# -Test case three', 'Test case three'],
+		['This is a looooooong tiiitlllle with moore thaaaaaaan eighty characters and a [link](linkurl) at the end', 'This is a looooooong tiiitlllle with moore thaaaaaaan eighty characters and a li'],
+		['', ''],
+		['These are [link1](one), [link2](two) and ![link3](three)', 'These are link1, link2 and link3'],
+		['No description link to [](https://joplinapp.org)', 'No description link to https://joplinapp.org'],
+		['&nbsp;\n\nThis is a test &nbsp; test.', 'This is a test   test.'],
+	])('should create a default note title from the note body (%j -> %j)', (body, expectedTitle) => {
+		expect(markdownUtils.titleFromBody(body)).toBe(expectedTitle);
+	});
 
 });


### PR DESCRIPTION
# Summary

Fixes #11662 by replacing `&nbsp;` with a space character when creating default note titles.

# Testing plan

In addition to an automated test, this pull request has been tested manually by:
1. Switching to the Rich Text Editor.
2. Creating a new note.
3. Pressing <kbd>enter</kbd> in the body.
4. Typing `Test`.
5. Verifying that the note title is `Test`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->