### PR TITLE
Linux,Windows: Fixes #12177: Allow opening secondary app instances from the "File" menu

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -562,6 +562,12 @@ function useMenu(props: Props) {
 				submenu: switchProfileMenuItems,
 			};
 
+			const profilesAndAppInstancesItems = [
+				openSecondaryAppInstance,
+				openPrimaryAppInstance,
+				switchProfileItem,
+			];
+
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			let toolsItems: any[] = [];
 
@@ -673,7 +679,7 @@ function useMenu(props: Props) {
 					platforms: ['darwin'],
 				},
 
-				shim.isMac() ? noItem : switchProfileItem,
+				...(shim.isMac() ? [] : profilesAndAppInstancesItems),
 
 				shim.isMac() ? {
 					label: _('Hide %s', 'Joplin'),
@@ -723,9 +729,7 @@ function useMenu(props: Props) {
 					printItem, {
 						type: 'separator',
 					},
-					switchProfileItem,
-					openSecondaryAppInstance,
-					openPrimaryAppInstance,
+					...profilesAndAppInstancesItems,
 				],
 			};
 


### PR DESCRIPTION
# Summary

This pull request adds the secondary app instance menu items to the "File" menu on Windows and Linux. Previously, these menu items were only available on MacOS.

Fixes #12177.

# Screenshot

![screenshot: "Open secondary app instance" highlighted in the "File" menu, just above a grayed-out "Open primary app instance" and "Switch profile" item](https://github.com/user-attachments/assets/78c88b30-de9f-4f08-966e-9990aa411c3a)


# Testing notes

Fedora 42 (MATE):
1. Start Joplin.
2. Open the "File" menu.
3. Click "Open secondary app instance".
4. Verify that a new Joplin window has been opened.
5. In the new window, click "File", then "Open primary app instance".
6. Verify that the original window (from step 1) is focused.

This pull request has only been tested on Linux (Fedora 42/MATE). (I will be unable to test on MacOS/Windows for the next few hours).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->