### PR TITLE
All: Translation: Add ro_MD.po

### DIFF
--- a/packages/tools/locales/ro_MD.po
+++ b/packages/tools/locales/ro_MD.po
@@ -1,0 +1,7353 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Laurent Cozic
+# This file is distributed under the same license as the Joplin-CLI package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Joplin-CLI 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Mihai Vasiliu <mihai.vasiliu.93@gmail.com>\n"
+"Language-Team: \n"
+"Language: ro_MD\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && "
+"n%100<=19) ? 1 : 2);\n"
+"X-Generator: Poedit 3.6\n"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:593
+msgid "- Camera: to allow taking a picture and attaching it to a note."
+msgstr ""
+"- Aparat foto: pentru a permite realizarea unei fotografii și atașarea "
+"acesteia la o notă."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:596
+msgid "- Location: to allow attaching geo-location information to a note."
+msgstr ""
+"- Locație: pentru a permite atașarea de informații de localizare geografică "
+"la o notă."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:590
+msgid ""
+"- Storage: to allow attaching files to notes and to enable filesystem "
+"synchronisation."
+msgstr ""
+"- Stocare: pentru a permite atașarea de fișiere la note și pentru a permite "
+"sincronizarea sistemului de fișiere."
+
+#: packages/lib/services/KeymapService.ts:331
+#: packages/lib/services/KeymapService.ts:337
+msgid "\"%s\" is missing the required \"%s\" property."
+msgstr "„%s” nu are proprietatea necesară „%s”."
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:267
+msgid "(%s)"
+msgstr "(%s)"
+
+#: packages/lib/services/plugins/api/JoplinViewsDialogs.ts:76
+msgid "(In plugin: %s)"
+msgstr "(În plugin-ul: %s)"
+
+#: packages/app-mobile/components/side-menu-content.tsx:265
+msgid "(level %d)"
+msgstr "(nivel %d)"
+
+#: packages/lib/SyncTargetNone.ts:16
+msgid "(None)"
+msgstr "(Nimic)"
+
+#: packages/lib/models/settings/builtInMetadata.ts:35
+#: packages/lib/models/settings/builtInMetadata.ts:36
+msgid "(wysiwyg: %s)"
+msgstr "(wysiwyg: %s)"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:757
+#: packages/lib/shim-init-node.ts:273
+msgid "(You may disable this prompt in the options)"
+msgstr "(Puteți dezactiva această solicitare în opțiuni)"
+
+#: packages/app-desktop/gui/MenuBar.tsx:1059
+#: packages/app-desktop/gui/MenuBar.tsx:750
+msgid "&Edit"
+msgstr "&Editează"
+
+#: packages/app-desktop/gui/MenuBar.tsx:1055
+#: packages/app-desktop/gui/MenuBar.tsx:623
+#: packages/app-desktop/gui/MenuBar.tsx:700
+msgid "&File"
+msgstr "&Fișier"
+
+#: packages/app-desktop/gui/MenuBar.tsx:880
+msgid "&Go"
+msgstr "Navi&ghează"
+
+#: packages/app-desktop/gui/MenuBar.tsx:935
+msgid "&Help"
+msgstr "&Ajutor"
+
+#: packages/app-desktop/gui/MenuBar.tsx:898
+msgid "&Note"
+msgstr "&Notiță"
+
+#: packages/app-desktop/gui/MenuBar.tsx:913
+msgid "&Tools"
+msgstr "&Unelte"
+
+#: packages/app-desktop/gui/MenuBar.tsx:792
+msgid "&View"
+msgstr "&Vizualizează"
+
+#: packages/app-desktop/gui/MenuBar.tsx:925
+msgid "&Window"
+msgstr "&Fereastră"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1538
+#: packages/lib/models/settings/builtInMetadata.ts:1814
+msgid "%d days"
+msgstr "%d zile"
+
+#: packages/lib/utils/joplinCloud/index.ts:148
+#: packages/lib/utils/joplinCloud/index.ts:149
+#: packages/lib/utils/joplinCloud/index.ts:150
+msgid "%d GB"
+msgstr "%d GO"
+
+#: packages/lib/utils/joplinCloud/index.ts:145
+#: packages/lib/utils/joplinCloud/index.ts:146
+#: packages/lib/utils/joplinCloud/index.ts:147
+msgid "%d GB storage space"
+msgstr "spațiu de stocare %d GO"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1282
+msgid "%d hour"
+msgstr "%d oră"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1283
+#: packages/lib/models/settings/builtInMetadata.ts:1284
+msgid "%d hours"
+msgstr "%d ore"
+
+#: packages/lib/utils/joplinCloud/index.ts:136
+#: packages/lib/utils/joplinCloud/index.ts:137
+#: packages/lib/utils/joplinCloud/index.ts:138
+msgid "%d MB"
+msgstr "%d MO"
+
+#: packages/lib/utils/joplinCloud/index.ts:133
+#: packages/lib/utils/joplinCloud/index.ts:134
+#: packages/lib/utils/joplinCloud/index.ts:135
+msgid "%d MB per note or attachment"
+msgstr "%d MO per notiță sau atașament"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1279
+#: packages/lib/models/settings/builtInMetadata.ts:1280
+#: packages/lib/models/settings/builtInMetadata.ts:1281
+msgid "%d minutes"
+msgstr "%d minute"
+
+#: packages/app-cli/app/command-rmnote.ts:34
+msgid "%d notes match this pattern. Delete them?"
+msgstr "Notițile: %d se potrivesc acestui model. Doriți sa le ștergeți?"
+
+#: packages/app-cli/app/command-rmnote.ts:40
+msgid "%d notes will be permanently deleted. Continue?"
+msgstr "%d notițe vor fi șterse permanent. Continui?"
+
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:228
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:238
+msgid "%s"
+msgstr "%s"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.ts:18
+msgid "%s - Copy"
+msgstr "%s - copie"
+
+#: packages/lib/services/ReportService.ts:192
+msgid "%s (%s) could not be uploaded: %s"
+msgstr "Acest fișier nu a putut fi încărcat: %s"
+
+#: packages/app-desktop/gui/MainScreen.tsx:563
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:68
+msgid "%s (%s) would like to share a notebook with you."
+msgstr "%s (%s) ar dori să partajeze un caiet cu tine."
+
+#: packages/lib/services/ReportService.ts:340
+msgid "%s (%s): %s"
+msgstr "%s (%s): %s"
+
+#: packages/app-desktop/checkForUpdates.ts:103
+msgid "%s (pre-release)"
+msgstr "%s (pre-lansare)"
+
+#: packages/lib/models/settings/builtInMetadata.ts:625
+#: packages/lib/models/settings/builtInMetadata.ts:626
+#: packages/lib/models/settings/builtInMetadata.ts:627
+msgid "%s / %s"
+msgstr "%s / %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:624
+msgid "%s / %s / %s"
+msgstr "%s / %s / %s"
+
+#: packages/lib/versionInfo.ts:86
+msgid "%s %s (%s, %s)"
+msgstr "%s %s (%s, %s)"
+
+#: packages/app-cli/app/command-config.ts:87
+msgid "%s = %s"
+msgstr "%s = %s"
+
+#: packages/app-cli/app/command-config.ts:85
+msgid "%s = %s (%s)"
+msgstr "%s = %s (%s)"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:32
+msgid "%s cannot be greater than %s"
+msgstr "%s nu poate fi mai mare decît %s"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:36
+msgid "%s cannot be less than %s"
+msgstr "%s nu poate fi mai mic decît %s"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:231
+msgid ""
+"%s is not optimised for synchronising many small files so your initial "
+"synchronisation will be slow."
+msgstr ""
+"%s nu este optimizat pentru sincronizarea multor fișiere mici, așa că "
+"sincronizarea inițială va fi lentă."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:26
+msgid "%s must be a valid whole number"
+msgstr "%s trebuie să fie un număr întreg valid"
+
+#: packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx:74
+msgid "%s tab opened"
+msgstr "Fila %s a fost deschisă"
+
+#: packages/lib/services/ReportService.ts:320
+#: packages/lib/services/ReportService.ts:321
+#: packages/lib/services/ReportService.ts:322
+#: packages/lib/services/ReportService.ts:325
+msgid "%s: %d"
+msgstr "%s: %d"
+
+#: packages/lib/services/ReportService.ts:377
+msgid "%s: %d notes"
+msgstr "%s: %d notițe"
+
+#: packages/lib/services/ReportService.ts:359
+msgid "%s: %d/%d"
+msgstr "%s: %d/%d"
+
+#: packages/app-cli/app/cli-utils.js:156
+#: packages/lib/services/ReportService.ts:264
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:224
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:265
+msgid "%s: Missing password."
+msgstr "%s: Parolă lipsă."
+
+#: packages/app-cli/app/command-tag.js:14
+msgid ""
+"<tag-command> can be \"add\", \"remove\", \"list\", or \"notetags\" to "
+"assign or remove [tag] from [note], to list notes associated with [tag], or "
+"to list tags associated with [note]. The command `tag list` can be used to "
+"list all the tags (use -l for long option)."
+msgstr ""
+"<tag-command> poate fi be \"add\", \"remove\", \"list\", sau \"notetags\" "
+"pentru a aloca sau a elimina [tag] dela [note], pentru a afișa lista de "
+"notițe asociate cu [tag], sau pentru a afișa lista de etichete asociate cu "
+"[note]. Comanda `tag list` poate fi utilizată pentru a afișa toată lista de "
+"etichete (folosește -l pentru opțiunea long)."
+
+#: packages/app-cli/app/command-todo.js:14
+msgid ""
+"<todo-command> can either be \"toggle\" or \"clear\". Use \"toggle\" to "
+"toggle the given to-do between completed and uncompleted state (If the "
+"target is a regular note it will be converted to a to-do). Use \"clear\" to "
+"convert the to-do back to a regular note."
+msgstr ""
+"<todo-command> poate fi \"toggle\" sau \"clear\". Folosește „toggle” pentru "
+"a comuta între starea finalizată și cea nefinalizată (dacă ținta este o "
+"notiță obișnuită, aceasta va fi transformată în listă de făcut). Folosește "
+"„clear” pentru a converti lista de făcut înapoi la o notiță obișnuită."
+
+#: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:37
+msgid "A new update (%s) is available"
+msgstr "O nouă actualizare (%s) este disponibilă"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1308
+msgid "A3"
+msgstr "A3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1306
+msgid "A4"
+msgstr "A4"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1309
+msgid "A5"
+msgstr "A5"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx:75
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:240
+msgid "About"
+msgstr "Despre"
+
+#: packages/app-desktop/gui/MenuBar.tsx:629
+#: packages/app-desktop/gui/MenuBar.tsx:977
+msgid "About Joplin"
+msgstr "Despre Joplin"
+
+#: packages/lib/services/KeymapService.ts:337
+#: packages/lib/services/KeymapService.ts:342
+msgid "accelerator"
+msgstr "accelerator"
+
+#: packages/lib/services/KeymapService.ts:394
+msgid "Accelerator \"%s\" is not valid."
+msgstr "Acceleratorul „%s” nu este valid."
+
+#: packages/lib/services/KeymapService.ts:363
+msgid ""
+"Accelerator \"%s\" is used for \"%s\" and \"%s\" commands. This may lead to "
+"unexpected behaviour."
+msgstr ""
+"Acceleratorul „%s” este utilizat pentru comenzile „%s” și „%s”. Acest lucru "
+"poate duce la un comportament neașteptat."
+
+#: packages/app-desktop/gui/MainScreen.tsx:564
+#: packages/app-mobile/components/screens/ShareManager/IncomingShareItem.tsx:40
+msgid "Accept"
+msgstr "Accept"
+
+#: packages/app-mobile/components/screens/ShareManager/index.tsx:98
+msgid "Accepted invitations"
+msgstr "Invitații acceptate"
+
+#: packages/lib/WebDavApi.js:460
+msgid "Access denied: Please check your username and password"
+msgstr "Acces refuzat: Te rog să vă verificați numele de utilizator și parola"
+
+#: packages/lib/WebDavApi.js:458
+msgid "Access denied: Please re-enter your password and/or username"
+msgstr ""
+"Acces refuzat: Te rog să reîntroduci parola și/sau numele de utilizator"
+
+#: packages/server/src/routes/admin/users.ts:144
+msgid "Account"
+msgstr "Cont"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:31
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:48
+msgid "Account information"
+msgstr "Informații cont"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:35
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:51
+msgid "Account type"
+msgstr "Tip cont"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:113
+msgid "Action"
+msgstr "Acțiune"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:172
+#: packages/app-mobile/components/ScreenHeader/index.tsx:651
+msgid "Actions"
+msgstr "Acțiuni"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:167
+msgid "Active"
+msgstr "Activ"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:18
+#: packages/app-desktop/gui/MenuBar.tsx:848
+msgid "Actual Size"
+msgstr "Dimensiunea actuală"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1571
+msgid "Add body"
+msgstr "Adaugă corp"
+
+#: packages/app-mobile/components/buttons/FloatingActionButton.tsx:64
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:131
+msgid "Add new"
+msgstr "Adaugă un nou"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.ts:43
+msgid "Add or remove tags:"
+msgstr "Adaugă sau elimină etichete:"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:277
+msgid "Add recipient:"
+msgstr "Adaugă destinatar:"
+
+#: packages/app-mobile/components/screens/NoteTagsDialog.tsx:94
+msgid "Add tag %s to note"
+msgstr "Adaugă eticheta %s la notița"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1648
+msgid "Add title"
+msgstr "Adaugă titlu"
+
+#: packages/lib/services/spellChecker/SpellCheckerService.ts:134
+msgid "Add to dictionary"
+msgstr "Adaugă în dicționar"
+
+#: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:98
+msgid "Add to note"
+msgstr "Adaugă la notiță"
+
+#: packages/server/src/services/MustacheService.ts:162
+#: packages/server/src/services/MustacheService.ts:286
+msgid "Admin"
+msgstr "Admin"
+
+#: packages/server/src/routes/admin/dashboard.ts:10
+msgid "Admin dashboard"
+msgstr "Panou de control administrativ"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:151
+msgid "Advanced options"
+msgstr "Opțiuni avansate"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:653
+msgid "Advanced settings"
+msgstr "Setări avansate"
+
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:196
+msgid "Advanced tools"
+msgstr "Instrumente avansate"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:18
+msgid "all"
+msgstr "toate"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:108
+msgid ""
+"All data, including notes, notebooks and tags will be permanently deleted."
+msgstr ""
+"Toate datele, inclusiv notițele, caietele de notițe și etichetele vor fi "
+"șterse definitiv."
+
+#: packages/lib/services/ReportService.ts:227
+msgid "All item sync failures have been marked as \"ignored\"."
+msgstr ""
+"Toate erorile de sincronizare ale elementelor au fost marcate ca „ignorate”."
+
+#: packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx:73
+#: packages/app-mobile/components/screens/Notes/Notes.tsx:208
+#: packages/app-mobile/components/side-menu-content.tsx:679
+msgid "All notes"
+msgstr "Toate notițele"
+
+#: packages/lib/onedrive-api-node-utils.js:46
+msgid "All potential ports are in use - please report the issue at %s"
+msgstr ""
+"Toate porturile potențiale sînt în uz - te rog să raportați problema la %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:931
+msgid "Allows debugging mobile plugins. See %s for details."
+msgstr ""
+"Permite depanarea plugin-urilor mobile. Vezi %s pentru mai multe detalii."
+
+#: packages/app-cli/app/command-config.ts:19
+msgid "Also displays unset and hidden config variables."
+msgstr "Afișează, de asemenea, variabile de configurare nesetate și ascunse."
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:205
+msgid "Also publish linked notes"
+msgstr "Publică, de asemenea, notițele asociate"
+
+#: packages/lib/versionInfo.ts:93
+msgid "Alternative instance ID: %s"
+msgstr "ID instanță alternativ: %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:412
+msgid "Always"
+msgstr "Mereu"
+
+#: packages/lib/models/settings/builtInMetadata.ts:887
+msgid "Always ask"
+msgstr "Întreabă mereu"
+
+#: packages/app-desktop/bridge.ts:462
+msgid "Always open %s files without asking."
+msgstr "Deschide mereu fișierele %s fără să mai întrebi."
+
+#: packages/lib/models/settings/builtInMetadata.ts:888
+msgid "Always resize"
+msgstr "Redimensionează mereu"
+
+#: packages/app-cli/app/command-mv.ts:37
+msgid ""
+"Ambiguous notebook \"%s\". Please use notebook id instead - press \"ti\" to "
+"see the short notebook id or use $b for current selected notebook"
+msgstr ""
+"Caiet ambiguu „%s”. Te rog să utilizezi ID-ul caietului în loc - tastează "
+"„ti” pentru a vedea ID-ul scurt al caietului sau utilizează $b pentru "
+"caietul selectat curent"
+
+#: packages/app-cli/app/command-mkbook.ts:33
+#: packages/app-cli/app/command-mv.ts:30
+msgid ""
+"Ambiguous notebook \"%s\". Please use short notebook id instead - press "
+"\"ti\" to see the short notebook id"
+msgstr ""
+"Caiet ambiguu „%s”. Te rog să folosești în schimb ID-ul scurt al caietului - "
+"tastează „ti” pentru a vedea ID-ul scurt al caietului"
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:13
+msgid "An autosaved drawing was found. Attach a copy of it to the note?"
+msgstr ""
+"A fost găsit un desen salvat automat. Atașezi o copie a acestuia la notiță?"
+
+#: packages/app-desktop/ElectronAppWrapper.ts:161
+msgid "An error occurred: %s"
+msgstr "S-a produs o eroare: %s"
+
+#: packages/app-desktop/checkForUpdates.ts:107
+msgid "An update is available, do you want to download it now?"
+msgstr "Este disponibilă o nouă actualizare, dorești să o descarci acum?"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:22
+msgid "Android API level: %d"
+msgstr "Nivel API Android: %d"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:48
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:24
+msgid ""
+"Any email sent to this address will be converted into a note and added to "
+"your collection. The note will be saved into the Inbox notebook"
+msgstr ""
+"Orice e-mail trimis la această adresă va fi convertit într-o notă și va fi "
+"adăugat la colecția dumneavoastră. Nota va fi salvată în carnețelul Inbox"
+
+#: packages/lib/models/Setting.ts:1177
+msgid "Appearance"
+msgstr "Aspect"
+
+#: packages/lib/models/Setting.ts:1182
+msgid "Application"
+msgstr "Aplicație"
+
+#: packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx:39
+msgid "Apply"
+msgstr "Aplică"
+
+#: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:146
+msgid ""
+"Are you sure that you want to restore the default toolbar layout?\n"
+"This cannot be undone."
+msgstr ""
+"Ești sigur că dorești să restaurezi aspectul implicit al barelor de unelte?\n"
+"Acest lucru nu poate fi anulat."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:39
+msgid "Are you sure you want to renew the authorisation token?"
+msgstr "Ești sigur că dorești să reînnoiești jetonul de autorizare?"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts:14
+msgid ""
+"Are you sure you want to return to the default layout? The current layout "
+"configuration will be lost."
+msgstr ""
+"Ești sigur că dorești să revii la aspectul implicit? Configurația actuală a "
+"aspectului va fi pierdută."
+
+#: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:235
+msgid "Arguments:"
+msgstr "Argumente:"
+
+#: packages/lib/models/settings/builtInMetadata.ts:54
+msgid "Aritim Dark"
+msgstr "Aritim întunecat"
+
+#: packages/app-mobile/utils/lockToSingleInstance.ts:15
+msgid ""
+"At present, Joplin Web can only be open in one tab at a time. Please close "
+"the other instance of Joplin."
+msgstr ""
+"La momentul actual, Joplin Web poate fi deschis într-o singură filă deodată. "
+"Te rog închide orice alte instanțe de Joplin."
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:25
+msgid "Attach"
+msgstr "Atașează"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:75
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:804
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:26
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:90
+msgid "Attach file"
+msgstr "Atașează fișier..."
+
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:95
+msgid "Attach photo"
+msgstr "Atașează imagine"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1200
+msgid "Attach..."
+msgstr "Atașează..."
+
+#: packages/app-cli/app/command-attach.ts:13
+msgid "Attaches the given file to the note."
+msgstr "Atașează fișierul în notiță."
+
+#: packages/server/src/models/UserModel.ts:247
+#: packages/server/src/models/UserModel.ts:264
+msgid "attachment"
+msgstr "atașament"
+
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:72
+msgid "Attachment"
+msgstr "Atașament"
+
+#: packages/lib/models/Resource.ts:509
+msgid "Attachment conflict: \"%s\""
+msgstr "Conflict atașament: „%s”"
+
+#: packages/lib/models/settings/builtInMetadata.ts:408
+msgid "Attachment download behaviour"
+msgstr "Comportamentul de descărcare ale atașamentelor"
+
+#: packages/lib/services/ReportService.ts:311
+msgid "Attachments"
+msgstr "Atașament"
+
+#: packages/lib/services/ReportService.ts:335
+msgid "Attachments that could not be downloaded"
+msgstr "Acest fișier nu a putut fi descărcat: %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:39
+msgid ""
+"Attention: If you change this location, make sure you copy all your content "
+"to it before syncing, otherwise all files will be removed! See the FAQ for "
+"more details: %s"
+msgstr ""
+"Atenție: dacă modificați această locație, asigurați-vă că copiați tot "
+"conținutul pe ea înainte de sincronizare, altfel toate fișierele vor fi "
+"eliminate! Consultați FAQ pentru mai multe detalii: %s"
+
+#: packages/app-cli/app/command-sync.ts:72
+#: packages/app-cli/app/command-sync.ts:86
+#: packages/app-desktop/gui/OneDriveLoginScreen.tsx:49
+msgid ""
+"Authentication was not completed (did not receive an authentication token)."
+msgstr ""
+"Autentificarea nu a fost finalizată (nu a primit un token de autentificare)."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:152
+msgid "Authorisation token:"
+msgstr "Token autorizare:"
+
+#: packages/app-desktop/gui/JoplinCloudLoginScreen.tsx:88
+#: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:162
+msgid "Authorise"
+msgstr "Autorizează"
+
+#: packages/lib/models/settings/builtInMetadata.ts:414
+msgid "Auto"
+msgstr "Auto"
+
+#: packages/server/src/services/TaskService.ts:30
+msgid "Auto-add disabled accounts for deletion"
+msgstr "Adaugă automat conturile dezactivate pentru ștergere"
+
+#: packages/lib/models/settings/builtInMetadata.ts:693
+msgid "Auto-format Markdown in the Rich Text Editor"
+msgstr "Formatează automat Markdown în editorul de text îmbogățit"
+
+#: packages/lib/models/settings/builtInMetadata.ts:661
+msgid "Auto-pair braces, parentheses, quotations, etc."
+msgstr "Împerechează automat parantezele, ghilimelele etc."
+
+#: packages/lib/models/settings/builtInMetadata.ts:672
+msgid "Autocomplete Markdown and HTML"
+msgstr "Autocompletare Markdown și HTML"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1253
+msgid "Automatically check for updates"
+msgstr "Verificarea automată a actualizărilor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1801
+msgid "Automatically delete notes in the trash after a number of days"
+msgstr ""
+"Șterge automat notițele din coșul de gunoi după un anumit număr de zile"
+
+#: packages/lib/models/settings/builtInMetadata.ts:572
+msgid "Automatically switch theme to match system theme"
+msgstr "Comută automat tema pentru a se potrivi cu tema sistemului"
+
+#: packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx:48
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:453
+#: packages/app-desktop/gui/NoteRevisionViewer.tsx:171
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:148
+#: packages/app-mobile/components/ScreenHeader/index.tsx:281
+#: packages/lib/commands/historyBackward.ts:6
+msgid "Back"
+msgstr "Înapoi"
+
+#: packages/lib/utils/joplinCloud/index.ts:347
+msgid "Basic"
+msgstr "De bază"
+
+#: packages/app-mobile/components/BetaChip.tsx:37
+#: packages/app-mobile/components/ScreenHeader/WebBetaButton.tsx:37
+#: packages/app-mobile/components/ScreenHeader/WebBetaButton.tsx:45
+msgid "Beta"
+msgstr "Beta"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:55
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:54
+msgid "Bold"
+msgstr "Aldin"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:222
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:319
+msgid "Browse all plugins"
+msgstr "Navigați toate plugin-urile"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:275
+msgid "Browse..."
+msgstr "Răsfoiește..."
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:223
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:54
+msgid "Built-in"
+msgstr "Inclus"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:85
+msgid "Bulleted List"
+msgstr "Listă cu marcatori"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:129
+msgid "by %s"
+msgstr "după %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:20
+msgid "by word"
+msgstr "după cuvînt"
+
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:74
+msgid "Camera"
+msgstr "Aparat foto"
+
+#: packages/server/src/routes/admin/users.ts:160
+msgid "Can Share"
+msgstr "Se poate partaja"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:120
+msgid "Can view"
+msgstr "Se poate vizualiza"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:121
+msgid "Can view and edit"
+msgstr "Se poate vizualiza și edita"
+
+#: packages/app-desktop/bridge.ts:385 packages/app-desktop/bridge.ts:401
+#: packages/app-desktop/bridge.ts:464
+#: packages/app-desktop/checkForUpdates.ts:109
+#: packages/app-desktop/commands/emptyTrash.ts:17
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:453
+#: packages/app-desktop/gui/DialogButtonRow.tsx:79
+#: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:99
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:11
+#: packages/app-desktop/gui/PromptDialog.tsx:289
+#: packages/app-desktop/gui/ResourceScreen.tsx:232
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:150
+#: packages/app-desktop/gui/Sidebar/Sidebar.tsx:27
+#: packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx:23
+#: packages/app-desktop/services/plugins/UserWebviewDialogButtonBar.tsx:20
+#: packages/app-mobile/components/ModalDialog.tsx:83
+#: packages/app-mobile/components/plugins/dialogs/PluginDialogWebView.tsx:125
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:116
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:80
+#: packages/app-mobile/components/screens/encryption-config.tsx:212
+#: packages/app-mobile/components/screens/Note/Note.tsx:230
+#: packages/app-mobile/components/screens/Note/Note.tsx:760
+#: packages/app-mobile/components/SelectDateTimeDialog.tsx:172
+#: packages/app-mobile/components/side-menu-content.tsx:348
+#: packages/app-mobile/components/side-menu-content.tsx:398
+#: packages/app-mobile/components/side-menu-content.tsx:434
+#: packages/app-mobile/components/side-menu-content.tsx:650
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:202
+#: packages/app-mobile/utils/makeShowMessageBox.ts:16
+#: packages/lib/commands/permanentlyDeleteNote.ts:21
+#: packages/lib/shim-init-node.ts:274
+msgid "Cancel"
+msgstr "Anulează"
+
+#: packages/app-cli/app/app.ts:142
+msgid "Cancelling background synchronisation... Please wait."
+msgstr "Se anulează sincronizarea... Te rog să aștepți."
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:193
+msgid ""
+"Cancelling will discard the recording. This cannot be undone. Are you sure "
+"you want to proceed?"
+msgstr ""
+"Anularea va duce la pierderea înregistrării. Acest lucru nu poate fi "
+"recuperat. Ești sigur că dorești să continui?"
+
+#: packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx:23
+#: packages/lib/Synchronizer.ts:206
+msgid "Cancelling..."
+msgstr "Se amînă..."
+
+#: packages/app-cli/app/command-sync.ts:289
+msgid "Cancelling... Please wait."
+msgstr "Se anulează... Te rog să aștepți."
+
+#: packages/lib/shim-init-node.ts:334
+msgid "Cannot access %s"
+msgstr "Nu se poate accesa %s"
+
+#: packages/app-cli/app/base-command.ts:19
+msgid "Cannot change encrypted item"
+msgstr "Nu se poate schimba itemul criptat"
+
+#: packages/lib/models/Note.ts:618
+msgid "Cannot copy note to \"%s\" notebook"
+msgstr "Nu se poate copia notița în caietul de notițe „%s”"
+
+#: packages/app-mobile/components/screens/Notes/Notes.tsx:195
+msgid "Cannot create a new note: %s"
+msgstr "Nu se poate create o notiță nouă: %s"
+
+#: packages/app-cli/app/command-attach.ts:22
+#: packages/app-cli/app/command-cat.ts:26 packages/app-cli/app/command-cp.ts:25
+#: packages/app-cli/app/command-cp.ts:28
+#: packages/app-cli/app/command-done.ts:22
+#: packages/app-cli/app/command-export.ts:38
+#: packages/app-cli/app/command-export.ts:43
+#: packages/app-cli/app/command-geoloc.ts:21
+#: packages/app-cli/app/command-help.ts:67
+#: packages/app-cli/app/command-import.ts:37
+#: packages/app-cli/app/command-mv.ts:25 packages/app-cli/app/command-mv.ts:46
+#: packages/app-cli/app/command-ren.ts:24
+#: packages/app-cli/app/command-restore.ts:20
+#: packages/app-cli/app/command-rmbook.ts:30
+#: packages/app-cli/app/command-rmnote.ts:30
+#: packages/app-cli/app/command-search.js:27
+#: packages/app-cli/app/command-set.ts:33
+#: packages/app-cli/app/command-tag.js:33
+#: packages/app-cli/app/command-tag.js:36
+#: packages/app-cli/app/command-tag.js:42
+#: packages/app-cli/app/command-tag.js:43
+#: packages/app-cli/app/command-tag.js:81
+#: packages/app-cli/app/command-tag.js:87
+#: packages/app-cli/app/command-todo.js:21
+#: packages/app-cli/app/command-use.ts:22
+#: packages/lib/services/interop/InteropService.ts:296
+#: packages/lib/services/interop/InteropService.ts:315
+msgid "Cannot find \"%s\"."
+msgstr "Nu poate fi găsit „%s”."
+
+#: packages/app-cli/app/command-mkbook.ts:28
+msgid "Cannot find: \"%s\""
+msgstr "Nu poate fi găsit „%s”"
+
+#: packages/app-cli/app/command-sync.ts:202
+msgid "Cannot initialise synchroniser."
+msgstr "Nu se poate inițializa sincronizatorul."
+
+#: packages/lib/services/interop/InteropService.ts:263
+msgid "Cannot load \"%s\" module for format \"%s\" and output \"%s\""
+msgstr "Nu se poate încărca modulul „%s” pentru formatul „%s” și ieșirea „%s”"
+
+#: packages/lib/services/interop/InteropService.ts:276
+msgid "Cannot load \"%s\" module for format \"%s\" and target \"%s\""
+msgstr "Nu se poate încărca modulul „%s” pentru formatul „%s” și ținta „%s”"
+
+#: packages/lib/models/Note.ts:630
+msgid "Cannot move note to \"%s\" notebook"
+msgstr "Nu se poate muta notița în caietul de notițe „%s”"
+
+#: packages/app-mobile/components/screens/folder.js:73
+#: packages/lib/models/Folder.ts:883
+msgid "Cannot move notebook to this location"
+msgstr "Nu se poate muta caietul de notițe în această locație"
+
+#: packages/lib/onedrive-api.ts:468
+msgid ""
+"Cannot refresh token: authentication data is missing. Starting the "
+"synchronisation again may fix the problem."
+msgstr ""
+"Nu se poate reactualiza token-ul: lipsesc datele de autentificare. Este "
+"posibil ca problema să fie rezolvată prin reluarea sincronizării."
+
+#: packages/server/src/models/UserModel.ts:246
+msgid "Cannot save %s \"%s\" because it is larger than the allowed limit (%s)"
+msgstr ""
+"Nu se poate salva %s „%s” deoarece este mai mare decît limita permisă (%s)"
+
+#: packages/server/src/models/UserModel.ts:263
+msgid ""
+"Cannot save %s \"%s\" because it would go over the total allowed size (%s) "
+"for this account"
+msgstr ""
+"Nu se poate salva %s „%s” pentru că ar depăși dimensiunea totală permisă "
+"(%s) pentru acest cont"
+
+#: packages/lib/services/share/ShareService.ts:338
+msgid ""
+"Cannot share encrypted notebook with recipient %s because they have not "
+"enabled end-to-end encryption. They may do so from the screen Configuration "
+"> Encryption."
+msgstr ""
+"Nu se poate partaja caietul criptat cu destinatarul %s deoarece acesta nu a "
+"activat criptarea end-to-end. Acesta poate face acest lucru din ecranul "
+"Configurare > Criptare."
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:331
+msgid "Case sensitive"
+msgstr "Case sensitive"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleLayoutMoveMode.ts:7
+msgid "Change application layout"
+msgstr "Modifică aspectul aplicației"
+
+#: packages/lib/services/spellChecker/SpellCheckerService.ts:210
+msgid "Change language"
+msgstr "Schimbă limba"
+
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:124
+msgid "Change ratio"
+msgstr "Schimbă raport"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:98
+msgid "Change shortcut for \"%s\""
+msgstr "Schimbă scurtătura pentru „%s”"
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:106
+msgid "Characters"
+msgstr "Caractere"
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:107
+msgid "Characters excluding spaces"
+msgstr "Caractere cu excepția spațiilor libere"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:163
+msgid "Check"
+msgstr "Bifează"
+
+#: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:168
+msgid "Check elements to display in the toolbar"
+msgstr "Bifează elementele ce vor fi afișate în bara de unelte"
+
+#: packages/app-desktop/gui/MenuBar.tsx:643
+#: packages/app-desktop/gui/MenuBar.tsx:951
+msgid "Check for updates..."
+msgstr "Verifică pentru actualizări..."
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:264
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:465
+msgid "Check synchronisation configuration"
+msgstr "Verificați configurația de sincronizare"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:90
+msgid "Checkbox"
+msgstr "Căsuțe de selecție"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/plugins/lists.js:2148
+msgid "Checkbox list"
+msgstr "Listă cu căsuțe de selecție"
+
+#: packages/app-mobile/components/Checkbox.tsx:49
+msgid "Checked"
+msgstr "Bifat"
+
+#: packages/lib/components/shared/config/config-shared.ts:97
+msgid "Checking... Please wait."
+msgstr "Se verifică... Te rog să aștepți."
+
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:98
+msgid "Choose an option"
+msgstr "Selectează o opțiune"
+
+#: packages/app-desktop/gui/ExtensionBadge.tsx:72
+msgid "Chrome Web Store"
+msgstr "Chrome Web Store"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:150
+#: packages/app-desktop/gui/PromptDialog.tsx:296
+#: packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.tsx:105
+#: packages/app-mobile/components/screens/SearchScreen/index.tsx:111
+msgid "Clear"
+msgstr "Șterge"
+
+#: packages/app-mobile/components/SelectDateTimeDialog.tsx:169
+msgid "Clear alarm"
+msgstr "Șterge alarma"
+
+#: packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx:67
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.tsx:140
+msgid "Clear search"
+msgstr "Șterge căutarea"
+
+#: packages/app-desktop/gui/NoteRevisionViewer.tsx:166
+msgid ""
+"Click \"%s\" to restore the note. It will be copied in the notebook named "
+"\"%s\". The current version of the note will not be replaced or modified."
+msgstr ""
+"Fă clic pe „%s” pentru a restaura notița. Aceasta fi copiată în caietul "
+"numit „%s”. Versiunea curentă a notiței nu va fi înlocuită sau modificată."
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:227
+msgid "Click \"start\" to attach a new voice memo to the note."
+msgstr "Apasă pe „start” pentru a atașa un memo vocal la notiță."
+
+#: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:61
+msgid "Click to add tags..."
+msgstr "Click pentru a adăuga etichete…"
+
+#: packages/lib/versionInfo.ts:89
+msgid "Client ID: %s"
+msgstr "Client ID: %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:23
+msgid "close"
+msgstr "închide"
+
+#: packages/app-desktop/gui/MenuBar.tsx:364
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:175
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:411
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:223
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:308
+#: packages/app-desktop/services/plugins/UserWebviewDialogButtonBar.tsx:23
+#: packages/app-mobile/components/DismissibleDialog.tsx:83
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:166
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:201
+#: packages/app-mobile/components/plugins/PluginNotification.tsx:17
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:140
+msgid "Close"
+msgstr "Închide"
+
+#: packages/app-mobile/components/Modal.tsx:139
+msgid "Close dialog"
+msgstr "Închide dialogul"
+
+#: packages/app-mobile/components/Dropdown.tsx:199
+msgid "Close dropdown"
+msgstr "Închideți meniul derulant"
+
+#: packages/app-mobile/components/SideMenu.tsx:303
+msgid "Close side menu"
+msgstr "Închide meniul lateral"
+
+#: packages/lib/models/settings/settingValidations.ts:33
+msgid ""
+"Close the application, then delete your profile in \"%s\", and start the "
+"application again. Make sure you create a backup first by exporting all your "
+"notes as JEX."
+msgstr ""
+"Închide aplicația, apoi șterge profilul tău din „%s” și pornește din nou "
+"aplicația. Asigură-te că creezi o copie de siguranță mai întîi prin "
+"exportarea tuturor notițelor ca fișier JEX."
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:26
+#: packages/app-desktop/gui/MenuBar.tsx:708
+msgid "Close Window"
+msgstr "Închide fereastra"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:168
+msgid "Closing session..."
+msgstr "Se închide sesiunea..."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:39
+msgid "Cmd-click to open"
+msgstr "Cmd-clic pentru a deschide"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:45
+msgid "Cmd-click to open: %s"
+msgstr "Cmd-clic pentru a deschide: %s"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:70
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:65
+msgid "Code"
+msgstr "Cod"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:814
+msgid "Code Block"
+msgstr "Bloc de cod"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:1559
+msgid "Code View"
+msgstr "Vizualizare code"
+
+#: packages/lib/utils/joplinCloud/index.ts:173
+msgid "Collaborate on a notebook with others"
+msgstr "Colaborează la caiet cu alte persoane"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:175
+msgid "Collaborate on notebooks with others"
+msgstr "Colaborează la caiete cu alte persoane"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
+msgid "Collapse all notebooks"
+msgstr "Restrînge toate caietele"
+
+#: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:23
+msgid "Collapsed"
+msgstr "Restrîns"
+
+#: packages/lib/services/ReportService.ts:385
+msgid "Coming alarms"
+msgstr "Alarmele următoare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1434
+msgid ""
+"Comma-separated list of paths to directories to load the certificates from, "
+"or path to individual cert files. For example: /my/cert_dir, /other/"
+"custom.pem. Note that if you make changes to the TLS settings, you must save "
+"your changes before clicking on \"Check synchronisation configuration\"."
+msgstr ""
+"Listă de căi de acces la directoare din care se încarcă certificatele sau "
+"calea de acces la fișierele de certificate individuale. De exemplu: /my/"
+"cert_dir, /other/custom.pem. Rețineți că, dacă efectuați modificări la "
+"setările TLS, trebuie să salvați modificările înainte de a face clic pe "
+"“Check synchronisation configuration” (Verificați configurația de "
+"sincronizare)."
+
+#: packages/lib/services/KeymapService.ts:331
+msgid "command"
+msgstr "command"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:188
+msgid "Command"
+msgstr "Comandă"
+
+#: packages/app-desktop/plugins/GotoAnything.tsx:791
+msgid "Command palette"
+msgstr "Paleta de comenzi"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/commandPalette.ts:7
+msgid "Command palette..."
+msgstr "Paleta de comenzi…"
+
+#: packages/lib/services/noteList/defaultListRenderer.ts:24
+msgid "Compact"
+msgstr "Compact"
+
+#: packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts:174
+msgid "Complete"
+msgstr "Finalizat"
+
+#: packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts:40
+msgid "Complete to-do"
+msgstr "Sarcini de făcut finalizate"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:12
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:84
+msgid "Completed"
+msgstr "Finalizat"
+
+#: packages/app-cli/app/command-e2ee.ts:80
+msgid "Completed decryption."
+msgstr "Decriptare finalizată."
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx:96
+msgid ""
+"Completed with warnings:\n"
+"%s"
+msgstr ""
+"Finalizată cu atenționări:\n"
+"%s"
+
+#: packages/lib/Synchronizer.ts:207
+msgid "Completed: %s (%s)"
+msgstr "Finalizat: %s (%s)"
+
+#: packages/lib/models/Note.ts:66
+msgid "completion date"
+msgstr "data realizării"
+
+#: packages/server/src/services/TaskService.ts:28
+msgid "Compress old changes"
+msgstr "Comprimă modificările vechi"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:126
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:819
+#: packages/app-mobile/components/side-menu-content.tsx:628
+msgid "Configuration"
+msgstr "Configurare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1173
+msgid "Configures the size of scrollbars used in the app."
+msgstr "Configurează mărimea barelor de derulare folosite în aplicație."
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:155
+msgid "Confirm password cannot be empty"
+msgstr "Confirmarea parolei nu poate fi un cîmp gol"
+
+#: packages/app-cli/app/command-e2ee.ts:95
+#: packages/app-mobile/components/screens/encryption-config.tsx:189
+msgid "Confirm password:"
+msgstr "Confirmare parolă:"
+
+#: packages/app-desktop/gui/Root.tsx:127
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:71
+msgid "Confirmation"
+msgstr "Confirmare"
+
+#: packages/lib/services/ReportService.ts:364
+msgid "Conflicted: %d"
+msgstr "În conflict: %d"
+
+#: packages/lib/models/Folder.ts:167
+msgid "Conflicts"
+msgstr "Conflicte"
+
+#: packages/lib/models/Resource.ts:478
+msgid "Conflicts (attachments)"
+msgstr "Conflicte (atașamente)"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:253
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:462
+msgid "Connect to Joplin Cloud"
+msgstr "Conectare la Joplin Cloud"
+
+#: packages/lib/utils/joplinCloud/index.ts:208
+msgid "Consolidated billing"
+msgstr "Facturare consolidată"
+
+#: packages/app-desktop/gui/Sidebar/listItemComponents/NoteCount.tsx:11
+msgid "Contains %d note"
+msgid_plural "Contains %d notes"
+msgstr[0] "Conține %d notiță"
+msgstr[1] "Conține %d notițe"
+msgstr[2] "Conține %d de notițe"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:106
+msgid "Content provided by %s"
+msgstr "Conținut asigurat de %s"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:102
+msgid "Content provided by: %s"
+msgstr "Conținut asigurat de: %s"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:75
+msgid "Continue"
+msgstr "Continuă"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:6
+msgid "Control character"
+msgstr "Caracter de control"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1266
+msgid "Convert to note"
+msgstr "Convertește în notiță"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1266
+msgid "Convert to todo"
+msgstr "Conversie în todo"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:168
+msgid "Converting speech to text..."
+msgstr "Conversia vorbirii în text…"
+
+#: packages/app-desktop/gui/MenuBar.tsx:610
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:35
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts:95
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:188
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:442
+msgid "Copy"
+msgstr "Copiază"
+
+#: packages/app-desktop/commands/copyDevCommand.ts:9
+msgid "Copy dev mode command to clipboard"
+msgstr "Copiază comanda dev mode în clipboard"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:229
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:243
+#: packages/app-desktop/gui/utils/NoteListUtils.ts:136
+#: packages/app-mobile/components/screens/Note/Note.tsx:1284
+msgid "Copy external link"
+msgstr "Copiază link-ul extern"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:171
+msgid "Copy image"
+msgstr "Copie imagine"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:209
+msgid "Copy Link Address"
+msgstr "Copiază adresa link-ului"
+
+#: packages/app-desktop/gui/JoplinCloudLoginScreen.tsx:94
+#: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:169
+msgid "Copy link to website"
+msgstr "Copiază legătură către website"
+
+#: packages/app-desktop/gui/utils/NoteListUtils.ts:121
+#: packages/app-mobile/components/screens/Note/Note.tsx:1275
+msgid "Copy Markdown link"
+msgstr "Copiază link-ul Markdown"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:156
+msgid "Copy path to clipboard"
+msgstr "Copiază locația în clipboard"
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:216
+msgid "Copy Shareable Link"
+msgid_plural "Copy Shareable Links"
+msgstr[0] "Copiază linkul care se poate partaja"
+msgstr[1] "Distribuie"
+msgstr[2] "Distribuie"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:52
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:75
+msgid "Copy to clipboard"
+msgstr "Copiază locația în clipboard"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:156
+msgid "Copy token"
+msgstr "Copie token"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:611
+msgid "Copy version info"
+msgstr "Copiază informații versiune"
+
+#: packages/lib/components/shared/dropbox-login-shared.js:43
+msgid ""
+"Could not authorise application:\n"
+"\n"
+"%s\n"
+"\n"
+"Please try again."
+msgstr ""
+"Nu s-a putut autoriza aplicația:\n"
+"\n"
+"%s\n"
+"\n"
+"Te rog să încerci din nou."
+
+#: packages/lib/JoplinServerApi.ts:113
+msgid ""
+"Could not connect to Joplin Server. Please check the Synchronisation options "
+"in the config screen. Full error was:\n"
+"\n"
+"%s"
+msgstr ""
+"Nu s-a putut conecta la serverul Joplin. Te rog să verificați opțiunile de "
+"sincronizare din ecranul de configurare. Eroarea completă a fost:\n"
+"\n"
+"%s"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:319
+msgid "Could not connect to plugin repository."
+msgstr "Nu s-a putut conecta la repozitoriul de plugin-uri."
+
+#: packages/app-desktop/InteropServiceHelper.ts:220
+msgid "Could not export notes: %s"
+msgstr "Nu s-au putut exporta notițele: %s"
+
+#: packages/lib/components/shared/config/plugins/useOnInstallHandler.ts:71
+msgid "Could not install plugin: %s"
+msgstr "Nu s-a putut instala plugin-ul: %s"
+
+#: packages/lib/services/share/invitationRespond.ts:24
+msgid ""
+"Could not respond to the invitation. Please try again, or check with the "
+"notebook owner if they are still sharing it.\n"
+"\n"
+"The error was: \"%s\""
+msgstr ""
+"Nu s-a putut răspunde la invitație. Te rog să încerci din nou sau să "
+"verifici cu deținătorul caietului îl mai partajează.\n"
+"\n"
+"Eroarea a fost: „%s”"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:60
+msgid "Could not switch profile: %s"
+msgstr "Nu s-a putut schimba profilul: %s"
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:224
+msgid "Could not upgrade master key: %s"
+msgstr "Nu s-a putut actualiza cheia principală: %s"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts:27
+msgid ""
+"Could not verify the share status of this notebook - aborting. Please try "
+"again when you are connected to the internet."
+msgstr ""
+"Nu s-a putut verifica starea de partajare a acestui caiet - se anulează. Te "
+"rog să încerci din nou cînd ești conectat la internet."
+
+#: packages/app-mobile/components/biometrics/biometricAuthenticate.ts:30
+msgid "Could not verify your identity: %s"
+msgstr "Nu s-a putut verifica identitatea dumneavoastră: %s"
+
+#: packages/app-desktop/gui/PromptDialog.tsx:275
+msgid "Create"
+msgstr "Create"
+
+#: packages/app-cli/app/command-mkbook.ts:19
+msgid "Create a new notebook under a parent notebook."
+msgstr "Creează o nouă secțiune într-un caiet."
+
+#: packages/app-mobile/components/NoteList.tsx:102
+msgid "Create a notebook"
+msgstr "Creează un caiet"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts:9
+#: packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx:88
+msgid "Create new profile..."
+msgstr "Creează un nou profil…"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:166
+msgid "Create notebook"
+msgstr "Creează un caiet"
+
+#: packages/server/src/routes/admin/users.ts:257
+msgid "Create user"
+msgstr "Creează un utilizator"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:14
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:81
+msgid "Created"
+msgstr "Creat"
+
+#: packages/lib/models/Note.ts:63
+msgid "created date"
+msgstr "data creării"
+
+#: packages/lib/Synchronizer.ts:199
+msgid "Created local items: %d."
+msgstr "Elemente locale create: %d."
+
+#: packages/lib/services/ReportService.ts:322
+msgid "Created locally"
+msgstr "Creat local"
+
+#: packages/lib/Synchronizer.ts:201
+msgid "Created remote items: %d."
+msgstr "Elemente la distanță create: %d."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:140
+msgid "Created: "
+msgstr "Creat: "
+
+#: packages/app-cli/app/command-import.ts:51
+#: packages/app-desktop/gui/ImportScreen.tsx:90
+msgid "Created: %d."
+msgstr "Creat: %d."
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:136
+#: packages/app-mobile/components/screens/Note/Note.tsx:1084
+msgid "Created: %s"
+msgstr "Creat: %s"
+
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:65
+msgid "Creates a new note with an attachment of type %s"
+msgstr "Creează o nouă notiță cu un atașament de tipul %s"
+
+#: packages/app-cli/app/command-mknote.js:12
+msgid "Creates a new note."
+msgstr "Creează o nouă notiță."
+
+#: packages/app-cli/app/command-mkbook.ts:14
+msgid "Creates a new notebook."
+msgstr "Creează un nou caiet."
+
+#: packages/app-cli/app/command-mktodo.js:12
+msgid "Creates a new to-do."
+msgstr "Creează o nouă listă de făcut."
+
+#: packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx:123
+msgid "Creating new note..."
+msgstr "Se creează o nouă notiță…"
+
+#: packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx:123
+msgid "Creating new to-do..."
+msgstr "Se creează o nouă listă de făcut…"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.tsx:29
+msgid "Creating report..."
+msgstr "Se creează un raport..."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:41
+msgid "Ctrl-click to open"
+msgstr "Ctrl-clic pentru a deschide"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:47
+msgid "Ctrl-click to open: %s"
+msgstr "Ctrl-clic pentru a deschide: %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:24
+msgid "current match"
+msgstr "potrivirea curentă"
+
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:153
+msgid "Current password"
+msgstr "Parola curentă"
+
+#: packages/app-desktop/checkForUpdates.ts:90
+msgid "Current version is up-to-date."
+msgstr "Versiunea curentă este actualizată."
+
+#: packages/lib/models/Note.ts:64
+msgid "custom order"
+msgstr "comandă personalizată"
+
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
+msgid "Custom order"
+msgstr "Comandă personalizată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1222
+msgid "Custom stylesheet for Joplin-wide app styles"
+msgstr "Stylesheet personalizat pentru stilurile aplicației Joplin-wide"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1205
+msgid "Custom stylesheet for rendered Markdown"
+msgstr "Stylesheet personalizat pentru Markdown redat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1433
+msgid "Custom TLS certificates"
+msgstr "Certificate TLS cusomizate"
+
+#: packages/lib/utils/joplinCloud/index.ts:194
+msgid "Customise the note publishing banner"
+msgstr "Personalizați bannerul de publicare a notițelor"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:40
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts:85
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:180
+msgid "Cut"
+msgstr "Decupează"
+
+#: packages/lib/models/settings/builtInMetadata.ts:49
+msgid "Dark"
+msgstr "Întunecat"
+
+#: packages/server/src/services/MustacheService.ts:117
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:169
+msgid "Date"
+msgstr "Data"
+
+#: packages/lib/models/settings/builtInMetadata.ts:473
+msgid "Date format"
+msgstr "Format dată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1538
+#: packages/lib/models/settings/builtInMetadata.ts:1814
+msgid "days"
+msgstr "zile"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:92
+msgid "Decrease indent level"
+msgstr "Reduceți nivelul de indentare"
+
+#: packages/app-cli/app/command-e2ee.ts:65
+msgid "Decrypted items: %d"
+msgstr "Elemente decriptate: %d"
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:45
+msgid "Decrypted items: %s / %s"
+msgstr "Se decriptează elementele: %s / %s"
+
+#: packages/app-desktop/gui/Sidebar/Sidebar.tsx:48
+#: packages/app-mobile/components/side-menu-content.tsx:637
+msgid "Decrypting items: %d/%d"
+msgstr "Se decriptează elementele: %d/%d"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1116
+#: packages/lib/models/settings/builtInMetadata.ts:1123
+#: packages/lib/models/settings/builtInMetadata.ts:1344
+msgid "Default"
+msgstr "Modul implicit"
+
+#: packages/app-cli/app/help-utils.js:71
+msgid "Default: %s"
+msgstr "Modul implicit: %s"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:185
+#: packages/app-desktop/gui/ResourceScreen.tsx:135
+#: packages/app-desktop/gui/ResourceScreen.tsx:232
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:135
+#: packages/app-mobile/components/ScreenHeader/index.tsx:451
+#: packages/app-mobile/components/ScreenHeader/index.tsx:529
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:207
+#: packages/app-mobile/components/screens/Note/Note.tsx:1315
+#: packages/app-mobile/components/side-menu-content.tsx:427
+#: packages/lib/commands/permanentlyDeleteNote.ts:21
+msgid "Delete"
+msgstr "Șterge"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:231
+msgid "Delete attachment \"%s\"?"
+msgstr "Ștergi atașamentul „%s”?"
+
+#: packages/server/src/services/TaskService.ts:27
+msgid "Delete expired sessions"
+msgstr "Șterge sesiunile expirate"
+
+#: packages/server/src/services/TaskService.ts:22
+msgid "Delete expired tokens"
+msgstr "Șterge token-urile expirate"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:110
+msgid "Delete line"
+msgstr "Șterge linia"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1246
+msgid "Delete local data and re-download from sync target"
+msgstr ""
+"Șterge datele locale și descarcă din nou de la destinația de sincronizare"
+
+#: packages/lib/commands/deleteNote.ts:7
+msgid "Delete note"
+msgstr "Șterge notița"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:9
+msgid "Delete notebook"
+msgstr "Șterge caietul"
+
+#: packages/lib/components/shared/config/plugins/useOnDeleteHandler.ts:16
+msgid "Delete plugin \"%s\"?"
+msgstr "Ștergi plugin-ul „%s”?"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:111
+msgid "Delete profile \"%s\""
+msgstr "Ștergi profilul „%s”?"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:453
+msgid "Delete selected notes"
+msgstr "Șterge aceste notițe"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:22
+#: packages/app-mobile/components/side-menu-content.tsx:407
+msgid ""
+"Delete the Inbox notebook?\n"
+"\n"
+"If you delete the inbox notebook, any email that's recently been sent to it "
+"may be lost."
+msgstr ""
+"Ștergi caietul Inbox?\n"
+"\n"
+"Dacă ștergi caietul de notițe Inbox, orice e-mail trimis recent în acesta "
+"poate fi pierdut."
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:246
+msgid ""
+"Delete this invitation? The recipient will no longer have access to this "
+"shared notebook."
+msgstr ""
+"Ștergi această invitație? Destinatarul nu va mai avea acces la acest caiet "
+"partajat."
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:107
+msgid "Delete this profile?"
+msgstr "Ștergi acest profil?"
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:83
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:207
+msgid "Deleted"
+msgstr "Șters"
+
+#: packages/lib/Synchronizer.ts:203
+msgid "Deleted local items: %d."
+msgstr "Elemente locale șterse: %d."
+
+#: packages/lib/Synchronizer.ts:204
+msgid "Deleted remote items: %d."
+msgstr "Elemente șterse de la distanță: %d."
+
+#: packages/app-cli/app/command-rmnote.ts:20
+msgid "Deletes notes permanently, skipping the trash."
+msgstr "Șterge notițele permanent, omițînd coșul de gunoi."
+
+#: packages/app-cli/app/command-rmbook.ts:14
+msgid "Deletes the given notebook."
+msgstr "Șterge caietul dat."
+
+#: packages/app-cli/app/command-rmbook.ts:19
+msgid "Deletes the notebook without asking for confirmation."
+msgstr "Șterge caietele de notițe fără a mai cere confirmarea."
+
+#: packages/app-cli/app/command-rmnote.ts:14
+msgid "Deletes the notes matching <note-pattern>."
+msgstr "Șterge notițele care se potrivesc cu <note-pattern>."
+
+#: packages/app-cli/app/command-rmnote.ts:19
+msgid "Deletes the notes without asking for confirmation."
+msgstr "Șterge notițele fără a cere confirmare."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:551
+msgid "Deletion log"
+msgstr "Jurnal ștergeri"
+
+#: packages/app-mobile/components/NoteItem.tsx:151
+msgid "Deselect"
+msgstr "Deselectează"
+
+#: packages/app-cli/app/command-export.ts:24
+msgid "Destination format: %s"
+msgstr "Format la destinație: %s"
+
+#: packages/lib/services/noteList/defaultLeftToRightListRenderer.ts:25
+#: packages/lib/services/noteList/defaultMultiColumnsRenderer.ts:8
+msgid "Detailed"
+msgstr "Detaliat"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:99
+msgid "Dev"
+msgstr "Dezvoltator"
+
+#: packages/lib/versionInfo.ts:88
+msgid "Device: %s"
+msgstr "Dispozitiv: %s"
+
+#: packages/lib/services/interop/Module.ts:62
+msgid "Directory"
+msgstr "dosar"
+
+#: packages/lib/models/settings/builtInMetadata.ts:142
+msgid "Directory to synchronise with (absolute path)"
+msgstr "Directorul cu care se sincronizează (cale absolută)"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:144
+msgid "Disable"
+msgstr "Dezactivează"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:226
+#: packages/app-mobile/components/screens/encryption-config.tsx:317
+msgid "Disable encryption"
+msgstr "Dezactivează criptarea"
+
+#: packages/app-desktop/gui/MainScreen.tsx:525
+msgid "Disable safe mode and restart"
+msgstr "Dezactivează modul de siguranță și repornește"
+
+#: packages/app-desktop/gui/MainScreen.tsx:594
+msgid "Disable synchronisation"
+msgstr "Dezactivează sincronizarea"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:97
+msgid "Disable Web Clipper Service"
+msgstr "Dezactivează serviciul Web Clipper"
+
+#: packages/app-cli/app/command-e2ee.ts:128
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:237
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:143
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:85
+#: packages/app-mobile/components/screens/encryption-config.tsx:353
+#: packages/lib/models/settings/builtInMetadata.ts:1278
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:322
+msgid "Disabled keys"
+msgstr "Taste dezactivate"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:200
+#: packages/app-mobile/components/screens/encryption-config.tsx:276
+msgid ""
+"Disabling encryption means *all* your notes and attachments are going to be "
+"re-synchronised and sent unencrypted to the sync target. Do you wish to "
+"continue?"
+msgstr ""
+"Dezactivarea criptării înseamnă că *toate* notele și atașamentele dvs. vor "
+"fi resincronizate și trimise necriptate către ținta de sincronizare. Doriți "
+"să continuați?"
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.ts:19
+msgid "Discard"
+msgstr "Renunțați"
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:105
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:269
+#: packages/app-mobile/components/screens/Note/Note.tsx:230
+msgid "Discard changes"
+msgstr "Renunțați la schimbări"
+
+#: packages/app-desktop/gui/NoteEditor/WarningBanner/BannerContent.tsx:20
+#: packages/app-mobile/root.tsx:1410
+msgid "Dismiss"
+msgstr "Respingeți"
+
+#: packages/app-cli/app/command-geoloc.ts:13
+msgid "Displays a geolocation URL for the note."
+msgstr "Afișează o adresă URL de geolocație pentru notiță."
+
+#: packages/app-cli/app/command-ls.ts:28
+msgid "Displays only the first top <num> notes."
+msgstr "Afișează numai primele <num> notițe."
+
+#: packages/app-cli/app/command-ls.ts:31
+msgid ""
+"Displays only the items of the specific type(s). Can be `n` for notes, `t` "
+"for to-dos, or `nt` for notes and to-dos (eg. `-tt` would display only the "
+"to-dos, while `-tnt` would display notes and to-dos."
+msgstr ""
+"Afișează numai elementele de tipul (tipurile) specific(e). Tipuri acceptate: "
+"\"n\" pentru notițe, \"t\" pentru to-dos, sau \"nt\" pentru notițe și to-dos "
+"(de exemplu, `-tt` afișează numai to-dos, în timp ce `-tnt` afișează notițe "
+"și to-dos."
+
+#: packages/app-cli/app/command-status.js:13
+msgid "Displays summary about the notes and notebooks."
+msgstr "Afișează un rezumat despre notițe și caiete."
+
+#: packages/app-cli/app/command-cat.ts:18
+msgid "Displays the complete information about note."
+msgstr "Afișează informațiile complete despre notiță."
+
+#: packages/app-cli/app/command-cat.ts:14
+msgid "Displays the given note."
+msgstr "Afișează notițele specificate."
+
+#: packages/app-cli/app/command-ls.ts:19
+msgid ""
+"Displays the notes in the current notebook. Use `ls /` to display the list "
+"of notebooks."
+msgstr ""
+"Afișează notițele din caietul curent. Folosește 'ls /' pentru a afișa lista "
+"de caiete."
+
+#: packages/app-cli/app/command-help.ts:13
+msgid "Displays usage information."
+msgstr "Afișați informațiile de utilizare."
+
+#: packages/app-cli/app/command-version.ts:11
+msgid "Displays version information"
+msgstr "Afișează informații despre versiune"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:338
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:11
+msgid "Do it now"
+msgstr "Fă-o acum"
+
+#: packages/app-cli/app/command-import.ts:28
+msgid "Do not ask for confirmation."
+msgstr "Nu cere confirmarea."
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:55
+msgid ""
+"Do not lose the password as, for security purposes, this will be the *only* "
+"way to decrypt the data! To enable encryption, please enter your password "
+"below."
+msgstr ""
+"Nu pierde parola, deoarece din motive de securitate, aceasta este *unica* "
+"modalitate de decriptare a datelor! Pentru a activa criptarea, te rog să "
+"întroduci parola mai jos."
+
+#: packages/lib/models/Setting.ts:1223
+msgid "Donate, website"
+msgstr "Donează, website"
+
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:145
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:199
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:200
+#: packages/lib/models/Resource.ts:34
+msgid "Done"
+msgstr "Realizat"
+
+#: packages/app-desktop/checkForUpdates.ts:109
+msgid "Download"
+msgstr "Descarcă"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:143
+msgid "Download and install the relevant extension for your browser:"
+msgstr "Descarcă și instalează extensia relevantă pentru navigatorul tău web:"
+
+#: packages/app-desktop/gui/MainScreen.tsx:586
+msgid "Download it now"
+msgstr "Descarc-o acum"
+
+#: packages/lib/models/Resource.ts:409
+msgid "Downloaded"
+msgstr "Descărcat"
+
+#: packages/lib/services/ReportService.ts:320
+msgid "Downloaded and decrypted"
+msgstr "Descărcat și decriptat"
+
+#: packages/lib/services/ReportService.ts:321
+msgid "Downloaded and encrypted"
+msgstr "Descărcat și criptat"
+
+#: packages/lib/models/Resource.ts:408
+msgid "Downloading"
+msgstr "Descărcare"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:170
+msgid "Downloading %s language files..."
+msgstr "Descărcarea fișierelor de limbă %s…"
+
+#: packages/app-cli/app/command-sync.ts:256
+msgid "Downloading resources..."
+msgstr "Se descarcă resursele..."
+
+#: packages/lib/models/settings/builtInMetadata.ts:50
+msgid "Dracula"
+msgstr "Dracula"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1207
+msgid "Draw picture"
+msgstr "Desenați imaginea"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:917
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:75
+msgid "Drawing"
+msgstr "Desen"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:1559
+msgid "Drop notes or files here"
+msgstr "Plasați notițe sau fișiere aici"
+
+#: packages/lib/SyncTargetDropbox.js:25
+msgid "Dropbox"
+msgstr "Dropbox"
+
+#: packages/app-desktop/gui/Root.tsx:190
+msgid "Dropbox Login"
+msgstr "Autentificare Dropbox"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:13
+msgid "Due"
+msgstr "Scadență"
+
+#: packages/lib/models/Note.ts:65
+msgid "due date"
+msgstr "data scadentă"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.ts:7
+#: packages/app-mobile/components/ScreenHeader/index.tsx:491
+#: packages/app-mobile/components/ScreenHeader/index.tsx:535
+msgid "Duplicate"
+msgstr "Duplică"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:114
+msgid "Duplicate line"
+msgstr "Duplică linia"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:493
+msgid "Duplicate selected notes"
+msgstr "Duplicarea notelor selectate"
+
+#: packages/app-cli/app/command-cp.ts:13
+msgid ""
+"Duplicates the notes matching <note> to [notebook]. If no notebook is "
+"specified the note is duplicated in the current notebook."
+msgstr ""
+"Duplică notițele care se potrivesc cu <note> în [notebook]. Dacă nu este "
+"specificat niciun caiet, notița va fi duplicată în caietul curent."
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:217
+msgid "Duration: %s"
+msgstr "Durată: %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts:94
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEditDialog.ts:83
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:435
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openFolderDialog.ts:12
+#: packages/app-mobile/components/NoteBodyViewer/hooks/useEditPopup.ts:133
+#: packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts:42
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:130
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:150
+#: packages/app-mobile/components/screens/Note/Note.tsx:1614
+#: packages/app-mobile/components/side-menu-content.tsx:414
+msgid "Edit"
+msgstr "Editează"
+
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:138
+msgid "Edit link"
+msgstr "Editează legătura"
+
+#: packages/app-cli/app/command-edit.ts:17
+msgid "Edit note."
+msgstr "Editează notiță."
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:166
+#: packages/app-mobile/components/screens/folder.js:97
+msgid "Edit notebook"
+msgstr "Editează caietul de notițe"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx:88
+msgid "Edit profile"
+msgstr "Editează profilul"
+
+#: packages/app-desktop/commands/editProfileConfig.ts:9
+msgid "Edit profile configuration..."
+msgstr "Editează configurările profilului…"
+
+#: packages/app-desktop/gui/MainScreen.tsx:129
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:144
+#: packages/lib/models/settings/builtInMetadata.ts:624
+#: packages/lib/models/settings/builtInMetadata.ts:625
+#: packages/lib/models/settings/builtInMetadata.ts:626
+msgid "Editor"
+msgstr "Editor"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/Toolbar.tsx:40
+msgid "Editor actions"
+msgstr "Acțiuni editor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1109
+msgid "Editor font"
+msgstr "Font editor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1135
+msgid "Editor font family"
+msgstr "Familie font editor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1097
+msgid "Editor font size"
+msgstr "Mărime font editor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1156
+msgid "Editor maximum width"
+msgstr "Lățimea maximă a editorului"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1148
+msgid "Editor monospace font family"
+msgstr "Familie font monospațiere editor"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:118
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:122
+msgid "Editor: %s"
+msgstr "Editor: %s"
+
+#: packages/app-cli/app/command-ls.ts:32
+msgid "Either \"text\" or \"json\""
+msgstr "Sau \"text\", sau \"json\""
+
+#: packages/lib/models/settings/builtInMetadata.ts:1345
+msgid "Emacs"
+msgstr "Emacs"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:39
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:55
+#: packages/server/src/routes/admin/emails.ts:127
+#: packages/server/src/routes/admin/users.ts:140
+msgid "Email"
+msgstr "Email"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:47
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:23
+msgid "Email to note"
+msgstr "Email to note"
+
+#: packages/lib/utils/joplinCloud/index.ts:187
+msgid "Email to Note"
+msgstr "Email to Note"
+
+#: packages/lib/models/Setting.ts:1216
+msgid "Email To Note, login information"
+msgstr "Email To Note, login information"
+
+#: packages/server/src/routes/admin/emails.ts:111
+#: packages/server/src/services/MustacheService.ts:133
+msgid "Emails"
+msgstr "Email"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:196
+msgid "emphasised text"
+msgstr "text accentuat"
+
+#: packages/app-desktop/commands/emptyTrash.ts:16
+#: packages/app-desktop/commands/emptyTrash.ts:8
+#: packages/app-mobile/components/side-menu-content.tsx:338
+#: packages/app-mobile/components/side-menu-content.tsx:342
+msgid "Empty trash"
+msgstr "Golește coșul"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:144
+#: packages/app-mobile/components/biometrics/BiometricPopup.tsx:86
+#: packages/app-mobile/components/screens/encryption-config.tsx:204
+msgid "Enable"
+msgstr "Activează"
+
+#: packages/lib/models/settings/builtInMetadata.ts:999
+msgid "Enable ^sup^ syntax"
+msgstr "Activează sintaxa ^sup^"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1003
+msgid "Enable ++insert++ syntax"
+msgstr "Activează sintaxa ++insert++"
+
+#: packages/lib/models/settings/builtInMetadata.ts:995
+msgid "Enable ==mark== syntax"
+msgstr "Activează sintaxa ==mark=="
+
+#: packages/lib/models/settings/builtInMetadata.ts:998
+msgid "Enable ~sub~ syntax"
+msgstr "Activează sintaxa ~sub~"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1001
+msgid "Enable abbreviation syntax"
+msgstr "Activează sintaxa abrevierii"
+
+#: packages/lib/models/settings/builtInMetadata.ts:992
+msgid "Enable audio player"
+msgstr "Activează playerul audio"
+
+#: packages/app-mobile/components/biometrics/BiometricPopup.tsx:82
+msgid "Enable biometrics authentication?"
+msgstr "Activează autentificarea biometrică?"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1000
+msgid "Enable deflist syntax"
+msgstr "Activează sintaxa deflist"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:226
+#: packages/app-mobile/components/screens/encryption-config.tsx:317
+msgid "Enable encryption"
+msgstr "Activează criptarea"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1015
+msgid "Enable file:// URLs for images and videos"
+msgstr "Activează URL-uri de tip file:// pentru imagini și videouri"
+
+#: packages/lib/models/settings/builtInMetadata.ts:996
+msgid "Enable footnotes"
+msgstr "Activează notele de subsol"
+
+#: packages/lib/models/settings/builtInMetadata.ts:989
+msgid "Enable Fountain syntax support"
+msgstr "Activează suportul pentru sintaxa Fountain"
+
+#: packages/lib/models/settings/builtInMetadata.ts:986
+msgid "Enable Linkify"
+msgstr "Activează Linkify"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1002
+msgid "Enable markdown emoji"
+msgstr "Activează emoji markdown"
+
+#: packages/lib/models/settings/builtInMetadata.ts:988
+msgid "Enable math expressions"
+msgstr "Activează expresiile matematice"
+
+#: packages/lib/models/settings/builtInMetadata.ts:990
+msgid "Enable Mermaid diagrams support"
+msgstr "Activează suportul pentru diagramele Mermaid"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1004
+msgid "Enable multimarkdown table extension"
+msgstr "Activează extensia de tabel multimarkdown"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1528
+msgid "Enable note history"
+msgstr "Activează istoricul notițelor"
+
+#: packages/lib/models/settings/builtInMetadata.ts:516
+msgid "Enable optical character recognition (OCR)"
+msgstr "Activează recunoașterea optică a caracterelor (OCR)"
+
+#: packages/lib/models/Setting.ts:1222
+msgid "Enable or disable plugins"
+msgstr "Activează sau dezactivează plugin-uri"
+
+#: packages/lib/models/settings/builtInMetadata.ts:994
+msgid "Enable PDF viewer"
+msgstr "Activează vizualizatorul PDF"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:119
+#: packages/lib/models/settings/builtInMetadata.ts:942
+msgid "Enable plugin support"
+msgstr "Activează suportul pentru plugin-uri"
+
+#: packages/lib/models/settings/builtInMetadata.ts:984
+msgid "Enable soft breaks"
+msgstr "Activează întreruperile ușoare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1358
+msgid "Enable spell checking in Markdown editor"
+msgstr "Activează verificarea ortografică în editorul Markdown"
+
+#: packages/lib/models/settings/builtInMetadata.ts:826
+msgid "Enable spellcheck in the text editor"
+msgstr "Activează verificarea ortografică în editorul de text"
+
+#: packages/lib/models/settings/builtInMetadata.ts:997
+msgid "Enable table of contents extension"
+msgstr "Activează extensia tabelului de conținut"
+
+#: packages/lib/models/settings/builtInMetadata.ts:837
+msgid "Enable the Markdown toolbar"
+msgstr "Activează bara de instrumente Markdown"
+
+#: packages/lib/models/settings/builtInMetadata.ts:985
+msgid "Enable typographer support"
+msgstr "Activează suportul pentru tipografii"
+
+#: packages/lib/models/settings/builtInMetadata.ts:993
+msgid "Enable video player"
+msgstr "Activează playerul video"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:117
+msgid "Enable Web Clipper Service"
+msgstr "Activează Web Clipper Service"
+
+#: packages/app-cli/app/command-e2ee.ts:128
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:176
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:237
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:95
+#: packages/app-mobile/components/screens/encryption-config.tsx:353
+msgid "Enabled"
+msgstr "Activat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:673
+msgid ""
+"Enables Markdown list continuation, auto-closing HTML tags, and other markup "
+"autocompletions."
+msgstr ""
+"Activează continuarea listei Markdown, auto-închiderea a tag-urilor HTML și "
+"alte auto-completări în markup."
+
+#: packages/lib/models/settings/builtInMetadata.ts:694
+msgid ""
+"Enables Markdown pattern replacement in the Rich Text Editor. For example, "
+"when enabled, typing **bold** creates bold text."
+msgstr ""
+"Activează înlocuire cu șablon Markdown în editorul de text îmbogățit. De "
+"exemplu, dacă este activat, tastînd **aldin** va crea text aldin."
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:50
+msgid ""
+"Enabling encryption means *all* your notes and attachments are going to be "
+"re-synchronised and sent encrypted to the sync target."
+msgstr ""
+"Activarea criptării înseamnă că *toate* notele și atașamentele dvs. vor fi "
+"resincronizate și trimise criptate către ținta de sincronizare."
+
+#: packages/lib/models/BaseItem.ts:923
+msgid "Encrypted"
+msgstr "Criptat"
+
+#: packages/lib/models/BaseItem.ts:985
+msgid "Encrypted items cannot be modified"
+msgstr "Itemii criptați nu pot fi editați"
+
+#: packages/lib/models/Setting.ts:1184
+msgid "Encryption"
+msgstr "Criptare"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:530
+#: packages/app-mobile/components/screens/encryption-config.tsx:334
+msgid "Encryption Config"
+msgstr "Configurație de criptare"
+
+#: packages/app-cli/app/command-e2ee.ts:128
+#: packages/app-mobile/components/screens/encryption-config.tsx:353
+msgid "Encryption is: %s"
+msgstr "Criptarea este: %s"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:160
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:261
+msgid "Encryption keys"
+msgstr "Cheile de criptare"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:237
+msgid "Encryption:"
+msgstr "Criptare:"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:235
+msgid "End-to-end encryption"
+msgstr "Criptare end-to-end"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:199
+msgid "Ends voice typing"
+msgstr "Termină transcrierea vocală"
+
+#: packages/app-mobile/components/screens/dropbox-login.tsx:70
+msgid "Enter code here"
+msgstr "Introdu codul aici"
+
+#: packages/app-cli/app/command-e2ee.ts:39
+#: packages/app-cli/app/command-e2ee.ts:85
+msgid "Enter master password:"
+msgstr "Introdu parola principală:"
+
+#: packages/app-mobile/components/screens/folder.js:100
+msgid "Enter notebook title"
+msgstr "Introdu titlul caietului"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:122
+msgid "Enter password"
+msgstr "Introdu parola"
+
+#: packages/app-mobile/components/NoteItem.tsx:129
+msgid "Entering selection mode"
+msgstr "Se intră în modul de selecție"
+
+#: packages/app-cli/app/help-utils.js:56
+msgid "Enum"
+msgstr "Enum"
+
+#: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:19
+#: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:29
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:102
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:60
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx:74
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:45
+#: packages/lib/models/Resource.ts:33 packages/lib/models/Resource.ts:410
+msgid "Error"
+msgstr "Eroare"
+
+#: packages/app-cli/app/command-edit.ts:83
+#: packages/app-desktop/commands/startExternalEditing.ts:23
+msgid "Error opening note in editor: %s"
+msgstr "Eroare deschidere notiță în editor: %s"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:64
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts:32
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginUploadButton.tsx:85
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:67
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:171
+#: packages/lib/services/KeymapService.ts:219
+msgid "Error: %s"
+msgstr "Eroare: %s"
+
+#: packages/lib/components/shared/config/config-shared.ts:101
+msgid ""
+"Error. Please check that URL, username, password, etc. are correct and that "
+"the sync target is accessible. The reported error was:"
+msgstr ""
+"Eroare. Te rog să verificați dacă adresa URL, numele de utilizator, parola "
+"etc. sînt corecte și că ținta de sincronizare este accesibilă. Eroarea "
+"raportată a fost:"
+
+#: packages/app-mobile/components/screens/LogScreen.tsx:237
+msgid "Errors only"
+msgstr "Doar erori"
+
+#: packages/lib/services/interop/InteropService.ts:76
+msgid "Evernote Export File (as HTML)"
+msgstr "Fișier export Evernote (ca HTML)"
+
+#: packages/lib/services/interop/InteropService.ts:85
+msgid "Evernote Export File (as Markdown)"
+msgstr "Fișier export Evernote (ca Markdown)"
+
+#: packages/lib/services/interop/InteropService.ts:94
+msgid "Evernote Export Files (Directory, as HTML)"
+msgstr "Fișiere export Evernote (dosar, ca HTML)"
+
+#: packages/lib/services/interop/InteropService.ts:103
+msgid "Evernote Export Files (Directory, as Markdown)"
+msgstr "Fișiere export Evernote (dosar, ca Markdown)"
+
+#: packages/app-cli/app/command-exit.ts:11
+msgid "Exits the application."
+msgstr "Ieșire din aplicație."
+
+#: packages/app-mobile/components/side-menu-content.tsx:212
+msgid "Expand %s"
+msgstr "Extinde %s"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
+msgid "Expand all notebooks"
+msgstr "Extinde toate caietele"
+
+#: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:21
+msgid "Expanded"
+msgstr "Extins"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:182
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:213
+#: packages/app-desktop/gui/utils/NoteListUtils.ts:186
+msgid "Export"
+msgstr "Exportă"
+
+#: packages/app-desktop/gui/MenuBar.tsx:662
+#: packages/app-desktop/gui/MenuBar.tsx:718
+msgid "Export all"
+msgstr "Exportă tot"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:20
+msgid "Export all notes as JEX"
+msgstr "Exportă toate notițele în format JEX"
+
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:199
+msgid "Export debug report"
+msgstr "Export debug report"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.tsx:14
+msgid "Export Debug Report"
+msgstr "Export Debug Report"
+
+#: packages/app-desktop/commands/exportDeletionLog.ts:11
+msgid "Export deletion log"
+msgstr "Exportă jurnal ștergeri"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:16
+msgid "Export profile"
+msgstr "Exportă profilul"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:70
+msgid "Exported successfully!"
+msgstr "Exportat cu succes!"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:36
+msgid "Exporting profile..."
+msgstr "Se exportă profilul..."
+
+#: packages/app-desktop/InteropServiceHelper.ts:199
+msgid "Exporting to \"%s\" as \"%s\" format. Please wait..."
+msgstr "Se exportă către „%s” în format „%s”. Te rog să aștepți..."
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:25
+msgid "Exporting..."
+msgstr "Se exportă..."
+
+#: packages/app-cli/app/command-export.ts:14
+msgid ""
+"Exports Joplin data to the given path. By default, it will export the "
+"complete database including notebooks, notes, tags and resources."
+msgstr ""
+"Exportă datele din Joplin în calea dată. În mod implicit, va exporta baza de "
+"date completă, inclusiv caietele, notițele, etichetele și resursele."
+
+#: packages/app-cli/app/command-export.ts:24
+msgid "Exports only the given note."
+msgstr "Exportă numai notița specificată."
+
+#: packages/app-cli/app/command-export.ts:24
+msgid "Exports only the given notebook."
+msgstr "Exportă doar caietul specificat."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1499
+msgid "Fail-safe"
+msgstr "Fail-safe"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1500
+msgid ""
+"Fail-safe: Do not wipe out local data when sync target is empty (often the "
+"result of a misconfiguration or bug)"
+msgstr ""
+"Fail-safe: Nu șterge datele locale atunci cînd ținta de sincronizare este "
+"goală (adesea rezultatul unei configurații greșite sau al unei erori)."
+
+#: packages/lib/services/synchronizer/syncInfoUtils.ts:134
+msgid ""
+"Fail-safe: Sync was interrupted to prevent data loss, because the sync "
+"target is empty or damaged. To override this behaviour disable the fail-safe "
+"in the sync settings."
+msgstr ""
+"Fail-safe: Sincronizarea a fost întreruptă pentru a preveni pierderea de "
+"date, deoarece ținta sincronizării este goală sau eronată. Pentru a anula "
+"acest comportament, dezactivează mecanismul de fail-safe din setările de "
+"sincronizare."
+
+#: packages/app-cli/app/main.js:107
+msgid "Fatal error:"
+msgstr "Eroare fatală:"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:618
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:626
+msgid "Feature flags"
+msgstr "Feature Flags"
+
+#: packages/lib/Synchronizer.ts:205
+msgid "Fetched items: %d/%d."
+msgstr "Elemente preluate: %d/%d."
+
+#: packages/app-desktop/gui/Sidebar/Sidebar.tsx:53
+#: packages/app-mobile/components/side-menu-content.tsx:642
+msgid "Fetching resources: %d/%d"
+msgstr "Încărcarea resurselor: %d/%d"
+
+#: packages/lib/services/interop/Module.ts:62
+msgid "File"
+msgstr "fișier"
+
+#: packages/lib/SyncTargetFilesystem.ts:18
+msgid "File system"
+msgstr "Sistem de fișiere"
+
+#: packages/app-mobile/components/screens/LogScreen.tsx:207
+#: packages/app-mobile/components/screens/LogScreen.tsx:208
+msgid "Filter"
+msgstr "Filtrează"
+
+#: packages/app-mobile/components/screens/NoteTagsDialog.tsx:227
+msgid "Filter tags"
+msgstr "Filtrează etichetele"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:14
+msgid "Find"
+msgstr "Găsește"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:253
+msgid "Find: "
+msgstr "Găsiți: "
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:208
+msgid "Finishes recording"
+msgstr "Finalizează înregistrarea"
+
+#: packages/app-desktop/gui/ExtensionBadge.tsx:65
+msgid "Firefox Extension"
+msgstr "Extensie Firefox"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:552
+msgid "Fix search index"
+msgstr "Fix search index"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:552
+msgid "Fixing search index..."
+msgstr "Fixing search index…"
+
+#: packages/app-desktop/gui/MenuBar.tsx:886
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts:8
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteTitle.ts:8
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts:9
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.ts:9
+#: packages/app-desktop/gui/NoteList/commands/focusElementNoteList.ts:10
+#: packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.ts:11
+msgid "Focus"
+msgstr "Focalizează pe"
+
+#: packages/lib/models/settings/builtInMetadata.ts:853
+#: packages/lib/models/settings/builtInMetadata.ts:870
+msgid "Focus body"
+msgstr "Focalizare pe corp"
+
+#: packages/lib/models/settings/builtInMetadata.ts:852
+#: packages/lib/models/settings/builtInMetadata.ts:869
+msgid "Focus title"
+msgstr "Focalizare pe titlu"
+
+#: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:97
+msgid "Follow link"
+msgstr "Urmează legătura"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:38
+msgid "For debugging purpose only: export your profile to an external SD card."
+msgstr "Numai în scop de depanare: exportați profilul pe un card SD extern."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1479
+msgid "For example \"%s\""
+msgstr "De exemplu, „%s”"
+
+#: packages/app-cli/app/command-help.ts:37
+msgid "For information on how to customise the shortcuts please visit %s"
+msgstr ""
+"Pentru informații despre cum să personalizați comenzile rapide, vizitați %s"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:338
+msgid ""
+"For more information about End-To-End Encryption (E2EE) and advice on how to "
+"enable it please check the documentation:"
+msgstr ""
+"Pentru mai multe informații despre criptarea de la un capăt la altul (E2EE) "
+"și sfaturi despre cum să o , te rog să consultați documentația:"
+
+#: packages/app-cli/app/command-help.ts:85
+msgid ""
+"For the list of keyboard shortcuts and config options, type `help keymap`"
+msgstr ""
+"Pentru lista de scurtături de la tastatură și opțiuni de configurare, "
+"tastează `help keymap`"
+
+#: packages/lib/models/settings/builtInMetadata.ts:306
+msgid "Force path style"
+msgstr "Forțați path style"
+
+#: packages/lib/commands/historyForward.ts:6
+msgid "Forward"
+msgstr "Înainte"
+
+#: packages/app-cli/app/command-import.ts:50
+#: packages/app-desktop/gui/ImportScreen.tsx:89
+msgid "Found: %d."
+msgstr "Găsit: %d."
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:47
+msgid "FTS enabled: %d"
+msgstr "FTS activat: %d"
+
+#: packages/app-desktop/checkForUpdates.ts:109
+msgid "Full changelog"
+msgstr "Lista completă a modificărilor"
+
+#: packages/server/src/routes/admin/users.ts:136
+msgid "Full name"
+msgstr "Nume și prenume"
+
+#: packages/lib/models/Setting.ts:1175
+#: packages/server/src/services/MustacheService.ts:114
+msgid "General"
+msgstr "General"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:240
+msgid "Generated"
+msgstr "Generate"
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:186
+msgid "Generating link..."
+msgid_plural "Generating links..."
+msgstr[0] "Se creează link..."
+msgstr[1] "Se crează un %s..."
+msgstr[2] "Se crează un %s..."
+
+#: packages/lib/models/Setting.ts:1218
+msgid "Geolocation, spellcheck, editor toolbar, image resize"
+msgstr ""
+"Geolocație, verificare ortografică, bara de instrumente a editorului, "
+"redimensionare imagine"
+
+#: packages/app-desktop/gui/ExtensionBadge.tsx:93
+msgid "Get it now:"
+msgstr "Obține acum:"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1254
+msgid "Get pre-releases when checking for updates"
+msgstr "Obține versiuni preliminare la verificarea actualizărilor"
+
+#: packages/app-cli/app/command-config.ts:14
+msgid ""
+"Gets or sets a config value. If [value] is not provided, it will show the "
+"value of [name]. If neither [name] nor [value] is provided, it will list the "
+"current configuration."
+msgstr ""
+"Obține sau setează o valoare de configurare. Dacă [valoare] nu este "
+"furnizată, va afișa valoarea [nume]. Dacă nu este furnizat nici [nume], nici "
+"[valoare], va afișa configurația curentă."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:13
+msgid "go"
+msgstr "mergi"
+
+#: packages/app-mobile/components/CameraView/CameraView.tsx:165
+msgid "Go back"
+msgstr "Mergi înapoi"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:44
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:59
+msgid "Go to Joplin Cloud profile"
+msgstr "Mergi la profilul Joplin Cloud"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:12
+msgid "Go to line"
+msgstr "Mergi la linia"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1096
+msgid "Go to source URL"
+msgstr "Accesați sursa URL"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.ts:18
+#: packages/app-desktop/plugins/GotoAnything.tsx:783
+msgid "Goto Anything..."
+msgstr "Mergi la..."
+
+#: packages/app-desktop/gui/Root.tsx:152
+msgid "Grant authorisation"
+msgstr "Acordarea autorizării"
+
+#: packages/app-cli/app/command-sync.ts:116
+msgid "Have you authorised the application login in the above URL?"
+msgstr "Ai autorizat autentificarea aplicației în URL-ul de mai sus?"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:19
+msgid "Header %d"
+msgstr "Antet %d"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:95
+msgid "Heading"
+msgstr "Titlu"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:228
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:265
+#: packages/app-desktop/gui/HelpButton.tsx:49
+#: packages/server/src/services/MustacheService.ts:284
+msgid "Help"
+msgstr "Ajutor"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:113
+msgid "Here's what we do to make plugins safer:"
+msgstr "Uite ceea ce facem pentru a face plugin-urile mai sigure:"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:49
+msgid "Hermes enabled: %d"
+msgstr "Hermes activat: %d"
+
+#: packages/app-desktop/gui/MenuBar.tsx:679
+msgid "Hide %s"
+msgstr "Ascundeți %s"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:221
+msgid "Hide advanced"
+msgstr "Ascundeți avansat"
+
+#: packages/server/src/routes/admin/users.ts:206
+msgid "Hide disabled"
+msgstr "Ascundeți dezactivat"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:160
+msgid "Hide disabled keys"
+msgstr "Ascundeți cheile dezactivate"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:22
+msgid "Hide Joplin"
+msgstr "Ascundeți Joplin"
+
+#: packages/app-mobile/components/screens/Note/commands/hideKeyboard.ts:7
+msgid "Hide keyboard"
+msgstr "Ascundeți tastatura"
+
+#: packages/app-desktop/gui/PasswordInput/PasswordInput.tsx:21
+msgid "Hide password"
+msgstr "Ascunde parola"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:14
+msgid "Highlight"
+msgstr "Evidențiază"
+
+#: packages/server/src/services/MustacheService.ts:150
+#: packages/server/src/services/MustacheService.ts:279
+msgid "Home"
+msgstr "Acasă"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:100
+msgid "Horizontal Rule"
+msgstr "Linie orizontală"
+
+#: packages/lib/services/interop/InteropService.ts:186
+msgid "HTML Directory"
+msgstr "Dosar HTML"
+
+#: packages/lib/services/interop/InteropService.ts:112
+msgid "HTML document"
+msgstr "Document HTML"
+
+#: packages/lib/services/interop/InteropService.ts:179
+msgid "HTML File"
+msgstr "Fișier HTML"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:65
+msgid "Hyperlink"
+msgstr "Hyperlink"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:141
+msgid "Icon"
+msgstr "Pictogramă"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:168
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:325
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:79
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:80
+#: packages/app-desktop/gui/ResourceScreen.tsx:112
+msgid "ID"
+msgstr "ID"
+
+#: packages/lib/models/Resource.ts:31 packages/lib/Synchronizer.ts:324
+msgid "Idle"
+msgstr "Inactiv"
+
+#: packages/lib/services/joplinCloudUtils.ts:37
+msgid ""
+"If you have already authorised, please wait for the application to sync to "
+"Joplin Cloud."
+msgstr ""
+"Dacă ai autorizat deja, te rog așteaptă ca aplicația să se sincronizeze cu "
+"Joplin Cloud."
+
+#: packages/app-desktop/ElectronAppWrapper.ts:155
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:360
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:121
+#: packages/app-mobile/components/screens/status.tsx:203
+msgid "Ignore"
+msgstr "Ignoră"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1458
+msgid "Ignore TLS certificate errors"
+msgstr "Ignoră erorile de certificat TLS"
+
+#: packages/lib/services/ReportService.ts:236
+msgid "Ignored items that cannot be synchronised"
+msgstr "Elemente ignorate care nu pot fi sincronizate"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:106
+msgid "Images"
+msgstr "Imagini"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:181
+#: packages/app-desktop/gui/MenuBar.tsx:658
+#: packages/app-desktop/gui/MenuBar.tsx:715
+#: packages/app-desktop/gui/Root.tsx:192
+msgid "Import"
+msgstr "Importă"
+
+#: packages/lib/models/Setting.ts:1189
+msgid "Import and Export"
+msgstr "Import și export"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:66
+msgid ""
+"Import failed. Make sure a JEX file was selected.\n"
+"Details: %s"
+msgstr ""
+"Importul a eșuat. Asigură-te că ai selectat un fișier JEX.\n"
+"Detalii: %s"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:21
+msgid "Import from JEX"
+msgstr "Importă din JEX"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:22
+msgid "Import notes from a JEX (Joplin Export) file."
+msgstr "Importă notițe dintr-un fișier JEX (Joplin Export)."
+
+#: packages/lib/models/Setting.ts:1221
+msgid "Import or export your data"
+msgstr "Importă sau exportă datele tale"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:76
+msgid "Imported successfully!"
+msgstr "Importat cu succes!"
+
+#: packages/app-desktop/gui/MenuBar.tsx:324
+msgid "Importing from \"%s\" as \"%s\" format. Please wait..."
+msgstr "Se exportă către „%s” în format „%s”. Te rog să aștepți..."
+
+#: packages/app-cli/app/command-import.ts:68
+msgid "Importing notes..."
+msgstr "Se importă notițe..."
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteImportButton.tsx:26
+msgid "Importing..."
+msgstr "Se importă..."
+
+#: packages/app-cli/app/command-import.ts:16
+msgid "Imports data into Joplin."
+msgstr "Importați date în Joplin."
+
+#: packages/lib/models/settings/builtInMetadata.ts:409
+msgid ""
+"In \"Manual\" mode, attachments are downloaded only when you click on them. "
+"In \"Auto\", they are downloaded when you open the note. In \"Always\", all "
+"the attachments are downloaded whether you open the note or not."
+msgstr ""
+"În modul „Manual”, atașamentele sînt descărcate numai atunci cînd faci clic "
+"pe ele. În modul „Auto”, acestea sînt descărcate cînd deschizi notița. În "
+"modul „Mereu”, toate atașamentele sînt descărcate indiferent dacă deschizi "
+"notița sau nu."
+
+#: packages/app-cli/app/command-help.ts:78
+msgid ""
+"In any command, a note or notebook can be referred to by title or ID, or "
+"using the shortcuts `$n` or `$b` for, respectively, the currently selected "
+"note or notebook. `$c` can be used to refer to the currently selected item."
+msgstr ""
+"În orice comandă, se poate face referire la o notă sau la un caiet de notițe "
+"prin titlu sau ID, sau folosind comenzile rapide `$n` sau `$b` pentru nota "
+"sau caietul selectat în acel moment. Se poate utiliza `$c` pentru a se "
+"referi la elementul selectat în mod curent."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:530
+msgid ""
+"In order to associate a geo-location with the note, the app needs your "
+"permission to access your location.\n"
+"\n"
+"You may turn off this option at any time in the Configuration screen."
+msgstr ""
+"Pentru a asocia o geolocație cu nota, aplicația are nevoie de permisiunea "
+"dvs. de a vă accesa locația.\n"
+"\n"
+"Puteți dezactiva această opțiune în orice moment în ecranul de configurare."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:346
+msgid ""
+"In order to do so, your entire data set will have to be encrypted and "
+"synchronised, so it is best to run it overnight.\n"
+"\n"
+"To start, please follow these instructions:\n"
+"\n"
+"1. Synchronise all your devices.\n"
+"2. Click \"%s\".\n"
+"3. Let it run to completion. While it runs, avoid changing any note on your "
+"other devices, to avoid conflicts.\n"
+"4. Once sync is done on this device, sync all your other devices and let it "
+"run to completion.\n"
+"\n"
+"Important: you only need to run this ONCE on one device."
+msgstr ""
+"Pentru a face acest lucru, întregul set de date va trebui să fie criptat și "
+"sincronizat, așa că cel mai bine este să îl execuți peste noapte.\n"
+"\n"
+"Pentru a începe, te rog să urmezi aceste instrucțiuni:\n"
+"\n"
+"1. Sincronizează-ți toate dispozitivele.\n"
+"2. Fă clic pe „%s”.\n"
+"3. Lasă-l să se execute pînă la finalizare. În timp ce se execută, evită să "
+"modifici orice notiță pe celelalte dispozitive, pentru a evita conflictele.\n"
+"4. Odată ce sincronizarea este finalizată pe acest dispozitiv, sincronizează "
+"toate celelalte dispozitive și las-o să se execute pînă la finalizare.\n"
+"\n"
+"Important: nu trebuie să execuți acest lucru decît O SINGURĂ dată pe un "
+"singur dispozitiv."
+
+#: packages/lib/services/synchronizer/syncInfoUtils.ts:499
+msgid "In order to synchronise, please upgrade your application to version %s+"
+msgstr ""
+"Pentru a utiliza sincronizarea, te rog actualizează aplicația la versiunea "
+"%s sau mai nouă"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:122
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:224
+msgid ""
+"In order to use file system synchronisation your permission to write to "
+"external storage is required."
+msgstr ""
+"Pentru a utiliza sincronizarea sistemului de fișiere este necesară "
+"permisiunea dumneavoastră de a scrie pe un spațiu de stocare extern."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:133
+msgid "In order to use the web clipper, you need to do the following:"
+msgstr "Pentru a utiliza web clipper, trebuie să faci următoarele:"
+
+#: packages/lib/Synchronizer.ts:325
+msgid "In progress"
+msgstr "În progres"
+
+#: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:597
+msgid "In: %s"
+msgstr "În: %s"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:69
+msgid "Incompatible"
+msgstr "Incompatibil"
+
+#: packages/app-desktop/gui/NoteList/utils/useOnKeyDown.ts:174
+msgid "Incomplete"
+msgstr "Incomplet"
+
+#: packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts:40
+msgid "Incomplete to-do"
+msgstr "Sarcini de făcut incomplete"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:97
+msgid "Increase indent level"
+msgstr "Creșteți nivelul de indentare"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:126
+msgid "Indent less"
+msgstr "Indentează la stînga"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:130
+msgid "Indent more"
+msgstr "Indentează la dreapta"
+
+#: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:22
+#: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:21
+msgid "Info"
+msgstr "Info"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:223
+msgid "Information"
+msgstr "Informație"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:822
+msgid "Inline Code"
+msgstr "Inline Cod"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:24
+msgid "Insert"
+msgstr "Inserați"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:198
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.ts:84
+msgid "Insert Hyperlink"
+msgstr "Inserează hyperlink"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:105
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:855
+#: packages/app-mobile/components/screens/Note/commands/insertDateTime.ts:8
+msgid "Insert time"
+msgstr "Inserează data și ora"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:191
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/buttons/InstallButton.tsx:18
+msgid "Install"
+msgstr "Instalează"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:226
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginUploadButton.tsx:25
+msgid "Install from file"
+msgstr "Instalează din fișier"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:193
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/buttons/InstallButton.tsx:19
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:92
+msgid "Installed"
+msgstr "Instalat"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:202
+msgid "Installed (%d):"
+msgstr "Instalat (%d):"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:192
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/buttons/InstallButton.tsx:17
+msgid "Installing..."
+msgstr "Se instalează…"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:36
+#: packages/app-desktop/gui/PasswordInput/LabelledPasswordInput.tsx:26
+msgid "Invalid"
+msgstr "Invalid"
+
+#: packages/lib/services/KeymapService.ts:342
+msgid "Invalid %s: %s."
+msgstr "Invalid %s: %s."
+
+#: packages/app-cli/app/cli-utils.js:167
+msgid "Invalid answer: %s"
+msgstr "Răspuns invalid: %s"
+
+#: packages/app-cli/app/command-tag.js:90
+msgid "Invalid command: \"%s\""
+msgstr "Comandă invalidă: „%s”"
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:371
+msgid "Invalid format. E.g.: 48.8581372, 2.2926735"
+msgstr "Format invalid. ex.: 48.8581372, 2.2926735"
+
+#: packages/lib/models/Setting.ts:665
+msgid "Invalid option value: \"%s\". Possible values are: %s."
+msgstr "Valoare nevalabilă a opțiunii: „%s”. Valorile posibile sînt: %s."
+
+#: packages/app-cli/app/command-e2ee.ts:47
+#: packages/app-mobile/components/screens/encryption-config.tsx:122
+msgid "Invalid password"
+msgstr "Parolă invalidă"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:24
+msgid "iOS version: %s"
+msgstr "Versiune iOS: %s"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:60
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:59
+msgid "Italic"
+msgstr "Cursiv"
+
+#: packages/lib/services/ReportService.ts:194
+msgid "Item \"%s\" could not be downloaded: %s"
+msgstr "Elementul „%s” nu a putut fi descărcat: %s"
+
+#: packages/server/src/services/MustacheService.ts:158
+#: packages/server/src/services/MustacheService.ts:281
+msgid "Items"
+msgstr "Elemente"
+
+#: packages/lib/services/ReportService.ts:252
+msgid "Items that cannot be decrypted"
+msgstr "Elemente care nu pot fi decriptate"
+
+#: packages/lib/services/ReportService.ts:185
+msgid "Items that cannot be synchronised"
+msgstr "Elementele nu pot fi sincronizați"
+
+#: packages/lib/services/ReportService.ts:294
+msgid "Items with error: %s"
+msgstr "Elemente cu eroarea: %s"
+
+#: packages/app-desktop/gui/MenuBar.tsx:945
+msgid "Join us on %s"
+msgstr "Alătură-te nouă pe %s"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:302
+msgid ""
+"Joplin can synchronise your notes using various providers. Select one from "
+"the list below."
+msgstr ""
+"Joplin îți poate sincroniza notițele folosind diverși furnizori. Selectează "
+"unul din lista de mai jos."
+
+#: packages/lib/models/Setting.ts:1187 packages/lib/SyncTargetJoplinCloud.ts:30
+msgid "Joplin Cloud"
+msgstr "Joplin Cloud"
+
+#: packages/app-desktop/gui/Root.tsx:191
+#: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:148
+msgid "Joplin Cloud Login"
+msgstr "Autentificare Joplin Cloud"
+
+#: packages/lib/services/plugins/PluginService.ts:533
+msgid "Joplin Desktop"
+msgstr "Joplin Desktop"
+
+#: packages/app-desktop/bridge.ts:460
+msgid ""
+"Joplin doesn't recognise the %s extension. Opening this file could be "
+"dangerous. What would you like to do?"
+msgstr ""
+"Joplin nu recunoaște extensia %s. Deschiderea acestui fișier poate fi "
+"periculoasă. Ce dorești să faci?"
+
+#: packages/lib/services/interop/InteropService.ts:159
+#: packages/lib/services/interop/InteropService.ts:68
+msgid "Joplin Export Directory"
+msgstr "Dosar export Joplin"
+
+#: packages/lib/services/interop/InteropService.ts:153
+#: packages/lib/services/interop/InteropService.ts:62
+msgid "Joplin Export File"
+msgstr "Fișier export Joplin"
+
+#: packages/lib/services/ReportService.ts:254
+msgid ""
+"Joplin failed to decrypt these items multiple times, possibly because they "
+"are corrupted or too large. These items will remain on the device but Joplin "
+"will no longer attempt to decrypt them."
+msgstr ""
+"Joplin nu a reușit să decripteze aceste elemente de mai multe ori, probabil "
+"din cauză că sînt corupte sau prea mari. Aceste elemente vor rămîne pe "
+"dispozitiv, dar Joplin nu va mai încerca să le decripteze."
+
+#: packages/app-desktop/gui/MenuBar.tsx:942
+msgid "Joplin Forum"
+msgstr "Forum Joplin"
+
+#: packages/app-mobile/utils/lockToSingleInstance.ts:16
+msgid "Joplin is already running."
+msgstr "Joplin deja rulează."
+
+#: packages/lib/services/plugins/PluginService.ts:531
+msgid "Joplin Mobile"
+msgstr "Joplin mobil"
+
+#: packages/lib/SyncTargetJoplinServer.ts:61
+msgid "Joplin Server"
+msgstr "Server Joplin"
+
+#: packages/lib/models/settings/builtInMetadata.ts:337
+msgid "Joplin Server email"
+msgstr "Email Joplin Server"
+
+#: packages/lib/models/settings/builtInMetadata.ts:349
+msgid "Joplin Server password"
+msgstr "Parolă Joplin Server"
+
+#: packages/lib/models/settings/builtInMetadata.ts:318
+msgid "Joplin Server URL"
+msgstr "URL server Joplin"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:132
+msgid ""
+"Joplin Web Clipper allows saving web pages and screenshots from your browser "
+"to Joplin."
+msgstr ""
+"Joplin Web Clipper permite salvarea paginilor web și a capturilor de ecran "
+"din browser-ul dumnevoastră în Joplin."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:605
+msgid "Joplin website"
+msgstr "Website Joplin"
+
+#: packages/lib/SyncTargetJoplinCloud.ts:34
+msgid ""
+"Joplin's own sync service. Also gives access to Joplin-specific features "
+"such as publishing notes or collaborating on notebooks with others."
+msgstr ""
+"Serviciul propriu de sincronizare al Joplin. Oferă de asemenea acces la "
+"caracteristici specifice Joplin, cum ar fi publicarea de notițe sau "
+"colaborarea la caiete cu alte persoane."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1540
+msgid "Keep note history for"
+msgstr "Păstrează istoricul notițelor pentru"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1818
+msgid "Keep notes in the trash for"
+msgstr "Păstrează notițele în coș pentru"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1340
+msgid "Keyboard Mode"
+msgstr "Mod tastatură"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:189
+msgid "Keyboard Shortcut"
+msgstr "Scurtătură de la tastatură"
+
+#: packages/lib/models/Setting.ts:1186
+msgid "Keyboard Shortcuts"
+msgstr "Scurtături tastatură"
+
+#: packages/lib/versionInfo.ts:92
+msgid "Keychain Supported: %s"
+msgstr "Lanț de chei suportat: %s"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:74
+msgid "Keys that need upgrading"
+msgstr "Chei care trebuie actualizate"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1317
+msgid "Landscape"
+msgstr "Peisaj"
+
+#: packages/lib/models/settings/builtInMetadata.ts:461
+msgid "Language"
+msgstr "Limbă"
+
+#: packages/lib/models/Setting.ts:1213
+msgid "Language, date format"
+msgstr "Limbă, format dată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1169
+msgid "Large"
+msgstr "Mare"
+
+#: packages/lib/Synchronizer.ts:208
+msgid "Last error: %s"
+msgstr "Ultima eroare: %s"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:338
+msgid "Later"
+msgstr "Mai tîrziu"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:7
+msgid "Latitude"
+msgstr "Latitudine"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:639
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:239
+msgid "Layout"
+msgstr "Aspect"
+
+#: packages/app-desktop/gui/MenuBar.tsx:803
+msgid "Layout button sequence"
+msgstr "Secvența butoanelor de aspect"
+
+#: packages/app-desktop/bridge.ts:465
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:118
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:52
+msgid "Learn more"
+msgstr "Află mai multe"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1771
+msgid "Leave it blank to download the language files from the default website"
+msgstr ""
+"Lăsați-l gol pentru a descărca fișierele de limbă de pe site-ul web implicit"
+
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:90
+msgid "Leave notebook"
+msgstr "Părăsește caietul"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts:11
+msgid "Leave notebook..."
+msgstr "Părăsește caietul…"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1311
+msgid "Legal"
+msgstr "Legal"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1307
+msgid "Letter"
+msgstr "Letter"
+
+#: packages/lib/models/settings/builtInMetadata.ts:48
+msgid "Light"
+msgstr "Luminos"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:110
+msgid ""
+"Like any software you install, plugins can potentially cause security issues "
+"or data loss."
+msgstr ""
+"Ca orice software instalezi, plugin-urile pot cauza probleme de securitate "
+"sau pierderi de date."
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:108
+msgid "Lines"
+msgstr "Linii"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:117
+msgid "Link"
+msgstr "Legătură"
+
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:92
+msgid "Link description"
+msgstr "Descriere legătură"
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:187
+msgid "Link has been copied to clipboard!"
+msgid_plural "Links have been copied to clipboard!"
+msgstr[0] "Legătura a fost copiată în clipboard!"
+msgstr[1] "Legăturile au fost copiate în clipboard!"
+msgstr[2] "Legăturile au fost copiate în clipboard!"
+
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:89
+msgid "Link text"
+msgstr "Text legătură"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts:13
+msgid "Link to note..."
+msgstr "Leagă la notița..."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:232
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:234
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:235
+msgid "List item"
+msgstr "Element listă"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:235
+msgid "Loaded"
+msgstr "Încărcat"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/FontSearch.tsx:43
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:117
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:164
+#: packages/app-mobile/root.tsx:1275
+msgid "Loading..."
+msgstr "Se încarcă…"
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:85
+msgid "Location"
+msgstr "Locație"
+
+#: packages/app-cli/app/command-sync.ts:155
+msgid ""
+"Lock file is already being hold. If you know that no synchronisation is "
+"taking place, you may delete the lock file at \"%s\" and resume the "
+"operation."
+msgstr ""
+"Fișierul de blocare este deja luat. Dacă știi că nu are loc nicio "
+"sincronizare, poți șterge fișierul de blocare de la „%s” și relua operația."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:550
+#: packages/app-mobile/components/screens/LogScreen.tsx:215
+#: packages/server/src/services/MustacheService.ts:282
+msgid "Log"
+msgstr "Jurnal"
+
+#: packages/app-desktop/gui/MainScreen.tsx:592
+msgid "Login to Joplin Cloud."
+msgstr "Autentificare în Joplin Cloud."
+
+#: packages/app-mobile/components/screens/dropbox-login.tsx:59
+msgid "Login with Dropbox"
+msgstr "Autentifică-te cu Dropbox"
+
+# vezi context
+#: packages/app-mobile/components/screens/onedrive-login.js:110
+msgid "Login with OneDrive"
+msgstr "Autentifică-te cu OneDrive"
+
+#: packages/server/src/services/MustacheService.ts:285
+msgid "Logout"
+msgstr "Logout"
+
+#: packages/lib/models/Setting.ts:1220
+msgid "Logs, profiles, sync status"
+msgstr "Locuri, profiluri, stare de sincronizare"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:8
+msgid "Longitude"
+msgstr "Longitudine"
+
+#: packages/app-desktop/gui/MenuBar.tsx:948
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:604
+msgid "Make a donation"
+msgstr "Donează"
+
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:221
+msgid "Manage master password"
+msgstr "Gestionează parola master"
+
+#: packages/lib/commands/openMasterPasswordDialog.ts:6
+msgid "Manage master password..."
+msgstr "Gestionează parola master…"
+
+#: packages/lib/utils/joplinCloud/index.ts:201
+msgid "Manage multiple users"
+msgstr "Gestionează mai mulți utilizatori"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:548
+msgid "Manage profiles"
+msgstr "Gestionează profilul"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:555
+msgid "Manage shared notebooks"
+msgstr "Gestionează caiete partajate"
+
+#: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:165
+msgid "Manage toolbar options"
+msgstr "Gestionează opțiunile barei de unelte"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:331
+msgid "Manage your plugins"
+msgstr "Gestionează-ți plugin-urile"
+
+#. `generate-ppk`
+#: packages/app-cli/app/command-e2ee.ts:19
+msgid ""
+"Manages E2EE configuration. Commands are `enable`, `disable`, `decrypt`, "
+"`status`, `decrypt-file`, and `target-status`."
+msgstr ""
+"Gestionează configurația E2EE. Comenzile sînt `enable`, `disable`, "
+"`decrypt`, `status`, `decrypt-file`, and `target-status`."
+
+#: packages/lib/models/settings/builtInMetadata.ts:413
+msgid "Manual"
+msgstr "Manual"
+
+#: packages/app-desktop/gui/ToggleEditorsButton/ToggleEditorsButton.tsx:28
+#: packages/lib/models/Setting.ts:1180
+#: packages/lib/services/interop/InteropService.ts:120
+#: packages/lib/services/interop/InteropService.ts:165
+msgid "Markdown"
+msgstr "Markdown"
+
+#: packages/lib/services/interop/InteropService.ts:128
+#: packages/lib/services/interop/InteropService.ts:171
+msgid "Markdown + Front Matter"
+msgstr "Markdown + Front Matter"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:379
+#: packages/app-mobile/components/NoteEditor/NoteEditor.tsx:360
+msgid "Markdown editor"
+msgstr "Editor Markdown"
+
+#: packages/app-cli/app/command-done.ts:15
+msgid "Marks a to-do as done."
+msgstr "Marcați o sarcină ca fiind terminată."
+
+#: packages/app-cli/app/command-undone.js:12
+msgid "Marks a to-do as non-completed."
+msgstr "Marcați o sarcină ca fiind necompletă."
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:88
+msgid "Markup"
+msgstr "Markup"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:135
+msgid "Master Key %s"
+msgstr "Cheia principală %s"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:114
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:273
+#: packages/app-mobile/components/screens/encryption-config.tsx:106
+msgid "Master password"
+msgstr "Parola principală"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:274
+#: packages/app-mobile/components/screens/encryption-config.tsx:234
+msgid "Master password:"
+msgstr "Parola principală:"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:19
+msgid "match case"
+msgstr "potrivește mărimea"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:72
+msgid "Math"
+msgstr "Matematică"
+
+#: packages/lib/models/settings/builtInMetadata.ts:437
+msgid "Max concurrent connections"
+msgstr "Conexiuni maxime simultane"
+
+#: packages/server/src/routes/admin/users.ts:148
+msgid "Max Item Size"
+msgstr "Dimensiunea maximă a itemului"
+
+#: packages/lib/utils/joplinCloud/index.ts:129
+msgid "Max note or attachment size"
+msgstr "Dimensiunea maximă a notiței sau a atașamentului"
+
+#: packages/server/src/routes/admin/users.ts:156
+msgid "Max Total Size"
+msgstr "Dimensiunea totală maximă"
+
+#: packages/lib/models/Setting.ts:1217
+msgid "Media player, math, diagrams, table of contents"
+msgstr "Media player, matematică, diagrame, cuprins"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1168
+msgid "Medium"
+msgstr "Medie"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:24
+msgid "Minimise"
+msgstr "Minimizează"
+
+#: packages/app-mobile/components/CameraView/CameraView.tsx:163
+msgid "Missing camera permission"
+msgstr "Permisiune cameră lipsă"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:320
+msgid "Missing keys"
+msgstr "Lipsesc cheile"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:307
+msgid "Missing Master Keys"
+msgstr "Cheile master lipsă"
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:120
+msgid "Missing permission to record audio."
+msgstr "Permisiune lipsă pentru a înregistra audio."
+
+#: packages/app-cli/app/cli-utils.js:112
+msgid "Missing required argument: %s"
+msgstr "Lipsește argumentul necesar: %s"
+
+#: packages/app-cli/app/cli-utils.js:135
+msgid "Missing required flag value: %s"
+msgstr "Lipsește valoarea indicatorului necesar: %s"
+
+#: packages/app-mobile/components/side-menu-content.tsx:663
+msgid "Mobile data - auto-sync disabled"
+msgstr "Mobile data - auto-sync disabled"
+
+#: packages/app-desktop/gui/MainScreen.tsx:555
+msgid "More info"
+msgstr "Informații suplimentare"
+
+#: packages/lib/models/Setting.ts:1190
+msgid "More information"
+msgstr "Informații suplimentare"
+
+#: packages/app-cli/app/app.ts:67
+msgid "More than one item match \"%s\". Please narrow down your query."
+msgstr ""
+"Mai multe elemente se potrivesc cu „%s\". Te rog să restrîngeți interogarea."
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:115
+msgid ""
+"Most plugins have source code available for review on the plugin website."
+msgstr ""
+"Majoritatea plugin-urilor au codul sursă disponibil pentru revizuire pe "
+"website-ul plugin-ului."
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:567
+msgid "Move %d notes to notebook \"%s\"?"
+msgstr "Muți %d notițe în caietul „%s”?"
+
+#: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:73
+msgid "Move down"
+msgstr "Mută în jos"
+
+#: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:74
+msgid "Move left"
+msgstr "Mută la stînga"
+
+#: packages/app-cli/app/command-rmbook.ts:38
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:20
+#: packages/app-mobile/components/side-menu-content.tsx:410
+msgid ""
+"Move notebook \"%s\" to the trash?\n"
+"\n"
+"All notes and sub-notebooks within this notebook will also be moved to the "
+"trash."
+msgstr ""
+"Muți caietul „%s” în coșul de gunoi?\n"
+"\n"
+"Toate notițele și secțiunile din acest caiet vor fi de asemenea mutate în "
+"coș."
+
+#: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:75
+msgid "Move right"
+msgstr "Mută la dreapta"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.ts:14
+msgid "Move to notebook"
+msgstr "Mută în alt caiet..."
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.ts:67
+msgid "Move to notebook:"
+msgstr "Mută în caietul:"
+
+#: packages/app-mobile/components/FolderPicker.tsx:58
+msgid "Move to notebook..."
+msgstr "Mută în alt caiet…"
+
+#: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:72
+msgid "Move up"
+msgstr "Mută în sus"
+
+#: packages/app-cli/app/command-mv.ts:14
+msgid "Moves the given <item> to [notebook]"
+msgstr "Mută <item> dat în [notebook]"
+
+#: packages/app-cli/app/cli-utils.js:177
+#: packages/app-cli/app/setupCommand.ts:23
+msgid "n"
+msgstr "n"
+
+#: packages/app-cli/app/setupCommand.ts:23
+msgid "N"
+msgstr "N"
+
+#: packages/lib/models/settings/builtInMetadata.ts:889
+msgid "Never resize"
+msgstr "Nu redimensiona niciodată"
+
+#: packages/app-mobile/setupQuickActions.ts:33
+msgid "New attachment"
+msgstr "Atașament nou"
+
+#: packages/app-mobile/setupQuickActions.ts:34
+msgid "New drawing"
+msgstr "Desen nou"
+
+#: packages/app-mobile/components/screens/ShareManager/index.tsx:120
+msgid "New invitations"
+msgstr "Invitații noi"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:62
+msgid ""
+"New model available\n"
+"A new voice typing model is available. Do you want to download it?"
+msgstr ""
+"Este disponibil un nou model\n"
+"Un nou model de transcriere vocală este disponibil. Dorești să îl descarci?"
+
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:111
+#: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:72
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts:10
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:109
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:98
+#: packages/app-mobile/setupQuickActions.ts:30
+msgid "New note"
+msgstr "Notiță nouă"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:44
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newFolder.ts:7
+msgid "New notebook"
+msgstr "Caiet nou"
+
+#: packages/app-mobile/components/side-menu-content.tsx:620
+msgid "New Notebook"
+msgstr "Caiet nou"
+
+#: packages/app-desktop/gui/ImportScreen.tsx:81
+msgid ""
+"New notebook \"%s\" will be created and file \"%s\" will be imported into it"
+msgstr "Un nou caiet „%s” va fi creat și fișierul „%s” va fi importat în el"
+
+#: packages/app-mobile/setupQuickActions.ts:32
+msgid "New photo"
+msgstr "Fotografie nouă"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:212
+msgid "New profile"
+msgstr "Profil nou"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newSubFolder.ts:6
+msgid "New sub-notebook"
+msgstr "Secțiune nouă"
+
+#: packages/app-mobile/components/screens/NoteTagsDialog.tsx:206
+msgid "New tags:"
+msgstr "Etichete noi:"
+
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:121
+#: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:72
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newTodo.ts:7
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:112
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:87
+#: packages/app-mobile/setupQuickActions.ts:31
+msgid "New to-do"
+msgstr "Listă de făcut nouă"
+
+#: packages/app-desktop/checkForUpdates.ts:108
+msgid "New version: %s"
+msgstr "Versiune nouă: %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:16
+msgid "next"
+msgstr "următoarea"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:271
+msgid "Next match"
+msgstr "Next match"
+
+#: packages/lib/SyncTargetNextcloud.js:25
+msgid "Nextcloud"
+msgstr "Nextcloud"
+
+#: packages/lib/models/settings/builtInMetadata.ts:181
+msgid "Nextcloud password"
+msgstr "Parolă Nextcloud"
+
+#: packages/lib/models/settings/builtInMetadata.ts:169
+msgid "Nextcloud username"
+msgstr "Nume utilizator Nextcloud"
+
+#: packages/lib/models/settings/builtInMetadata.ts:156
+msgid "Nextcloud WebDAV URL"
+msgstr "URL NextCloud WebDAV"
+
+#: packages/lib/models/settings/builtInMetadata.ts:36
+msgid "no"
+msgstr "nu"
+
+#: packages/app-desktop/services/plugins/UserWebviewDialogButtonBar.tsx:22
+#: packages/app-mobile/components/screens/Note/Note.tsx:759
+#: packages/lib/shim-init-node.ts:274 packages/lib/versionInfo.ts:92
+msgid "No"
+msgstr "Nu"
+
+#: packages/app-cli/app/command-edit.ts:41
+msgid "No active notebook."
+msgstr "Niciun caiet de notițe activ."
+
+#: packages/app-mobile/components/screens/ShareManager/index.tsx:92
+msgid "No new invitations"
+msgstr "Nicio nouă invitație"
+
+#: packages/app-cli/app/app.ts:104
+msgid "No notebook has been specified."
+msgstr "Niciun caiet de notițe nu a fost specificat."
+
+#: packages/app-cli/app/app.ts:98
+msgid "No notebook selected."
+msgstr "Niciun caiet de notițe nu a fost selectat."
+
+#: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:15
+msgid "No notes in here. Create one by clicking on \"New note\"."
+msgstr ""
+"Nu ai niciun caiet de notițe creat. Creează unul făcînd click pe „Notiță "
+"nouă”."
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:202
+msgid "No plugins are installed."
+msgstr "Niciun plugin instalat."
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:312
+msgid "No resources!"
+msgstr "Fără resurse!"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:83
+msgid "No results"
+msgstr "Fără rezultate"
+
+#: packages/app-cli/app/app.ts:231
+msgid "No such command: %s"
+msgstr "Nu există o asemenea comandă: %s"
+
+#: packages/lib/services/spellChecker/SpellCheckerService.ts:125
+msgid "No suggestions"
+msgstr "Fără sugestii"
+
+#: packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx:119
+msgid "No tab selected"
+msgstr "Nicio filă selectată"
+
+#: packages/app-cli/app/command-edit.ts:31
+msgid ""
+"No text editor is defined. Please set it using `config editor <editor-path>`"
+msgstr ""
+"Nu este definit niciun editor de text. Te rog să definești unul folosind "
+"comanda `config editor <editor-path>`"
+
+#: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:63
+msgid "No updates available"
+msgstr "Nu există actualizări"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.ts:44
+msgid "None"
+msgstr "Niciuna"
+
+#: packages/lib/models/settings/builtInMetadata.ts:53
+msgid "Nord"
+msgstr "Nord"
+
+#: packages/app-cli/app/command-sync.ts:123
+msgid "Not authenticated with %s. Please provide any missing credentials."
+msgstr "Neautentificat cu %s. Te rog să furnizezi orice acreditări lipsă."
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:163
+msgid "Not checked"
+msgstr "Nebifat"
+
+#: packages/lib/models/Resource.ts:407
+msgid "Not downloaded"
+msgstr "Nu este descărcat"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:240
+msgid "Not generated"
+msgstr "Nu sînt generate"
+
+#: packages/app-mobile/components/biometrics/BiometricPopup.tsx:91
+msgid "Not now"
+msgstr "Nu acum"
+
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:109
+#: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:71
+#: packages/server/src/models/UserModel.ts:247
+#: packages/server/src/models/UserModel.ts:264
+msgid "note"
+msgstr "notiță"
+
+#: packages/app-desktop/gui/MainScreen.tsx:678
+#: packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx:41
+#: packages/lib/models/Setting.ts:1178
+msgid "Note"
+msgstr "Notițe"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1604
+msgid "Note area growth factor"
+msgstr "Factor de creștere zonă notiță"
+
+#: packages/app-desktop/gui/Root.tsx:194
+msgid "Note attachments"
+msgstr "Atașamente notiță"
+
+#: packages/app-desktop/gui/MenuBar.tsx:583
+msgid "Note attachments..."
+msgstr "Atașamente notițe..."
+
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteBody.ts:7
+msgid "Note body"
+msgstr "Corp notiță"
+
+#: packages/app-cli/app/command-edit.ts:47
+msgid "Note does not exist: \"%s\". Create it?"
+msgstr "Notița nu există: „%s”. Dorești să o creezi?"
+
+#: packages/app-mobile/components/NoteEditor/NoteEditor.tsx:141
+msgid "Note editor"
+msgstr "Editor notiță"
+
+#: packages/app-cli/app/command-edit.ts:98
+msgid "Note has been saved."
+msgstr "Notița a fost salvată."
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:87
+#: packages/lib/models/Setting.ts:1183
+msgid "Note History"
+msgstr "Istoric notițe"
+
+#: packages/app-cli/app/command-done.ts:23
+msgid "Note is not a to-do: \"%s\""
+msgstr "Notița nu este o sarcină: „%s”"
+
+#: packages/app-desktop/gui/MainScreen.tsx:128
+#: packages/app-desktop/gui/NoteList/commands/focusElementNoteList.ts:9
+#: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:181
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNoteList.ts:23
+msgid "Note list"
+msgstr "Listă de notițe"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1589
+msgid "Note list growth factor"
+msgstr "Factor de creștere listă notițe"
+
+#: packages/app-desktop/gui/MenuBar.tsx:807
+msgid "Note list style"
+msgstr "Stilul listei de notițe"
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:490
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showNoteProperties.ts:7
+msgid "Note properties"
+msgstr "Proprietăți notiță"
+
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteTitle.ts:7
+#: packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx:124
+msgid "Note title"
+msgstr "Titlul notiței"
+
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts:8
+#: packages/app-desktop/gui/NoteTextViewer.tsx:242
+msgid "Note viewer"
+msgstr "Vizualizator notiță"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1030
+msgid "Note: Does not work in all desktop environments."
+msgstr "Notă: Nu funcționează în toate mediile desktop."
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:193
+msgid ""
+"Note: When a note is shared, it will no longer be encrypted on the server."
+msgstr ""
+"Notă: Cînd o notă este partajată, aceasta nu va mai fi criptată pe server."
+
+#: packages/app-desktop/gui/MenuBar.tsx:892
+msgid "Note&book"
+msgstr "&Caiet"
+
+#: packages/app-desktop/plugins/GotoAnything.tsx:608
+#: packages/lib/models/Setting.ts:1179
+msgid "Notebook"
+msgstr "Caiet"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1574
+msgid "Notebook list growth factor"
+msgstr "Factor de mărire listă caiete de notițe"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:5
+#: packages/app-mobile/components/side-menu-content.tsx:441
+msgid "Notebook: %s"
+msgstr "Caiet: %s"
+
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:81
+msgid "Notebook: %s (%s)"
+msgstr "Caiet: %s (%s)"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts:54
+#: packages/app-mobile/components/side-menu-content.tsx:686
+#: packages/lib/services/ReportService.ts:369
+msgid "Notebooks"
+msgstr "Caiete"
+
+#: packages/lib/models/Folder.ts:936
+msgid "Notebooks cannot be named \"%s\", which is a reserved title."
+msgstr "Caietele nu pot fi denumite „%s” deoarece este un titlu rezervat."
+
+#: packages/app-desktop/gui/NoteList/NoteList2.tsx:297
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderField.ts:8
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderReverse.ts:9
+msgid "Notes"
+msgstr "Notițe"
+
+#: packages/lib/models/Setting.ts:1202
+msgid "Notes and settings are stored in: %s"
+msgstr "Notițele și setările sînt stocate în: %s"
+
+#: packages/app-cli/app/command-mknote.js:16
+#: packages/app-cli/app/command-mktodo.js:16
+msgid "Notes can only be created within a notebook."
+msgstr "Notițele pot fi create numai în cadrul unui caiet de notițe."
+
+#: packages/app-desktop/gui/PopupNotification/PopupNotificationList.tsx:32
+msgid "Notifications"
+msgstr "Notificări"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:80
+msgid "Numbered List"
+msgstr "Listă numerotată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:547
+msgid "OCR: Clear cache and re-download language data files"
+msgstr ""
+"OCR: Golește cache-ul și descarcă din nou fișierele cu date lingvistice"
+
+#: packages/lib/models/settings/builtInMetadata.ts:528
+msgid "OCR: Language data URL or path"
+msgstr "OCR: URL sau cale date lingvistice"
+
+#: packages/app-desktop/bridge.ts:372 packages/app-desktop/bridge.ts:385
+#: packages/app-desktop/bridge.ts:399 packages/app-desktop/bridge.ts:415
+#: packages/app-desktop/gui/ConfigScreen/ButtonBar.tsx:34
+#: packages/app-desktop/gui/DialogButtonRow.tsx:71
+#: packages/app-desktop/gui/MenuBar.tsx:610
+#: packages/app-desktop/gui/PromptDialog.tsx:282
+#: packages/app-desktop/services/plugins/UserWebviewDialogButtonBar.tsx:19
+#: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:17
+#: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:22
+#: packages/app-mobile/components/DialogManager/hooks/useDialogControl.ts:30
+#: packages/app-mobile/components/ModalDialog.tsx:80
+#: packages/app-mobile/components/plugins/dialogs/PluginDialogWebView.tsx:128
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:225
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:61
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx:75
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:66
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:56
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:68
+#: packages/app-mobile/components/side-menu-content.tsx:392
+#: packages/app-mobile/utils/makeShowMessageBox.ts:12
+#: packages/lib/components/shared/config/plugins/useOnInstallHandler.ts:72
+msgid "OK"
+msgstr "OK"
+
+#: packages/lib/models/settings/builtInMetadata.ts:55
+msgid "OLED Dark"
+msgstr "OLED întunecat"
+
+#: packages/lib/services/ReportService.ts:390
+msgid "On %s: %s"
+msgstr "Pe %s: %s"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:27
+msgid "on line"
+msgstr "pe linie"
+
+#: packages/app-desktop/gui/MainScreen.tsx:548
+msgid "One of your master keys use an obsolete encryption method."
+msgstr ""
+"Una dintre cheile dvs. master utilizează o metodă de criptare învechită."
+
+#: packages/app-cli/app/gui/NoteWidget.js:48
+msgid ""
+"One or more items are currently encrypted and you may need to supply a "
+"master password. To do so please type `e2ee decrypt`. If you have already "
+"supplied the password, the encrypted items are being decrypted in the "
+"background and will be available soon."
+msgstr ""
+"Unul sau mai multe elemente sînt criptate în prezent și este posibil să fie "
+"necesar să furnizați o parolă master. Pentru a face acest lucru, te rog să "
+"tastați `e2ee decriptare`. Dacă ați furnizat deja parola, elementele "
+"criptate sînt decriptate în fundal și vor fi disponibile în curînd."
+
+#: packages/app-desktop/gui/MainScreen.tsx:577
+msgid "One or more master keys need a password."
+msgstr "Una sau mai multe chei master au nevoie de o parolă."
+
+#: packages/lib/SyncTargetOneDrive.ts:36
+msgid "OneDrive"
+msgstr "OneDrive"
+
+#: packages/app-desktop/gui/Root.tsx:189
+msgid "OneDrive Login"
+msgstr "Autentificare OneDrive"
+
+#: packages/lib/services/interop/InteropService.ts:144
+msgid "OneNote Notebook"
+msgstr "Caiet OneNote"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/print.ts:18
+msgid "Only one note can be printed at a time."
+msgstr "Doar o singură notiță se poate imprima."
+
+#: packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts:40
+msgid "Open"
+msgstr "Deschide"
+
+#: packages/app-desktop/app.ts:203
+msgid "Open %s"
+msgstr "Deschide %s"
+
+#: packages/app-desktop/commands/startExternalEditing.ts:10
+msgid "Open in external editor"
+msgstr "Deschide într-un editor extern"
+
+#: packages/app-desktop/commands/openNoteInNewWindow.ts:10
+msgid "Open in new window"
+msgstr "Deschide într-o fereastră nouă"
+
+#: packages/app-desktop/bridge.ts:466
+msgid "Open it"
+msgstr "Deschide-l"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openPdfViewer.ts:7
+msgid "Open PDF viewer"
+msgstr "Deschide vizualizator PDF"
+
+#: packages/app-desktop/commands/openPrimaryAppInstance.ts:8
+msgid "Open primary app instance..."
+msgstr "Deschide instanța primară a aplicației..."
+
+#: packages/app-desktop/commands/openProfileDirectory.ts:8
+msgid "Open profile directory"
+msgstr "Deschide dosarul profilului"
+
+#: packages/app-desktop/commands/openSecondaryAppInstance.ts:8
+msgid "Open secondary app instance..."
+msgstr "Deschide instanța secundară a aplicației..."
+
+#: packages/app-mobile/components/CameraView/CameraView.tsx:164
+msgid "Open settings"
+msgstr "Deschide setări"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:115
+msgid "Open Source"
+msgstr "Deschide sursa"
+
+#: packages/lib/models/settings/builtInMetadata.ts:89
+msgid "Open Sync Wizard..."
+msgstr "Deschide ghidul de sincronizare…"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:85
+msgid "Open..."
+msgstr "Deschide..."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:206
+msgid "Opening section %s"
+msgstr "Se deschide secțiunea %s"
+
+#: packages/app-mobile/components/Dropdown.tsx:215
+msgid "Opens dropdown"
+msgstr "Deschide caseta de derulare"
+
+#: packages/app-mobile/components/NoteItem.tsx:163
+msgid "Opens note"
+msgstr "Deschide notița"
+
+#: packages/app-mobile/components/side-menu-content.tsx:273
+msgid "Opens notebook"
+msgstr "Deschide un caiet de notițe"
+
+#: packages/app-cli/app/command-e2ee.ts:41
+#: packages/app-cli/app/command-e2ee.ts:87
+#: packages/app-cli/app/command-e2ee.ts:97
+msgid "Operation cancelled"
+msgstr "Operațiunea a fost amînată"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:28
+#: packages/app-desktop/gui/MenuBar.tsx:572
+#: packages/app-desktop/gui/Root.tsx:193
+msgid "Options"
+msgstr "Opțiuni"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:77
+msgid "Ordered list"
+msgstr "Listă ordonată"
+
+#: packages/app-desktop/gui/MenuBar.tsx:525
+msgid "Other applications..."
+msgstr "Alte aplicații…"
+
+#: packages/app-cli/app/command-import.ts:29
+msgid "Output format: %s"
+msgstr "Formatul sursei: %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1314
+msgid "Page orientation for PDF export"
+msgstr "Page orientation for PDF export"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1304
+msgid "Page size for PDF export"
+msgstr "Dimensiunea paginii pentru exportul PDF"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:32
+msgid "Panel \"%s\" is visible"
+msgstr "Panoul „%s” este vizibil"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:32
+msgid "Panel %s is hidden"
+msgstr "Panoul „%s” este ascuns"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:170
+msgid "Password"
+msgstr "Parolă"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:153
+msgid "Password cannot be empty"
+msgstr "Parolă nu poate fi un cîmp gol"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:138
+#: packages/app-mobile/components/screens/encryption-config.tsx:176
+msgid "Password:"
+msgstr "Parolă:"
+
+#: packages/app-cli/app/command-e2ee.ts:101
+#: packages/app-mobile/components/screens/encryption-config.tsx:156
+msgid "Passwords do not match!"
+msgstr "Parolele nu se potrivesc!"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:45
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts:105
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:195
+msgid "Paste"
+msgstr "Lipește"
+
+#: packages/app-desktop/gui/NoteEditor/commands/pasteAsText.ts:6
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:202
+msgid "Paste as text"
+msgstr "Lipește ca text"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/SettingComponent.tsx:261
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportProfileButton.tsx:54
+msgid "Path:"
+msgstr "Cale:"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts:11
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.ts:25
+msgid "PDF File"
+msgstr "Fișier PDF"
+
+#: packages/lib/utils/joplinCloud/index.ts:408
+msgid "Per user. Minimum of %d users."
+msgstr "Per utilizator. Minim %d utilizatori."
+
+#: packages/lib/commands/permanentlyDeleteNote.ts:8
+msgid "Permanently delete note"
+msgstr "Șterge notița permanent"
+
+#: packages/lib/models/Note.ts:942
+msgid "Permanently delete note \"%s\"?"
+msgstr "Șterge notițele „%s”?"
+
+#: packages/app-cli/app/command-rmbook.ts:36
+msgid ""
+"Permanently delete notebook \"%s\"?\n"
+"\n"
+"All notes and sub-notebooks within this notebook will be permanently deleted."
+msgstr ""
+"Ștergi caietul „%s” permanent?\n"
+"\n"
+"Toate notițele și secțiunile din acest caiet vor fi șterse permanent."
+
+#: packages/lib/models/Note.ts:944
+msgid "Permanently delete these %d notes?"
+msgstr "Șterge aceste %d notițe?"
+
+#: packages/app-cli/app/command-rmbook.ts:20
+msgid "Permanently deletes the notebook, skipping the trash."
+msgstr "Șterge permanent caietul, omițînd coșul."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:531
+msgid "Permission needed"
+msgstr "Permisiune necesară"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:261
+msgid ""
+"Please click on \"%s\" to proceed, or set the passwords in the \"%s\" list "
+"below."
+msgstr ""
+"Te rog să faci clic pe „%s” pentru a continua sau să setezi parolele în "
+"lista „%s” de mai jos."
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:64
+msgid ""
+"Please confirm that you would like to re-encrypt your complete database."
+msgstr ""
+"Te rog să confirmi că dorești să criptezi din nou întreaga bază de date."
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:213
+msgid ""
+"Please enter your password in the master key list below before upgrading the "
+"key."
+msgstr ""
+"Te rog să îți întroduci parola în lista de chei principale de mai jos "
+"înainte de a-ți actualiza cheia."
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:380
+msgid ""
+"Please note that if it is a large notebook, it may take a few minutes for "
+"all the notes to show up on the recipient's device."
+msgstr ""
+"Te rog ia aminte că dacă este vorba de un caiet de notițe mare, este posibil "
+"să dureze cîteva minute pentru ca toate notițele să apară pe dispozitivul "
+"destinatarului."
+
+#: packages/lib/onedrive-api-node-utils.js:118
+msgid ""
+"Please open the following URL in your browser to authenticate the "
+"application. The application will create a directory in \"Apps/Joplin\" and "
+"will only read and write files in this directory. It will have no access to "
+"any files outside this directory nor to any other personal data. No data "
+"will be shared with any third party."
+msgstr ""
+"Te rog să deschizi următoarea adresă URL în browser pentru a autentifica "
+"aplicația. Aplicația va crea un dosar în „Apps/Joplin” și va citi și scrie "
+"doar fișiere în acest dosar. Nu va avea acces la nici un fișier din afara "
+"acestui dosar și nici la alte date personale. Nu se vor partaja date cu "
+"nicio terță parte."
+
+#: packages/lib/services/share/ShareService.ts:332
+msgid "Please provide the recipient email"
+msgstr "Te rog furnizează adresa de e-mail a destinatarului"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:166
+msgid "Please record your voice..."
+msgstr "Te rog să îți înregistrezi vocea…"
+
+#: packages/app-cli/app/command-ls.ts:66
+msgid "Please select a notebook first."
+msgstr "Te rog să selectezi mai întîi un caiet de notițe."
+
+#: packages/app-cli/app/app-gui.js:468
+msgid "Please select the note or notebook to be deleted first."
+msgstr "Te rog să selectezi mai întîi notița sau caietul care trebuie șters."
+
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:31
+msgid "Please select where the sync status should be exported to"
+msgstr "Te rog să selectezi unde trebuie exportată starea sincronizării"
+
+#: packages/lib/services/interop/InteropService.ts:309
+msgid "Please specify import format for %s"
+msgstr "Te rog să specifici formatul de import pentru %s"
+
+#: packages/lib/services/interop/InteropService_Importer_Md.ts:38
+msgid "Please specify the notebook where the notes should be imported to."
+msgstr "Te rog să specifici caietul în care trebuie importate notițele."
+
+#: packages/lib/services/plugins/PluginService.ts:527
+msgid "Please upgrade Joplin to version %s or later to use this plugin."
+msgstr ""
+"Te rog să actualizezi Joplin la versiunea %s sau mai nouă pentru a utiliza "
+"acest plugin."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:1559
+msgid ""
+"Please wait for all attachments to be downloaded and decrypted. You may also "
+"switch to %s to edit the note."
+msgstr ""
+"Te rog să aștepți descărcarea și decriptarea tuturor atașamentelor. De "
+"asemenea, poți comuta la %s pentru a edita notița."
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:118
+#: packages/app-desktop/gui/ResourceScreen.tsx:309
+msgid "Please wait..."
+msgstr "Te rog să aștepți..."
+
+#: packages/app-mobile/services/plugins/PlatformImplementation.ts:51
+msgid "Plugin message"
+msgstr "Mesaj plugin"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:402
+msgid "Plugin panels"
+msgstr "Panouri plugin"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:111
+msgid "Plugin repository failed to load"
+msgstr "Repository-ul plugin-ului a eșuat să se încarce"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:29
+msgid "Plugin search"
+msgstr "Plugin"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:107
+msgid "Plugin security"
+msgstr "Plugin"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:329
+msgid "Plugin tools"
+msgstr "Instrumente Plugin"
+
+#: packages/lib/models/settings/builtInMetadata.ts:930
+msgid "Plugin WebView debugging"
+msgstr "Plugin depanare WebView"
+
+#: packages/app-desktop/gui/ConfigScreen/Sidebar.tsx:148
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:523
+#: packages/app-mobile/components/screens/ConfigScreen/SectionSelector/index.tsx:42
+#: packages/lib/models/Setting.ts:1181
+msgid "Plugins"
+msgstr "Plugin-uri"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:103
+msgid ""
+"Plugins extend Joplin with features that are not present by default. Plugins "
+"can extend Joplin's editor, viewer, and more."
+msgstr ""
+"Plugin-urile extind Joplin cu funcții care nu sînt implicit prezente. Plugin-"
+"urile pot extinde funcționalitatea editorului, vizualizatorului și mai multe."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1316
+msgid "Portrait"
+msgstr "Portret"
+
+#: packages/app-cli/app/help-utils.js:77
+msgid "Possible keys/values:"
+msgstr "Posibile chei/valori:"
+
+#: packages/app-cli/app/help-utils.js:57
+msgid "Possible values: %s."
+msgstr "Valori posibile: %s."
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:28
+msgid "Preferences"
+msgstr "Preferințe"
+
+#: packages/app-desktop/gui/MenuBar.tsx:636
+msgid "Preferences..."
+msgstr "Preferințe..."
+
+#: packages/lib/models/settings/builtInMetadata.ts:602
+msgid "Preferred dark theme"
+msgstr "Tema întunecată preferată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:586
+msgid "Preferred light theme"
+msgstr "Tema luminoasă preferată"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1783
+msgid "Preferred voice typing provider"
+msgstr "Furnizorul preferat de transcriere vocală"
+
+#: packages/lib/models/settings/builtInMetadata.ts:683
+msgid "Preserve colours when pasting text in Rich Text Editor"
+msgstr "Păstrează culorile la lipirea textului în editorul de text îmbogățit"
+
+#: packages/app-cli/app/app-gui.js:758
+msgid "Press Ctrl+D or type \"exit\" to exit the application"
+msgstr "Apăsați Ctrl+D ori scrieți \"exit\" pentru a ieși din aplicație"
+
+#: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:70
+msgid "Press the shortcut"
+msgstr "Apăsați comanda rapidă"
+
+#: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:69
+msgid ""
+"Press the shortcut and then press ENTER. Or, press BACKSPACE to clear the "
+"shortcut."
+msgstr ""
+"Apăsați comanda rapidă și apoi apăsați ENTER. Sau apăsați BACKSPACE pentru a "
+"șterge comanda rapidă."
+
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:40
+msgid "Press to set the decryption password."
+msgstr "Apăsați pentru a seta parola de decriptare."
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:17
+msgid "previous"
+msgstr "anterior"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:281
+msgid "Previous match"
+msgstr "Potrivirea anterioară"
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:423
+msgid "Previous versions of this note"
+msgstr "Versiunile anterioare ale acestei notițe"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/print.ts:8
+msgid "Print"
+msgstr "Tipărește"
+
+#: packages/lib/utils/joplinCloud/index.ts:222
+msgid "Priority support"
+msgstr "Suport prioritar"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:606
+msgid "Privacy Policy"
+msgstr "Politica de confidențialitate"
+
+#: packages/lib/utils/joplinCloud/index.ts:369
+msgid "Pro"
+msgstr "Pro"
+
+#: packages/server/src/services/TaskService.ts:26
+msgid "Process failed payment subscriptions"
+msgstr "Procesarea subscripțiilor de plată eșuate"
+
+#: packages/server/src/services/TaskService.ts:24
+msgid "Process oversized accounts"
+msgstr "Procesarea conturilor de dimensiuni prea mari"
+
+#: packages/server/src/services/TaskService.ts:29
+msgid "Process user deletions"
+msgstr "Procesarea ștergerilor de utilizator"
+
+#: packages/lib/models/Resource.ts:32
+msgid "Processing"
+msgstr "Se procesează"
+
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:111
+msgid "Processing photo..."
+msgstr "Se procesează imaginea..."
+
+#: packages/server/src/routes/admin/users.ts:254
+msgid "Profile"
+msgstr "Profil"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileEditor.tsx:96
+msgid "Profile name"
+msgstr "Numele profilului"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/addProfile.ts:18
+msgid "Profile name:"
+msgstr "Numele profilului:"
+
+#: packages/lib/versionInfo.ts:91
+msgid "Profile Version: %s"
+msgstr "Versiunea profil: %s"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:199
+msgid "Profiles"
+msgstr "Profiluri"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1293
+msgid "Properties"
+msgstr "Proprietăți"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1468
+msgid "Proxy enabled"
+msgstr "Proxy activat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1490
+msgid "Proxy timeout (seconds)"
+msgstr "Timeout proxy (secunde)"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1478
+msgid "Proxy URL"
+msgstr "URL proxy"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:240
+msgid "Public-private key pair:"
+msgstr "Pereche de chei publice-private:"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showShareNoteDialog.ts:6
+msgid "Publish note..."
+msgstr "Publică notița…"
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:213
+msgid "Publish Notes"
+msgstr "Publică notițele"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:174
+#: packages/lib/utils/joplinCloud/index.ts:153
+msgid "Publish notes to the internet"
+msgstr "Publică notițele pe internet"
+
+#: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:78
+msgid "QR Code"
+msgstr "Cod QR"
+
+#: packages/app-desktop/app.ts:205
+#: packages/app-desktop/ElectronAppWrapper.ts:151
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:16
+#: packages/app-desktop/gui/MenuBar.tsx:429
+msgid "Quit"
+msgstr "Ieșire"
+
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:190
+msgid "Re-download model"
+msgstr "Descarcă din nou modelul"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:342
+msgid "Re-encrypt data"
+msgstr "Re-criptați datele"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:354
+msgid "Re-encryption"
+msgstr "Re-criptare"
+
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:181
+msgid "Re-enter password"
+msgstr "Introdu parola din nou"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1235
+msgid "Re-upload local data to sync target"
+msgstr "Reîncărcarea datelor locale către destinația de sincronizare"
+
+#: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:47
+msgid "Read more about it"
+msgstr "Citiți mai multe despre aceasta"
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:159
+msgid "Read time: %s min"
+msgstr "Durata lecturii: %s min"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:313
+msgid "Recipient has accepted the invitation"
+msgstr "Destinatarul a acceptat invitația"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:311
+msgid "Recipient has not yet accepted the invitation"
+msgstr "Destinatarul nu a acceptat încă invitația"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:312
+msgid "Recipient has rejected the invitation"
+msgstr "Destinatarul a respins invitația"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:341
+msgid "Recipients:"
+msgstr "Destinatari:"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:72
+msgid "Recommended"
+msgstr "Recomandat"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:114
+msgid "Recommended plugins"
+msgstr "Plugin-uri recomandate"
+
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:91
+msgid "Record audio"
+msgstr "Înregistrează audio"
+
+#: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:73
+msgid "Recording"
+msgstr "Înregistrare"
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:224
+msgid "Recording..."
+msgstr "Se înregistrează…"
+
+#: packages/app-desktop/gui/MenuBar.tsx:767
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:122
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:168
+#: packages/app-mobile/components/ScreenHeader/index.tsx:353
+msgid "Redo"
+msgstr "Refă"
+
+#: packages/app-mobile/components/screens/LogScreen.tsx:229
+#: packages/app-mobile/components/screens/onedrive-login.js:121
+#: packages/app-mobile/components/screens/status.tsx:248
+msgid "Refresh"
+msgstr "Reîmprospătează"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:316
+msgid "Regular expression"
+msgstr "Expresie regulată"
+
+#: packages/app-desktop/gui/MainScreen.tsx:566
+#: packages/app-desktop/gui/Root.tsx:153
+#: packages/app-mobile/components/screens/ShareManager/IncomingShareItem.tsx:45
+msgid "Reject"
+msgstr "Respinge"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:107
+msgid "Remove"
+msgstr "Șterge"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:330
+msgid "Remove %s from share"
+msgstr "Elimină %s din partajare"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:111
+msgid "Remove tag \"%s\" from all notes?"
+msgstr "Elimini eticheta „%s” din toate notițele?"
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:113
+msgid "Remove this search from the sidebar?"
+msgstr "Elimini această căutare din panoul lateral?"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameFolder.ts:8
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameTag.ts:8
+msgid "Rename"
+msgstr "Redenumește"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameFolder.ts:22
+msgid "Rename notebook:"
+msgstr "Redenumește caietul:"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/renameTag.ts:22
+msgid "Rename tag:"
+msgstr "Redenumește eticheta:"
+
+#: packages/app-cli/app/command-ren.ts:14
+msgid "Renames the given <item> (note or notebook) to <name>."
+msgstr "Redenumește <item> dat (notiță sau caiet) în <name>."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:162
+msgid "Renew token"
+msgstr "Reînnoiește jetonul"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:21
+msgid "replace"
+msgstr "înlocuiește"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:15
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:291
+msgid "Replace"
+msgstr "Înlocuiește"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:22
+msgid "replace all"
+msgstr "înlocuiește tot"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:301
+msgid "Replace all"
+msgstr "Înlocuiește tot"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:239
+msgid "Replace with..."
+msgstr "Înlocuiește cu…"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:260
+msgid "Replace: "
+msgstr "Înlocuiește: "
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:25
+msgid "replaced $ matches"
+msgstr "s-au înlocuit $ potriviri"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:26
+msgid "replaced match on line $"
+msgstr "s-a înlocuit potrivirea pe linia $"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:162
+msgid "Report an issue"
+msgstr "Raportează o problemă"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:219
+msgid "Report any issues concerning the plugin."
+msgstr "Raportează orice problemă legată de plugin."
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:224
+msgid "Report fraudulent plugin"
+msgstr "Raportează plugin fraudulos"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:116
+msgid "Report system"
+msgstr "Raportează sistem"
+
+#: packages/server/src/services/MustacheService.ts:137
+msgid "Reports"
+msgstr "Rapoarte"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts:7
+msgid "Reset application layout"
+msgstr "Resetează aspectul aplicației"
+
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:221
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:222
+msgid "Reset master password"
+msgstr "Resetare parolei master"
+
+#: packages/lib/models/settings/builtInMetadata.ts:883
+msgid "Resize large images:"
+msgstr "Redimensionează imaginile mari:"
+
+#: packages/app-cli/app/command-import.ts:54
+#: packages/app-desktop/gui/ImportScreen.tsx:93
+msgid "Resources: %d."
+msgstr "Resurse: %d."
+
+#: packages/app-desktop/gui/MainScreen.tsx:537
+msgid "Restart and upgrade"
+msgstr "Repornește și actualizează"
+
+#: packages/app-desktop/ElectronAppWrapper.ts:158
+msgid "Restart in safe mode"
+msgstr "Repornește în modul sigur"
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:405
+#: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:48
+msgid "Restart now"
+msgstr "Repornește acum"
+
+#: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:96
+#: packages/app-desktop/gui/NoteRevisionViewer.tsx:165
+#: packages/app-mobile/components/ScreenHeader/index.tsx:471
+#: packages/app-mobile/components/ScreenHeader/index.tsx:473
+#: packages/app-mobile/components/screens/Note/Note.tsx:1301
+#: packages/app-mobile/components/side-menu-content.tsx:359
+msgid "Restore"
+msgstr "Restaurează"
+
+#: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:156
+msgid "Restore defaults"
+msgstr "Restaurează implicitele"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreNote.ts:10
+msgid "Restore note"
+msgstr "Restaurează notița"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/restoreFolder.ts:9
+msgid "Restore notebook"
+msgstr "Restaurează caietul"
+
+#: packages/app-cli/app/command-restore.ts:12
+msgid "Restore the items matching <pattern> from the trash."
+msgstr ""
+"Restaurează elementele care se potrivesc cu <pattern> din coșul de gunoi."
+
+#: packages/lib/services/trash/index.ts:88
+msgid "Restored items"
+msgstr "Elemente restaurate"
+
+#: packages/lib/services/RevisionService.ts:250
+msgid "Restored Notes"
+msgstr "Notițe restaurate"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.tsx:162
+msgid "Results (%d):"
+msgstr "Rezultate (%d):"
+
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:133
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:112
+#: packages/app-mobile/components/screens/status.tsx:197
+msgid "Retry"
+msgstr "Reîncearcă"
+
+#: packages/app-desktop/gui/StatusScreen/StatusScreen.tsx:80
+#: packages/app-mobile/components/screens/status.tsx:191
+msgid "Retry All"
+msgstr "Reîncearcă toate"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:131
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/revealResourceFile.ts:8
+msgid "Reveal file in folder"
+msgstr "Afișează fișierul în dosar"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderReverse.ts:8
+#: packages/lib/models/settings/builtInMetadata.ts:725
+#: packages/lib/models/settings/builtInMetadata.ts:804
+msgid "Reverse sort order"
+msgstr "Inversați ordinea sortării"
+
+#: packages/app-cli/app/command-ls.ts:30
+msgid "Reverses the sorting order."
+msgstr "Inversează ordinea sortării."
+
+#: packages/lib/versionInfo.ts:65
+msgid "Revision: %s (%s)"
+msgstr "Revizie: %s (%s)"
+
+#: packages/app-desktop/gui/ToggleEditorsButton/ToggleEditorsButton.tsx:28
+msgid "Rich Text"
+msgstr "Text îmbogățit"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx:716
+msgid "Rich Text editor. Press Escape then Tab to escape focus."
+msgstr "Editor text îmbogățit. Apasă Escape, apoi Tab pentru a pierde focusul."
+
+#: packages/app-cli/app/command-batch.js:10
+msgid ""
+"Runs the commands contained in the text file. There should be one command "
+"per line."
+msgstr ""
+"Execută comenzile conținute în fișierul text. Ar trebui să existe cîte o "
+"comandă pe linie."
+
+#: packages/lib/SyncTargetAmazonS3.js:28
+msgid "S3"
+msgstr "S3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:282
+msgid "S3 access key"
+msgstr "Cheie acces S3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:239
+msgid "S3 bucket"
+msgstr "Bucket S3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:270
+msgid "S3 region"
+msgstr "Regiune S3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:294
+msgid "S3 secret key"
+msgstr "Cheie secretă S3"
+
+#: packages/lib/models/settings/builtInMetadata.ts:255
+msgid "S3 URL"
+msgstr "URL S3"
+
+#: packages/app-desktop/gui/MainScreen.tsx:524
+msgid ""
+"Safe mode is currently active. Note rendering and all plugins are "
+"temporarily disabled."
+msgstr ""
+"Modul safe este activ în prezent. Notă redarea și toate plugin-urile sînt "
+"temporar dezactivate."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:129
+#: packages/app-desktop/gui/KeymapConfig/ShortcutRecorder.tsx:93
+#: packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx:222
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:165
+#: packages/app-mobile/components/screens/encryption-config.tsx:124
+#: packages/app-mobile/components/screens/encryption-config.tsx:256
+msgid "Save"
+msgstr "Salvează"
+
+#: packages/app-mobile/components/SelectDateTimeDialog.tsx:166
+msgid "Save alarm"
+msgstr "Salvează alarma"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:105
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:112
+msgid "Save as %s"
+msgstr "Salvează ca %s"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:92
+msgid "Save as..."
+msgstr "Salvează ca..."
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:352
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:110
+#: packages/app-mobile/components/ScreenHeader/index.tsx:307
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:269
+#: packages/app-mobile/components/screens/Note/Note.tsx:230
+msgid "Save changes"
+msgstr "Salvează schimbările"
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:103
+msgid "Save changes?"
+msgstr "Salvezi schimbările?"
+
+#: packages/lib/models/settings/builtInMetadata.ts:805
+msgid "Save geo-location with notes"
+msgstr "Salvează geo-locația în notițe"
+
+#: packages/app-mobile/components/CameraView/ScannedBarcodes.tsx:89
+msgid "Scanned code"
+msgstr "Cod scanat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1172
+msgid "Scrollbar size"
+msgstr "Mărime bară derulare"
+
+#: packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx:67
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:112
+#: packages/app-mobile/components/ScreenHeader/index.tsx:381
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:784
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx:29
+#: packages/app-mobile/components/screens/SearchScreen/index.tsx:87
+msgid "Search"
+msgstr "Caută"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/SearchPlugins.tsx:118
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/SearchPlugins.tsx:157
+msgid "Search for plugins..."
+msgstr "Caută plugin-uri…"
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:226
+msgid "Search for..."
+msgstr "Caută după…"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:170
+msgid "Search hidden"
+msgstr "Căutare ascunsă"
+
+#: packages/app-desktop/gui/NoteListControls/commands/focusSearch.ts:6
+msgid "Search in all the notes"
+msgstr "Caută în toate notițele"
+
+#: packages/app-desktop/gui/NoteEditor/commands/showLocalSearch.ts:7
+msgid "Search in current note"
+msgstr "Caută în notița curentă"
+
+#: packages/app-desktop/plugins/GotoAnything.tsx:703
+msgid "Search results"
+msgstr "Rezultate căutare"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:170
+msgid "Search shown"
+msgstr "Căutare afișată"
+
+#: packages/app-cli/app/gui/FolderListWidget.ts:56
+msgid "Search:"
+msgstr "Caută:"
+
+#: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:178
+#: packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx:80
+#: packages/app-desktop/gui/NoteSearchBar.tsx:194
+#: packages/app-desktop/gui/ResourceScreen.tsx:306
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:785
+msgid "Search..."
+msgstr "Caută..."
+
+#: packages/app-cli/app/command-search.js:13
+msgid "Searches for the given <pattern> in all the notes."
+msgstr "Caută după <pattern> dat în toate notițele."
+
+#: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:39
+msgid "See changelog"
+msgstr "Vezi lista de schimbări"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1254
+msgid "See the pre-release page for more details: %s"
+msgstr "Pentru mai multe detalii, consultați pagina de pre-reluase: %s"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:205
+#: packages/app-mobile/components/NoteItem.tsx:151
+msgid "Select"
+msgstr "Selectează"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:50
+#: packages/app-mobile/components/ScreenHeader/index.tsx:366
+msgid "Select all"
+msgstr "Selectează tot"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:145
+msgid "Select emoji..."
+msgstr "Alege un emoji…"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:149
+msgid "Select file..."
+msgstr "Alege o imagine…"
+
+#: packages/app-mobile/components/screens/folder.js:109
+msgid "Select parent notebook"
+msgstr "Selectează caietul părinte"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.ts:9
+msgid "Selection deleted"
+msgstr "Selecția a fost ștearsă"
+
+#: packages/app-mobile/components/FolderPicker.tsx:67
+msgid "Selects a notebook"
+msgstr "Selectează un caiet"
+
+#: packages/app-desktop/gui/MenuBar.tsx:364
+msgid "Send bug report"
+msgstr "Trimiteți un raport de eroare"
+
+#: packages/app-cli/app/command-server.js:38
+msgid "Server is already running on port %d"
+msgstr "Serverul rulează deja pe portul %d"
+
+#: packages/app-cli/app/command-server.js:44
+#: packages/app-cli/app/command-server.js:47
+msgid "Server is not running."
+msgstr "Serverul nu rulează."
+
+#: packages/app-cli/app/command-server.js:44
+msgid "Server is running on port %d"
+msgstr "Serverul rulează pe portul %d"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.ts:12
+#: packages/app-mobile/components/screens/Note/Note.tsx:1214
+#: packages/app-mobile/components/SelectDateTimeDialog.tsx:161
+msgid "Set alarm"
+msgstr "Setează alarma"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.ts:30
+msgid "Set alarm:"
+msgstr "Setează alarma:"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1156
+msgid ""
+"Set it to 0 to make it take the complete available space. Recommended width "
+"is 600."
+msgstr ""
+"Setează-o la 0 pentru a ocupa tot spațiul disponibil. Lățimea recomandată "
+"este de 600."
+
+#: packages/app-desktop/gui/MainScreen.tsx:531
+#: packages/app-desktop/gui/MainScreen.tsx:578
+msgid "Set the password"
+msgstr "Setează parola"
+
+#: packages/app-cli/app/command-set.ts:22
+msgid ""
+"Sets the property <name> of the given <note> to the given [value]. Possible "
+"properties are:\n"
+"\n"
+"%s"
+msgstr ""
+"Setează proprietatea <name> a <note> date la [value] dată. Proprietățile "
+"posibile sînt:\n"
+"\n"
+"%s"
+
+#: packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx:74
+msgid "Settings"
+msgstr "Setări"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:281
+#: packages/app-mobile/components/NoteBodyViewer/hooks/useOnResourceLongPress.ts:44
+#: packages/app-mobile/components/screens/LogScreen.tsx:56
+#: packages/app-mobile/components/screens/Note/Note.tsx:1225
+msgid "Share"
+msgstr "Distribuie"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.tsx:21
+msgid ""
+"Share a copy of all notes in a file format that can be imported by Joplin on "
+"a computer."
+msgstr ""
+"Partajați o copie a tuturor notițelor într-un format de fișier care poate fi "
+"importat de Joplin pe un computer."
+
+#: packages/lib/utils/joplinCloud/index.ts:125
+msgid "Share a notebook with others"
+msgstr "Partajează un caiet cu alții"
+
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:82
+#: packages/app-mobile/components/screens/ShareManager/IncomingShareItem.tsx:33
+msgid "Share from %s (%s)"
+msgstr "Partajează din %s (%s)"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:400
+msgid "Share Notebook"
+msgstr "Partajează caiet"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showShareFolderDialog.ts:6
+msgid "Share notebook..."
+msgstr "Partajează caiet..."
+
+#: packages/lib/utils/joplinCloud/index.ts:215
+msgid "Share permissions"
+msgstr "Permisiuni de partajare"
+
+#: packages/app-desktop/gui/Sidebar/listItemComponents/FolderItem.tsx:57
+msgid "Shared"
+msgstr "Partajat"
+
+#: packages/app-mobile/components/screens/ShareManager/index.tsx:107
+msgid "Shares"
+msgstr "Partajări"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:364
+msgid "Sharing notebook..."
+msgstr "Se partajează caietul..."
+
+#: packages/app-cli/app/command-help.ts:45
+msgid "Shortcuts are not available in CLI mode."
+msgstr "Scurtăturile nu sînt disponibile în modul CLI."
+
+#: packages/app-mobile/components/NoteEditor/SearchPanel.tsx:211
+msgid "Show advanced"
+msgstr "Afișează avansat"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/ToggleAdvancedSettingsButton.tsx:24
+msgid "Show Advanced Settings"
+msgstr "Afișează opțiunile avansate"
+
+#: packages/app-mobile/components/screens/LogScreen.tsx:237
+msgid "Show all"
+msgstr "Afișează tot"
+
+#: packages/lib/models/settings/builtInMetadata.ts:633
+msgid "Show completed to-dos"
+msgstr "Afișează sarcinile terminate"
+
+#: packages/server/src/routes/admin/users.ts:206
+msgid "Show disabled"
+msgstr "Afișează dezactivatele"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:160
+msgid "Show disabled keys"
+msgstr "Afișează cheile dezactivate"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/FontSearch.tsx:51
+msgid "Show monospace fonts only."
+msgstr "Afișează doar fonturi monospațiere."
+
+#: packages/lib/models/settings/builtInMetadata.ts:615
+msgid "Show note counts"
+msgstr "Afișează numărul de notițe"
+
+#: packages/app-mobile/components/side-menu-content.tsx:258
+msgid "Show notebook options"
+msgstr "Afișează opțiuni caiet"
+
+#: packages/app-desktop/gui/PasswordInput/PasswordInput.tsx:21
+msgid "Show password"
+msgstr "Afișează parola"
+
+#: packages/lib/models/settings/builtInMetadata.ts:735
+msgid "Show sort order buttons"
+msgstr "Afișează butoanele de ordonare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1028
+msgid "Show tray icon"
+msgstr "Afișează pictograma în zona de notificări"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:265
+msgid "Show/hide the sidebar"
+msgstr "Afișează/Ascunde panoul lateral"
+
+#: packages/app-mobile/components/screens/tags.tsx:76
+msgid "Shows notes for tag"
+msgstr "Afișează notițele pentru etichetă"
+
+#: packages/lib/models/settings/builtInMetadata.ts:884
+msgid "Shrink large images before adding them to notes."
+msgstr "Micșorează imaginile mari înainte de a le adăuga la notițe."
+
+#: packages/app-mobile/components/SideMenu.tsx:258
+msgid "Side menu closed"
+msgstr "Meniu lateral închis"
+
+#: packages/app-mobile/components/SideMenu.tsx:258
+msgid "Side menu opened"
+msgstr "Meniu lateral deschis"
+
+#: packages/app-desktop/gui/MainScreen.tsx:127
+#: packages/app-desktop/gui/Sidebar/commands/focusElementSideBar.ts:10
+#: packages/app-desktop/gui/Sidebar/Sidebar.tsx:77
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleSideBar.ts:23
+#: packages/app-mobile/components/ScreenHeader/index.tsx:264
+msgid "Sidebar"
+msgstr "Panou lateral"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:111
+msgid "Size"
+msgstr "Mărime"
+
+#: packages/app-desktop/checkForUpdates.ts:109
+msgid "Skip this version"
+msgstr "Sari peste această versiune"
+
+#: packages/app-cli/app/command-e2ee.ts:66
+msgid "Skipped items: %d (use --retry-failed-items to retry decrypting them)"
+msgstr ""
+"Elemente omise: %d (folosește --retry-failed-items pentru a reîncerca "
+"decriptarea acestora)"
+
+#: packages/app-cli/app/command-import.ts:53
+#: packages/app-desktop/gui/ImportScreen.tsx:92
+msgid "Skipped: %d."
+msgstr "Omise: %d."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1167
+msgid "Small"
+msgstr "Mică"
+
+#: packages/lib/models/settings/builtInMetadata.ts:52
+msgid "Solarised Dark"
+msgstr "Solarizat întunecat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:51
+msgid "Solarised Light"
+msgstr "Solarizat luminos"
+
+#: packages/lib/models/settings/settingValidations.ts:21
+msgid ""
+"Some attachments could not be downloaded. Please try to download them again."
+msgstr ""
+"Unele atașamente nu au putut fi descărcate. Te rog încearcă să le descarci "
+"din nou."
+
+#: packages/lib/models/settings/settingValidations.ts:18
+msgid ""
+"Some attachments need to be downloaded. Set the attachment download mode to "
+"\"always\" and try again."
+msgstr ""
+"Unele atașamente trebuie să fie descărcate. Setează module de descărcare al "
+"atașamentelor la „mereu” și încearcă din nou."
+
+#: packages/app-desktop/gui/MainScreen.tsx:542
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:52
+msgid "Some items cannot be decrypted."
+msgstr "Unele elemente nu pot fi decriptate."
+
+#: packages/app-desktop/gui/MainScreen.tsx:571
+msgid "Some items cannot be synchronised."
+msgstr "Unele elemente nu pot fi sincronizate."
+
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:43
+msgid "Some items cannot be synchronised. Press for more info."
+msgstr ""
+"Unele elemente nu pot fi sincronizate. Apăsați pentru mai multe informații."
+
+#: packages/lib/models/settings/settingValidations.ts:24
+msgid ""
+"Some items could not be synchronised. Please try to synchronise them first."
+msgstr ""
+"Unele elemente nu au putut fi sincronizate. Te rog încearcă să le "
+"sincronizezi mai întîi."
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:92
+msgid "Sort \"%s\" in ascending order"
+msgstr "Sortează „%s” în ordine ascendentă"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:92
+msgid "Sort \"%s\" in descending order"
+msgstr "Sortează „%s” în ordine descendentă"
+
+#: packages/lib/models/settings/builtInMetadata.ts:791
+msgid "Sort notebooks by"
+msgstr "Sortează notițele după"
+
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
+#: packages/app-mobile/components/ScreenHeader/index.tsx:509
+#: packages/lib/models/settings/builtInMetadata.ts:641
+msgid "Sort notes by"
+msgstr "Sortează notițele după"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:138
+msgid "Sort selected lines"
+msgstr "Sortează liniile selectate"
+
+#: packages/app-cli/app/command-ls.ts:29
+msgid "Sorts the item by <field> (eg. title, updated_time, created_time)."
+msgstr ""
+"Sortează elementul după <field> (ex: titlu, data_actualizării, data_creării)."
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:9
+msgid "Source"
+msgstr "Sursă"
+
+#: packages/app-cli/app/command-import.ts:27
+msgid "Source format: %s"
+msgstr "Formatul sursei: %s"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:139
+msgid "Source: "
+msgstr "Sursă: "
+
+#: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:436
+msgid "Spacer"
+msgstr "Distanțier"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1518
+msgid ""
+"Specify the port that should be used by the API server. If not set, a "
+"default will be used."
+msgstr ""
+"Specifică portul care trebuie utilizat de serverul API. Dacă nu este setat, "
+"se va utiliza un port implicit."
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showSpellCheckerMenu.ts:11
+#: packages/lib/services/spellChecker/SpellCheckerService.ts:218
+msgid "Spell checker"
+msgstr "Corector ortografic"
+
+#: packages/lib/models/settings/builtInMetadata.ts:624
+#: packages/lib/models/settings/builtInMetadata.ts:626
+#: packages/lib/models/settings/builtInMetadata.ts:627
+msgid "Split View"
+msgstr "Divizare vizualizare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1043
+msgid "Start application minimised in the tray icon"
+msgstr "Pornește aplicația minimizat în zona de notificări a sistemului"
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:199
+msgid "Start recording"
+msgstr "Începe înregistrarea"
+
+#: packages/app-cli/app/command-server.js:14
+msgid ""
+"Start, stop or check the API server. To specify on which port it should run, "
+"set the api.port config variable. Commands are (%s)."
+msgstr ""
+"Pornește, oprește sau verifică server-ul API. Pentru a specifica pe ce port "
+"trebuie să ruleze, setează variabila de configurare api.port. Comenzile sînt "
+"(%s)."
+
+#: packages/app-cli/app/command-e2ee.ts:57
+msgid ""
+"Starting decryption... Please wait as it may take several minutes depending "
+"on how much there is to decrypt."
+msgstr ""
+"Se începe decriptarea... Te rog să aștepți, deoarece poate dura cîteva "
+"minute, în funcție de cît este de decriptat."
+
+#: packages/app-cli/app/command-sync.ts:233
+msgid "Starting synchronisation..."
+msgstr "Se începe sincronizarea..."
+
+#: packages/app-cli/app/command-edit.ts:76
+msgid "Starting to edit note. Close the editor to get back to the prompt."
+msgstr ""
+"Începere să editeze nota. Închideți editorul pentru a reveni la prompt."
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:163
+msgid "Statistics"
+msgstr "Statistici"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/showNoteContentProperties.ts:8
+msgid "Statistics..."
+msgstr "Statistici..."
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:352
+#: packages/app-mobile/components/screens/status.tsx:246
+msgid "Status"
+msgstr "Stare"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:91
+msgid "Status: %s"
+msgstr "Stare: %s"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:85
+msgid "Status: Started on port %d"
+msgstr "Stare: Portul %d"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:136
+msgid "Step 1: Enable the clipper service"
+msgstr "Pasul 1: Activează clipper service"
+
+#: packages/app-cli/app/command-sync.ts:82
+#: packages/app-desktop/gui/DropboxLoginScreen.tsx:46
+#: packages/app-mobile/components/screens/dropbox-login.tsx:63
+msgid "Step 1: Open this URL in your browser to authorise the application:"
+msgstr ""
+"Pasul 1: Deschideți adresa URL în navigatorul dumneavoastră web pentru a "
+"autoriza aplicația:"
+
+#: packages/app-cli/app/command-sync.ts:84
+#: packages/app-desktop/gui/DropboxLoginScreen.tsx:50
+#: packages/app-mobile/components/screens/dropbox-login.tsx:69
+msgid "Step 2: Enter the code provided by Dropbox:"
+msgstr "Pasul 2: Introdu codul oferit de Dropbox:"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:142
+msgid "Step 2: Install the extension"
+msgstr "Pasul 2: Instalează extensia"
+
+#: packages/app-desktop/commands/toggleExternalEditing.ts:29
+msgid "Stop"
+msgstr "Stop"
+
+#: packages/app-desktop/commands/stopExternalEditing.ts:8
+msgid "Stop external editing"
+msgstr "Oprește editarea externă"
+
+#: packages/lib/utils/joplinCloud/index.ts:141
+msgid "Storage space"
+msgstr "Spațiu de stocare"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:19
+msgid "Strikethrough"
+msgstr "Tăietură oblică"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:195
+msgid "strong text"
+msgstr "text strong"
+
+#: packages/app-desktop/gui/DropboxLoginScreen.tsx:55
+#: packages/app-mobile/components/screens/dropbox-login.tsx:72
+msgid "Submit"
+msgstr "Trimite"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:36
+msgid "Subscript"
+msgstr "Subscripție"
+
+#: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:16
+msgid "Success"
+msgstr "Succes"
+
+#: packages/lib/components/shared/config/config-shared.ts:99
+msgid "Success! Synchronisation configuration appears to be correct."
+msgstr "Succes! Configurația de sincronizare pare a fi corectă."
+
+#: packages/app-desktop/gui/InlineCombobox.tsx:182
+msgid "Suggestions"
+msgstr "Sugestii"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:30
+msgid "Superscript"
+msgstr "Superscript"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:146
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:102
+msgid "Swap line down"
+msgstr "Interschimbă cu linia de jos"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:142
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:107
+msgid "Swap line up"
+msgstr "Interschimbă cu linia de sus"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNoteType.ts:7
+msgid "Switch between note and to-do type"
+msgstr "Comută între notiță și listă de făcut"
+
+#: packages/app-desktop/gui/MenuBar.tsx:561
+#: packages/app-mobile/components/side-menu-content.tsx:625
+msgid "Switch profile"
+msgstr "Comută profilul"
+
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:101
+msgid "Switch to back-facing camera"
+msgstr "Comută la camera din spate"
+
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:101
+msgid "Switch to front-facing camera"
+msgstr "Comută la camera din față"
+
+#: packages/app-desktop/gui/utils/NoteListUtils.ts:83
+msgid "Switch to note type"
+msgstr "Comută la tipul de notiță"
+
+#: packages/app-desktop/commands/switchProfile1.ts:7
+#: packages/app-desktop/commands/switchProfile2.ts:7
+#: packages/app-desktop/commands/switchProfile3.ts:7
+msgid "Switch to profile %d"
+msgstr "Treceți la profilul %d"
+
+#: packages/app-desktop/gui/ToggleEditorsButton/ToggleEditorsButton.tsx:28
+msgid "Switch to the %s Editor"
+msgstr "Comută la editorul %s"
+
+#: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:78
+msgid "Switch to the legacy editor"
+msgstr "Comută la editorul învechit"
+
+#: packages/app-desktop/gui/utils/NoteListUtils.ts:92
+msgid "Switch to to-do type"
+msgstr "Treceți la tipul to-do"
+
+#: packages/app-cli/app/command-use.ts:12
+msgid ""
+"Switches to [notebook] - all further operations will happen within this "
+"notebook."
+msgstr ""
+"Comută la [notebook] - toate operațiunile ulterioare vor avea loc în acest "
+"caiet."
+
+#: packages/lib/utils/joplinCloud/index.ts:160
+msgid "Sync as many devices as you want"
+msgstr "Sincronizați cît de multe dispozitive doriți"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:549
+msgid "Sync Status"
+msgstr "Sync Status"
+
+#: packages/lib/services/ReportService.ts:355
+msgid "Sync status (synced items / total items)"
+msgstr "Starea de sincronizare (elemente sincronizate / total elemente)"
+
+#: packages/app-cli/app/command-sync.ts:271
+msgid "Sync target must be upgraded! Run `%s` to proceed."
+msgstr ""
+"Obiectivul de sincronizare trebuie să fie actualizat! Rulați `%s` pentru a "
+"continua."
+
+#: packages/app-mobile/components/screens/UpgradeSyncTargetScreen.tsx:59
+msgid "Sync Target Upgrade"
+msgstr "Sync Target Upgrade"
+
+#: packages/app-cli/app/command-sync.ts:41
+msgid "Sync to provided target (defaults to sync.target config value)"
+msgstr ""
+"Sincronizarea cu o ținta specificată (presetat la valoare de configurare "
+"sync.target)"
+
+#: packages/lib/versionInfo.ts:90
+msgid "Sync Version: %s"
+msgstr "Versiunea de sincronizare: %s"
+
+#: packages/app-desktop/gui/SyncWizard/Dialog.tsx:173
+msgid "Sync your notes"
+msgstr "Sincronizează-ți notițele"
+
+#: packages/lib/models/Setting.ts:1215
+msgid "Sync, encryption, proxy"
+msgstr "Sincronizare, criptare, proxy"
+
+#: packages/lib/models/Setting.ts:1176
+msgid "Synchronisation"
+msgstr "Sincronizare"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1275
+msgid "Synchronisation interval"
+msgstr "Interval de sincronizare"
+
+#: packages/app-cli/app/command-sync.ts:150
+msgid "Synchronisation is already in progress."
+msgstr "Sincronizarea este deja în progres."
+
+#: packages/app-desktop/gui/MenuBar.tsx:541
+#: packages/app-desktop/gui/Root.tsx:195
+msgid "Synchronisation Status"
+msgstr "Starea sincronizării"
+
+#: packages/lib/models/settings/builtInMetadata.ts:100
+msgid "Synchronisation target"
+msgstr "Țintă de sincronizare"
+
+#: packages/app-cli/app/command-sync.ts:200
+msgid "Synchronisation target: %s (%s)"
+msgstr "Țintă sincronizare: %s (%s)"
+
+#: packages/app-desktop/gui/Sidebar/Sidebar.tsx:27
+#: packages/app-mobile/components/side-menu-content.tsx:650
+#: packages/lib/commands/synchronize.ts:8
+msgid "Synchronise"
+msgstr "Sincronizează"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1295
+msgid "Synchronise only over WiFi connection"
+msgstr "Sincronizare numai prin conexiune WiFi"
+
+#: packages/app-cli/app/command-sync.ts:36
+msgid "Synchronises with remote storage."
+msgstr "Sincronizarea cu stocarea de la distanță."
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:185
+msgid "Synchronising..."
+msgstr "Se sincronizează..."
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:363
+msgid "Synchronizing..."
+msgstr "Se sincronizează..."
+
+#: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
+msgid "Tab indents"
+msgstr "Tasta tab indentează"
+
+#: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
+#: packages/lib/models/settings/builtInMetadata.ts:713
+msgid "Tab moves focus"
+msgstr "Tasta tab mută focalizarea"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1310
+msgid "Tabloid"
+msgstr "Tabloid"
+
+#: packages/app-mobile/components/screens/NoteTagsDialog.tsx:215
+msgid "tag1, tag2, ..."
+msgstr "eticheta1, eticheta2, …"
+
+#: packages/app-cli/app/command-import.ts:55
+#: packages/app-desktop/gui/ImportScreen.tsx:94
+msgid "Tagged: %d."
+msgstr "Etichetate: %d."
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:10
+#: packages/app-desktop/gui/Sidebar/hooks/useSidebarListData.ts:75
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/setTags.ts:7
+#: packages/app-mobile/components/screens/Note/commands/setTags.ts:7
+#: packages/app-mobile/components/screens/tags.tsx:87
+#: packages/app-mobile/components/side-menu-content.tsx:622
+msgid "Tags"
+msgstr "Etichete"
+
+#: packages/app-mobile/components/CameraView/ActionButtons.tsx:111
+#: packages/app-mobile/components/screens/Note/commands/attachFile.ts:96
+msgid "Take photo"
+msgstr "Fotografiază"
+
+#: packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/TaskButton.tsx:73
+msgid "Task \"%s\" failed with error: %s"
+msgstr "Sarcina „%s” a eșuat cu eroarea: %s"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:87
+msgid "Task list"
+msgstr "Listă de sarcini"
+
+#: packages/server/src/services/MustacheService.ts:129
+#: packages/server/src/services/MustacheService.ts:283
+msgid "Tasks"
+msgstr "Sarcini"
+
+#: packages/lib/utils/joplinCloud/index.ts:391
+msgid "Teams"
+msgstr "Echipe"
+
+#: packages/lib/services/interop/InteropService.ts:136
+msgid "Text document"
+msgstr "Document text"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1303
+msgid "Text editor command"
+msgstr "Comandă editor de text"
+
+#: packages/lib/utils/joplinCloud/index.ts:167
+msgid ""
+"The [Web Clipper](%s) is a browser extension that allows you to save web "
+"pages and screenshots from your browser."
+msgstr ""
+"[Web Clipper](%s) este o extensie pentru navigatorul web care îți permite să "
+"salvezi pagini web și capturi de ecran direct din acesta."
+
+#: packages/lib/services/profileConfig/index.ts:106
+msgid ""
+"The active profile cannot be deleted. Switch to a different profile and try "
+"again."
+msgstr ""
+"Profilul activ nu poate fi șters. Treceți la un alt profil și încercați din "
+"nou."
+
+#: packages/app-desktop/bridge.ts:569
+msgid ""
+"The app is now going to close. Please relaunch it to complete the process."
+msgstr ""
+"Aplicația se va închide acum. Te rog să o relansați pentru a finaliza "
+"procesul."
+
+#: packages/app-desktop/app.ts:339
+msgid ""
+"The application did not close properly. Would you like to start in safe mode?"
+msgstr "Aplicația nu s-a închis corect. Doriți să porniți în modul sigur?"
+
+#: packages/lib/onedrive-api-node-utils.js:87
+msgid ""
+"The application has been authorised - you may now close this browser tab."
+msgstr ""
+"Aplicația a fost autorizată - acum poți închide această fereastră "
+"browserului."
+
+#: packages/lib/components/shared/dropbox-login-shared.js:39
+msgid "The application has been authorised!"
+msgstr "Aplicația a fost autorizată!"
+
+#: packages/lib/onedrive-api-node-utils.js:89
+msgid "The application has been successfully authorised."
+msgstr "Aplicația a fost autorizată cu succes."
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:327
+msgid "The application must be restarted for these changes to take effect."
+msgstr ""
+"Aplicația trebuie repornită pentru ca aceste modificări să intre în vigoare."
+
+#: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:566
+msgid ""
+"The attachments will no longer be watched when you switch to a different "
+"note."
+msgstr ""
+"Atașamentele nu vor mai fi urmărite atunci cînd treceți la o altă notă."
+
+#: packages/app-cli/app/app.ts:282
+msgid "The command \"%s\" is only available in GUI mode"
+msgstr "Comanda „%s” este disponibilă doar în modul GUI"
+
+#: packages/server/src/middleware/notificationHandler.ts:25
+msgid ""
+"The default admin password is insecure and has not been changed! [Change it "
+"now](%s)"
+msgstr ""
+"Parola implicită a administratorului este nesigură și nu a fost schimbată! "
+"[Change it now](%s)"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:344
+msgid ""
+"The default encryption method has been changed to a more secure one and it "
+"is recommended that you apply it to your data."
+msgstr ""
+"Metoda implicită de criptare a fost schimbată într-una mai sigură și se "
+"recomandă să o aplicați datelor dumnevoastră."
+
+#: packages/app-desktop/gui/MainScreen.tsx:554
+msgid ""
+"The default encryption method has been changed, you should re-encrypt your "
+"data."
+msgstr ""
+"Metoda implicită de criptare a fost modificată, ar trebui să vă criptați din "
+"nou datele."
+
+#: packages/lib/services/profileConfig/index.ts:105
+msgid "The default profile cannot be deleted"
+msgstr "Profilul implicit nu poate fi șters"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1303
+msgid ""
+"The editor command (may include arguments) that will be used to open a note. "
+"If none is provided it will try to auto-detect the default editor."
+msgstr ""
+"Comanda editorului (poate include argumente) care va fi utilizată pentru a "
+"deschide o notă. Dacă nu este furnizat niciunul, se va încerca să se "
+"detecteze automat editorul implicit."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1576
+#: packages/lib/models/settings/builtInMetadata.ts:1591
+#: packages/lib/models/settings/builtInMetadata.ts:1606
+msgid ""
+"The factor property sets how the item will grow or shrink to fit the "
+"available space in its container with respect to the other items. Thus an "
+"item with a factor of 2 will take twice as much space as an item with a "
+"factor of 1.Restart app to see changes."
+msgstr ""
+"Proprietatea factor stabilește modul în care elementul va crește sau se va "
+"micșora pentru a se potrivi spațiului disponibil în containerul său în "
+"raport cu celelalte elemente. Astfel, un element cu un factor de 2 va ocupa "
+"de două ori mai mult spațiu decît un element cu un factor de 1. Reporniți "
+"aplicația pentru a vedea modificările."
+
+#: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:581
+msgid "The following attachment matches your search query:"
+msgid_plural "The following attachments match your search query:"
+msgstr[0] "Următorul atașament corespunde căutării dumneavoastră:"
+msgstr[1] "Următoarele atașamente corespund căutării dumneavoastră:"
+msgstr[2] "Următoarele atașamente corespund căutării dumneavoastră:"
+
+#: packages/app-desktop/gui/NoteEditor/NoteEditor.tsx:565
+msgid "The following attachments are being watched for changes:"
+msgstr "Următoarele atașamente sînt urmărite pentru modificări:"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:75
+msgid ""
+"The following keys use an out-dated encryption algorithm and it is "
+"recommended to upgrade them. The upgraded key will still be able to decrypt "
+"and encrypt your data as usual."
+msgstr ""
+"Următoarele chei utilizează un algoritm de criptare depășit și se recomandă "
+"actualizarea lor. Cheia actualizată va fi în continuare capabilă să "
+"decripteze și să cripteze datele dumneavoastră ca de obicei."
+
+#: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:83
+msgid "The following plugins may not support the current markdown editor:"
+msgstr ""
+"Următoarele plugin-uri ar putea să nu fie suportate de editorul curent "
+"Markdown:"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:257
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/RecommendedBadge.tsx:49
+msgid ""
+"The Joplin team has vetted this plugin and it meets our standards for "
+"security and performance."
+msgstr ""
+"Echipa Joplin a verificat acest plugin și acesta îndeplinește standardele "
+"noastre de securitate și performanță."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:321
+msgid ""
+"The keys with these IDs are used to encrypt some of your items, however the "
+"application does not currently have access to them. It is likely they will "
+"eventually be downloaded via synchronisation."
+msgstr ""
+"Cheile cu aceste ID-uri sînt folosite pentru a cripta unele dintre "
+"elementele dvs., însă aplicația nu are în prezent acces la ele. Este "
+"probabil ca acestea să fie descărcate în cele din urmă prin sincronizare."
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:222
+msgid "The master key has been upgraded successfully!"
+msgstr "Cheia master a fost actualizată cu succes!"
+
+#: packages/app-mobile/components/screens/encryption-config.tsx:308
+msgid ""
+"The master keys with these IDs are used to encrypt some of your items, "
+"however the application does not currently have access to them. It is likely "
+"they will eventually be downloaded via synchronisation."
+msgstr ""
+"Cheile master cu aceste ID-uri sînt utilizate pentru a cripta unele dintre "
+"elementele dvs., însă aplicația nu are în prezent acces la ele. Este "
+"probabil ca acestea să fie descărcate în cele din urmă prin sincronizare."
+
+#: packages/lib/services/RevisionService.ts:274
+msgid "The note \"%s\" has been successfully restored to the notebook \"%s\"."
+msgstr "Notița „%s” a fost restaurată cu succes în caietul „%s”."
+
+#: packages/app-desktop/gui/TrashNotification/TrashNotification.tsx:45
+msgid "The note was successfully moved to the trash."
+msgid_plural "The notes were successfully moved to the trash."
+msgstr[0] "Notița a fost mutată cu succes în coșul de gunoi."
+msgstr[1] "Notițele au fost mutate cu succes în coșul de gunoi."
+msgstr[2] "Notițele au fost mutate cu succes în coșul de gunoi."
+
+#: packages/app-desktop/gui/TrashNotification/TrashNotification.tsx:43
+msgid "The notebook and its content was successfully moved to the trash."
+msgstr "Caietul și conținutul său au fost mutate cu succes în coșul de gunoi."
+
+#: packages/app-mobile/components/screens/folder.js:76
+msgid "The notebook could not be saved: %s"
+msgstr "Caietul de notițe nu a puut fi salvat: %s"
+
+#: packages/app-cli/app/command-import.ts:73
+#: packages/app-desktop/gui/ImportScreen.tsx:110
+msgid "The notes have been imported: %s"
+msgstr "Notițele au fost importante: %s"
+
+#: packages/app-cli/app/command-help.ts:74
+msgid "The possible commands are:"
+msgstr "Comenzile posibile sînt:"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:252
+msgid ""
+"The recipient could not be removed from the list. Please try again.\n"
+"\n"
+"The error was: \"%s\""
+msgstr ""
+"Destinatarul nu a putut fi eliminat din listă. Te rog să încercați din nou.\n"
+"\n"
+"Eroarea a fost: „%s”"
+
+#: packages/lib/models/settings/settingValidations.ts:35
+msgid ""
+"The sync target cannot be changed for the following reason: %s\n"
+"\n"
+"If the issue cannot be resolved, you may need to clear your data first by "
+"following these instructions:\n"
+"\n"
+"%s"
+msgstr ""
+"Ținta sincronizării nu poate fi schimbată din următorul motiv: %s\n"
+"\n"
+"Dacă problema nu poate fi rezolvată, va trebui să cureți datele mai întîi, "
+"urmînd următoarele instrucțiuni:\n"
+"\n"
+"%s"
+
+#: packages/app-desktop/gui/MainScreen.tsx:536
+msgid ""
+"The sync target needs to be upgraded before Joplin can sync. The operation "
+"may take a few minutes to complete and the app needs to be restarted. To "
+"proceed please click on the link."
+msgstr ""
+"Destinația de sincronizare trebuie să fie actualizată înainte ca Joplin să "
+"se poată sincroniza. Este posibil ca operațiunea să dureze cîteva minute "
+"pentru a fi finalizată, iar aplicația trebuie repornită. Pentru a continua, "
+"te rog să faci clic pe legătură."
+
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:46
+msgid "The sync target needs to be upgraded. Press this banner to proceed."
+msgstr ""
+"Destinația de sincronizare trebuie să fie actualizată. Apăsați acest banner "
+"pentru a continua."
+
+#: packages/app-desktop/gui/MainScreen.tsx:530
+msgid "The synchronisation password is missing."
+msgstr "Lipsește parola de sincronizare."
+
+#: packages/lib/models/Tag.ts:233
+msgid "The tag \"%s\" already exists. Please choose a different name."
+msgstr "Eticheta „%s” există deja. Te rog să alegeți un alt nume."
+
+#: packages/lib/models/settings/builtInMetadata.ts:102
+msgid ""
+"The target to synchronise to. Each sync target may have additional "
+"parameters which are named as `sync.NUM.NAME` (all documented below)."
+msgstr ""
+"Ținta la care se sincronizează. Fiecare țintă de sincronizare poate avea "
+"parametri suplimentari care sînt numiți `sync.NUM.NAME` (toți documentați "
+"mai jos)."
+
+#: packages/lib/services/share/invitationRespond.ts:22
+msgid ""
+"The web client does not support accepting encrypted shared notebooks. Please "
+"switch to the desktop or mobile app before accepting the share.\n"
+"\n"
+"Error: \"%s\""
+msgstr ""
+"Acceptarea caietelor partajate criptate din clientul web nu este suportată . "
+"Te rog comută la aplicația Desktop sau mobilă înainte de a accepta caietul "
+"partajat.\n"
+"\n"
+"Eroare: „%s”"
+
+#: packages/app-desktop/gui/Root.tsx:151
+msgid "The Web Clipper needs your authorisation to access your data."
+msgstr ""
+"Web Clipper are nevoie de autorizația dumneavoastră pentru a vă accesa "
+"datele."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:104
+msgid "The web clipper service cannot be enabled in this instance of Joplin."
+msgstr ""
+"Serviciul web clipper nu poate fi activat în această instanță de Joplin."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:79
+msgid "The web clipper service is enabled and set to auto-start."
+msgstr "Serviciul web clipper este activat și setat la pornire automată."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:110
+msgid "The web clipper service is not enabled."
+msgstr "Serviciul web clipper nu este activat."
+
+#: packages/lib/utils/webDAVUtils.ts:28
+msgid ""
+"The WebDAV implementation of %s is incompatible with Joplin, and as such is "
+"no longer supported. Please use a different sync method."
+msgstr ""
+"Implementarea WebDAV a lui %s este incompatibilă cu Joplin și, ca atare, nu "
+"mai este susținută. Te rog să folosiți o altă metodă de sincronizare."
+
+#: packages/lib/models/settings/builtInMetadata.ts:559
+msgid "Theme"
+msgstr "Temă"
+
+#: packages/lib/models/Setting.ts:1214
+msgid "Themes, editor font"
+msgstr "Teme, editor font"
+
+#: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:17
+msgid "There are currently no notes. Create one by clicking on the (+) button."
+msgstr "Momentan nu există notițe. Creează făcînd clic pe butonul (+)."
+
+#: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:9
+msgid "There are no notes in the trash folder."
+msgstr "Nu există notițe în coșul de gunoi."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:268
+msgid "There are unsaved changes."
+msgstr "Există schimbări nesalvate."
+
+#: packages/lib/services/interop/InteropService_Exporter_Jex.ts:36
+msgid "There is no data to export."
+msgstr "Nu există date de exportat."
+
+#: packages/lib/models/Resource.ts:510
+msgid ""
+"There was a [conflict](%s) on the attachment below.\n"
+"\n"
+"%s"
+msgstr ""
+"A existat un [conflict](%s) în atașamentul de mai jos.\n"
+"\n"
+"%s"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:50
+msgid "There was an error downloading this attachment:"
+msgstr "A apărut o eroare la descărcarea acestui atașament:"
+
+#: packages/lib/services/ReportService.ts:237
+msgid ""
+"These items failed to sync, but have been marked as \"ignored\". They won't "
+"cause the sync warning to appear, but still aren't synced. To unignore, "
+"click \"retry\"."
+msgstr ""
+"Sincronizarea acestor elemente a eșuat și au fost marcate ca „ignorate”. "
+"Astfel ele nu vor mai cauza apariția atenționărilor de sincronizare, dar "
+"nici nu vor fi sincronizate. Pentru a nu le marca ca ignorate, apară pe "
+"„reîncearcă”."
+
+#: packages/lib/services/ReportService.ts:187
+msgid ""
+"These items will remain on the device but will not be uploaded to the sync "
+"target. In order to find these items, either search for the title or the ID "
+"(which is displayed in brackets above)."
+msgstr ""
+"Aceste elemente vor rămîne pe dispozitiv, dar nu vor fi încărcate pe "
+"obiectivul de sincronizare. Pentru a găsi aceste elemente, căutați fie "
+"titlul, fie ID-ul (care este afișat în paranteze mai sus)."
+
+#: packages/lib/models/Setting.ts:1199
+msgid ""
+"These plugins enhance the Markdown renderer with additional features. Please "
+"note that, while these features might be useful, they are not standard "
+"Markdown and thus most of them will only work in Joplin. Additionally, some "
+"of them are *incompatible* with the WYSIWYG editor. If you open a note that "
+"uses one of these plugins in that editor, you will lose the plugin "
+"formatting. It is indicated below which plugins are compatible or not with "
+"the WYSIWYG editor."
+msgstr ""
+"Aceste plugin-uri îmbunătățesc funcția de redare Markdown cu caracteristici "
+"suplimentare. Te rog să reții că, deși aceste caracteristici ar putea fi "
+"utile, ele nu sînt Markdown standard și, prin urmare, cele mai multe dintre "
+"ele vor funcționa numai în Joplin. În plus, unele dintre ele sînt "
+"*incompatibile* cu editorul WYSIWYG. Dacă deschizi o notiță care utilizează "
+"unul dintre aceste plugin-uri în acel editor, vei pierde formatarea plugin-"
+"ului. Mai jos este indicat ce plugin-uri sînt compatibile sau nu cu editorul "
+"WYSIWYG."
+
+#: packages/lib/utils/joplinCloud/index.ts:174
+msgid ""
+"This allows another user to share a notebook with you, and you can then both "
+"collaborate on it. It does not however allow you to share a notebook with "
+"someone else, unless you have the feature \"%s\"."
+msgstr ""
+"Acest lucru permite unui alt utilizator să partajeze un caiet cu tine, iar "
+"apoi veți putea colabora amîndoi la el. Cu toate acestea, nu îți permite să "
+"partajezi un caiet cu altcineva, cu excepția cazului în care ai "
+"caracteristica „%s”."
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:148
+msgid "This attachment does not have OCR data (Status: %s)"
+msgstr "Acest atașament nu are date OCR (Stare: %s)"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:52
+#: packages/lib/services/ResourceEditWatcher/index.ts:241
+msgid "This attachment is not downloaded or not decrypted yet"
+msgstr "Acest atașament nu este descărcat sau nu este încă decriptat"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:159
+msgid ""
+"This authorisation token is only needed to allow third-party applications to "
+"access Joplin."
+msgstr ""
+"Acest token de autorizare este necesar doar pentru a permite aplicațiilor "
+"terțe părți să acceseze Joplin."
+
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:103
+msgid "This drawing may have unsaved changes."
+msgstr "Acest desen poate avea modificări nesalvate."
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:298
+msgid ""
+"This is an advanced tool to show the attachments that are linked to your "
+"notes. Please be careful when deleting one of them as they cannot be "
+"restored afterwards."
+msgstr ""
+"Acesta este un instrument avansat pentru a afișa atașamentele care sînt "
+"legate de notele dumnevoastră. Te rog să fiți atenți la ștergerea uneia "
+"dintre ele, deoarece acestea nu pot fi restaurate ulterior."
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:239
+msgid "This note could not be deleted: %s"
+msgid_plural "These notes could not be deleted: %s"
+msgstr[0] "Acest fișier nu a putut fi deschis: %s"
+msgstr[1] "Acest fișier nu a putut fi deschis: %s"
+msgstr[2] "Această notiță nu a putut fi ștearsă: %s"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:226
+msgid "This note could not be duplicated: %s"
+msgid_plural "These notes could not be duplicated: %s"
+msgstr[0] "Aceste notițe nu pot fi duplicate: %s"
+msgstr[1] "Caietul de notițe nu a puut fi salvat: %s"
+msgstr[2] "Caietul de notițe nu a puut fi salvat: %s"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:584
+msgid "This note could not be moved: %s"
+msgid_plural "These notes could not be moved: %s"
+msgstr[0] "Aceste notițe nu pot fi mutate: %s"
+msgstr[1] "Caietul de notițe nu a puut fi salvat: %s"
+msgstr[2] "Caietul de notițe nu a puut fi salvat: %s"
+
+#: packages/lib/models/Note.ts:130
+msgid "This note does not have geolocation information."
+msgstr "Această notă nu conține informații despre geolocalizare."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:229
+msgid "This note has been modified:"
+msgstr "Această notiță a fost modificată:"
+
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:639
+#: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx:239
+msgid ""
+"This note has no content. Click on \"%s\" to toggle the editor and edit the "
+"note."
+msgstr ""
+"Această notiță nu are conținut. Fă clic pe „%s” pentru a comuta editorul și "
+"a edita notița."
+
+#: packages/app-desktop/gui/NoteRevisionViewer.tsx:65
+msgid "This note has no history"
+msgstr "Această notă nu are istoric"
+
+#: packages/lib/services/plugins/PluginService.ts:535
+msgid "This plugin doesn't support %s."
+msgstr "Acest plugin nu suportă %s."
+
+#: packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.tsx:52
+msgid ""
+"This Rich Text editor has a number of limitations and it is recommended to "
+"be aware of them before using it."
+msgstr ""
+"Acest editor Rich Text are o serie de limitări și este recomandat să le "
+"cunoașteți înainte de a-l utiliza."
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:137
+msgid ""
+"This service allows the browser extension to communicate with Joplin. When "
+"enabling it your firewall may ask you to give permission to Joplin to listen "
+"to a particular port."
+msgstr ""
+"Acest serviciu permite extensia browserul-ui pentru a comunica cu Joplin. "
+"Atunci cînd se permite firewall poate cere să dea permisiunea Joplin pentru "
+"a asculta un anumit port."
+
+#: packages/lib/components/shared/NoteList/getEmptyFolderMessage.ts:11
+msgid "This subfolder of the trash has no notes."
+msgstr "Acest sub-dosar din coșul de gunoi nu conține notițe."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1030
+msgid ""
+"This will allow Joplin to run in the background. It is recommended to enable "
+"this setting so that your notes are constantly being synchronised, thus "
+"reducing the number of conflicts."
+msgstr ""
+"Acest lucru va permite ca Joplin să ruleze în fundal. Se recomandă să  "
+"această setare pentru ca notele dvs. să fie sincronizate în mod constant, "
+"reducînd astfel numărul de conflicte."
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:148
+msgid "This will open a new screen. Save your current changes?"
+msgstr ""
+"Se va deschide un nou ecran. Doriți să salvați modificările dumnevoastră "
+"actuale?"
+
+#: packages/app-desktop/commands/emptyTrash.ts:14
+#: packages/app-mobile/components/side-menu-content.tsx:340
+msgid "This will permanently delete all items in the trash. Continue?"
+msgstr ""
+"Acest lucru va șterge permanent toate elementele din coșul de gunoi. "
+"Continui?"
+
+#: packages/app-cli/app/command-rmnote.ts:40
+msgid "This will permanently delete the note \"%s\". Continue?"
+msgstr "Acest lucru va șterge permanent notița „%s”. Continui?"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/leaveSharedFolder.ts:17
+#: packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.tsx:60
+msgid ""
+"This will remove the notebook from your collection and you will no longer "
+"have access to its content. Do you wish to continue?"
+msgstr ""
+"Aceasta va elimina caietul din colecția ta și nu vei mai avea acces la "
+"conținutul său. Dorești să continui?"
+
+#: packages/lib/models/settings/builtInMetadata.ts:497
+msgid "Time format"
+msgstr "Format oră"
+
+#: packages/lib/models/Folder.ts:48 packages/lib/models/Note.ts:61
+msgid "title"
+msgstr "titlu"
+
+#: packages/app-desktop/gui/EditFolderDialog/Dialog.tsx:136
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:11
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:5
+#: packages/app-desktop/gui/ResourceScreen.tsx:110
+msgid "Title"
+msgstr "Titlu"
+
+#: packages/app-cli/app/command-sync.ts:81
+#: packages/app-desktop/gui/DropboxLoginScreen.tsx:45
+#: packages/app-mobile/components/screens/dropbox-login.tsx:62
+msgid ""
+"To allow Joplin to synchronise with Dropbox, please follow the steps below:"
+msgstr ""
+"Pentru a permite Joplin să se sincronizeze cu Dropbox, te rog urmează pașii "
+"de mai jos:"
+
+#: packages/app-cli/app/command-sync.ts:110
+#: packages/app-desktop/gui/JoplinCloudLoginScreen.tsx:84
+#: packages/app-mobile/components/screens/JoplinCloudLoginScreen.tsx:153
+msgid ""
+"To allow Joplin to synchronise with Joplin Cloud, please login using this "
+"URL:"
+msgstr ""
+"Pentru a permite Joplin să se sincronizeze cu Joplin Cloud, te rog "
+"autentifică-te folosind acest URL:"
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:53
+msgid "To continue, please enter your master password below."
+msgstr "Pentru a continua, te rog să întroduci parola principală mai jos."
+
+#: packages/app-cli/app/app-gui.js:458
+msgid "To delete a tag, untag the associated notes."
+msgstr ""
+"Pentru a șterge o eticheta, elimină eticheta respectivă din cadrul notițelor "
+"aferente."
+
+#: packages/lib/services/ReportService.ts:365
+msgid "To delete: %d"
+msgstr "De șters: %d"
+
+#: packages/app-cli/app/command-help.ts:83
+msgid "To enter command line mode, press \":\""
+msgstr "Pentru a intra în linia de comandă, tastează „:”"
+
+#: packages/app-cli/app/command-help.ts:84
+msgid "To exit command line mode, press ESCAPE"
+msgstr "Pentru a ieși din modul linie de comandă, apăsați ESCAPE"
+
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
+msgid ""
+"To manually sort the notes, the sort order must be changed to \"%s\" in the "
+"menu \"%s\" > \"%s\""
+msgstr ""
+"Pentru a sorta notițele manual, ordinea trebuie sa fie schimbată în „%s” în "
+"meniu „%s” > „%s”"
+
+#: packages/app-cli/app/command-help.ts:82
+msgid "To maximise/minimise the console, press \"tc\"."
+msgstr "Pentru a maximiza/minimiza consola, tastează „tc”."
+
+#: packages/app-cli/app/command-help.ts:80
+msgid "To move from one pane to another, press Tab or Shift+Tab."
+msgstr "Pentru a vă muta dintr-un panou în altul, apăsați Tab ori Shift+Tab."
+
+#: packages/app-cli/app/command-status.js:44
+msgid ""
+"To retry decryption of these items. Run `e2ee decrypt --retry-failed-items`"
+msgstr ""
+"Pentru a reîncerca decriptarea acestor elemente. Rulați `e2ee decrypt --"
+"retry-failed-items`"
+
+#: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:64
+msgid ""
+"To switch the profile, the app is going to close and you will need to "
+"restart it."
+msgstr ""
+"Pentru a schimba profilul, aplicația se va închide și va trebui să o "
+"reporniți."
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:587
+msgid ""
+"To work correctly, the app needs the following permissions. Please enable "
+"them in your phone settings, in Apps > Joplin > Permissions"
+msgstr ""
+"Pentru a funcționa corect, aplicația are nevoie de următoarele permisiuni. "
+"Te rog să le  în setările telefonului dumneavoastră, în Aplicații > Joplin > "
+"Permisiuni"
+
+#: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:119
+#: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:71
+msgid "to-do"
+msgstr "de făcut"
+
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:6
+msgid "To-do"
+msgstr "De făcut"
+
+#: packages/app-mobile/components/NoteItem.tsx:158
+msgid "to-do: %s"
+msgstr "de făcut: %s"
+
+#: packages/lib/commands/toggleAllFolders.ts:8
+msgid "Toggle all notebooks"
+msgstr "Comută toate caietele"
+
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:134
+msgid "Toggle comment"
+msgstr "Comută comentariu"
+
+#: packages/app-desktop/gui/MenuBar.tsx:961
+msgid "Toggle development tools"
+msgstr "Comută instrumentele de dezvoltare"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleVisiblePanes.ts:6
+msgid "Toggle editor layout"
+msgstr "Comută aspect editor"
+
+#: packages/lib/commands/toggleEditorPlugin.ts:11
+msgid "Toggle editor plugin"
+msgstr "Comută plugin editor"
+
+#: packages/app-desktop/commands/toggleTabMovesFocus.ts:8
+msgid "Toggle editor tab key navigation"
+msgstr "Comută navigarea în editor cu tasta tab"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleEditors.ts:8
+msgid "Toggle editors"
+msgstr "Comută editoarele"
+
+#: packages/app-desktop/commands/toggleExternalEditing.ts:8
+msgid "Toggle external editing"
+msgstr "Comută editare externă"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleMenuBar.ts:7
+msgid "Toggle menu bar"
+msgstr "Comută bară meniu"
+
+#: packages/lib/models/Setting.ts:1219
+msgid "Toggle note history, keep notes for"
+msgstr "Comută istoricul notițelor, păstrează notițele pentru"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNoteList.ts:10
+msgid "Toggle note list"
+msgstr "Comută listă de notițe"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/togglePerFolderSortOrder.ts:7
+msgid "Toggle own sort order"
+msgstr "Comută propria ordine de sortare"
+
+#: packages/app-mobile/components/ScreenHeader/index.tsx:434
+msgid "Toggle plugin editor"
+msgstr "Comută editor plugin"
+
+#: packages/app-desktop/commands/toggleSafeMode.ts:8
+msgid "Toggle safe mode"
+msgstr "Comută modul safe"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleSideBar.ts:10
+msgid "Toggle sidebar"
+msgstr "Comută panou lateral"
+
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderField.ts:7
+msgid "Toggle sort order field"
+msgstr "Comută cîmpul de ordine de sortare"
+
+#: packages/app-desktop/gui/ClipperConfigScreen.tsx:35
+msgid "Token has been copied to the clipboard!"
+msgstr "Token-ul a fost copiat în clipboard!"
+
+#: packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.ts:8
+msgid "Toolbar"
+msgstr "Bara de instrumente"
+
+#: packages/lib/models/Setting.ts:1188
+msgid "Tools"
+msgstr "Instrumente"
+
+#: packages/server/src/routes/admin/users.ts:152
+msgid "Total Size"
+msgstr "Dimensiunea totală"
+
+#: packages/lib/services/ReportService.ts:362
+msgid "Total: %d/%d"
+msgstr "Total: %d/%d"
+
+#: packages/lib/services/trash/index.ts:44
+msgid "Trash"
+msgstr "Coș de gunoi"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:319
+#: packages/app-mobile/components/biometrics/BiometricPopup.tsx:123
+msgid "Try again"
+msgstr "Încearcă din nou"
+
+#: packages/lib/utils/joplinCloud/index.ts:362
+#: packages/lib/utils/joplinCloud/index.ts:384
+#: packages/lib/utils/joplinCloud/index.ts:406
+msgid "Try it now"
+msgstr "Încearcă acum"
+
+#: packages/app-cli/app/command-help.ts:72
+msgid ""
+"Type `help [command]` for more information about a command; or type `help "
+"all` for the complete usage information."
+msgstr ""
+"Tastați `help [command]` pentru mai multe informații despre o comandă; sau "
+"tastați „help all\" pentru informații complete de utilizare."
+
+#: packages/app-cli/app/main.js:105
+msgid "Type `joplin help` for usage information."
+msgstr "Tastați `joplin help` pentru informații de utilizare."
+
+#: packages/app-desktop/plugins/GotoAnything.tsx:716
+msgid ""
+"Type a note title or part of its content to jump to it. Or type # followed "
+"by a tag name, or @ followed by a notebook name. Or type : to search for "
+"commands."
+msgstr ""
+"Tastați titlul unei notițe sau o parte din conținutul acesteia pentru a "
+"trece la ea. Sau tastați # urmat de numele unei etichete sau @ urmat de "
+"numele unui caiet. Sau tastați : pentru a căuta comenzi."
+
+#: packages/app-desktop/plugins/GotoAnything.tsx:714
+msgid "Type a note title to search for it."
+msgstr "Tastează un titlu de notiță pentru a-l căuta."
+
+#: packages/app-mobile/components/screens/NoteTagsDialog.tsx:235
+msgid "Type new tags or select from list"
+msgstr "Tastează etichete noi sau selectează din listă"
+
+#: packages/app-cli/app/help-utils.js:56
+msgid "Type: %s."
+msgstr "Tip: %s."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:991
+msgid "Unable to edit resource of type %s"
+msgstr "Nu se poate edita resursa de tip %s"
+
+#: packages/app-mobile/components/screens/LogScreen.tsx:108
+msgid "Unable to share log data. Reason: %s"
+msgstr "Imposibilitatea de a partaja datele din jurnal. Motivul: %s"
+
+#: packages/app-mobile/components/Checkbox.tsx:51
+msgid "Unchecked"
+msgstr "Debifat"
+
+#: packages/lib/models/settings/builtInMetadata.ts:632
+msgid "Uncompleted to-dos on top"
+msgstr "Sarcini nefinalizate în partea de sus"
+
+#: packages/app-desktop/gui/MenuBar.tsx:763
+#: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:118
+#: packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx:167
+#: packages/app-mobile/components/ScreenHeader/index.tsx:343
+msgid "Undo"
+msgstr "Anulează"
+
+#: packages/lib/models/settings/settingValidations.ts:32
+msgid ""
+"Uninstall and reinstall the application. Make sure you create a backup first "
+"by exporting all your notes as JEX from the desktop application."
+msgstr ""
+"Dezinstalează și reinstalează aplicația. Asigură-te că creezi mai întîi o "
+"copie de siguranță prin exportarea tuturor notițelor ca fișiere JEX din "
+"aplicația Desktop."
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:13
+#: packages/app-mobile/utils/getVersionInfoText.ts:14
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: packages/app-desktop/bridge.ts:458
+msgid "Unknown file type"
+msgstr "Tip de fișier necunoscut"
+
+#: packages/lib/utils/processStartFlags.ts:209
+msgid "Unknown flag: %s"
+msgstr "Unknown flag: %s"
+
+#: packages/lib/Synchronizer.ts:1135
+msgid ""
+"Unknown item type downloaded - please upgrade Joplin to the latest version"
+msgstr ""
+"Tip de element necunoscut descărcat - te rog să actualizați Joplin la cea "
+"mai recentă versiune"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:28
+msgid "Unknown platform"
+msgstr "Platformă necunoscută"
+
+#: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:82
+msgid "Unordered list"
+msgstr "Listă neordonată"
+
+#: packages/app-desktop/gui/ShareNoteDialog.tsx:165
+msgid "Unpublish note"
+msgstr "Notă de retragere a publicării"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:168
+msgid "Unshare"
+msgstr "Unsoare"
+
+#: packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx:387
+msgid ""
+"Unshare this notebook? The recipients will no longer have access to its "
+"content."
+msgstr ""
+"Anulezi partajarea acestui caiet? Destinatarii nu vor mai avea acces la "
+"conținutul acestuia."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:856
+msgid "Unsupported image type: %s"
+msgstr "Tip de imagine neacceptat: %s"
+
+#: packages/app-desktop/gui/NoteRevisionViewer.tsx:136
+#: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts:47
+msgid "Unsupported link or message: %s"
+msgstr "Legătură sau mesaj nesuportat: %s"
+
+#: packages/app-mobile/commands/openItem.ts:60
+msgid ""
+"Unsupported link or message: %s.\n"
+"Error: %s"
+msgstr ""
+"Legătură sau mesaj nesuportat: %s.\n"
+"Eroare: %s"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:123
+#: packages/lib/models/BaseItem.ts:924 packages/lib/path-utils.ts:27
+#: packages/lib/path-utils.ts:71
+msgid "Untitled"
+msgstr "Fără nume"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:206
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:172
+msgid "Update"
+msgstr "Actualizează"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/PluginChips.tsx:77
+msgid "Update available"
+msgstr "Actualizare disponibilă"
+
+#: packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx:53
+msgid "Update later"
+msgstr "Actualizează mai tîrziu"
+
+#: packages/server/src/routes/admin/users.ts:257
+#: packages/server/src/routes/index/users.ts:91
+msgid "Update profile"
+msgstr "Actualizează profilul"
+
+#: packages/server/src/services/TaskService.ts:23
+msgid "Update total sizes"
+msgstr "Actualizează dimensiunile totale"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:208
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:209
+#: packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts:15
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:82
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:171
+msgid "Updated"
+msgstr "Actualizat"
+
+#: packages/lib/models/Folder.ts:49 packages/lib/models/Note.ts:62
+msgid "updated date"
+msgstr "data actualizării"
+
+#: packages/lib/Synchronizer.ts:200
+msgid "Updated local items: %d."
+msgstr "Elemente locale actualizate: %d."
+
+#: packages/lib/Synchronizer.ts:202
+msgid "Updated remote items: %d."
+msgstr "Elemente la distanță actualizate: %d."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:140
+msgid "Updated: "
+msgstr "Actualizat: "
+
+#: packages/app-cli/app/command-import.ts:52
+#: packages/app-desktop/gui/ImportScreen.tsx:91
+msgid "Updated: %d."
+msgstr "Actualizat: %d."
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1085
+msgid "Updated: %s"
+msgstr "Actualizat: %s"
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginBox.tsx:207
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx:170
+msgid "Updating..."
+msgstr "Se actualizează…"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:80
+msgid "Upgrade"
+msgstr "Actualizare majoră"
+
+#: packages/app-cli/app/command-sync.ts:42
+msgid "Upgrade the sync target to the latest version."
+msgstr "Actualizează ținta de sincronizare la cea mai recentă versiune."
+
+#: packages/app-desktop/gui/NotePropertiesDialog.tsx:86
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:109
+#: packages/app-mobile/components/NoteEditor/EditLinkDialog.tsx:112
+msgid "URL"
+msgstr "URL"
+
+#: packages/lib/utils/processStartFlags.ts:31
+#: packages/lib/utils/processStartFlags.ts:44
+#: packages/lib/utils/processStartFlags.ts:95
+msgid "Usage: %s"
+msgstr "Utilizare: %s"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1656
+msgid "Use biometrics to secure access to the app"
+msgstr "Folosește date biometrice pentru a securiza accesul la aplicație"
+
+#: packages/app-cli/app/command-ls.ts:33 packages/app-cli/app/command-tag.js:18
+msgid ""
+"Use long list format. Format is ID, NOTE_COUNT (for notebook), DATE, "
+"TODO_CHECKED (for to-dos), TITLE"
+msgstr ""
+"Utilizează formatul lung al listei. Formatul este ID, NOTE_COUNT (pentru "
+"caiet), DATE, TODO_CHECKED (pentru liste de făcut), TITLE"
+
+#: packages/lib/services/spellChecker/SpellCheckerService.ts:185
+msgid "Use spell checker"
+msgstr "Folosește corectorul ortografic"
+
+#: packages/app-cli/app/command-help.ts:81
+msgid ""
+"Use the arrows and page up/down to scroll the lists and text areas "
+"(including this console)."
+msgstr ""
+"Folosește săgețile și tastele „page up/down” pentru a derula listele și "
+"zonele de text (inclusiv această consolă)."
+
+#: packages/app-desktop/gui/MainScreen.tsx:794
+msgid "Use the arrows to move the layout items. Press \"Escape\" to exit."
+msgstr ""
+"Folosiți săgețile pentru a muta elementele de prezentare. Apăsați “Escape” "
+"pentru a ieși."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1402
+msgid "Use the legacy Markdown editor"
+msgstr "Folosește editorul Markdown învechit"
+
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:552
+msgid ""
+"Use this to rebuild the search index if there is a problem with search. It "
+"may take a long time depending on the number of notes."
+msgstr ""
+"Folosește această opțiune pentru a reconstrui indexul de căutare dacă există "
+"o problemă cu căutarea. Poate dura mult timp, în funcție de numărul de "
+"notițe."
+
+#: packages/app-mobile/components/biometrics/BiometricPopup.tsx:83
+msgid ""
+"Use your biometrics to secure access to your application. You can always set "
+"it up later in Settings."
+msgstr ""
+"Folosiți datele biometrice pentru a securiza accesul la aplicația dvs. "
+"Puteți oricînd să o configurați mai tîrziu în Setări."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1137
+msgid ""
+"Used for most text in the markdown editor. If not found, a generic "
+"proportional (variable width) font is used."
+msgstr ""
+"Folosit pentru majoritatea textului din editorul markdown. Dacă nu se "
+"găsește, se utilizează un font generic proporțional (cu lățime variabilă)."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1150
+msgid ""
+"Used where a fixed width font is needed to lay out text legibly (e.g. "
+"tables, checkboxes, code). If not found, a generic monospace (fixed width) "
+"font is used."
+msgstr ""
+"Se utilizează atunci cînd este necesar un font cu lățime fixă pentru a "
+"prezenta textul în mod lizibil (de exemplu, tabele, căsuțe de selectare, "
+"coduri). Dacă nu se găsește, se utilizează un font generic monospace (lățime "
+"fixă)."
+
+#: packages/server/src/services/MustacheService.ts:125
+msgid "User deletions"
+msgstr "Ștergeri de utilizatori"
+
+#: packages/server/src/routes/admin/users.ts:197
+#: packages/server/src/services/MustacheService.ts:121
+#: packages/server/src/services/MustacheService.ts:280
+msgid "Users"
+msgstr "Utilizatori"
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:171
+#: packages/app-desktop/gui/PasswordInput/LabelledPasswordInput.tsx:23
+#: packages/app-mobile/components/screens/encryption-config.tsx:122
+msgid "Valid"
+msgstr "Valid"
+
+#: packages/app-mobile/components/biometrics/biometricAuthenticate.ts:10
+msgid "Verify your identity"
+msgstr "Verificați identitatea dumneavoastră"
+
+#: packages/app-desktop/gui/NoteList/utils/canManuallySortNotes.ts:10
+msgid "View"
+msgstr "Vizualizează"
+
+#: packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts:139
+msgid "View OCR text"
+msgstr "Vizualizează textul OCR"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1089
+msgid "View on map"
+msgstr "Vizualizează pe hartă"
+
+#: packages/app-desktop/gui/MainScreen.tsx:543
+#: packages/app-desktop/gui/MainScreen.tsx:549
+#: packages/app-desktop/gui/MainScreen.tsx:572
+msgid "View them now"
+msgstr "Vizualizează-le acum"
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:145
+#: packages/lib/models/settings/builtInMetadata.ts:624
+#: packages/lib/models/settings/builtInMetadata.ts:625
+#: packages/lib/models/settings/builtInMetadata.ts:627
+msgid "Viewer"
+msgstr "Vizualizator"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1083
+msgid "Viewer font size"
+msgstr "Mărime font vizualizator"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1346
+msgid "Vim"
+msgstr "Vim"
+
+#: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:224
+msgid "Voice recorder"
+msgstr "Înregistrator vocal"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1772
+msgid "Voice typing language files (URL)"
+msgstr "Fișiere de limbă de tastare vocală (URL)"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:1236
+#: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:205
+msgid "Voice typing..."
+msgstr "Tastarea vocală…"
+
+#: packages/lib/models/settings/builtInMetadata.ts:1791
+msgid "Vosk"
+msgstr "Vosk"
+
+#: packages/lib/services/joplinCloudUtils.ts:27
+msgid "Waiting for authorisation..."
+msgstr "Se așteaptă autorizarea..."
+
+#: packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx:224
+#: packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx:122
+msgid "Warning"
+msgstr "Atenție"
+
+#: packages/app-desktop/gui/ResourceScreen.tsx:316
+msgid "Warning: not all resources shown for performance reasons (limit: %s)."
+msgstr ""
+"Atenție: nu toate resursele sînt afișate din motive de performanță (limită: "
+"%s)."
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:116
+msgid "We have a system for reporting and removing problematic plugins."
+msgstr ""
+"Dispunem de un sistem pentru raportarea și eliminarea plugin-urilor "
+"problematice."
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:114
+msgid ""
+"We mark plugins developed by trusted Joplin community members as "
+"\"recommended\"."
+msgstr ""
+"Marcăm plugin-urile dezvoltate de membri de încredere ai comunității Joplin "
+"ca „recomandate”."
+
+#: packages/lib/models/Setting.ts:1185
+#: packages/lib/utils/joplinCloud/index.ts:166
+msgid "Web Clipper"
+msgstr "Web Clipper"
+
+#: packages/lib/SyncTargetWebDAV.js:24
+msgid "WebDAV"
+msgstr "WebDAV"
+
+#: packages/lib/models/settings/builtInMetadata.ts:219
+msgid "WebDAV password"
+msgstr "Parolă WebDAV"
+
+#: packages/lib/models/settings/builtInMetadata.ts:194
+msgid "WebDAV URL"
+msgstr "URL-ul WebDAV"
+
+#: packages/lib/models/settings/builtInMetadata.ts:207
+msgid "WebDAV username"
+msgstr "Nume utilizator WebDAV"
+
+#: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:20
+#: packages/app-desktop/gui/MenuBar.tsx:938
+msgid "Website and documentation"
+msgstr "Website și documentație"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:14
+msgid "WebView package: %s"
+msgstr "Pachet WebView: %s"
+
+#: packages/app-mobile/utils/getVersionInfoText.ts:13
+msgid "WebView version: %s"
+msgstr "Versiune WebView: %s"
+
+#: packages/app-cli/app/gui/NoteWidget.js:36
+msgid ""
+"Welcome to Joplin!\n"
+"\n"
+"Type `:help shortcuts` for the list of keyboard shortcuts, or just `:help` "
+"for usage information.\n"
+"\n"
+"For example, to create a notebook press `mb`; to create a note press `mn`."
+msgstr ""
+"Bine ai venit în Joplin!\n"
+"\n"
+"Tastează `:help shortcuts` pentru afișarea listei de scurtături sau doar "
+"`:help` pentru informații despre utilizare.\n"
+"\n"
+"De exemplu, pentru a crea un caiet de notițe apasă `mb`; pentru a crea o "
+"notiță apasă `mn`."
+
+#: packages/lib/WelcomeUtils.ts:63
+msgid "Welcome!"
+msgstr "Bine ai venit!"
+
+#: packages/app-mobile/components/screens/ConfigScreen/plugins/EnablePluginSupportPage.tsx:100
+msgid "What are plugins?"
+msgstr "Ce sînt plugin-urile?"
+
+#: packages/lib/models/settings/builtInMetadata.ts:866
+msgid "When creating a new note:"
+msgstr "Cînd este creată o nouă notiță:"
+
+#: packages/lib/models/settings/builtInMetadata.ts:849
+msgid "When creating a new to-do:"
+msgstr "Cînd este creată o nouă listă de făcut:"
+
+#: packages/lib/models/settings/builtInMetadata.ts:517
+msgid ""
+"When enabled, the application will scan your attachments and extract the "
+"text from it. This will allow you to search for text in these attachments."
+msgstr ""
+"Atunci cînd este activată, aplicația va scana atașamentele și va extrage "
+"textul din ele. Acest lucru vă va permite să căutați text în aceste "
+"atașamente."
+
+#: packages/lib/models/settings/builtInMetadata.ts:1792
+msgid "Whisper"
+msgstr "Whisper"
+
+#: packages/app-desktop/ElectronAppWrapper.ts:249
+msgid "Window unresponsive."
+msgstr "Fereastra nu răspunde."
+
+#: packages/app-desktop/gui/NoteContentPropertiesDialog.tsx:105
+msgid "Words"
+msgstr "Cuvinte"
+
+#: packages/app-cli/app/setupCommand.ts:23
+msgid "y"
+msgstr "y"
+
+#: packages/app-cli/app/cli-utils.js:177
+#: packages/app-cli/app/setupCommand.ts:23
+msgid "Y"
+msgstr "Y"
+
+#: packages/lib/models/settings/builtInMetadata.ts:35
+msgid "yes"
+msgstr "da"
+
+#: packages/app-desktop/services/plugins/UserWebviewDialogButtonBar.tsx:21
+#: packages/app-mobile/components/screens/Note/Note.tsx:758
+#: packages/lib/shim-init-node.ts:274 packages/lib/versionInfo.ts:92
+msgid "Yes"
+msgstr "Da"
+
+#: packages/app-mobile/components/screens/Note/Note.tsx:757
+#: packages/lib/shim-init-node.ts:273
+msgid ""
+"You are about to attach a large image (%dx%d pixels). Would you like to "
+"resize it down to %d pixels before attaching it?"
+msgstr ""
+"Ești pe cale să atașezi o imagine mare (%dx%d pixeli). Doriți să îl "
+"redimensionați pînă la %d pixeli înainte de a-l atașa?"
+
+#: packages/lib/services/joplinCloudUtils.ts:45
+msgid "You are logged in into Joplin Cloud, you can leave this screen now."
+msgstr "Ești autentificat la Joplin Cloud, poți acum să părăsești acest ecran."
+
+#: packages/app-desktop/gui/MainScreen.tsx:585
+msgid ""
+"You are running the Intel version of Joplin on an Apple Silicon processor. "
+"Download the Apple Silicon one for better performance."
+msgstr ""
+"Rulezi versiunea Intel a Joplin pe un procesor cu siliciu Apple. Descarcă "
+"versiunea pentru procesoare Apple pentru o performanță mai mare."
+
+#: packages/app-mobile/components/NoteList.tsx:98
+msgid "You currently have no notebooks."
+msgstr "Nu aveți niciun caiet de notițe activ."
+
+#: packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx:280
+msgid "You do not have any installed plugin."
+msgstr "Nu aveți niciun plugin instalat."
+
+#: packages/app-cli/app/gui/NoteWidget.js:50
+msgid "You may also type `status` for more information."
+msgstr "De asemenea, poți tasta `status` pentru mai multe informații."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:344
+msgid ""
+"You may use the tool below to re-encrypt your data, for example if you know "
+"that some of your notes are encrypted with an obsolete encryption method."
+msgstr ""
+"Puteți utiliza instrumentul de mai jos pentru a vă cripta din nou datele, de "
+"exemplu, dacă știți că unele note sînt criptate cu o metodă de criptare "
+"învechită."
+
+#: packages/lib/services/joplinCloudUtils.ts:53
+msgid ""
+"You were unable to connect to Joplin Cloud. Please check your credentials "
+"and try again. Error:"
+msgstr ""
+"Nu ai putut să te conectezi la Joplin Cloud. Te rog verifică-ți datele de "
+"conectare și încearcă din nou. Eroare:"
+
+#: packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:55
+#: packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.tsx:70
+msgid "Your account doesn't have access to this feature"
+msgstr "Contul tău nu are acces la această funcție"
+
+#: packages/app-cli/app/cli-utils.js:160
+msgid "Your choice: "
+msgstr "Alegerea ta: "
+
+#: packages/lib/components/EncryptionConfigScreen/utils.ts:70
+msgid "Your data is going to be re-encrypted and synced again."
+msgstr "Datele tale vor fi recriptate și sincronizate din nou."
+
+#: packages/app-desktop/gui/MainScreen.tsx:591
+#: packages/app-mobile/components/ScreenHeader/WarningBanner.tsx:55
+msgid "Your Joplin Cloud credentials are invalid, please login."
+msgstr ""
+"Datele tale de conectare la Joplin Cloud sînt invalide, te rog autentifică-"
+"te din nou."
+
+#: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:259
+msgid "Your password is needed to decrypt some of your data."
+msgstr "Parola dvs. este necesară pentru a decripta unele dintre datele dvs."
+
+#: packages/app-cli/app/command-sync.ts:262
+msgid ""
+"Your password is needed to decrypt some of your data. Type `:e2ee decrypt` "
+"to set it."
+msgstr ""
+"Parola ta este necesară pentru a decripta unele dintre date. Tastează `:e2ee "
+"decrypt` pentru a o seta."
+
+#: packages/app-desktop/checkForUpdates.ts:108
+msgid "Your version: %s"
+msgstr "Versiunea ta: %s"
+
+#: packages/app-desktop/gui/MenuBar.tsx:859
+#: packages/app-desktop/gui/MenuBar.tsx:865
+msgid "Zoom In"
+msgstr "Mărește"
+
+#: packages/app-desktop/gui/MenuBar.tsx:872
+msgid "Zoom Out"
+msgstr "Micșorează"
+
+#~ msgid "Close menu"
+#~ msgstr "Închide meniul"
+
+#~ msgid "Collapsed, press space to expand."
+#~ msgstr "Restrîns, apasă spațiu pentru a extinde."
+
+#~ msgid ""
+#~ "Delete model and re-download?\n"
+#~ "This cannot be undone."
+#~ msgstr ""
+#~ "Ștergi modelul și îl descarci din nou?\n"
+#~ "Acest lucru nu poate fi anulat."
+
+#~ msgid "Download updated model"
+#~ msgstr "Descarcă modelul actualizat"
+
+#~ msgid "Edit in..."
+#~ msgstr "Editează în..."
+
+#~ msgid "Expanded, press space to collapse."
+#~ msgstr "Extins, apasă spațiu pentru a restrînge."
+
+#, fuzzy
+#~ msgid "Take picture"
+#~ msgstr "Desenați imaginea"
+
+#~ msgid ""
+#~ "Biometric unlock is not setup on the device. Please set it up in order to "
+#~ "unlock Joplin. If the device is on lockout, consider switching it off and "
+#~ "on to reset biometrics scanning."
+#~ msgstr ""
+#~ "Deblocarea biometrică nu este configurată pe dispozitiv. Vă rugăm să îl "
+#~ "configurați pentru a debloca Joplin. Dacă dispozitivul este blocat, luați "
+#~ "în considerare oprirea și pornirea acestuia pentru a reseta scanarea "
+#~ "biometrică."
+
+#, fuzzy
+#~ msgid "Collapse %s"
+#~ msgstr "Restrînge"
+
+#~ msgid "Find and replace"
+#~ msgstr "Găsiți și înlocuiți"
+
+#~ msgid "Formatting"
+#~ msgstr "Formatare"
+
+#~ msgid "Headers"
+#~ msgstr "Headers"
+
+#~ msgid "Hide more actions"
+#~ msgstr "Ascundeți mai multe acțiuni"
+
+#~ msgid "KaTeX"
+#~ msgstr "KaTeX"
+
+#~ msgid "Links with protocol \"%s\" are not supported"
+#~ msgstr "Legăturile cu protocolul “%s” nu sînt acceptate"
+
+#~ msgid "Lists"
+#~ msgstr "Liste"
+
+#~ msgid "No item with ID %s"
+#~ msgstr "Niciun item cu ID-ul %s"
+
+#~ msgid "Permission to use camera"
+#~ msgstr "Permisiunea de a utliza camera"
+
+#~ msgid "Show more actions"
+#~ msgstr "Afișare mai multe acțiuni"
+
+#~ msgid ""
+#~ "The Joplin mobile app does not currently support this type of link: %s"
+#~ msgstr "Aplicația mobilă Joplin nu acceptă în prezent acest tip de link: %s"
+
+#~ msgid "This attachment is not downloaded or not decrypted yet."
+#~ msgstr "Acest atașament nu este descărcat sau nu este încă decriptat."
+
+#~ msgid "Your permission to use your camera is required."
+#~ msgstr "Este necesară permisiunea dumnevoastră de a utiliza camera."
+
+#, fuzzy
+#~ msgid "From a plugin"
+#~ msgstr "Navigați toate plugin-urile"
+
+#, fuzzy
+#~ msgid "Browse and install community plugins."
+#~ msgstr "Navigați toate plugin-urile"
+
+#, fuzzy
+#~ msgid "Install new plugins"
+#~ msgstr "Navigați toate plugin-urile"
+
+#, fuzzy
+#~ msgid "Installed plugins"
+#~ msgstr "Instalat"
+
+#, fuzzy
+#~ msgid "Search plugins"
+#~ msgstr "Căutare de plugin-uri…"
+
+#, fuzzy
+#~ msgid "You currently have %d plugin installed."
+#~ msgid_plural "You currently have %d plugins installed."
+#~ msgstr[0] "Nu aveți niciun caiet de notițe activ."
+#~ msgstr[1] "Nu aveți niciun caiet de notițe activ."
+#~ msgstr[2] "Nu aveți niciun caiet de notițe activ."
+
+#, fuzzy
+#~ msgid "Incoming shares"
+#~ msgstr "Alarmele următoare"
+
+#, fuzzy
+#~ msgid "Leave share"
+#~ msgstr "Salvați schimbările"
+
+#, fuzzy
+#~ msgid "Loading plugin repository..."
+#~ msgstr "Nu s-a putut conecta la repozitoriul de plugin-uri."
+
+#, fuzzy
+#~ msgid "No description"
+#~ msgstr "Descriere link"
+
+#~ msgid "Folders"
+#~ msgstr "Fișiere"
+
+#~ msgid "Database v%s"
+#~ msgstr "Baza de date v%s"
+
+#~ msgid ""
+#~ "There is currently no notebook. Create one by clicking on \"New "
+#~ "notebook\"."
+#~ msgstr ""
+#~ "În prezent, nu există niciun notebook. Creați unul făcînd clic pe "
+#~ "“Notebook nou”."
+
+#~ msgid "Unable to export or share data. Reason: %s"
+#~ msgstr "Imposibilitatea de a exporta sau de a partaja date. Motivul: %s"
+
+#~ msgid ""
+#~ "Warnings:\n"
+#~ "%s"
+#~ msgstr "Avertizare: %s"
+
+#, fuzzy
+#~ msgid ""
+#~ "To allow Joplin to synchronise with Joplin Cloud, open this URL in your "
+#~ "browser to authorise the application:"
+#~ msgstr ""
+#~ "Pasul 1: Deschideți adresa URL în navigatorul dumneavoastră web pentru a "
+#~ "autoriza aplicația:"
+
+#~ msgid "Delete note?"
+#~ msgstr "Ștergeți notița?"
+
+#~ msgid "Joplin Cloud email"
+#~ msgstr "Joplin Cloud email"
+
+#~ msgid "Joplin Cloud password"
+#~ msgstr "Joplin Cloud parolă"
+
+#~ msgid "Login"
+#~ msgstr "Login"
+
+#~ msgid "Login below."
+#~ msgstr "Autentificați-vă mai jos."
+
+#~ msgid "Or create an account."
+#~ msgstr "Sau creați-vă un cont."
+
+#~ msgid "Thank you! Your Joplin Cloud account is now setup and ready to use."
+#~ msgstr ""
+#~ "Vă mulțumesc! Contul dumneavoastră Joplin Cloud este acum configurat și "
+#~ "gata de utilizare."
+
+#, fuzzy
+#~ msgid "%s: Missing password"
+#~ msgstr "Introduceți parola master:"
+
+#, fuzzy
+#~ msgid "Share and collaborate on a notebook"
+#~ msgstr "Notițele pot fi create numai în cadrul unui caiet de notițe."
+
+#~ msgid "Encrypted notebooks cannot be renamed"
+#~ msgstr "Itemii criptați nu pot fi editați"
+
+#, fuzzy
+#~ msgid "Changes have been saved"
+#~ msgstr "Notița a fost salvată."
+
+#, fuzzy
+#~ msgid "Create KaTeX region"
+#~ msgstr "Creat: %s"
+
+#, fuzzy
+#~ msgid "Create link"
+#~ msgstr "Creat"
+
+#, fuzzy
+#~ msgid "Remove KaTeX region"
+#~ msgstr "Creat: %s"
+
+#, fuzzy
+#~ msgid "Unitalic"
+#~ msgstr "Italic"
+
+#, fuzzy
+#~ msgid "Bold text"
+#~ msgstr "Bold"
+
+#, fuzzy
+#~ msgid "Edit Link"
+#~ msgstr "Editați caietul de notițe"
+
+#~ msgid "Insert Date Time"
+#~ msgstr "Introduceți data și ora"
+
+#, fuzzy
+#~ msgid "Italicize"
+#~ msgstr "Italic"
+
+#, fuzzy
+#~ msgid "Save as SVG"
+#~ msgstr "Salvați ca..."
+
+#~ msgid "Automatically update the application"
+#~ msgstr "Actualizați automat aplicația"
+
+#~ msgid "Notebook title:"
+#~ msgstr "Titlul agendei:"
+
+#~ msgid "AWS S3"
+#~ msgstr "AWS S3"
+
+#~ msgid "Master keys that need upgrading"
+#~ msgstr "Chei master care necesită actualizare"
+
+#~ msgid ""
+#~ "The following master keys use an out-dated encryption algorithm and it is "
+#~ "recommended to upgrade them. The upgraded master key will still be able "
+#~ "to decrypt and encrypt your data as usual."
+#~ msgstr ""
+#~ "Următoarele chei master utilizează un algoritm de criptare învechit și se "
+#~ "recomandă actualizarea acestora. Cheia principală actualizată va putea în "
+#~ "continuare să decripteze și să cripteze datele dumnevoastră ca de obicei."
+
+#, fuzzy
+#~ msgid "Master Keys"
+#~ msgstr "Cheia master %s"
+
+#~ msgid "Password OK"
+#~ msgstr "Parolă OK"
+
+#~ msgid "Encryption is:"
+#~ msgstr "Criptarea este:"
+
+#, javascript-format
+#~ msgid "%s %s (%s)"
+#~ msgstr "%s %s (%s)"
+
+#~ msgid "Insert template"
+#~ msgstr "Inserați șablonul"
+
+#~ msgid "Template file:"
+#~ msgstr "Fișier template:"
+
+#~ msgid "Create note from template"
+#~ msgstr "Creați o notă din șablon"
+
+#~ msgid "Create to-do from template"
+#~ msgstr "Creați to-do din șablon"
+
+#~ msgid "Open template directory"
+#~ msgstr "Deschideți directorul șablonului"
+
+#~ msgid "Refresh templates"
+#~ msgstr "Actualizați șabloanele"
+
+#~ msgid "Templates"
+#~ msgstr "Șabloane"
+
+#~ msgid "Share Notes"
+#~ msgstr "Distribuie notițe"
+
+#, fuzzy
+#~ msgid "Joplin Server Directory"
+#~ msgstr "Deschideți directorul șablonului"
+
+#, fuzzy
+#~ msgid "marked text"
+#~ msgstr "text accentuat"
+
+#, fuzzy
+#~ msgid "Mark"
+#~ msgstr "Markup"
+
+#~ msgid "Full Release Notes"
+#~ msgstr "Descrierea versiunii instalate"
+
+#~ msgid "Checking..."
+#~ msgstr "Verificare..."
+
+#~ msgid ""
+#~ "The Joplin Nextcloud App is either not installed or misconfigured. Please "
+#~ "see the full error message below:"
+#~ msgstr ""
+#~ "Aplicația Joplin Nextcloud nu este instalată sau configurată greșit. "
+#~ "Consultați mesajul de eroare complet de mai jos:"
+
+#~ msgid "Show Log"
+#~ msgstr "Afișați log"
+
+#~ msgid "Joplin Nextcloud App status:"
+#~ msgstr "Joplin Nextcloud App status:"
+
+#~ msgid "Check Status"
+#~ msgstr "Verificare Status"
+
+#~ msgid "OneDrive Dev (For testing only)"
+#~ msgstr "OneDrive Dev (Doar pentru teste)"
+
+#~ msgid ""
+#~ "Type a note title or part of its content to jump to it. Or type # "
+#~ "followed by a tag name, or @ followed by a notebook name."
+#~ msgstr ""
+#~ "Tastați un titlu de notă sau o parte din conținutul acesteia pentru a "
+#~ "trece la ea. Sau tastați # urmat de un nume de etichetă sau @ urmat de un "
+#~ "nume de agendă."
+
+#~ msgid "Name"
+#~ msgstr "Nume"
+
+#~ msgid "Notebook properties"
+#~ msgstr "Proprietățile agendei"
+
+#, fuzzy
+#~ msgid "emphasized text"
+#~ msgstr "text accentuat"
+
+#~ msgid "Click to stop external editing"
+#~ msgstr "Faceți click pentru a opri editarea în aplicația externă"
+
+#, fuzzy
+#~ msgid "Content Properties"
+#~ msgstr "Titlul caietului de notițe:"
+
+#~ msgid "Please create a notebook first."
+#~ msgstr "Creați un caiet de sarcini prima dată."
+
+#~ msgid "Usage"
+#~ msgstr "Utilizare"
+
+#~ msgid "Exit"
+#~ msgstr "Ieșiți"
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmați"
+
+#~ msgid "Attach any file"
+#~ msgstr "Atașați orice fișier"
+
+#~ msgid "Unknown log level: %s"
+#~ msgstr "Nivel de log necunoscut: %s"
+
+#~ msgid "Unknown level ID: %s"
+#~ msgstr "ID nivel necunoscut: %s"
+
+#, fuzzy
+#~ msgid "Synchronize"
+#~ msgstr "Sincronizați"
+
+#~ msgid ""
+#~ "This item is currently encrypted: %s \"%s\". Please wait for all items to "
+#~ "be decrypted and try again."
+#~ msgstr ""
+#~ "Acest element este criptat în prezent:% s \"% s\". Vă rugăm să așteptați "
+#~ "ca toate elementele să fie decriptate și să încercați din nou."
+
+#~ msgid "Remove tag \"%s\" and its descendant tags from all notes?"
+#~ msgstr ""
+#~ "Eliminați eticheta \"% s\" și etichetele descendente din toate notițele?"
+
+#~ msgid ""
+#~ "Could not synchronise with OneDrive.\n"
+#~ "\n"
+#~ "This error often happens when using OneDrive for Business, which "
+#~ "unfortunately cannot be supported.\n"
+#~ "\n"
+#~ "Please consider using a regular OneDrive account."
+#~ msgstr ""
+#~ "Nu s-a putut sincroniza cu OneDrive.\n"
+#~ "\n"
+#~ "Această eroare se întîmplă adesea atunci cînd se utilizează OneDrive "
+#~ "pentru Business, care, din păcate, nu poate fi suportată. \n"
+#~ "\n"
+#~ "Vă rugăm să luați în considerare utilizarea unui cont OneDrive obișnuit."
+
+#, fuzzy
+#~ msgid "Cannot move tag to this location."
+#~ msgstr "Nu se poate muta caietul de notițe în această locație"
+
+#~ msgid "Add or remove tags"
+#~ msgstr "Adăugați ori eliminați etichete"
+
+#, fuzzy
+#~ msgid "Resources"
+#~ msgstr "Resurse: %d."
+
+#, fuzzy
+#~ msgid "Confirm master password:"
+#~ msgstr "Setați parola"
+
+#, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Confirmați"
+
+#, fuzzy
+#~ msgid "Missing required argument: note"
+#~ msgstr "Lipsește argumentul necesar: %s"
+
+#~ msgid "Synchronisation status"
+#~ msgstr "Statusul sincronizării"
+
+#~ msgid "General Options"
+#~ msgstr "Opțiuni Generale"
+
+#~ msgid "Encryption options"
+#~ msgstr "Opțiuni de criptare"
+
+#~ msgid "Encryption Options"
+#~ msgstr "Opțiuni de criptare"
+
+#~ msgid "Clipper Options"
+#~ msgstr "Opțiuni Clipper"
+
+#~ msgid "Show metadata"
+#~ msgstr "Afișați metadatele"
+
+#~ msgid "Separate each tag by a comma."
+#~ msgstr "Separați fiecare etichetă printr-o virgulă."
+
+#~ msgid "State: %s."
+#~ msgstr "Statut: %s."
+
+#~ msgid "A notebook with this title already exists: \"%s\""
+#~ msgstr "Un caiet de notițe cu acest titlu există deja: \"%s\""

