### PR TITLE
Desktop: Accessibility: Add more standard keyboard shortcuts for the notebook sidebar

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -417,6 +417,7 @@ const useOnRenderItem = (props: Props) => {
 				key={item.key}
 				anchorRef={anchorRef}
 				selected={selected}
+				item={item}
 				index={index}
 				itemCount={itemCount}
 			/>;
@@ -425,7 +426,7 @@ const useOnRenderItem = (props: Props) => {
 				<ListItemWrapper
 					key={item.key}
 					containerRef={anchorRef}
-					depth={0}
+					depth={1}
 					selected={selected}
 					itemIndex={index}
 					itemCount={itemCount}

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -74,10 +74,8 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			if (isFolderWithParent) {
 				indexChange = getParentOffset(selectedIndex, listItems) ?? 0;
 			}
-		} else if (selectedItem && event.code === 'ArrowRight') { // Jump to first child
-			if (selectedItem.hasChildren) {
-				indexChange = 1;
-			}
+		} else if (selectedItem?.hasChildren && event.code === 'ArrowRight') { // Jump to first child
+			indexChange = 1;
 		} else if (event.code === 'ArrowUp') {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -12,7 +12,6 @@ interface Props {
 	updateSelectedIndex: SetSelectedIndexCallback;
 }
 
-
 const isToggleShortcut = (keyCode: string, selectedItem: ListItem, collapsedFolderIds: string[]) => {
 	if (selectedItem.kind !== ListItemType.Header && selectedItem.kind !== ListItemType.Folder) {
 		return false;
@@ -22,12 +21,32 @@ const isToggleShortcut = (keyCode: string, selectedItem: ListItem, collapsedFold
 		return false;
 	}
 
+	if (!selectedItem.hasChildren) {
+		return false;
+	}
+
 	if (keyCode === 'Space') {
 		return true;
 	}
 
 	const isCollapsed = 'expanded' in selectedItem ? !selectedItem.expanded : collapsedFolderIds.includes(selectedItem.folder.id);
 	return (keyCode === 'ArrowRight') === isCollapsed;
+};
+
+const getParentOffset = (childIndex: number, listItems: ListItem[]): number|null => {
+	const childItem = listItems[childIndex];
+	const targetDepth = childItem.depth - 1;
+
+	let indexChange = 0;
+	for (let i = childIndex; i >= 0; i--) {
+		const otherItem = listItems[i];
+		if (otherItem.depth === targetDepth) {
+			return indexChange;
+		}
+		indexChange --;
+	}
+
+	return null;
 };
 
 const useOnSidebarKeyDownHandler = (props: Props) => {
@@ -48,12 +67,23 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 			} else if (selectedItem.kind === ListItemType.Header) {
 				toggleHeader(selectedItem.id);
 			}
-		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') { // ctrl+a or cmd+a
-			event.preventDefault();
+		} else if (selectedItem && event.code === 'ArrowLeft') { // Jump to parent
+			const isFolderWithParent = selectedItem.kind === ListItemType.Folder && selectedItem.folder.parent_id;
+			// For now, only allow this shortcut for folders with parents -- jumping to the tags or
+			// folders headers could be confusing.
+			if (isFolderWithParent) {
+				indexChange = getParentOffset(selectedIndex, listItems) ?? 0;
+			}
+		} else if (selectedItem && event.code === 'ArrowRight') { // Jump to first child
+			if (selectedItem.hasChildren) {
+				indexChange = 1;
+			}
 		} else if (event.code === 'ArrowUp') {
 			indexChange = -1;
 		} else if (event.code === 'ArrowDown') {
 			indexChange = 1;
+		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') { // ctrl+a or cmd+a
+			event.preventDefault();
 		} else if (event.code === 'Enter' && !event.shiftKey) {
 			event.preventDefault();
 			void CommandService.instance().execute('focusElement', 'noteList');

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -20,6 +20,8 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				kind: ListItemType.Tag,
 				tag,
 				key: tag.id,
+				depth: 1,
+				hasChildren: false,
 			};
 		});
 	}, [props.tags]);
@@ -38,7 +40,7 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				kind: ListItemType.Folder,
 				folder,
 				hasChildren,
