### PR TITLE
Mobile: Plugins: Add command to hide the plugin panel viewer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -583,6 +583,7 @@ packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js
+packages/app-mobile/commands/dismissPluginPanels.js
 packages/app-mobile/commands/index.js
 packages/app-mobile/commands/newNote.test.js
 packages/app-mobile/commands/newNote.js

--- a/.gitignore
+++ b/.gitignore
@@ -558,6 +558,7 @@ packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js
+packages/app-mobile/commands/dismissPluginPanels.js
 packages/app-mobile/commands/index.js
 packages/app-mobile/commands/newNote.test.js
 packages/app-mobile/commands/newNote.js

--- a/packages/app-mobile/commands/dismissPluginPanels.ts
+++ b/packages/app-mobile/commands/dismissPluginPanels.ts
@@ -1,0 +1,16 @@
+import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
+
+export const declaration: CommandDeclaration = {
+	name: 'dismissPluginPanels',
+};
+
+export const runtime = (): CommandRuntime => {
+	return {
+		execute: async (context: CommandContext) => {
+			context.dispatch({
+				type: 'SET_PLUGIN_PANELS_DIALOG_VISIBLE',
+				visible: false,
+			});
+		},
+	};
+};

--- a/packages/app-mobile/commands/index.ts
+++ b/packages/app-mobile/commands/index.ts
@@ -1,10 +1,12 @@
 // AUTO-GENERATED using `gulp buildScriptIndexes`
+import * as dismissPluginPanels from './dismissPluginPanels';
 import * as newNote from './newNote';
 import * as openItem from './openItem';
 import * as openNote from './openNote';
 import * as scrollToHash from './scrollToHash';
 
 const index: any[] = [
+	dismissPluginPanels,
 	newNote,
 	openItem,
 	openNote,

--- a/packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx
+++ b/packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx
@@ -12,8 +12,8 @@ import PluginUserWebView from './PluginUserWebView';
 import { View, StyleSheet, AccessibilityInfo } from 'react-native';
 import { _ } from '@joplin/lib/locale';
 import Setting from '@joplin/lib/models/Setting';
-import { Dispatch } from 'redux';
 import DismissibleDialog, { DialogSize } from '../../../components/DismissibleDialog';
+import CommandService from '@joplin/lib/services/CommandService';
 
 interface Props {
 	themeId: number;
@@ -21,7 +21,6 @@ interface Props {
 	pluginHtmlContents: PluginHtmlContents;
 	pluginStates: PluginStates;
 	visible: boolean;
-	dispatch: Dispatch;
 }
 
 
@@ -157,11 +156,8 @@ const PluginPanelViewer: React.FC<Props> = props => {
 	};
 
 	const onClose = useCallback(() => {
-		props.dispatch({
-			type: 'SET_PLUGIN_PANELS_DIALOG_VISIBLE',
-			visible: false,
-		});
-	}, [props.dispatch]);
+		void CommandService.instance().execute('dismissPluginPanels');
+	}, []);
 
 	return (
 		<Portal>


### PR DESCRIPTION
# Summary

This pull request adds a command that can be used to dismiss the plugin panel viewer from a plugin.

This implements a feature requested [on the Joplin
forum](https://discourse.joplinapp.org/t/plugin-api-what-should-panels-show-and-panels-visible-do-on-mobile/37507/3) by @benlau.

# Testing plan

(Web, with #12017 merged)
1. Install a plugin that shows a panel (tested with the debug info plugin).
2. Open the plugin panel.
3. Close it by clicking the "X" button.
4. Verify that the plugin panel viewer closes.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->