### PR TITLE
Mobile: Increase space between new note/to-do buttons

### DIFF
--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 	},
 	mainButtonRow: {
 		flexWrap: 'wrap',
-		gap: 6,
+		gap: 12,
 	},
 	shortcutButton: {
 		flexGrow: 1,

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 	},
 	mainButtonRow: {
 		flexWrap: 'wrap',
-		gap: 12,
+		gap: 16,
 	},
 	shortcutButton: {
 		flexGrow: 1,

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 	},
 	mainButtonRow: {
 		flexWrap: 'wrap',
-		gap: 16,
+		gap: 12,
 	},
 	shortcutButton: {
 		flexGrow: 1,


### PR DESCRIPTION
# Summary

This pull request approximately restores the [original space](https://github.com/laurent22/joplin/pull/12163/files#diff-f726294fde379908daa5ae76e278f5df6bf9c9b6ad8c21fbebc557fc1fd839acL38) between the new note/to-do buttons (as before #12163).

This should [resolve an issue raised here](https://github.com/laurent22/joplin/issues/12191#issuecomment-2842142945).


> [!NOTE]
>
> This pull request targets `release-3.3`.

# Screenshots

**Android 13**:

| Before this PR | After |
|----|----|
| ![fullscreen_before_en -- less space between the "new note" and "new to-do" buttons](https://github.com/user-attachments/assets/4f581a2c-d6fb-4efe-a64b-9edb72029738) | ![fullscreen_after_en -- more space between the "new note" and "new to-do" buttons](https://github.com/user-attachments/assets/d87f78d9-1947-49bf-90c4-95780465cf6f) |
| ![screenshot -- smaller screen, less space between buttons](https://github.com/user-attachments/assets/c1d4160b-0848-4ba8-b712-28407c6556ff) | ![screenshot -- smaller screen, more space between "new note" and "new to-do" buttons](https://github.com/user-attachments/assets/c587f432-1c36-4985-8e4e-7ff06307b6bf) |

**Web (after)**
| Before | After |
|----|----|
| ![screenshot -- less space between buttons](https://github.com/user-attachments/assets/546b3112-7a62-441c-9af1-e0b1ffa47ece) | ![screenshot -- more space between buttons](https://github.com/user-attachments/assets/33d682c2-f08e-47ac-993b-cb502eb2e463) |


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->