### PR TITLE
iOS: Fixes #11835: Allow attaching videos to notes

### DIFF
--- a/packages/app-mobile/components/screens/Note/commands/attachFile.ts
+++ b/packages/app-mobile/components/screens/Note/commands/attachFile.ts
@@ -47,6 +47,7 @@ export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 		const response: ImagePickerResponse = await launchImageLibrary({
 			mediaType: 'mixed',
 			videoQuality: 'low',
+			formatAsMp4: true,
 			includeBase64: false,
 			selectionLimit: 200,
 		});

--- a/packages/app-mobile/components/screens/Note/commands/attachFile.ts
+++ b/packages/app-mobile/components/screens/Note/commands/attachFile.ts
@@ -44,7 +44,12 @@ export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 	};
 	const attachPhoto = async () => {
 		// the selection Limit should be specified. I think 200 is enough?
-		const response: ImagePickerResponse = await launchImageLibrary({ mediaType: 'photo', includeBase64: false, selectionLimit: 200 });
+		const response: ImagePickerResponse = await launchImageLibrary({
+			mediaType: 'mixed',
+			videoQuality: 'low',
+			includeBase64: false,
+			selectionLimit: 200,
+		});
 
 		if (response.errorCode) {
 			logger.warn('Got error from picker', response.errorCode);
@@ -57,7 +62,7 @@ export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 		}
 
 		for (const asset of response.assets) {
-			await props.attachFile(asset, 'image');
+			await props.attachFile(asset, asset.type);
 		}
 	};
 


### PR DESCRIPTION
# Summary

This pull request fixes #11835 by allowing videos to be selected in the photo picker on iOS.

# Testing plan

Manual testing (iOS 18.3.1):
1. Open an existing note.
2. Open "Attach..." from the note actions menu.
3. Click "Attach photo".
4. Repeat steps 2-3 if the "attach photo" dialog doesn't appear.
   - See https://github.com/laurent22/joplin/pull/11839.
6. Select a video to attach.
7. Verify that the video is attached.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->