### PR TITLE
All : Fix for Share with Nobody : Added proper error message

### DIFF
--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -329,7 +329,7 @@ export default class ShareService {
 		let recipientMasterKey: MasterKeyEntity = null;
 
 		if (getEncryptionEnabled()) {
-			if (!recipientEmail) throw new Error(_('Kindly provide proper recipient address'));
+			if (!recipientEmail) throw new Error(_('Please provide the recipient email'));
 			const syncInfo = localSyncInfo();
 			const masterKey = syncInfo.masterKeys.find(m => m.id === masterKeyId);
 			if (!masterKey) throw new Error(`Cannot find master key with ID "${masterKeyId}"`);

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -329,8 +329,7 @@ export default class ShareService {
 		let recipientMasterKey: MasterKeyEntity = null;
 
 		if (getEncryptionEnabled()) {
-			if(!recipientEmail) throw new Error(_('Kindly provide proper recipient address'));
-			
+			if (!recipientEmail) throw new Error(_('Kindly provide proper recipient address'));
 			const syncInfo = localSyncInfo();
 			const masterKey = syncInfo.masterKeys.find(m => m.id === masterKeyId);
 			if (!masterKey) throw new Error(`Cannot find master key with ID "${masterKeyId}"`);

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -329,6 +329,8 @@ export default class ShareService {
 		let recipientMasterKey: MasterKeyEntity = null;
 
 		if (getEncryptionEnabled()) {
+			if(!recipientEmail) throw new Error(_('Kindly provide proper recipient address'));
+			
 			const syncInfo = localSyncInfo();
 			const masterKey = syncInfo.masterKeys.find(m => m.id === masterKeyId);
 			if (!masterKey) throw new Error(`Cannot find master key with ID "${masterKeyId}"`);


### PR DESCRIPTION
**Summary :** 

- All: Resolves #11923 - Fix added with Proper error message - "Kindly provide proper recipient address"

This pull request contains fix which throws error with message "Kindly provide proper recipient address", so that user will know the issue and act accordingly. Added screenshots below.

![image](https://github.com/user-attachments/assets/3d723d2d-83fb-4a26-87ba-6b418b8aee91)

Manual Test Process :
1. Configure Synchronization target as Joplin server.
2. Click and open "Share notebook" dialog under "Notebook" menu.
3. Enter nothing under "Add recipient" Text box, Click share.
4. You will see the proper message associated with it.
