### PR TITLE
Desktop: Allow minimizing the OCR search results

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -273,6 +273,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useWebViewApi.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js
+packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.js
 packages/app-desktop/gui/NoteEditor/StatusBar.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/BannerContent.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.js

--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useWebViewApi.js
 packages/app-desktop/gui/NoteEditor/NoteEditor.js
 packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.js
+packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.js
 packages/app-desktop/gui/NoteEditor/StatusBar.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/BannerContent.js
 packages/app-desktop/gui/NoteEditor/WarningBanner/WarningBanner.js

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -20,7 +20,7 @@ import Button, { ButtonLevel } from '../Button/Button';
 import eventManager, { EventName } from '@joplin/lib/eventManager';
 import { AppState } from '../../app.reducer';
 import ToolbarButtonUtils, { ToolbarButtonInfo } from '@joplin/lib/services/commands/ToolbarButtonUtils';
-import { _, _n } from '@joplin/lib/locale';
+import { _ } from '@joplin/lib/locale';
 import NoteTitleBar from './NoteTitle/NoteTitleBar';
 import markupLanguageUtils from '@joplin/lib/utils/markupLanguageUtils';
 import Setting from '@joplin/lib/models/Setting';
@@ -56,6 +56,7 @@ import PluginService from '@joplin/lib/services/plugins/PluginService';
 import EditorPluginHandler from '@joplin/lib/services/plugins/EditorPluginHandler';
 import useResourceUnwatcher from './utils/useResourceUnwatcher';
 import StatusBar from './StatusBar';
+import ResourceSearchResultsBanner, { OnBannerResourceClick } from './ResourceSearchResultsBanner';
 
 const debounce = require('debounce');
 
@@ -490,10 +491,8 @@ function NoteEditorContent(props: NoteEditorProps) {
 		setShowRevisions(false);
 	}, []);
 
-	const onBannerResourceClick = useCallback(async (event: React.MouseEvent<HTMLAnchorElement>) => {
-		event.preventDefault();
-		const resourceId = event.currentTarget.getAttribute('data-resource-id');
-		await openItemById(resourceId, props.dispatch);
+	const onBannerResourceClick: OnBannerResourceClick = useCallback(async (event) => {
+		await openItemById(event.item_id, props.dispatch);
 	}, [props.dispatch]);
 
 	if (showRevisions) {
@@ -569,21 +568,11 @@ function NoteEditorContent(props: NoteEditorProps) {
 	}
 
 	const renderResourceInSearchResultsNotification = () => {
-		const resourceResults = props.searchResults.filter(r => r.id === props.noteId && r.item_type === ModelType.Resource);
-		if (!resourceResults.length) return null;
-
-		const renderResource = (id: string, title: string) => {
-			return <li key={id}><a data-resource-id={id} onClick={onBannerResourceClick} href="#">{title}</a></li>;
-		};
-
-		return (
-			<div style={styles.resourceWatchBanner}>
-				<p style={styles.resourceWatchBannerLine}>{_n('The following attachment matches your search query:', 'The following attachments match your search query:', resourceResults.length)}</p>
-				<ul>
-					{resourceResults.map(r => renderResource(r.item_id, r.title))}
-				</ul>
-			</div>
-		);
+		return <ResourceSearchResultsBanner
+			searchResults={props.searchResults}
+			onResourceLinkClick={onBannerResourceClick}
+			noteId={props.noteId}
+		/>;
 	};
 
 	function renderSearchInfo() {

--- a/packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { ProcessResultsRow } from '@joplin/lib/services/search/SearchEngine';
+import { ModelType } from '@joplin/lib/BaseModel';
+import { useCallback } from 'react';
+import { _n } from '@joplin/lib/locale';
+
+export type OnBannerResourceClick = (searchResult: ProcessResultsRow)=> void;
+
+interface Props {
+	searchResults: ProcessResultsRow[];
+	noteId: string;
+	onResourceLinkClick: OnBannerResourceClick;
+}
+
+interface ResourceResultProps {
+	result: ProcessResultsRow;
+	onResourceClick: OnBannerResourceClick;
+}
+
+const ResourceResult: React.FC<ResourceResultProps> = ({ result, onResourceClick }) => {
+	const onClick = useCallback(() => {
+		onResourceClick(result);
+	}, [result, onResourceClick]);
+
+	return <button
+		onClick={onClick}
+		className='link-button'
+	>{result.title}</button>;
+};
+
+const ResourceSearchResultsBanner: React.FC<Props> = ({
+	searchResults,
+	onResourceLinkClick,
+	noteId,
+}) => {
+	const resourceResults = searchResults.filter(r => r.id === noteId && r.item_type === ModelType.Resource);
+
+	const renderResource = (resource: ProcessResultsRow) => {
+		return <li key={resource.item_id}>
+			<ResourceResult result={resource} onResourceClick={onResourceLinkClick}/>
+		</li>;
+	};
+
+	if (resourceResults.length) {
+		return (
+			<details className='resource-search-results-banner' open>
+				<summary className='description'>{_n('The following attachment matches your search query:', 'The following attachments match your search query:', resourceResults.length)}</summary>
+				<ul>
+					{resourceResults.map(r => renderResource(r))}
+				</ul>
+			</details>
+		);
+	}
+	return null;
+};
+
+export default ResourceSearchResultsBanner;

--- a/packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.tsx
+++ b/packages/app-desktop/gui/NoteEditor/ResourceSearchResultsBanner.tsx
@@ -25,6 +25,7 @@ const ResourceResult: React.FC<ResourceResultProps> = ({ result, onResourceClick
 	return <button
 		onClick={onClick}
 		className='link-button'
+		role='link'
 	>{result.title}</button>;
 };
 
@@ -41,17 +42,17 @@ const ResourceSearchResultsBanner: React.FC<Props> = ({
 		</li>;
 	};
 
-	if (resourceResults.length) {
-		return (
-			<details className='resource-search-results-banner' open>
-				<summary className='description'>{_n('The following attachment matches your search query:', 'The following attachments match your search query:', resourceResults.length)}</summary>
-				<ul>
-					{resourceResults.map(r => renderResource(r))}
-				</ul>
-			</details>
-		);
-	}
-	return null;
+	return (
+		<details className={`resource-search-results-banner ${resourceResults.length ? '-visible' : ''}`} open>
+			<summary>
+				<div className='marker' aria-hidden/>
+				{_n('The following attachment matches your search query:', 'The following attachments match your search query:', resourceResults.length)}
+			</summary>
+			<ul>
+				{resourceResults.map(r => renderResource(r))}
+			</ul>
+		</details>
+	);
 };
 
 export default ResourceSearchResultsBanner;

--- a/packages/app-desktop/gui/NoteEditor/style.scss
+++ b/packages/app-desktop/gui/NoteEditor/style.scss
@@ -10,3 +10,5 @@
 @use "./styles/tag-bar.scss";
 @use "./styles/editor-status-bar.scss";
 @use "./styles/editor-status-indicator.scss";
+@use "./styles/resource-search-results-banner.scss";
+

--- a/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
+++ b/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
@@ -4,6 +4,16 @@
 	margin-left: 5px;
 	margin-bottom: 10px;
 	background-color: var(--joplin-warning-background-color);
+	display: none;
+	--marker-content: '[+]';
+
+	&[open] {
+		--marker-content: '[-]';
+	}
+
+	&.-visible {
+		display: block;
+	}
 
 	> summary {
 		cursor: pointer;
@@ -13,13 +23,12 @@
 			display: none;
 		}
 
-		&::before {
-			content: '[+]';
+		& > .marker {
+			&::before {
+				content: var(--marker-content);
+			}
 			float: right;
+            display: inline-block;
 		}
-	}
-
-	&[open] > summary::before {
-		content: '[-]';
 	}
 }

--- a/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
+++ b/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
@@ -28,7 +28,7 @@
 				content: var(--marker-content);
 			}
 			float: right;
-            display: inline-block;
+			display: inline-block;
 		}
 	}
 }

