### PR TITLE
Chore: Improve note list test reliability

### DIFF
--- a/packages/app-desktop/integration-tests/models/NoteList.ts
+++ b/packages/app-desktop/integration-tests/models/NoteList.ts
@@ -25,6 +25,7 @@ export default class NoteList {
 
 	public async focusContent(electronApp: ElectronApplication) {
 		await activateMainMenuItem(electronApp, 'Note list', 'Focus');
+		await expect(this.container.locator(':focus')).toBeAttached();
 	}
 
 	// The resultant locator may fail to resolve if the item is not visible


### PR DESCRIPTION
# Summary

This pull request checks that the note list is focused, before attempting to navigate in it using keyboard shortcuts. This may make the note list tests less likely to fail in CI.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->