### PR TITLE
Windows: Rich Text Editor: Fix dropping a URL from the Firefox addressbar inserts nothing

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useDropHandler.ts
@@ -62,18 +62,20 @@ export default function useDropHandler(dependencies: HookDependencies): DropHand
 				paths.push(path);
 			}
 
-			const props: DropCommandValue = {
-				type: 'files',
-				pos: eventPosition,
-				paths: paths,
-				createFileURL: createFileURL,
-			};
+			if (paths.length > 0) {
+				const props: DropCommandValue = {
+					type: 'files',
+					pos: eventPosition,
+					paths: paths,
+					createFileURL: createFileURL,
+				};
 
-			editorRef.current.execCommand({
-				name: 'dropItems',
-				value: props,
-			});
-			return true;
+				editorRef.current.execCommand({
+					name: 'dropItems',
+					value: props,
+				});
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
# Summary

Partially fixes #12275 — previously, when dragging and dropping the text from the Firefox addressbar into Joplin's Rich Text Editor, nothing was inserted.

**Notes**:
- This **may** fix the  similar issues for other browsers identified in #12275 (e.g. I suspect that this fixes the issue for Chrome).
- This does not cause URLs dropped from Microsoft Edge's addressbar to be formatted.

# Testing plan

**Windows 11**:
1. Open Firefox and navigate to `https://joplinapp.org/`
2. Open Joplin's Rich Text Editor.
3. Drag the 'joplinapp.org' URL from Firefox into Joplin's Rich Text Editor.
4. Verify that a [Joplin](https://joplinapp.org/) URL is added to the editor.
5. **Regression testing**: Drag and drop a file from File Explorer into Joplin's Rich Text Editor (tested with a `.log` file from `Downloads/`). Verify that the file is attached to the note.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->