### PR TITLE
Mobile: Accessibility: Make default modal close button accessible

### DIFF
--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -61,9 +61,6 @@ const useStyles = (hasScrollView: boolean, backgroundColor: string|undefined) =>
 				width: '100%',
 				zIndex: -1,
 			},
-			dismissButtonFocused: {
-				backgroundColor,
-			},
 		});
 	}, [hasScrollView, isLandscape, backgroundColor]);
 };


### PR DESCRIPTION
# Summary

It's possible for sighted users to dismiss most Joplin modals by clicking in the modal background region. This pull request makes it possible to dismiss dialogs in a similar way using VoiceOver and TalkBack.

**Goal**: Make it possible for VoiceOver/TalkBack to use a button-like control that was previously only usable with a touchscreen/mouse.

# Testing plan

**Android 13**: 
1. Enable TalkBack and open the "sort notes by" dialog.
2. Move accessibility focus to the item after "show completed to-dos, checkbox".
3. Verify that TalkBack describes the focused item as "Close dialog, button".
4. Double-tap.
5. Verify that this closes the "sort notes by" dialog.
6. Open a plugin info dialog.
7. Move focus to the last item ("Close dialog, button").
8. Double-tap.
9. Verify that the plugin info dialog has been dismissed.
10. Disable TalkBack.

**iOS 18**:
1. Enable VoiceOver.
2. Open the "sort notes by" dialog.
3. Move focus to the item after "Show completed to-dos"
4. Verify that VoiceOver reads "Close dialog, button"
5. Double-tap.
6. Verify that the "sort notes by" dialog has been dismissed.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->