### PR TITLE
Chore: Web: Simplify accessing certain global APIs in dev mode

### DIFF
--- a/packages/app-mobile/index.web.ts
+++ b/packages/app-mobile/index.web.ts
@@ -1,5 +1,15 @@
 import { AppRegistry } from 'react-native';
 import Root from './root';
+import Setting from '@joplin/lib/models/Setting';
+import Note from '@joplin/lib/models/Note';
+import Folder from '@joplin/lib/models/Folder';
+import CommandService from '@joplin/lib/services/CommandService';
+import RevisionService from '@joplin/lib/services/RevisionService';
+import MigrationService from '@joplin/lib/services/MigrationService';
+import DecryptionWorker from '@joplin/lib/services/DecryptionWorker';
+import PluginService from '@joplin/lib/services/plugins/PluginService';
+import Tag from '@joplin/lib/models/Tag';
+import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 
 require('./web/rnVectorIconsSetup.js');
 
@@ -11,6 +21,26 @@ interface ExtendedNavigator extends Navigator {
 	virtualKeyboard?: { overlaysContent: boolean };
 }
 declare const navigator: ExtendedNavigator;
+
+// Add properties useful for debugging from the console window:
+interface ExtendedWindow extends Window {
+	joplin: unknown;
+}
+declare const window: ExtendedWindow;
+if (__DEV__) {
+	window.joplin = {
+		Setting,
+		Note,
+		Folder,
+		Tag,
+		revisionService: RevisionService.instance(),
+		migrationService: MigrationService.instance(),
+		decryptionWorker: DecryptionWorker.instance(),
+		commandService: CommandService.instance(),
+		pluginService: PluginService.instance(),
+		searchEngine: SearchEngine.instance(),
+	};
+}
 
 // Should prevent the browser from auto-deleting background data.
 const requestPersistentStorage = async () => {


### PR DESCRIPTION
# Summary

Occasionally, it's useful to access `Setting`, `Note`, `Folder`, and similar APIs in development mode. In development mode, this pull request exposes a `joplin` API that can be used from the development tools to adjust/access application state.

**Note**: The debug API added by this pull request is modeled on the similar API provided by the desktop app:

https://github.com/laurent22/joplin/blob/dfa7ed0a5ce9213d76929da729e1d070743695ac/packages/app-desktop/app.ts#L652-L665

# Testing plan

1. Open the web app in development mode.
2. From the development tools, run `joplin.Setting.value('env')`.
3. Verify that this logs `dev` to the development console.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->