### PR TITLE
fix(import): skip standard web/mail links in Markdown importer to prevent ENAMETOOLONG

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -2,15 +2,11 @@ import InteropService_Importer_Md from '../../services/interop/InteropService_Im
 import Note from '../../models/Note';
 import Folder from '../../models/Folder';
 import * as fs from 'fs-extra';
-import {
-	createTempDir,
-	setupDatabaseAndSynchronizer,
-	supportDir,
-	switchClient,
-} from '../../testing/test-utils';
+import { createTempDir, setupDatabaseAndSynchronizer, supportDir, switchClient } from '../../testing/test-utils';
 import { MarkupToHtml } from '@joplin/renderer';
 import { FolderEntity, NoteEntity, ResourceEntity } from '../database/types';
 import Resource from '../../models/Resource';
+
 
 describe('InteropService_Importer_Md', () => {
 	let tempDir: string;
@@ -57,9 +53,7 @@ describe('InteropService_Importer_Md', () => {
 		expect(inexistentLinkUnchanged).toBe(true);
 	});
 	it('should only create 1 resource for duplicate links, all tags should be updated', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-duplicate-links.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-duplicate-links.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
@@ -68,28 +62,20 @@ describe('InteropService_Importer_Md', () => {
 		expect(matched.length).toBe(2);
 	});
 	it('should import linked files and modify tags appropriately when link is also in alt text', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-link-in-alt-text.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-link-in-alt-text.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
 	it('should passthrough unchanged if no links present', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-no-links.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-no-links.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
-		expect(note.body).toContain(
-			'Unidentified vessel travelling at sub warp speed, bearing 235.7. Fluctuations in energy readings from it, Captain. All transporters off.',
-		);
+		expect(note.body).toContain('Unidentified vessel travelling at sub warp speed, bearing 235.7. Fluctuations in energy readings from it, Captain. All transporters off.');
 	});
 	it('should import linked image with special characters in name', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-special-chars.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-special-chars.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -99,9 +85,7 @@ describe('InteropService_Importer_Md', () => {
 		expect(spaceSyntaxLeft).toBe(false);
 	});
 	it('should import resources and notes for files', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-files.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-files.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -120,35 +104,27 @@ describe('InteropService_Importer_Md', () => {
 		expect(noteBIds[0]).toEqual(noteA.id);
 	});
 	it('should not import resources from file:// links', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-file-links.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-file-links.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
 		expect(note.body).toContain('![sample](file://../../photo.jpg)');
 	});
 	it('should attach resources that are missing the file extension', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-no-extension.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-no-extension.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
 	it('should attach resources that include anchor links', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-anchor-link.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-anchor-link.md`);
 
 		const itemIds = await Note.linkedItemIds(note.body);
 		expect(itemIds.length).toBe(1);
 		expect(note.body).toContain(`[Section 1](:/${itemIds[0]}#markdown)`);
 	});
 	it('should attach resources that include a title', async () => {
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-link-title.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-link-title.md`);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -172,76 +148,47 @@ describe('InteropService_Importer_Md', () => {
 
 		await importNoteDirectory(`${tempDir}/non-empty`);
 		const allFolders = await Folder.all();
-		expect(
-			allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty'),
-		).toBeGreaterThanOrEqual(0);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty')).toBeGreaterThanOrEqual(0);
 	});
 	it('should not import empty directory', async () => {
 		await fs.mkdirp(`${tempDir}/empty1/empty2`);
 
 		await importNoteDirectory(`${tempDir}/empty1`);
 		const allFolders = await Folder.all();
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty1')).toBe(
-			0,
-		);
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty2')).toBe(
-			-1,
-		);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty1')).toBe(0);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty2')).toBe(-1);
 	});
 	it('should import directory with non-empty subdirectory', async () => {
-		await fs.mkdirp(
-			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-empty`,
-		);
-		await fs.mkdirp(
-			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty`,
-		);
-		await fs.writeFile(
-			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty/sample.md`,
-			'# Sample',
-		);
+		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-empty`);
+		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty`);
+		await fs.writeFile(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty/sample.md`, '# Sample');
 
 		await importNoteDirectory(`${tempDir}/non-empty-subdir`);
 		const allFolders = await Folder.all();
-		expect(
-			allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty-subdir'),
-		).toBeGreaterThanOrEqual(0);
-		expect(
-			allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-empty'),
-		).toBe(-1);
-		expect(
-			allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-non-empty'),
-		).toBeGreaterThanOrEqual(0);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty-subdir')).toBeGreaterThanOrEqual(0);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-empty')).toBe(-1);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-non-empty')).toBeGreaterThanOrEqual(0);
 	});
 
 	it('should import all files before replacing links', async () => {
 		await fs.mkdirp(`${tempDir}/links/0/1/2`);
 		await fs.mkdirp(`${tempDir}/links/Target_folder`);
-		await fs.writeFile(
-			`${tempDir}/links/Target_folder/Targeted_note.md`,
-			'# Targeted_note',
-		);
-		await fs.writeFile(
-			`${tempDir}/links/0/1/2/Note_with_reference_to_another_note.md`,
-			'# 20\n[Target_folder:Targeted_note](../../../Target_folder/Targeted_note.md)',
-		);
+		await fs.writeFile(`${tempDir}/links/Target_folder/Targeted_note.md`, '# Targeted_note');
+		await fs.writeFile(`${tempDir}/links/0/1/2/Note_with_reference_to_another_note.md`, '# 20\n[Target_folder:Targeted_note](../../../Target_folder/Targeted_note.md)');
 
 		await importNoteDirectory(`${tempDir}/links`);
 
 		const allFolders = await Folder.all();
 		const allNotes = await Note.all();
-		const targetFolder = allFolders.find((f) => f.title === 'Target_folder');
-		const noteBeingReferenced = allNotes.find(
-			(n) => n.title === 'Targeted_note',
-		);
+		const targetFolder = allFolders.find(f => f.title === 'Target_folder');
+		const noteBeingReferenced = allNotes.find(n => n.title === 'Targeted_note');
 
 		expect(noteBeingReferenced.parent_id).toBe(targetFolder.id);
 	});
 
 	it('should not fail to import file that contains a link to a file that does not exist', async () => {
 		// The first implicit test is that the below call doesn't throw due to the invalid image
-		const note = await importNote(
-			`${supportDir}/test_notes/md/invalid-image-link.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/invalid-image-link.md`);
 		const links = Note.linkedItemIds(note.body);
 		expect(links.length).toBe(1);
 		const resource: ResourceEntity = await Resource.load(links[0]);
@@ -251,17 +198,12 @@ describe('InteropService_Importer_Md', () => {
 
 	it('should not fail to import file that contains a malformed URI', async () => {
 		// The first implicit test is that the below call doesn't throw due to the malformed URI
-		const note = await importNote(
-			`${supportDir}/test_notes/md/sample-malformed-uri.md`,
-		);
+		const note = await importNote(`${supportDir}/test_notes/md/sample-malformed-uri.md`);
 		const itemIds = Note.linkedItemIds(note.body);
 		expect(itemIds.length).toBe(0);
 		// The malformed link is imported as-is
-		expect(note.body).toContain(
-			'![malformed link](https://malformed_uri/%E0%A4%A.jpg)',
-		);
+		expect(note.body).toContain('![malformed link](https://malformed_uri/%E0%A4%A.jpg)');
 	});
-
 	it('should not treat very long http links as local files (Issue #12172)', async () => {
 		const longUrl =
       'https://l.facebook.com/l.php?u=https%3A%2F%2Fix.sk%2FNiBZH%3Futm_source%3DYouTube%2520Instagram%26utm_medium%3D2HIqFSGVVB2mFsVTJClrQ7ZnuGJaUt6hu1MNH0vUMjcrgWnUsK%26utm_campaign%3D%25F0%259F%2598%25A9%25F0%259F%2598%258E%25F0%259F%2598%25BF%25F0%259F%25A4%2594%25F0%259F%2598%25A9%25F0%259F%2599%2583%25F0%259F%25A4%25AF%25F0%259F%25A5%25B0%25F0%259F%2598%25AB%25F0%259F%2598%25BA%26utm_id%3D%25F0%259F%2598%258B%25F0%259F%2598%25A5%25F0%259F%25A4%25A1%25F0%259F%2598%25A0%25F0%259F%2598%2587%25F0%259F%25A5%25B4%25F0%259F%25A7%2590%25F0%259F%2598%258E%25F0%259F%2598%2582%25F0%259F%2598%259E%26utm_term%3D%25F0%259F%2598%2584%25F0%259F%25A4%25A9%25F0%259F%2599%2580%25F0%259F%2598%2593%25F0%259F%25A4%25AF%25F0%259F%25A4%25A5%25F0%259F%2591%25BE%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%25A4%25A5%26utm_content%3D%25F0%259F%2591%25BD%25F0%259F%2598%25AB%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%2598%25A9%25F0%259F%2599%2589%26fbclid%3DIwAR0I3l5DBLypLaTjDTCGPQ1i1MmPB2-pE8iqrxrgUK9Kkvq3OX5Mjejibzw&h=AT3nNxW4G-9nAkhXU1EVN-aVGl1o_-DzDAaWFx9xbprpN3JRBOh17lCQQHNAlIMv6iE4P2vobBAAivLvdzy00K8xqIqb-CvGj6YnnBX6R9wwtj5Y&__tn__=H-y-R&c[0]=AT0eE6OXx_t9HzpPmMgTdOWAw2ZRNPRDIHJWf699NZYkYzugbWS6g3rOndhPA8fwrCIgk1zn2D1To7phLW9wXkqfgZU1ayT3887_dxrfN-x822Pos0lCjTIhoQcxfBl516pTz1XrRG_MbtPpLzUFAGu4nw5W86UR1EkBCZhustNbgTX4wVReiVSuwAWu7Sp1yiWvUm5JXlo76663333hhsgsu';

--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -2,11 +2,15 @@ import InteropService_Importer_Md from '../../services/interop/InteropService_Im
 import Note from '../../models/Note';
 import Folder from '../../models/Folder';
 import * as fs from 'fs-extra';
-import { createTempDir, setupDatabaseAndSynchronizer, supportDir, switchClient } from '../../testing/test-utils';
+import {
+	createTempDir,
+	setupDatabaseAndSynchronizer,
+	supportDir,
+	switchClient,
+} from '../../testing/test-utils';
 import { MarkupToHtml } from '@joplin/renderer';
 import { FolderEntity, NoteEntity, ResourceEntity } from '../database/types';
 import Resource from '../../models/Resource';
-
 
 describe('InteropService_Importer_Md', () => {
 	let tempDir: string;
@@ -53,7 +57,9 @@ describe('InteropService_Importer_Md', () => {
 		expect(inexistentLinkUnchanged).toBe(true);
 	});
 	it('should only create 1 resource for duplicate links, all tags should be updated', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-duplicate-links.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-duplicate-links.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
@@ -62,20 +68,28 @@ describe('InteropService_Importer_Md', () => {
 		expect(matched.length).toBe(2);
 	});
 	it('should import linked files and modify tags appropriately when link is also in alt text', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-link-in-alt-text.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-link-in-alt-text.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
 	it('should passthrough unchanged if no links present', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-no-links.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-no-links.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
-		expect(note.body).toContain('Unidentified vessel travelling at sub warp speed, bearing 235.7. Fluctuations in energy readings from it, Captain. All transporters off.');
+		expect(note.body).toContain(
+			'Unidentified vessel travelling at sub warp speed, bearing 235.7. Fluctuations in energy readings from it, Captain. All transporters off.',
+		);
 	});
 	it('should import linked image with special characters in name', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-special-chars.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-special-chars.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -85,7 +99,9 @@ describe('InteropService_Importer_Md', () => {
 		expect(spaceSyntaxLeft).toBe(false);
 	});
 	it('should import resources and notes for files', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-files.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-files.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -104,27 +120,35 @@ describe('InteropService_Importer_Md', () => {
 		expect(noteBIds[0]).toEqual(noteA.id);
 	});
 	it('should not import resources from file:// links', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-file-links.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-file-links.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(0);
 		expect(note.body).toContain('![sample](file://../../photo.jpg)');
 	});
 	it('should attach resources that are missing the file extension', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-no-extension.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-no-extension.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(1);
 	});
 	it('should attach resources that include anchor links', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-anchor-link.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-anchor-link.md`,
+		);
 
 		const itemIds = await Note.linkedItemIds(note.body);
 		expect(itemIds.length).toBe(1);
 		expect(note.body).toContain(`[Section 1](:/${itemIds[0]}#markdown)`);
 	});
 	it('should attach resources that include a title', async () => {
-		const note = await importNote(`${supportDir}/test_notes/md/sample-link-title.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-link-title.md`,
+		);
 
 		const items = await Note.linkedItems(note.body);
 		expect(items.length).toBe(3);
@@ -148,47 +172,76 @@ describe('InteropService_Importer_Md', () => {
 
 		await importNoteDirectory(`${tempDir}/non-empty`);
 		const allFolders = await Folder.all();
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty')).toBeGreaterThanOrEqual(0);
+		expect(
+			allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty'),
+		).toBeGreaterThanOrEqual(0);
 	});
 	it('should not import empty directory', async () => {
 		await fs.mkdirp(`${tempDir}/empty1/empty2`);
 
 		await importNoteDirectory(`${tempDir}/empty1`);
 		const allFolders = await Folder.all();
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty1')).toBe(0);
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty2')).toBe(-1);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty1')).toBe(
+			0,
+		);
+		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('empty2')).toBe(
+			-1,
+		);
 	});
 	it('should import directory with non-empty subdirectory', async () => {
-		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-empty`);
-		await fs.mkdirp(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty`);
-		await fs.writeFile(`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty/sample.md`, '# Sample');
+		await fs.mkdirp(
+			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-empty`,
+		);
+		await fs.mkdirp(
+			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty`,
+		);
+		await fs.writeFile(
+			`${tempDir}/non-empty-subdir/non-empty-subdir/subdir-non-empty/sample.md`,
+			'# Sample',
+		);
 
 		await importNoteDirectory(`${tempDir}/non-empty-subdir`);
 		const allFolders = await Folder.all();
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty-subdir')).toBeGreaterThanOrEqual(0);
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-empty')).toBe(-1);
-		expect(allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-non-empty')).toBeGreaterThanOrEqual(0);
+		expect(
+			allFolders.map((f: FolderEntity) => f.title).indexOf('non-empty-subdir'),
+		).toBeGreaterThanOrEqual(0);
+		expect(
+			allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-empty'),
+		).toBe(-1);
+		expect(
+			allFolders.map((f: FolderEntity) => f.title).indexOf('subdir-non-empty'),
+		).toBeGreaterThanOrEqual(0);
 	});
 
 	it('should import all files before replacing links', async () => {
 		await fs.mkdirp(`${tempDir}/links/0/1/2`);
 		await fs.mkdirp(`${tempDir}/links/Target_folder`);
-		await fs.writeFile(`${tempDir}/links/Target_folder/Targeted_note.md`, '# Targeted_note');
-		await fs.writeFile(`${tempDir}/links/0/1/2/Note_with_reference_to_another_note.md`, '# 20\n[Target_folder:Targeted_note](../../../Target_folder/Targeted_note.md)');
+		await fs.writeFile(
+			`${tempDir}/links/Target_folder/Targeted_note.md`,
+			'# Targeted_note',
+		);
+		await fs.writeFile(
+			`${tempDir}/links/0/1/2/Note_with_reference_to_another_note.md`,
+			'# 20\n[Target_folder:Targeted_note](../../../Target_folder/Targeted_note.md)',
+		);
 
 		await importNoteDirectory(`${tempDir}/links`);
 
 		const allFolders = await Folder.all();
 		const allNotes = await Note.all();
-		const targetFolder = allFolders.find(f => f.title === 'Target_folder');
-		const noteBeingReferenced = allNotes.find(n => n.title === 'Targeted_note');
+		const targetFolder = allFolders.find((f) => f.title === 'Target_folder');
+		const noteBeingReferenced = allNotes.find(
+			(n) => n.title === 'Targeted_note',
+		);
 
 		expect(noteBeingReferenced.parent_id).toBe(targetFolder.id);
 	});
 
 	it('should not fail to import file that contains a link to a file that does not exist', async () => {
 		// The first implicit test is that the below call doesn't throw due to the invalid image
-		const note = await importNote(`${supportDir}/test_notes/md/invalid-image-link.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/invalid-image-link.md`,
+		);
 		const links = Note.linkedItemIds(note.body);
 		expect(links.length).toBe(1);
 		const resource: ResourceEntity = await Resource.load(links[0]);
@@ -198,10 +251,30 @@ describe('InteropService_Importer_Md', () => {
 
 	it('should not fail to import file that contains a malformed URI', async () => {
 		// The first implicit test is that the below call doesn't throw due to the malformed URI
-		const note = await importNote(`${supportDir}/test_notes/md/sample-malformed-uri.md`);
+		const note = await importNote(
+			`${supportDir}/test_notes/md/sample-malformed-uri.md`,
+		);
 		const itemIds = Note.linkedItemIds(note.body);
 		expect(itemIds.length).toBe(0);
 		// The malformed link is imported as-is
-		expect(note.body).toContain('![malformed link](https://malformed_uri/%E0%A4%A.jpg)');
+		expect(note.body).toContain(
+			'![malformed link](https://malformed_uri/%E0%A4%A.jpg)',
+		);
+	});
+
+	it('should not treat very long http links as local files (Issue #12172)', async () => {
+		const longUrl =
+      'https://l.facebook.com/l.php?u=https%3A%2F%2Fix.sk%2FNiBZH%3Futm_source%3DYouTube%2520Instagram%26utm_medium%3D2HIqFSGVVB2mFsVTJClrQ7ZnuGJaUt6hu1MNH0vUMjcrgWnUsK%26utm_campaign%3D%25F0%259F%2598%25A9%25F0%259F%2598%258E%25F0%259F%2598%25BF%25F0%259F%25A4%2594%25F0%259F%2598%25A9%25F0%259F%2599%2583%25F0%259F%25A4%25AF%25F0%259F%25A5%25B0%25F0%259F%2598%25AB%25F0%259F%2598%25BA%26utm_id%3D%25F0%259F%2598%258B%25F0%259F%2598%25A5%25F0%259F%25A4%25A1%25F0%259F%2598%25A0%25F0%259F%2598%2587%25F0%259F%25A5%25B4%25F0%259F%25A7%2590%25F0%259F%2598%258E%25F0%259F%2598%2582%25F0%259F%2598%259E%26utm_term%3D%25F0%259F%2598%2584%25F0%259F%25A4%25A9%25F0%259F%2599%2580%25F0%259F%2598%2593%25F0%259F%25A4%25AF%25F0%259F%25A4%25A5%25F0%259F%2591%25BE%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%25A4%25A5%26utm_content%3D%25F0%259F%2591%25BD%25F0%259F%2598%25AB%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%2598%25A9%25F0%259F%2599%2589%26fbclid%3DIwAR0I3l5DBLypLaTjDTCGPQ1i1MmPB2-pE8iqrxrgUK9Kkvq3OX5Mjejibzw&h=AT3nNxW4G-9nAkhXU1EVN-aVGl1o_-DzDAaWFx9xbprpN3JRBOh17lCQQHNAlIMv6iE4P2vobBAAivLvdzy00K8xqIqb-CvGj6YnnBX6R9wwtj5Y&__tn__=H-y-R&c[0]=AT0eE6OXx_t9HzpPmMgTdOWAw2ZRNPRDIHJWf699NZYkYzugbWS6g3rOndhPA8fwrCIgk1zn2D1To7phLW9wXkqfgZU1ayT3887_dxrfN-x822Pos0lCjTIhoQcxfBl516pTz1XrRG_MbtPpLzUFAGu4nw5W86UR1EkBCZhustNbgTX4wVReiVSuwAWu7Sp1yiWvUm5JXlo76663333hhsgsu';
+		const mdContent = `# Test\n\n[Long Link](${longUrl})`;
+		const tempFilePath = `${tempDir}/long_link_test.md`;
+
+		await fs.writeFile(tempFilePath, mdContent);
+		// Use the helper function defined in this test file
+		const note = await importNote(tempFilePath);
+
+		// Check the link wasn't modified or treated as a resource
+		expect(note.body).toContain(`[Long Link](${longUrl})`);
+		const linkedItems = await Note.linkedItemIds(note.body);
+		expect(linkedItems.length).toBe(0);
 	});
 });

--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -204,18 +204,16 @@ describe('InteropService_Importer_Md', () => {
 		// The malformed link is imported as-is
 		expect(note.body).toContain('![malformed link](https://malformed_uri/%E0%A4%A.jpg)');
 	});
-	it('should not treat very long http links as local files (Issue #12172)', async () => {
-		const longUrl =
-      'https://l.facebook.com/l.php?u=https%3A%2F%2Fix.sk%2FNiBZH%3Futm_source%3DYouTube%2520Instagram%26utm_medium%3D2HIqFSGVVB2mFsVTJClrQ7ZnuGJaUt6hu1MNH0vUMjcrgWnUsK%26utm_campaign%3D%25F0%259F%2598%25A9%25F0%259F%2598%258E%25F0%259F%2598%25BF%25F0%259F%25A4%2594%25F0%259F%2598%25A9%25F0%259F%2599%2583%25F0%259F%25A4%25AF%25F0%259F%25A5%25B0%25F0%259F%2598%25AB%25F0%259F%2598%25BA%26utm_id%3D%25F0%259F%2598%258B%25F0%259F%2598%25A5%25F0%259F%25A4%25A1%25F0%259F%2598%25A0%25F0%259F%2598%2587%25F0%259F%25A5%25B4%25F0%259F%25A7%2590%25F0%259F%2598%258E%25F0%259F%2598%2582%25F0%259F%2598%259E%26utm_term%3D%25F0%259F%2598%2584%25F0%259F%25A4%25A9%25F0%259F%2599%2580%25F0%259F%2598%2593%25F0%259F%25A4%25AF%25F0%259F%25A4%25A5%25F0%259F%2591%25BE%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%25A4%25A5%26utm_content%3D%25F0%259F%2591%25BD%25F0%259F%2598%25AB%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%2598%25A9%25F0%259F%2599%2589%26fbclid%3DIwAR0I3l5DBLypLaTjDTCGPQ1i1MmPB2-pE8iqrxrgUK9Kkvq3OX5Mjejibzw&h=AT3nNxW4G-9nAkhXU1EVN-aVGl1o_-DzDAaWFx9xbprpN3JRBOh17lCQQHNAlIMv6iE4P2vobBAAivLvdzy00K8xqIqb-CvGj6YnnBX6R9wwtj5Y&__tn__=H-y-R&c[0]=AT0eE6OXx_t9HzpPmMgTdOWAw2ZRNPRDIHJWf699NZYkYzugbWS6g3rOndhPA8fwrCIgk1zn2D1To7phLW9wXkqfgZU1ayT3887_dxrfN-x822Pos0lCjTIhoQcxfBl516pTz1XrRG_MbtPpLzUFAGu4nw5W86UR1EkBCZhustNbgTX4wVReiVSuwAWu7Sp1yiWvUm5JXlo76663333hhsgsu';
-		const mdContent = `# Test\n\n[Long Link](${longUrl})`;
+	it('should not treat very long http links as local files', async () => {
+		const longUrl = 'https://l.facebook.com/l.php?u=https%3A%2F%2Fix.sk%2FNiBZH%3Futm_source%3DYouTube%2520Instagram%26utm_medium%3D2HIqFSGVVB2mFsVTJClrQ7ZnuGJaUt6hu1MNH0vUMjcrgWnUsK%26utm_campaign%3D%25F0%259F%2598%25A9%25F0%259F%2598%258E%25F0%259F%2598%25BF%25F0%259F%25A4%2594%25F0%259F%2598%25A9%25F0%259F%2599%2583%25F0%259F%25A4%25AF%25F0%259F%25A5%25B0%25F0%259F%2598%25AB%25F0%259F%2598%25BA%26utm_id%3D%25F0%259F%2598%258B%25F0%259F%2598%25A5%25F0%259F%25A4%25A1%25F0%259F%2598%25A0%25F0%259F%2598%2587%25F0%259F%25A5%25B4%25F0%259F%25A7%2590%25F0%259F%2598%258E%25F0%259F%2598%2582%25F0%259F%2598%259E%26utm_term%3D%25F0%259F%2598%2584%25F0%259F%25A4%25A9%25F0%259F%2599%2580%25F0%259F%2598%2593%25F0%259F%25A4%25AF%25F0%259F%25A4%25A5%25F0%259F%2591%25BE%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%25A4%25A5%26utm_content%3D%25F0%259F%2591%25BD%25F0%259F%2598%25AB%25F0%259F%2591%25BF%25F0%259F%2598%25BD%25F0%259F%2598%25A9%25F0%259F%2599%2589%26fbclid%3DIwAR0I3l5DBLypLaTjDTCGPQ1i1MmPB2-pE8iqrxrgUK9Kkvq3OX5Mjejibzw&h=AT3nNxW4G-9nAkhXU1EVN-aVGl1o_-DzDAaWFx9xbprpN3JRBOh17lCQQHNAlIMv6iE4P2vobBAAivLvdzy00K8xqIqb-CvGj6YnnBX6R9wwtj5Y&__tn__=H-y-R&c[0]=AT0eE6OXx_t9HzpPmMgTdOWAw2ZRNPRDIHJWf699NZYkYzugbWS6g3rOndhPA8fwrCIgk1zn2D1To7phLW9wXkqfgZU1ayT3887_dxrfN-x822Pos0lCjTIhoQcxfBl516pTz1XrRG_MbtPpLzUFAGu4nw5W86UR1EkBCZhustNbgTX4wVReiVSuwAWu7Sp1yiWvUm5JXlo';
+		const mdContent = `# Test\n\n[${longUrl}](<${longUrl}>)`;
 		const tempFilePath = `${tempDir}/long_link_test.md`;
 
 		await fs.writeFile(tempFilePath, mdContent);
-		// Use the helper function defined in this test file
 		const note = await importNote(tempFilePath);
 
 		// Check the link wasn't modified or treated as a resource
-		expect(note.body).toContain(`[Long Link](${longUrl})`);
+		expect(note.body).toContain(`[${longUrl}](<${longUrl}>)`);
 		const linkedItems = await Note.linkedItemIds(note.body);
 		expect(linkedItems.length).toBe(0);
 	});

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -5,20 +5,14 @@ import InteropService_Importer_Base from './InteropService_Importer_Base';
 import Folder from '../../models/Folder';
 import Note from '../../models/Note';
 import { NoteEntity } from '../database/types';
-import {
-	basename,
-	filename,
-	rtrimSlashes,
-	fileExtension,
-	dirname,
-} from '../../path-utils';
+import { basename, filename, rtrimSlashes, fileExtension, dirname } from '../../path-utils';
 import shim from '../../shim';
 import markdownUtils from '../../markdownUtils';
 import htmlUtils from '../../htmlUtils';
 import { unique } from '../../ArrayUtils';
 const { pregQuote } = require('../../string-utils-common');
 import { MarkupToHtml } from '@joplin/renderer';
-import { hasProtocol, isDataUrl } from '@joplin/utils/url';
+import { isDataUrl, hasProtocol } from '@joplin/utils/url';
 import { stripBom } from '../../string-utils';
 
 export default class InteropService_Importer_Md extends InteropService_Importer_Base {
@@ -32,9 +26,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 		const filePaths = [];
 		if (await shim.fsDriver().isDirectory(sourcePath)) {
 			if (!this.options_.destinationFolder) {
-				const folderTitle = await Folder.findUniqueItemTitle(
-					basename(sourcePath),
-				);
+				const folderTitle = await Folder.findUniqueItemTitle(basename(sourcePath));
 				const folder = await Folder.save({ title: folderTitle });
 				parentFolderId = folder.id;
 			} else {
@@ -54,19 +46,12 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 		for (const importedLocalPath of Object.keys(this.importedNotes)) {
 			const note = this.importedNotes[importedLocalPath];
-			const updatedBody = await this.importLocalFiles(
-				importedLocalPath,
-				note.body,
-				note.parent_id,
-			);
+			const updatedBody = await this.importLocalFiles(importedLocalPath, note.body, note.parent_id);
 			const updatedNote = {
 				...this.importedNotes[importedLocalPath],
 				body: updatedBody || note.body,
 			};
-			this.importedNotes[importedLocalPath] = await Note.save(updatedNote, {
-				isNew: false,
-				autoTimestamp: false,
-			});
+			this.importedNotes[importedLocalPath] = await Note.save(updatedNote, { isNew: false, autoTimestamp: false });
 		}
 
 		return result;
@@ -82,22 +67,10 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				if (await this.isDirectoryEmpty(`${dirPath}/${stat.path}`)) {
 					continue;
 				}
-				const folderTitle = await Folder.findUniqueItemTitle(
-					basename(stat.path),
-				);
-				const folder = await Folder.save({
-					title: folderTitle,
-					parent_id: parentFolderId,
-				});
-				await this.importDirectory(
-					`${dirPath}/${basename(stat.path)}`,
-					folder.id,
-				);
-			} else if (
-				supportedFileExtension.indexOf(
-					fileExtension(stat.path).toLowerCase(),
-				) >= 0
-			) {
+				const folderTitle = await Folder.findUniqueItemTitle(basename(stat.path));
+				const folder = await Folder.save({ title: folderTitle, parent_id: parentFolderId });
+				await this.importDirectory(`${dirPath}/${basename(stat.path)}`, folder.id);
+			} else if (supportedFileExtension.indexOf(fileExtension(stat.path).toLowerCase()) >= 0) {
 				await this.importFile(`${dirPath}/${stat.path}`, parentFolderId);
 			}
 		}
@@ -113,15 +86,12 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				if (!(await this.isDirectoryEmpty(`${dirPath}/${innerStat.path}`))) {
 					return false;
 				}
-			} else if (
-				supportedFileExtension.indexOf(
-					fileExtension(innerStat.path).toLowerCase(),
-				) >= 0
-			) {
+			} else if (supportedFileExtension.indexOf(fileExtension(innerStat.path).toLowerCase()) >= 0) {
 				return false;
 			}
 		}
 		return true;
+
 	}
 
 	private trimAnchorLink(link: string) {
@@ -134,11 +104,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 	// Parse text for links, attempt to find local file, if found create Joplin resource
 	// and update link accordingly.
-	public async importLocalFiles(
-		filePath: string,
-		md: string,
-		parentFolderId: string,
-	) {
+	public async importLocalFiles(filePath: string, md: string, parentFolderId: string) {
 		let updated = md;
 		const markdownLinks = markdownUtils.extractFileUrls(md);
 		const htmlLinks = htmlUtils.extractFileUrls(md);
@@ -151,10 +117,10 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				// If the URI cannot be decoded, leave it as it is.
 				continue;
 			}
-
 			if (hasProtocol(link, ['http', 'https', 'mailto'])) {
 				continue;
 			}
+
 
 			if (isDataUrl(link)) {
 				// Just leave it as it is. We could potentially import
@@ -163,13 +129,8 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 			} else {
 				// Handle anchor links appropriately
 				const trimmedLink = this.trimAnchorLink(link);
-				const attachmentPath = filename(
-					`${dirname(filePath)}/${trimmedLink}`,
-					true,
-				);
-				const pathWithExtension = `${attachmentPath}.${fileExtension(
-					trimmedLink,
-				)}`;
+				const attachmentPath = filename(`${dirname(filePath)}/${trimmedLink}`, true);
+				const pathWithExtension = `${attachmentPath}.${fileExtension(trimmedLink)}`;
 				const stat = await shim.fsDriver().stat(pathWithExtension);
 				const isDir = stat ? stat.isDirectory() : false;
 				if (stat && !isDir) {
@@ -177,11 +138,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 					const resolvedPath = shim.fsDriver().resolve(pathWithExtension);
 					let id = '';
 					// If the link looks like a note, then import it
-					if (
-						supportedFileExtension.indexOf(
-							fileExtension(trimmedLink).toLowerCase(),
-						) >= 0
-					) {
+					if (supportedFileExtension.indexOf(fileExtension(trimmedLink).toLowerCase()) >= 0) {
 						// If the note hasn't been imported yet, do so now
 						if (!this.importedNotes[resolvedPath]) {
 							await this.importFile(resolvedPath, parentFolderId);
@@ -189,11 +146,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 						id = this.importedNotes[resolvedPath].id;
 					} else {
-						const resource = await shim.createResourceFromPath(
-							pathWithExtension,
-							null,
-							{ resizeLargeImages: 'never' },
-						);
+						const resource = await shim.createResourceFromPath(pathWithExtension, null, { resizeLargeImages: 'never' });
 						id = resource.id;
 					}
 
@@ -201,20 +154,13 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 					// Only opening patterns are consider in order to cover all occurrences
 					// We need to use the encoded link as well because some links (link's with spaces)
 					// will appear encoded in the source. Other links (unicode chars) will not
-					const linksToReplace = [
-						this.trimAnchorLink(link),
-						this.trimAnchorLink(encodedLink),
-					];
+					const linksToReplace = [this.trimAnchorLink(link), this.trimAnchorLink(encodedLink)];
 
 					for (let j = 0; j < linksToReplace.length; j++) {
 						const linkToReplace = pregQuote(linksToReplace[j]);
 
 						// Markdown links
-						updated = markdownUtils.replaceResourceUrl(
-							updated,
-							linkToReplace,
-							id,
-						);
+						updated = markdownUtils.replaceResourceUrl(updated, linkToReplace, id);
 
 						// HTML links
 						updated = htmlUtils.replaceResourceUrl(updated, linkToReplace, id);
@@ -227,9 +173,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 	public async importFile(filePath: string, parentFolderId: string) {
 		const resolvedPath = shim.fsDriver().resolve(filePath);
-		if (this.importedNotes[resolvedPath]) {
-			return this.importedNotes[resolvedPath];
-		}
+		if (this.importedNotes[resolvedPath]) return this.importedNotes[resolvedPath];
 
 		const stat = await shim.fsDriver().stat(resolvedPath);
 		if (!stat) throw new Error(`Cannot read ${resolvedPath}`);
@@ -247,9 +191,7 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 			user_created_time: stat.birthtime.getTime(),
 			markup_language: ext === 'html' ? MarkupToHtml.MARKUP_LANGUAGE_HTML : MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN,
 		};
-		this.importedNotes[resolvedPath] = await Note.save(note, {
-			autoTimestamp: false,
-		});
+		this.importedNotes[resolvedPath] = await Note.save(note, { autoTimestamp: false });
 
 		return this.importedNotes[resolvedPath];
 	}

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -5,14 +5,20 @@ import InteropService_Importer_Base from './InteropService_Importer_Base';
 import Folder from '../../models/Folder';
 import Note from '../../models/Note';
 import { NoteEntity } from '../database/types';
-import { basename, filename, rtrimSlashes, fileExtension, dirname } from '../../path-utils';
+import {
+	basename,
+	filename,
+	rtrimSlashes,
+	fileExtension,
+	dirname,
+} from '../../path-utils';
 import shim from '../../shim';
 import markdownUtils from '../../markdownUtils';
 import htmlUtils from '../../htmlUtils';
 import { unique } from '../../ArrayUtils';
 const { pregQuote } = require('../../string-utils-common');
 import { MarkupToHtml } from '@joplin/renderer';
-import { isDataUrl } from '@joplin/utils/url';
+import { hasProtocol, isDataUrl } from '@joplin/utils/url';
 import { stripBom } from '../../string-utils';
 
 export default class InteropService_Importer_Md extends InteropService_Importer_Base {
@@ -26,7 +32,9 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 		const filePaths = [];
 		if (await shim.fsDriver().isDirectory(sourcePath)) {
 			if (!this.options_.destinationFolder) {
-				const folderTitle = await Folder.findUniqueItemTitle(basename(sourcePath));
+				const folderTitle = await Folder.findUniqueItemTitle(
+					basename(sourcePath),
+				);
 				const folder = await Folder.save({ title: folderTitle });
 				parentFolderId = folder.id;
 			} else {
@@ -46,12 +54,19 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 		for (const importedLocalPath of Object.keys(this.importedNotes)) {
 			const note = this.importedNotes[importedLocalPath];
-			const updatedBody = await this.importLocalFiles(importedLocalPath, note.body, note.parent_id);
+			const updatedBody = await this.importLocalFiles(
+				importedLocalPath,
+				note.body,
+				note.parent_id,
+			);
 			const updatedNote = {
 				...this.importedNotes[importedLocalPath],
 				body: updatedBody || note.body,
 			};
-			this.importedNotes[importedLocalPath] = await Note.save(updatedNote, { isNew: false, autoTimestamp: false });
+			this.importedNotes[importedLocalPath] = await Note.save(updatedNote, {
+				isNew: false,
+				autoTimestamp: false,
+			});
 		}
 
 		return result;
@@ -67,10 +82,22 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				if (await this.isDirectoryEmpty(`${dirPath}/${stat.path}`)) {
 					continue;
 				}
-				const folderTitle = await Folder.findUniqueItemTitle(basename(stat.path));
-				const folder = await Folder.save({ title: folderTitle, parent_id: parentFolderId });
-				await this.importDirectory(`${dirPath}/${basename(stat.path)}`, folder.id);
-			} else if (supportedFileExtension.indexOf(fileExtension(stat.path).toLowerCase()) >= 0) {
+				const folderTitle = await Folder.findUniqueItemTitle(
+					basename(stat.path),
+				);
+				const folder = await Folder.save({
+					title: folderTitle,
+					parent_id: parentFolderId,
+				});
+				await this.importDirectory(
+					`${dirPath}/${basename(stat.path)}`,
+					folder.id,
+				);
+			} else if (
+				supportedFileExtension.indexOf(
+					fileExtension(stat.path).toLowerCase(),
+				) >= 0
+			) {
 				await this.importFile(`${dirPath}/${stat.path}`, parentFolderId);
 			}
 		}
@@ -86,12 +113,15 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				if (!(await this.isDirectoryEmpty(`${dirPath}/${innerStat.path}`))) {
 					return false;
 				}
-			} else if (supportedFileExtension.indexOf(fileExtension(innerStat.path).toLowerCase()) >= 0) {
+			} else if (
+				supportedFileExtension.indexOf(
+					fileExtension(innerStat.path).toLowerCase(),
+				) >= 0
+			) {
 				return false;
 			}
 		}
 		return true;
-
 	}
 
 	private trimAnchorLink(link: string) {
@@ -104,7 +134,11 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 	// Parse text for links, attempt to find local file, if found create Joplin resource
 	// and update link accordingly.
-	public async importLocalFiles(filePath: string, md: string, parentFolderId: string) {
+	public async importLocalFiles(
+		filePath: string,
+		md: string,
+		parentFolderId: string,
+	) {
 		let updated = md;
 		const markdownLinks = markdownUtils.extractFileUrls(md);
 		const htmlLinks = htmlUtils.extractFileUrls(md);
@@ -118,6 +152,10 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				continue;
 			}
 
+			if (hasProtocol(link, ['http', 'https', 'mailto'])) {
+				continue;
+			}
+
 			if (isDataUrl(link)) {
 				// Just leave it as it is. We could potentially import
 				// it as a resource but for now that's good enough.
@@ -125,8 +163,13 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 			} else {
 				// Handle anchor links appropriately
 				const trimmedLink = this.trimAnchorLink(link);
-				const attachmentPath = filename(`${dirname(filePath)}/${trimmedLink}`, true);
-				const pathWithExtension = `${attachmentPath}.${fileExtension(trimmedLink)}`;
+				const attachmentPath = filename(
+					`${dirname(filePath)}/${trimmedLink}`,
+					true,
+				);
+				const pathWithExtension = `${attachmentPath}.${fileExtension(
+					trimmedLink,
+				)}`;
 				const stat = await shim.fsDriver().stat(pathWithExtension);
 				const isDir = stat ? stat.isDirectory() : false;
 				if (stat && !isDir) {
@@ -134,7 +177,11 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 					const resolvedPath = shim.fsDriver().resolve(pathWithExtension);
 					let id = '';
 					// If the link looks like a note, then import it
-					if (supportedFileExtension.indexOf(fileExtension(trimmedLink).toLowerCase()) >= 0) {
+					if (
+						supportedFileExtension.indexOf(
+							fileExtension(trimmedLink).toLowerCase(),
+						) >= 0
+					) {
 						// If the note hasn't been imported yet, do so now
 						if (!this.importedNotes[resolvedPath]) {
 							await this.importFile(resolvedPath, parentFolderId);
@@ -142,7 +189,11 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 						id = this.importedNotes[resolvedPath].id;
 					} else {
-						const resource = await shim.createResourceFromPath(pathWithExtension, null, { resizeLargeImages: 'never' });
+						const resource = await shim.createResourceFromPath(
+							pathWithExtension,
+							null,
+							{ resizeLargeImages: 'never' },
+						);
 						id = resource.id;
 					}
 
@@ -150,13 +201,20 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 					// Only opening patterns are consider in order to cover all occurrences
 					// We need to use the encoded link as well because some links (link's with spaces)
 					// will appear encoded in the source. Other links (unicode chars) will not
-					const linksToReplace = [this.trimAnchorLink(link), this.trimAnchorLink(encodedLink)];
+					const linksToReplace = [
+						this.trimAnchorLink(link),
+						this.trimAnchorLink(encodedLink),
+					];
 
 					for (let j = 0; j < linksToReplace.length; j++) {
 						const linkToReplace = pregQuote(linksToReplace[j]);
 
 						// Markdown links
-						updated = markdownUtils.replaceResourceUrl(updated, linkToReplace, id);
+						updated = markdownUtils.replaceResourceUrl(
+							updated,
+							linkToReplace,
+							id,
+						);
 
 						// HTML links
 						updated = htmlUtils.replaceResourceUrl(updated, linkToReplace, id);
@@ -169,7 +227,9 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 
 	public async importFile(filePath: string, parentFolderId: string) {
 		const resolvedPath = shim.fsDriver().resolve(filePath);
-		if (this.importedNotes[resolvedPath]) return this.importedNotes[resolvedPath];
+		if (this.importedNotes[resolvedPath]) {
+			return this.importedNotes[resolvedPath];
+		}
 
 		const stat = await shim.fsDriver().stat(resolvedPath);
 		if (!stat) throw new Error(`Cannot read ${resolvedPath}`);
@@ -187,7 +247,9 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 			user_created_time: stat.birthtime.getTime(),
 			markup_language: ext === 'html' ? MarkupToHtml.MARKUP_LANGUAGE_HTML : MarkupToHtml.MARKUP_LANGUAGE_MARKDOWN,
 		};
-		this.importedNotes[resolvedPath] = await Note.save(note, { autoTimestamp: false });
+		this.importedNotes[resolvedPath] = await Note.save(note, {
+			autoTimestamp: false,
+		});
 
 		return this.importedNotes[resolvedPath];
 	}

--- a/packages/lib/services/interop/InteropService_Importer_Md.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.ts
@@ -117,6 +117,12 @@ export default class InteropService_Importer_Md extends InteropService_Importer_
 				// If the URI cannot be decoded, leave it as it is.
 				continue;
 			}
+			// Strip the angle brackets if they exist
+			if (link.startsWith('<') && link.endsWith('>')) {
+				link = link.substring(1, link.length - 1);
+			}
+
+			// Use the normal protocol check
 			if (hasProtocol(link, ['http', 'https', 'mailto'])) {
 				continue;
 			}


### PR DESCRIPTION
### Summary
Ensure that any link starting with `http://`, `https://`, or `mailto:` is treated as a URL rather than a local file path—preventing `ENAMETOOLONG` errors during Markdown import.

### What it does
When importing Markdown, any link beginning with a standard web or mail protocol is now recognized and **skipped** for file-path resolution.

### Why
Long URLs were being mis-interpreted as local file paths, triggering OS-level `ENAMETOOLONG` errors and aborting the import process.

### How
- Use the existing `hasProtocol(url, ['http', 'https', 'mailto'])` utility from `@joplin/utils/url`.   
- If `hasProtocol` returns true, the link is left intact and not passed to the file-system layer.

### Closes
Closes #12172

### Testing Plan
1. Create a Markdown file containing a very long web link (e.g., the Facebook redirect URL from #12172).  
2. Run `joplin import /path/to/file.md` in the desktop or CLI importer.  
3. **Verify** import completes without any `ENAMETOOLONG` errors.  
4. **Confirm** the long URL appears verbatim in the resulting note.  
5. Add a mailto link (e.g. `[Email me](mailto:someone@example.com)`) and repeat—ensure it too is preserved and import succeeds.