--- a/packages/tools/locales/ro_RO.po
+++ b/packages/tools/locales/ro_RO.po
@@ -7,9 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Joplin-CLI 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
 "Last-Translator: Mihai Vasiliu <mihai.vasiliu.93@gmail.com>\n"
 "Language-Team: \n"
-"Language: ro\n"
+"Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -204,13 +206,12 @@ msgid "%s = %s (%s)"
 msgstr "%s = %s (%s)"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:32
-#, fuzzy
 msgid "%s cannot be greater than %s"
-msgstr "Nu se poate create o notiță nouă: %s"
+msgstr "%s nu poate fi mai mare decât %s"
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:36
 msgid "%s cannot be less than %s"
-msgstr ""
+msgstr "%s nu poate fi mai mic decât %s"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:231
 msgid ""
@@ -222,7 +223,7 @@ msgstr ""
 
 #: packages/app-mobile/components/screens/ConfigScreen/ValidatedIntegerInput.tsx:26
 msgid "%s must be a valid whole number"
-msgstr ""
+msgstr "%s trebuie să fie un număr întreg valid"
 
 #: packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx:74
 msgid "%s tab opened"
@@ -466,9 +467,8 @@ msgid "Also publish linked notes"
 msgstr "Publică, de asemenea, notițele asociate"
 
 #: packages/lib/versionInfo.ts:93
