### PR TITLE
Chore: Fix yarn tsc fails when run from packages/utils

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,8 @@
     "@types/markdown-it": "13.0.9",
     "@types/node-fetch": "2.6.12",
     "jest": "29.7.0",
-    "ts-jest": "29.1.5"
+    "ts-jest": "29.1.5",
+    "typescript": "5.4.5"
   },
   "gitHead": "05a29b450962bf05a8642bbd39446a1f679a96ba"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8994,6 +8994,7 @@ __metadata:
     node-fetch: 2.6.7
     sprintf-js: 1.1.3
     ts-jest: 29.1.5
+    typescript: 5.4.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# Summary

`@joplin/utils` was missing a dependency on `typescript`. As a result, running `yarn tsc` directly from `packages/utils` would fail. 

This pull request selects the same version of TypeScript as is used in `app-mobile/package.json`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->