### PR TITLE
Desktop: Fixes #11833: Restore notebook from trash without requiring selection

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -14,7 +14,7 @@ import { store } from '@joplin/lib/reducer';
 import Folder from '@joplin/lib/models/Folder';
 import bridge from '../../../services/bridge';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
-import CommandService from '@joplin/lib/services/CommandService';
+import CommandService, { CommandToMenuItemOptions } from '@joplin/lib/services/CommandService';
 import { FolderEntity } from '@joplin/lib/services/database/types';
 import InteropService from '@joplin/lib/services/interop/InteropService';
 import InteropServiceHelper from '../../../InteropServiceHelper';
@@ -263,8 +263,14 @@ const useOnRenderItem = (props: Props) => {
 			}
 		} else {
 			if (itemType === BaseModel.TYPE_FOLDER) {
+				const commandOptions: CommandToMenuItemOptions = {
+					commandName: 'restoreFolder',
+					whenClauseContextOptions: {
+						commandFolderId: itemId,
+					},
+				};
 				menu.append(
-					new MenuItem(menuUtils.commandToStatefulMenuItem('restoreFolder', { folderId: itemId })),
+					new MenuItem(menuUtils.commandToStatefulMenuItem(commandOptions, itemId)),
 				);
 			}
 		}

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -264,7 +264,7 @@ const useOnRenderItem = (props: Props) => {
 		} else {
 			if (itemType === BaseModel.TYPE_FOLDER) {
 				menu.append(
-					new MenuItem(menuUtils.commandToStatefulMenuItem('restoreFolder', itemId)),
+					new MenuItem(menuUtils.commandToStatefulMenuItem('restoreFolder', { folderId: itemId })),
 				);
 			}
 		}

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts
@@ -10,12 +10,10 @@ export const declaration: CommandDeclaration = {
 	iconName: 'fas fa-trash-restore',
 };
 