-				depth,
+				depth: depth + 1,
 				key: folder.id,
 			};
 		});
@@ -57,11 +59,13 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				['data-folder-id']: '',
 			},
 			supportsFolderDrop: true,
+			depth: 0,
+			hasChildren: folderItems.items.length > 0,
 		};
 		const foldersSectionContent: ListItem[] = props.folderHeaderIsExpanded ? [
-			{ kind: ListItemType.AllNotes, key: 'all-notes' },
+			{ kind: ListItemType.AllNotes, key: 'all-notes', depth: 1, hasChildren: false },
 			...folderItems.items,
-			{ kind: ListItemType.Spacer, key: 'after-folders-spacer' },
+			{ kind: ListItemType.Spacer, key: 'after-folders-spacer', depth: 0, hasChildren: false },
 		] : [];
 
 		const tagsHeader: HeaderListItem = {
@@ -74,6 +78,8 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			onClick: toggleHeader,
 			extraProps: { },
 			supportsFolderDrop: false,
+			depth: 0,
+			hasChildren: tagItems.items.length > 0,
 		};
 		const tagsSectionContent: ListItem[] = props.tagHeaderIsExpanded ? tagItems.items : [];
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -40,7 +40,9 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				kind: ListItemType.Folder,
 				folder,
 				hasChildren,
-				depth: depth,
+				// The toplevel headers have depth 1, so the toplevel notebook needs
+				// depth 2.
+				depth: depth + 1,
 				key: folder.id,
 			};
 		});
@@ -59,13 +61,13 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				['data-folder-id']: '',
 			},
 			supportsFolderDrop: true,
-			depth: 0,
+			depth: 1,
 			hasChildren: folderItems.items.length > 0,
 		};
 		const foldersSectionContent: ListItem[] = props.folderHeaderIsExpanded ? [
-			{ kind: ListItemType.AllNotes, key: 'all-notes', depth: 1, hasChildren: false },
+			{ kind: ListItemType.AllNotes, key: 'all-notes', depth: 2, hasChildren: false },
 			...folderItems.items,
-			{ kind: ListItemType.Spacer, key: 'after-folders-spacer', depth: 0, hasChildren: false },
+			{ kind: ListItemType.Spacer, key: 'after-folders-spacer', depth: 1, hasChildren: false },
 		] : [];
 
 		const tagsHeader: HeaderListItem = {
@@ -78,7 +80,7 @@ const useSidebarListData = (props: Props): ListItem[] => {
 			onClick: toggleHeader,
 			extraProps: { },
 			supportsFolderDrop: false,
-			depth: 0,
+			depth: 1,
 			hasChildren: tagItems.items.length > 0,
 		};
 		const tagsSectionContent: ListItem[] = props.tagHeaderIsExpanded ? tagItems.items : [];

--- a/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts
@@ -40,7 +40,7 @@ const useSidebarListData = (props: Props): ListItem[] => {
 				kind: ListItemType.Folder,
 				folder,
 				hasChildren,
-				depth: depth + 1,
+				depth: depth,
 				key: folder.id,
 			};
 		});

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -11,6 +11,7 @@ import { _ } from '@joplin/lib/locale';
 import { connect } from 'react-redux';
 import EmptyExpandLink from './EmptyExpandLink';
 import ListItemWrapper, { ListItemRef } from './ListItemWrapper';
+import { ListItem } from '../types';
 const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 
 const Menu = bridge().Menu;
@@ -20,6 +21,7 @@ interface Props {
 	dispatch: Dispatch;
 	anchorRef: ListItemRef;
 	selected: boolean;
+	item: ListItem;
 	index: number;
 	itemCount: number;
 }