-#, fuzzy
 msgid "Alternative instance ID: %s"
-msgstr "Client ID: %s"
+msgstr "ID instanță alternativ: %s"
 
 #: packages/lib/models/settings/builtInMetadata.ts:412
 msgid "Always"
@@ -552,7 +552,7 @@ msgstr ""
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:39
 msgid "Are you sure you want to renew the authorisation token?"
-msgstr "Sunteți sigur că doriți să reînnoiți token-ul de autorizare?"
+msgstr "Ești sigur că dorești să reînnoiești jetonul de autorizare?"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/resetLayout.ts:14
 msgid ""
@@ -607,7 +607,6 @@ msgid "attachment"
 msgstr "atașament"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:72
-#, fuzzy
 msgid "Attachment"
 msgstr "Atașament"
 
@@ -660,15 +659,15 @@ msgstr "Auto"
 
 #: packages/server/src/services/TaskService.ts:30
 msgid "Auto-add disabled accounts for deletion"
-msgstr "Adăugarea automată a conturilor dezactivate pentru ștergere"
+msgstr "Adaugă automat conturile dezactivate pentru ștergere"
 
 #: packages/lib/models/settings/builtInMetadata.ts:693
 msgid "Auto-format Markdown in the Rich Text Editor"
-msgstr ""
+msgstr "Formatează automat Markdown în editorul de text îmbogățit"
 
 #: packages/lib/models/settings/builtInMetadata.ts:661
 msgid "Auto-pair braces, parentheses, quotations, etc."
