### PR TITLE
Mobile: Add "swap line up" and "swap line down" to toolbar extended options

### DIFF
--- a/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/allToolbarCommandNamesFromState.ts
@@ -22,6 +22,8 @@ const builtInCommandNames = [
 	'-',
 	EditorCommandType.IndentLess,
 	EditorCommandType.IndentMore,
+	`editor.${EditorCommandType.SwapLineDown}`,
+	`editor.${EditorCommandType.SwapLineUp}`,
 	'-',
 	'insertDateTime',
 	'-',

--- a/packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.ts
+++ b/packages/app-mobile/components/EditorToolbar/utils/selectedCommandNamesFromState.ts
@@ -1,3 +1,4 @@
+import { EditorCommandType } from '@joplin/editor/types';
 import { AppState } from '../../../utils/types';
 import allToolbarCommandNamesFromState from './allToolbarCommandNamesFromState';
 import { Platform } from 'react-native';
@@ -7,6 +8,8 @@ const omitFromDefault: string[] = [
 	'editor.textHeading3',
 	'editor.textHeading4',
 	'editor.textHeading5',
+	`editor.${EditorCommandType.SwapLineDown}`,
+	`editor.${EditorCommandType.SwapLineUp}`,
 ];
 
 // The "hide keyboard" button is only needed on iOS, so only show it there by default.

--- a/packages/app-mobile/components/NoteEditor/commandDeclarations.ts
+++ b/packages/app-mobile/components/NoteEditor/commandDeclarations.ts
@@ -98,6 +98,16 @@ const declarations: CommandDeclaration[] = [
 		iconName: 'ant indent-right',
 	},
 	{
+		name: `editor.${EditorCommandType.SwapLineDown}`,
+		label: () => _('Swap line down'),
+		iconName: 'material chevron-double-down',
+	},
+	{
+		name: `editor.${EditorCommandType.SwapLineUp}`,
+		label: () => _('Swap line up'),
+		iconName: 'material chevron-double-up',
+	},
+	{
 		name: EditorCommandType.ToggleSearch,
 		label: () => _('Search'),
 		iconName: 'material magnify',


### PR DESCRIPTION
# Summary

This pull request adds "swap line up" and "swap line down" buttons to the "Choose items to display in the toolbar" screen. With this pull request, these actions are not included in the toolbar by default.

This implements [a feature request from the Joplin forum](https://discourse.joplinapp.org/t/android-toolbar-feature-request-add-ability-to-move-line-up-down/44702).

# Screenshot

![screenshot: Swap line down and swap line up shown in the toolbar options just after increase and decrease indent level buttons](https://github.com/user-attachments/assets/8b01da88-47b4-445d-a499-5d3ee65f2ba4)

# Testing plan

**Web app**:
1. Open the editor.
2. Add the "swap line down" and "swap line up" buttons to the toolbar.
3. Move the cursor near the middle of a list with several items.
4. Click "swap line down" and verify that the line containing the cursor is moved down.
5. Click "Swap line up" and verify that the line containing the cursor is moved up.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->