### PR TITLE
Mobile: Fixes #11827: Canceling dev plugin path setup shows error

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
@@ -39,11 +39,15 @@ const useFileSystemPath = (settingId: string, updateSettingValue: UpdateSettingV
 		if (shim.mobilePlatform() === 'web') {
 			// Directory picker IDs can't include certain characters.
 			const pickerId = `setting-${settingId}`.replace(/[^a-zA-Z]/g, '_');
-			const handle = await self.showDirectoryPicker({ id: pickerId, mode: accessMode });
-			const fsDriver = shim.fsDriver() as FsDriverWeb;
-			const uri = await fsDriver.mountExternalDirectory(handle, pickerId, accessMode);
-			await updateSettingValue(settingId, uri);
-			setFileSystemPath(uri);
+			try {
+				const handle = await self.showDirectoryPicker({ id: pickerId, mode: accessMode });
+				const fsDriver = shim.fsDriver() as FsDriverWeb;
+				const uri = await fsDriver.mountExternalDirectory(handle, pickerId, accessMode);
+				await updateSettingValue(settingId, uri);
+				setFileSystemPath(uri);
+			} catch (error) {
+				return;
+			}
 		} else {
 			try {
 				const doc = await openDocumentTree(true);

--- a/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
@@ -46,7 +46,11 @@ const useFileSystemPath = (settingId: string, updateSettingValue: UpdateSettingV
 				await updateSettingValue(settingId, uri);
 				setFileSystemPath(uri);
 			} catch (error) {
-				return;
+				if (error.name === 'AbortError') {
+					return;
+				} else {
+					throw error;
+				}
 			}
 		} else {
 			try {

--- a/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx
@@ -46,11 +46,7 @@ const useFileSystemPath = (settingId: string, updateSettingValue: UpdateSettingV
 				await updateSettingValue(settingId, uri);
 				setFileSystemPath(uri);
 			} catch (error) {
-				if (error.name === 'AbortError') {
-					return;
-				} else {
-					throw error;
-				}
+				if (error.name !== 'AbortError') throw error;
 			}
 		} else {
 			try {


### PR DESCRIPTION
# What It Does
Fixes the following issue
### Trying to set development plugin path and then cancelling displays an error page #11827
* In Settings => Plugins => Advanced settings.
* Click on "Development plugins"
* Cancel the dialog
-> An error message is displayed

# How it does it
The showDirectoryPicker method throws AbortError when user dismisses the prompt without making a selection. The method was not wrapped in a try catch block to handle the error.
This pr fixes the same by wrapping up showDirectoryPicker call inside a try catch block.

- References: [Window: showDirectoryPicker() method](https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker)

# Video

## Before
https://github.com/user-attachments/assets/3a9ae68c-f83e-487b-9461-b5ac44e13b89

## After
https://github.com/user-attachments/assets/2858b4a5-e3ba-4437-be39-3aa72d6825f6