### PR TITLE
Desktop: Plugin API: Fix compatibility with YesYouKan plugin

### DIFF
--- a/packages/app-desktop/services/plugins/UserWebviewIndex.js
+++ b/packages/app-desktop/services/plugins/UserWebviewIndex.js
@@ -1,75 +1,40 @@
 // This is the API that JS files loaded from the webview can see
-const webviewApiPromises_ = {};
-let viewMessageHandler_ = () => {};
-const postMessage = (message) => {
-	parent.postMessage(message, '*');
-};
-
-
-function serializeForm(form) {
-	const output = {};
-	const formData = new FormData(form);
-	for (const key of formData.keys()) {
-		output[key] = formData.get(key);
-	}
-	return output;
-}
-
-function serializeForms(document) {
-	const forms = document.getElementsByTagName('form');
-	const output = {};
-	let untitledIndex = 0;
-
-	for (const form of forms) {
-		const name = `${form.getAttribute('name')}` || (`form${untitledIndex++}`);
-		output[name] = serializeForm(form);
-	}
-
-	return output;
-}
-
-function watchElementSize(element, onChange) {
-	const emitSizeChange = () => {
-		onChange(element.getBoundingClientRect());
-	};
-	const observer = new ResizeObserver(emitSizeChange);
-	observer.observe(element);
-
-	// Initial size
-	requestAnimationFrame(emitSizeChange);
-}
-
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-const webviewApi = {
-	postMessage: function(message) {
-		const messageId = `userWebview_${Date.now()}${Math.random()}`;
-
-		const promise = new Promise((resolve, reject) => {
-			webviewApiPromises_[messageId] = { resolve, reject };
-		});
-
-		postMessage({
-			target: 'postMessageService.message',
-			message: {
-				from: 'userWebview',
-				to: 'plugin',
-				id: messageId,
-				content: message,
-			},
-		});
-
-		return promise;
-	},
-
-	onMessage: function(viewMessageHandler) {
-		viewMessageHandler_ = viewMessageHandler;
-		postMessage({
-			target: 'postMessageService.registerViewMessageHandler',
-		});
-	},
-};
-
 (function() {
+	const webviewApiPromises_ = {};
+	let viewMessageHandler_ = () => {};
+	const postMessage = (message) => {
+		parent.postMessage(message, '*');
+	};
+
+	window.webviewApi = {
+		postMessage: function(message) {
+			const messageId = `userWebview_${Date.now()}${Math.random()}`;
+
+			const promise = new Promise((resolve, reject) => {
+				webviewApiPromises_[messageId] = { resolve, reject };
+			});
+
+			postMessage({
+				target: 'postMessageService.message',
+				message: {
+					from: 'userWebview',
+					to: 'plugin',
+					id: messageId,
+					content: message,
+				},
+			});
+
+			return promise;
+		},
+
+		onMessage: function(viewMessageHandler) {
+			viewMessageHandler_ = viewMessageHandler;
+			postMessage({
+				target: 'postMessageService.registerViewMessageHandler',
+			});
+		},
+	};
+
 	function docReady(fn) {
 		if (document.readyState === 'complete' || document.readyState === 'interactive') {
 			setTimeout(fn, 1);
@@ -84,6 +49,39 @@ const webviewApi = {
 		const output = path.split('.');
 		if (output.length <= 1) return '';
 		return output[output.length - 1];
+	}
+
+	function serializeForm(form) {
+		const output = {};
+		const formData = new FormData(form);
+		for (const key of formData.keys()) {
+			output[key] = formData.get(key);
+		}
+		return output;
+	}
+
+	function serializeForms(document) {
+		const forms = document.getElementsByTagName('form');
+		const output = {};
+		let untitledIndex = 0;
+
+		for (const form of forms) {
+			const name = `${form.getAttribute('name')}` || (`form${untitledIndex++}`);
+			output[name] = serializeForm(form);
+		}
+
+		return output;
+	}
+
+	function watchElementSize(element, onChange) {
+		const emitSizeChange = () => {
+			onChange(element.getBoundingClientRect());
+		};
+		const observer = new ResizeObserver(emitSizeChange);
+		observer.observe(element);
+
+		// Initial size
+		requestAnimationFrame(emitSizeChange);
 	}
 
 	docReady(() => {


### PR DESCRIPTION
# Summary

This pull request moves global helper functions into a local `(function () { ... })()` scope. One of these helpers was added in https://github.com/laurent22/joplin/pull/12083 and conflicts with a DOM API used by YesYouKan.

Fixes https://github.com/joplin/plugin-yesyoukan/issues/46

# Testing plan

1. Open the YesYouKan editor view for a Kanban note.
2. Add unchecked checkboxes to a card.
3. Check one of the checkboxes.
4. Switch notes.
5. Switch back to the Kanban note.
6. Verify that the checkbox is still checked.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->