### PR TITLE
Desktop: Fixes #11847: Hide extra clear button in search field

### DIFF
--- a/packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx
+++ b/packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx
@@ -33,6 +33,10 @@ export const SearchInput = styled(StyledInput)`
 	padding-right: 20px;
 	flex: 1;
 	width: 10px;
+
+	&::-webkit-search-cancel-button {
+		display: none;
+	}
 `;
 
 interface Props {


### PR DESCRIPTION
# Summary

This pull request fixes #11847 by hiding the Electron-provided clear button in the search input.

# Screenshot

![screenshot: just one "x" button to the right of the search query](https://github.com/user-attachments/assets/2a7bed41-b8eb-4819-a0a9-b390d3507843)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->