### PR TITLE
Android: Resolves #11955: Voice typing: Improve re-download button UI

### DIFF
--- a/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
@@ -35,6 +35,7 @@ const useVoiceTyping = ({ locale, provider, onSetPreview, onText }: UseVoiceTypi
 	const [error, setError] = useState<Error|null>(null);
 	const [mustDownloadModel, setMustDownloadModel] = useState<boolean | null>(null);
 	const [modelIsOutdated, setModelIsOutdated] = useState(false);
+	const [stoppingSession, setIsStoppingSession] = useState(false);
 
 	const onTextRef = useRef(onText);
 	onTextRef.current = onText;
@@ -95,14 +96,16 @@ const useVoiceTyping = ({ locale, provider, onSetPreview, onText }: UseVoiceTypi
 	}, []);
 
 	const onRequestRedownload = useCallback(async () => {
+		setIsStoppingSession(true);
 		await voiceTypingRef.current?.cancel();
 		await builder.clearDownloads();
 		setMustDownloadModel(true);
+		setIsStoppingSession(false);
 		setRedownloadCounter(value => value + 1);
 	}, [builder]);
 
 	return {
-		error, mustDownloadModel, voiceTyping, onRequestRedownload, modelIsOutdated,
+		error, mustDownloadModel, stoppingSession, voiceTyping, onRequestRedownload, modelIsOutdated,
 	};
 };
 
@@ -113,6 +116,7 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 		error: modelError,
 		mustDownloadModel,
 		voiceTyping,
+		stoppingSession,
 		onRequestRedownload,
 		modelIsOutdated,
 	} = useVoiceTyping({
@@ -137,6 +141,12 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 	}, [mustDownloadModel]);
 
 	useEffect(() => {
+		if (stoppingSession) {
+			setRecorderState(RecorderState.Processing);
+		}
+	}, [stoppingSession]);
+
+	useEffect(() => {
 		if (recorderState === RecorderState.Recording) {
 			void voiceTyping.start();
 		}
@@ -156,7 +166,9 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 			[RecorderState.Loading]: () => _('Loading...'),
 			[RecorderState.Idle]: () => 'Waiting...', // Not used for now
 			[RecorderState.Recording]: () => _('Please record your voice...'),
-			[RecorderState.Processing]: () => _('Converting speech to text...'),
+			[RecorderState.Processing]: () => (
+				stoppingSession ? _('Closing session...') : _('Converting speech to text...')
+			),
 			[RecorderState.Downloading]: () => _('Downloading %s language files...', languageName(props.locale)),
 			[RecorderState.Error]: () => _('Error: %s', modelError?.message),
 		};
@@ -168,7 +180,12 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 		return <Text variant='labelSmall'>{preview}</Text>;
 	};
 
-	const reDownloadButton = <Button onPress={onRequestRedownload}>
+	const reDownloadButton = <Button
+		// Usually, stoppingSession is true because the re-download button has
+		// just been pressed.
+		disabled={stoppingSession}
+		onPress={onRequestRedownload}
+	>
 		{modelIsOutdated ? _('Download updated model') : _('Re-download model')}
 	</Button>;
 	const allowReDownload = recorderState === RecorderState.Error || modelIsOutdated;

--- a/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
+++ b/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
@@ -2,7 +2,6 @@ import shim from '@joplin/lib/shim';
 import Logger from '@joplin/utils/Logger';
 import { PermissionsAndroid, Platform } from 'react-native';
 import unzip from './utils/unzip';
-import { _ } from '@joplin/lib/locale';
 const md5 = require('md5');
 
 const logger = Logger.create('voiceTyping');
@@ -87,12 +86,7 @@ export default class VoiceTyping {
 	}
 
 	public async clearDownloads() {
-		const confirmed = await shim.showConfirmationDialog(
-			_('Delete model and re-download?\nThis cannot be undone.'),
-		);
-		if (confirmed) {
-			await this.provider.deleteCachedModels(this.locale);
-		}
+		await this.provider.deleteCachedModels(this.locale);
 	}
 
 	public async download() {


### PR DESCRIPTION
# Summary

This pull request adjusts the UI for the re-download button. With this change,
- Clicking "Download updated model":
   1. Disables the "Download updated model" button.
   2. Shows a "Closing session..." message.
   3. After the session closes, starts the download.
- A confirmation dialog is no longer shown.

Resolves #11955.

# Screen recording


https://github.com/user-attachments/assets/6fc97018-7cd8-4b9c-849e-6666497c5286

The above screen recording starts with the "Voice typing..." dialog open. The user clicks the "Download updated model" button to the left of the "Done" button. The "Download updated model" button becomes disabled and the dialog's subheading changes to "Closing session...". After about 8 seconds, the "Download updated model" button is hidden and the description changes to "Downloading English language files...".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->