### PR TITLE
Android: Resolves #11956: Voice typing: Transcribe more unprocessed audio after pressing "done"

### DIFF
--- a/packages/app-mobile/components/voiceTyping/RecordingControls.tsx
+++ b/packages/app-mobile/components/voiceTyping/RecordingControls.tsx
@@ -43,12 +43,15 @@ const styles = StyleSheet.create({
 
 const RecordingControls: React.FC<Props> = props => {
 	const renderIcon = () => {
+		const loadingIcon: IconSource = ({ size }: { size: number }) => {
+			return <ActivityIndicator animating={true} style={{ width: size, height: size }} />;
+		};
 		const components: Record<RecorderState, IconSource> = {
-			[RecorderState.Loading]: ({ size }: { size: number }) => <ActivityIndicator animating={true} style={{ width: size, height: size }} />,
+			[RecorderState.Loading]: loadingIcon,
 			[RecorderState.Recording]: 'microphone',
 			[RecorderState.Idle]: 'microphone',
-			[RecorderState.Processing]: 'microphone',
-			[RecorderState.Downloading]: ({ size }: { size: number }) => <ActivityIndicator animating={true} style={{ width: size, height: size }} />,
+			[RecorderState.Processing]: loadingIcon,
+			[RecorderState.Downloading]: loadingIcon,
 			[RecorderState.Error]: 'alert-circle-outline',
 		};
 

--- a/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
+++ b/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
@@ -19,6 +19,7 @@ export interface SpeechToTextCallbacks {
 export interface VoiceTypingSession {
 	start(): Promise<void>;
 	stop(): Promise<void>;
+	cancel(): Promise<void>;
 }
 
 export interface BuildProviderOptions {

--- a/packages/app-mobile/services/voiceTyping/vosk.android.ts
+++ b/packages/app-mobile/services/voiceTyping/vosk.android.ts
@@ -154,6 +154,14 @@ export const startRecording = (vosk: Vosk, options: StartOptions): VoiceTypingSe
 		completeRecording(e.data, null);
 	}));
 
+	const stopOrCancel = () => {
+		if (state_ === State.Recording) {
+			logger.info('Cancelling...');
+			state_ = State.Completing;
+			vosk.stopOnly();
+			completeRecording('', null);
+		}
+	};
 
 	return {
 		start: async () => {
@@ -161,12 +169,10 @@ export const startRecording = (vosk: Vosk, options: StartOptions): VoiceTypingSe
 			await vosk.start();
 		},
 		stop: async () => {
-			if (state_ === State.Recording) {
-				logger.info('Cancelling...');
-				state_ = State.Completing;
-				vosk.stopOnly();
-				completeRecording('', null);
-			}
+			stopOrCancel();
+		},
+		cancel: async () => {
+			stopOrCancel();
 		},
 	};
 };

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -103,10 +103,6 @@ class Whisper implements VoiceTypingSession {
 			const prefix = this.isFirstParagraph ? '' : '\n\n';
 			this.callbacks.onFinalize(`${prefix}${data}`);
 			this.isFirstParagraph = false;
-			// The output draft usually contains some of the data being finalized.
-			// Clear it to prevent duplicate output should `outputDraft` be added
-			// to the note.
-			this.outputDraft = '';
 		}
 	}
 

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -75,7 +75,6 @@ class WhisperConfig {
 }
 
 class Whisper implements VoiceTypingSession {
-	private lastPreviewData = '';
 	private closeCounter = 0;
 	private isFirstParagraph = true;
 
@@ -124,13 +123,12 @@ class Whisper implements VoiceTypingSession {
 
 				logger.debug('done reading block. Length', data?.length);
 				if (this.sessionId !== null) {
-					this.lastPreviewData = await SpeechToTextModule.getPreview(this.sessionId);
-					this.callbacks.onPreview(this.postProcessSpeech(this.lastPreviewData));
+					const previewText = await SpeechToTextModule.getPreview(this.sessionId);
+					this.callbacks.onPreview(this.postProcessSpeech(previewText));
 				}
 			}
 		} catch (error) {
 			logger.error('Whisper error:', error);
-			this.lastPreviewData = '';
 			await this.cancel();
 			throw error;
 		}


### PR DESCRIPTION
# Summary

This pull request updates the Android voice typing logic to finish transcription of buffered audio data after clicking "done".

**Partially** resolves #11956.

> [!NOTE]
>
> This does not fully resolve #11956 — some speech may still remain untranscribed if there are more than about 30 seconds of untranscribed data (more data than the maximum buffer/processing size). 
>
> A full solution will likely involve:
> - Increasing `maxLengthSeconds` in `AudioRecorder.kt`
> - Either:
>    1. Calling `processAvailable` multiple times in `whisper.ts`, until all buffered data has been transcribed.
>    2. Modifying `processAvailable` to run transcription multiple times (until all buffered data has been transcribed).


# Testing plan

## Manual regression testing

**Android 13**:
1. In settings, set the voice typing provider to Vosk.
2. Open a note and start voice typing.
3. Say something. Wait for it to be added to the note.
4. Click "done".
5. Verify that the voice typing dialog closes successfully.

## Testing the new changes

**Android 13**:
1. In settings, switch the voice typing provider to Whisper.
2. Open a note and start voice typing.
3. Speak until the preview updates with text.
4. Speak for a few seconds longer.
5. Click "done".
6. Verify that a loading indicator is shown.
7. Verify that the words spoken just before pressing "done" were added to the note as a part of the transcription.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->