### PR TITLE
Android: Voice typing: Improve processing with larger models

### DIFF
--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -122,10 +122,11 @@ std::string
 WhisperSession::transcribeNextChunkNoPreview_() {
 	std::stringstream result;
 
+	// Handles a silence detected between (splitStart, splitEnd).
 	auto splitAndProcess = [&] (int splitStart, int splitEnd) {
 		int tolerance = WHISPER_SAMPLE_RATE / 20; // 0.05s
 		bool isCompletelySilent = splitStart < tolerance && splitEnd > audioBuffer_.size() - tolerance;
-		LOGD("WhisperSession: Silence range %.2f -> %.2f", splitStart / (float) WHISPER_SAMPLE_RATE, splitEnd / (float) WHISPER_SAMPLE_RATE);
+		LOGD("WhisperSession: Found silence range from %.2f -> %.2f", splitStart / (float) WHISPER_SAMPLE_RATE, splitEnd / (float) WHISPER_SAMPLE_RATE);
 
 		if (isCompletelySilent) {
 			audioBuffer_.clear();
@@ -142,7 +143,7 @@ WhisperSession::transcribeNextChunkNoPreview_() {
 
 	// Handle paragraph breaks indicated by long pauses
 	while (audioBuffer_.size() > WHISPER_SAMPLE_RATE * 3) {
-		LOGD("WhisperSession: Checking for a longer paragraph break.");
+		LOGD("WhisperSession: Checking for a longer pauses.");
 		// Allow brief pauses to create new paragraphs:
 		float minSilenceSeconds = 1.5f;
 		auto splitPoint = findLongestSilence(

--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -34,9 +34,9 @@ WhisperSession::buildWhisperParams_() {
 	// WHISPER_SAMPLING_BEAM_SEARCH is an alternative to greedy:
 	// params.beam_search = { .beam_size = 2 };
 	params.print_realtime = false;
-    // Disable timestamps: They make creating custom Whisper models more difficult:
+	// Disable timestamps: They make creating custom Whisper models more difficult:
 	params.print_timestamps = false;
-    params.no_timestamps = true;
+	params.no_timestamps = true;
 
 	params.print_progress = false;
 	params.translate = false;
@@ -105,126 +105,126 @@ WhisperSession::splitAndTranscribeBefore_(int transcribeUpTo, int trimTo) {
 }
 
 bool WhisperSession::isBufferSilent_() {
-    int toleranceSamples = WHISPER_SAMPLE_RATE / 8; // 0.125s
-    auto silence = findLongestSilence(
-            audioBuffer_,
-            LongestSilenceOptions {
-                    .sampleRate = WHISPER_SAMPLE_RATE,
-                    .minSilenceLengthSeconds = 0.0f,
-                    .maximumSilenceStartSamples = toleranceSamples, // 0.5s
-                    .returnFirstMatch = true
-            }
-    );
-    return silence.end >= audioBuffer_.size() - toleranceSamples;
+	int toleranceSamples = WHISPER_SAMPLE_RATE / 8; // 0.125s
+	auto silence = findLongestSilence(
+			audioBuffer_,
+			LongestSilenceOptions {
+					.sampleRate = WHISPER_SAMPLE_RATE,
+					.minSilenceLengthSeconds = 0.0f,
+					.maximumSilenceStartSamples = toleranceSamples, // 0.5s
+					.returnFirstMatch = true
+			}
+	);
+	return silence.end >= audioBuffer_.size() - toleranceSamples;
 }
 
 std::string
 WhisperSession::transcribeNextChunkNoPreview_() {
 	std::stringstream result;
 
-    auto splitAndProcess = [&] (int splitStart, int splitEnd) {
-        int tolerance = WHISPER_SAMPLE_RATE / 20; // 0.05s
-        bool isCompletelySilent = splitStart < tolerance && splitEnd > audioBuffer_.size() - tolerance;
-        LOGD("WhisperSession: Silence range %.2f -> %.2f", splitStart / (float) WHISPER_SAMPLE_RATE, splitEnd / (float) WHISPER_SAMPLE_RATE);
+	auto splitAndProcess = [&] (int splitStart, int splitEnd) {
+		int tolerance = WHISPER_SAMPLE_RATE / 20; // 0.05s
+		bool isCompletelySilent = splitStart < tolerance && splitEnd > audioBuffer_.size() - tolerance;
+		LOGD("WhisperSession: Silence range %.2f -> %.2f", splitStart / (float) WHISPER_SAMPLE_RATE, splitEnd / (float) WHISPER_SAMPLE_RATE);
 
-        if (isCompletelySilent) {
-            audioBuffer_.clear();
-            return false;
-        } else if (splitEnd > tolerance) { // Anything to transcribe?
-            result << splitAndTranscribeBefore_(splitStart, splitEnd) << "\n\n";
-            return true;
-        }
+		if (isCompletelySilent) {
+			audioBuffer_.clear();
+			return false;
+		} else if (splitEnd > tolerance) { // Anything to transcribe?
+			result << splitAndTranscribeBefore_(splitStart, splitEnd) << "\n\n";
+			return true;
+		}
 
-        return false;
-    };
+		return false;
+	};
 
 	int maximumSamples = WHISPER_SAMPLE_RATE * 25;
 
-    // Handle paragraph breaks indicated by long pauses
-    while (audioBuffer_.size() > WHISPER_SAMPLE_RATE * 3) {
-        LOGD("WhisperSession: Checking for a longer paragraph break.");
+	// Handle paragraph breaks indicated by long pauses
+	while (audioBuffer_.size() > WHISPER_SAMPLE_RATE * 3) {
+		LOGD("WhisperSession: Checking for a longer paragraph break.");
 		// Allow brief pauses to create new paragraphs:
 		float minSilenceSeconds = 1.5f;
 		auto splitPoint = findLongestSilence(
 			audioBuffer_,
-            LongestSilenceOptions {
-                .sampleRate = WHISPER_SAMPLE_RATE,
-                .minSilenceLengthSeconds = minSilenceSeconds,
-                .maximumSilenceStartSamples = maximumSamples,
-                .returnFirstMatch = true
-            }
+			LongestSilenceOptions {
+				.sampleRate = WHISPER_SAMPLE_RATE,
+				.minSilenceLengthSeconds = minSilenceSeconds,
+				.maximumSilenceStartSamples = maximumSamples,
+				.returnFirstMatch = true
+			}
 		);
 		if (!splitPoint.isValid) {
-            break;
-        }
-        if (!splitAndProcess(splitPoint.start, splitPoint.end)) {
-            break;
-        }
+			break;
+		}
+		if (!splitAndProcess(splitPoint.start, splitPoint.end)) {
+			break;
+		}
 	}
 
-    // If there are no long pauses, force a paragraph break somewhere
-    if (audioBuffer_.size() >= maximumSamples) {
-        LOGD("WhisperSession: Allowing shorter pauses to break.");
-        float minSilenceSeconds = 0.3f;
-        auto silenceRange = findLongestSilence(
-                audioBuffer_,
-                LongestSilenceOptions {
-                        .sampleRate = WHISPER_SAMPLE_RATE,
-                        .minSilenceLengthSeconds = minSilenceSeconds,
-                        .maximumSilenceStartSamples = maximumSamples,
-                        .returnFirstMatch = false
-                }
-        );
+	// If there are no long pauses, force a paragraph break somewhere
+	if (audioBuffer_.size() >= maximumSamples) {
+		LOGD("WhisperSession: Allowing shorter pauses to break.");
+		float minSilenceSeconds = 0.3f;
+		auto silenceRange = findLongestSilence(
+				audioBuffer_,
+				LongestSilenceOptions {
+						.sampleRate = WHISPER_SAMPLE_RATE,
+						.minSilenceLengthSeconds = minSilenceSeconds,
+						.maximumSilenceStartSamples = maximumSamples,
+						.returnFirstMatch = false
+				}
+		);
 
-        // In this case, the audio is long enough that it needs to be split somewhere. If there's
-        // no suitable pause available, default to splitting in the middle.
-        int halfBufferSize = audioBuffer_.size() / 2;
-        int splitStart = silenceRange.isValid ? silenceRange.start : halfBufferSize;
-        int splitEnd = silenceRange.isValid ? silenceRange.end : halfBufferSize;
-        splitAndProcess(splitStart, splitEnd);
-    }
+		// In this case, the audio is long enough that it needs to be split somewhere. If there's
+		// no suitable pause available, default to splitting in the middle.
+		int halfBufferSize = audioBuffer_.size() / 2;
+		int splitStart = silenceRange.isValid ? silenceRange.start : halfBufferSize;
+		int splitEnd = silenceRange.isValid ? silenceRange.end : halfBufferSize;
+		splitAndProcess(splitStart, splitEnd);
+	}
 
 	return result.str();
 }
 
 
 void WhisperSession::addAudio(const float *pAudio, int sizeAudio) {
-    // Update the local audio buffer
-    for (int i = 0; i < sizeAudio; i++) {
-        audioBuffer_.push_back(pAudio[i]);
-    }
+	// Update the local audio buffer
+	for (int i = 0; i < sizeAudio; i++) {
+		audioBuffer_.push_back(pAudio[i]);
+	}
 }
 
 std::string WhisperSession::transcribeNextChunk() {
-    std::string finalizedContent = transcribeNextChunkNoPreview_();
-    previewText_ = transcribe_(audioBuffer_, audioBuffer_.size());
-    return finalizedContent;
+	std::string finalizedContent = transcribeNextChunkNoPreview_();
+	previewText_ = transcribe_(audioBuffer_, audioBuffer_.size());
+	return finalizedContent;
 }
 
 std::string WhisperSession::transcribeAll() {
-    if (isBufferSilent_()) {
-        return "";
-    }
+	if (isBufferSilent_()) {
+		return "";
+	}
 
-    std::stringstream result;
+	std::stringstream result;
 
-    std::string transcribed;
-    auto update_transcribed = [&] {
-        transcribed = transcribeNextChunkNoPreview_();
-        return !transcribed.empty();
-    };
-    while (update_transcribed()) {
-        result << transcribed << "\n\n";
-    }
+	std::string transcribed;
+	auto update_transcribed = [&] {
+		transcribed = transcribeNextChunkNoPreview_();
+		return !transcribed.empty();
+	};
+	while (update_transcribed()) {
+		result << transcribed << "\n\n";
+	}
 
-    // Transcribe content considered by transcribeNextChunk as partial:
-    if (!isBufferSilent_()) {
-        result << transcribe_(audioBuffer_, audioBuffer_.size());
-    }
-    audioBuffer_.clear();
+	// Transcribe content considered by transcribeNextChunk as partial:
+	if (!isBufferSilent_()) {
+		result << transcribe_(audioBuffer_, audioBuffer_.size());
+	}
+	audioBuffer_.clear();
 
-    previewText_ = "";
-    return result.str();
+	previewText_ = "";
+	return result.str();
 }
 
 std::string WhisperSession::getPreview() {

--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
@@ -7,7 +7,13 @@ class WhisperSession {
 public:
 	WhisperSession(const std::string& modelPath, std::string lang, std::string prompt);
 	~WhisperSession();
-	std::string transcribeNextChunk(const float *pAudio, int sizeAudio);
+    // Adds to the buffer
+    void addAudio(const float *pAudio, int sizeAudio);
+    // Returns the next finalized slice of audio (if any) and updates the preview.
+	std::string transcribeNextChunk();
+    // Transcribes all buffered audio data that hasn't been finalized yet
+    std::string transcribeAll();
+    // Returns the transcription of any unfinalized audio
 	std::string getPreview();
 
 private:
@@ -17,6 +23,13 @@ private:
 	whisper_full_params buildWhisperParams_();
 	std::string transcribe_(const std::vector<float>& audio, size_t samplesToTranscribe);
 	std::string splitAndTranscribeBefore_(int transcribeUpTo, int trimTo);
+    // Like transcribeNextChunk, but does not update the preview state
+    // and does not add a new chunk to the buffer.
+    // Since updating the preview state can be slow, this may be preferred
+    // for internal operations where the preview does not need to be kept up-to-date.
+    std::string transcribeNextChunkNoPreview_();
+
+    bool isBufferSilent_();
 
 	whisper_context *pContext_;
 	const std::string lang_;

--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
@@ -5,7 +5,7 @@
 
 class WhisperSession {
 public:
-	WhisperSession(const std::string& modelPath, std::string lang, std::string prompt);
+	WhisperSession(const std::string& modelPath, std::string lang, std::string prompt, bool shortAudioContext);
 	~WhisperSession();
 	// Adds to the buffer
 	void addAudio(const float *pAudio, int sizeAudio);
@@ -34,6 +34,7 @@ private:
 	whisper_context *pContext_;
 	const std::string lang_;
 	const std::string prompt_;
+    const bool shortAudioContext_;
 
 	std::vector<float> audioBuffer_;
 };

--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.h
@@ -7,13 +7,13 @@ class WhisperSession {
 public:
 	WhisperSession(const std::string& modelPath, std::string lang, std::string prompt);
 	~WhisperSession();
-    // Adds to the buffer
-    void addAudio(const float *pAudio, int sizeAudio);
-    // Returns the next finalized slice of audio (if any) and updates the preview.
+	// Adds to the buffer
+	void addAudio(const float *pAudio, int sizeAudio);
+	// Returns the next finalized slice of audio (if any) and updates the preview.
 	std::string transcribeNextChunk();
-    // Transcribes all buffered audio data that hasn't been finalized yet
-    std::string transcribeAll();
-    // Returns the transcription of any unfinalized audio
+	// Transcribes all buffered audio data that hasn't been finalized yet
+	std::string transcribeAll();
+	// Returns the transcription of any unfinalized audio
 	std::string getPreview();
 
 private:
@@ -23,13 +23,13 @@ private:
 	whisper_full_params buildWhisperParams_();
 	std::string transcribe_(const std::vector<float>& audio, size_t samplesToTranscribe);
 	std::string splitAndTranscribeBefore_(int transcribeUpTo, int trimTo);
-    // Like transcribeNextChunk, but does not update the preview state
-    // and does not add a new chunk to the buffer.
-    // Since updating the preview state can be slow, this may be preferred
-    // for internal operations where the preview does not need to be kept up-to-date.
-    std::string transcribeNextChunkNoPreview_();
+	// Like transcribeNextChunk, but does not update the preview state
+	// and does not add a new chunk to the buffer.
+	// Since updating the preview state can be slow, this may be preferred
+	// for internal operations where the preview does not need to be kept up-to-date.
+	std::string transcribeNextChunkNoPreview_();
 
-    bool isBufferSilent_();
+	bool isBufferSilent_();
 
 	whisper_context *pContext_;
 	const std::string lang_;

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.cpp
@@ -19,14 +19,18 @@ static void highpass(std::vector<float>& data, int sampleRate) {
 
 SilenceRange findLongestSilence(
 	const std::vector<float>& audioData,
-	int sampleRate,
-	float minSilenceLengthSeconds,
-	int maxSilencePosition
+	LongestSilenceOptions options
 ) {
+    // Options variables
+    int sampleRate = options.sampleRate;
+    int maxSilencePosition = options.maximumSilenceStartSamples;
+    float minSilenceLengthSeconds = options.minSilenceLengthSeconds;
+    bool returnFirstMatch = options.returnFirstMatch;
+
+    // State
 	int bestCandidateLength = 0;
 	int bestCandidateStart = -1;
 	int bestCandidateEnd = -1;
-
 	int currentCandidateStart = -1;
 
 	std::vector<float> processedAudio { audioData };
@@ -35,7 +39,7 @@ SilenceRange findLongestSilence(
 	// Break into windows of size `windowSize`:
 	int windowSize = 256;
 	int windowsPerSecond = sampleRate / windowSize;
-	int quietWindows = 0;
+	int quietWindows = 0; // Number of relatively quiet windows encountered
 
 	// Finishes the current candidate for longest silence
 	auto finalizeCandidate = [&] (int currentOffset) {
@@ -86,12 +90,20 @@ SilenceRange findLongestSilence(
 		}
 
 		int minQuietWindows = static_cast<int>(windowsPerSecond * minSilenceLengthSeconds);
-		if (quietWindows >= minQuietWindows && currentCandidateStart == -1) {
-			// Found a candidate. Start it.
-			currentCandidateStart = windowOffset;
-		} else if (quietWindows == 0) {
+		if (quietWindows >= minQuietWindows && currentCandidateStart == -1) { // Found silence
+            // Ignore the first window, which probably contains some of the start of the audio
+            // and the most recent window, which came after windowOffset.
+            int windowsToIgnore = 2;
+            int estimatedQuietSamples = std::max(0, quietWindows - windowsToIgnore) * windowSize;
+			currentCandidateStart = windowOffset - estimatedQuietSamples;
+		} else if (quietWindows == 0) { // Silence ended
 			// Ended a candidate. Is it better than the best?
 			finalizeCandidate(windowOffset);
+
+            // Search for more candidates or return now?
+            if (returnFirstMatch && bestCandidateLength > 0) {
+                break;
+            }
 		}
 	}
 

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.cpp
@@ -21,13 +21,13 @@ SilenceRange findLongestSilence(
 	const std::vector<float>& audioData,
 	LongestSilenceOptions options
 ) {
-    // Options variables
-    int sampleRate = options.sampleRate;
-    int maxSilencePosition = options.maximumSilenceStartSamples;
-    float minSilenceLengthSeconds = options.minSilenceLengthSeconds;
-    bool returnFirstMatch = options.returnFirstMatch;
+	// Options variables
+	int sampleRate = options.sampleRate;
+	int maxSilencePosition = options.maximumSilenceStartSamples;
+	float minSilenceLengthSeconds = options.minSilenceLengthSeconds;
+	bool returnFirstMatch = options.returnFirstMatch;
 
-    // State
+	// State
 	int bestCandidateLength = 0;
 	int bestCandidateStart = -1;
 	int bestCandidateEnd = -1;
@@ -91,19 +91,19 @@ SilenceRange findLongestSilence(
 
 		int minQuietWindows = static_cast<int>(windowsPerSecond * minSilenceLengthSeconds);
 		if (quietWindows >= minQuietWindows && currentCandidateStart == -1) { // Found silence
-            // Ignore the first window, which probably contains some of the start of the audio
-            // and the most recent window, which came after windowOffset.
-            int windowsToIgnore = 2;
-            int estimatedQuietSamples = std::max(0, quietWindows - windowsToIgnore) * windowSize;
+			// Ignore the first window, which probably contains some of the start of the audio
+			// and the most recent window, which came after windowOffset.
+			int windowsToIgnore = 2;
+			int estimatedQuietSamples = std::max(0, quietWindows - windowsToIgnore) * windowSize;
 			currentCandidateStart = windowOffset - estimatedQuietSamples;
 		} else if (quietWindows == 0) { // Silence ended
 			// Ended a candidate. Is it better than the best?
 			finalizeCandidate(windowOffset);
 
-            // Search for more candidates or return now?
-            if (returnFirstMatch && bestCandidateLength > 0) {
-                break;
-            }
+			// Search for more candidates or return now?
+			if (returnFirstMatch && bestCandidateLength > 0) {
+				break;
+			}
 		}
 	}
 

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.h
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.h
@@ -10,15 +10,24 @@ struct SilenceRange {
 	int end;
 };
 
+struct LongestSilenceOptions {
+    int sampleRate;
+
+    // Minimum length of a silence range (e.g. 3.0 seconds)
+    float minSilenceLengthSeconds;
+
+    // The maximum position for a silence range to start (ignore
+    // all silences after this position).
+    int maximumSilenceStartSamples;
+
+    // Return the first silence satisfying the conditions instead of
+    // the longest.
+    bool returnFirstMatch;
+};
+
 SilenceRange findLongestSilence(
 	const std::vector<float>& audioData,
-	int sampleRate,
-
-	// Minimum length of silence in seconds
-	float minSilenceLengthSeconds,
-
-	// Doesn't check for silence at a position greater than maximumSilenceStart
-	int maximumSilenceStart
+	LongestSilenceOptions options
 );
 
 

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.h
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence.h
@@ -11,18 +11,18 @@ struct SilenceRange {
 };
 
 struct LongestSilenceOptions {
-    int sampleRate;
+	int sampleRate;
 
-    // Minimum length of a silence range (e.g. 3.0 seconds)
-    float minSilenceLengthSeconds;
+	// Minimum length of a silence range (e.g. 3.0 seconds)
+	float minSilenceLengthSeconds;
 
-    // The maximum position for a silence range to start (ignore
-    // all silences after this position).
-    int maximumSilenceStartSamples;
+	// The maximum position for a silence range to start (ignore
+	// all silences after this position).
+	int maximumSilenceStartSamples;
 
-    // Return the first silence satisfying the conditions instead of
-    // the longest.
-    bool returnFirstMatch;
+	// Return the first silence satisfying the conditions instead of
+	// the longest.
+	bool returnFirstMatch;
 };
 
 SilenceRange findLongestSilence(

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence_test.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence_test.cpp
@@ -122,12 +122,12 @@ static float samplesToSeconds(int samples, int sampleRate) {
 static void expectNoSilence(const GeneratedAudio& audio, const std::string& testLabel) {
 	auto silence = findLongestSilence(
 			audio.data,
-            LongestSilenceOptions {
-                .sampleRate = audio.sampleRate,
-                .minSilenceLengthSeconds = 0.02f,
-                .maximumSilenceStartSamples = audio.sampleCount,
-                .returnFirstMatch = false,
-            }
+			LongestSilenceOptions {
+				.sampleRate = audio.sampleRate,
+				.minSilenceLengthSeconds = 0.02f,
+				.maximumSilenceStartSamples = audio.sampleCount,
+				.returnFirstMatch = false,
+			}
 	);
 	if (silence.isValid) {
 		std::stringstream errorBuilder;
@@ -144,12 +144,12 @@ static void expectNoSilence(const GeneratedAudio& audio, const std::string& test
 static void expectSilenceBetween(const GeneratedAudio& audio, float startTimeSeconds, float stopTimeSeconds, const std::string& testLabel) {
 	auto silenceResult = findLongestSilence(
 			audio.data,
-            LongestSilenceOptions {
-                    .sampleRate = audio.sampleRate,
-                    .minSilenceLengthSeconds = 0.02f,
-                    .maximumSilenceStartSamples = audio.sampleCount,
-                    .returnFirstMatch = false,
-            }
+			LongestSilenceOptions {
+					.sampleRate = audio.sampleRate,
+					.minSilenceLengthSeconds = 0.02f,
+					.maximumSilenceStartSamples = audio.sampleCount,
+					.returnFirstMatch = false,
+			}
 	);
 
 	if (!silenceResult.isValid) {

--- a/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence_test.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/findLongestSilence_test.cpp
@@ -122,9 +122,12 @@ static float samplesToSeconds(int samples, int sampleRate) {
 static void expectNoSilence(const GeneratedAudio& audio, const std::string& testLabel) {
 	auto silence = findLongestSilence(
 			audio.data,
-			audio.sampleRate,
-			0.02f,
-			audio.sampleCount
+            LongestSilenceOptions {
+                .sampleRate = audio.sampleRate,
+                .minSilenceLengthSeconds = 0.02f,
+                .maximumSilenceStartSamples = audio.sampleCount,
+                .returnFirstMatch = false,
+            }
 	);
 	if (silence.isValid) {
 		std::stringstream errorBuilder;
@@ -141,9 +144,12 @@ static void expectNoSilence(const GeneratedAudio& audio, const std::string& test
 static void expectSilenceBetween(const GeneratedAudio& audio, float startTimeSeconds, float stopTimeSeconds, const std::string& testLabel) {
 	auto silenceResult = findLongestSilence(
 			audio.data,
-			audio.sampleRate,
-			0.02f,
-			audio.sampleCount
+            LongestSilenceOptions {
+                    .sampleRate = audio.sampleRate,
+                    .minSilenceLengthSeconds = 0.02f,
+                    .maximumSilenceStartSamples = audio.sampleCount,
+                    .returnFirstMatch = false,
+            }
 	);
 
 	if (!silenceResult.isValid) {

--- a/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
@@ -54,13 +54,14 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_init(
 		jobject thiz,
 		jstring modelPath,
 		jstring language,
-		jstring prompt
+		jstring prompt,
+        jboolean useShortAudioContext
 ) {
 	whisper_log_set(log_android, nullptr);
 
 	try {
 		auto *pSession = new WhisperSession(
-				stringToCXX(env, modelPath), stringToCXX(env, language), stringToCXX(env, prompt)
+				stringToCXX(env, modelPath), stringToCXX(env, language), stringToCXX(env, prompt), useShortAudioContext
 		);
 		return (jlong) pSession;
 	} catch (const std::exception& exception) {

--- a/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
@@ -78,8 +78,8 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_free(JNIEnv *env, jo
 }
 
 extern "C"
-JNIEXPORT jstring JNICALL
-Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_fullTranscribe(JNIEnv *env,
+JNIEXPORT void JNICALL
+Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_addAudio(JNIEnv *env,
 																		   jobject thiz,
 																		   jlong pointer,
 																		   jfloatArray audio_data) {
@@ -89,21 +89,53 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_fullTranscribe(JNIEn
 	std::string result;
 
 	try {
-		LOGD("Starting Whisper, transcribe %d", lenAudioData);
-		result = pSession->transcribeNextChunk(pAudioData, lenAudioData);
-		auto preview = pSession->getPreview();
-		LOGD("Ran Whisper. Got %s (preview %s)", result.c_str(), preview.c_str());
+		pSession->addAudio(pAudioData, lenAudioData);
 	} catch (const std::exception& exception) {
-		LOGW("Failed to run whisper: %s", exception.what());
+		LOGW("Failed to add to audio buffer: %s", exception.what());
 		throwException(env, exception.what());
 	}
 
 	// JNI_ABORT: "free the buffer without copying back the possible changes", pass 0 to copy
 	// changes (there should be no changes)
 	env->ReleaseFloatArrayElements(audio_data, pAudioData, JNI_ABORT);
-
-	return stringToJava(env, result);
 }
+
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeNextChunk(JNIEnv *env,
+                                                                                jobject thiz,
+                                                                                jlong pointer) {
+    auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
+    std::string result;
+
+    try {
+        result = pSession->transcribeNextChunk();
+    } catch (const std::exception& exception) {
+        LOGW("Failed to run whisper: %s", exception.what());
+        throwException(env, exception.what());
+    }
+
+    return stringToJava(env, result);
+}
+
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeRemaining(JNIEnv *env,
+                                                                                jobject thiz,
+                                                                                jlong pointer) {
+    auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
+    std::string result;
+
+    try {
+        result = pSession->transcribeAll();
+    } catch (const std::exception& exception) {
+        LOGW("Failed to run whisper: %s", exception.what());
+        throwException(env, exception.what());
+    }
+
+    return stringToJava(env, result);
+}
+
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_getPreview(

--- a/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
@@ -103,37 +103,37 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_addAudio(JNIEnv *env
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeNextChunk(JNIEnv *env,
-                                                                                jobject thiz,
-                                                                                jlong pointer) {
-    auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
-    std::string result;
+																				jobject thiz,
+																				jlong pointer) {
+	auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
+	std::string result;
 
-    try {
-        result = pSession->transcribeNextChunk();
-    } catch (const std::exception& exception) {
-        LOGW("Failed to run whisper: %s", exception.what());
-        throwException(env, exception.what());
-    }
+	try {
+		result = pSession->transcribeNextChunk();
+	} catch (const std::exception& exception) {
+		LOGW("Failed to run whisper: %s", exception.what());
+		throwException(env, exception.what());
+	}
 
-    return stringToJava(env, result);
+	return stringToJava(env, result);
 }
 
 extern "C"
 JNIEXPORT jstring JNICALL
 Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeRemaining(JNIEnv *env,
-                                                                                jobject thiz,
-                                                                                jlong pointer) {
-    auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
-    std::string result;
+																				jobject thiz,
+																				jlong pointer) {
+	auto *pSession = reinterpret_cast<WhisperSession *> (pointer);
+	std::string result;
 
-    try {
-        result = pSession->transcribeAll();
-    } catch (const std::exception& exception) {
-        LOGW("Failed to run whisper: %s", exception.what());
-        throwException(env, exception.what());
-    }
+	try {
+		result = pSession->transcribeAll();
+	} catch (const std::exception& exception) {
+		LOGW("Failed to run whisper: %s", exception.what());
+		throwException(env, exception.what());
+	}
 
-    return stringToJava(env, result);
+	return stringToJava(env, result);
 }
 
 extern "C"

--- a/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
@@ -114,6 +114,7 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeNextChunk(
 	} catch (const std::exception& exception) {
 		LOGW("Failed to run whisper: %s", exception.what());
 		throwException(env, exception.what());
+        return nullptr;
 	}
 
 	return stringToJava(env, result);
@@ -132,6 +133,7 @@ Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_transcribeRemaining(
 	} catch (const std::exception& exception) {
 		LOGW("Failed to run whisper: %s", exception.what());
 		throwException(env, exception.what());
+        return nullptr;
 	}
 
 	return stringToJava(env, result);

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/AudioRecorder.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/AudioRecorder.kt
@@ -15,7 +15,9 @@ typealias AudioRecorderFactory = (context: Context)->AudioRecorder;
 
 class AudioRecorder(context: Context) : Closeable {
 	private val sampleRate = 16_000
-	private val maxLengthSeconds = 30 // Whisper supports a maximum of 30s
+	// Don't allow the unprocessed audio buffer to grow indefinitely -- discard
+	// data if longer than this:
+	private val maxLengthSeconds = 120
 	private val maxBufferSize = sampleRate * maxLengthSeconds
 	private val buffer = FloatArray(maxBufferSize)
 	private var bufferWriteOffset = 0

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/NativeWhisperLib.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/NativeWhisperLib.kt
@@ -19,19 +19,37 @@ class NativeWhisperLib(
 		private external fun init(modelPath: String, languageCode: String, prompt: String): Long;
 		private external fun free(pointer: Long): Unit;
 
-		private external fun fullTranscribe(pointer: Long, audioData: FloatArray): String;
+		private external fun addAudio(pointer: Long, audioData: FloatArray): Unit;
+		private external fun transcribeNextChunk(pointer: Long): String;
+		private external fun transcribeRemaining(pointer: Long): String;
 		private external fun getPreview(pointer: Long): String;
 	}
 
 	private var closed = false
 	private val pointer: Long = init(modelPath, languageCode, prompt)
 
-	fun transcribe(audioData: FloatArray): String {
+	fun addAudio(audioData: FloatArray) {
+		if (closed) {
+			throw Exception("Cannot add audio data to a closed session")
+		}
+
+		Companion.addAudio(pointer, audioData)
+	}
+
+	fun transcribeNextChunk(): String {
 		if (closed) {
 			throw Exception("Cannot transcribe using a closed session")
 		}
 
-		return fullTranscribe(pointer, audioData)
+		return Companion.transcribeNextChunk(pointer)
+	}
+
+	fun transcribeRemaining(): String {
+		if (closed) {
+			throw Exception("Cannot transcribeAll using a closed session")
+		}
+
+		return Companion.transcribeRemaining(pointer)
 	}
 
 	fun getPreview(): String {

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/NativeWhisperLib.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/NativeWhisperLib.kt
@@ -6,6 +6,7 @@ class NativeWhisperLib(
 	modelPath: String,
 	languageCode: String,
 	prompt: String,
+	shortAudioContext: Boolean,
 ) : Closeable {
 	companion object {
 		init {
@@ -16,7 +17,7 @@ class NativeWhisperLib(
 
 		// TODO: The example whisper.cpp project transfers pointers as Longs to the Kotlin code.
 		// This seems unsafe. Try changing how this is managed.
-		private external fun init(modelPath: String, languageCode: String, prompt: String): Long;
+		private external fun init(modelPath: String, languageCode: String, prompt: String, shortAudioContext: Boolean): Long;
 		private external fun free(pointer: Long): Unit;
 
 		private external fun addAudio(pointer: Long, audioData: FloatArray): Unit;
@@ -26,7 +27,7 @@ class NativeWhisperLib(
 	}
 
 	private var closed = false
-	private val pointer: Long = init(modelPath, languageCode, prompt)
+	private val pointer: Long = init(modelPath, languageCode, prompt, shortAudioContext)
 
 	fun addAudio(audioData: FloatArray) {
 		if (closed) {

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextConverter.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextConverter.kt
@@ -8,6 +8,7 @@ class SpeechToTextConverter(
 	modelPath: String,
 	locale: String,
 	prompt: String,
+	useShortAudioCtx: Boolean,
 	recorderFactory: AudioRecorderFactory,
 	context: Context,
 ) : Closeable {
@@ -17,6 +18,7 @@ class SpeechToTextConverter(
 		modelPath,
 		languageCode,
 		prompt,
+		useShortAudioCtx,
 	)
 
 	fun start() {

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextConverter.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextConverter.kt
@@ -25,7 +25,8 @@ class SpeechToTextConverter(
 
 	private fun convert(data: FloatArray): String {
 		Log.d("Whisper", "Pre-transcribe data of size ${data.size}")
-		val result = whisper.transcribe(data)
+		whisper.addAudio(data)
+		val result = whisper.transcribeNextChunk()
 		Log.d("Whisper", "Post transcribe. Got $result")
 		return result;
 	}
@@ -47,7 +48,8 @@ class SpeechToTextConverter(
 	// Converts as many seconds of buffered data as possible, without waiting
 	fun convertRemaining(): String {
 		val buffer = recorder.pullAvailable()
-		return convert(buffer)
+		whisper.addAudio(buffer)
+		return whisper.transcribeRemaining()
 	}
 
 	fun getPreview(): String {

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextPackage.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextPackage.kt
@@ -43,11 +43,11 @@ class SpeechToTextPackage : ReactPackage {
 		}
 
 		@ReactMethod
-		fun openSession(modelPath: String, locale: String, prompt: String, promise: Promise) {
+		fun openSession(modelPath: String, locale: String, prompt: String, useShortAudioCtx: Boolean, promise: Promise) {
 			val appContext = context.applicationContext
 
 			try {
-				val sessionId = sessionManager.openSession(modelPath, locale, prompt, appContext)
+				val sessionId = sessionManager.openSession(modelPath, locale, prompt, useShortAudioCtx, appContext)
 				promise.resolve(sessionId)
 			} catch (exception: Throwable) {
 				promise.reject(exception)

--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextSessionManager.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/SpeechToTextSessionManager.kt
@@ -21,12 +21,13 @@ class SpeechToTextSessionManager(
 		modelPath: String,
 		locale: String,
 		prompt: String,
+		useShortAudioCtx: Boolean,
 		context: Context,
 	): Int {
 		val sessionId = nextSessionId++
 		sessions[sessionId] = SpeechToTextSession(
 			SpeechToTextConverter(
-				modelPath, locale, prompt, recorderFactory = AudioRecorder.factory, context,
+				modelPath, locale, prompt, useShortAudioCtx, recorderFactory = AudioRecorder.factory, context,
 			)
 		)
 		return sessionId

--- a/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
@@ -165,6 +165,9 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 	};
 
 	const renderPreview = () => {
+		if (recorderState !== RecorderState.Recording) {
+			return null;
+		}
 		return <Text variant='labelSmall'>{preview}</Text>;
 	};
 

--- a/packages/app-mobile/services/voiceTyping/whisper.test.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.test.ts
@@ -19,6 +19,7 @@ jest.mock('react-native', () => {
 		}),
 		closeSession: jest.fn(),
 		startRecording: jest.fn(),
+		convertAvailable: jest.fn(() => ''),
 	};
 
 	return reactNative;

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -86,15 +86,25 @@ class Whisper implements VoiceTypingSession {
 	}
 
 	private postProcessSpeech(data: string) {
-		data = data.trim();
+		const paragraphs = data.split('\n\n');
 
-		for (const [key, value] of this.config.stringReplacements) {
-			data = data.split(key).join(value);
+		const result = [];
+		for (let paragraph of paragraphs) {
+			paragraph = paragraph.trim();
+
+			for (const [key, value] of this.config.stringReplacements) {
+				paragraph = paragraph.split(key).join(value);
+			}
+			for (const [key, value] of this.config.regexReplacements) {
+				paragraph = paragraph.replace(key, value);
+			}
+
+			if (paragraph) {
+				result.push(paragraph);
+			}
 		}
-		for (const [key, value] of this.config.regexReplacements) {
-			data = data.replace(key, value);
-		}
-		return data;
+
+		return result.join('\n\n');
 	}
 
 	private onDataFinalize(data: string) {

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -70,6 +70,8 @@ class WhisperConfig {
 			}
 		};
 
+		// Models fine-tuned as per https://github.com/futo-org/whisper-acft should have
+		// "shortAudioContext": true in their config.json.
 		if ('shortAudioContext' in json) {
 			this.supportsShortAudioCtx = !!json.shortAudioContext;
 		}

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -13,6 +13,7 @@ const { SpeechToTextModule } = NativeModules;
 
 class WhisperConfig {
 	public prompts: Map<string, string> = new Map();
+	public supportsShortAudioCtx = false;
 	public stringReplacements: [string, string][] = [];
 	public regexReplacements: [RegExp, string][] = [];
 
@@ -68,6 +69,10 @@ class WhisperConfig {
 				});
 			}
 		};
+
+		if ('shortAudioContext' in json) {
+			this.supportsShortAudioCtx = !!json.shortAudioContext;
+		}
 
 		processPrompts();
 		processOutputSettings();
@@ -245,8 +250,9 @@ const whisper: VoiceTypingProvider = {
 			throw new Error(`Model not found at path ${modelPath}`);
 		}
 
+		logger.debug('Starting whisper session', config.supportsShortAudioCtx ? '(short audio context)' : '');
 		const sessionId = await SpeechToTextModule.openSession(
-			modelPath, locale, getPrompt(locale, config.prompts),
+			modelPath, locale, getPrompt(locale, config.prompts), config.supportsShortAudioCtx,
 		);
 		return new Whisper(sessionId, callbacks, config);
 	},


### PR DESCRIPTION
# Summary

This pull request changes how the Android-specific voice typing logic handles large amounts of unprocessed data.

Specifically this change:
1. Allows more unprocessed audio to be buffered.
2. Processes all (up to two minutes of) previously-unprocessed data when clicking "Done".
    - Depending on the size of selected voice typing model, **this can take a long time** (see the screen recording below).
    - Previously, up to 1-2 paragraphs of unprocessed data were processed when clicking "Done".
3. Allows running certain larger models in a faster way (adds support for [whisper-acft models](https://github.com/futo-org/whisper-acft)).
    - This should prevent the slowdown mentioned above. 

Resolves #11956.

# Possible changes

At present, if voice typing transcription is significantly slower than the user's speaking rate, the processing that happens after a user clicks "Done" can take a long time. As such, it may make sense to:
- Show transcription progress in addition to "Converting speech to text...".
   - Requires refactoring, may not be necessary with faster models.
- Show a "Cancel" button to cancel an in-progress transcription.
- Avoid generating a preview when voice typing is using a slow model. This should improve performance by reducing the total number of times the model is used for transcription.
    - At present, voice typing only avoids generating a preview if processing older buffered data (e.g. after the user clicks "Done").
- [x] Provide [faster multilingual models](https://github.com/futo-org/whisper-acft) (may require changes to `WhisperSession.cpp`).

# Screen recording

https://github.com/user-attachments/assets/c2a19d9b-5894-49d1-9eef-29d327661c0e

The above screen recording demonstrates voice typing with the unquantized `base` model, which is larger than the currently-default `tiny-q8_0` model. About 10-15 seconds after speech starts, the preview view updates. About 15 seconds after this, "done" is clicked and the dialog label changes to "Converting text to speech...". Roughly **45 seconds later**, the recognized speech is added to the note. 



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->