### PR TITLE
Desktop: Resolves #12058: Fix pasting images in the Rich Text Editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -60,7 +60,7 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 	useEffect(() => {
 		if (!editor) return () => {};
 
-		const contextMenuItems = menuItems(dispatch, htmlToMd, mdToHtml);
+		const contextMenuItems = menuItems(dispatch);
 		const targetWindow = bridge().activeWindow();
 
 		const makeMainMenuItems = (element: Element) => {


### PR DESCRIPTION
# Summary

This pull request resolves #12058 by adding support for pasting images from the "Paste" option in the Rich Text Editor's right click menu.

# Testing plan

1. Copy an image.
2. Open the Rich Text Editor.
3. Right-click.
4. Verify that the right-click menu has a single "Paste" option.
5. Click "Paste".
6. Verify that the image has been pasted into the editor.
7. Copy text.
8. Right-click in the Rich Text Editor.
9. Click "Paste".
10. Verify that the text has been pasted in the Rich Text Editor.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->