-msgstr "Împerechere automată de paranteze, ghilimele etc."
+msgstr "Împerechează automat parantezele, ghilimelele etc."
 
 #: packages/lib/models/settings/builtInMetadata.ts:672
 msgid "Autocomplete Markdown and HTML"
@@ -739,7 +738,7 @@ msgstr "după cuvânt"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:74
 msgid "Camera"
-msgstr ""
+msgstr "Aparat foto"
 
 #: packages/server/src/routes/admin/users.ts:160
 msgid "Can Share"
@@ -795,6 +794,8 @@ msgid ""
 "Cancelling will discard the recording. This cannot be undone. Are you sure "
 "you want to proceed?"
 msgstr ""
+"Anularea va duce la pierderea înregistrării. Acest lucru nu poate fi "
+"recuperat. Ești sigur că dorești să continui?"
 
 #: packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx:23
 #: packages/lib/Synchronizer.ts:206
@@ -935,9 +936,8 @@ msgid "Characters excluding spaces"
 msgstr "Caractere cu excepția spațiilor libere"
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:163
-#, fuzzy
 msgid "Check"
-msgstr "Căsuțe de selecție"
+msgstr "Bifează"
 
 #: packages/app-mobile/components/EditorToolbar/ToolbarEditorDialog.tsx:168
 msgid "Check elements to display in the toolbar"
