### PR TITLE
Mobile: Plugins: Support the showToast API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -695,6 +695,7 @@ packages/app-mobile/components/buttons/index.js
 packages/app-mobile/components/getResponsiveValue.test.js
 packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/global-style.js
+packages/app-mobile/components/plugins/PluginNotification.js
 packages/app-mobile/components/plugins/PluginRunner.js
 packages/app-mobile/components/plugins/PluginRunnerWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializeDialogWebView.js

--- a/.gitignore
+++ b/.gitignore
@@ -670,6 +670,7 @@ packages/app-mobile/components/buttons/index.js
 packages/app-mobile/components/getResponsiveValue.test.js
 packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/global-style.js
+packages/app-mobile/components/plugins/PluginNotification.js
 packages/app-mobile/components/plugins/PluginRunner.js
 packages/app-mobile/components/plugins/PluginRunnerWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializeDialogWebView.js

--- a/packages/app-mobile/components/plugins/PluginNotification.tsx
+++ b/packages/app-mobile/components/plugins/PluginNotification.tsx
@@ -27,6 +27,8 @@ const PluginNotification: React.FC<Props> = props => {
 		props.dispatch({ type: 'TOAST_HIDE' });
 	}, [props.dispatch]);
 
+	// Reload the <Portal> for each new toast. This keeps the toast notification on top
+	// of other <Portal> components and resets the toast timestamp when its message changes.
 	return <Portal key={`toast-${props.toast?.timestamp}`}>
 		<Snackbar
 			visible={!!props.toast}

--- a/packages/app-mobile/components/plugins/PluginNotification.tsx
+++ b/packages/app-mobile/components/plugins/PluginNotification.tsx
@@ -27,7 +27,7 @@ const PluginNotification: React.FC<Props> = props => {
 		props.dispatch({ type: 'TOAST_HIDE' });
 	}, [props.dispatch]);
 
-	return <Portal>
+	return <Portal key={`toast-${props.toast?.timestamp}`}>
 		<Snackbar
 			visible={!!props.toast}
 			onDismiss={onDismiss}

--- a/packages/app-mobile/components/plugins/PluginNotification.tsx
+++ b/packages/app-mobile/components/plugins/PluginNotification.tsx
@@ -6,6 +6,7 @@ import { AppState } from '../../utils/types';
 import { Toast } from '@joplin/lib/services/plugins/api/types';
 import { useCallback } from 'react';
 import { Dispatch } from 'redux';
