### PR TITLE
Chore: Desktop: Make useFormNote test less likely to fail

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useFormNote.ts
@@ -15,6 +15,7 @@ import Logger from '@joplin/utils/Logger';
 import eventManager, { EventName } from '@joplin/lib/eventManager';
 import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
 import useQueuedAsyncEffect from '@joplin/lib/hooks/useQueuedAsyncEffect';
+import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 
 const logger = Logger.create('useFormNote');
 
@@ -29,8 +30,8 @@ export interface HookDependencies {
 	titleInputRef: RefObject<HTMLInputElement>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	editorRef: any;
-	onBeforeLoad(event: OnLoadEvent): void;
-	onAfterLoad(event: OnLoadEvent): void;
+	onBeforeLoad(event: OnLoadEvent): void|Promise<void>;
+	onAfterLoad(event: OnLoadEvent): void|Promise<void>;
 	builtInEditorVisible: boolean;
 }
 
@@ -67,7 +68,8 @@ function resourceInfosChanged(a: ResourceInfos, b: ResourceInfos): boolean {
 	return false;
 }
 
-type InitNoteStateCallback = (note: NoteEntity, isNew: boolean)=> Promise<FormNote>;
+type CancelEvent = { cancelled: boolean };
+type InitNoteStateCallback = (note: NoteEntity, isNew: boolean, cancelEvent: CancelEvent)=> Promise<FormNote>;
 const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: string, noteId: string, initNoteState: InitNoteStateCallback, builtInEditorVisible: boolean) => {
 	// Increasing the value of this counter cancels any ongoing note refreshes and starts
 	// a new refresh.
@@ -95,7 +97,7 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 				return;
 			}
 
-			await initNoteState(n, false);
+			await initNoteState(n, false, event);
 			if (event.cancelled) return;
 			setFormNoteRefreshScheduled(oldValue => {
 				// If a new refresh was scheduled between initNoteState
@@ -114,8 +116,8 @@ const useRefreshFormNoteOnChange = (formNoteRef: RefObject<FormNote>, editorId: 
 	const refreshFormNote = useCallback(() => {
 		// Increase the counter to cancel any ongoing refresh attempts
 		// and start a new one.
-		setFormNoteRefreshScheduled(formNoteRefreshScheduled + 1);
-	}, [formNoteRefreshScheduled]);
+		setFormNoteRefreshScheduled(count => count + 1);
+	}, []);
 
 	// When switching from the plugin editor to the built-in editor, we refresh the note since the
 	// plugin may have modified it via the data API.
@@ -165,7 +167,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 	const formNoteRef = useRef(formNote);
 	formNoteRef.current = formNote;
 
-	const initNoteState: InitNoteStateCallback = useCallback(async (n, isNewNote) => {
+	const initNoteState: InitNoteStateCallback = useCallback(async (n, isNewNote, cancelEvent) => {
 		let originalCss = '';
 
 		if (n.markup_language === MarkupToHtml.MARKUP_LANGUAGE_HTML) {
@@ -201,7 +203,7 @@ export default function useFormNote(dependencies: HookDependencies) {
 
 		// If the user changes the note while resources are loading, this can lead to
 		// a note being incorrectly marked as "unchanged".
-		if (!isNewNote && formNoteRef.current?.hasChanged) {
+		if (!isNewNote && (formNoteRef.current?.hasChanged || cancelEvent.cancelled)) {
 			logger.info('Cancelled note refresh -- form note changed while loading attached resources.');
 			return null;
 		}
@@ -218,15 +220,13 @@ export default function useFormNote(dependencies: HookDependencies) {
 
 	useRefreshFormNoteOnChange(formNoteRef, editorId, noteId, initNoteState, builtInEditorVisible);
 
-	useEffect(() => {
+	useAsyncEffect(async (event) => {
 		if (!noteId) {
 			if (formNote.id) setFormNote(defaultFormNote());
-			return () => {};
+			return;
 		}
 
-		if (formNote.id === noteId) return () => {};
-
-		let cancelled = false;
+		if (formNote.id === noteId) return;
 
 		logger.debug('Loading existing note', noteId);
 
@@ -244,29 +244,20 @@ export default function useFormNote(dependencies: HookDependencies) {
 			});
 		}
 
-		async function loadNote() {
-			const n = await Note.load(noteId);
-			if (cancelled) return;
-			if (!n) throw new Error(`Cannot find note with ID: ${noteId}`);
-			logger.debug('Loaded note:', n);
+		const n = await Note.load(noteId);
+		if (event.cancelled) return;
+		if (!n) throw new Error(`Cannot find note with ID: ${noteId}`);
+		logger.debug('Loaded note:', n);
 
-			await onBeforeLoad({ formNote });
+		await onBeforeLoad({ formNote });
 
-			const newFormNote = await initNoteState(n, true);
+		const newFormNote = await initNoteState(n, true, event);
 
-			setIsNewNote(isProvisional);
+		setIsNewNote(isProvisional);
 
-			await onAfterLoad({ formNote: newFormNote });
+		await onAfterLoad({ formNote: newFormNote });
 
-			handleAutoFocus(!!n.is_todo);
-		}
-
-		void loadNote();
-
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
+		handleAutoFocus(!!n.is_todo);
 	}, [noteId, isProvisional, formNote]);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied


### PR DESCRIPTION
# Summary

This pull request makes a `useFormNote` test that [frequently failed in CI] less likely to fail.

# Testing plan

Previously, when the `useFormNote` tests were run multiple times on a single CPU (with `taskset --cpu-list 1 yarn test useFormNote`), the "should update note when decryption completes" test frequently failed. As such, this change has been tested by:
- Running `taskset --cpu-list 1 yarn test useFormNote`.
- Verifying that the `useFormNote` tests all passed.
- Repeating the above steps four more times.
Run `useFormNote.test.ts` several times on a single CPU and 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->