### PR TITLE
- All: Update README.md of joplin-renderer package

### DIFF
--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -4,14 +4,14 @@ This is the renderer used by [Joplin](https://github.com/laurent22/joplin) to re
 
 ## Installation
 
-	npm i -s joplin-renderer
+	npm i @joplin/renderer
 
 Certain plugins require additional assets like CSS, fonts, etc. These assets are in the `/assets` directory and should be copied to wherever the application can find them at runtime.
 
 ## Usage
 
 ```js
-const { MarkupToHtml } = require('joplin-renderer');
+const { MarkupToHtml } = require('@joplin/renderer');
 
 const options = {};
 


### PR DESCRIPTION
The package installed using `npm i -s joplin-renderer` is relatively outdated, and using `const { MarkupToHtml } = require('joplin-renderer');` often leads to the error `e.apply is not a function`. To fix the outdated `README.md`, use the updated package by running `npm i @joplin/renderer` and initialize it with `const { MarkupToHtml } = require('@joplin/renderer');`

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->