### PR TITLE
Desktop: Accessibility: Fix "focus viewer" doesn't move foucs to the correct line for sufficiently large documents

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -420,7 +420,7 @@
 				// When a screen reader is enabled, focus stays on the lineElement.
 				setTimeout(() => {
 					reset();
-				}, 50);
+				}, 1000);
 			}
 		}
 

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -391,36 +391,22 @@
 			return lastLineElement;
 		};
 
-		const makeTemporarilyFocusable = (element) => {
-			const dataOriginalTabIndexAttr = 'data-original-tabindex';
-			const originalTabIndex = (
-				element.getAttribute(dataOriginalTabIndexAttr) ?? element.getAttribute('tabindex')
-			);
-			element.setAttribute(dataOriginalTabIndexAttr, originalTabIndex);
-			element.setAttribute('tabindex', '0');
-
-			return {
-				reset: () => {
-					element.setAttribute('tabindex', originalTabIndex);
-					element.removeAttribute(dataOriginalTabIndexAttr);
-				},
-			};
-		};
-
 		ipc.focusLine = (event) => {
 			const targetLine = event.line;
 			const lineElement = getLineCorrespondingTo(targetLine);
 			if (lineElement) {
-				// To allow focusing, the element needs to briefly have tabindex=0.
-				const { reset } = makeTemporarilyFocusable(lineElement);
+				const doFocus = () => {
+					lineElement.focus({ preventScroll: true });
+				};
+				doFocus();
 
-				lineElement.focus({ preventScroll: true });
-
-				// Reset the tabindex after the browser has had time to focus the element.
-				// When a screen reader is enabled, focus stays on the lineElement.
-				setTimeout(() => {
-					reset();
-				}, 1000);
+				// Handle the case where the element is not naturally focusable.
+				if (!lineElement.contains(document.activeElement)) {
+					// tabindex=-1 allows focusing with JavaScript, but does not add the element
+					// to the focus order.
+					lineElement.setAttribute('tabindex', '-1');
+					doFocus();
+				}
 			}
 		}
 


### PR DESCRIPTION
# Summary

Previously, focusing the viewer relied on a timeout. On Windows with NVDA, the timeout was not sufficiently large — the "focus viewer" command would often move focus to the top of the viewer, rather than the cursor location. 

This pull request changes the approach, using [`tabindex="-1"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex#accessibility_concerns) for otherwise unfocusable elements, making them focusable by JavaScript, without changing the focus order.

# Testing plan

1. Start Joplin.
2. Open a large note.
3. Scroll past roughly 3/4ths of the document.
4. Move the cursor to a location roughly 3/4ths of the way through the document.
5. Run "focus viewer" (e.g. using a user-assigned keyboard shortcut).
6. Verify that **screen reader focus** is moved to the paragraph corresponding to the cursor location in the note viewer.
7. Repeat for another paragraph. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->