### PR TITLE
All: Resolves minor bug: Fixed absoluteUrl and baseUrl functions

### DIFF
--- a/packages/lib/clipperUtils.ts
+++ b/packages/lib/clipperUtils.ts
@@ -11,7 +11,7 @@ function absoluteUrl(url: string) {
 	} else if (url[0] === '/') {
 		return `${location.protocol}//${location.host}${url}`;
 	} else {
-		return `${baseUrl()}/${url}`;
+		return `${baseUrl()}${url}`;
 	}
 }
 

--- a/packages/lib/clipperUtils.ts
+++ b/packages/lib/clipperUtils.ts
@@ -11,7 +11,7 @@ function absoluteUrl(url: string) {
 	} else if (url[0] === '/') {
 		return `${location.protocol}//${location.host}${url}`;
 	} else {
-		return `${baseUrl()}${url}`;
+		return `${baseUrl()}/${url}`;
 	}
 }
 
@@ -33,6 +33,9 @@ function baseUrl() {
 		const output2 = output.split('/');
 		output2.pop();
 		output = output2.join('/');
+	}
+	if (output.endsWith("/")){
+		output = output.slice(0, -1);
 	}
 	return output;
 }

--- a/packages/lib/clipperUtils.ts
+++ b/packages/lib/clipperUtils.ts
@@ -34,7 +34,7 @@ function baseUrl() {
 		output2.pop();
 		output = output2.join('/');
 	}
-	if (output.endsWith("/")){
+	if (output[output.length - 1] === '/'){
 		output = output.slice(0, -1);
 	}
 	return output;

--- a/packages/lib/clipperUtils.ts
+++ b/packages/lib/clipperUtils.ts
@@ -34,7 +34,7 @@ function baseUrl() {
 		output2.pop();
 		output = output2.join('/');
 	}
-	if (output[output.length - 1] === '/'){
+	if (output[output.length - 1] === '/') {
 		output = output.slice(0, -1);
 	}
 	return output;


### PR DESCRIPTION
# All: Resolves minor bug: Fixed absoluteUrl function (/packages/lib/clipperUtils.ts)

Fixes an issue with the absoluteUrl function, which occurs when the function is invoked with a relative URL (a path-only URL).
I found this bug while running my own white-box unit tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

### My own test result screen:
![image](https://github.com/user-attachments/assets/639b2832-1e91-4ea9-b5cf-9935e23e34e3)

### Old code with my comment:
```typescript
function absoluteUrl(url: string) {
	if (!url) return url;
	const protocol = url.toLowerCase().split(':')[0];
	if (['http', 'https', 'file', 'data'].indexOf(protocol) >= 0) return url;

	if (url.indexOf('//') === 0) {
		return location.protocol + url;
	} else if (url[0] === '/') {
		return `${location.protocol}//${location.host}${url}`;
	} else {
		return `${baseUrl()}/${url}`; //double '/' here: baseUrl() can ends with '/'
	}
}
```

```typescript
function baseUrl() {
	let output = pageLocationOrigin() + location.pathname; //location.pathname can be "/" or can ends with "/"
	if (output[output.length - 1] !== '/') {
		const output2 = output.split('/');
		output2.pop();
		output = output2.join('/');
	}
	return output;
}
```


### New version of baseUrl():
```typescript
function baseUrl() {
	let output = pageLocationOrigin() + location.pathname;
	if (output[output.length - 1] !== '/') {
			const output2 = output.split('/');
			output2.pop();
			output = output2.join('/');
	}
	if (output[output.length - 1] === '/') {
			output = output.slice(0, -1);
	}
	return output;
}