@@ -962,9 +962,8 @@ msgid "Checkbox list"
 msgstr "Listă cu căsuțe de selecție"
 
 #: packages/app-mobile/components/Checkbox.tsx:49
-#, fuzzy
 msgid "Checked"
-msgstr "Căsuțe de selecție"
+msgstr "Bifat"
 
 #: packages/lib/components/shared/config/config-shared.ts:97
 msgid "Checking... Please wait."
@@ -1004,7 +1003,7 @@ msgstr ""
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:227
 msgid "Click \"start\" to attach a new voice memo to the note."
-msgstr ""
+msgstr "Apasă pe „start” pentru a atașa un memo vocal la notiță."
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:61
 msgid "Click to add tags..."
@@ -1033,9 +1032,8 @@ msgid "Close"
 msgstr "Închide"
 
 #: packages/app-mobile/components/Modal.tsx:139
-#, fuzzy
 msgid "Close dialog"
-msgstr "Închide fereastra"
+msgstr "Închide dialogul"
 
 #: packages/app-mobile/components/Dropdown.tsx:199
 msgid "Close dropdown"
@@ -1062,7 +1060,7 @@ msgstr "Închide fereastra"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:168
 msgid "Closing session..."
-msgstr ""
+msgstr "Se închide sesiunea..."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useLinkTooltips.ts:39
 msgid "Cmd-click to open"
