### PR TITLE
Desktop: Fix returning form data from plugin dialogs

### DIFF
--- a/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
@@ -1,0 +1,51 @@
+// Allows referencing the Joplin global:
+/* eslint-disable no-undef */
+
+// Allows the `joplin-manifest` block comment:
+/* eslint-disable multiline-comment-style */
+
+/* joplin-manifest:
+{
+	"id": "org.joplinapp.plugins.example.dialogs",
+	"manifest_version": 1,
+	"app_min_version": "3.1",
+	"name": "JS Bundle test",
+	"description": "JS Bundle Test plugin",
+	"version": "1.0.0",
+	"author": "",
+	"homepage_url": "https://joplinapp.org"
+}
+*/
+
+joplin.plugins.register({
+	onStart: async function() {
+		const dialogs = joplin.views.dialogs;
+		const dialogHandle = await dialogs.create('test-dialog');
+		await dialogs.setHtml(
+			dialogHandle,
+			`
+				<form name="main-form">
+					<label>Test: <input type="checkbox" name="test" checked/></label>
+				</form>
+			`,
+		);
+		await dialogs.setButtons(dialogHandle, [
+			{
+				id: 'ok',
+				title: 'Okay',
+			},
+		]);
+		await joplin.commands.register({
+			name: 'showTestDialog',
+			label: 'showTestDialog',
+			iconName: 'fas fa-drum',
+			execute: async () => {
+				const result = await joplin.views.dialogs.open(dialogHandle);
+				await joplin.commands.execute('editor.setText', JSON.stringify({
+					id: result.id,
+					hasFormData: !!result.formData,
+				}));
+			},
+		});
+	},
+});

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -46,9 +46,9 @@ export default function UserWebviewDialog(props: Props) {
 	const buttons: ButtonSpec[] = (props.buttons ? props.buttons : defaultButtons()).map((b: ButtonSpec) => {
 		return {
 			...b,
-			onClick: () => {
+			onClick: async () => {
 				const response: DialogResult = { id: b.id };
-				const formData = webviewRef.current.formData();
+				const formData = await webviewRef.current.formData();
 				if (formData && Object.keys(formData).length) response.formData = formData;
 				viewController().closeWithResponse(response);
 			},

--- a/packages/app-desktop/services/plugins/hooks/useFormData.ts
+++ b/packages/app-desktop/services/plugins/hooks/useFormData.ts
@@ -17,7 +17,7 @@ const useFormData = (viewRef: RefObject<HTMLIFrameElement>, postMessage: PostMes
 			const listeners = [...formDataListenersRef.current];
 			formDataListenersRef.current = [];
 			for (const listener of listeners) {
-				listener(event.data.formData);
+				listener(formData);
 			}
 		}
 	});
@@ -26,7 +26,7 @@ const useFormData = (viewRef: RefObject<HTMLIFrameElement>, postMessage: PostMes
 		return {
 			getFormData: () => {
 				return new Promise<FormDataRecord>(resolve => {
-					postMessage('getFormData', null);
+					postMessage('serializeForms', null);
 					formDataListenersRef.current.push((data) => {
 						resolve(data);
 					});


### PR DESCRIPTION
# Summary

This pull request fixes a recent regression from https://github.com/laurent22/joplin/commit/527627b8bb3c654ee9c630ac5ad37f2c8343d488 — form data was not returned while submitting dialogs.

# Testing

In addition to the automated test added by this pull request, it has been verified that the [template selection prompt from this pull request](https://github.com/joplin/plugin-templates/pull/110) (which uses a dialog with form data) can be used to select a template. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->