### PR TITLE
Desktop: Accessibility: Add a menu item that moves focus to the note viewer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -272,6 +272,7 @@ packages/app-desktop/gui/NoteEditor/WarningBanner/BannerContent.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementNoteTitle.js
+packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.js
 packages/app-desktop/gui/NoteEditor/commands/index.js
 packages/app-desktop/gui/NoteEditor/commands/pasteAsText.js

--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ packages/app-desktop/gui/NoteEditor/WarningBanner/BannerContent.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementNoteTitle.js
+packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.js
 packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.js
 packages/app-desktop/gui/NoteEditor/commands/index.js
 packages/app-desktop/gui/NoteEditor/commands/pasteAsText.js

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -479,6 +479,7 @@ function useMenu(props: Props) {
 				menuItemDic.focusElementNoteList,
 				menuItemDic.focusElementNoteTitle,
 				menuItemDic.focusElementNoteBody,
+				menuItemDic.focusElementNoteViewer,
 				menuItemDic.focusElementToolbar,
 			];
 

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -172,6 +172,7 @@ interface Props {
 	pluginMenus: any[];
 	['spellChecker.enabled']: boolean;
 	['spellChecker.languages']: string[];
+	markdownEditorVisible: boolean;
 	plugins: PluginStates;
 	customCss: string;
 	locale: string;
@@ -278,6 +279,7 @@ function useMenuStates(menu: any, props: Props) {
 		props['notes.sortOrder.reverse'],
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 		props['folders.sortOrder.reverse'],
+		props.markdownEditorVisible,
 		props.tabMovesFocus,
 		props.noteListRendererId,
 		props.showNoteCounts,
@@ -1141,7 +1143,7 @@ function MenuBar(props: Props): any {
 
 
 const mapStateToProps = (state: AppState): Partial<Props> => {
-	const whenClauseContext = stateToWhenClauseContext(state);
+	const whenClauseContext = stateToWhenClauseContext(state, { windowId: state.windowId });
 
 	const secondaryWindowFocused = state.windowId !== defaultWindowId;
 
@@ -1167,6 +1169,7 @@ const mapStateToProps = (state: AppState): Partial<Props> => {
 		pluginMenus: stateUtils.selectArrayShallow({ array: pluginUtils.viewsByType(state.pluginService.plugins, 'menu') }, 'menuBar.pluginMenus'),
 		['spellChecker.languages']: state.settings['spellChecker.languages'],
 		['spellChecker.enabled']: state.settings['spellChecker.enabled'],
+		markdownEditorVisible: whenClauseContext.markdownEditorVisible,
 		plugins: state.pluginService.plugins,
 		customCss: state.customViewerCss,
 		profileConfig: state.profileConfig,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts
@@ -129,6 +129,14 @@ const useEditorCommands = (props: Props) => {
 					props.webviewRef.current.send('focus');
 				}
 			},
+			'viewer.focus': () => {
+				if (props.visiblePanes.includes('viewer')) {
+					const editorCursorLine = editorRef.current.getCursor().line;
+					props.webviewRef.current.focusLine(editorCursorLine);
+				} else {
+					logger.info('Viewer not focused (not visible).');
+				}
+			},
 			search: () => {
 				return editorRef.current.execCommand(EditorCommandType.ShowSearch);
 			},

--- a/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts
+++ b/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts
@@ -1,0 +1,19 @@
+import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import { FocusElementOptions } from '../../../commands/focusElement';
+
+export const declaration: CommandDeclaration = {
+	name: 'focusElementNoteViewer',
+	label: () => _('Note viewer'),
+	parentLabel: () => _('Focus'),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+export const runtime = (comp: any): CommandRuntime => {
+	return {
+		execute: async (_context: unknown, options?: FocusElementOptions) => {
+			comp.editorRef.current.execCommand({ name: 'viewer.focus', value: options });
+		},
+		// enabledCondition: 'markdownEditorVisible',
+	};
+};

--- a/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts
+++ b/packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts
@@ -1,6 +1,7 @@
 import { CommandRuntime, CommandDeclaration } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import { FocusElementOptions } from '../../../commands/focusElement';
+import { WindowCommandDependencies } from '../utils/types';
 
 export const declaration: CommandDeclaration = {
 	name: 'focusElementNoteViewer',
@@ -8,12 +9,14 @@ export const declaration: CommandDeclaration = {
 	parentLabel: () => _('Focus'),
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export const runtime = (comp: any): CommandRuntime => {
+export const runtime = (dependencies: WindowCommandDependencies): CommandRuntime => {
 	return {
 		execute: async (_context: unknown, options?: FocusElementOptions) => {
-			comp.editorRef.current.execCommand({ name: 'viewer.focus', value: options });
+			await dependencies.editorRef.current.execCommand({
+				name: 'viewer.focus',
+				value: options,
+			});
 		},
-		// enabledCondition: 'markdownEditorVisible',
+		enabledCondition: 'markdownEditorVisible',
 	};
 };

--- a/packages/app-desktop/gui/NoteEditor/commands/index.ts
+++ b/packages/app-desktop/gui/NoteEditor/commands/index.ts
@@ -1,6 +1,7 @@
 // AUTO-GENERATED using `gulp buildScriptIndexes`
 import * as focusElementNoteBody from './focusElementNoteBody';
 import * as focusElementNoteTitle from './focusElementNoteTitle';
+import * as focusElementNoteViewer from './focusElementNoteViewer';
 import * as focusElementToolbar from './focusElementToolbar';
 import * as pasteAsText from './pasteAsText';
 import * as showLocalSearch from './showLocalSearch';
@@ -9,6 +10,7 @@ import * as showRevisions from './showRevisions';
 const index: any[] = [
 	focusElementNoteBody,
 	focusElementNoteTitle,
+	focusElementNoteViewer,
 	focusElementToolbar,
 	pasteAsText,
 	showLocalSearch,

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -163,6 +163,9 @@ const declarations: CommandDeclaration[] = [
 	{
 		name: 'editor.execCommand',
 	},
+	{
+		name: 'viewer.focus',
+	},
 ];
 
 export default declarations;

--- a/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
@@ -10,6 +10,7 @@ const commandsWithDependencies = [
 	require('../commands/showLocalSearch'),
 	require('../commands/focusElementNoteTitle'),
 	require('../commands/focusElementNoteBody'),
+	require('../commands/focusElementNoteViewer'),
 	require('../commands/focusElementToolbar'),
 	require('../commands/pasteAsText'),
 ];

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -28,6 +28,7 @@ export interface NoteViewerControl {
 	domReady(): boolean;
 	setHtml(html: string, options: SetHtmlOptions): void;
 	send(channel: string, arg0?: unknown, arg1?: unknown): void;
+	focusLine(editorLine: number): void;
 	focus(): void;
 	hasFocus(): boolean;
 }
@@ -107,6 +108,10 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 					win.postMessage({ target: 'webview', name: 'focus', data: {} }, '*');
 				}
 
+				if (channel === 'focusLine') {
+					win.postMessage({ target: 'webview', name: 'focusLine', data: { line: arg0 } }, '*');
+				}
+
 				// External code should use .setHtml (rather than send('setHtml', ...))
 				if (channel === 'setHtml') {
 					win.postMessage({ target: 'webview', name: 'setHtml', data: { html: arg0, options: arg1 } }, '*');
@@ -138,6 +143,15 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 			},
 			hasFocus: () => {
 				return webviewRef.current?.contains(parentDoc.activeElement);
+			},
+			focusLine: (lineNumber: number) => {
+				if (webviewRef.current) {
+					focus('NoteTextViewer::focusLine', webviewRef.current);
+					// A timeout seems necessary after focusing the viewer to prevent focus from jumping to the top
+					setTimeout(() => {
+						result.send('focusLine', lineNumber);
+					}, 100);
+				}
 			},
 		};
 		return result;

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -4,6 +4,7 @@ export default function() {
 		'copyDevCommand',
 		'exportPdf',
 		'focusElementNoteBody',
+		'focusElementNoteViewer',
 		'focusElementNoteList',
 		'focusElementNoteTitle',
 		'focusElementSideBar',

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -377,6 +377,34 @@
 			contentElement.scrollTop = scrollTop;
 		}
 
+		const getLineCorrespondingTo = (editorLineNumber) => {
+			const lineElements = document.getElementsByClassName('maps-to-line');
+			let lastLineElement;
+			let lastLine = 0;
+			for (const element of lineElements) {
+				// Stop just before the element that corresponds to a greater position
+				if (Number(element.getAttribute('source-line')) > editorLineNumber) {
+					break;
+				}
+				lastLineElement = element;
+			}
+			return lastLineElement;
+		};
+
+		ipc.focusLine = (event) => {
+			const targetLine = event.line;
+			const lineElement = getLineCorrespondingTo(targetLine);
+			if (lineElement) {
+				const originalTabIndex = lineElement.getAttribute('tabindex');
+				lineElement.setAttribute('tabindex', 0);
+				lineElement.focus();
+
+				setTimeout(() => {
+					lineElement.setAttribute('tabindex', originalTabIndex);
+				}, 50);
+			}
+		}
+
 		const rewriteFileUrls = (accessKey) => {
 			if (!accessKey) return;
 

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -391,16 +391,35 @@
 			return lastLineElement;
 		};
 
+		const makeTemporarilyFocusable = (element) => {
+			const dataOriginalTabIndexAttr = 'data-original-tabindex';
+			const originalTabIndex = (
+				element.getAttribute(dataOriginalTabIndexAttr) ?? element.getAttribute('tabindex')
+			);
+			element.setAttribute(dataOriginalTabIndexAttr, originalTabIndex);
+			element.setAttribute('tabindex', '0');
+
+			return {
+				reset: () => {
+					element.setAttribute('tabindex', originalTabIndex);
+					element.removeAttribute(dataOriginalTabIndexAttr);
+				},
+			};
+		};
+
 		ipc.focusLine = (event) => {
 			const targetLine = event.line;
 			const lineElement = getLineCorrespondingTo(targetLine);
 			if (lineElement) {
-				const originalTabIndex = lineElement.getAttribute('tabindex');
-				lineElement.setAttribute('tabindex', 0);
-				lineElement.focus();
+				// To allow focusing, the element needs to briefly have tabindex=0.
+				const { reset } = makeTemporarilyFocusable(lineElement);
 
+				lineElement.focus({ preventScroll: true });
+
+				// Reset the tabindex after the browser has had time to focus the element.
+				// When a screen reader is enabled, focus stays on the lineElement.
 				setTimeout(() => {
-					lineElement.setAttribute('tabindex', originalTabIndex);
+					reset();
 				}, 50);
 			}
 		}

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -230,5 +230,28 @@ test.describe('markdownEditor', () => {
 		// Editor should be focused
 		await expect(focusInMarkdownEditor).toBeAttached();
 	});
+
+	test('focusElementNoteViewer should move focus to the viewer', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.waitFor();
+		const noteEditor = mainScreen.noteEditor;
+
+		await mainScreen.createNewNote('Note');
+
+		await noteEditor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('# Test');
+		await mainWindow.keyboard.press('Enter');
+		await mainWindow.keyboard.press('Enter');
+		await mainWindow.keyboard.type('Test paragraph.');
+
+		// Wait for rendering
+		await expect(noteEditor.getNoteViewerFrameLocator().getByText('Test paragraph.')).toBeAttached();
+
+		// Move focus
+		await mainScreen.goToAnything.runCommand(electronApp, 'focusElementNoteViewer');
+
+		// Note viewer should be focused
+		await expect(noteEditor.noteViewerContainer).toBeFocused();
+	});
 });
 


### PR DESCRIPTION
# Summary

This pull request implements a feature request [from the Joplin forum](https://discourse.joplinapp.org/t/desktop-accessibility-add-a-shortcut-for-jumping-into-note-content/44129/11?u=personalizedrefriger). 

This pull request adds a "Note viewer" item to the "Focus" menu:
- As discussed on the forum, focus moves to roughly the location of the cursor in the editor. For example, if the cursor is on a line containing `- [ ] Checkbox` in the editor, focus would move to the rendered line containing the checkbox in the viewer.
- The "Note viewer" menu item is disabled when the Rich Text Editor is open.
- There is no default shortcut assigned to the "Note viewer" focus command. However, one can be assigned in settings > keyboard shortcuts. (Suggestions on a default keyboard shortcut would be welcome!)

# Related WCAG guidelines

[WCAG 2.2 SC 2.1.1: Keyboard](https://www.w3.org/TR/WCAG22/#keyboard) states:
> All [functionality](https://www.w3.org/TR/WCAG22/#dfn-functionality) of the content is operable through a [keyboard interface](https://www.w3.org/TR/WCAG22/#dfn-keyboard-interface) without requiring specific timings for individual keystrokes, except where the underlying function requires input that depends on the path of the user's movement and not just the endpoints.

Using a mouse, it's simple to move focus from a line in the note editor to the same line in viewer, since Joplin syncs scroll positions between the viewer and editor. Users might use this when, for example, checking/unchecking items in a checklist. This pull request provides similar functionality for keyboard-only users.


# Testing plan

1. Start Joplin.
2. Assign a keyboard shortcut for "Focus: Note viewer".
3. Restart Joplin.
4. Open the note editor and show the note viewer.
5. Create a checklist with 5 items.
6. Move the cursor to the 4th item.
7. Press the keyboard shortcut assigned in step 2.
8. Verify that focus moves to the viewer.
9. Press <kbd>tab</kbd>.
10. Verify that the checkbox in the 4th item has focus.
11. Enable the Orca screen reader and restart Joplin.
12. Move focus to the 4th item in the checklist in the note editor.
13. Press the <kbd>up</kbd> arrow key (verify that this moves to the 3rd item in the editor).
14. Press the <kbd>down</kbd> arrow key (verify that this moves back to the 4th item in the editor).
15. Press the keyboard shortcut assigned in step 2.
16. Verify that Orca reads "List with 5 items", then the name of the 4th list item.
17. Press <kbd>tab</kbd>.
18. Verify that Orca focuses the checkbox in this list item.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->