### PR TITLE
Mobile: Accessibility: Fix "new note" and "new to-do" buttons are focusable even while invisible

### DIFF
--- a/.yarn/patches/react-native-paper-npm-5.13.1-f153e542e2.patch
+++ b/.yarn/patches/react-native-paper-npm-5.13.1-f153e542e2.patch
@@ -1,0 +1,50 @@
+# This is a (hopefully temporary) fix for an accessibility issue in the FAB.Group
+# component. See https://github.com/callstack/react-native-paper/pull/4498 for details.
+diff --git a/lib/commonjs/components/FAB/FABGroup.js b/lib/commonjs/components/FAB/FABGroup.js
+index 26933dd7ac6862c0dd95e52b8cd91c8bbd0b6efc..417c91a0257849eb597afb5e339e13b6d1d54486 100644
+--- a/lib/commonjs/components/FAB/FABGroup.js
++++ b/lib/commonjs/components/FAB/FABGroup.js
+@@ -209,8 +209,9 @@ const FABGroup = _ref => {
+       }],
+       pointerEvents: open ? 'box-none' : 'none',
+       accessibilityRole: "button",
+-      importantForAccessibility: "yes",
+-      accessible: true,
++      importantForAccessibility: open ? 'yes' : 'no-hide-descendants',
++      accessibilityElementsHidden: !open,
++      accessible: open,
+       accessibilityLabel: accessibilityLabel
+     }, it.label && /*#__PURE__*/React.createElement(_reactNative.View, null, /*#__PURE__*/React.createElement(_Card.default, {
+       mode: isV3 ? 'contained' : 'elevated',
+diff --git a/lib/module/components/FAB/FABGroup.js b/lib/module/components/FAB/FABGroup.js
+index ca5c02679539b17b048d4c82f570791dd8b57545..a06902b744b3bfb06b0644930eda0ba2ce2967ca 100644
+--- a/lib/module/components/FAB/FABGroup.js
++++ b/lib/module/components/FAB/FABGroup.js
+@@ -200,8 +200,9 @@ const FABGroup = _ref => {
+       }],
+       pointerEvents: open ? 'box-none' : 'none',
+       accessibilityRole: "button",
+-      importantForAccessibility: "yes",
+-      accessible: true,
++      importantForAccessibility: open ? 'yes' : 'no-hide-descendants',
++      accessibilityElementsHidden: !open,
++      accessible: open,
+       accessibilityLabel: accessibilityLabel
+     }, it.label && /*#__PURE__*/React.createElement(View, null, /*#__PURE__*/React.createElement(Card, {
+       mode: isV3 ? 'contained' : 'elevated',
+diff --git a/src/components/FAB/FABGroup.tsx b/src/components/FAB/FABGroup.tsx
+index af1e85c4cbabfdd05499f9befb9f851be5911835..d010393975b0b31852efba1b7ce9cb09da4feaec 100644
+--- a/src/components/FAB/FABGroup.tsx
++++ b/src/components/FAB/FABGroup.tsx
+@@ -383,8 +383,9 @@ const FABGroup = ({
+                 ]}
+                 pointerEvents={open ? 'box-none' : 'none'}
+                 accessibilityRole="button"
+-                importantForAccessibility="yes"
+-                accessible={true}
++                importantForAccessibility={open ? 'yes' : 'no-hide-descendants'}
++                accessibilityElementsHidden={!open}
++                accessible={open}
+                 accessibilityLabel={accessibilityLabel}
+               >
+                 {it.label && (

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "rn-fetch-blob@0.12.0": "patch:rn-fetch-blob@npm%3A0.12.0#./.yarn/patches/rn-fetch-blob-npm-0.12.0-cf02e3c544.patch",
     "app-builder-lib@26.0.0-alpha.7": "patch:app-builder-lib@npm%3A26.0.0-alpha.7#./.yarn/patches/app-builder-lib-npm-26.0.0-alpha.7-e1b3dca119.patch",
     "app-builder-lib@24.13.3": "patch:app-builder-lib@npm%3A24.13.3#./.yarn/patches/app-builder-lib-npm-24.13.3-86a66c0bf3.patch",
-    "react-native-sqlite-storage@6.0.1": "patch:react-native-sqlite-storage@npm%3A6.0.1#./.yarn/patches/react-native-sqlite-storage-npm-6.0.1-8369d747bd.patch"
+    "react-native-sqlite-storage@6.0.1": "patch:react-native-sqlite-storage@npm%3A6.0.1#./.yarn/patches/react-native-sqlite-storage-npm-6.0.1-8369d747bd.patch",
+    "react-native-paper@5.13.1": "patch:react-native-paper@npm%3A5.13.1#./.yarn/patches/react-native-paper-npm-5.13.1-f153e542e2.patch"
   }
 }

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -62,7 +62,7 @@
     "react-native-image-picker": "7.1.1",
     "react-native-localize": "3.2.1",
     "react-native-modal-datetime-picker": "17.1.0",
-    "react-native-paper": "5.12.5",
+    "react-native-paper": "5.13.1",
     "react-native-popup-menu": "0.16.1",
     "react-native-quick-actions": "0.3.13",
     "react-native-quick-crypto": "0.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8426,7 +8426,7 @@ __metadata:
     react-native-image-picker: 7.1.1
     react-native-localize: 3.2.1
     react-native-modal-datetime-picker: 17.1.0
-    react-native-paper: 5.12.5
+    react-native-paper: 5.13.1
     react-native-popup-menu: 0.16.1
     react-native-quick-actions: 0.3.13
     react-native-quick-crypto: 0.7.5
@@ -39983,9 +39983,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-paper@npm:5.12.5":
-  version: 5.12.5
-  resolution: "react-native-paper@npm:5.12.5"
+"react-native-paper@npm:5.13.1":
+  version: 5.13.1
+  resolution: "react-native-paper@npm:5.13.1"
   dependencies:
     "@callstack/react-theme-provider": ^3.0.9
     color: ^3.1.2
@@ -39995,7 +39995,23 @@ __metadata:
     react-native: "*"
     react-native-safe-area-context: "*"
     react-native-vector-icons: "*"
-  checksum: 35ce56e0bb19c46ce85adc47a504527b7ec455d1a15f3ace0d6fd438abd51b1fe30e1b44351950e16d6376ddbc18ecc94b558e267767d0a9fd886a5f66a4c322
+  checksum: ef16fbb57986f09f2080e98ddb7977c494d6accb36767101de32199849bba8764e2bcd528a5d1c08940f4430cb86dabb6baaf5b33a539670221cbbfcc01f2d5e
+  languageName: node
+  linkType: hard
+
+"react-native-paper@patch:react-native-paper@npm%3A5.13.1#./.yarn/patches/react-native-paper-npm-5.13.1-f153e542e2.patch::locator=root%40workspace%3A.":
+  version: 5.13.1
+  resolution: "react-native-paper@patch:react-native-paper@npm%3A5.13.1#./.yarn/patches/react-native-paper-npm-5.13.1-f153e542e2.patch::version=5.13.1&hash=3fecbb&locator=root%40workspace%3A."
+  dependencies:
+    "@callstack/react-theme-provider": ^3.0.9
+    color: ^3.1.2
+    use-latest-callback: ^0.1.5
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-safe-area-context: "*"
+    react-native-vector-icons: "*"
+  checksum: 381a35e3b26a177e2299fd0ce597e5b7bd0626276dc0116cc3eb1e0217634977c2f957c1985bb5938b1c88b4f1566273fa494c8a6bb6eb2a05c18f9a963e2743
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades and patches `react-native-paper`. This is done to fix a focus issue that has been reported a few times on the forum and Mastodon.

See also:
- A work-in-progress [pull request that switches to a custom component for the new note menu](https://github.com/laurent22/joplin/pull/11780).
   - This pull request can be reverted after the custom component PR has been merged.
- The [(unmerged) upstream pull request](https://github.com/callstack/react-native-paper/pull/4498), which describes the issue.

> [!NOTE]
>
> **Notes**:
> - This only applies to Android and iOS. This does not fix the issue on web. This also only fixes the focus issue. It does not label the fullscreen close button shown behind the menu items.
> - This pull request should also apply without the React Native Paper upgrade. The version bump was included to prevent https://github.com/laurent22/joplin/pull/11826  from needing to migrate the patch (#11826 includes an RN Paper upgrade).

# Testing plan

**Android 13:**
1. Enable TalkBack.
2. Open the sidemenu.
3. Move focus to the "Synchronize" button.
4. Swipe to the right.
5. Verify that this moves focus to the "collapsed, add new, button".
6. Double-tap
7. Verify that TalkBack reads "expanded".
8. Swipe left.
9. Verify that TalkBack moves focus to "New note, button".
   - **Note**: It may make more sense for "new note, button" to be **after** the "add new, button" in the focus order. This, however, would require a larger patch. Would it make sense to try to address that here?
10. Swipe left.
11. Verify that TalkBack moves focus to "New to-do, button".
12. Double-tap.
13. Verify that TalkBack reads "editing, add title, edit box"
14. Open a note in view mode.
15. Click the "edit" button.
16. Verify that this switches the note to edit mode.

**iOS 18 .1 simulator:**
1. Enable VoiceOver in MacOS system settings.
2. Move VoiceOver focus into the simulator.
3. Move focus to the last note before the "add new" button.
4. Move focus to the next item.
5. Verify that VoiceOver reads "collapsed Add new, button".
6. Press <kbd>ctrl</kbd>-<kbd>option</kbd>-<kbd>space</kbd>.
7. Verify that VoiceOver reads "Expanded, add new, button".
8. Move focus to the previous item.
9. Verify that this moves focus to "New note, button".
10. Press  <kbd>ctrl</kbd>-<kbd>option</kbd>-<kbd>space</kbd>.
11. Verify that this creates a new note and focuses the title.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->