### PR TITLE
iOS: Fixes #12314: Fix error shown the first time a user attempts to record

### DIFF
--- a/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/AudioRecordingBanner.tsx
@@ -14,7 +14,7 @@ import { Text } from 'react-native-paper';
 import { AndroidAudioEncoder, AndroidOutputFormat, IOSAudioQuality, IOSOutputFormat, RecordingOptions } from 'expo-av/build/Audio';
 import time from '@joplin/lib/time';
 import { toFileExtension } from '@joplin/lib/mime-utils';
-import { formatMsToDurationCompat } from '@joplin/utils/time';
+import { formatMsToDurationCompat, msleep } from '@joplin/utils/time';
 
 const logger = Logger.create('AudioRecording');
 
@@ -119,6 +119,11 @@ const useAudioRecorder = (onFileSaved: OnFileSavedCallback, onDismiss: ()=> void
 				if (!response.granted) {
 					throw new Error(_('Missing permission to record audio.'));
 				}
+
+				// Work around "This experience is currently in the background, so the audio session could not be activated"
+				// See https://github.com/expo/expo/issues/21782
+				// May be resolved by migrating to expo-audio.
+				await msleep(500);
 			}
 
 			await Audio.setAudioModeAsync({


### PR DESCRIPTION
# Summary

Fixes #12314.

> [!NOTE]
>
> This pull request targets `release-3.3`. An alternate fix (but a larger change) [might be to set staysActiveInBackground to `true`](https://github.com/laurent22/joplin/issues/12314#issuecomment-2893059479) and add the necessary permissions to `Info.plist`. After this pull request is merged, it may make sense to [enable `staysActiveInBackground`](https://docs.expo.dev/versions/latest/sdk/audio-av/#playing-or-recording-audio-in-background) on the dev branch for the 3.4 release.
>
> **Update**: It isn't sufficient to set [`staysActiveInBackground: true`](https://github.com/laurent22/joplin/pull/12330). With just this change (and no timeout) I get the following error: "Recording error: Error: Prepare encountered an error: recorder not prepared". 

# Testing

**Web**  (regression testing):
1. Start Joplin and open a note.
    - Joplin should initially not have microphone permissions.
2. Click "Attach", then "Record audio".
4. Verify that a permissions prompt is shown. Click "Allow this time".
3. Click "Start recording".
5. Say something.
6. Click "Done".
7. Verify that the recording is added to the note.

**iOS 18.5**:
1. Start Joplin, create the initial notebook, and create a note using the "recording" button.
    - Joplin should initially not have microphone permissions.
3. Click "Start recording", grant recording permissions, and speak.
7. Click "Done".
8. Verify that the recording is added to the note.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->