### PR TITLE
Desktop: Linux: Add more input-method-related start flags

### DIFF
--- a/packages/lib/utils/processStartFlags.ts
+++ b/packages/lib/utils/processStartFlags.ts
@@ -152,10 +152,21 @@ const processStartFlags = async (argv: string[], setDefaults = true) => {
 			continue;
 		}
 
-		if (arg.indexOf('--enable-wayland-ime') === 0) {
+		if (
+			arg === '--enable-wayland-ime'
+			|| arg === '--disable-gtk-ime'
+			|| arg.startsWith('--wayland-text-input-version=')
+		) {
 			// Electron-specific flag - ignore it
-			// Enables input method support on Linux/Wayland
+			// Enables/configures input method support on Linux/Wayland
 			// See https://github.com/laurent22/joplin/issues/10345
+			argv.splice(0, 1);
+			continue;
+		}
+
+		if (arg.startsWith('--gtk-version=')) {
+			// Electron-specific flag. Allows forcing a different GTK version.
+			// See https://wiki.archlinux.org/title/Chromium#Native_Wayland_support
 			argv.splice(0, 1);
 			continue;
 		}


### PR DESCRIPTION
# Summary

This pull request allows users to pass some of the input-method-related start flags [discussed here](https://wiki.archlinux.org/title/Chromium#Native_Wayland_support). See https://github.com/laurent22/joplin/issues/12113.

# Testing plan

1. Start Joplin with `yarn start --enable-wayland-ime --ozone-platform=wayland --gtk-version=4 --disable-gtk-ime`.
2. Verify that Joplin starts without showing an "unknown flag" error message.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->