### PR TITLE
Web: Accessibility: Fix "sort notes by" button is sometimes not keyboard focusable

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -502,15 +502,15 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		function sortButton(styles: any, onPress: OnPressCallback) {
 			return (
-				<TouchableOpacity
+				<IconButton
 					onPress={onPress}
+					themeId={themeId}
 
-					accessibilityLabel={_('Sort notes by')}
-					accessibilityRole="button">
-					<View style={styles.iconButton}>
-						<Icon name="filter-outline" style={styles.topIcon} />
-					</View>
-				</TouchableOpacity>
+					description={_('Sort notes by')}
+					iconName='ionicon filter-outline'
+					contentWrapperStyle={styles.iconButton}
+					iconStyle={styles.topIcon}
+				/>
 			);
 		}
 


### PR DESCRIPTION
# Summary

Before this pull request, the "sort notes by" button could become inaccessible by keyboard after:
1. Opening the sort by dialog with the keyboard (focusing "sort notes by", then pressing <kbd>enter</kbd>), then
2. Pressing <kbd>shift</kbd>-<kbd>tab</kbd>.
3. Pressing <kbd>tab</kbd>.

In this case, focus would skip the "sort notes by" button and jump to the notes list.

Switching from a `TouchableOpacity` to an `IconButton` (matching most other toolbar buttons) seems to fix the issue.

# Testing plan

1.  Open Joplin Web in Chromium.
5. Move focus to the "sort notes by" button.
6. Press <kbd>enter</kbd>.
7. Verify that this shows the "sort notes by" dialog.
8. Press <kbd>escape</kbd>.
9. Verify that this hides the "sort notes by" dialog.
10. Press <kbd>shift</kbd>-<kbd>tab</kbd>.
11. Press <kbd>tab</kbd>.
12. Verify that the "sort notes by" button is focused.
13. Press <kbd>enter</kbd>.
14. Verify that this opens the "sort notes by" dialog.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->