### PR TITLE
Android: Voice typing: Improve transcription at the end of paragraphs

### DIFF
--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -64,7 +64,7 @@ WhisperSession::buildWhisperParams_() {
 
 std::string
 WhisperSession::transcribe_(const std::vector<float>& audio, size_t transcribeCount) {
-    // Whisper won't transcribe anything shorter than 1s.
+	// Whisper won't transcribe anything shorter than 1s.
 	int minTranscribeLength = WHISPER_SAMPLE_RATE; // 1s
 	if (transcribeCount < minTranscribeLength) {
 		return "";
@@ -153,11 +153,11 @@ WhisperSession::transcribeNextChunkNoPreview_() {
 			audioBuffer_.clear();
 			return false;
 		} else if (splitEnd > tolerance) { // Anything to transcribe?
-            // Include some of the silence between the start and the end. Excluding it
-            // seems to make Whisper more likely to omit trailing punctuation.
-            int maximumSilentSamples = WHISPER_SAMPLE_RATE;
-            int silentSamplesToAdd = std::min(maximumSilentSamples, (splitEnd - splitStart) / 2);
-            splitStart += silentSamplesToAdd;
+			// Include some of the silence between the start and the end. Excluding it
+			// seems to make Whisper more likely to omit trailing punctuation.
+			int maximumSilentSamples = WHISPER_SAMPLE_RATE;
+			int silentSamplesToAdd = std::min(maximumSilentSamples, (splitEnd - splitStart) / 2);
+			splitStart += silentSamplesToAdd;
 
 			result << splitAndTranscribeBefore_(splitStart, splitEnd) << "\n\n";
 			return true;

--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -64,7 +64,8 @@ WhisperSession::buildWhisperParams_() {
 
 std::string
 WhisperSession::transcribe_(const std::vector<float>& audio, size_t transcribeCount) {
-	int minTranscribeLength = WHISPER_SAMPLE_RATE / 2; // 0.5s
+    // Whisper won't transcribe anything shorter than 1s.
+	int minTranscribeLength = WHISPER_SAMPLE_RATE; // 1s
 	if (transcribeCount < minTranscribeLength) {
 		return "";
 	}
@@ -152,6 +153,12 @@ WhisperSession::transcribeNextChunkNoPreview_() {
 			audioBuffer_.clear();
 			return false;
 		} else if (splitEnd > tolerance) { // Anything to transcribe?
+            // Include some of the silence between the start and the end. Excluding it
+            // seems to make Whisper more likely to omit trailing punctuation.
+            int maximumSilentSamples = WHISPER_SAMPLE_RATE;
+            int silentSamplesToAdd = std::min(maximumSilentSamples, (splitEnd - splitStart) / 2);
+            splitStart += silentSamplesToAdd;
+
 			result << splitAndTranscribeBefore_(splitStart, splitEnd) << "\n\n";
 			return true;
 		}


### PR DESCRIPTION
# Summary

This pull request adds padding to the end of paragraph transcriptions (up to one second of the silence that created the paragraph break).

Previously, it was observed that the last word and/or ending punctuation was sometimes not included in transcribed paragraphs. Including part of the silence that was detected so far seems to fix the issue.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->