### PR TITLE
Desktop: Remove outline from list of plugins that are broken in the new editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx
@@ -36,7 +36,6 @@ const incompatiblePluginIds = [
 	// cSpell:disable
 	'com.septemberhx.Joplin.Enhancement',
 	'ylc395.noteLinkSystem',
-	'outline',
 	'joplin.plugin.cmoptions',
 	'com.asdibiase.joplin-languagetool',
 	// cSpell:enable


### PR DESCRIPTION
# Summary

According to the Outline plugin's [description of the 1.5.14 release,](https://github.com/cqroot/joplin-outline/releases/tag/1.5.14) the CodeMirror 6 editor should now be supported.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->