### PR TITLE
Desktop: Rich Text Editor: Fix "Remove color" button doesn't work

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -736,7 +736,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: any) => {
 					joplinSub: { inline: 'sub', remove: 'all' },
 					joplinSup: { inline: 'sup', remove: 'all' },
 					code: { inline: 'code', remove: 'all', attributes: { spellcheck: 'false' } },
-					forecolor: { inline: 'span', styles: { color: '%value' } },
+					// Foreground color: The remove_similar: true is necessary here for the "remove formatting"
+					// button to work. See https://github.com/tinymce/tinymce/issues/5026.
+					forecolor: { inline: 'span', styles: { color: '%value' }, remove_similar: true },
 				},
 				text_patterns: props.enableTextPatterns ? [
 					// See https://www.tiny.cloud/docs/tinymce/latest/content-behavior-options/#text_patterns


### PR DESCRIPTION
# Summary

This pull request fixes the "Remove color" button in the Rich Text Editor's "change color" dropdown based on [comments in a related upstream issue report](https://github.com/tinymce/tinymce/issues/5026).

This issue was originally reported [on the Joplin forum](https://discourse.joplinapp.org/t/rte-the-remove-color-of-the-color-tool-is-bugging/44587).

# Testing plan

1. Select text in the Rich Text Editor.
2. Change the color using the color option in the menubar.
3. Reset the color by clicking "remove color" in the color selection menu: ![screenshot: remove color button](https://github.com/user-attachments/assets/bdff2067-66e7-4792-afe8-c5befbf716cb).
4. Verify that the default color has been restored.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->