### PR TITLE
Android: Fix voice typing fails to start on certain devices

### DIFF
--- a/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/AudioRecorder.kt
+++ b/packages/app-mobile/android/app/src/main/java/net/cozic/joplin/audio/AudioRecorder.kt
@@ -18,6 +18,7 @@ class AudioRecorder(context: Context) : Closeable {
 	// Don't allow the unprocessed audio buffer to grow indefinitely -- discard
 	// data if longer than this:
 	private val maxLengthSeconds = 120
+	private val maxRecorderBufferLengthSeconds = 20
 	private val maxBufferSize = sampleRate * maxLengthSeconds
 	private val buffer = FloatArray(maxBufferSize)
 	private var bufferWriteOffset = 0
@@ -45,7 +46,7 @@ class AudioRecorder(context: Context) : Closeable {
 				.setChannelMask(AudioFormat.CHANNEL_IN_MONO)
 				.build()
 		)
-		.setBufferSizeInBytes(maxBufferSize * Float.SIZE_BYTES)
+		.setBufferSizeInBytes(maxRecorderBufferLengthSeconds * sampleRate * Float.SIZE_BYTES)
 		.build()
 
 	// Discards the first [samples] samples from the start of the buffer. Conceptually, this


### PR DESCRIPTION
# Summary

This pull request fixes an issue observed on an older Android device — some devices are unable to allocate a 120s buffer for the audio recorder. This reduces the recorder's internal buffer size to 20s, but keeps the size of Joplin's buffer at 120s.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->