### PR TITLE
Desktop: Fix adding tags to a note through drag-and-drop

### DIFF
--- a/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/ListItemWrapper.tsx
@@ -23,6 +23,7 @@ interface Props {
 	draggable?: boolean;
 	'data-folder-id'?: string;
 	'data-id'?: string;
+	'data-tag-id'?: string;
 	'data-type'?: ModelType;
 }
 
@@ -55,6 +56,7 @@ const ListItemWrapper: React.FC<Props> = props => {
 			style={style}
 			data-folder-id={props['data-folder-id']}
 			data-id={props['data-id']}
+			data-tag-id={props['data-tag-id']}
 			data-type={props['data-type']}
 		>
 			{props.children}


### PR DESCRIPTION
# Summary

This pull request adds a previously-missing property to tag items in the tag list. This missing property prevented assigning tags through drag-and-drop from working.

See [the issue report on the forum for details](https://discourse.joplinapp.org/t/tagging-broken-on-one-client-only/44127).

# Testing plan

**Fedora 41 Linux**:
1. Create a new note.
2. Drag the note from the note list to a tag in the tag list.
3. Drop the note.
4. Verify that the note is now associated with the tag from step 2.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->