### PR TITLE
Desktop: Improve OneNote converter debugging by keeping track of which page is being parsed

### DIFF
--- a/packages/onenote-converter/Cargo.lock
+++ b/packages/onenote-converter/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "encoding_rs",
  "enum-primitive-derive",
  "itertools",
+ "lazy_static",
  "log",
  "mime_guess",
  "num-traits",

--- a/packages/onenote-converter/Cargo.toml
+++ b/packages/onenote-converter/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1.0"
 uuid = "1.1.2"
 widestring = "1.0.2"
 wasm-bindgen = "0.2"
+lazy_static = "1.4"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/packages/onenote-converter/src/page/embedded_file.rs
+++ b/packages/onenote-converter/src/page/embedded_file.rs
@@ -69,9 +69,7 @@ impl<'a> Renderer<'a> {
             }
 
             let path = PathBuf::from(filename);
-            let ext = path
-                .extension()
-                .unwrap_or_default();
+            let ext = path.extension().unwrap_or_default();
             let base = path
                 .as_os_str()
                 .to_str()

--- a/packages/onenote-converter/src/parser/onenote/mod.rs
+++ b/packages/onenote-converter/src/parser/onenote/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod rich_text;
 pub(crate) mod section;
 pub(crate) mod table;
 
+extern crate lazy_static;
 extern crate console_error_panic_hook;
 
 /// The OneNote file parser.

--- a/packages/onenote-converter/src/parser/onenote/mod.rs
+++ b/packages/onenote-converter/src/parser/onenote/mod.rs
@@ -26,8 +26,8 @@ pub(crate) mod rich_text;
 pub(crate) mod section;
 pub(crate) mod table;
 
-extern crate lazy_static;
 extern crate console_error_panic_hook;
+extern crate lazy_static;
 
 /// The OneNote file parser.
 pub struct Parser;

--- a/packages/onenote-converter/src/utils.rs
+++ b/packages/onenote-converter/src/utils.rs
@@ -1,13 +1,13 @@
 use crate::parser::errors::Result;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
+use std::sync::Mutex;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use widestring::U16CString;
-use lazy_static::lazy_static;
-use std::sync::Mutex;
 
 pub(crate) fn px(inches: f32) -> String {
     format!("{}px", (inches * 48.0).round())

--- a/packages/onenote-converter/src/utils.rs
+++ b/packages/onenote-converter/src/utils.rs
@@ -6,6 +6,8 @@ use std::fmt::Display;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use widestring::U16CString;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
 
 pub(crate) fn px(inches: f32) -> String {
     format!("{}px", (inches * 48.0).round())
@@ -138,6 +140,9 @@ pub mod utils {
 
     macro_rules! log_warn {
         ( $( $t:tt )* ) => {
+            use crate::utils::get_current_page;
+
+            web_sys::console::warn_1(&format!("OneNoteConverter: Warning around the following page: {}", get_current_page().unwrap()).into());
             web_sys::console::warn_2(&format!("OneNoteConverter: ").into(), &format!( $( $t )* ).into());
         }
     }
@@ -161,4 +166,18 @@ impl Utf16ToString for &[u8] {
         let value = U16CString::from_vec_truncate(data);
         Ok(value.to_string().unwrap())
     }
+}
+
+lazy_static! {
+    static ref CURRENT_PAGE: Mutex<Option<String>> = Mutex::new(None);
+}
+
+pub fn set_current_page(page_name: String) {
+    let mut current_page = CURRENT_PAGE.lock().unwrap();
+    *current_page = Some(page_name.to_string());
+}
+
+pub fn get_current_page() -> Option<String> {
+    let current_page = CURRENT_PAGE.lock().unwrap();
+    current_page.clone()
 }


### PR DESCRIPTION
# Summary

I made some modification in the parser to help debugging in the future, the changes are meant to keep track which page is being parsed, so it can later be used in logs.

Unfortunately, we can't really be sure that the logged note is the faulty one since the bug might be happening before the page is parsed, but we probably can narrow down much of the work in cases like this.

I also added the debugging information to all `log_warn`, since they are usually used when a error case is being avoided with a default value, for example.