### PR TITLE
Desktop: Fixes #12197: Fix inserting note links using the mouse

### DIFF
--- a/packages/app-desktop/integration-tests/goToAnything.spec.ts
+++ b/packages/app-desktop/integration-tests/goToAnything.spec.ts
@@ -65,22 +65,28 @@ test.describe('goToAnything', () => {
 		}
 	});
 
-	test('should be possible to show the set tags dialog from goToAnything', async ({ electronApp, mainWindow }) => {
-		const mainScreen = await new MainScreen(mainWindow).setup();
-		await mainScreen.createNewNote('Test note');
+	for (const activateWithClick of [true, false]) {
+		test(`should be possible to show the set tags dialog from goToAnything (show with click: ${activateWithClick})`, async ({ electronApp, mainWindow }) => {
+			const mainScreen = await new MainScreen(mainWindow).setup();
+			await mainScreen.createNewNote('Test note');
 
-		const goToAnything = mainScreen.goToAnything;
-		await goToAnything.open(electronApp);
-		await goToAnything.inputLocator.fill(':setTags');
+			const goToAnything = mainScreen.goToAnything;
+			await goToAnything.open(electronApp);
+			await goToAnything.inputLocator.fill(':setTags');
 
-		// Should show a matching command
-		await expect(goToAnything.containerLocator.getByText('Tags (setTags)')).toBeAttached();
+			// Should show a matching command
+			const result = goToAnything.containerLocator.getByText('Tags (setTags)');
+			await expect(result).toBeAttached();
+			if (activateWithClick) {
+				await result.click();
+			} else {
+				await mainWindow.keyboard.press('Enter');
+			}
+			await goToAnything.expectToBeClosed();
 
-		await mainWindow.keyboard.press('Enter');
-		await goToAnything.expectToBeClosed();
-
-		// Should show the "set tags" dialog
-		const setTagsLabel = mainWindow.getByText('Add or remove tags:');
-		await expect(setTagsLabel).toBeVisible();
-	});
+			// Should show the "set tags" dialog
+			const setTagsLabel = mainWindow.getByText('Add or remove tags:');
+			await expect(setTagsLabel).toBeVisible();
+		});
+	}
 });

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -12,6 +12,10 @@ export default class GoToAnything {
 		this.inputLocator = this.containerLocator.getByRole('textbox');
 	}
 
+	public async waitFor() {
+		await this.containerLocator.waitFor();
+	}
+
 	public async open(electronApp: ElectronApplication) {
 		await this.mainScreen.waitFor();
 		await activateMainMenuItem(electronApp, 'Goto Anything...');
@@ -19,8 +23,25 @@ export default class GoToAnything {
 		return this.waitFor();
 	}
 
-	public async waitFor() {
-		await this.containerLocator.waitFor();
+	public async openLinkToNote(electronApp: ElectronApplication) {
+		await this.mainScreen.waitFor();
+		await activateMainMenuItem(electronApp, 'Link to note...');
+		return this.waitFor();
+	}
+
+	public resultLocator(resultText: string|RegExp) {
+		return this.containerLocator.getByRole('option', { name: resultText });
+	}
+
+	public async searchForWithRetry(query: string, resultLocator: Locator) {
+		// If note indexing hasn't finished, it's sometimes necessary to search multiple times.
+		// This expect.poll retries the search if it initially fails.
+		await expect.poll(async () => {
+			await this.inputLocator.clear();
+			await this.inputLocator.fill(query);
+			await expect(resultLocator).toBeVisible({ timeout: 1000 });
+			return true;
+		}, { timeout: 6000 }).toBe(true);
 	}
 
 	public async expectToBeClosed() {

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -39,9 +39,9 @@ export default class GoToAnything {
 		await expect.poll(async () => {
 			await this.inputLocator.clear();
 			await this.inputLocator.fill(query);
-			await expect(resultLocator).toBeVisible({ timeout: 1000 });
+			await expect(resultLocator).toBeVisible({ timeout: 1600 });
 			return true;
-		}, { timeout: 6000 }).toBe(true);
+		}, { timeout: 12000 }).toBe(true);
 	}
 
 	public async expectToBeClosed() {

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -39,9 +39,15 @@ export default class GoToAnything {
 		await expect.poll(async () => {
 			await this.inputLocator.clear();
 			await this.inputLocator.fill(query);
-			await expect(resultLocator).toBeVisible({ timeout: 1600 });
+			try {
+				await expect(resultLocator).toBeVisible({ timeout: 1000 });
+			} catch (error) {
+				// Return, rather than throw, the error -- expect.poll doesn't retry
+				// if the callback throws.
+				return error;
+			}
 			return true;
-		}, { timeout: 12000 }).toBe(true);
+		}, { timeout: 10_000 }).toBe(true);
 	}
 
 	public async expectToBeClosed() {

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -572,16 +572,8 @@ class DialogComponent extends React.PureComponent<Props, State> {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private listItem_onClick(event: any) {
-		const itemId = event.currentTarget.getAttribute('data-id');
-		const parentId = event.currentTarget.getAttribute('data-parent-id');
-		const itemType = Number(event.currentTarget.getAttribute('data-type'));
-
-		void this.gotoItem({
-			id: itemId,
-			parent_id: parentId,
-			type: itemType,
-			commandArgs: this.state.commandArgs,
-		});
+		const targetResultId = event.currentTarget.getAttribute('id');
+		void this.gotoItem(this.selectedItem(targetResultId));
 	}
 
 	public renderItem(item: GotoAnythingSearchResult, index: number) {
@@ -642,8 +634,8 @@ class DialogComponent extends React.PureComponent<Props, State> {
 		return -1;
 	}
 
-	public selectedItem() {
-		const index = this.selectedItemIndex();
+	public selectedItem(itemId: string = undefined) {
+		const index = this.selectedItemIndex(undefined, itemId);
 		if (index < 0) return null;
 		return { ...this.state.results[index], commandArgs: this.state.commandArgs };
 	}


### PR DESCRIPTION
# Summary

This pull request fixes an inconsistency in how `GotoAnything.tsx` returns results when activated by a command.

Fixes #12197.

**Note**: This pull request targets `release-3.3`.

# Testing

This pull request includes automated tests.


Additionally, it has been tested manually by:
1. Opening a note.
2. Pressing <kbd>alt</kbd>-<kbd>shift</kbd>-<kbd>l</kbd> to open the "insert link" dialog.
3. Searching for a note.
4. Pressing <kbd>enter</kbd>.
5. Verifying that a link to the target note has been inserted.
6. Repeating steps 1-5, but selecting the result by clicking, instead of pressing enter.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->