### PR TITLE
Mobile: Fix error when attempting to show message boxes in some cases

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -885,6 +885,7 @@ packages/app-mobile/utils/injectedJs.js
 packages/app-mobile/utils/ipc/RNToWebViewMessenger.js
 packages/app-mobile/utils/ipc/WebViewToRNMessenger.js
 packages/app-mobile/utils/lockToSingleInstance.js
+packages/app-mobile/utils/makeShowMessageBox.test.js
 packages/app-mobile/utils/makeShowMessageBox.js
 packages/app-mobile/utils/pickDocument.js
 packages/app-mobile/utils/polyfills/bufferPolyfill.js

--- a/.gitignore
+++ b/.gitignore
@@ -859,6 +859,7 @@ packages/app-mobile/utils/injectedJs.js
 packages/app-mobile/utils/ipc/RNToWebViewMessenger.js
 packages/app-mobile/utils/ipc/WebViewToRNMessenger.js
 packages/app-mobile/utils/lockToSingleInstance.js
+packages/app-mobile/utils/makeShowMessageBox.test.js
 packages/app-mobile/utils/makeShowMessageBox.js
 packages/app-mobile/utils/pickDocument.js
 packages/app-mobile/utils/polyfills/bufferPolyfill.js

--- a/packages/app-mobile/utils/makeShowMessageBox.test.ts
+++ b/packages/app-mobile/utils/makeShowMessageBox.test.ts
@@ -1,0 +1,27 @@
+import { DialogControl } from '../components/DialogManager';
+import { PromptButtonSpec } from '../components/DialogManager/types';
+import makeShowMessageBox from './makeShowMessageBox';
+
+type OnPrompt = (buttons: PromptButtonSpec[])=> void;
+const makeMockDialogControl = (onPrompt: OnPrompt): DialogControl => {
+	return {
+		info: jest.fn(),
+		error: jest.fn(),
+		prompt: jest.fn((_title, _message, buttons) => {
+			onPrompt(buttons);
+		}),
+		showMenu: jest.fn(),
+	};
+};
+
+describe('makeShowMessageBox', () => {
+	test('should resolve with the index of the selected button', async () => {
+		const dialogControl = makeMockDialogControl(buttons => {
+			buttons.find(button => button.text === 'OK').onPress();
+		});
+		const showMessageBox = makeShowMessageBox({ current: dialogControl });
+
+		const okButtonIndex = 0;
+		expect(await showMessageBox('test')).toBe(okButtonIndex);
+	});
+});

--- a/packages/app-mobile/utils/makeShowMessageBox.ts
+++ b/packages/app-mobile/utils/makeShowMessageBox.ts
@@ -6,7 +6,7 @@ import { MessageBoxType, ShowMessageBoxOptions } from '@joplin/lib/shim';
 import { PromptButtonSpec } from '../components/DialogManager/types';
 
 
-const makeShowMessageBox = (dialogControl: null|RefObject<DialogControl>) => (message: string, options: ShowMessageBoxOptions = null) => {
+const makeShowMessageBox = (dialogControl: null|RefObject<DialogControl>) => (message: string, options: ShowMessageBoxOptions = {}) => {
 	return new Promise<number>(resolve => {
 		const okButton: PromptButtonSpec = {
 			text: _('OK'),


### PR DESCRIPTION
# Summary

This pull request fixes an issue when `shim.showMessageBox` was called with a message, but no options, on mobile.

Previously, `options` defaulted to `null`, while code accessing the options assumed that `options` was always non-null.

# Testing plan

On web (in Chromium 135):
1. Open plugin settings tab and enable plugin support.
2. Open advanced settings and click "Install from file".
3. Select a file that is not a plugin (e.g. a PDF).
4. Verify that an error dialog is shown.
    - Previously, an error message was logged to the console, and no error dialog was shown.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->