### PR TITLE
Desktop: Default plugins: Update Freehand Drawing to v3.0.0

### DIFF
--- a/packages/default-plugins/pluginRepositories.json
+++ b/packages/default-plugins/pluginRepositories.json
@@ -7,6 +7,6 @@
 	"io.github.personalizedrefrigerator.js-draw": {
 		"cloneUrl": "https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing.git",
 		"branch": "main",
-		"commit": "3153fb0fc8dab23426accdcd4319b0654d364d2b"
+		"commit": "0edb52b167ba6d5084f5c969464f6d2a0cbef4be"
 	}
 }


### PR DESCRIPTION
# Summary

This pull request updates the built-in Freehand Drawing plugin to [v3.0.0](https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/commit/0edb52b167ba6d5084f5c969464f6d2a0cbef4be). This fixes a potential future incompatibility with the Rich Text Editor and a regression involving loading the default image template.

**Note**: The major version increase is due to dropping support for Joplin < v3.0.9. 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->