### PR TITLE
Fix toolbar for richtext v2

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -617,6 +617,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 				background: none;
 				background-color: ${theme.backgroundColor3} !important;
 			}
+
+			.tox .tox-tbtn,
+			.tox .tox-tbtn button,
+			.tox .tox-split-button,
+			.tox .tox-split-button button {
+				margin: 0 !important;
+			}
 		`));
 
 		return () => {
@@ -673,7 +680,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 			// we create small groups of just one button towards the end.
 
 			const toolbar = [
-				'bold', 'italic', 'joplinHighlight', 'joplinStrikethrough', 'formattingExtras', '|',
+				'bold', 'italic', 'joplinHighlight', 'joplinStrikethrough', '|',
+				'joplinInsert', 'joplinSup', 'joplinSub', 'forecolor', '|',
 				'link', 'joplinInlineCode', 'joplinCodeBlock', 'joplinAttach', '|',
 				'bullist', 'numlist', 'joplinChecklist', '|',
 				'h1', 'h2', 'h3', '|',

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts
@@ -60,14 +60,12 @@ export default function(editor: any) {
 		});
 	}
 
-	const items: string[] = definitions.filter(d => !!d.grouped).map(d => d.name);
-
-	// Additional built-in buttons to show in the formatting sub-menu:
-	items.push('forecolor');
-
-	editor.ui.registry.addGroupToolbarButton('formattingExtras', {
-		icon: 'image-options',
-		tooltip: _('Formatting'),
-		items: items.join(' '),
-	});
+	// Old code to format a group of buttons into a dropdown
+	// const items: string[] = definitions.filter(d => !!d.grouped).map(d => d.name);
+	// items.push('forecolor');
+	// editor.ui.registry.addGroupToolbarButton('formattingExtras', {
+	// 	icon: 'image-options',
+	// 	tooltip: _('Formatting'),
+	// 	items: items.join(' '),
+	// });
 }


### PR DESCRIPTION
Desktop: Resolves https://github.com/laurent22/joplin/issues/11663: Improved TinyMCE Toolbar Structure (Rich Text) v2

This pull request refactors the TinyMCE toolbar configuration in Joplin’s desktop application to improve button accessibility and appearance when users resize the notes window.

Key Changes:

Decoupled formattingExtras buttons: Removed unnecessary grouping to prevent duplicate dropdowns.
Modified TinyMCE toolbar structure: Placed buttons individually in the toolbar for better visibility.
Applied CSS adjustments: Fixed height inconsistencies for the forecolor button to keep uniform height.

Before
![before_01](https://github.com/user-attachments/assets/4e4ea125-a891-43fb-95e5-3e33acee5be1)
![before_02](https://github.com/user-attachments/assets/887dcc98-4801-41d8-bd56-90a2241f2f5d)


After
![after_02](https://github.com/user-attachments/assets/d950b5f7-a1f0-423a-afb0-a780e81efe1d)
![after_01](https://github.com/user-attachments/assets/9f06d9fc-7432-44e0-be45-cf700fa7999d)