--- a/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
+++ b/packages/app-desktop/gui/NoteEditor/styles/resource-search-results-banner.scss
@@ -1,0 +1,25 @@
+
+.resource-search-results-banner {
+	padding: 10px;
+	margin-left: 5px;
+	margin-bottom: 10px;
+	background-color: var(--joplin-warning-background-color);
+
+	> summary {
+		cursor: pointer;
+
+		&::marker {
+			content: '';
+			display: none;
+		}
+
+		&::before {
+			content: '[+]';
+			float: right;
+		}
+	}
+
+	&[open] > summary::before {
+		content: '[-]';
+	}
+}

--- a/packages/app-desktop/utils/window/eventHandlerOverrides.js
+++ b/packages/app-desktop/utils/window/eventHandlerOverrides.js
@@ -17,7 +17,7 @@ document.addEventListener('click', (event) => {
 	// checkboxes. Such a global event handler is probably not a good idea
 	// anyway but keeping it for now, as it doesn't seem to break anything else.
 	// https://github.com/facebook/react/issues/13477#issuecomment-489274045
-	if (['LABEL', 'INPUT'].includes(event.target.nodeName)) return;
+	if (['LABEL', 'INPUT', 'DETAILS', 'SUMMARY'].includes(event.target.nodeName)) return;
 
 	event.preventDefault();
 });


### PR DESCRIPTION
# Summary

This pull request converts the OCR search results to a `<details>` element, allowing to be expanded/collapsed.

> [!NOTE]
>
> At present, the `<details>` element is expanded by default. Whether the element is expanded or collapsed does not persist when the editor is closed and re-opened (e.g. by opening and closing settings). This could be changed by adding a `editor.resourceSearchResults.expanded` setting to `builtInMetadata.ts`.


# Screenshots

Expanded (default):
![screenshot: The following attachments match your query:, toggle button, expanded, list with two items, where each item is a link](https://github.com/user-attachments/assets/9da7e1b6-6839-4a93-8d9f-c512cf746475)

Hidden:
![screenshot: The following attachments match your query:, toggle button, collapsed](https://github.com/user-attachments/assets/edcb4c95-6ede-4619-8dc0-ff22b41ac924)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->