### PR TITLE
Android: Voice typing: Fix incorrectly-calculated audio length

### DIFF
--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -69,10 +69,10 @@ WhisperSession::transcribe_(const std::vector<float>& audio, size_t transcribeCo
 		return "";
 	}
 
-    float seconds = static_cast<float>(audio.size()) / WHISPER_SAMPLE_RATE;
-    if (seconds > 30.0f) {
-        LOGW("Warning: Audio is longer than 30 seconds. Not all audio will be transcribed");
-    }
+	float seconds = static_cast<float>(transcribeCount) / WHISPER_SAMPLE_RATE;
+	if (seconds > 30.0f) {
+		LOGW("Warning: Audio is longer than 30 seconds. Not all audio will be transcribed");
+	}
 
 	whisper_full_params params = buildWhisperParams_();
 


### PR DESCRIPTION
# Summary

This pull request fixes an incorrect calculation in `WhisperSession.cpp`. `audio.size()` was used to calculate the value of `params.audio_ctx`. Instead, `transcribeCount` (the number of samples to transcribe) should have been used.


# Testing plan

1. Start voice typing.
2. Talk for 10-20 seconds.
3. Click "Done".
4. Verify that the spoken content has been transcribed.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->