### PR TITLE
Chore: Testing: Make Rich Text Editor attachment test more reliable

### DIFF
--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -62,6 +62,9 @@ test.describe('richTextEditor', () => {
 		await setFilePickerResponse(electronApp, [pathToAttach]);
 		await editor.attachFileButton.click();
 
+		// Wait for it to render
+		await expect(editor.getNoteViewerFrameLocator().getByText('test-file.txt')).toBeVisible();
+
 		// Switch to the RTE
 		await editor.toggleEditorsButton.click();
 		await editor.richTextEditor.waitFor();


### PR DESCRIPTION
# Summary

This pull request should make the `should watch resources for changes when opened with ctrl+click` test more reliable by waiting for an action to complete (attaching a file) before continuing. I observed a related test failure while running the end-to-end tests locally. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->