### PR TITLE
Android: Voice typing: Disable "Download update" button while downloading an updated model

### DIFF
--- a/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
@@ -186,7 +186,7 @@ const SpeechToTextComponent: React.FC<Props> = props => {
 	const reDownloadButton = <Button
 		// Usually, stoppingSession is true because the re-download button has
 		// just been pressed.
-		disabled={stoppingSession}
+		disabled={stoppingSession || recorderState === RecorderState.Downloading}
 		onPress={onRequestRedownload}
 	>
 		{modelIsOutdated ? _('Download updated model') : _('Re-download model')}


### PR DESCRIPTION
# Summary

This pull request disables the "Download updated model" button while downloading an updated model.

Previously, the "Download updated model" button was briefly clickable just after the voice typing session finished closing.

# Testing plan

1. Change the voice typing model URL in settings.
2. Start voice typing.
3. Click "Download updated model".
4. Verify that "Download updated model" is first disabled (while closing the current voice typing session and briefly after), then removed (while downloading the new model).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->