### PR TITLE
Server: Resolves #12138: Add CSS style for description list elements

### DIFF
--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -228,6 +228,16 @@ export default function(theme: any, options: Options = null) {
 			margin-bottom: 0;
 		}
 
+		dt {
+			font-weight: bold;
+			margin-bottom: 0.25em;
+		}
+
+		dd {
+			margin-inline-start: 2.5em;
+			margin-bottom: 0.5em;
+		}
+
 		.resource-icon {
 			display: inline-block;
 			position: relative;

--- a/packages/server/public/css/items/note.css
+++ b/packages/server/public/css/items/note.css
@@ -1,13 +1,3 @@
-dt {
-	font-weight: bold;
-	margin-bottom: 0.25em;
-}
-
-dd {
-	margin-inline-start: 2.5em;
-	margin-bottom: 0.5em;
-}
-
 .main {
 	padding-left: 0;
 	padding-right: 0;

--- a/packages/server/public/css/items/note.css
+++ b/packages/server/public/css/items/note.css
@@ -1,3 +1,13 @@
+dt {
+	font-weight: bold;
+	margin-bottom: 0.25em;
+}
+
+dd {
+	margin-inline-start: 2.5em;
+	margin-bottom: 0.5em;
+}
+
 .main {
 	padding-left: 0;
 	padding-right: 0;


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/12138

# Summary

We didn't had any type of style for `<dt>` and `<dd>` tags, I'm adding some basic formatting.

Shared notes:
![2025-04-24_16-07](https://github.com/user-attachments/assets/61656d3d-80e8-4e8d-ae8d-4a39af1b69ff)

Desktop Markdown:
![2025-04-28_15-47](https://github.com/user-attachments/assets/baaa36cb-40b6-416d-9898-4f53c0454658)

Desktop RTE:
![2025-04-28_15-47_1](https://github.com/user-attachments/assets/b79c4a90-aa46-4afd-8e16-8eb8d085a22a)

Web:
![2025-04-28_16-04](https://github.com/user-attachments/assets/9f034d23-23a7-447c-85eb-d199a97f8f2c)

Mobile:
![photo_4934148903587131009_y](https://github.com/user-attachments/assets/ba7a6877-4dd1-4147-bdc9-6e770b41038a)


Reference:
![Image](https://github.com/user-attachments/assets/1133249b-64ba-46f9-b92b-cc071081586f)

I didn't add the `text-weight: bold` for the `<p>` inside the `<dl>` like MDN example, not sure if it is needed. I think since there is other ways for the user to add bold to the text is not needed.