### PR TITLE
Web: Fix crash on opening settings

### DIFF
--- a/packages/app-mobile/utils/shim-init-react/index.ts
+++ b/packages/app-mobile/utils/shim-init-react/index.ts
@@ -172,10 +172,6 @@ export default function shimInit() {
 		return false;
 	};
 
-	shim.platformArch = () => {
-		return ''; // Not supported
-	};
-
 	shim.appVersion = () => {
 		const p = require('react-native-version-info').default;
 		return p.appVersion;

--- a/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
+++ b/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
@@ -79,6 +79,10 @@ const shimInitShared = () => {
 		return Platform.OS;
 	};
 
+	shim.platformArch = () => {
+		return ''; // Not supported
+	};
+
 	shim.injectedJs = function(name) {
 		if (!(name in injectedJs)) throw new Error(`Cannot find injectedJs file (add it to "injectedJs" object): ${name}`);
 		return injectedJs[name as keyof typeof injectedJs];


### PR DESCRIPTION
# Summary

Fixes an "Error: platformArch is not implemented" error when opening settings on web.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->