### PR TITLE
Desktop,Mobile: Markdown Editor: Fix numbered sublist renumbering

### DIFF
--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
@@ -64,4 +64,36 @@ describe('renumberSelectedLists', () => {
 			'# End',
 		].join('\n'));
 	});
+
+	it('should handle nested lists', async () => {
+		const listText = [
+			'2. This',
+			'\t1. is',
+			'\t2. a',
+			'\t\t3. test',
+			'\t4. test',
+			'\t5. test',
+			'\t6. test',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			`${listText}\n\n# End`,
+			EditorSelection.range(0, listText.length),
+			['OrderedList', 'ATXHeading1'],
+		);
+
+		editor.dispatch(renumberSelectedLists(editor.state));
+
+		expect(editor.state.doc.toString()).toBe([
+			'2. This',
+			'\t1. is',
+			'\t2. a',
+			'\t\t1. test',
+			'\t3. test',
+			'\t4. test',
+			'\t5. test',
+			'',
+			'# End',
+		].join('\n'));
+	});
 });

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
@@ -65,35 +65,91 @@ describe('renumberSelectedLists', () => {
 		].join('\n'));
 	});
 
-	it('should handle nested lists', async () => {
-		const listText = [
-			'2. This',
-			'\t1. is',
-			'\t2. a',
-			'\t\t3. test',
-			'\t4. test',
-			'\t5. test',
-			'\t6. test',
-		].join('\n');
-
+	it.each([
+		{
+			// Should handle the case where a single item is over-indented
+			before: [
+				'- This',
+				'- is',
+				'\t1. a',
+				'\t\t2. test',
+				'\t3. of',
+				'\t4. lists',
+			].join('\n'),
+			after: [
+				'- This',
+				'- is',
+				'\t1. a',
+				'\t\t1. test',
+				'\t2. of',
+				'\t3. lists',
+			].join('\n'),
+		},
+		{
+			// Should handle the case where multiple sublists need to be renumbered
+			before: [
+				'- This',
+				'- is',
+				'\t1. a',
+				'\t\t2. test',
+				'\t3. of',
+				'\t\t4. lists',
+				'\t\t5. lists',
+				'\t\t6. lists',
+				'\t7. lists',
+				'',
+				'',
+				'1. New list',
+				'\t3. Item',
+			].join('\n'),
+			after: [
+				'- This',
+				'- is',
+				'\t1. a',
+				'\t\t1. test',
+				'\t2. of',
+				'\t\t1. lists',
+				'\t\t2. lists',
+				'\t\t3. lists',
+				'\t3. lists',
+				'',
+				'',
+				'1. New list',
+				'\t1. Item',
+			].join('\n'),
+		},
+		{
+			before: [
+				'2. This',
+				'\t1. is',
+				'\t2. a',
+				'\t\t3. test',
+				'\t4. test',
+				'\t5. test',
+				'\t6. test',
+			].join('\n'),
+			after: [
+				'2. This',
+				'\t1. is',
+				'\t2. a',
+				'\t\t1. test',
+				'\t3. test',
+				'\t4. test',
+				'\t5. test',
+			].join('\n'),
+		},
+	])('should handle nested lists (case %#)', async ({ before, after }) => {
+		const suffix = '\n\n# End';
+		before += suffix;
+		after += suffix;
 		const editor = await createTestEditor(
-			`${listText}\n\n# End`,
-			EditorSelection.range(0, listText.length),
+			before,
+			EditorSelection.range(0, before.length - suffix.length),
 			['OrderedList', 'ATXHeading1'],
 		);
 
 		editor.dispatch(renumberSelectedLists(editor.state));
 
-		expect(editor.state.doc.toString()).toBe([
-			'2. This',
-			'\t1. is',
-			'\t2. a',
-			'\t\t1. test',
-			'\t3. test',
-			'\t4. test',
-			'\t5. test',
-			'',
-			'# End',
-		].join('\n'));
+		expect(editor.state.doc.toString()).toBe(after);
 	});
 });

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
@@ -49,11 +49,14 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 			const indentation = match[1];
 
 			const indentationLen = tabsToSpaces(state, indentation).length;
-			let targetIndentLen = tabsToSpaces(state, currentGroupIndentation).length;
-			const indentIncreased = indentationLen > targetIndentLen;
-			const indentDecreased = indentationLen < targetIndentLen;
+			let currentGroupIndentLength = tabsToSpaces(state, currentGroupIndentation).length;
+			const indentIncreased = indentationLen > currentGroupIndentLength;
+			const indentDecreased = indentationLen < currentGroupIndentLength;
 			if (indentIncreased) {
-				listNumberStack.push({ nextListNumber, indentationLength: indentationLen });
+				// Save the state of the previous group so that it can be restored later.
+				listNumberStack.push({
+					nextListNumber, indentationLength: currentGroupIndentLength,
+				});
 				nextListNumber = 1;
 			} else if (indentDecreased) {
 				nextListNumber = parseInt(match[2], 10);
@@ -63,13 +66,13 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 				//    1. test
 				//      1. test
 				// 2. test
-				while (targetIndentLen > indentationLen) {
+				while (indentationLen < currentGroupIndentLength) {
 					const listNumberRecord = listNumberStack.pop();
 
 					if (!listNumberRecord) {
 						break;
 					} else {
-						targetIndentLen = listNumberRecord.indentationLength;
+						currentGroupIndentLength = listNumberRecord.indentationLength;
 						nextListNumber = listNumberRecord.nextListNumber;
 					}
 				}

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
@@ -50,10 +50,12 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 
 			const indentationLen = tabsToSpaces(state, indentation).length;
 			let targetIndentLen = tabsToSpaces(state, currentGroupIndentation).length;
-			if (targetIndentLen < indentationLen) {
+			const indentIncreased = indentationLen > targetIndentLen;
+			const indentDecreased = indentationLen < targetIndentLen;
+			if (indentIncreased) {
 				listNumberStack.push({ nextListNumber, indentationLength: indentationLen });
 				nextListNumber = 1;
-			} else if (targetIndentLen > indentationLen) {
+			} else if (indentDecreased) {
 				nextListNumber = parseInt(match[2], 10);
 
 				// Handle the case where we deindent multiple times. For example,
@@ -74,9 +76,7 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 
 			}
 
-			if (targetIndentLen !== indentationLen) {
-				currentGroupIndentation = indentation;
-			}
+			currentGroupIndentation = indentation;
 
 			const from = line.to - filteredText.length;
 			const to = from + match[0].length;


### PR DESCRIPTION
# Summary

This pull request fixes an issue [originally reported on the Joplin forum](https://discourse.joplinapp.org/t/bulleted-numbered-and-checkboxed-lists-strange-behaviour-rte-bug-github/44715/4) — in certain cases, list renumbering after indentation or deindentation was incorrect.

# Testing

This pull request includes automated tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->