### PR TITLE
Mobile: Accessibility: Make it possible to create and edit profiles with a screen reader

### DIFF
--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -1,10 +1,9 @@
-const React = require('react');
+import * as React from 'react';
 import { useCallback, useContext, useMemo, useState } from 'react';
-const { View, FlatList, StyleSheet } = require('react-native');
+import { View, FlatList, StyleSheet } from 'react-native';
 import createRootStyle from '../../utils/createRootStyle';
 import ScreenHeader from '../ScreenHeader';
-const { FAB, List } = require('react-native-paper');
-import { Profile } from '@joplin/lib/services/profileConfig/types';
+import { Profile, ProfileConfig } from '@joplin/lib/services/profileConfig/types';
 import useProfileConfig from './useProfileConfig';
 import { _ } from '@joplin/lib/locale';
 import { deleteProfileById } from '@joplin/lib/services/profileConfig';
@@ -12,11 +11,15 @@ import { saveProfileConfig, switchProfile } from '../../services/profiles';
 import { themeStyle } from '../global-style';
 import shim from '@joplin/lib/shim';
 import { DialogContext } from '../DialogManager';
+import { FAB, List, Portal } from 'react-native-paper';
+import { TextStyle } from 'react-native';
+import useOnLongPressProps from '../../utils/hooks/useOnLongPressProps';
+import { Dispatch } from 'redux';
+import NavService from '@joplin/lib/services/NavService';
 
 interface Props {
 	themeId: number;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	dispatch: Function;
+	dispatch: Dispatch;
 }
 
 const useStyle = (themeId: number) => {
@@ -39,16 +42,14 @@ const useStyle = (themeId: number) => {
 	}, [themeId]);
 };
 
-export default (props: Props) => {
-	const style = useStyle(props.themeId);
-	const [profileConfigTime, setProfileConfigTime] = useState(Date.now());
+interface ProfileItemProps {
+	themeId: number;
+	profile: Profile;
+	profileConfig: ProfileConfig;
+	setProfileConfigTime: (time: number)=> void;
+}
 
-	const profileConfig = useProfileConfig(profileConfigTime);
-
-	const profiles = useMemo(() => {
-		return profileConfig ? profileConfig.profiles : [];
-	}, [profileConfig]);
-
+const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, setProfileConfigTime, themeId }) => {
 	const dialogs = useContext(DialogContext);
 
 	const onProfileItemPress = useCallback(async (profile: Profile) => {
@@ -86,12 +87,10 @@ export default (props: Props) => {
 	}, [dialogs]);
 
 	const onEditProfile = useCallback(async (profileId: string) => {
-		props.dispatch({
-			type: 'NAV_GO',
-			routeName: 'ProfileEditor',
-			profileId: profileId,
+		await NavService.go('ProfileEditor', {
+			profileId,
 		});
-	}, [props.dispatch]);
+	}, []);
 
 	const onDeleteProfile = useCallback(async (profile: Profile) => {
 		const doIt = async () => {
@@ -120,51 +119,74 @@ export default (props: Props) => {
 				},
 			],
 		);
-	}, [dialogs, profileConfig]);
+	}, [dialogs, profileConfig, setProfileConfigTime]);
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	const renderProfileItem = (event: any) => {
-		const profile = event.item as Profile;
-		const onConfigure = (event: Event) => {
-			event.preventDefault();
-
-			dialogs.prompt(
-				_('Configuration'),
-				'',
-				[
-					{
-						text: _('Edit'),
-						onPress: () => onEditProfile(profile.id),
-						style: 'default',
-					},
-					{
-						text: _('Delete'),
-						onPress: () => onDeleteProfile(profile),
-						style: 'default',
-					},
-					{
-						text: _('Close'),
-						onPress: () => {},
-						style: 'cancel',
-					},
-				],
-			);
-		};
-
-		const titleStyle = { fontWeight: profile.id === profileConfig.currentProfileId ? 'bold' : 'normal' };
-		return (
-			<List.Item
-				title={profile.name}
-				style={style.profileListItem}
-				titleStyle={titleStyle}
-				left={() => <List.Icon icon="file-account-outline" />}
-				key={profile.id}
-				profileId={profile.id}
-				onPress={() => { void onProfileItemPress(profile); }}
-				onLongPress={onConfigure}
-				onContextMenu={onConfigure}
-			/>
+	const onConfigure = () => {
+		dialogs.prompt(
+			_('Configuration'),
+			'',
+			[
+				{
+					text: _('Edit'),
+					onPress: () => onEditProfile(profile.id),
+					style: 'default',
+				},
+				{
+					text: _('Delete'),
+					onPress: () => onDeleteProfile(profile),
+					style: 'default',
+				},
+				{
+					text: _('Close'),
+					onPress: () => {},
+					style: 'cancel',
+				},
+			],
 		);
+	};
+
+	const longPressProps = useOnLongPressProps({
+		onLongPress: () => onConfigure(),
+		actionDescription: _('Edit'),
+	});
+
+	const style = useStyle(themeId);
+	const titleStyle: TextStyle = { fontWeight: profile.id === profileConfig.currentProfileId ? 'bold' : 'normal' };
+	return (
+		<List.Item
+			title={profile.name}
+			style={style.profileListItem}
+			titleStyle={titleStyle}
+			left={() => <List.Icon icon="file-account-outline" />}
+			key={profile.id}
+			onPress={() => { void onProfileItemPress(profile); }}
+			{...longPressProps}
+		/>
+	);
+};
+
+export default (props: Props) => {
+	const style = useStyle(props.themeId);
+	const [profileConfigTime, setProfileConfigTime] = useState(Date.now());
+
+	const profileConfig = useProfileConfig(profileConfigTime);
+
+	const profiles = useMemo(() => {
+		return profileConfig ? profileConfig.profiles : [];
+	}, [profileConfig]);
+
+	const extraListItemData = useMemo(() => {
+		return { profileConfig, themeId: props.themeId };
+	}, [props.themeId, profileConfig]);
+
+
+	const renderProfileItem = (event: { item: Profile }) => {
+		return <ProfileListItem
+			profile={event.item}
+			themeId={extraListItemData.themeId}
+			profileConfig={extraListItemData.profileConfig}
+			setProfileConfigTime={setProfileConfigTime}
+		/>;
 	};
 
 	return (
@@ -174,20 +196,24 @@ export default (props: Props) => {
 				<FlatList
 					data={profiles}
 					renderItem={renderProfileItem}
-					keyExtractor={(profile: Profile) => profile.id}
+					keyExtractor={profile => profile.id}
+					// Needed so that the list rerenders when its dependencies change:
+					extraData={extraListItemData}
 				/>
 			</View>
-			<FAB
-				icon="plus"
-				style={style.fab}
-				onPress={() => {
-					props.dispatch({
-						type: 'NAV_GO',
-						routeName: 'ProfileEditor',
-					});
-				}}
-			/>
-
+			<Portal>
+				<FAB
+					icon="plus"
+					accessibilityLabel={_('New profile')}
+					style={style.fab}
+					onPress={() => {
+						props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'ProfileEditor',
+						});
+					}}
+				/>
+			</Portal>
 		</View>
 	);
 };

