### PR TITLE
Desktop: Fix infinite loop on startup after quickly moving folders

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -248,12 +248,16 @@ export default class Folder extends BaseItem {
 			let parentId = noteCount.folder_id;
 
 			let i = 0;
+			let checkedForCycle = false;
 			do {
 				// Handle invalid state, preventing infinite loops -- check whether the current
 				// folder has itself as a parent.
-				if (i++ > 100 && Folder.checkForFolderHierarchyCycle_(foldersById, parentId)) {
-					logger.warn(`Invalid state: Folder ${parentId} has itself as a parent.`);
-					break;
+				if (i++ > 100 && !checkedForCycle) {
+					if (Folder.checkForFolderHierarchyCycle_(foldersById, parentId)) {
+						logger.warn(`Invalid state: Folder ${parentId} has itself as a parent.`);
+						break;
+					}
+					checkedForCycle = true;
 				}
 
 				const folder = foldersById[parentId];

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -187,6 +187,24 @@ export default class Folder extends BaseItem {
 		};
 	}
 
+	// Checks for invalid state -- whether startId or its parents is part of a cycle
+	// in the folder graph (which should be a tree).
+	private static checkForFolderHierarchyCycle_(
+		idToFolder: Record<string, FolderEntity>,
+		startId: string,
+	) {
+		let folderId = startId;
+		const seenIds = new Set();
+		for (; idToFolder[folderId]; folderId = idToFolder[folderId].parent_id) {
+			if (seenIds.has(folderId)) {
+				return true;
+			}
+			seenIds.add(folderId);
+		}
+
+		return false;
+	}
+
 	// Calculates note counts for all folders and adds the note_count attribute to each folder
 	// Note: this only calculates the overall number of nodes for this folder and all its descendants
 	public static async addNoteCounts(folders: FolderEntity[], includeCompletedTodos = true) {
@@ -226,10 +244,18 @@ export default class Folder extends BaseItem {
 		}
 
 		const noteCounts: NoteCount[] = await this.db().selectAll(sql);
-		// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-		noteCounts.forEach((noteCount) => {
+		for (const noteCount of noteCounts) {
 			let parentId = noteCount.folder_id;
+
+			let i = 0;
 			do {
+				// Handle invalid state, preventing infinite loops -- check whether the current
+				// folder has itself as a parent.
+				if (i++ > 100 && Folder.checkForFolderHierarchyCycle_(foldersById, parentId)) {
+					logger.warn(`Invalid state: Folder ${parentId} has itself as a parent.`);
+					break;
+				}
+
 				const folder = foldersById[parentId];
 				if (!folder) break; // https://github.com/laurent22/joplin/issues/2079
 				folder.note_count = (folder.note_count || 0) + noteCount.note_count;
@@ -240,7 +266,7 @@ export default class Folder extends BaseItem {
 
 				parentId = folder.parent_id;
 			} while (parentId);
-		});
+		}
 	}
 
 	// Folders that contain notes that have been modified recently go on top.


### PR DESCRIPTION
# Summary

This pull request fixes an infinite loop that could be caused by an invalid folder hierarchy. This issue could prevent the app from starting or cause Joplin to display a blank screen.

## Background

The issue fixed by this pull request was observed while investigating #11902 — after quickly moving folders in and out of the trash, Joplin failed to start. If [`debugEarlyBugs`](https://github.com/laurent22/joplin/blob/f71ffa1644ad989a6be208c8313eacc88617c89c/packages/app-desktop/ElectronAppWrapper.ts#L183) is enabled, the window is blank and the console is empty.

I haven't been able to reproduce the issue by quickly moving folders in a new profile.

## Alternatives

This fix isn't ideal. It fixes the infinite loop, but doesn't fix or prevent invalid folder hierarchies. Alternatives include:
1. Adding a startup task to check for and remove cycles in the folder hierarchy.
    - Possible concern: This only fixes the issue at startup. Joplin can still create cycles in the folder hierarchy during runtime.
    - Possible concern: Startup performance for large numbers of folders — this should be done after loading the list of all folders.
2. Adding a database migration to check for cycles **and** add a check to `Folder.save`.
    - Possible issue: Loading parent folders is `async`, unless information about the folder hierarchy can be fetched without accessing the database. Async database access in this check may lead to race conditions.


# Testing plan

1. Start Joplin
2. Verify that Joplin starts and that an `Invalid state` warning is logged.
4. Verify that it's possible to open a folder and create a new note.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->