### PR TITLE
iOS: Accessibility: Fix plugins can't be installed using VoiceOver

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -81,10 +81,11 @@ const PluginBox: React.FC<Props> = props => {
 	const styles = useStyles(props.isCompatible);
 
 	const CardWrapper = props.onShowPluginInfo ? TouchableRipple : View;
+	const containerIsButton = !!props.onShowPluginInfo;
 	return (
 		<CardWrapper
-			accessibilityRole={props.onShowPluginInfo ? 'button' : null}
-			accessible={true}
+			accessibilityRole={containerIsButton ? 'button' : null}
+			accessible={containerIsButton}
 			onPress={props.onShowPluginInfo ? onPress : null}
 			style={styles.cardContainer}
 		>


### PR DESCRIPTION
# Summary

This pull request fixes an issue where buttons within an installable plugin's card were not focusable using VoiceOver (they worked as expected using TalkBack on Android). If VoiceOver is considered a "keyboard interface", this may be related to [WCAG 2.2's SC 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).

The issue was caused by the card wrapper having  `accessible=true`, which prevented VoiceOver from focusing elements within the card. With this pull request, the card is marked `accessible=true` only when the full card is clickable (when the plugin is already installed).

# Testing plan

Manual testing (iOS 18.1 simulator):
1. Move VoiceOver focus to an installed plugin's card.
2. Activate it with ctrl-option-space.
3. Verify that this shows a dialog.
4. Close the dialog and search for "Rich" in the plugin search.
5. Move focus to Rich Markdown's 'Install' button.
   - Verify that VoiceOver describes this button as "Install Rich Markdown, button".
6. Install Rich Markdown using VoiceOver (activate the button with ctrl-option-space).
7. Verify that this installs Rich Markdown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->