### PR TITLE
Desktop: Markdown editor: Scroll linked-to headers to the top of the editor

### DIFF
--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
@@ -72,7 +72,9 @@ const jumpToHash = (view: EditorView, hash: string) => {
 	if (targetLocation !== undefined) {
 		view.dispatch({
 			selection: EditorSelection.cursor(targetLocation),
-			scrollIntoView: true,
+			effects: [
+				EditorView.scrollIntoView(targetLocation, { y: 'start' }),
+			],
 		});
 		return true;
 	}

--- a/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
+++ b/packages/editor/CodeMirror/editorCommands/jumpToHash.ts
@@ -73,6 +73,9 @@ const jumpToHash = (view: EditorView, hash: string) => {
 		view.dispatch({
 			selection: EditorSelection.cursor(targetLocation),
 			effects: [
+				// Scrolls the target header/anchor to the top of the editor --
+				// users are usually interested in the content just below a header
+				// when clicking on a header link.
 				EditorView.scrollIntoView(targetLocation, { y: 'start' }),
 			],
 		});


### PR DESCRIPTION
# Summary

This pull request fixes an issue observed after merging https://github.com/laurent22/joplin/pull/12118 — linked-to headers aren't always scrolled to the top of the editor.

# Testing plan

1. Open a short note with a link to a header near the bottom of another note (but still with at least a page of scroll below the header).
2. Click the link.
3. Verify that the header is scrolled to the top of the editor.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->