@@ -1094,14 +1092,12 @@ msgid "Collaborate on notebooks with others"
 msgstr "Colaborează la caiete cu alte persoane"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
-#, fuzzy
 msgid "Collapse all notebooks"
-msgstr "Creează un caiet"
+msgstr "Restrânge toate caietele"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:23
-#, fuzzy
 msgid "Collapsed"
-msgstr "Restrânge"
+msgstr "Restrâns"
 
 #: packages/lib/services/ReportService.ts:385
 msgid "Coming alarms"
@@ -1186,7 +1182,7 @@ msgstr "Configurare"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1173
 msgid "Configures the size of scrollbars used in the app."
-msgstr ""
+msgstr "Configurează mărimea barelor de derulare folosite în aplicație."
 
 #: packages/app-mobile/components/screens/encryption-config.tsx:155
 msgid "Confirm password cannot be empty"
@@ -1450,9 +1446,8 @@ msgid "Created: %s"
 msgstr "Creat: %s"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:65
-#, fuzzy
 msgid "Creates a new note with an attachment of type %s"
-msgstr "Creează o nouă secțiune într-un caiet."
+msgstr "Creează o nouă notiță cu un atașament de tipul %s"
 
 #: packages/app-cli/app/command-mknote.js:12
 msgid "Creates a new note."
