### PR TITLE
Update POSTGRES_HOST in docker-compose.server-dev.yml to 'db' for pro…

### DIFF
--- a/docker-compose.server-dev.yml
+++ b/docker-compose.server-dev.yml
@@ -16,7 +16,7 @@ services:
             - POSTGRES_DATABASE=joplin
             - POSTGRES_USER=joplin
             - POSTGRES_PORT=5432
-            - POSTGRES_HOST=localhost
+            - POSTGRES_HOST=db
     db:
         image: postgres:16
         ports:


### PR DESCRIPTION
Description:
This PR updates the docker-compose.server-dev.yml file to fix a connection issue between the app and the database.

Current Behavior:

The POSTGRES_HOST environment variable is set to localhost, which causes connection failure between the app and db services in Docker Compose since both are running in different containers. Docker services cannot communicate via localhost.

Expected Behavior:

The POSTGRES_HOST is updated to db (the service name for the PostgreSQL container), allowing proper service-to-service communication via Docker’s internal network.
Changes:
Modify POSTGRES_HOST in the app service environment to db.
This will resolve the connection issue and ensure proper communication between the app and db services.

Fixes issue: #11885 