### PR TITLE
Mobile: Accessibility: Improve back button labels

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -604,6 +604,7 @@ packages/app-mobile/commands/openNote.js
 packages/app-mobile/commands/scrollToHash.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/commands/util/showResource.js
+packages/app-mobile/components/BackButtonHandler.js
 packages/app-mobile/components/BetaChip.js
 packages/app-mobile/components/BottomDrawer.js
 packages/app-mobile/components/CameraView/ActionButtons.js
@@ -689,6 +690,7 @@ packages/app-mobile/components/NoteList.js
 packages/app-mobile/components/ProfileSwitcher/ProfileEditor.js
 packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.js
 packages/app-mobile/components/ProfileSwitcher/useProfileConfig.js
+packages/app-mobile/components/ScreenHeader/BackButton.js
 packages/app-mobile/components/ScreenHeader/Menu.js
 packages/app-mobile/components/ScreenHeader/WarningBanner.test.js
 packages/app-mobile/components/ScreenHeader/WarningBanner.js
@@ -856,6 +858,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/checkPermissions.js
 packages/app-mobile/utils/createRootStyle.js

--- a/.gitignore
+++ b/.gitignore
@@ -578,6 +578,7 @@ packages/app-mobile/commands/openNote.js
 packages/app-mobile/commands/scrollToHash.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/commands/util/showResource.js
+packages/app-mobile/components/BackButtonHandler.js
 packages/app-mobile/components/BetaChip.js
 packages/app-mobile/components/BottomDrawer.js
 packages/app-mobile/components/CameraView/ActionButtons.js
@@ -663,6 +664,7 @@ packages/app-mobile/components/NoteList.js
 packages/app-mobile/components/ProfileSwitcher/ProfileEditor.js
 packages/app-mobile/components/ProfileSwitcher/ProfileSwitcher.js
 packages/app-mobile/components/ProfileSwitcher/useProfileConfig.js
+packages/app-mobile/components/ScreenHeader/BackButton.js
 packages/app-mobile/components/ScreenHeader/Menu.js
 packages/app-mobile/components/ScreenHeader/WarningBanner.test.js
 packages/app-mobile/components/ScreenHeader/WarningBanner.js
@@ -830,6 +832,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/checkPermissions.js
 packages/app-mobile/utils/createRootStyle.js

--- a/packages/app-mobile/components/BackButtonHandler.tsx
+++ b/packages/app-mobile/components/BackButtonHandler.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { useEffect, useId, useRef } from 'react';
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
+import { BackHandlerState, BackHandlerOnBack } from '../utils/types';
+
+interface Props {
+	dispatch: Dispatch;
+	enabled: boolean;
+	description: string|null;
+	runsParentAction?: boolean;
+	onBack: BackHandlerOnBack;
+}
+
+const BackButtonHandler: React.FC<Props> = ({
+	dispatch, enabled, runsParentAction, description, onBack,
+}) => {
+	const onBackRef = useRef(onBack);
+	onBackRef.current = onBack;
+	const id = useId();
+
+	useEffect(() => {
+		const handler: BackHandlerState = {
+			id,
+			enabled,
+			description,
+			onBack: () => onBackRef.current?.(),
+			runsParent: runsParentAction ?? false,
+		};
+		dispatch({
+			type: 'BACK_HANDLER_ADD_OR_UPDATE',
+			handler,
+		});
+	}, [enabled, description, id, runsParentAction, dispatch]);
+
+	useEffect(() => () => {
+		dispatch({
+			type: 'BACK_HANDLER_REMOVE',
+			id,
+		});
+	}, [id, dispatch]);
+
+	return null;
+};
+
+export default connect(() => ({}))(BackButtonHandler);

--- a/packages/app-mobile/components/CameraView/CameraView.tsx
+++ b/packages/app-mobile/components/CameraView/CameraView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { connect } from 'react-redux';
 import { Text, StyleSheet, Linking, View, Platform, useWindowDimensions } from 'react-native';
@@ -10,7 +10,6 @@ import ActionButtons from './ActionButtons';
 import { CameraDirection } from '@joplin/lib/models/settings/builtInMetadata';
 import Setting from '@joplin/lib/models/Setting';
 import { LinkButton, PrimaryButton } from '../buttons';
