### PR TITLE
Desktop: Fixes #12168: Preserve search query when opening a note in a new window

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -1,6 +1,6 @@
 import { AppState } from '../../app.reducer';
 import * as React from 'react';
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useContext } from 'react';
 import SearchBar from '../SearchBar/SearchBar';
 import Button, { ButtonLevel, ButtonSize, buttonSizePx } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -14,6 +14,7 @@ import stateToWhenClauseContext from '../../services/commands/stateToWhenClauseC
 import { getTrashFolderId } from '@joplin/lib/services/trash';
 import { Breakpoints } from '../NoteList/utils/types';
 import { stateUtils } from '@joplin/lib/reducer';
+import { WindowIdContext } from '../NewWindowOrIFrame';
 
 interface Props {
 	showNewNoteButtons: boolean;
@@ -245,11 +246,12 @@ function NoteListControls(props: Props) {
 		);
 	}
 
+	const windowId = useContext(WindowIdContext);
 	return (
 		<StyledRoot ref={noteControlsRef} padding={props.padding} buttonVerticalGap={props.buttonVerticalGap}>
 			{renderNewNoteButtons()}
 			<BottomRow ref={searchAndSortRef} className="search-and-sort">
-				<SearchBar inputRef={searchBarRef}/>
+				<SearchBar inputRef={searchBarRef} windowId={windowId}/>
 				{showsSortOrderButtons() &&
 					<SortOrderButtonsContainer>
 						<StyledPairButtonL

--- a/packages/app-desktop/gui/SearchBar/SearchBar.tsx
+++ b/packages/app-desktop/gui/SearchBar/SearchBar.tsx
@@ -5,7 +5,7 @@ import Setting from '@joplin/lib/models/Setting';
 import { stateUtils } from '@joplin/lib/reducer';
 import BaseModel from '@joplin/lib/BaseModel';
 import uuid from '@joplin/lib/uuid';
-const { connect } = require('react-redux');
+import { connect } from 'react-redux';
 import Note from '@joplin/lib/models/Note';
 import { AppState } from '../../app.reducer';
 import { blur, focus } from '@joplin/lib/utils/focusHandler';
@@ -180,10 +180,15 @@ function SearchBar(props: Props) {
 	);
 }
 
-const mapStateToProps = (state: AppState) => {
+interface OwnProps {
+	windowId: string;
+}
+
+const mapStateToProps = (state: AppState, ownProps: OwnProps) => {
+	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
 	return {
-		notesParentType: state.notesParentType,
-		selectedNoteId: stateUtils.selectedNoteId(state),
+		notesParentType: windowState.notesParentType,
+		selectedNoteId: stateUtils.selectedNoteId(windowState),
 		isFocused: state.focusedField === 'globalSearch',
 	};
 };


### PR DESCRIPTION
# Summary

This pull request fixes an issue where opening a note in a new window cleared the search input. Previously, the search input used the global state to determine whether a search was in progress. This has been changed to the per-window state.

Fixes #12168.

# Testing plan

On desktop:
1. Search for a term with at least one result.
2. Double-click on the result to open it in a new window.
3. Verify that the search input box still contains the search query.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->