### PR TITLE
Desktop: Accessibility: Improve "toggle all notebooks" accessibility

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -22,6 +22,8 @@ interface CollapseExpandAllButtonProps {
 }
 
 const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
+	// To allow it to be accessed by accessibility tools, the toggle button
+	// is not included in the portion of the list with role='tree'.
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
 	const label = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -22,13 +22,16 @@ interface CollapseExpandAllButtonProps {
 }
 
 const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
-	// To allow it to be accessed by accessibility tools, the new folder button
-	// is not included in the portion of the list with role='tree'.
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
+	const title = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
 
-	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall'>
+	return <button
+		onClick={() => onToggleAllFolders(props.allFoldersCollapsed)}
+		className='sidebar-header-button -collapseall'
+		title={title}
+	>
 		<i
-			aria-label={_('Collapse / Expand all notebooks')}
+			aria-label={title}
 			role='img'
 			className={icon}
 		/>

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -23,15 +23,11 @@ interface CollapseExpandAllButtonProps {
 
 const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
-	const title = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
+	const label = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
 
-	return <button
-		onClick={() => onToggleAllFolders(props.allFoldersCollapsed)}
-		className='sidebar-header-button -collapseall'
-		title={title}
-	>
+	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall'>
 		<i
-			aria-label={title}
+			aria-label={label}
 			role='img'
 			className={icon}
 		/>


### PR DESCRIPTION
# Summary

This pull request improves the accessibility of the "toggle all notebooks" button by improving the accessible description.

Previously, some information was presented only visually — whether the button expands or collapses notebooks. This pull request adds that information to the label.

The label change also causes screen readers to announce the change in the button's description, letting users know that something changed (related: [WCAG 2.2 guidance on status messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html)).

# Testing plan

**Fedora 41 Linux/Orca**:
1. Enable Orca
2. Start Joplin
3. Verify that all notebooks are collapsed
4. Focus to a toplevel notebook that's visible in the sidebar
5. Move focus to the "Expand all notebooks button"
6. Press <kbd>enter</kbd>.
7. Verify that Orca reads "Collapse all notebooks".
8. Press <kbd>enter</kbd>.
9. Verify that Orca reads "Expand all notebooks".
8. Press <kbd>enter</kbd>.
7. Verify that Orca reads "Collapse all notebooks".

<details><summary>Screen reader output</summary>

```
left shift
Test Shared Contains 3 notes Collapsed, press space to expand.
collapsed.
tree level 2
Focus mode
left shift
New notebook button
Browse mode
Expand all notebooks button
return
Collapse all notebooks
return
Expand all notebooks
return
Collapse all notebooks
```

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->