### PR TITLE
Desktop: Fix Rich Text right-click and paste regressions

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1344,7 +1344,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		editor.on(TinyMceEditorEvents.KeyUp, onKeyUp);
 		editor.on(TinyMceEditorEvents.KeyDown, onKeyDown);
 		editor.on(TinyMceEditorEvents.KeyPress, onKeypress);
-		editor.on(TinyMceEditorEvents.Paste, onPaste);
+		editor.on(TinyMceEditorEvents.Paste, onPaste, true);
 		editor.on(TinyMceEditorEvents.PasteAsText, onPasteAsText);
 		editor.on(TinyMceEditorEvents.Copy, onCopy);
 		// `compositionend` means that a user has finished entering a Chinese

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1344,6 +1344,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 		editor.on(TinyMceEditorEvents.KeyUp, onKeyUp);
 		editor.on(TinyMceEditorEvents.KeyDown, onKeyDown);
 		editor.on(TinyMceEditorEvents.KeyPress, onKeypress);
+		// Passing `true` adds the listener to the front of the listener list.
+		// This allows overriding TinyMCE's built-in paste handler with .preventDefault.
 		editor.on(TinyMceEditorEvents.Paste, onPaste, true);
 		editor.on(TinyMceEditorEvents.PasteAsText, onPasteAsText);
 		editor.on(TinyMceEditorEvents.Copy, onCopy);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -8,7 +8,7 @@ import { menuItems } from '../../../utils/contextMenu';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
 import Setting from '@joplin/lib/models/Setting';
-import type { Event as ElectronEvent } from 'electron';
+import type { Event as ElectronEvent, MenuItemConstructorOptions } from 'electron';
 
 import Resource from '@joplin/lib/models/Resource';
 import { TinyMceEditorEvents } from './types';
@@ -17,6 +17,7 @@ import { Editor } from 'tinymce';
 import { EditDialogControl } from './useEditDialog';
 import { Dispatch } from 'redux';
 import { _ } from '@joplin/lib/locale';
+import type { MenuItem as MenuItemType } from 'electron';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -137,13 +138,20 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 			event.preventDefault();
 
 			const menu = new Menu();
-			const menuItems = [];
+			const menuItems: MenuItemType[] = [];
+			const toMenuItems = (specs: MenuItemConstructorOptions[]) => {
+				return specs.map(spec => new MenuItem(spec));
+			};
 
 			menuItems.push(...makeEditableMenuItems(element));
 			menuItems.push(...makeMainMenuItems(element));
 			const spellCheckerMenuItems = SpellCheckerService.instance().contextMenuItems(params.misspelledWord, params.dictionarySuggestions);
-			menuItems.push(...spellCheckerMenuItems);
-			menuItems.push(...menuUtils.pluginContextMenuItems(plugins, MenuItemLocation.EditorContextMenu));
+			menuItems.push(
+				...toMenuItems(spellCheckerMenuItems),
+			);
+			menuItems.push(
+				...toMenuItems(menuUtils.pluginContextMenuItems(plugins, MenuItemLocation.EditorContextMenu)),
+			);
 
 			for (const item of menuItems) {
 				menu.append(item);


### PR DESCRIPTION
# Summary

This pull request fixes two Rich Text Editor regressions (probably related to the TinyMCE upgrade):
- Pasting content with <kbd>ctrl</kbd>-<kbd>v</kbd> pasted it twice. This was [originally reported on the forum](https://discourse.joplinapp.org/t/ctrl-v-is-making-the-job-twice/43852).
- The right-click menu failed to appear in some cases. This [menu issue was also originally reported on the forum](https://discourse.joplinapp.org/t/no-access-to-right-click-with-a-word-with-inside/43853).

# Testing plan

1. Create a new note in the Rich Text Editor.
2. Set its content to "This is a test".
3. Copy "test" and paste it with <kbd>ctrl</kbd>-<kbd>v</kbd>.
4. Verify that "test" is pasted only once.
5. Bold both "test"s and copy them.
6. Paste them at the beginning of the document (also with <kbd>ctrl</kbd>-<kbd>v</kbd>).
7. Verify that the pasted text is bolded.
8. Right-click on a misspelling and correct it.
9. Verify that the right-click menu is shown.
10. Select a word with a hyphen.
11. Right-click > copy it.
12. Paste it using the right-click menu.
13. Verify that the word pastes successfully.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->