### PR TITLE
Windows: Fix printing

### DIFF
--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -111,8 +111,10 @@ export default class InteropServiceHelper {
 							// 2024-01-31: Printing with webContents.print still
 							// fails on Linux (even if run in the main process).
 							// As such, we use window.print(), which seems to work.
+							//
+							// 2025-05-03: Windows also needs the window.print() workaround.
 
-							if (shim.isLinux()) {
+							if (shim.isLinux() || shim.isWindows()) {
 								await win.webContents.executeJavaScript(`
 									// Blocks while the print dialog is open
 									window.print();


### PR DESCRIPTION
# Summary

This pull request fixes an issue [reported on the Joplin forum](https://discourse.joplinapp.org/t/joplin-not-opening-printer/45131/6) — in the latest 3.3 release, File > Print doesn't work on Windows.

Before this change, attempting to print on Windows resulted in the following error: 
> Printer settings invalid for Microsoft Print to PDF (destination type kLocal): content size is empty; page size is empty; printable area is empty

When this happened, no print dialog would be shown and the completion callback provided to `webContents.print` would not be called. As a result, Joplin considered the print task to be incomplete and blocked future attempts to print or export to PDF.

This pull request applies the existing Linux printing workaround to Windows.

> [!IMPORTANT]
>
> - This pull request targets the `release-3.3` branch.
> - With this change, the user's "page size" setting is not passed to the printer (but should still be used for PDF export). 

# Notes

I suspect that this issue is related to one of the Electron upgrades between Joplin 3.2.x and Joplin 3.3.10. In Joplin 3.3.10, `webContents.print(options, callback)` seems to only work if `options` is `{}` or `undefined`. Specifying any options (e.g. `pageSize`) results in the error mentioned above.

# Testing plan

**Windows 11**:
1. Open a medium-length note in Joplin.
2. Run File > Print.
3. Print to PDF.
4. Open the PDF. Verify that it includes the note's content.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->