### PR TITLE
Desktop: Fixes #11823: Fixed "cancel" behavior when switching config screens

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -148,6 +148,8 @@ class ConfigScreenComponent extends React.Component<any, any> {
 				const ok = await shim.showConfirmationDialog(_('This will open a new screen. Save your current changes?'));
 				if (ok) {
 					await shared.saveSettings(this);
+				} else {
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
Issue #11823 describes behavior where clicking cancel on the dialog "This will open a new screen. Save your current changes?" switches screens anyway and retains changes. Added "else" statement to return the switchSection function on cancel before it reaches `this.setState({ selectedSectionName: section.name, screenName: screenName });`.

I had a typo in my Github email address so it did not recognize me as a contributor in the previous PR. Re-submitting with corrected email.