### PR TITLE
Chore: Make useFormNote.test.ts less likely to fail in CI

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -97,7 +97,15 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 
 			await initNoteState(n, false);
 			if (event.cancelled) return;
-			setFormNoteRefreshScheduled(0);
+			setFormNoteRefreshScheduled(oldValue => {
+				// If a new refresh was scheduled between initNoteState
+				// and now:
+				if (oldValue !== formNoteRefreshScheduled) {
+					return oldValue;
+				}
+				// Unschedule future refreshes
+				return 0;
+			});
 		};
 
 		await loadNote();

--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -103,7 +103,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 				if (oldValue !== formNoteRefreshScheduled) {
 					return oldValue;
 				}
-				// Unschedule future refreshes
+				// A refresh is no longer scheduled
 				return 0;
 			});
 		};


### PR DESCRIPTION
# Summary

This pull request attempts to fix a frequent CI test failure by fixing a potential race condition. Previously, if a form note refresh was scheduled just before the end of the previous form note refresh, the scheduled refresh could be ignored.

Example of failed test output ([from this CI run](https://github.com/laurent22/joplin/actions/runs/14109039479/job/39522598709)):
```
 ➤ YN0000: [@joplin/app-desktop]: Summary of all failing tests
➤ YN0000: [@joplin/app-desktop]: FAIL gui/NoteEditor/utils/useFormNote.test.ts (19.121 s)
➤ YN0000: [@joplin/app-desktop]:   ● useFormNote › should update note when decryption completes
➤ YN0000: [@joplin/app-desktop]: 
➤ YN0000: [@joplin/app-desktop]:     Timed out in waitFor after 15000ms.
➤ YN0000: [@joplin/app-desktop]: 
➤ YN0000: [@joplin/app-desktop]:       73 |
➤ YN0000: [@joplin/app-desktop]:       74 | 		// Ending decryption should also cause a re-render
➤ YN0000: [@joplin/app-desktop]:     > 75 | 		await formNote.waitFor(() => {
➤ YN0000: [@joplin/app-desktop]:          | 		^
➤ YN0000: [@joplin/app-desktop]:       76 | 			expect(formNote.result.current.formNote).toMatchObject({
➤ YN0000: [@joplin/app-desktop]:       77 | 				encryption_applied: 0,
➤ YN0000: [@joplin/app-desktop]:       78 | 			});
➤ YN0000: [@joplin/app-desktop]: 
➤ YN0000: [@joplin/app-desktop]:       at Object.waitFor (node_modules/@testing-library/react-hooks/lib/core/asyncUtils.js:64:13)
➤ YN0000: [@joplin/app-desktop]:       at Object.<anonymous> (gui/NoteEditor/utils/useFormNote.test.ts:75:3)
```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->