@@ -53,7 +55,7 @@ const AllNotesItem: React.FC<Props> = props => {
 			containerRef={props.anchorRef}
 			key="allNotesHeader"
 			selected={props.selected}
-			depth={1}
+			depth={props.item.depth}
 			className={'list-item-container list-item-depth-0 all-notes'}
 			highlightOnHover={true}
 			itemIndex={props.index}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -52,7 +52,7 @@ const HeaderItem: React.FC<Props> = props => {
 			itemCount={props.itemCount}
 			expanded={props.item.expanded}
 			onContextMenu={onContextMenu}
-			depth={0}
+			depth={item.depth}
 			highlightOnHover={false}
 			className='sidebar-header-container'
 			{...item.extraProps}

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -40,8 +40,7 @@ const ListItemWrapper: React.FC<Props> = props => {
 			aria-setsize={props.itemCount}
 			aria-selected={props.selected}
 			aria-expanded={props.expanded}
-			// aria-level is 1-based, where depth is zero-based
-			aria-level={props.depth + 1}
+			aria-level={props.depth}
 			tabIndex={props.selected ? 0 : -1}
 
 			onContextMenu={props.onContextMenu}

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -5,7 +5,10 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 16px);
+	// The top-level folder has depth 2, so we need to subtract for the item
+	// to have the correct padding
+	--absolute-depth: calc(var(--depth) - 2);
+	padding-left: calc(var(--joplin-main-padding) + (var(--absolute-depth) * 16px));
 	background: none;
 	transition: 0.1s;
 

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 16px);
+	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 32px);
 	background: none;
 	transition: 0.1s;
 

--- a/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/list-item-wrapper.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 32px);
+	padding-left: calc(var(--joplin-main-padding) + (var(--depth) * 16px) - 16px);
 	background: none;
 	transition: 0.1s;
 

