### PR TITLE
Desktop,CLI,Mobile: Update immer to v9.0.21

### DIFF
--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import Setting from '@joplin/lib/models/Setting';
 import { defaultState, defaultWindowState, State, WindowState } from '@joplin/lib/reducer';
 import iterateItems from './gui/ResizableLayout/utils/iterateItems';

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -92,7 +92,7 @@ class Application extends BaseApplication {
 	public reducer(state: AppState = appDefaultState, action: any) {
 		let newState = appReducer(state, action);
 		newState = resourceEditWatcherReducer(newState, action);
-		newState = super.reducer(newState, action);
+		newState = super.reducer(newState, action) as AppState;
 		return newState;
 	}
 

--- a/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/controls/plugins/PluginsStates.tsx
@@ -7,7 +7,7 @@ import SearchPlugins from './SearchPlugins';
 import PluginBox, { UpdateState } from './PluginBox';
 import Button, { ButtonLevel, ButtonSize } from '../../../Button/Button';
 import bridge from '../../../../services/bridge';
-import produce from 'immer';
+import { produce } from 'immer';
 import { OnChangeEvent } from '../../../lib/SearchInput/SearchInput';
 import { PluginItem, ItemEvent, OnPluginSettingChangeEvent } from '@joplin/lib/components/shared/config/plugins/types';
 import RepositoryApi, { InstallMode } from '@joplin/lib/services/plugins/RepositoryApi';

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -17,7 +17,7 @@ import { AppState } from '../app.reducer';
 import { saveLayout, loadLayout } from './ResizableLayout/utils/persist';
 import Setting from '@joplin/lib/models/Setting';
 import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/config/shouldShowMissingPasswordWarning';
-import produce from 'immer';
+import { produce } from 'immer';
 import shim from '@joplin/lib/shim';
 import bridge from '../services/bridge';
 import styled from 'styled-components';

--- a/packages/app-desktop/gui/ResizableLayout/utils/movements.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/movements.ts
@@ -1,6 +1,6 @@
 import iterateItems from './iterateItems';
 import { LayoutItem, LayoutItemDirection, tempContainerPrefix } from './types';
-import produce from 'immer';
+import { produce } from 'immer';
 import uuid from '@joplin/lib/uuid';
 import validateLayout from './validateLayout';
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/persist.ts
@@ -1,5 +1,5 @@
 import { LayoutItem, Size } from './types';
-import produce from 'immer';
+import { produce } from 'immer';
 import iterateItems from './iterateItems';
 import validateLayout from './validateLayout';
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/removeItem.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/removeItem.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import iterateItems from './iterateItems';
 import { LayoutItem } from './types';
 import validateLayout from './validateLayout';

--- a/packages/app-desktop/gui/ResizableLayout/utils/removeKeylessItems.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/removeKeylessItems.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import iterateItems from './iterateItems';
 import { LayoutItem } from './types';
 import validateLayout from './validateLayout';

--- a/packages/app-desktop/gui/ResizableLayout/utils/setLayoutItemProps.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/setLayoutItemProps.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import { LayoutItem } from './types';
 import validateLayout from './validateLayout';
 

--- a/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
+++ b/packages/app-desktop/gui/ResizableLayout/utils/validateLayout.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import iterateItems from './iterateItems';
 import { LayoutItem, LayoutItemDirection } from './types';
 

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -179,7 +179,7 @@
     "formatcoords": "1.1.3",
     "fs-extra": "11.2.0",
     "highlight.js": "11.10.0",
-    "immer": "7.0.15",
+    "immer": "9.0.21",
     "keytar": "7.9.0",
     "mark.js": "8.11.1",
     "md5": "2.3.0",

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -454,7 +454,7 @@ const appReducer = (state = appDefaultState, action: any) => {
 		throw error;
 	}
 
-	return reducer(newState, action);
+	return reducer(newState, action) as AppState;
 };
 
 const store = createStore(appReducer, applyMiddleware(generalMiddleware));

