### PR TITLE
Mobile: Accessibility: Auto-fill the editor search input with the global search

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
@@ -48,6 +48,7 @@ describe('NoteEditor', () => {
 				<NoteEditor
 					themeId={Setting.THEME_ARITIM_DARK}
 					initialText='Testing...'
+					globalSearch=''
 					noteId=''
 					noteHash=''
 					style={{}}

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -457,10 +457,7 @@ function NoteEditor(props: Props, ref: any) {
 	const html = useHtml(css);
 	const [selectionState, setSelectionState] = useState<SelectionFormatting>(defaultSelectionFormatting);
 	const [linkDialogVisible, setLinkDialogVisible] = useState(false);
-	const [searchState, setSearchState] = useState({
-		...defaultSearchState,
-		searchText: props.globalSearch,
-	});
+	const [searchState, setSearchState] = useState(defaultSearchState);
 
 	const onEditorEvent = useRef((_event: EditorEvent) => {});
 

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -43,6 +43,7 @@ interface Props {
 	initialText: string;
 	noteId: string;
 	noteHash: string;
+	globalSearch: string;
 	initialSelection?: SelectionRange;
 	style: ViewStyle;
 	toolbarEnabled: boolean;
@@ -329,12 +330,18 @@ const useEditorControl = (
 function NoteEditor(props: Props, ref: any) {
 	const webviewRef = useRef<WebViewControl>(null);
 
-	const setInitialSelectionJS = props.initialSelection ? `
+	const setInitialSelectionJs = props.initialSelection ? `
 		cm.select(${props.initialSelection.start}, ${props.initialSelection.end});
 		cm.execCommand('scrollSelectionIntoView');
 	` : '';
 	const jumpToHashJs = props.noteHash ? `
 		cm.jumpToHash(${JSON.stringify(props.noteHash)});
+	` : '';
+	const setInitialSearchJs = props.globalSearch ? `
+		cm.setSearchState(${JSON.stringify({
+		...defaultSearchState,
+		searchText: props.globalSearch,
+	})})
 	` : '';
 
 	const editorSettings: EditorSettings = useMemo(() => ({
@@ -398,7 +405,8 @@ function NoteEditor(props: Props, ref: any) {
 					${jumpToHashJs}
 					// Set the initial selection after jumping to the header -- the initial selection,
 					// if specified, should take precedence.
-					${setInitialSelectionJS}
+					${setInitialSelectionJs}
+					${setInitialSearchJs}
 
 					window.onresize = () => {
 						cm.execCommand('scrollSelectionIntoView');
@@ -449,7 +457,10 @@ function NoteEditor(props: Props, ref: any) {
 	const html = useHtml(css);
 	const [selectionState, setSelectionState] = useState<SelectionFormatting>(defaultSelectionFormatting);
 	const [linkDialogVisible, setLinkDialogVisible] = useState(false);
-	const [searchState, setSearchState] = useState(defaultSearchState);
+	const [searchState, setSearchState] = useState({
+		...defaultSearchState,
+		searchText: props.globalSearch,
+	});
 
 	const onEditorEvent = useRef((_event: EditorEvent) => {});
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1587,6 +1587,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						noteHash={this.props.noteHash}
 						initialText={note.body}
 						initialSelection={this.selection}
+						globalSearch={this.props.searchQuery}
 						onChange={this.onMarkdownEditorTextChange}
 						onSelectionChange={this.onMarkdownEditorSelectionChange}
 						onUndoRedoDepthChange={this.onUndoRedoDepthChange}


### PR DESCRIPTION
# Summary

This pull request initializes the search input in the note editor with the global search query, if available. If there is no ongoing global search, the search input is initially empty, as before.

# Related accessibility guideline

The understanding document for [WCAG 2.2/Redundant entry (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html) summarizes the guideline as
> **What to do**: Don't ask for the same information twice in the same session.

and provides the following example:
> A search results page pre-fills the search input with the previously entered search term in the same process.


# Testing plan

**Web (Chromium 136):**
1. Search for "test" from the notes list screen.
2. Open a note.
3. Open the editor.
4. Click "search".
5. Verify that the search input is pre-filled with "test".
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->