### PR TITLE
Docs: update "Importing from other applications" help section

### DIFF
--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -48,12 +48,7 @@ Joplin can also import OneNote notebooks. To do this:
 
 ### Importing from other applications
 
-In general the way to import notes from any application into Joplin is to convert the notes to ENEX files (Evernote format) and to import these ENEX files into Joplin using the method above. Most note-taking applications support ENEX files so it should be relatively straightforward. For help about specific applications, see below:
-
-* Standard Notes: Please see [this tutorial](https://programadorwebvalencia.com/migrate-notes-from-standard-notes-to-joplin/)
-* Tomboy Notes: Export the notes to ENEX files [as described here](https://askubuntu.com/questions/243691/how-can-i-export-my-tomboy-notes-into-evernote/608551) for example, and import these ENEX files into Joplin.
-* OneNote: First [import the notes from OneNote into Evernote](https://discussion.evernote.com/topic/107736-is-there-a-way-to-import-from-onenote-into-evernote-on-the-mac/). Then export the ENEX file from Evernote and import it into Joplin.
-* NixNote: Synchronise with Evernote, then export the ENEX files and import them into Joplin. More info [in this thread](https://discourse.joplinapp.org/t/import-from-nixnote/183/3).
+In general the way to import notes from any application into Joplin is to convert the notes to ENEX files (Evernote format) and to import these ENEX files into Joplin using the method above. For help about specific applications, see <https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425>.
 
 ## Exporting
 

--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -48,7 +48,7 @@ Joplin can also import OneNote notebooks. To do this:
 
 ### Importing from other applications
 
-In general the way to import notes from any application into Joplin is to convert the notes to ENEX files (Evernote format) and to import these ENEX files into Joplin using the method above. For help about specific applications, see <https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425>.
+In general the way to import notes from other applications into Joplin is to convert the notes to ENEX files (Evernote format), HTML or Markdown, and to import these files into Joplin. For help about specific applications, see this wiki document: [Importing notes from other notebook applications](https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425).
 
 ## Exporting
 


### PR DESCRIPTION
This is a small change to the [help page about importing and exporting](https://joplinapp.org/help/apps/import_export/#importing-from-other-applications). There are only a few applications mentioned and the information about OneNote import is not up-to-date. I think it would be good provide a general link to the [forum wiki](https://discourse.joplinapp.org/t/importing-notes-from-other-notebook-applications/22425) instead. It contains more apps and can be edited by forum members directly.

Justification for the removed apps:

* Standard Notes: Covered by the forum wiki.
* Tomboy Notes: Covered by the forum wiki.
* OneNote: Information was not up-to-date, since there is the built-in Onenote importer now. Additional scripts are mentioned at the forum wiki.
* NixNote: Covered by the forum wiki.