### PR TITLE
Chore: Desktop: Enable debug logging in end-to-end tests

### DIFF
--- a/packages/app-desktop/integration-tests/util/createStartupArgs.ts
+++ b/packages/app-desktop/integration-tests/util/createStartupArgs.ts
@@ -7,7 +7,7 @@ const createStartupArgs = (profileDirectory: string) => {
 
 	// We need to run with --env dev to disable the single instance check.
 	return [
-		mainPath, '--env', 'dev', '--no-welcome', '--running-tests', '--profile', resolve(profileDirectory),
+		mainPath, '--env', 'dev', '--log-level', 'debug', '--no-welcome', '--running-tests', '--profile', resolve(profileDirectory),
 	];
 };
 


### PR DESCRIPTION
# Summary

This change enables debug logging while running end-to-end tests on desktop. Previously, the default log level was used and `logger.debug` output was omitted from end-to-end test logs.

**Goal**: Make it easier to debug end-to-end test failures.

See also https://github.com/laurent22/joplin/pull/12007.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->