### PR TITLE
Android: Voice typing: Fix potential output duplication when finalizing voice typing

### DIFF
--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -121,6 +121,7 @@ class Whisper implements VoiceTypingSession {
 				logger.debug('reading block');
 				const data: string = await SpeechToTextModule.convertNext(this.sessionId, 4);
 				this.onDataFinalize(data);
+				this.lastPreviewData = '';
 
 				logger.debug('done reading block. Length', data?.length);
 				if (this.sessionId !== null) {

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -107,8 +107,8 @@ class Whisper implements VoiceTypingSession {
 			this.callbacks.onFinalize(`${prefix}${data}`);
 			this.isFirstParagraph = false;
 			// The output draft usually contains some of the data being finalized.
-			// Clear it to prevent duplicate output (allows the last draft to be
-			// finalized)
+			// Clear it to prevent duplicate output should `outputDraft` be added
+			// to the note.
 			this.outputDraft = '';
 		}
 	}

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -75,9 +75,11 @@ class WhisperConfig {
 }
 
 class Whisper implements VoiceTypingSession {
-	private lastPreviewData = '';
 	private closeCounter = 0;
 	private isFirstParagraph = true;
+	// Voice typing output that hasn't been added to the document yet --
+	// this is usually the data last shown in the preview window.
+	private outputDraft = '';
 
 	public constructor(
 		private sessionId: number|null,
@@ -104,6 +106,10 @@ class Whisper implements VoiceTypingSession {
 			const prefix = this.isFirstParagraph ? '' : '\n\n';
 			this.callbacks.onFinalize(`${prefix}${data}`);
 			this.isFirstParagraph = false;
+			// The output draft usually contains some of the data being finalized.
+			// Clear it to prevent duplicate output (allows the last draft to be
+			// finalized)
+			this.outputDraft = '';
 		}
 	}
 
@@ -121,17 +127,16 @@ class Whisper implements VoiceTypingSession {
 				logger.debug('reading block');
 				const data: string = await SpeechToTextModule.convertNext(this.sessionId, 4);
 				this.onDataFinalize(data);
-				this.lastPreviewData = '';
 
 				logger.debug('done reading block. Length', data?.length);
 				if (this.sessionId !== null) {
-					this.lastPreviewData = await SpeechToTextModule.getPreview(this.sessionId);
-					this.callbacks.onPreview(this.postProcessSpeech(this.lastPreviewData));
+					this.outputDraft = await SpeechToTextModule.getPreview(this.sessionId);
+					this.callbacks.onPreview(this.postProcessSpeech(this.outputDraft));
 				}
 			}
 		} catch (error) {
 			logger.error('Whisper error:', error);
-			this.lastPreviewData = '';
+			this.outputDraft = '';
 			await this.stop();
 			throw error;
 		}
@@ -148,8 +153,8 @@ class Whisper implements VoiceTypingSession {
 		this.sessionId = null;
 		this.closeCounter ++;
 
-		if (this.lastPreviewData) {
-			this.onDataFinalize(this.lastPreviewData);
+		if (this.outputDraft) {
+			this.onDataFinalize(this.outputDraft);
 		}
 
 		return SpeechToTextModule.closeSession(sessionId);


### PR DESCRIPTION
# Summary

This pull request should fix an issue where, during voice typing, the last output could be duplicated.

# Testing plan

1. Start voice typing with the `whisper-tiny` model.
2. Speak until content is shown in the preview.
3. Click "stop" before the content is added to the document.
4. Verify that the content is added to the document only once.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->