### PR TITLE
Plugin API: expose hash from clicked cross-note link

### DIFF
--- a/packages/lib/services/plugins/api/JoplinWorkspace.ts
+++ b/packages/lib/services/plugins/api/JoplinWorkspace.ts
@@ -197,4 +197,14 @@ export default class JoplinWorkspace {
 		return this.store.getState().selectedNoteIds.slice();
 	}
 
+	/**
+	 * Gets the last hash (note section ID) from cross-note link targeting specific section.
+	 * New hash is available after `onNoteSelectionChange()` is triggered.
+	 * Example of cross-note link where `hello-world` is a hash: [Other Note Title](:/9bc9a5cb83f04554bf3fd3e41b4bb415#hello-world).
+	 * Method returns empty value when a note was navigated with method other than cross-note link containing valid hash.
+	 */
+	public async selectedNoteHash(): Promise<string> {
+		return this.store.getState().selectedNoteHash;
+	}
+
 }


### PR DESCRIPTION
## 📌 Description

This PR adds a new method to the plugin API:

```ts
public async selectedNoteHash(): Promise<string>
```

This method returns the **section hash** (i.e., the anchor ID) from a cross-note link, such as in the following format:

```
[Other Note Title](:/note-id#section-id)
```

If the note was navigated via a cross-note link that includes a valid section hash, the method returns that hash (e.g., `"section-id"`). Otherwise, it returns an empty string.

---

## ✅ Motivation
- **Cross-note navigation awareness**: Helps plugins differentiate between a standard note switch and a targeted jump to a section.
- Currently, plugins can detect when a note changes, but not **which specific section** was targeted within that note. This enhancement makes that distinction possible by exposing the last navigated hash value via a stable method.

## 🧠 Notes

- The hash is updated after `onNoteSelectionChange()` is triggered.
- It complements existing navigation APIs by adding **section-level granularity**.