-import BackButtonService from '../../services/BackButtonService';
 import { themeStyle } from '../global-style';
 import fitRectIntoBounds from './utils/fitRectIntoBounds';
 import useBarcodeScanner from './utils/useBarcodeScanner';
@@ -18,6 +17,7 @@ import ScannedBarcodes from './ScannedBarcodes';
 import { CameraRef } from './Camera/types';
 import Camera from './Camera';
 import { CameraResult } from './types';
+import BackButtonHandler from '../BackButtonHandler';
 
 interface Props {
 	themeId: number;
@@ -103,17 +103,6 @@ const CameraViewComponent: React.FC<Props> = props => {
 	const styles = useStyles(props);
 	const cameraRef = useRef<CameraRef|null>(null);
 	const [cameraReady, setCameraReady] = useState(false);
-
-	useEffect(() => {
-		const handler = () => {
-			props.onCancel();
-			return true;
-		};
-		BackButtonService.addHandler(handler);
-		return () => {
-			BackButtonService.removeHandler(handler);
-		};
-	}, [props.onCancel]);
 
 	const onCameraReverse = useCallback(() => {
 		const newDirection = props.cameraType === CameraDirection.Front ? CameraDirection.Back : CameraDirection.Front;
@@ -201,6 +190,11 @@ const CameraViewComponent: React.FC<Props> = props => {
 				onHasPermission={onHasPermission}
 			/>
 			{overlay}
+			<BackButtonHandler
+				enabled={true}
+				onBack={props.onCancel}
+				description={_('Cancel')}
+			/>
 		</View>
 	);
 };

--- a/packages/app-mobile/components/ScreenHeader/BackButton.tsx
+++ b/packages/app-mobile/components/ScreenHeader/BackButton.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { ViewStyle, TextStyle } from 'react-native';
+import IconButton from '../IconButton';
+import { _ } from '@joplin/lib/locale';
+import { AppState, BackHandlerState } from '../../utils/types';
+import { connect } from 'react-redux';
+import BackButtonService from '../../services/BackButtonService';
+import { useCallback } from 'react';
+
+interface Props {
+	containerStyleEnabled: ViewStyle;
+	containerStyleDisabled: ViewStyle;
+	iconStyle: TextStyle;
+
+	themeId: number;
+	backHandler: BackHandlerState|null;
+}
+
+const BackButton: React.FC<Props> = ({
+	themeId, containerStyleEnabled, containerStyleDisabled, iconStyle, backHandler,
+}) => {
+	const onPress = useCallback(() => {
+		void BackButtonService.back();
+	}, []);
+	const disabled = !backHandler?.enabled;
+	const description = backHandler?.description ? _('Back: %s', backHandler.description) : _('Back');
+
+	return <IconButton
+		onPress={onPress}
+		contentWrapperStyle={disabled ? containerStyleDisabled : containerStyleEnabled}
+		themeId={themeId}
+		disabled={!!disabled}
+		description={description}
+		iconName={'ionicon arrow-back'}
+		iconStyle={iconStyle}
+	/>;
+};
+
+export default connect((state: AppState) => {
+	return {
+		themeId: state.settings.theme,
+		backHandler: state.activeBackHandler,
+	};
+})(BackButton);

--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -3,7 +3,6 @@ import { PureComponent, ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { View, Text, StyleSheet, TouchableOpacity, Image, ViewStyle, Platform } from 'react-native';
 const Icon = require('react-native-vector-icons/Ionicons').default;
-import BackButtonService from '../../services/BackButtonService';
 import NavService from '@joplin/lib/services/NavService';
 import { _, _n } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
@@ -26,6 +25,7 @@ import WebBetaButton from './WebBetaButton';
 import Menu, { MenuOptionType } from './Menu';
 import shim from '@joplin/lib/shim';
 import CommandService from '@joplin/lib/services/CommandService';
+import BackButton from './BackButton';
 export { MenuOptionType };
 
 // Rather than applying a padding to the whole bar, it is applied to each
@@ -189,14 +189,6 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		this.props.dispatch({ type: 'SIDE_MENU_TOGGLE' });
 	}
 
-	private async backButton_press() {
-		if (this.props.noteSelectionEnabled) {
-			this.props.dispatch({ type: 'NOTE_SELECTION_END' });
-		} else {
-			await BackButtonService.back();
-		}
-	}
-
 	private selectAllButton_press() {
 		this.props.dispatch({ type: 'NOTE_SELECT_ALL_TOGGLE' });
 	}
@@ -272,22 +264,12 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		}
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		function backButton(styles: any, onPress: OnPressCallback, disabled: boolean) {
-			return (
-				<TouchableOpacity
-					onPress={onPress}
-					disabled={disabled}
-
-					accessibilityLabel={_('Back')}
-					accessibilityRole="button">
-					<View style={disabled ? styles.backButtonDisabled : styles.backButton}>
-						<Icon
-							name="arrow-back"
-							style={styles.topIcon}
-						/>
-					</View>
-				</TouchableOpacity>
-			);
+		function backButton(styles: any) {
+			return <BackButton
+				iconStyle={styles.topIcon}
+				containerStyleEnabled={styles.backButton}
+				containerStyleDisabled={styles.backButtonDisabled}
+			/>;
 		}
 
 		function saveButton(
@@ -611,12 +593,10 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 		const showContextMenuButton = this.props.showContextMenuButton !== false;
 		const showBackButton = !!this.props.noteSelectionEnabled || this.props.showBackButton !== false;
 
-		let backButtonDisabled = !this.props.historyCanGoBack;
-		if (this.props.noteSelectionEnabled) backButtonDisabled = false;
 		const headerItemDisabled = !(this.props.selectedNoteIds.length > 0);
 
 		const sideMenuComp = !showSideMenuButton ? null : sideMenuButton(this.styles(), () => this.sideMenuButton_press());
-		const backButtonComp = !showBackButton ? null : backButton(this.styles(), () => this.backButton_press(), backButtonDisabled);
+		const backButtonComp = !showBackButton ? null : backButton(this.styles());
 		const pluginPanelsComp = pluginPanelToggleButton(this.styles(), () => this.pluginPanelToggleButton_press());
 		const betaIconComp = betaIconButton();
 		const selectAllButtonComp = !showSelectAllButton ? null : selectAllButton(this.styles(), () => this.selectAllButton_press());

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -16,7 +16,6 @@ import Resource from '@joplin/lib/models/Resource';
 import Folder from '@joplin/lib/models/Folder';
 const Clipboard = require('@react-native-clipboard/clipboard').default;
 const md5 = require('md5');
-import BackButtonService from '../../../services/BackButtonService';
 import NavService, { OnNavigateCallback as OnNavigateCallback } from '@joplin/lib/services/NavService';
 import { ModelType } from '@joplin/lib/BaseModel';
 import FloatingActionButton from '../../buttons/FloatingActionButton';
@@ -68,6 +67,7 @@ import getActivePluginEditorView from '@joplin/lib/services/plugins/utils/getAct
 import EditorPluginHandler from '@joplin/lib/services/plugins/EditorPluginHandler';
 import AudioRecordingBanner from '../../voiceTyping/AudioRecordingBanner';
 import SpeechToTextBanner from '../../voiceTyping/SpeechToTextBanner';
+import BackButtonHandler from '../../BackButtonHandler';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const emptyArray: any[] = [];
@@ -154,7 +154,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private editorRef: any;
 	private titleTextFieldRef: RefObject<TextInput>;
 	private navHandler: OnNavigateCallback;
-	private backHandler: ()=> Promise<boolean>;
 	private undoRedoService_: UndoRedoService;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private noteTagDialog_closeRequested: any;
@@ -239,48 +238,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 		this.navHandler = async () => {
 			return await saveDialog();
-		};
-
-		this.backHandler = async () => {
-
-			if (this.isModified()) {
-				await this.saveNoteButton_press();
-			}
-
-			const isProvisionalNote = this.props.provisionalNoteIds.includes(this.props.noteId);
-
-			if (isProvisionalNote) {
-				return false;
-			}
-
-			if (this.state.mode === 'edit') {
-				Keyboard.dismiss();
-
-				this.setState({
-					mode: 'view',
-				});
-
-				await this.undoRedoService_.reset();
-
-				return true;
-			}
-
-			if (this.state.fromShare) {
-				// Note: In the past, NAV_BACK caused undesired behaviour in this case:
-				// - share to Joplin from some other app
-				// - open Joplin and open any note
-				// - go back -- with NAV_BACK this causes the app to exit rather than just showing notes
-				// This no longer seems to happen, but this case should be checked when adjusting navigation
-				// history behavior.
-				this.props.dispatch({
-					type: 'NAV_BACK',
-				});
-
-				ShareExtension.close();
-				return true;
-			}
-
-			return false;
 		};
 
 		this.noteTagDialog_closeRequested = () => {
@@ -427,6 +384,59 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		};
 	}
 
+	private getBackHandler = () => {
+		const saveIfModified = async () => {
+			if (this.isModified()) {
+				await this.saveNoteButton_press();
+			}
+		};
+
+		const isProvisional = this.props.provisionalNoteIds.includes(this.props.noteId);
+		if (isProvisional) {
+			return {
+				onBack: saveIfModified,
+				runParent: true,
+			};
+		}
+
+		if (this.state.mode === 'edit') {
+			return {
+				onBack: async () => {
+					Keyboard.dismiss();
+
+					this.setState({
+						mode: 'view',
+					});
+
+					await this.undoRedoService_.reset();
+				},
+				label: _('Show viewer'),
+			};
+		}
+
+		if (this.state.fromShare) {
+			// Note: In the past, NAV_BACK caused undesired behaviour in this case:
+			// - share to Joplin from some other app
+			// - open Joplin and open any note
+			// - go back -- with NAV_BACK this causes the app to exit rather than just showing notes
+			// This no longer seems to happen, but this case should be checked when adjusting navigation
+			// history behavior.
+			return {
+				onBack: () => {
+					this.props.dispatch({
+						type: 'NAV_BACK',
+					});
+
+					ShareExtension.close();
+				},
+				label: _('Show note list'),
+			};
+		}
+
+		return null;
+	};
+
+
 	public styles() {
 		const themeId = this.props.themeId;
 		const theme = themeStyle(themeId);
@@ -541,7 +551,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	public async componentDidMount() {
-		BackButtonService.addHandler(this.backHandler);
 		NavService.addHandler(this.navHandler);
 
 		shared.clearResourceCache();
@@ -649,7 +658,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	}
 
 	public componentWillUnmount() {
-		BackButtonService.removeHandler(this.backHandler);
 		NavService.removeHandler(this.navHandler);
 
 		shared.uninstallResourceHandling(this.refreshResource);
@@ -1675,6 +1683,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		};
 
 		const { editorPlugin: activeEditorPlugin } = getActivePluginEditorView(this.props.plugins);
+		const backHandler = this.getBackHandler();
 
 		return (
 			<View style={this.rootStyle(this.props.themeId).root}>
@@ -1702,6 +1711,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				<SelectDateTimeDialog themeId={this.props.themeId} shown={this.state.alarmDialogShown} date={dueDate} onAccept={this.onAlarmDialogAccept} onReject={this.onAlarmDialogReject} />
 
 				{noteTagDialog}
+				<BackButtonHandler
+					description={backHandler?.label}
+					enabled={!!backHandler}
+					runsParentAction={backHandler?.runParent}
+					onBack={backHandler?.onBack}
+				/>
 			</View>
 		);
 	}

--- a/packages/app-mobile/components/screens/ShareManager/index.test.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/index.test.tsx
@@ -8,10 +8,10 @@ import { ShareInvitation, ShareUserStatus } from '@joplin/lib/services/share/red
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 import ShareService from '@joplin/lib/services/share/ShareService';
 import makeMockShareInvitation from '@joplin/lib/testing/share/makeMockShareInvitation';
-import { Provider } from 'react-redux';
 import createMockReduxStore from '../../../utils/testing/createMockReduxStore';
 import { AppState } from '../../../utils/types';
 import { Store } from 'redux';
+import TestProviderStack from '../../testing/TestProviderStack';
 
 interface WrapperProps {
 	shareInvitations: ShareInvitation[];
@@ -20,13 +20,13 @@ interface WrapperProps {
 
 const ShareManagerWrapper: React.FC<WrapperProps> = props => {
 	return (
-		<Provider store={props.store}>
+		<TestProviderStack store={props.store}>
 			<ShareManagerComponent
 				themeId={Setting.THEME_LIGHT}
 				shareInvitations={props.shareInvitations}
 				processingShareInvitationResponse={false}
 			/>
-		</Provider>
+		</TestProviderStack>
 	);
 };
 

--- a/packages/app-mobile/services/BackButtonService.ts
+++ b/packages/app-mobile/services/BackButtonService.ts
@@ -1,13 +1,17 @@
 import { BackHandler } from 'react-native';
+import { Store } from 'redux';
+import { AppState } from '../utils/types';
 
-export type BackButtonHandler = ()=> boolean|Promise<boolean>;
+export type BackButtonHandler = {
+	onBackPress: ()=> boolean|Promise<boolean>;
+	describeAction: ()=> string|null;
+};
 
 export default class BackButtonService {
-	private static handlers_: BackButtonHandler[] = [];
-	private static defaultHandler_: BackButtonHandler;
+	private static store: Store<AppState>|null = null;
 
-	public static initialize(defaultHandler: BackButtonHandler) {
-		this.defaultHandler_ = defaultHandler;
+	public static initialize(store: Store<AppState>) {
+		this.store = store;
 
 		BackHandler.addEventListener('hardwareBackPress', () => {
 			void this.back();
@@ -16,26 +20,15 @@ export default class BackButtonService {
 	}
 
 	public static async back() {
-		if (this.handlers_.length) {
-			const r = await this.handlers_[this.handlers_.length - 1]();
-			if (r) return r;
+		const handlers = this.store.getState().backHandlers;
+		for (let i = handlers.length - 1; i >= 0; i --) {
+			if (handlers[i].enabled) {
+				await handlers[i].onBack();
+				if (!handlers[i].runsParent) {
+					break;
+				}
+			}
 		}
-
-		return await this.defaultHandler_();
-	}
-
-	public static addHandler(handler: BackButtonHandler) {
-		for (let i = this.handlers_.length - 1; i >= 0; i--) {
-			const h = this.handlers_[i];
-			if (h === handler) return false;
-		}
-
-		this.handlers_.push(handler);
-		return true;
-	}
-
-	public static removeHandler(handler: BackButtonHandler) {
-		this.handlers_ = this.handlers_.filter(h => h !== handler);
 	}
 }
 

--- a/packages/app-mobile/utils/appDefaultState.ts
+++ b/packages/app-mobile/utils/appDefaultState.ts
@@ -16,6 +16,9 @@ const appDefaultState: AppState = {
 	isOnMobileData: false,
 	disableSideMenuGestures: false,
 	showPanelsDialog: false,
+	backHandlers: [],
+	activeBackHandler: null,
+	navHistory: [],
 	...defaultState,
 
 	// On mobile, it's possible to select notes that aren't in the selected folder/tag/etc.

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -1,0 +1,233 @@
+import reducer from '@joplin/lib/reducer';
+import appDefaultState from './appDefaultState';
+import Logger from '@joplin/utils/Logger';
+import fastDeepEqual = require('fast-deep-equal');
+import { AppState, BackHandlerState } from './types';
+
+const logger = Logger.create('appReducer');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+function historyCanGoBackTo(route: any) {
+	if (route.routeName === 'Folder') return false;
+
+	// There's no point going back to these screens in general and, at least in OneDrive case,
+	// it can be buggy to do so, due to incorrectly relying on global state (reg.syncTarget...)
+	if (route.routeName === 'OneDriveLogin') return false;
+	if (route.routeName === 'DropboxLogin') return false;
+
+	return true;
+}
+
+const activeBackHandler = (backHandlers: BackHandlerState[]) => {
+	for (let i = backHandlers.length - 1; i >= 0; i--) {
+		const handler = backHandlers[i];
+		if (handler.enabled) {
+			return handler;
+		}
+	}
+	return null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+const appReducer = (state = appDefaultState, action: any) => {
+	let newState = state;
+	let historyGoingBack = false;
+
+	try {
+		switch (action.type) {
+
+		case 'NAV_BACK':
+		case 'NAV_GO': {
+			const navHistory = [...state.navHistory];
+
+			if (action.type === 'NAV_BACK') {
+				if (!state.navHistory.length) break;
+
+				const newAction = navHistory.pop();
+				action = newAction ? newAction : navHistory.pop();
+
+				historyGoingBack = true;
+			}
+
+			{
+				const currentRoute = state.route;
+
+				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
+					const previousRoute = navHistory.length && navHistory[navHistory.length - 1];
+					const isDifferentRoute = !previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute);
+
+					// Avoid multiple consecutive duplicate screens in the navigation history -- these can make
+					// pressing "back" seem to have no effect.
+					if (isDifferentRoute) {
+						navHistory.push(currentRoute);
+					}
+				}
+
+				if (action.clearHistory) {
+					navHistory.splice(0, navHistory.length);
+				}
+
+				newState = { ...state, navHistory };
+
+				newState.selectedNoteHash = '';
+
+				if (action.routeName === 'Search') {
+					newState.notesParentType = 'Search';
+				}
+
+				if ('noteId' in action) {
+					newState.selectedNoteIds = action.noteId ? [action.noteId] : [];
+				}
+
+				if ('folderId' in action) {
+					newState.selectedFolderId = action.folderId;
+					newState.notesParentType = 'Folder';
+				}
+
+				if ('tagId' in action) {
+					newState.selectedTagId = action.tagId;
+					newState.notesParentType = 'Tag';
+				}
+
+				if ('smartFilterId' in action) {
+					newState.smartFilterId = action.smartFilterId;
+					newState.selectedSmartFilterId = action.smartFilterId;
+					newState.notesParentType = 'SmartFilter';
+				}
+
+				if ('itemType' in action) {
+					newState.selectedItemType = action.itemType;
+				}
+
+				if ('noteHash' in action) {
+					newState.selectedNoteHash = action.noteHash;
+				}
+
+				if ('sharedData' in action) {
+					newState.sharedData = action.sharedData;
+				} else {
+					newState.sharedData = null;
+				}
+
+				newState.route = action;
+				newState.historyCanGoBack = !!navHistory.length;
+
+				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
+			}
+			break;
+		}
+
+		case 'BACK_HANDLER_ADD_OR_UPDATE': {
+			let added = false;
+			newState = { ...newState };
+			newState.backHandlers = newState.backHandlers.map(handler => {
+				if (handler.id === action.handler.id) {
+					added = true;
+					return action.handler;
+				} else {
+					return handler;
+				}
+			});
+			if (!added) {
+				newState.backHandlers = [...newState.backHandlers, action.handler];
+			}
+			newState.activeBackHandler = activeBackHandler(newState.backHandlers);
+			break;
+		}
+		case 'BACK_HANDLER_REMOVE':
+			newState = { ...newState };
+			newState.backHandlers = newState.backHandlers.filter(handler => {
+				return handler.id !== action.id;
+			});
+			newState.activeBackHandler = activeBackHandler(newState.backHandlers);
+			break;
+
+		case 'SIDE_MENU_TOGGLE':
+
+			newState = { ...state };
+			newState.showSideMenu = !newState.showSideMenu;
+			break;
+
+		case 'SIDE_MENU_OPEN':
+
+			newState = { ...state };
+			newState.showSideMenu = true;
+			break;
+
+		case 'SIDE_MENU_CLOSE':
+
+			newState = { ...state };
+			newState.showSideMenu = false;
+			break;
+
+		case 'SET_PLUGIN_PANELS_DIALOG_VISIBLE':
+			newState = { ...state };
+			newState.showPanelsDialog = action.visible;
+			break;
+
+		case 'NOTE_SELECTION_TOGGLE':
+
+			{
+				newState = { ...state };
+
+				const noteId = action.id;
+				const newSelectedNoteIds = state.selectedNoteIds.slice();
+				const existingIndex = state.selectedNoteIds.indexOf(noteId);
+
+				if (existingIndex >= 0) {
+					newSelectedNoteIds.splice(existingIndex, 1);
+				} else {
+					newSelectedNoteIds.push(noteId);
+				}
+
+				newState.selectedNoteIds = newSelectedNoteIds;
+				newState.noteSelectionEnabled = !!newSelectedNoteIds.length;
+			}
+			break;
+
+		case 'NOTE_SELECTION_START':
+
+			if (!state.noteSelectionEnabled) {
+				newState = { ...state };
+				newState.noteSelectionEnabled = true;
+				newState.selectedNoteIds = [action.id];
+			}
+			break;
+
+		case 'NOTE_SELECTION_END':
+
+			newState = { ...state };
+			newState.noteSelectionEnabled = false;
+			newState.selectedNoteIds = [];
+			break;
+
+		case 'NOTE_SIDE_MENU_OPTIONS_SET':
+
+			newState = { ...state };
+			newState.noteSideMenuOptions = action.options;
+			break;
+
+		case 'SET_SIDE_MENU_TOUCH_GESTURES_DISABLED':
+			newState = { ...state };
+			newState.disableSideMenuGestures = action.disableSideMenuGestures;
+			break;
+
+		case 'MOBILE_DATA_WARNING_UPDATE':
+
+			newState = { ...state };
+			newState.isOnMobileData = action.isOnMobileData;
+			break;
+
+		case 'KEYBOARD_VISIBLE_CHANGE':
+			newState = { ...state, keyboardVisible: action.visible };
+			break;
+		}
+	} catch (error) {
+		error.message = `In reducer: ${error.message} Action: ${JSON.stringify(action)}`;
+		throw error;
+	}
+
+	return reducer(newState, action) as AppState;
+};
+
+export default appReducer;

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -1,13 +1,45 @@
 import { State } from '@joplin/lib/reducer';
 
+// Returns true to prevent the default action.
+export type BackHandlerOnBack = ()=> Promise<void>|void;
+
+export interface BackHandlerState {
+	id: string;
+	enabled: boolean;
+	description: string;
+	onBack: BackHandlerOnBack;
+	runsParent: boolean;
+}
+
+export interface NavAction {
+	routeName: string;
+	clearHistory?: boolean;
+
+	folderId?: string;
+	noteId?: string;
+	tagId?: string;
+	smartFilterId?: string;
+	noteHash?: string;
+	itemType?: string;
+	sharedData?: string;
+}
+
+export interface Route {
+	routeName: string;
+	noteId?: string;
+}
+
 export interface AppState extends State {
 	showPanelsDialog: boolean;
 	isOnMobileData: boolean;
 	keyboardVisible: boolean;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	route: any;
+	route: Route;
 	smartFilterId: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	noteSideMenuOptions: any;
 	disableSideMenuGestures: boolean;
+	navHistory: NavAction[];
+
+	backHandlers: BackHandlerState[];
+	activeBackHandler: BackHandlerState|null;
 }


### PR DESCRIPTION
# Summary

This pull request makes the "back" button accessibility label more specific, describing what the back button navigates to. For example, when the note editor is open, this change causes the back button to read "Back: Show viewer". When the note viewer is open, the back button might read "Back: Show note list".

Partially resolves #12124 (related to an issue raised during accessibility testing).

Feedback on this proposed change is welcome! After [this workflow finishes running](https://github.com/personalizedrefrigerator/joplin/actions/runs/14893547562), a version of this change should be available at [personalizedrefrigerator.github.io/joplin/web-client/](https://personalizedrefrigerator.github.io/joplin/web-client/). If testing without a screen reader enabled, long-pressing on the "back" button should reveal its accessible label.

# Notes

- It may be helpful to include information about the current screen in the back button. At least on Android, focus defaults to the "back" button when certain screens are first opened. Reading information about the previous screen just after navigating to a new screen may be confusing.
- This pull request refactors `BackButtonService` to simplify associating back button actions with a label.
   - This refactoring may also simplify implementing [this feature request](https://discourse.joplinapp.org/t/mobile-feature-request-return-to-notebook-quickly-after-opening-multiple-notes/44771/2?u=personalizedrefriger).
- According to the WCAG, [status messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html) might be necessary when switching screens, which may also help resolve confusion about what action was taken by the back button.

## Comparison with other apps

Summary of the apps I've surveyed:
- iOS native apps: Some include a very brief name of the previous screen both in the UI and the accessibility label:
   - Freeform on iOS: **Sometimes** includes the name of the previous screen in the back button (e.g. "freeform, back button").
   - iOS settings: Includes the name of the previous screen in the back button (e.g. "settings, back button").
   - iOS safari: "Back, button", but gives the name of the previous screen after double-tap-long-press.
   - iOS app store: Includes previous screen name in the back button (e.g. "search, back button").
   - Firefox: "Back, button".
- Other apps on iOS
	- Discord: "Back, button"
	- Outlook: "Back button"


# Tasks

- [ ] Determine whether information about the current screen should be included in the back button label, or if it's possible/feasible to have focus default to the screen title (rather than the back button).
- [ ] Write a specification in `/readme/dev/spec` that describes how `BackButtonService` and the related components work.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->