### PR TITLE
Mobile: Note editor: Hash links: Move cursor to header or anchor associated with link target

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
@@ -49,6 +49,7 @@ describe('NoteEditor', () => {
 					themeId={Setting.THEME_ARITIM_DARK}
 					initialText='Testing...'
 					noteId=''
+					noteHash=''
 					style={{}}
 					toolbarEnabled={true}
 					readOnly={false}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -440,7 +440,9 @@ function NoteEditor(props: Props, ref: any) {
 			isFirstScrollRef.current = false;
 			return;
 		}
-		webviewRef.current?.injectJS(jumpToHashJs);
+		if (jumpToHashJs && webviewRef.current) {
+			webviewRef.current.injectJS(jumpToHashJs);
+		}
 	}, [jumpToHashJs]);
 
 	const html = useHtml(css);

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -435,8 +435,9 @@ function NoteEditor(props: Props, ref: any) {
 	// Scroll to the new hash, if it changes.
 	const isFirstScrollRef = useRef(true);
 	useEffect(() => {
+		// The first "jump to header" is handled during editor setup and shouldn't
+		// be handled a second time:
 		if (isFirstScrollRef.current) {
-			// The first "jump to header" is handled during editor setup.
 			isFirstScrollRef.current = false;
 			return;
 		}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -42,6 +42,7 @@ interface Props {
 	themeId: number;
 	initialText: string;
 	noteId: string;
+	noteHash: string;
 	initialSelection?: SelectionRange;
 	style: ViewStyle;
 	toolbarEnabled: boolean;
@@ -332,6 +333,9 @@ function NoteEditor(props: Props, ref: any) {
 		cm.select(${props.initialSelection.start}, ${props.initialSelection.end});
 		cm.execCommand('scrollSelectionIntoView');
 	` : '';
+	const jumpToHashJs = props.noteHash ? `
+		cm.jumpToHash(${JSON.stringify(props.noteHash)});
+	` : '';
 
 	const editorSettings: EditorSettings = useMemo(() => ({
 		themeId: props.themeId,
@@ -391,6 +395,9 @@ function NoteEditor(props: Props, ref: any) {
 						settings
 					);
 
+					${jumpToHashJs}
+					// Set the initial selection after jumping to the header -- the initial selection,
+					// if specified, should take precedence.
 					${setInitialSelectionJS}
 
 					window.onresize = () => {
@@ -424,6 +431,17 @@ function NoteEditor(props: Props, ref: any) {
 			`);
 		}
 	}, [css]);
+
+	// Scroll to the new hash, if it changes.
+	const isFirstScrollRef = useRef(true);
+	useEffect(() => {
+		if (isFirstScrollRef.current) {
+			// The first "jump to header" is handled during editor setup.
+			isFirstScrollRef.current = false;
+			return;
+		}
+		webviewRef.current?.injectJS(jumpToHashJs);
+	}, [jumpToHashJs]);
 
 	const html = useHtml(css);
 	const [selectionState, setSelectionState] = useState<SelectionFormatting>(defaultSelectionFormatting);

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1585,6 +1585,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						toolbarEnabled={this.props.toolbarEnabled}
 						themeId={this.props.themeId}
 						noteId={this.props.noteId}
+						noteHash={this.props.noteHash}
 						initialText={note.body}
 						initialSelection={this.selection}
 						onChange={this.onMarkdownEditorTextChange}


### PR DESCRIPTION
# Summary

This pull request adds support for scrolling to a header or anchor in the Markdown editor on mobile.

Related to https://github.com/laurent22/joplin/pull/12118.

# Notes

- Initial cursor positioning provided to the editor by `Note.tsx` takes precedence over the new jump-to-hash logic.

# Screen recording

[Screencast from 2025-04-17 15-59-05.webm](https://github.com/user-attachments/assets/67d54a41-6f85-4433-a2e7-bd1b5b9cd22f)

The above screen recording shows:
1. The note viewer initially open to a note with two links, both pointing to headers in another note.
2. Clicking on one of the links.
3. The other note opening in the note viewer.
4. Switching to the note editor.
5. The editor cursor placed at the end of the line containing the linked header.
6. Going back to the note from step 1.
7. Repeating 2-5 for the other link.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->