--- a/packages/app-mobile/utils/testing/createMockReduxStore.ts
+++ b/packages/app-mobile/utils/testing/createMockReduxStore.ts
@@ -4,12 +4,12 @@ import appDefaultState from '../appDefaultState';
 import Setting from '@joplin/lib/models/Setting';
 import { AppState } from '../types';
 
-const testReducer = (state: AppState|undefined, action: unknown) => {
+const testReducer = (state: AppState|undefined, action: unknown): AppState => {
 	state ??= {
 		...appDefaultState,
 		settings: Setting.toPlainObject(),
 	};
-	return reducer(state, action);
+	return { ...state, ...reducer(state, action) };
 };
 
 const createMockReduxStore = () => {

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -48,7 +48,7 @@ import MigrationService from './services/MigrationService';
 import ShareService from './services/share/ShareService';
 import handleSyncStartupOperation from './services/synchronizer/utils/handleSyncStartupOperation';
 import SyncTargetJoplinCloud from './SyncTargetJoplinCloud';
-const { setAutoFreeze } = require('immer');
+import { setAutoFreeze } from 'immer';
 import { getEncryptionEnabled } from './services/synchronizer/syncInfoUtils';
 import { loadMasterKeysFromSettings, migrateMasterPassword } from './services/e2ee/utils';
 import SyncTargetNone from './SyncTargetNone';

--- a/packages/lib/components/shared/config/plugins/useOnDeleteHandler.ts
+++ b/packages/lib/components/shared/config/plugins/useOnDeleteHandler.ts
@@ -2,7 +2,7 @@ import { _ } from '../../../../locale';
 import PluginService, { PluginSettings, defaultPluginSetting } from '../../../../services/plugins/PluginService';
 import type * as React from 'react';
 import shim from '../../../../shim';
-import produce from 'immer';
+import { produce } from 'immer';
 import { ItemEvent, OnPluginSettingChangeHandler } from './types';
 
 const useOnDeleteHandler = (

--- a/packages/lib/components/shared/config/plugins/useOnInstallHandler.ts
+++ b/packages/lib/components/shared/config/plugins/useOnInstallHandler.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import Logger from '@joplin/utils/Logger';
 import { ItemEvent, OnPluginSettingChangeHandler } from './types';
 import type * as React from 'react';

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -72,7 +72,7 @@
     "html-entities": "1.4.0",
     "html-minifier": "4.0.0",
     "image-data-uri": "2.0.1",
-    "immer": "7.0.15",
+    "immer": "9.0.21",
     "js-yaml": "4.1.0",
     "markdown-it": "13.0.2",
     "md5": "2.3.0",

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1,4 +1,4 @@
-import produce, { Draft, original } from 'immer';
+import { produce, Draft, original } from 'immer';
 import pluginServiceReducer, { stateRootKey as pluginServiceStateRootKey, defaultState as pluginServiceDefaultState, State as PluginServiceState } from './services/plugins/reducer';
 import shareServiceReducer, { stateRootKey as shareServiceStateRootKey, defaultState as shareServiceDefaultState, State as ShareServiceState } from './services/share/reducer';
 import Note from './models/Note';

--- a/packages/lib/services/ResourceEditWatcher/reducer.ts
+++ b/packages/lib/services/ResourceEditWatcher/reducer.ts
@@ -1,4 +1,4 @@
-import produce, { Draft } from 'immer';
+import { produce, Draft } from 'immer';
 import { defaultWindowId, stateUtils } from '../../reducer';
 
 export const defaultState = {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -8,7 +8,7 @@ import { filename, dirname, rtrimSlashes } from '../../path-utils';
 import Setting from '../../models/Setting';
 import Logger from '@joplin/utils/Logger';
 import RepositoryApi from './RepositoryApi';
-import produce from 'immer';
+import { produce } from 'immer';
 import { PluginManifest } from './utils/types';
 import isCompatible from './utils/isCompatible';
 import { AppType } from './api/types';

--- a/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
+++ b/packages/lib/services/plugins/defaultPlugins/defaultPluginsUtils.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import { produce } from 'immer';
 import Setting from '../../../models/Setting';
 import shim from '../../../shim';
 import PluginService, { defaultPluginSetting, DefaultPluginsInfo, Plugins, PluginSettings } from '../PluginService';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8306,7 +8306,7 @@ __metadata:
     glob: 10.4.5
     gulp: 4.0.2
     highlight.js: 11.10.0
-    immer: 10.1.1
+    immer: 9.0.21
     jest: 29.7.0
     jest-environment-jsdom: 29.7.0
     js-sha512: 0.9.0
@@ -8639,7 +8639,7 @@ __metadata:
     html-entities: 1.4.0
     html-minifier: 4.0.0
     image-data-uri: 2.0.1
-    immer: 10.1.1
+    immer: 9.0.21
     jest: 29.7.0
     js-yaml: 4.1.0
     jsdom: 23.2.0
@@ -28529,14 +28529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:10.1.1":
-  version: 10.1.1
-  resolution: "immer@npm:10.1.1"
-  checksum: 07c67970b7d22aded73607193d84861bf786f07d47f7d7c98bb10016c7a88f6654ad78ae1e220b3c623695b133aabbf24f5eb8d9e8060cff11e89ccd81c9c10b
-  languageName: node
-  linkType: hard
-
-"immer@npm:^9.0.7":
+"immer@npm:9.0.21, immer@npm:^9.0.7":
   version: 9.0.21
   resolution: "immer@npm:9.0.21"
   checksum: 70e3c274165995352f6936695f0ef4723c52c92c92dd0e9afdfe008175af39fa28e76aafb3a2ca9d57d1fb8f796efc4dd1e1cc36f18d33fa5b74f3dfb0375432

--- a/yarn.lock
+++ b/yarn.lock
@@ -8306,7 +8306,7 @@ __metadata:
     glob: 10.4.5
     gulp: 4.0.2
     highlight.js: 11.10.0
-    immer: 7.0.15
+    immer: 10.1.1
     jest: 29.7.0
     jest-environment-jsdom: 29.7.0
     js-sha512: 0.9.0
@@ -8639,7 +8639,7 @@ __metadata:
     html-entities: 1.4.0
     html-minifier: 4.0.0
     image-data-uri: 2.0.1
-    immer: 7.0.15
+    immer: 10.1.1
     jest: 29.7.0
     js-yaml: 4.1.0
     jsdom: 23.2.0
@@ -28529,10 +28529,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:7.0.15":
-  version: 7.0.15
-  resolution: "immer@npm:7.0.15"
-  checksum: d79deb76f8bce71fff95bfbfa6a614bf55dd1f500eea189d3dcc587d94ed911b048e875c810b4e1214b3a6a7c8db148628e0c62e6fd8a649e84002cba0053e34
+"immer@npm:10.1.1":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 07c67970b7d22aded73607193d84861bf786f07d47f7d7c98bb10016c7a88f6654ad78ae1e220b3c623695b133aabbf24f5eb8d9e8060cff11e89ccd81c9c10b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades `immer` to v9.0.21.

> [!NOTE]
>
> In the future, before upgrading to `immer` [v10](https://github.com/immerjs/immer/releases/tag/v10.0.0), we'll need to check that React Native Hermes supports all of the required JS features.

# Breaking changes

- [v9](https://github.com/immerjs/immer/releases/tag/v9.0.0): Immer updated when it's permissible to return `undefined` from a recipe. Additionally return types from a recipe must match the `state` parameter type.
- [v8](https://github.com/immerjs/immer/releases/tag/v8.0.0): Freeze even when `immer` is in dev mode. 

# Testing

Most of the `immer`-related logic is covered by automated tests. However, it has been manually tested that:
- The web app starts and it's possible to create a new note and folder.
- It's possible to enable file system sync from the web app.
- The desktop app starts and it's possible to create and switch between secondary windows.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->