### PR TITLE
Desktop: Fixes #9291: A note scrolls to top if reached by following a link to a section

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -139,11 +139,8 @@
 			const viewerPercent = scrollmap.translateL2V(percent);
 			const newScrollTop = viewerPercent * maxScrollTop();
 
-			// Even if the scroll position hasn't changed (percent is the same),
-			// we still ignore the next scroll event, so that it doesn't create
-			// undesired side effects.
-			// https://github.com/laurent22/joplin/issues/7617
-			ignoreNextScrollEvent();
+			// The next scroll event cannot be skipped in order to correctly
+			// scroll to the target section in a different note when follwing a link
 			
 			if (Math.floor(contentElement.scrollTop) !== Math.floor(newScrollTop)) {
 				percentScroll_ = percent;


### PR DESCRIPTION
# Summary
This pull request should fix issue #9291 by changing the index.html file in note-viewer. In the code, there was another issue referenced, issue #7617, however, I've ran the test case indicated in the bug report and wasn't able to reproduce it, the behaviour of the application was the same before and after the changes. I've uploaded a video showing the fix so it's easier to detect any unwanted modifications to the application: https://youtu.be/ndEz3OySuTs.
# Testing plan
1. Open the markdown editor with text view next to it
2. Create two notes
3. Write some text to fill more than the length of the monitor
4. Below that text, write a header (or sub-header)
5. Include a reference to the target header in the other note
6. On the note that doesn't include the header, click on the link to it
7. Verify that the markdown editor now scrolls to the correct section and is synchronized with the text view instead of staying at the top of the note, disconnected from it