--- a/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
+++ b/packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx
@@ -151,7 +151,8 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 	});
 
 	const style = useStyle(themeId);
-	const titleStyle: TextStyle = { fontWeight: profile.id === profileConfig.currentProfileId ? 'bold' : 'normal' };
+	const isSelected = profile.id === profileConfig.currentProfileId;
+	const titleStyle: TextStyle = { fontWeight: isSelected ? 'bold' : 'normal' };
 	return (
 		<List.Item
 			title={profile.name}
@@ -161,6 +162,10 @@ const ProfileListItem: React.FC<ProfileItemProps> = ({ profile, profileConfig, s
 			key={profile.id}
 			onPress={() => { void onProfileItemPress(profile); }}
 			{...longPressProps}
+
+			accessibilityRole='button'
+			accessibilityState={isSelected ? { selected: true } : null}
+			aria-selected={isSelected ? true : null}
 		/>
 	);
 };


### PR DESCRIPTION
# Summary

This pull request improves the accessibility of the profile switcher screen.

In particular, it:
1. Labels the "add profile" button.
   - Previously, TalkBack skipped the "add profile" button during navigation due to a missing label.
   - Related: [WCAG 2.2 SC 1.1.1: Non-text content](https://www.w3.org/TR/WCAG22/#non-text-content).
2. Exposes the long-press action on profile list items to screen readers.
   - To use an existing hook for building the long press action, the profile list items rendering was refactored into a separate component.
   - Possibly related: [WCAG 2.2 SC 3.3.2: Labels or instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
3. Exposes which profile is selected to screen readers.
   - Previously, this was only conveyed by bolding the active profile.
   - Related: [SC 4.1.2: Name, role, value](https://www.w3.org/TR/WCAG22/#name-role-value)

See also #11661.

# Testing plan

**Android 13**:
1. Enable TalkBack.
1. Open the profile configuration screen (in an app with multiple profiles, a non-default profile selected).
2. Move TalkBack focus to the first profile.
3. Verify that TalkBack reads "Default, Button", then "double-tap to activate", then "double-tap and hold to edit".
4. Double-tap and hold.
5. Verify that TalkBack reads "Configuration", then "Edit, button".
6. Close the dialog.
7. Move TalkBack focus to the active profile.
8. Verify that TalkBack describes the profile as "selected".
9. Move TalkBack focus to the new profile button.
10. Verify that the button is described as "New profile, button".
11. Double-tap.
12. Title the profile "Test".
   - Remaining issue: The React Native Paper edit box's label isn't programmatically associated with the input. TalkBack can read the title, but only when the title itself is focused. The title is next in the focus order after the edit box.
13. Move focus to the save button and click it.
14. Move TalkBack focus to the new profile's list item.
15. Using TalkBack, rename the new profile to "Test 2".
16. Using TalkBack, delete one of the existing profiles.
17. Using TalkBack, switch to the just-created "Test 2" profile.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->