--- a/packages/app-desktop/gui/Sidebar/types.ts
+++ b/packages/app-desktop/gui/Sidebar/types.ts
@@ -16,9 +16,15 @@ export enum ListItemType {
 
 interface BaseListItem {
 	key: string;
+	depth: number;
+	hasChildren: boolean;
 }
 
-export interface HeaderListItem extends BaseListItem {
+interface ToplevelListItem extends BaseListItem {
+	depth: 0;
+}
+
+export interface HeaderListItem extends ToplevelListItem {
 	kind: ListItemType.Header;
 	label: string;
 	expanded: boolean;
@@ -42,10 +48,9 @@ export interface FolderListItem extends BaseListItem {
 	kind: ListItemType.Folder;
 	folder: FolderEntity;
 	hasChildren: boolean;
-	depth: number;
 }
 
-export interface SpacerListItem extends BaseListItem {
+export interface SpacerListItem extends ToplevelListItem {
 	kind: ListItemType.Spacer;
 }
 

--- a/packages/app-desktop/gui/Sidebar/types.ts
+++ b/packages/app-desktop/gui/Sidebar/types.ts
@@ -21,7 +21,7 @@ interface BaseListItem {
 }
 
 interface ToplevelListItem extends BaseListItem {
-	depth: 0;
+	depth: 1;
 }
 
 export interface HeaderListItem extends ToplevelListItem {

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -59,10 +59,10 @@ test.describe('sidebar', () => {
 		await folderDHeader.dragTo(folderCHeader);
 
 		// Folders should have correct initial levels
-		await expect(folderAHeader).toHaveJSProperty('ariaLevel', '1');
-		await expect(folderBHeader).toHaveJSProperty('ariaLevel', '2');
-		await expect(folderCHeader).toHaveJSProperty('ariaLevel', '2');
-		await expect(folderDHeader).toHaveJSProperty('ariaLevel', '3');
+		await expect(folderAHeader).toHaveJSProperty('ariaLevel', '2');
+		await expect(folderBHeader).toHaveJSProperty('ariaLevel', '3');
+		await expect(folderCHeader).toHaveJSProperty('ariaLevel', '3');
+		await expect(folderDHeader).toHaveJSProperty('ariaLevel', '4');
 
 		await sidebar.forceUpdateSorting(electronApp);
 		await folderBHeader.click();

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -44,6 +44,48 @@ test.describe('sidebar', () => {
 		await expect(mainWindow.locator(':focus')).toHaveText('All notes');
 	});
 
+	test('left/right arrow keys should expand/collapse notebooks', async ({ electronApp, mainWindow }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		const sidebar = mainScreen.sidebar;
+
+		// Build the folder hierarchy
+		const folderAHeader = await sidebar.createNewFolder('Folder A');
+		await expect(folderAHeader).toBeVisible();
+		const folderBHeader = await sidebar.createNewFolder('Folder B');
+		const folderCHeader = await sidebar.createNewFolder('Folder C');
+		const folderDHeader = await sidebar.createNewFolder('Folder D');
+		await folderBHeader.dragTo(folderAHeader);
+		await folderCHeader.dragTo(folderAHeader);
+		await folderDHeader.dragTo(folderCHeader);
+
+		// Folders should have correct initial levels
+		await expect(folderAHeader).toHaveJSProperty('ariaLevel', '1');
+		await expect(folderBHeader).toHaveJSProperty('ariaLevel', '2');
+		await expect(folderCHeader).toHaveJSProperty('ariaLevel', '2');
+		await expect(folderDHeader).toHaveJSProperty('ariaLevel', '3');
+
+		await sidebar.forceUpdateSorting(electronApp);
+		await folderBHeader.click();
+
+		// Pressing [left] on a folder with no children should jump to its parent
+		await mainWindow.keyboard.press('ArrowLeft');
+		await expect(mainWindow.locator(':focus')).toHaveText('Folder A');
+
+		// Pressing [left] again should collapse the folder
+		await expect(folderAHeader).toHaveJSProperty('ariaExpanded', 'true');
+		await mainWindow.keyboard.press('ArrowLeft');
+		await expect(folderAHeader).toHaveJSProperty('ariaExpanded', 'false');
+		// Should still be focused
+		await expect(mainWindow.locator(':focus')).toHaveText('Folder A');
+
+		// Pressing [right] on a collapsed folder should expand it
+		await mainWindow.keyboard.press('ArrowRight');
+		await expect(folderAHeader).toHaveJSProperty('ariaExpanded', 'true');
+		// Pressing [right] again should move to the next item
+		await mainWindow.keyboard.press('ArrowRight');
+		await expect(mainWindow.locator(':focus')).toHaveText('Folder B');
+	});
+
 	test('should allow changing the parent of a folder by drag-and-drop', async ({ electronApp, mainWindow }) => {
 		const mainScreen = await new MainScreen(mainWindow).setup();
 		const sidebar = mainScreen.sidebar;


### PR DESCRIPTION
# Summary

This pull request adjusts the behavior of the <kbd>left</kbd> and <kbd>right</kbd> arrow keys in the notebook sidebar. In particular,
- <kbd>left</kbd>: If focus is on a collapsed notebook, focus moves to the parent notebook. 
- <kbd>right</kbd>: If focus is on an expanded notebook (or one of the "notebook"/"tag" headings), focus jumps to the first item within the notebook.

This makes Joplin more closely follow the [Tree View Pattern (ARIA Authoring Practices Guide)](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/).

See the [relevant forum post](https://discourse.joplinapp.org/t/accessibility-desktop-expand-collapse-notebooks-and-sub-notebooks-without-root-focus/44044/2?u=personalizedrefriger).


# Testing

This pull request includes an automated Playwright test.

## Screen reader transcript


<details><summary>Transcript from Orca on Fedora 41 Linux:</summary>

**Note**: In the test app, the folder structure is the following:
1. All notes
2. Test
   1. Test 2
      3. Sub
   2. Test 3
2. Trash

```
Sub.
tree level 4
down
Test 3.
tree level 3
down
Trash.
tree level 2
There are no notes in the trash folder.
up
Test 3.
tree level 3
No notes in here.
 Create one by clicking on  New note .
up
Sub.
tree level 4
left
Test 2 Expanded, press space to collapse.
expanded.
tree level 3
left
collapsed
Test 2 Collapsed, press space to expand.
left
Test Contains 1 note Expanded, press space to collapse.
expanded.
tree level 2
Tab moves focus
left
collapsed
Test Contains 1 note Collapsed, press space to expand.
left
up
All notes.
up
NOTEBOOKS.
expanded.
tree level 1
right
All notes.
tree level 2
down
Test Contains 1 note Collapsed, press space to expand.
collapsed.
down
Trash.
There are no notes in the trash folder.
```
</details>
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->