### PR TITLE
All : Fix for "Changing the type of one list changes it for all the lists" issue

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.ts
@@ -12,25 +12,25 @@ describe('markdownCommands.bulletedVsChecklist', () => {
 	const initialDocText = `${bulletedListPart}\n\n${checklistPart}`;
 	const expectedTags = ['BulletList', 'Task'];
 
-	it('should remove a checklist following a bulleted list without modifying the bulleted list', async () => {
+	it('should remove a checklist following a bulleted list without modifying the bulleted list only at the selected line', async () => {
 		const editor = await createTestEditor(
 			initialDocText, EditorSelection.cursor(bulletedListPart.length + 5), expectedTags,
 		);
 
 		toggleList(ListType.CheckList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			`${bulletedListPart}\n\nThis is a checklist\nwith multiple items.\n☑`,
+			`${bulletedListPart}\n\nThis is a checklist\n- [ ] with multiple items.\n- [ ] ☑`,
 		);
 	});
 
-	it('should remove an unordered list following a checklist without modifying the checklist', async () => {
+	it('should remove an unordered list only at the selected line following a checklist without modifying the checklist', async () => {
 		const editor = await createTestEditor(
 			initialDocText, EditorSelection.cursor(bulletedListPart.length - 5), expectedTags,
 		);
 
 		toggleList(ListType.UnorderedList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			`Test\nThis is a test.\n3\n4\n5\n\n${checklistPart}`,
+			`- Test\n- This is a test.\n- 3\n4\n- 5\n\n${checklistPart}`,
 		);
 	});
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -196,7 +196,7 @@ describe('markdownCommands.toggleList', () => {
 
 		toggleList(ListType.CheckList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			'- [ ] Foo\n2. Bar\3. Baz\n\t- Test\n\t- of\n\t- sublists\n4. Foo',
+			'- [ ] Foo\n2. Bar\n3. Baz\n\t- Test\n\t- of\n\t- sublists\n4. Foo',
 		);
 	});
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -9,7 +9,7 @@ describe('markdownCommands.toggleList', () => {
 
 	jest.retryTimes(2);
 
-	it('should remove the same type of list', async () => {
+	it('should remove the list only at the selected line', async () => {
 		const initialDocText = '- testing\n- this is a `test`\n';
 
 		const editor = await createTestEditor(
@@ -20,11 +20,11 @@ describe('markdownCommands.toggleList', () => {
 
 		toggleList(ListType.UnorderedList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			'testing\nthis is a `test`\n',
+			'testing\n- this is a `test`\n',
 		);
 	});
 
-	it('should insert a numbered list with correct numbering', async () => {
+	it('should insert a numbered list with correct numbering only at the selected line', async () => {
 		const initialDocText = 'Testing...\nThis is a test\nof list toggling...';
 		const editor = await createTestEditor(
 			initialDocText,
@@ -50,7 +50,7 @@ describe('markdownCommands.toggleList', () => {
 
 	const unorderedListText = '- 1\n- 2\n- 3\n- 4\n- 5\n- 6\n- 7';
 
-	it('should correctly replace an unordered list with a numbered list', async () => {
+	it('should correctly replace an unordered list with a numbered list only at the selected line', async () => {
 		const editor = await createTestEditor(
 			unorderedListText,
 			EditorSelection.cursor(unorderedListText.length),
@@ -59,7 +59,7 @@ describe('markdownCommands.toggleList', () => {
 
 		toggleList(ListType.OrderedList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			'1. 1\n2. 2\n3. 3\n4. 4\n5. 5\n6. 6\n7. 7',
+			'- 1\n- 2\n- 3\n- 4\n- 5\n- 6\n1. 7',
 		);
 	});
 
@@ -70,26 +70,31 @@ describe('markdownCommands.toggleList', () => {
 			'- [ ] This',
 			'- [ ] is',
 			'',
-		].join('\n');
-
-		const checklistEndText = [
 			'- [ ] a',
 			'- [ ] test',
 		].join('\n');
 
 		const editor = await createTestEditor(
-			`${checklistStartText}\n${checklistEndText}`,
+			`${checklistStartText}`,
 
 			// Place the cursor on the blank line between the checklist
 			// regions
-			EditorSelection.cursor(unorderedListText.length + 1),
+			EditorSelection.cursor(7),
 			['BulletList', 'ATXHeading1'],
 		);
 
 		// Should create a checkbox on the blank line
 		toggleList(ListType.CheckList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			`${checklistStartText}- [ ] \n${checklistEndText}`,
+			[
+				'# Test',
+				'- [ ] ',
+				'- [ ] This',
+				'- [ ] is',
+				'',
+				'- [ ] a',
+				'- [ ] test',
+			].join('\n'),
 		);
 	});
 
@@ -180,7 +185,7 @@ describe('markdownCommands.toggleList', () => {
 	// 	);
 	// });
 
-	it('should toggle a numbered list without changing its sublists', async () => {
+	it('should toggle only a numbered list at selected line without changing its sublists', async () => {
 		const initialDocText = '1. Foo\n2. Bar\n3. Baz\n\t- Test\n\t- of\n\t- sublists\n4. Foo';
 
 		const editor = await createTestEditor(
@@ -191,7 +196,7 @@ describe('markdownCommands.toggleList', () => {
 
 		toggleList(ListType.CheckList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			'- [ ] Foo\n- [ ] Bar\n- [ ] Baz\n\t- Test\n\t- of\n\t- sublists\n- [ ] Foo',
+			'- [ ] Foo\n2. Bar\3. Baz\n\t- Test\n\t- of\n\t- sublists\n4. Foo',
 		);
 	});
 
@@ -218,7 +223,7 @@ describe('markdownCommands.toggleList', () => {
 		);
 	});
 
-	it('should toggle lists properly within block quotes', async () => {
+	it('should toggle only list on the selected line properly within block quotes', async () => {
 		const preSubListText = '> # List test\n> * This\n> * is\n';
 		const initialDocText = `${preSubListText}> \t* a\n> \t* test\n> * of list toggling`;
 		const editor = await createTestEditor(
@@ -228,9 +233,9 @@ describe('markdownCommands.toggleList', () => {
 
 		toggleList(ListType.OrderedList)(editor);
 		expect(editor.state.doc.toString()).toBe(
-			'> # List test\n> * This\n> * is\n> \t1. a\n> \t2. test\n> * of list toggling',
+			'> # List test\n> * This\n> * is\n> \t1. a\n> \t* test\n> * of list toggling',
 		);
-		expect(editor.state.selection.main.from).toBe(preSubListText.length);
+		expect(editor.state.selection.main.from).toBe(preSubListText.length + 7);
 	});
 
 	it('should not treat a list of IP addresses as a numbered list', async () => {

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -192,7 +192,7 @@ export const toggleList = (listType: ListType): Command => {
 			// cursor is on an empty line, in which case, the user
 			// probably wants to add a list item (and not select the entire
 			// list).
-			if (sel.empty && fromLine.text.trim() == '') {
+			if (sel.empty && fromLine.text.trim() === '') {
 				sel = growSelectionToNode(state, sel, [orderedListTag, unorderedListTag]);
 				computeSelectionProps();
 			}

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -192,7 +192,7 @@ export const toggleList = (listType: ListType): Command => {
 			// cursor is on an empty line, in which case, the user
 			// probably wants to add a list item (and not select the entire
 			// list).
-			if (sel.empty && fromLine.text.trim() !== '') {
+			if (sel.empty && fromLine.text.trim() == '') {
 				sel = growSelectionToNode(state, sel, [orderedListTag, unorderedListTag]);
 				computeSelectionProps();
 			}


### PR DESCRIPTION
**Summary :**

- All: Resolves #11971 
- This pull request contains fix for the above issue, now only the focused or selected text will change (This fix affects all ListTypes). 
- Kindly refer attached video below.


https://github.com/user-attachments/assets/c90204ef-4903-4d42-8ea8-f5b98510acd6


**Manual Test Process :**

1. Have a note with this content:

  ```
- One list
	- one
	- two
	- three

- | <-- caret here
  ```
2. Click the list options (All 3 will be affected in this change) button to convert the new list to a checkbox list.
3. The editor will select the current list and apply the changes only to the list. 