### PR TITLE
Chore: Fix locale test

### DIFF
--- a/packages/lib/locale.test.ts
+++ b/packages/lib/locale.test.ts
@@ -26,7 +26,7 @@ describe('locale', () => {
 	it('should translate plurals - fr_FR', () => {
 		setLocale('fr_FR');
 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copier le lien partageable');
-		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 2)).toBe('Copier liens partageables');
+		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 2)).toBe('Copier les liens partageables');
 	});
 
 	it('should translate plurals - pl_PL', () => {

--- a/packages/lib/locale.test.ts
+++ b/packages/lib/locale.test.ts
@@ -25,7 +25,7 @@ describe('locale', () => {
 
 	it('should translate plurals - fr_FR', () => {
 		setLocale('fr_FR');
-		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copier lien partageable');
+		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copier le lien partageable');
 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 2)).toBe('Copier liens partageables');
 	});
 


### PR DESCRIPTION
# Summary

This pull request fixes a test failure [observed in CI](https://github.com/laurent22/joplin/actions/runs/14778256427/job/41491230221), possibly related to https://github.com/laurent22/joplin/pull/12161 and https://github.com/laurent22/joplin/commit/a6b430a0667d86efe855e9d548a90814240287b9.

## The test failure

```
➤ YN0000: [@joplin/lib]: Summary of all failing tests
➤ YN0000: [@joplin/lib]: FAIL ./locale.test.js
➤ YN0000: [@joplin/lib]:   ● locale › should translate plurals - fr_FR
➤ YN0000: [@joplin/lib]: 
➤ YN0000: [@joplin/lib]:     expect(received).toBe(expected) // Object.is equality
➤ YN0000: [@joplin/lib]: 
➤ YN0000: [@joplin/lib]:     Expected: "Copier lien partageable"
➤ YN0000: [@joplin/lib]:     Received: "Copier le lien partageable"
➤ YN0000: [@joplin/lib]: 
➤ YN0000: [@joplin/lib]:       26 | 	it('should translate plurals - fr_FR', () => {
➤ YN0000: [@joplin/lib]:       27 | 		setLocale('fr_FR');
➤ YN0000: [@joplin/lib]:     > 28 | 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copier lien partageable');
➤ YN0000: [@joplin/lib]:          | 		                                                             ^
➤ YN0000: [@joplin/lib]:       29 | 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 2)).toBe('Copier liens partageables');
➤ YN0000: [@joplin/lib]:       30 | 	});
➤ YN0000: [@joplin/lib]:       31 |
➤ YN0000: [@joplin/lib]: 
➤ YN0000: [@joplin/lib]:       at Object.toBe (locale.test.ts:28:64)
```
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->