### PR TITLE
Desktop: Upgrade to Electron 35.2.1

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -144,7 +144,7 @@
     "@types/styled-components": "5.1.32",
     "@types/tesseract.js": "2.0.0",
     "axios": "^1.7.7",
-    "electron": "35.1.4",
+    "electron": "35.2.1",
     "electron-builder": "24.13.3",
     "glob": "10.4.5",
     "gulp": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8297,7 +8297,7 @@ __metadata:
     compare-versions: 6.1.1
     countable: 3.0.1
     debounce: 1.2.1
-    electron: 35.1.4
+    electron: 35.2.1
     electron-builder: 24.13.3
     electron-updater: 6.2.1
     electron-window-state: 5.0.3
@@ -22973,16 +22973,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:35.1.4":
-  version: 35.1.4
-  resolution: "electron@npm:35.1.4"
+"electron@npm:35.2.1":
+  version: 35.2.1
+  resolution: "electron@npm:35.2.1"
   dependencies:
     "@electron/get": ^2.0.0
     "@types/node": ^22.7.7
     extract-zip: ^2.0.1
   bin:
     electron: cli.js
-  checksum: 78ac69d76823d9f2096726684f57b9d9e1bbf90a2207aaa003d69ed96eb2c7d93b0b8a6cee25a99382332606f09ea3b6b9f0868a5a6eca53429b5ff087fa1c10
+  checksum: c2a3511bdecb08d57976f4c37fc12155c5feaf2f78e5001f592f2241d3e63524a9d5cf8caecada45432e2cb9b1013035f35bf7bebcd8656e882ff95902adb782
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades Electron to 35.2.1. According to the [upstream list of changes](https://releases.electronjs.org/release/compare/v35.1.4/v35.2.1), this fixes an [accessibility issue](https://github.com/electron/electron/pull/46562) in the case where an app has multiple windows:
> NativeWindow::window_id() always returned the same value, no matter which NativeWindow was being queried. This caused ElectronAccessibilityUI to behave unpredictably because RequestNativeUITree() could sometimes key in on the wrong native window. Introduced in https://github.com/electron/electron/commit/3f37ff87d224ceaebb479cd58241df5ca1dd4b0e.

# Testing

- **Manual testing**: Verified that Joplin can start in development mode on Fedora 42 Linux.
- **Automated testing**: Playwright tests were run locally on Fedora 42 Linux and will be run in CI.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->