### PR TITLE
Chore: Remove unused `canvas` dependency

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -141,11 +141,6 @@ jobs:
           echo "RUNNER_ARCH=$RUNNER_ARCH"
           echo "DOCKER_IMAGE_PLATFORM=$DOCKER_IMAGE_PLATFORM"
 
-          # Canvas is only needed for tests and it doesn't build in ARM64 so remove it
-          cd packages/lib
-          yarn remove canvas
-          cd ../..
-          
           yarn install
           yarn buildServerDocker --platform $DOCKER_IMAGE_PLATFORM --tag-name server-v0.0.0 --repository joplin/server
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -29,7 +29,6 @@
     "@types/node-rsa": "1.1.4",
     "@types/react": "18.3.3",
     "@types/uuid": "9.0.7",
-    "canvas": "2.11.2",
     "clean-html": "1.5.0",
     "jest": "29.7.0",
     "jest-expect-message": "1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9061,7 +9061,6 @@ __metadata:
     base-64: 1.0.0
     base64-stream: 1.0.0
     builtin-modules: 3.3.0
-    canvas: 2.11.2
     chokidar: 3.6.0
     clean-html: 1.5.0
     color: 3.2.1
@@ -18885,18 +18884,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:2.11.2, canvas@npm:^2.11.2":
-  version: 2.11.2
-  resolution: "canvas@npm:2.11.2"
-  dependencies:
-    "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.17.0
-    node-gyp: latest
-    simple-get: ^3.0.3
-  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
-  languageName: node
-  linkType: hard
-
 "capital-case@npm:^1.0.4":
   version: 1.0.4
   resolution: "capital-case@npm:1.0.4"
@@ -22050,15 +22037,6 @@ __metadata:
   dependencies:
     mimic-response: ^1.0.0
   checksum: 952552ac3bd7de2fc18015086b09468645c9638d98a551305e485230ada278c039c91116e946d07894b39ee53c0f0d5b6473f25a224029344354513b412d7380
-  languageName: node
-  linkType: hard
-
-"decompress-response@npm:^4.2.0":
-  version: 4.2.1
-  resolution: "decompress-response@npm:4.2.1"
-  dependencies:
-    mimic-response: ^2.0.0
-  checksum: 4e783ca4dfe9417354d61349750fe05236f565a4415a6ca20983a311be2371debaedd9104c0b0e7b36e5f167aeaae04f84f1a0b3f8be4162f1d7d15598b8fdba
   languageName: node
   linkType: hard
 
@@ -34852,13 +34830,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "mimic-response@npm:2.1.0"
-  checksum: 014fad6ab936657e5f2f48bd87af62a8e928ebe84472aaf9e14fec4fcb31257a5edff77324d8ac13ddc6685ba5135cf16e381efac324e5f174fb4ddbf902bf07
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
@@ -35498,7 +35469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:2.19.0, nan@npm:^2.17.0":
+"nan@npm:2.19.0":
   version: 2.19.0
   resolution: "nan@npm:2.19.0"
   dependencies:
@@ -37967,7 +37938,6 @@ __metadata:
   version: 3.11.174
   resolution: "pdfjs-dist@npm:3.11.174"
   dependencies:
-    canvas: ^2.11.2
     path2d-polyfill: ^2.0.1
   dependenciesMeta:
     canvas:
@@ -37982,7 +37952,6 @@ __metadata:
   version: 3.11.174
   resolution: "pdfjs-dist@patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch::version=3.11.174&hash=4ecadb&locator=root%40workspace%3A."
   dependencies:
-    canvas: ^2.11.2
     path2d-polyfill: ^2.0.1
   dependenciesMeta:
     canvas:
@@ -43482,17 +43451,6 @@ __metadata:
   version: 1.0.1
   resolution: "simple-concat@npm:1.0.1"
   checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
-  languageName: node
-  linkType: hard
-
-"simple-get@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "simple-get@npm:3.1.1"
-  dependencies:
-    decompress-response: ^4.2.0
-    once: ^1.3.1
-    simple-concat: ^1.0.0
-  checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request:
- Removes the direct dependency on node-canvas from `packages/lib/package.json`, which, since 5b2f409254f58f28550a8bd8fbf635a6e54b625a, is unused.
- Removes the indirect dependency on node-canvas (an optional dependency of `pdfjs-dist`).
   - Despite Joplin's [pdfjs-dist patch](https://github.com/laurent22/joplin/blob/dev/.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch), `canvas` was still built by Yarn as a dependency of `pdfjs-dist`. This pull request removes `canvas` from the `pdfjs-dist` dependency list in `yarn.lock`.

Related: https://github.com/laurent22/joplin/commit/5b2f409254f58f28550a8bd8fbf635a6e54b625a — removed the **need** for the node `canvas` dependency, but did not remove the dependency.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->