@@ -1711,7 +1706,7 @@ msgstr "Dezvoltator"
 
 #: packages/lib/versionInfo.ts:88
 msgid "Device: %s"
-msgstr ""
+msgstr "Dispozitiv: %s"
 
 #: packages/lib/services/interop/Module.ts:62
 msgid "Directory"
@@ -1735,9 +1730,8 @@ msgid "Disable safe mode and restart"
 msgstr "Dezactivează modul de siguranță și repornește"
 
 #: packages/app-desktop/gui/MainScreen.tsx:594
-#, fuzzy
 msgid "Disable synchronisation"
-msgstr "Amânați sincronizarea"
+msgstr "Dezactivează sincronizarea"
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:97
 msgid "Disable Web Clipper Service"
@@ -1868,9 +1862,8 @@ msgid "Download and install the relevant extension for your browser:"
 msgstr "Descarcă și instalează extensia relevantă pentru navigatorul tău web:"
 
 #: packages/app-desktop/gui/MainScreen.tsx:586
-#, fuzzy
 msgid "Download it now"
-msgstr "Descărcare"
+msgstr "Descarc-o acum"
 
 #: packages/lib/models/Resource.ts:409
 msgid "Downloaded"
@@ -1952,9 +1945,8 @@ msgstr ""
 "specificat niciun caiet, notița va fi duplicată în caietul curent."
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:217
-#, fuzzy
 msgid "Duration: %s"
