### PR TITLE
All: add giflib to devbox dependencies

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -25,7 +25,8 @@
       "version":            "latest",
       "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
     },
-    "git": "latest",
+    "git":    "latest",
+    "giflib": "latest",
   },
   "shell": {
     "init_hook": [


### PR DESCRIPTION
**Operating System**: Linux Mint

The dependency canvas@npm:2.11.2 wouldn't compile because of a missing header file, namely <gif_lib.h>. See [build.log](https://github.com/user-attachments/files/19108490/canvas-build.log).
This PR adds giflib@latest to devbox, which resolves this issue.