-type RestoreFolderCommandOptionType = { folderId?: string };
 export const runtime = (): CommandRuntime => {
 	return {
-		execute: async (context: CommandContext, options: RestoreFolderCommandOptionType = {}) => {
-			let { folderId } = options;
-			if (!folderId) folderId = context.state.selectedFolderId;
+		execute: async (context: CommandContext, folderId: string = null) => {
+			if (folderId === null) folderId = context.state.selectedFolderId;
 
 			const folder = await Folder.load(folderId);
 			if (!folder) throw new Error(`No such folder: ${folderId}`);

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts
@@ -10,10 +10,12 @@ export const declaration: CommandDeclaration = {
 	iconName: 'fas fa-trash-restore',
 };
 
+type RestoreFolderCommandOptionType = { folderId?: string };
 export const runtime = (): CommandRuntime => {
 	return {
-		execute: async (context: CommandContext, folderId: string = null) => {
-			if (folderId === null) folderId = context.state.selectedFolderId;
+		execute: async (context: CommandContext, options: RestoreFolderCommandOptionType = {}) => {
+			let { folderId } = options;
+			if (!folderId) folderId = context.state.selectedFolderId;
 
 			const folder = await Folder.load(folderId);
 			if (!folder) throw new Error(`No such folder: ${folderId}`);

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -97,6 +97,11 @@ interface CommandByNameOptions {
 	runtimeMustBeRegistered?: boolean;
 }
 
+export interface CommandToMenuItemOptions {
+	commandName: string;
+	whenClauseContextOptions: WhenClauseContextOptions;
+}
+
 export interface SearchResult {
 	commandName: string;
 	title: string;

--- a/packages/lib/services/CommandService.ts
+++ b/packages/lib/services/CommandService.ts
@@ -3,7 +3,7 @@ import eventManager, { EventListenerCallback, EventName } from '../eventManager'
 import BaseService from './BaseService';
 import shim from '../shim';
 import WhenClause from './WhenClause';
-import type { WhenClauseContext } from './commands/stateToWhenClauseContext';
+import type { WhenClauseContext, WhenClauseContextOptions } from './commands/stateToWhenClauseContext';
 
 type LabelFunction = ()=> string;
 type EnabledCondition = string;
@@ -337,8 +337,8 @@ export default class CommandService extends BaseService {
 		}, 10);
 	}
 
-	public currentWhenClauseContext(): WhenClauseContext {
-		return this.stateToWhenClauseContext_(this.store_.getState());
+	public currentWhenClauseContext(options?: WhenClauseContextOptions): WhenClauseContext {
+		return this.stateToWhenClauseContext_(this.store_.getState(), options);
 	}
 
 	public isPublic(commandName: string) {

--- a/packages/lib/services/commands/MenuUtils.ts
+++ b/packages/lib/services/commands/MenuUtils.ts
@@ -1,9 +1,8 @@
 import { MenuItemLocation } from '../plugins/api/types';
-import CommandService from '../CommandService';
+import CommandService, { CommandToMenuItemOptions } from '../CommandService';
 import KeymapService from '../KeymapService';
 import { PluginStates, utils as pluginUtils } from '../plugins/reducer';
 import propsHaveChanged from './propsHaveChanged';
-import { WhenClauseContextOptions } from './stateToWhenClauseContext';
 const { createSelectorCreator, defaultMemoize } = require('reselect');
 const { createCachedSelector } = require('re-reselect');
 
@@ -104,13 +103,16 @@ export default class MenuUtils {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public commandToStatefulMenuItem(commandName: string, ...args: any[]): MenuItem {
-		let options: WhenClauseContextOptions;
-		if (args && args[0] && args[0].folderId) {
-			options = { commandFolderId: args[0].folderId };
+	public commandToStatefulMenuItem(options: string|CommandToMenuItemOptions, ...args: any[]): MenuItem {
+		let whenClauseContext, commandName;
+		if (typeof options === 'string') {
+			commandName = options;
+			whenClauseContext = this.service.currentWhenClauseContext();
+		} else {
+			commandName = options.commandName;
+			const whenClauseContextOptions = options.whenClauseContextOptions;
+			whenClauseContext = this.service.currentWhenClauseContext(whenClauseContextOptions);
 		}
-
-		const whenClauseContext = this.service.currentWhenClauseContext(options);
 
 		const menuItem = this.commandToMenuItem(commandName, () => {
 			return this.service.execute(commandName, ...args);

--- a/packages/lib/services/commands/MenuUtils.ts
+++ b/packages/lib/services/commands/MenuUtils.ts
@@ -3,6 +3,7 @@ import CommandService from '../CommandService';
 import KeymapService from '../KeymapService';
 import { PluginStates, utils as pluginUtils } from '../plugins/reducer';
 import propsHaveChanged from './propsHaveChanged';
+import { WhenClauseContextOptions } from './stateToWhenClauseContext';
 const { createSelectorCreator, defaultMemoize } = require('reselect');
 const { createCachedSelector } = require('re-reselect');
 
@@ -104,7 +105,12 @@ export default class MenuUtils {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public commandToStatefulMenuItem(commandName: string, ...args: any[]): MenuItem {
-		const whenClauseContext = this.service.currentWhenClauseContext();
+		const options: WhenClauseContextOptions = {};
+		if (args && args[0] && (typeof args[0] === 'string')) {
+			options.commandFolderId = args[0];
+		}
+
+		const whenClauseContext = this.service.currentWhenClauseContext(options);
 
 		const menuItem = this.commandToMenuItem(commandName, () => {
 			return this.service.execute(commandName, ...args);

--- a/packages/lib/services/commands/MenuUtils.ts
+++ b/packages/lib/services/commands/MenuUtils.ts
@@ -105,9 +105,9 @@ export default class MenuUtils {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public commandToStatefulMenuItem(commandName: string, ...args: any[]): MenuItem {
-		const options: WhenClauseContextOptions = {};
-		if (args && args[0] && (typeof args[0] === 'string')) {
-			options.commandFolderId = args[0];
+		let options: WhenClauseContextOptions;
+		if (args && args[0] && args[0].folderId) {
+			options = { commandFolderId: args[0].folderId };
 		}
 
 		const whenClauseContext = this.service.currentWhenClauseContext(options);


### PR DESCRIPTION
# What this PR does?
- Resolves the issue where restore notebook does not work if the notebook is not selected first.
- Fixes #11833 

 ## Issue Description
- Open Joplin profile with multiple notebooks.
- Delete a notebook (move to trash).
- Right-click deleted notebook in trash. A context menu with "Restore notebook" appears.
- Click "Restore notebook". Nothing happens.

# Root Cause
- The enable condition for restore notebook option was the 'folderIsDeleted' flag in the WhenClauseContext object.
<img width="896" alt="code for restoreFolder command runtime" src="https://github.com/user-attachments/assets/ef9f6215-6f0b-45c0-ba6f-59d0570d4914" /><br>

<br>

- The stateToWhenClauseContext function is responsible for converting current state to WhenClauseContext object.
- It sets the context options for the current menu item based on the commandFolder which if not explicitly set is taken to be the currently selected entity by default.
<img width="1000" alt="code for stateToWhenClauseContext function" src="https://github.com/user-attachments/assets/562eaef2-4b9e-4f74-9b81-435f414578c0" />
<img width="729" alt="code for stateToWhenClauseContext function" src="https://github.com/user-attachments/assets/45822d85-6f83-43e5-b6bb-d3ccb07e288b" /><br>

<br>

- Since the currently selected item does not have 'folderIsDeleted' property set to true hence the restore notebook option is disabled.

# Issue resolution
- We can pass WhenClauseContextOptions to the 'stateToWhenClauseContext' function through which we can explicitly specify the id of the command folder for the current menu item.
- The itemId of the currently clicked item was already being passes as an argument to the function which converts the command to a stateful menu item.
- I extracted the itemId and passed it as current commandFolderId option to the 'stateToWhenClauseContext' context function and this resolves the issue.
<img width="824" alt="code for context option creation" src="https://github.com/user-attachments/assets/a33846ac-89b0-4f34-958b-b01e50dc8534" />

# Video

## Before

https://github.com/user-attachments/assets/c5a145b2-30c1-46e2-9f4e-63ffb8c37994

## After

https://github.com/user-attachments/assets/0d014336-9dfb-46a8-8cac-450bdb61c9a4