-msgstr "Versiunea ta: %s"
+msgstr "Durată: %s"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts:94
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEditDialog.ts:83
@@ -2220,6 +2212,8 @@ msgid ""
 "Enables Markdown pattern replacement in the Rich Text Editor. For example, "
 "when enabled, typing **bold** creates bold text."
 msgstr ""
+"Activează înlocuire cu șablon Markdown în editorul de text îmbogățit. De "
+"exemplu, dacă este activat, tastând **aldin** va crea text aldin."
 
 #: packages/lib/components/EncryptionConfigScreen/utils.ts:50
 msgid ""
@@ -2355,14 +2349,12 @@ msgid "Expand %s"
 msgstr "Extinde %s"
 
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx:28
-#, fuzzy
 msgid "Expand all notebooks"
-msgstr "Editează caietul de notițe"
+msgstr "Extinde toate caietele"
 
 #: packages/app-desktop/gui/Sidebar/listItemComponents/ExpandIcon.tsx:21
-#, fuzzy
 msgid "Expanded"
-msgstr "Extindeți"
+msgstr "Extins"
 
 #: packages/app-desktop/gui/KeymapConfig/KeymapConfigScreen.tsx:182
 #: packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx:213
@@ -2436,7 +2428,7 @@ msgid ""
 "Fail-safe: Do not wipe out local data when sync target is empty (often the "
 "result of a misconfiguration or bug)"
 msgstr ""
-"Fail-safe: Nu ștergeți datele locale atunci când ținta de sincronizare este "
+"Fail-safe: Nu șterge datele locale atunci când ținta de sincronizare este "
 "goală (adesea rezultatul unei configurații greșite sau al unei erori)."
 
 #: packages/lib/services/synchronizer/syncInfoUtils.ts:134
@@ -2445,6 +2437,10 @@ msgid ""
 "target is empty or damaged. To override this behaviour disable the fail-safe "
 "in the sync settings."
 msgstr ""
+"Fail-safe: Sincronizarea a fost întreruptă pentru a preveni pierderea de "
+"date, deoarece ținta sincronizării este goală sau eronată. Pentru a anula "
+"acest comportament, dezactivează mecanismul de fail-safe din setările de "
+"sincronizare."
 
 #: packages/app-cli/app/main.js:107
 msgid "Fatal error:"
@@ -2491,7 +2487,7 @@ msgstr "Găsiți: "
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:208
 msgid "Finishes recording"
-msgstr ""
+msgstr "Finalizează înregistrarea"
 
 #: packages/app-desktop/gui/ExtensionBadge.tsx:65
 msgid "Firefox Extension"
@@ -3018,7 +3014,7 @@ msgstr "Comandă invalidă: „%s”"
 
 #: packages/app-desktop/gui/NotePropertiesDialog.tsx:371
 msgid "Invalid format. E.g.: 48.8581372, 2.2926735"
-msgstr ""
+msgstr "Format invalid. ex.: 48.8581372, 2.2926735"
 
 #: packages/lib/models/Setting.ts:665
 msgid "Invalid option value: \"%s\". Possible values are: %s."
@@ -3056,9 +3052,8 @@ msgid "Items that cannot be synchronised"
 msgstr "Elementele nu pot fi sincronizați"
 
 #: packages/lib/services/ReportService.ts:294
-#, fuzzy
 msgid "Items with error: %s"
-msgstr "Ultima eroare: %s"
+msgstr "Elemente cu eroarea: %s"
 
 #: packages/app-desktop/gui/MenuBar.tsx:945
 msgid "Join us on %s"
@@ -3204,7 +3199,7 @@ msgstr "Limbă, format dată"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1169
 msgid "Large"
-msgstr ""
+msgstr "Mare"
 
 #: packages/lib/Synchronizer.ts:208
 msgid "Last error: %s"
@@ -3290,9 +3285,8 @@ msgid "Link text"
 msgstr "Text legătură"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.ts:13
-#, fuzzy
 msgid "Link to note..."
-msgstr "Mută în alt caiet…"
+msgstr "Leagă la notița..."
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:232
 #: packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx:234
@@ -3475,7 +3469,7 @@ msgstr "Media player, matematică, diagrame, cuprins"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1168
 msgid "Medium"
-msgstr ""
+msgstr "Medie"
 
 #: packages/app-desktop/gui/KeymapConfig/utils/getLabel.ts:24
 msgid "Minimise"
@@ -3494,9 +3488,8 @@ msgid "Missing Master Keys"
 msgstr "Cheile master lipsă"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:120
-#, fuzzy
 msgid "Missing permission to record audio."
-msgstr "Permisiune cameră lipsă"
+msgstr "Permisiune lipsă pentru a înregistra audio."
 
 #: packages/app-cli/app/cli-utils.js:112
 msgid "Missing required argument: %s"
@@ -3535,13 +3528,12 @@ msgid "Move %d notes to notebook \"%s\"?"
 msgstr "Muți %d notițe în caietul „%s”?"
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:73
-#, fuzzy
 msgid "Move down"
-msgstr "Închideți meniul derulant"
+msgstr "Mută în jos"
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:74
 msgid "Move left"
-msgstr ""
+msgstr "Mută la stânga"
 
 #: packages/app-cli/app/command-rmbook.ts:38
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.ts:20
@@ -3559,7 +3551,7 @@ msgstr ""
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:75
 msgid "Move right"
-msgstr ""
+msgstr "Mută la dreapta"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.ts:14
 msgid "Move to notebook"
@@ -3575,7 +3567,7 @@ msgstr "Mută în alt caiet…"
 
 #: packages/app-desktop/gui/ResizableLayout/MoveButtons.tsx:72
 msgid "Move up"
-msgstr ""
+msgstr "Mută în sus"
 
 #: packages/app-cli/app/command-mv.ts:14
 msgid "Moves the given <item> to [notebook]"
@@ -3607,11 +3599,12 @@ msgid "New invitations"
 msgstr "Invitații noi"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:62
-#, fuzzy
 msgid ""
 "New model available\n"
 "A new voice typing model is available. Do you want to download it?"
-msgstr "Este disponibilă o nouă actualizare, dorești să o descarci acum?"
+msgstr ""
+"Este disponibil un nou model\n"
+"Un nou model de transcriere vocală este disponibil. Dorești să îl descarci?"
 
 #: packages/app-desktop/gui/NoteListControls/NoteListControls.tsx:111
 #: packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx:72
@@ -3641,9 +3634,8 @@ msgid "New photo"
 msgstr "Fotografie nouă"
 
 #: packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.tsx:212
-#, fuzzy
 msgid "New profile"
-msgstr "Comută profilul"
+msgstr "Profil nou"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newSubFolder.ts:6
 msgid "New sub-notebook"
@@ -3771,7 +3763,7 @@ msgstr "Neautentificat cu %s. Te rog să furnizezi orice acreditări lipsă."
 
 #: packages/app-desktop/gui/SyncWizard/Dialog.tsx:163
 msgid "Not checked"
-msgstr ""
+msgstr "Nebifat"
 
 #: packages/lib/models/Resource.ts:407
 msgid "Not downloaded"
@@ -3862,9 +3854,8 @@ msgstr "Titlul notiței"
 
 #: packages/app-desktop/gui/NoteEditor/commands/focusElementNoteViewer.ts:8
 #: packages/app-desktop/gui/NoteTextViewer.tsx:242
-#, fuzzy
 msgid "Note viewer"
-msgstr "Titlul notiței"
+msgstr "Vizualizator notiță"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1030
 msgid "Note: Does not work in all desktop environments."
@@ -3924,9 +3915,8 @@ msgid "Notes can only be created within a notebook."
 msgstr "Notițele pot fi create numai în cadrul unui caiet de notițe."
 
 #: packages/app-desktop/gui/PopupNotification/PopupNotificationList.tsx:32
-#, fuzzy
 msgid "Notifications"
-msgstr "Locație"
+msgstr "Notificări"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:80
 msgid "Numbered List"
@@ -4023,14 +4013,12 @@ msgid "Open %s"
 msgstr "Deschide %s"
 
 #: packages/app-desktop/commands/startExternalEditing.ts:10
-#, fuzzy
 msgid "Open in external editor"
-msgstr "Editează într-un editor extern"
+msgstr "Deschide într-un editor extern"
 
 #: packages/app-desktop/commands/openNoteInNewWindow.ts:10
-#, fuzzy
 msgid "Open in new window"
-msgstr "Editează într-o fereastră nouă"
+msgstr "Deschide într-o fereastră nouă"
 
 #: packages/app-desktop/bridge.ts:466
 msgid "Open it"
@@ -4042,7 +4030,7 @@ msgstr "Deschide vizualizator PDF"
 
 #: packages/app-desktop/commands/openPrimaryAppInstance.ts:8
 msgid "Open primary app instance..."
-msgstr ""
+msgstr "Deschide instanța primară a aplicației..."
 
 #: packages/app-desktop/commands/openProfileDirectory.ts:8
 msgid "Open profile directory"
@@ -4050,7 +4038,7 @@ msgstr "Deschide dosarul profilului"
 
 #: packages/app-desktop/commands/openSecondaryAppInstance.ts:8
 msgid "Open secondary app instance..."
-msgstr ""
+msgstr "Deschide instanța secundară a aplicației..."
 
 #: packages/app-mobile/components/CameraView/CameraView.tsx:164
 msgid "Open settings"
@@ -4118,11 +4106,11 @@ msgstr "Dimensiunea paginii pentru exportul PDF"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:32
 msgid "Panel \"%s\" is visible"
-msgstr ""
+msgstr "Panoul „%s” este vizibil"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts:32
 msgid "Panel %s is hidden"
-msgstr ""
+msgstr "Panoul „%s” este ascuns"
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:170
 msgid "Password"
@@ -4244,7 +4232,7 @@ msgstr ""
 
 #: packages/lib/services/share/ShareService.ts:332
 msgid "Please provide the recipient email"
-msgstr ""
+msgstr "Te rog furnizează adresa de e-mail a destinatarului"
 
 #: packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx:166
 msgid "Please record your voice..."
@@ -4554,17 +4542,15 @@ msgstr "Plugin-uri recomandate"
 
 #: packages/app-mobile/components/screens/Note/commands/attachFile.ts:91
 msgid "Record audio"
-msgstr ""
+msgstr "Înregistrează audio"
 
 #: packages/app-mobile/components/screens/Notes/NewNoteButton.tsx:73
-#, fuzzy
 msgid "Recording"
-msgstr "Titlu"
+msgstr "Înregistrare"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:224
-#, fuzzy
 msgid "Recording..."
-msgstr "Se încarcă…"
+msgstr "Se înregistrează…"
 
 #: packages/app-desktop/gui/MenuBar.tsx:767
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:122
@@ -4870,7 +4856,7 @@ msgstr "Cod scanat"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1172
 msgid "Scrollbar size"
-msgstr ""
+msgstr "Mărime bară derulare"
 
 #: packages/app-desktop/gui/lib/SearchInput/SearchInput.tsx:67
 #: packages/app-mobile/components/NoteEditor/commandDeclarations.ts:112
@@ -5169,7 +5155,7 @@ msgstr "Omise: %d."
 
 #: packages/lib/models/settings/builtInMetadata.ts:1167
 msgid "Small"
-msgstr ""
+msgstr "Mică"
 
 #: packages/lib/models/settings/builtInMetadata.ts:52
 msgid "Solarised Dark"
@@ -5283,7 +5269,7 @@ msgstr "Pornește aplicația minimizat în zona de notificări a sistemului"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:199
 msgid "Start recording"
-msgstr ""
+msgstr "Începe înregistrarea"
 
 #: packages/app-cli/app/command-server.js:14
 msgid ""
@@ -5384,18 +5370,16 @@ msgid "Subscript"
 msgstr "Subscripție"
 
 #: packages/app-desktop/gui/PopupNotification/NotificationItem.tsx:16
-#, fuzzy
 msgid "Success"
-msgstr "Cheie acces S3"
+msgstr "Succes"
 
 #: packages/lib/components/shared/config/config-shared.ts:99
 msgid "Success! Synchronisation configuration appears to be correct."
 msgstr "Succes! Configurația de sincronizare pare a fi corectă."
 
 #: packages/app-desktop/gui/InlineCombobox.tsx:182
-#, fuzzy
 msgid "Suggestions"
-msgstr "Fără sugestii"
+msgstr "Sugestii"
 
 #: packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.ts:30
 msgid "Superscript"
@@ -5547,12 +5531,12 @@ msgstr "Se sincronizează..."
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
 msgid "Tab indents"
-msgstr ""
+msgstr "Tasta tab indentează"
 
 #: packages/app-desktop/gui/NoteEditor/StatusBar.tsx:72
 #: packages/lib/models/settings/builtInMetadata.ts:713
 msgid "Tab moves focus"
-msgstr ""
+msgstr "Tasta tab mută focalizarea"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1310
 msgid "Tabloid"
@@ -5638,7 +5622,7 @@ msgstr "Aplicația nu s-a închis corect. Doriți să porniți în modul sigur?"
 msgid ""
 "The application has been authorised - you may now close this browser tab."
 msgstr ""
-"Aplicația a fost autorizată - acum puteți închide această fereastră "
+"Aplicația a fost autorizată - acum poți închide această fereastră "
 "browserului."
 
 #: packages/lib/components/shared/dropbox-login-shared.js:39
@@ -5885,9 +5869,9 @@ msgstr ""
 "datele."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:104
-#, fuzzy
 msgid "The web clipper service cannot be enabled in this instance of Joplin."
-msgstr "Serviciul web clipper este activat și setat la pornire automată."
+msgstr ""
+"Serviciul web clipper nu poate fi activat în această instanță de Joplin."
 
 #: packages/app-desktop/gui/ClipperConfigScreen.tsx:79
 msgid "The web clipper service is enabled and set to auto-start."
@@ -6239,9 +6223,8 @@ msgid "to-do: %s"
 msgstr "de făcut: %s"
 
 #: packages/lib/commands/toggleAllFolders.ts:8
-#, fuzzy
 msgid "Toggle all notebooks"
-msgstr "Selectează un caiet"
+msgstr "Comută toate caietele"
 
 #: packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts:134
 msgid "Toggle comment"
@@ -6260,9 +6243,8 @@ msgid "Toggle editor plugin"
 msgstr "Comută plugin editor"
 
 #: packages/app-desktop/commands/toggleTabMovesFocus.ts:8
-#, fuzzy
 msgid "Toggle editor tab key navigation"
-msgstr "Comută aspect editor"
+msgstr "Comută navigarea în editor cu tasta tab"
 
 #: packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleEditors.ts:8
 msgid "Toggle editors"
@@ -6289,9 +6271,8 @@ msgid "Toggle own sort order"
 msgstr "Comută propria ordine de sortare"
 
 #: packages/app-mobile/components/ScreenHeader/index.tsx:434
-#, fuzzy
 msgid "Toggle plugin editor"
-msgstr "Comută editoarele"
+msgstr "Comută editor plugin"
 
 #: packages/app-desktop/commands/toggleSafeMode.ts:8
 msgid "Toggle safe mode"
@@ -6310,9 +6291,8 @@ msgid "Token has been copied to the clipboard!"
 msgstr "Token-ul a fost copiat în clipboard!"
 
 #: packages/app-desktop/gui/NoteEditor/commands/focusElementToolbar.ts:8
-#, fuzzy
 msgid "Toolbar"
-msgstr "Instrumente"
+msgstr "Bara de instrumente"
 
 #: packages/lib/models/Setting.ts:1188
 msgid "Tools"
@@ -6364,9 +6344,8 @@ msgstr ""
 "numele unui caiet. Sau tastați : pentru a căuta comenzi."
 
 #: packages/app-desktop/plugins/GotoAnything.tsx:714
-#, fuzzy
 msgid "Type a note title to search for it."
-msgstr "Tastează etichete noi sau selectează din listă"
+msgstr "Tastează un titlu de notiță pentru a-l căuta."
 
 #: packages/app-mobile/components/screens/NoteTagsDialog.tsx:235
 msgid "Type new tags or select from list"
@@ -6386,7 +6365,7 @@ msgstr "Imposibilitatea de a partaja datele din jurnal. Motivul: %s"
 
 #: packages/app-mobile/components/Checkbox.tsx:51
 msgid "Unchecked"
-msgstr ""
+msgstr "Debifat"
 
 #: packages/lib/models/settings/builtInMetadata.ts:632
 msgid "Uncompleted to-dos on top"
@@ -6671,9 +6650,8 @@ msgid "Viewer"
 msgstr "Vizualizator"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1083
-#, fuzzy
 msgid "Viewer font size"
-msgstr "Mărime font editor"
+msgstr "Mărime font vizualizator"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1346
 msgid "Vim"
@@ -6681,7 +6659,7 @@ msgstr "Vim"
 
 #: packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx:224
 msgid "Voice recorder"
-msgstr ""
+msgstr "Înregistrator vocal"
 
 #: packages/lib/models/settings/builtInMetadata.ts:1772
 msgid "Voice typing language files (URL)"
@@ -6850,6 +6828,8 @@ msgid ""
 "You are running the Intel version of Joplin on an Apple Silicon processor. "
 "Download the Apple Silicon one for better performance."
 msgstr ""
+"Rulezi versiunea Intel a Joplin pe un procesor cu siliciu Apple. Descarcă "
+"versiunea pentru procesoare Apple pentru o performanță mai mare."
 
 #: packages/app-mobile/components/NoteList.tsx:98
 msgid "You currently have no notebooks."
@@ -6861,7 +6841,7 @@ msgstr "Nu aveți niciun plugin instalat."
 
 #: packages/app-cli/app/gui/NoteWidget.js:50
 msgid "You may also type `status` for more information."
-msgstr "De asemenea, puteți introduce `status` pentru mai multe informații."
+msgstr "De asemenea, poți tasta `status` pentru mai multe informații."
 
 #: packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:344
 msgid ""


### PR DESCRIPTION
This PR adds the ro_MD translation file and also renames the ro.po to ro_RO.po.

@tessus Can you update the Language selection dropdown from options to reflect this change? It should be:
- Română (România) for ro_RO
- Română (Moldova) for ro_MD

Or just tell me how to do it and I can do it myself.