### PR TITLE
Desktop: Fixes #12204: Fix crash after removing "toggle tab indentation" keyboard shortcut

### DIFF
--- a/packages/lib/services/KeymapService.test.js
+++ b/packages/lib/services/KeymapService.test.js
@@ -337,4 +337,9 @@ describe('services_KeymapService', () => {
 			}
 		});
 	});
+
+	it('getAriaKeyShortcuts should return null if there is no associated shortcut', () => {
+		keymapService.registerCommandAccelerator('some-command', null);
+		expect(keymapService.getAriaKeyShortcuts('some-command')).toBe(null);
+	});
 });

--- a/packages/lib/services/KeymapService.test.js
+++ b/packages/lib/services/KeymapService.test.js
@@ -338,8 +338,8 @@ describe('services_KeymapService', () => {
 		});
 	});
 
-	it('getAriaKeyShortcuts should return null if there is no associated shortcut', () => {
+	it('getAriaKeyShortcuts should return undefined if there is no associated shortcut', () => {
 		keymapService.registerCommandAccelerator('some-command', null);
-		expect(keymapService.getAriaKeyShortcuts('some-command')).toBe(null);
+		expect(keymapService.getAriaKeyShortcuts('some-command')).toBe(undefined);
 	});
 });

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -427,9 +427,9 @@ export default class KeymapService extends BaseService {
 
 	// Electron and aria-keyshortcuts have slightly different formats for accelerators.
 	// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts
-	public getAriaKeyShortcuts(commandName: string) {
+	public getAriaKeyShortcuts(commandName: string): string|null {
 		const electronAccelerator = this.getAccelerator(commandName);
-		return electronAccelerator.replace('Ctrl', 'Control');
+		return electronAccelerator?.replace('Ctrl', 'Control');
 	}
 
 	public on<Name extends EventName>(eventName: Name, callback: EventListenerCallback<Name>) {

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -427,7 +427,7 @@ export default class KeymapService extends BaseService {
 
 	// Electron and aria-keyshortcuts have slightly different formats for accelerators.
 	// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts
-	public getAriaKeyShortcuts(commandName: string): string|null {
+	public getAriaKeyShortcuts(commandName: string): string|undefined {
 		const electronAccelerator = this.getAccelerator(commandName);
 		return electronAccelerator?.replace('Ctrl', 'Control');
 	}


### PR DESCRIPTION
# Summary

This pull request adds support for `null` accelerators to `getAriaKeyShortcuts`, fixing a crash.

Fixes #12204, targets `release-3.3`.

# Testing

1. Start Joplin and open the "Keyboard shortcuts" screen.
2. Search for "tab".
3. Clear the shortcut for "Toggle editor tab key navigation".
4. Click "back".
5. Verify that Joplin doesn't crash.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->