### PR TITLE
Windows: Add portable executable for each architecture

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -61,6 +61,18 @@
             "x64",
             "ia32"
           ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "ia32"
+          ]
         }
       ],
       "extraFiles": [
@@ -78,7 +90,7 @@
       "allowToChangeInstallationDirectory": false
     },
     "portable": {
-      "artifactName": "${productName}Portable.${ext}"
+      "artifactName": "${productName}Portable-${arch}.${ext}"
     },
     "mac": {
       "icon": "../../Assets/macOs.icns",


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
The current portable executable for Windows is over 300MB because it includes binaries for both x86 and x64 architectures. However, in most cases, users only need one of these.
![图片](https://github.com/user-attachments/assets/7e9628cd-9451-41c9-8326-944dff46d752)

This PR adds portable build targets for each single architecture, reducing the executable size to under 170MB. This also improves startup performance because the portable executable always extracts itself to a temporary folder on Windows before running. A smaller size can reduce the loading time.
![图片](https://github.com/user-attachments/assets/97cfa218-3ce7-48c6-b8c1-51e556ae1809)

## Notes
1. I didn't remove the old portable build target in `package.json` because some users might still need a universal portable executable. Also, There might be some hard-coded links referring to the `JoplinPortable.exe` and removing it could cause failures. However, I can also remove the old build target if you wish.
2. The code in `electron-builder` ensures that adding the new `-${arch}` suffix won't change the original executable name.
https://github.com/electron-userland/electron-builder/commit/7194c388f64cf9074e7ae14e74a7783da76ea284#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867R134
https://github.com/electron-userland/electron-builder/blob/e41c24ca47165a363a2ebb847416058f20047b9c/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts#L173
https://www.electron.build/file-patterns.html#file-macros
> `${arch}` — expanded to `ia32`, `x64`. If no `arch`, macro will be removed from your pattern with leading space, `-` and `_` (so, you don’t need to worry and can reuse pattern).