### PR TITLE
Desktop: Fixes #11759: Preserve attachment file extensions regardless of the mime type 

### DIFF
--- a/packages/lib/shim-init-node.test.ts
+++ b/packages/lib/shim-init-node.test.ts
@@ -18,7 +18,7 @@ describe('shim-init-node', () => {
 		expect(resource.mime).toBe('application/pdf');
 	});
 
-	test('should keep file extension from filename if mime type is not recognized', async () => {
+	test('it should preserve the file extension if one is provided regardless of the mime type', async () => {
 		const originalFilePath = `${supportDir}/valid_pdf_without_ext`;
 		const fileWithDifferentExtension = `${originalFilePath}.mscz`;
 		await copyFile(originalFilePath, fileWithDifferentExtension);

--- a/packages/lib/shim-init-node.test.ts
+++ b/packages/lib/shim-init-node.test.ts
@@ -2,6 +2,7 @@
 const { shimInit } = require('./shim-init-node');
 import shim from './shim';
 import { setupDatabaseAndSynchronizer, supportDir } from './testing/test-utils';
+import { copyFile } from 'fs-extra';
 
 describe('shim-init-node', () => {
 
@@ -16,4 +17,15 @@ describe('shim-init-node', () => {
 
 		expect(resource.mime).toBe('application/pdf');
 	});
+
+	test('should keep file extension from filename if mime type is not recognized', async () => {
+		const originalFilePath = `${supportDir}/valid_pdf_without_ext`;
+		const fileWithDifferentExtension = `${originalFilePath}.mscz`;
+		await copyFile(originalFilePath, fileWithDifferentExtension);
+
+		const resource = await shim.createResourceFromPath(fileWithDifferentExtension);
+
+		expect(resource.file_extension).toBe('mscz');
+	});
+
 });

--- a/packages/lib/shim-init-node.test.ts
+++ b/packages/lib/shim-init-node.test.ts
@@ -11,14 +11,14 @@ describe('shim-init-node', () => {
 		shimInit();
 	});
 
-	test('should set mime the correct mime for a PDF file even if the extension is missing', async () => {
+	test('should set the correct mime for a PDF file even if the extension is missing', async () => {
 		const filePath = `${supportDir}/valid_pdf_without_ext`;
 		const resource = await shim.createResourceFromPath(filePath);
 
 		expect(resource.mime).toBe('application/pdf');
 	});
 
-	test('it should preserve the file extension if one is provided regardless of the mime type', async () => {
+	test('should preserve the file extension if one is provided regardless of the mime type', async () => {
 		const originalFilePath = `${supportDir}/valid_pdf_without_ext`;
 		const fileWithDifferentExtension = `${originalFilePath}.mscz`;
 		await copyFile(originalFilePath, fileWithDifferentExtension);

--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -344,7 +344,7 @@ function shimInit(options: ShimInitOptions = null) {
 			const detectedType = await fileTypeFromFile(filePath);
 
 			if (detectedType) {
-				fileExt = detectedType.ext;
+				fileExt = fileExt ? fileExt : detectedType.ext;
 				resource.mime = detectedType.mime;
 			} else {
 				resource.mime = 'application/octet-stream';


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11759

# Summary

When the change of mime detection was added, a more powerful library was included, allowing us to detect other file types like PDF even if the file doesn't have the extension on the file name. (Old PR: https://github.com/laurent22/joplin/pull/10907/files)

One issue that we didn't consider was the false recognitions that the library could produce, like the one reported in the issue.

To fix this I'm assuming that the extension on the filename is correct unless there isn't any, which in this case I'm adding the one found by the `file-type` library. This behaviour mimics what was already happening before for most resources before the change of the library.

**Reminder**: this part of the code only runs when the file extension is not recognized by the original "mime detection library":

https://github.com/laurent22/joplin/blob/dev/packages/lib/shim-init-node.ts#L335-L339

# Testing

I added an automated test.

A manual test steps:

1. Install MuseScore
2. [Download .mscz file ](https://www.dropbox.com/scl/fi/liknrg1t47erdbms6l0qb/Four_Chords-emptyMel.mscz?rlkey=5ob0ldoimx5gyciea0q4yue86&st=4a5cw49j&dl=0)
3. Add as an attachment on a Joplin note
4. Ctrl-Click into the resource link
5. It should show the pop-up asking if it is ok to open this type of file, after clicking Ok
6. It should open the MuseScore program