### PR TITLE
Docs: Remove information from release notes about a reverted 3.3 change

### DIFF
--- a/readme/news/20250428-release-3-3.md
+++ b/readme/news/20250428-release-3-3.md
@@ -64,7 +64,7 @@ The redesigned "New Note" menu takes note creation to a whole new level of flexi
 
 ## Security and bug fixes
 
-As always, we continue to reinforce the security of Joplin. This version implements a robust content security policy for the Rich Text Editor, safeguarding the application against malicious content. Similarly, the note viewer, plugin panels, and dialogues are now better isolated, reducing the impact of potential vulnerabilities.
+As always, we continue to reinforce the security of Joplin. This version implements a robust content security policy for the Rich Text Editor, safeguarding the application against malicious content.
 
 In total, this version delivers 39 bug fixes on desktop and 17 on mobile, enhancing both the security and stability of the application.
 


### PR DESCRIPTION
# Summary

This pull request removes information from the 3.3 release notes about a reverted change.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->