### PR TITLE
MacOS: Fixes #12240: Fix printing

### DIFF
--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -112,9 +112,11 @@ export default class InteropServiceHelper {
 							// fails on Linux (even if run in the main process).
 							// As such, we use window.print(), which seems to work.
 							//
-							// 2025-05-03: Windows also needs the window.print() workaround.
+							// 2025-05-03: Windows and MacOS also need the window.print() workaround.
+							// See https://github.com/electron/electron/pull/46937.
 
-							if (shim.isLinux() || shim.isWindows()) {
+							const applyWorkaround = true;
+							if (applyWorkaround) {
 								await win.webContents.executeJavaScript(`
 									// Blocks while the print dialog is open
 									window.print();


### PR DESCRIPTION
# Summary

This pull request applies the [Windows printing issue workaround](https://github.com/laurent22/joplin/pull/12219) to MacOS.

Fixes #12240.

# Testing

**Note**: For me, prior to this pull request (both Joplin 3.3.x and Joplin 3.2.x), File > Print showed a "No printers available on this network" error dialog (rather than the issue described in #12240). With this pull request, a print dialog is shown that allows selecting a printer or saving as a PDF.

Mac OS Sequoia:
1. Open a note in Joplin.
2. Click "File", then "Print".
3. Near the bottom left of the dialog, expand the "PDF" menu.
4. Click "Open in Preview".
5. Verify that a PDF version of the note is shown in the MacOS preview app.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->