+import { ViewStyle } from 'react-native';
 
 interface Props {
 	dispatch: Dispatch;
@@ -14,6 +15,11 @@ interface Props {
 
 const snackbarAction = {
 	label: _('Close'),
+};
+
+const wrapperStyle: ViewStyle = {
+	maxWidth: 600,
+	alignSelf: 'center',
 };
 
 const PluginNotification: React.FC<Props> = props => {
@@ -26,6 +32,7 @@ const PluginNotification: React.FC<Props> = props => {
 			visible={!!props.toast}
 			onDismiss={onDismiss}
 			duration={props.toast?.duration}
+			wrapperStyle={wrapperStyle}
 			action={snackbarAction}
 		>{props.toast?.message ?? ''}</Snackbar>
 	</Portal>;

--- a/packages/app-mobile/components/plugins/PluginNotification.tsx
+++ b/packages/app-mobile/components/plugins/PluginNotification.tsx
@@ -1,0 +1,36 @@
+import { _ } from '@joplin/lib/locale';
+import * as React from 'react';
+import { Portal, Snackbar } from 'react-native-paper';
+import { connect } from 'react-redux';
+import { AppState } from '../../utils/types';
+import { Toast } from '@joplin/lib/services/plugins/api/types';
+import { useCallback } from 'react';
+import { Dispatch } from 'redux';
+
+interface Props {
+	dispatch: Dispatch;
+	toast: Toast;
+}
+
+const snackbarAction = {
+	label: _('Close'),
+};
+
+const PluginNotification: React.FC<Props> = props => {
+	const onDismiss = useCallback(() => {
+		props.dispatch({ type: 'TOAST_HIDE' });
+	}, [props.dispatch]);
+
+	return <Portal>
+		<Snackbar
+			visible={!!props.toast}
+			onDismiss={onDismiss}
+			duration={props.toast?.duration}
+			action={snackbarAction}
+		>{props.toast?.message ?? ''}</Snackbar>
+	</Portal>;
+};
+
+export default connect((state: AppState) => ({
+	toast: state.toast,
+}))(PluginNotification);

--- a/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
@@ -16,7 +16,6 @@ import usePrevious from '@joplin/lib/hooks/usePrevious';
 import PlatformImplementation from '../../services/plugins/PlatformImplementation';
 import AccessibleView from '../accessibility/AccessibleView';
 import useOnDevPluginsUpdated from './utils/useOnDevPluginsUpdated';
-import PluginNotification from './PluginNotification';
 
 const logger = Logger.create('PluginRunnerWebView');
 
@@ -184,7 +183,6 @@ const PluginRunnerWebViewComponent: React.FC<Props> = props => {
 					pluginHtmlContents={props.pluginHtmlContents}
 					pluginStates={props.pluginStates}
 				/>
-				<PluginNotification/>
 			</>
 		);
 	};

--- a/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
@@ -16,6 +16,7 @@ import usePrevious from '@joplin/lib/hooks/usePrevious';
 import PlatformImplementation from '../../services/plugins/PlatformImplementation';
 import AccessibleView from '../accessibility/AccessibleView';
 import useOnDevPluginsUpdated from './utils/useOnDevPluginsUpdated';
+import PluginNotification from './PluginNotification';
 
 const logger = Logger.create('PluginRunnerWebView');
 
@@ -183,6 +184,7 @@ const PluginRunnerWebViewComponent: React.FC<Props> = props => {
 					pluginHtmlContents={props.pluginHtmlContents}
 					pluginStates={props.pluginStates}
 				/>
+				<PluginNotification/>
 			</>
 		);
 	};

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -139,6 +139,7 @@ import DialogManager from './components/DialogManager';
 import lockToSingleInstance from './utils/lockToSingleInstance';
 import { AppState } from './utils/types';
 import { getDisplayParentId } from '@joplin/lib/services/trash';
+import PluginNotification from './components/plugins/PluginNotification';
 
 const logger = Logger.create('root');
 
@@ -1302,8 +1303,12 @@ class AppComponent extends React.Component {
 		// a smaller edge hit width.
 		const menuEdgeHitWidth = menuPosition === 'right' ? 20 : 30;
 
+		// For toasts to be shown above most other content, including floating action buttons,
+		// they need to be before other components in the rendering order:
+		const toasts = <PluginNotification/>;
 		const mainContent = (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
+				{toasts}
 				<SideMenu
 					menu={sideMenuContent}
 					edgeHitWidth={menuEdgeHitWidth}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -1303,12 +1303,8 @@ class AppComponent extends React.Component {
 		// a smaller edge hit width.
 		const menuEdgeHitWidth = menuPosition === 'right' ? 20 : 30;
 
-		// For toasts to be shown above most other content, including floating action buttons,
-		// they need to be before other components in the rendering order:
-		const toasts = <PluginNotification/>;
 		const mainContent = (
 			<View style={{ flex: 1, backgroundColor: theme.backgroundColor }}>
-				{toasts}
 				<SideMenu
 					menu={sideMenuContent}
 					edgeHitWidth={menuEdgeHitWidth}
@@ -1337,6 +1333,7 @@ class AppComponent extends React.Component {
 					</MenuProvider>
 				</SideMenu>
 				<PluginRunnerWebView />
+				<PluginNotification/>
 			</View>
 		);
 

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1520,6 +1520,9 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 				timestamp: Date.now(),
 			};
 			break;
+		case 'TOAST_HIDE':
+			draft.toast = null;
+			break;
 
 		}
 	} catch (error) {


### PR DESCRIPTION
# Summary

This pull request adds support for `joplin.views.dialogs.showToast` on mobile.

**Note**: Only one toast message can be shown at a time.

# Screenshot

![screenshot: A toast notification is shown above the "+" button](https://github.com/user-attachments/assets/e642e6c1-6923-4477-b795-44b29572799a)


# Testing plan

On web (Firefox 135):
1. Open the development tools for a running plugin's `<iframe>`.
2. Run `joplin.views.dialogs.showToast({ message: 'Test' })`
3. Verify that a toast message is shown.
4. Click the "Close" button.
5. Verify that the toast is no longer visible.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->