### PR TITLE
Chore: Desktop: Fix occasional end-to-end test failure related to the settings screen

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx
@@ -40,7 +40,7 @@ export default function ButtonBar(props: Props) {
 	}
 
 	return (
-		<StyledRoot>
+		<StyledRoot className='button-bar'>
 			<Button
 				onClick={props.onCancelClick}
 				level={ButtonLevel.Secondary}

--- a/packages/app-desktop/integration-tests/models/SettingsScreen.ts
+++ b/packages/app-desktop/integration-tests/models/SettingsScreen.ts
@@ -2,20 +2,22 @@
 import { Page, Locator } from '@playwright/test';
 
 export default class SettingsScreen {
+	private readonly container: Locator;
 	public readonly okayButton: Locator;
 	public readonly appearanceTabButton: Locator;
 
-	public constructor(private page: Page) {
-		this.okayButton = page.locator('button', { hasText: 'OK' });
+	public constructor(page: Page) {
+		this.container = page.locator('.config-screen');
+		this.okayButton = this.container.locator('.button-bar button', { hasText: 'OK' });
 		this.appearanceTabButton = this.getTabLocator('Appearance');
 	}
 
 	public getTabLocator(tabName: string) {
-		return this.page.getByRole('tab', { name: tabName });
+		return this.container.getByRole('tab', { name: tabName });
 	}
 
 	public getLastTab() {
-		return this.page.getByRole('tablist').getByRole('tab').last();
+		return this.container.getByRole('tablist').getByRole('tab').last();
 	}
 
 	public async waitFor() {


### PR DESCRIPTION
# Summary

This change makes a Playwright locator more specific. Previously, if the "new folder" dialog was still visible after opening settings, a locator could match both the "OK" button in the settings screen and the dialog. This could cause the `SettingsScreen.waitFor` function to occasionally fail.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->