### PR TITLE
iOS: Accessibility: Fix focus gets stuck on "Attach" in the note actions menu

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -92,8 +92,8 @@ const MenuComponent: React.FC<Props> = props => {
 			);
 		} else {
 			// Don't auto-focus on iOS -- as of RN 0.74, this causes focus to get stuck. However,
-			// the auto-focus seems to be necessary on web (and possibly Android) to avoid focusing
-			// the dismiss button first:
+			// the auto-focus seems to be necessary on web (and possibly Android) to avoid first focusing
+			// the dismiss button and other items not in the menu:
 			const canAutoFocus = isFirst && Platform.OS !== 'ios';
 			const key = `menuOption_${option.key ?? keyCounter++}`;
 			menuOptionComponents.push(

--- a/packages/app-mobile/components/ScreenHeader/Menu.tsx
+++ b/packages/app-mobile/components/ScreenHeader/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
-import { StyleSheet, TextStyle, View, Text, ScrollView, useWindowDimensions } from 'react-native';
+import { StyleSheet, TextStyle, View, Text, ScrollView, useWindowDimensions, Platform } from 'react-native';
 import { themeStyle } from '../global-style';
 import { Menu, MenuOption as MenuOptionComponent, MenuOptions, MenuTrigger } from 'react-native-popup-menu';
 import AccessibleView from '../accessibility/AccessibleView';
@@ -91,7 +91,10 @@ const MenuComponent: React.FC<Props> = props => {
 				<View key={`menuOption_divider_${keyCounter++}`} style={styles.divider} />,
 			);
 		} else {
-			const canAutoFocus = isFirst;
+			// Don't auto-focus on iOS -- as of RN 0.74, this causes focus to get stuck. However,
+			// the auto-focus seems to be necessary on web (and possibly Android) to avoid focusing
+			// the dismiss button first:
+			const canAutoFocus = isFirst && Platform.OS !== 'ios';
 			const key = `menuOption_${option.key ?? keyCounter++}`;
 			menuOptionComponents.push(
 				<MenuOptionComponent value={option.onPress} key={key} style={styles.contextMenuItem} disabled={!!option.disabled}>


### PR DESCRIPTION
# Summary

Prior to this pull request, opening the note actions menu caused focus to become stuck on the "Attach..." action. When this happened, left and right swipes did not move the focus to the next/previous items until the user tapped somewhere on the screen. After tapping somewhere, focus was again able to move to other items in the note actions (kebab) menu.

This issue was observed on a physical iOS device that may be a regression from https://github.com/laurent22/joplin/pull/11929.

# Testing plan

**iOS 18** (physical device):
1. Enable VoiceOver.
2. Open a note.
3. Open the note actions menu.
4. Move focus to the "Actions" button.
5. Double-tap.
6. Verify that focus moves to "Attach...".
7. Swipe right.
8. Verify that VoiceOver reads "Draw picture".
9. Swipe left twice.
10. Verify that VoiceOver reads "Dismiss, button".
11. Double-tap.
12. Verify that the note actions menu has been dismissed.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->