### PR TITLE
iOS: Fix "attach file" doesn't work the first time after startup

### DIFF
--- a/packages/app-mobile/components/screens/Note/commands/attachFile.ts
+++ b/packages/app-mobile/components/screens/Note/commands/attachFile.ts
@@ -5,6 +5,7 @@ import { Platform } from 'react-native';
 import pickDocument from '../../../../utils/pickDocument';
 import { ImagePickerResponse, launchImageLibrary } from 'react-native-image-picker';
 import Logger from '@joplin/utils/Logger';
+import { msleep } from '@joplin/utils/time';
 
 const logger = Logger.create('attachFile');
 
@@ -83,6 +84,13 @@ export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 			buttons.push({ text: _('Take photo'), id: AttachFileAction.TakePhoto });
 
 			buttonId = await props.dialogs.showMenu(_('Choose an option'), buttons) as AttachFileAction;
+
+			if (Platform.OS === 'ios') {
+				// Fixes an issue: The first time "attach file" or "attach photo" is chosen after starting Joplin
+				// on iOS, no attach dialog was shown. Adding a brief delay after the "choose an option" dialog is
+				// dismissed seems to fix the issue.
+				await msleep(1);
+			}
 		}
 
 		if (buttonId === AttachFileAction.TakePhoto) await takePhoto();


### PR DESCRIPTION
# Summary

This pull request fixes an issue with attaching files on iOS using the "Attach..." menu — clicking "Attach file" previously did nothing the first time it was clicked after launching the app (observed on iOS 18.3).

# Testing plan

Manual testing (iOS simulator/iPad OS 18.1):
1. Immediately after launching the app, create a new note.
2. Click "Attach" from the note actions menu.
3. Choose "Attach file".
4. Verify that the file picker dialog is shown.
5. Choose a file.
6. Verify that the file is attached to the note.
7. **Checking that the issue occurred before this change**: Remove the msleep added by this commit.
8. Allow the React Native bundled JS to reload.
9. Close and re-open the app.
10. Repeat steps 1-3. Observe that the file picker does not appear.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->