### PR TITLE
Desktop: Make default window color match system theme

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -6,7 +6,7 @@ const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import { FileLocker } from '@joplin/utils/fs';
 import { IpcMessageHandler, IpcServer, Message, newHttpError, sendMessage, SendMessageOptions, startServer, stopServer } from '@joplin/utils/ipc';
-import { BrowserWindow, Tray, WebContents, screen, App, BrowserWindowConstructorOptions, nativeTheme } from 'electron';
+import { BrowserWindow, Tray, WebContents, screen, App, nativeTheme } from 'electron';
 import bridge from './bridge';
 const url = require('url');
 const path = require('path');
@@ -207,7 +207,8 @@ export default class ElectronAppWrapper {
 		// Load the previous state with fallback to defaults
 		const windowState = windowStateKeeper(stateOptions);
 
-		const windowOptions: BrowserWindowConstructorOptions = {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		const windowOptions: any = {
 			x: windowState.x,
 			y: windowState.y,
 			width: windowState.width,
@@ -222,6 +223,7 @@ export default class ElectronAppWrapper {
 				nodeIntegration: true,
 				contextIsolation: false,
 				spellcheck: true,
+				enableRemoteModule: true,
 			},
 			// We start with a hidden window, which is then made visible depending on the showTrayIcon setting
 			// https://github.com/laurent22/joplin/issues/2031

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -214,7 +214,10 @@ export default class ElectronAppWrapper {
 			height: windowState.height,
 			minWidth: 100,
 			minHeight: 100,
-			backgroundColor: nativeTheme.shouldUseDarkColors ? '#333' : '#fff',
+			// A backgroundColor is needed to enable sub-pixel rendering.
+			// Based on https://github.com/electron/electron/issues/10955#issuecomment-437182679, both #000 and #fff
+			// should work:
+			backgroundColor: nativeTheme.shouldUseDarkColors ? '#000' : '#fff',
 			webPreferences: {
 				nodeIntegration: true,
 				contextIsolation: false,

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -215,9 +215,9 @@ export default class ElectronAppWrapper {
 			minWidth: 100,
 			minHeight: 100,
 			// A backgroundColor is needed to enable sub-pixel rendering.
-			// Based on https://github.com/electron/electron/issues/10955#issuecomment-437182679, both #000 and #fff
-			// should work:
-			backgroundColor: nativeTheme.shouldUseDarkColors ? '#000' : '#fff',
+			// Based on https://www.electronjs.org/docs/latest/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do,
+			// this needs to be a non-transparent color:
+			backgroundColor: nativeTheme.shouldUseDarkColors ? '#333' : '#fff',
 			webPreferences: {
 				nodeIntegration: true,
 				contextIsolation: false,

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -6,7 +6,7 @@ const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import { FileLocker } from '@joplin/utils/fs';
 import { IpcMessageHandler, IpcServer, Message, newHttpError, sendMessage, SendMessageOptions, startServer, stopServer } from '@joplin/utils/ipc';
-import { BrowserWindow, Tray, WebContents, screen, App } from 'electron';
+import { BrowserWindow, Tray, WebContents, screen, App, BrowserWindowConstructorOptions, nativeTheme } from 'electron';
 import bridge from './bridge';
 const url = require('url');
 const path = require('path');
@@ -207,20 +207,18 @@ export default class ElectronAppWrapper {
 		// Load the previous state with fallback to defaults
 		const windowState = windowStateKeeper(stateOptions);
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const windowOptions: any = {
+		const windowOptions: BrowserWindowConstructorOptions = {
 			x: windowState.x,
 			y: windowState.y,
 			width: windowState.width,
 			height: windowState.height,
 			minWidth: 100,
 			minHeight: 100,
-			backgroundColor: '#fff', // required to enable sub pixel rendering, can't be in css
+			backgroundColor: nativeTheme.shouldUseDarkColors ? '#333' : '#fff',
 			webPreferences: {
 				nodeIntegration: true,
 				contextIsolation: false,
 				spellcheck: true,
-				enableRemoteModule: true,
 			},
 			// We start with a hidden window, which is then made visible depending on the showTrayIcon setting
 			// https://github.com/laurent22/joplin/issues/2031


### PR DESCRIPTION
# Summary

This pull request should resolve an issue raised on [the Joplin forum](https://discourse.joplinapp.org/t/joplin-for-windows-white-screen-on-launch/45395) — when the OS uses a dark theme, this pull request sets the initial window background to `#333`, instead of `#fff`.

# Screenshots

Starting the app with the OS theme set to dark:
![screenshot: App has a dark gray background](https://github.com/user-attachments/assets/be5421d3-427f-47f1-a9e1-f83fad427269)

Starting the app with the OS theme set to light:
![screenshot: App has a light background](https://github.com/user-attachments/assets/297e9332-f900-41de-a69e-b1555a205d20)


# Testing plan

**Fedora 42 Linux/GNOME**:
1. Set the system theme to dark.
2. Start Joplin.
3. Verify that the initial window background is dark gray.
4. Set the system theme to light.
5. Restart Joplin.
3. Verify that the initial window background is white.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->