### PR TITLE
Mobile: Fix #11858: Fix disabled encryption keys list showing enabled keys

### DIFF
--- a/packages/app-mobile/components/screens/encryption-config.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.tsx
@@ -233,17 +233,15 @@ const EncryptionConfigScreen = (props: Props) => {
 		}
 	};
 
-	for (let i = 0; i < props.masterKeys.filter(mk => masterKeyEnabled(mk)).length; i++) {
-		const mk = props.masterKeys[i];
-		mkComps.push(renderMasterKey(mk));
+	for (const enabledKey of props.masterKeys.filter(mk => masterKeyEnabled(mk))) {
+		mkComps.push(renderMasterKey(enabledKey));
 
-		const idx = nonExistingMasterKeyIds.indexOf(mk.id);
+		const idx = nonExistingMasterKeyIds.indexOf(enabledKey.id);
 		if (idx >= 0) nonExistingMasterKeyIds.splice(idx, 1);
 	}
 
-	for (let i = 0; i < props.masterKeys.filter(mk => !masterKeyEnabled(mk)).length; i++) {
-		const mk = props.masterKeys[i];
-		disabledMkComps.push(renderMasterKey(mk));
+	for (const disabledKey of props.masterKeys.filter(mk => !masterKeyEnabled(mk))) {
+		disabledMkComps.push(renderMasterKey(disabledKey));
 	}
 
 	const onToggleButtonClick = async () => {


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/11858#event-16365212354

# Summary

Fixing wrong logic/code. I think my mistake was caused mostly by my lack of understanding about the functionality.

What end up helping me understand now was connecting the mobile and desktop to the same sync target and toggling which key is enabled and disable on the desktop and synching it with the mobile app.

# Testing

1. Run Joplin Server
2. Connect from Desktop app
3. Connect from Mobile app
4. Create encryption key on Desktop and synch it to mobile
5. **Check if encryption key is not showing on disabled key list**
6. Disable encryption key on Desktop and synch it to mobile
7.  **Check if encryption key IS showing on disabled key list**
