### PR TITLE
Desktop: Fixes #9588: Rich Text Editor: Fix keyboard and plugin-opened context menus sometimes not displayed or have incorrect content

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -7,8 +7,7 @@ import { ContextMenuOptions, ContextMenuItemType } from '../../../utils/contextM
 import { menuItems } from '../../../utils/contextMenu';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
-import Setting from '@joplin/lib/models/Setting';
-import type { Event as ElectronEvent, MenuItemConstructorOptions } from 'electron';
+import type { ContextMenuParams, Event as ElectronEvent, MenuItemConstructorOptions } from 'electron';
 
 import Resource from '@joplin/lib/models/Resource';
 import { TinyMceEditorEvents } from './types';
@@ -22,33 +21,6 @@ import type { MenuItem as MenuItemType } from 'electron';
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
 const menuUtils = new MenuUtils(CommandService.instance());
-
-// x and y are the absolute coordinates, as returned by the context-menu event
-// handler on the webContent. This function will return null if the point is
-// not within the TinyMCE editor.
-function contextMenuElement(editor: Editor, x: number, y: number) {
-	if (!editor || !editor.getDoc()) return null;
-
-	const containerDoc = editor.getContainer().ownerDocument;
-	const iframes = containerDoc.getElementsByClassName('tox-edit-area__iframe');
-	if (!iframes.length) return null;
-
-	const zoom = Setting.value('windowContentZoomFactor') / 100;
-	const xScreen = x / zoom;
-	const yScreen = y / zoom;
-
-	// We use .elementFromPoint to handle the case where a dialog is covering
-	// part of the editor.
-	const targetElement = containerDoc.elementFromPoint(xScreen, yScreen);
-	if (targetElement !== iframes[0]) {
-		return null;
-	}
-
-	const iframeRect = iframes[0].getBoundingClientRect();
-	const relativeX = xScreen - iframeRect.left;
-	const relativeY = yScreen - iframeRect.top;
-	return editor.getDoc().elementFromPoint(relativeX, relativeY);
-}
 
 interface ContextMenuActionOptions {
 	current: ContextMenuOptions;
@@ -130,13 +102,7 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 			return [];
 		};
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		function onContextMenu(event: ElectronEvent, params: any) {
-			const element = contextMenuElement(editor, params.x, params.y);
-			if (!element) return;
-
-			event.preventDefault();
-
+		const showContextMenu = (element: HTMLElement, misspelledWord: string|null, dictionarySuggestions: string[]) => {
 			const menu = new Menu();
 			const menuItems: MenuItemType[] = [];
 			const toMenuItems = (specs: MenuItemConstructorOptions[]) => {
@@ -145,7 +111,7 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 
 			menuItems.push(...makeEditableMenuItems(element));
 			menuItems.push(...makeMainMenuItems(element));
-			const spellCheckerMenuItems = SpellCheckerService.instance().contextMenuItems(params.misspelledWord, params.dictionarySuggestions);
+			const spellCheckerMenuItems = SpellCheckerService.instance().contextMenuItems(misspelledWord, dictionarySuggestions);
 			menuItems.push(
 				...toMenuItems(spellCheckerMenuItems),
 			);
@@ -157,13 +123,49 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 				menu.append(item);
 			}
 			menu.popup({ window: targetWindow });
-		}
+		};
 
-		targetWindow.webContents.prependListener('context-menu', onContextMenu);
+		let lastTarget: EventTarget|null = null;
+		const onElectronContextMenu = (event: ElectronEvent, params: ContextMenuParams) => {
+			if (!lastTarget) return;
+			const element = lastTarget as HTMLElement;
+			lastTarget = null;
+
+			event.preventDefault();
+			showContextMenu(element, params.misspelledWord, params.dictionarySuggestions);
+		};
+
+		const onBrowserContextMenu = (event: PointerEvent) => {
+			const isKeyboard = event.buttons === 0;
+			if (isKeyboard) {
+				// Context menu events from the keyboard seem to always use <body> as the
+				// event target. Since which context menu is displayed depends on what the
+				// target is, using event.target for keyboard-triggered contextmenu events
+				// would prevent keyboard-only users from accessing certain functionality.
+				// To fix this, use the selection instead.
+				lastTarget = editor.selection.getNode();
+			} else {
+				lastTarget = event.target;
+			}
+
+			// Plugins in the Rich Text Editor (e.g. the mermaid renderer) can sometimes
+			// create custom right-click events. These don't trigger the Electron 'context-menu'
+			// event. As such, the context menu must be shown manually.
+			const isFromPlugin = !event.isTrusted;
+			if (isFromPlugin) {
+				event.preventDefault();
+				showContextMenu(lastTarget as HTMLElement, null, []);
+				lastTarget = null;
+			}
+		};
+
+		targetWindow.webContents.prependListener('context-menu', onElectronContextMenu);
+		editor.on('contextmenu', onBrowserContextMenu);
 
 		return () => {
+			editor.off('contextmenu', onBrowserContextMenu);
 			if (!targetWindow.isDestroyed() && targetWindow?.webContents?.off) {
-				targetWindow.webContents.off('context-menu', onContextMenu);
+				targetWindow.webContents.off('context-menu', onElectronContextMenu);
 			}
 		};
 	}, [editor, plugins, dispatch, htmlToMd, mdToHtml, editDialog]);


### PR DESCRIPTION
# Summary

This pull request changes how context menu events are handled in the Rich Text Editor. Rather than determining the target element using Electron `context-menu` events, this is done with browser `contextmenu` events.

This change was originally intended to fix <!----> #12058. Unfortunately, it doesn't do so. However, it does resolve two similar issues:
- **Accessibility issue**: Context menus opened from the keyboard didn't target the correct element. For example, the "Edit" action for code blocks couldn't be accessed from a keyboard-opened contextmenu unless the user also moved the mouse over the code block.
- **Mermaid issue**: The mermaid download button opens the context menu by dispatching a `contextmenu` event. This does not trigger the Electron `context-menu` event. As a result, previously, no context menu was displayed. (#9588).
   - **Note**: With this change, the mermaid download button context menu may not be particularly helpful (it lacks many of the mermaid-specific items from the note viewer's context menu). As a result, a change similar to #12055 may still make sense.
 
# Testing

**Testing plan** (Fedora 41 Linux):
1. Copy text.
1. Create a new, empty note.
2. Right-click.
3. Verify that the context menu has "Paste" and "Paste as text" items.
4. Click "paste".
5. Verify that the text is pasted.
6. Repeat steps 3-5 with a context menu opened from the keyboard (using <kbd>shift</kbd>-<kbd>f10</kbd>).
7. Verify that the image is pasted.
8. Open the code block dialog.
9. Verify that the "Cut"/"Copy"/"Paste" context menu is shown for content within the dialog.
10. Select everything and copy, using a context menu.
11. Click "OK".
12. Right-click on the code block and click "Edit".
13. Close the code block dialog.
14. Move the mouse away from the code block.
15. Move keyboard focus to the code block.
16. Press <kbd>shift</kbd>-<kbf>f10</kbd> to open the context menu.
17. Verify that the context menu includes an "Edit" option.
18. Select and activate the "Edit" option.
19. Dismiss the edit dialog.
20. Add a misspelled word below the edit dialog.
21. Right-click on it.
22. Verify that the right-click menu includes spelling suggestions.
23. Click on a spelling suggestion.
24. Verify that the word is replaced with the suggestion.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->