### PR TITLE
Mobile: Fixes #11864: Fix voice recorder crash

### DIFF
--- a/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
@@ -14,6 +14,7 @@ import { Text } from 'react-native-paper';
 import { AndroidAudioEncoder, AndroidOutputFormat, IOSAudioQuality, IOSOutputFormat, RecordingOptions } from 'expo-av/build/Audio';
 import time from '@joplin/lib/time';
 import { toFileExtension } from '@joplin/lib/mime-utils';
+import { formatMsToDurationCompat } from '@joplin/utils/time';
 
 const logger = Logger.create('AudioRecording');
 
@@ -184,13 +185,6 @@ const useAudioRecorder = (onFileSaved: OnFileSavedCallback, onDismiss: ()=> void
 	return { onStartStopRecording, error, duration, recordingState };
 };
 
-const formatDuration = (duration: number) => {
-	const seconds = Math.floor(duration / 1000);
-	const minutes = Math.floor(seconds / 60);
-	const paddedSeconds = `${seconds}`.padStart(2, '0');
-	return `${minutes}:${paddedSeconds}`;
-};
-
 const AudioRecordingBanner: React.FC<Props> = props => {
 	const { recordingState, onStartStopRecording, duration, error } = useAudioRecorder(props.onFileSaved, props.onDismiss);
 
@@ -218,7 +212,7 @@ const AudioRecordingBanner: React.FC<Props> = props => {
 	const renderDuration = () => {
 		if (recordingState !== RecorderState.Recording) return null;
 
-		const durationValue = formatDuration(duration);
+		const durationValue = formatMsToDurationCompat(duration);
 		return <Text
 			accessibilityLabel={_('Duration: %s', durationValue)}
 			accessibilityRole='timer'

--- a/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
@@ -14,7 +14,6 @@ import { Text } from 'react-native-paper';
 import { AndroidAudioEncoder, AndroidOutputFormat, IOSAudioQuality, IOSOutputFormat, RecordingOptions } from 'expo-av/build/Audio';
 import time from '@joplin/lib/time';
 import { toFileExtension } from '@joplin/lib/mime-utils';
-import { formatMsToDurationLocal } from '@joplin/utils/time';
 
 const logger = Logger.create('AudioRecording');
 
@@ -185,6 +184,13 @@ const useAudioRecorder = (onFileSaved: OnFileSavedCallback, onDismiss: ()=> void
 	return { onStartStopRecording, error, duration, recordingState };
 };
 
+const formatDuration = (duration: number) => {
+	const seconds = Math.floor(duration / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const paddedSeconds = `${seconds}`.padStart(2, '0');
+	return `${minutes}:${paddedSeconds}`;
+};
+
 const AudioRecordingBanner: React.FC<Props> = props => {
 	const { recordingState, onStartStopRecording, duration, error } = useAudioRecorder(props.onFileSaved, props.onDismiss);
 
@@ -212,7 +218,7 @@ const AudioRecordingBanner: React.FC<Props> = props => {
 	const renderDuration = () => {
 		if (recordingState !== RecorderState.Recording) return null;
 
-		const durationValue = formatMsToDurationLocal(duration);
+		const durationValue = formatDuration(duration);
 		return <Text
 			accessibilityLabel={_('Duration: %s', durationValue)}
 			accessibilityRole='timer'

--- a/packages/utils/time.test.ts
+++ b/packages/utils/time.test.ts
@@ -1,12 +1,13 @@
-import { formatMsToDurationLocal, Hour, Minute } from './time';
+import { formatMsToDurationCompat, Hour, Minute, Second } from './time';
 
 describe('time', () => {
 	test.each([
 		[0, '0:00'],
+		[2500, '0:02'],
 		[Minute * 3, '3:00'],
-		[Hour * 4 + Minute * 3, '4:03:00'],
-		[Hour * 25, '0000-00-01T01:00'],
+		[Hour + Minute * 3, '63:00'],
+		[Hour + Minute * 3 + Second, '63:01'],
 	])('should support formatting durations', (input, expected) => {
-		expect(formatMsToDurationLocal(input)).toBe(expected);
+		expect(formatMsToDurationCompat(input)).toBe(expected);
 	});
 });

--- a/packages/utils/time.ts
+++ b/packages/utils/time.ts
@@ -158,3 +158,11 @@ export const formatDateTimeLocalToMs = (anything: string) => {
 	return dayjs(anything).unix() * 1000;
 };
 
+export const formatMsToDurationCompat = (ms: number) => {
+	// Avoid using dayjs (and @joplin/utils/time) for formatting here.
+	// See https://github.com/laurent22/joplin/issues/11864
+	const seconds = Math.floor(ms / Second) % 60;
+	const minutes = Math.floor(ms / Minute);
+	const paddedSeconds = `${seconds}`.padStart(2, '0');
+	return `${minutes}:${paddedSeconds}`;
+};

--- a/packages/utils/time.ts
+++ b/packages/utils/time.ts
@@ -10,8 +10,6 @@ import * as dayjs from 'dayjs';
 // - import * as dayJsRelativeTimeType causes a runtime error.
 import type * as dayJsRelativeTimeType from 'dayjs/plugin/relativeTime';
 const dayJsRelativeTime: typeof dayJsRelativeTimeType = require('dayjs/plugin/relativeTime');
-import type * as dayJsDurationType from 'dayjs/plugin/duration';
-const dayJsDuration: typeof dayJsDurationType = require('dayjs/plugin/duration');
 
 const supportedLocales: Record<string, unknown> = {
 	'ar': require('dayjs/locale/ar'),
@@ -65,7 +63,6 @@ export const Week = 7 * Day;
 export const Month = 30 * Day;
 
 function initDayJs() {
-	dayjs.extend(dayJsDuration);
 	dayjs.extend(dayJsRelativeTime);
 }
 
@@ -161,14 +158,3 @@ export const formatDateTimeLocalToMs = (anything: string) => {
 	return dayjs(anything).unix() * 1000;
 };
 
-export const formatMsToDurationLocal = (ms: number) => {
-	let format;
-	if (ms < Hour) {
-		format = 'm:ss';
-	} else if (ms < Day) {
-		format = 'H:mm:ss';
-	} else {
-		format = 'YYYY-MM-DDTHH:mm';
-	}
-	return dayjs.duration(ms).format(format);
-};


### PR DESCRIPTION
# Summary

This pull request fixes a crash when attaching a new audio recording on Android and iOS. It avoids use of `dayjs`, which may not work correctly in React Native for Android/iOS. 

Fixes #11864.

# Testing plan

On Android 13:
1. Click "Attach..." from the note actions menu
2. Click "Record audio"
3. Click "Start recording"
4. Verify that a time stamp in the format "0:12" is shown and the right number increases once per second.
5. Wait roughly one minute.
6. Verify that the first number increases to "1".
7. Click "Done".
8. Verify that this attaches a new recording to the note.
9. Verify that the recording can be played.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->