### PR TITLE
Web: Upgrade react-native-web to v0.19.13

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -121,7 +121,7 @@
     "nodemon": "3.1.7",
     "punycode": "2.3.1",
     "react-dom": "18.3.1",
-    "react-native-web": "0.19.12",
+    "react-native-web": "0.19.13",
     "react-test-renderer": "18.3.1",
     "sharp": "0.33.4",
     "sqlite3": "5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8437,7 +8437,7 @@ __metadata:
     react-native-vector-icons: 10.1.0
     react-native-version-info: 1.1.1
     react-native-vosk: 0.1.12
-    react-native-web: 0.19.12
+    react-native-web: 0.19.13
     react-native-webview: 13.10.5
     react-native-zip-archive: 6.1.2
     react-redux: 8.1.3
@@ -40083,9 +40083,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-web@npm:0.19.12":
-  version: 0.19.12
-  resolution: "react-native-web@npm:0.19.12"
+"react-native-web@npm:0.19.13":
+  version: 0.19.13
+  resolution: "react-native-web@npm:0.19.13"
   dependencies:
     "@babel/runtime": ^7.18.6
     "@react-native/normalize-colors": ^0.74.1
@@ -40098,7 +40098,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 676b1ba510c92e01dc69cb3102080f83976d2d209647323fb0a3a14113a455a6a506cf78d3e392c3fa33015135b61e2d6a3eed837a6876665064a6eb87516781
+  checksum: 15077f88204cb980203b8e3784c092c8c25c972bf281db43fd4ccc9696b603380a49f5289fb9a742daddd8e7599baab5798a1f1c857bdd634add827bc39fd8d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request should fix a few "`accessibility*` is deprecated" warnings when running the web app. (We still use `accessibilityLabel` and similar because, for some components, `aria-label`, `role`, and other props don't seem to work on Android/iOS.)

See the relevant upstream commit: https://github.com/necolas/react-native-web/commit/fc423ba4fea944ca50ab4bbc11f8eee6511d92c5


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->