### PR TITLE
Desktop: Fixes #11783: Plugins: Fix toast notifications don't reappear unless parameters are changed

### DIFF
--- a/packages/app-desktop/gui/PluginNotification/PluginNotification.tsx
+++ b/packages/app-desktop/gui/PluginNotification/PluginNotification.tsx
@@ -35,6 +35,9 @@ export default (props: Props) => {
 		};
 
 		notyfContext.open(options);
+		// toast.timestamp needs to be included in the dependency list to allow
+		// showing multiple toasts with the same message, one after another.
+		// See https://github.com/laurent22/joplin/issues/11783
 	}, [toast.message, toast.duration, toast.type, toast.timestamp, notyfContext]);
 
 	return <div style={{ display: 'none' }}/>;

--- a/packages/app-desktop/gui/PluginNotification/PluginNotification.tsx
+++ b/packages/app-desktop/gui/PluginNotification/PluginNotification.tsx
@@ -35,7 +35,7 @@ export default (props: Props) => {
 		};
 
 		notyfContext.open(options);
-	}, [toast.message, toast.duration, toast.type, notyfContext]);
+	}, [toast.message, toast.duration, toast.type, toast.timestamp, notyfContext]);
 
 	return <div style={{ display: 'none' }}/>;
 };

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -1,5 +1,5 @@
 
-import { test } from './util/test';
+import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
 
 test.describe('pluginApi', () => {
@@ -21,6 +21,23 @@ test.describe('pluginApi', () => {
 		await editor.goBack();
 
 		await editor.expectToHaveText('PASS');
+	});
+
+	test('should be possible to create multiple toasts with the same text from a plugin', async ({ startAppWithPlugins }) => {
+		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/showToast.js']);
+		const mainScreen = await new MainScreen(mainWindow).setup();
+
+		await mainScreen.goToAnything.runCommand(app, 'testShowToastNotification');
+		const notificationLocator = mainWindow.getByText('Toast: This is a test info message.');
+		await expect(notificationLocator).toBeVisible();
+
+		// Running the command again, there should be two notifications with the same text.
+		await mainScreen.goToAnything.runCommand(app, 'testShowToastNotification');
+		await expect(notificationLocator.nth(1)).toBeVisible();
+		await expect(notificationLocator.nth(0)).toBeVisible();
+
+		await mainScreen.goToAnything.runCommand(app, 'testShowToastNotification');
+		await expect(notificationLocator).toHaveCount(3);
 	});
 });
 

--- a/packages/app-desktop/integration-tests/resources/test-plugins/showToast.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/showToast.js
@@ -1,0 +1,34 @@
+// Allows referencing the Joplin global:
+/* eslint-disable no-undef */
+
+// Allows the `joplin-manifest` block comment:
+/* eslint-disable multiline-comment-style */
+
+/* joplin-manifest:
+{
+	"id": "org.joplinapp.plugins.example.showToast",
+	"manifest_version": 1,
+	"app_min_version": "3.1",
+	"name": "JS Bundle test",
+	"description": "JS Bundle Test plugin",
+	"version": "1.0.0",
+	"author": "",
+	"homepage_url": "https://joplinapp.org"
+}
+*/
+
+joplin.plugins.register({
+	onStart: async function() {
+		await joplin.commands.register({
+			name: 'testShowToastNotification',
+			label: 'testShowToastNotification',
+			iconName: 'fas fa-drum',
+			execute: async () => {
+				await joplin.views.dialogs.showToast({
+					message: 'Toast: This is a test info message.',
+					duration: 1_000 * 60 * 60, // One hour
+				});
+			},
+		});
+	},
+});


### PR DESCRIPTION
# Summary

This pull request fixes #11783 by adding a hook dependency.

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->