### PR TITLE
Mobile: New note menu: Force quick action shortcuts to have the same size

### DIFF
--- a/packages/app-mobile/components/buttons/LabelledIconButton.tsx
+++ b/packages/app-mobile/components/buttons/LabelledIconButton.tsx
@@ -57,7 +57,11 @@ const LabelledIconButton: React.FC<Props> = ({ title, icon, style, themeId, ...o
 	>
 		<View style={styles.buttonContent}>
 			<Icon style={styles.icon} accessibilityLabel={null} name={icon}/>
-			<Text variant='labelMedium'>{title}</Text>
+			<Text
+				variant='labelMedium'
+				ellipsizeMode='tail'
+				numberOfLines={1}
+			>{title}</Text>
 		</View>
 	</TouchableRipple>;
 };

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -35,6 +35,8 @@ const styles = StyleSheet.create({
 	},
 	shortcutButton: {
 		flexGrow: 1,
+		flexShrink: 1,
+		flexBasis: 0,
 	},
 	mainButton: {
 		flexShrink: 1,


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/laurent22/joplin/pull/12194#issuecomment-2843463640.

# Screenshots

## Android 13

![screenshot: Joplin with the new note menu open, UI language in French. Longer items in the quick actions list are ellipsized](https://github.com/user-attachments/assets/403f500b-8848-4334-8db7-3e0454f5c81b)
![screenshot: Slightly smaller screen, more items ellipsized](https://github.com/user-attachments/assets/27f44913-79a6-41a9-9348-d0ef3c46e671)
![screenshot: Small screen, English UI, most items partially ellipsized.](https://github.com/user-attachments/assets/390f0084-0db1-4419-8c25-55d1f03d72a4)

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->