### PR TITLE
Desktop: Fix "Open" option for attachments shown in context menu for web links

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -17,6 +17,7 @@ import { EditDialogControl } from './useEditDialog';
 import { Dispatch } from 'redux';
 import { _ } from '@joplin/lib/locale';
 import type { MenuItem as MenuItemType } from 'electron';
+import isItemId from '@joplin/lib/models/utils/isItemId';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -40,11 +41,16 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 			let resourceId = '';
 			let linkToCopy = null;
 
+			const pathToId = (path: string) => {
+				const id = Resource.pathToId(path);
+				return isItemId(id) ? id : '';
+			};
+
 			if (element.nodeName === 'IMG') {
 				itemType = ContextMenuItemType.Image;
-				resourceId = Resource.pathToId((element as HTMLImageElement).src);
+				resourceId = pathToId((element as HTMLImageElement).src);
 			} else if (element.nodeName === 'A') {
-				resourceId = Resource.pathToId((element as HTMLAnchorElement).href);
+				resourceId = pathToId((element as HTMLAnchorElement).href);
 				itemType = resourceId ? ContextMenuItemType.Resource : ContextMenuItemType.Link;
 				linkToCopy = element.getAttribute('href') || '';
 			} else {


### PR DESCRIPTION
# Summary

This pull request prevents the Rich Text Editor from giving web links and remote images the type `ContextMenuItemType.Resource` when opening a context menu.

This prevents a non-working "Open" context menu item from being shown for these elements.

# Testing plan

1. Create a note with the following content:
  ```markdown
  http://example.com/

  http://example.com/?test=1
  ```
2. Add a Joplin image attachment to the note.
3. Switch to the Rich Text Editor.
4. Right-click on the first link. Verify that the available options are "Paste", "Paste as text", and "Copy Link Address".
5. Right-click on the second link. Verify that the available options are again "Paste", "Paste as text", and "Copy Link Address".
6. Right-click on the image attachment.
7. Click "Open".
8. Verify that the attachment opens.
9. Attach a non-image file to the note.
10. Right-click on the attachment link and click "Open".
11. Verify that this opens the attachment in an external program.
12. Ctrl-click on the first link. Verify that this opens it in a web browser.
13. Ctrl-click on the second link. Verify that this opens it in a web browser.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->