### PR TITLE
Desktop, Mobile: Resolves #11845: Adjust list toggle behavior for consistency with other apps

### DIFF
--- a/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
@@ -2,11 +2,10 @@ import { EditorSelection } from '@codemirror/state';
 import {
 	insertHorizontalRule,
 	insertOrIncreaseIndent,
-	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleList, toggleMath, updateLink,
+	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleMath, updateLink,
 } from './markdownCommands';
 import createTestEditor from '../testUtil/createTestEditor';
 import { blockMathTagName } from './MarkdownMathExtension';
-import { ListType } from '../../types';
 
 describe('markdownCommands', () => {
 
@@ -324,54 +323,6 @@ describe('markdownCommands', () => {
 		insertHorizontalRule(editor);
 
 		expect(editor.state.doc.toString()).toBe('testing\n* * *\n* * *\n\n> this is a test\n> * * *\n> * * *');
-	});
-
-	it('should convert a nested bulleted list to an ordered list', async () => {
-		const initialDocText = [
-			'- Item 1',
-			'    - Sub-item 1',
-			'    - Sub-item 2',
-			'- Item 2',
-		].join('\n');
-
-		const expectedDocText = [
-			'1. Item 1',
-			'    1. Sub-item 1',
-			'    2. Sub-item 2',
-			'2. Item 2',
-		].join('\n');
-
-		const editor = await createTestEditor(
-			initialDocText,
-			EditorSelection.range(0, initialDocText.length),
-			['BulletList'],
-		);
-
-		toggleList(ListType.OrderedList)(editor);
-
-		expect(editor.state.doc.toString()).toBe(expectedDocText);
-	});
-
-	it('should convert a mixed nested list to a bulleted list', async () => {
-		const initialDocText = `1. Item 1
-			1. Sub-item 1
-			2. Sub-item 2
-		2. Item 2`;
-
-		const expectedDocText = `- Item 1
-			- Sub-item 1
-			- Sub-item 2
-		- Item 2`;
-
-		const editor = await createTestEditor(
-			initialDocText,
-			EditorSelection.range(0, initialDocText.length),
-			['OrderedList'],
-		);
-
-		toggleList(ListType.UnorderedList)(editor);
-
-		expect(editor.state.doc.toString()).toBe(expectedDocText);
 	});
 });
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.test.ts
@@ -2,10 +2,11 @@ import { EditorSelection } from '@codemirror/state';
 import {
 	insertHorizontalRule,
 	insertOrIncreaseIndent,
-	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleMath, updateLink,
+	toggleBolded, toggleCode, toggleHeaderLevel, toggleItalicized, toggleList, toggleMath, updateLink,
 } from './markdownCommands';
 import createTestEditor from '../testUtil/createTestEditor';
 import { blockMathTagName } from './MarkdownMathExtension';
+import { ListType } from '../../types';
 
 describe('markdownCommands', () => {
 
@@ -324,5 +325,55 @@ describe('markdownCommands', () => {
 
 		expect(editor.state.doc.toString()).toBe('testing\n* * *\n* * *\n\n> this is a test\n> * * *\n> * * *');
 	});
+
+	it('should convert a nested bulleted list to an ordered list', async () => {
+		const initialDocText = [
+			'- Item 1',
+			'    - Sub-item 1',
+			'    - Sub-item 2',
+			'- Item 2',
+		].join('\n');
+
+		const expectedDocText = [
+			'1. Item 1',
+			'    1. Sub-item 1',
+			'    2. Sub-item 2',
+			'2. Item 2',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['BulletList'],
+		);
+
+		toggleList(ListType.OrderedList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
+
+	it('should convert a mixed nested list to a bulleted list', async () => {
+		const initialDocText = `1. Item 1
+			1. Sub-item 1
+			2. Sub-item 2
+		2. Item 2`;
+
+		const expectedDocText = `- Item 1
+			- Sub-item 1
+			- Sub-item 2
+		- Item 2`;
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['OrderedList'],
+		);
+
+		toggleList(ListType.UnorderedList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
 });
+
+
 

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -398,4 +398,38 @@ A block quote:
 
 		expect(editor.state.doc.toString()).toBe(expectedDocText);
 	});
+
+	it('should preserve non-list sub-items when changing list formatting', async () => {
+		const initialDocText = `1. Item 1
+			1. Sub-item 1
+
+			   \`\`\`
+			   code
+			   \`\`\`
+			2. Sub-item 2
+			   Not part of the list
+			   Also not part of the list
+		2. Item 2`;
+
+		const expectedDocText = `- Item 1
+			- Sub-item 1
+
+			   \`\`\`
+			   code
+			   \`\`\`
+			- Sub-item 2
+			   Not part of the list
+			   Also not part of the list
+		- Item 2`;
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['OrderedList'],
+		);
+
+		toggleList(ListType.UnorderedList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -260,4 +260,44 @@ describe('markdownCommands.toggleList', () => {
 		toggleList(ListType.CheckList)(editor);
 		expect(editor.state.doc.toString()).toBe(expectedAfterToggle);
 	});
+
+	it('should correctly toggle sublists within block quotes', async () => {
+		const listInBlockQuote = `
+A block quote:
+> - This *
+>	- is
+>	  
+>		- a test. *
+>  
+>		
+>
+>			- TEST
+>		- Test *
+>	- a
+> - test`.trim();
+		const editor = await createTestEditor(
+			listInBlockQuote,
+			EditorSelection.range(
+				'A block quote:'.length + 1,
+				listInBlockQuote.length,
+			),
+			['BlockQuote', 'BulletList'],
+		);
+
+		toggleList(ListType.OrderedList)(editor);
+		expect(editor.state.doc.toString()).toBe(`
+A block quote:
+> 1. This *
+>	1. is
+>	  
+>		1. a test. *
+>  
+>		
+>
+>			1. TEST
+>		2. Test *
+>	2. a
+> 2. test
+		`.trim());
+	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -265,15 +265,15 @@ describe('markdownCommands.toggleList', () => {
 		const listInBlockQuote = `
 A block quote:
 > - This *
->	- is
+> 	- is
 >	  
->		- a test. *
+> 		- a test. *
 >  
 >		
 >
->			- TEST
->		- Test *
->	- a
+> 			- TEST
+> 		- Test *
+> 	- a
 > - test`.trim();
 		const editor = await createTestEditor(
 			listInBlockQuote,
@@ -288,15 +288,15 @@ A block quote:
 		expect(editor.state.doc.toString()).toBe(`
 A block quote:
 > 1. This *
->	1. is
+> 	1. is
 >	  
->		1. a test. *
+> 		1. a test. *
 >  
 >		
 >
->			1. TEST
->		2. Test *
->	2. a
+> 			1. TEST
+> 		2. Test *
+> 	2. a
 > 2. test
 		`.trim());
 	});

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -312,7 +312,7 @@ A block quote:
  
  			- TEST
  		- Test (cursor)
- 	- a
+ 	- a (cursor)
  - test
  		`.trim();
 
@@ -340,8 +340,8 @@ A block quote:
  		
  
  			- TEST
- 		1. Test (cursor)
- 	- a
+ 		2. Test (cursor)
+ 	1. a (cursor)
  - test
 		`.trim());
 		expect(

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -350,4 +350,52 @@ A block quote:
 			getExpectedCursorLocations(editor.state.doc.toString()),
 		);
 	});
+
+	it('should convert a nested bulleted list to an ordered list', async () => {
+		const initialDocText = [
+			'- Item 1',
+			'    - Sub-item 1',
+			'    - Sub-item 2',
+			'- Item 2',
+		].join('\n');
+
+		const expectedDocText = [
+			'1. Item 1',
+			'    1. Sub-item 1',
+			'    2. Sub-item 2',
+			'2. Item 2',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['BulletList'],
+		);
+
+		toggleList(ListType.OrderedList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
+
+	it('should convert a mixed nested list to a bulleted list', async () => {
+		const initialDocText = `1. Item 1
+			1. Sub-item 1
+			2. Sub-item 2
+		2. Item 2`;
+
+		const expectedDocText = `- Item 1
+			- Sub-item 1
+			- Sub-item 2
+		- Item 2`;
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['OrderedList'],
+		);
+
+		toggleList(ListType.UnorderedList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -432,4 +432,38 @@ A block quote:
 
 		expect(editor.state.doc.toString()).toBe(expectedDocText);
 	});
+
+	it('should remove list formatting when toggling formatting in an existing list item', async () => {
+		const initialDocText = `- [ ] Item 1
+			- [ ] Sub-item 1
+
+			   \`\`\`
+			   code
+			   \`\`\`
+			- [ ] Sub-item 2
+			   Not part of the list
+			   Also not part of the list
+		- [ ] Item 2`;
+
+		const expectedDocText = `Item 1
+			Sub-item 1
+
+			   \`\`\`
+			   code
+			   \`\`\`
+			Sub-item 2
+			   Not part of the list
+			   Also not part of the list
+		Item 2`;
+
+		const editor = await createTestEditor(
+			initialDocText,
+			EditorSelection.range(0, initialDocText.length),
+			['BulletList'],
+		);
+
+		toggleList(ListType.CheckList)(editor);
+
+		expect(editor.state.doc.toString()).toBe(expectedDocText);
+	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.toggleList.test.ts
@@ -63,34 +63,20 @@ describe('markdownCommands.toggleList', () => {
 		);
 	});
 
-	it('should not toggle a the full list when the cursor is on a blank line', async () => {
-		const checklistStartText = [
-			'# Test',
-			'',
-			'- [ ] This',
-			'- [ ] is',
-			'',
-		].join('\n');
+	it('should not toggle the full list when the cursor is on a blank line', async () => {
+		const checklistStartText = ['- [ ] This', '- [ ] is'].join('\n');
+		const checklistEndText = ['- [ ] a', '- [ ] test'].join('\n');
 
-		const checklistEndText = [
-			'- [ ] a',
-			'- [ ] test',
-		].join('\n');
+		const input = `${checklistStartText}\n\n${checklistEndText}`;
+		const expected = `${checklistStartText}\n\n${checklistEndText}`; // no change
 
 		const editor = await createTestEditor(
-			`${checklistStartText}\n${checklistEndText}`,
-
-			// Place the cursor on the blank line between the checklist
-			// regions
-			EditorSelection.cursor(unorderedListText.length + 1),
-			['BulletList', 'ATXHeading1'],
+			input,
+			EditorSelection.cursor(checklistStartText.length + 1), // place cursor on the blank line
+			['BulletList'],
 		);
-
-		// Should create a checkbox on the blank line
 		toggleList(ListType.CheckList)(editor);
-		expect(editor.state.doc.toString()).toBe(
-			`${checklistStartText}- [ ] \n${checklistEndText}`,
-		);
+		expect(editor.state.doc.toString()).toBe(expected);
 	});
 
 	// it('should correctly replace an unordered list with a checklist', async () => {
@@ -246,5 +232,32 @@ describe('markdownCommands.toggleList', () => {
 		expect(editor.state.doc.toString()).toBe(
 			'- 192.168.1.1. This\n- 127.0.0.1. is\n- 0.0.0.0. a list',
 		);
+	});
+
+	it('should preserve blank lines when toggling a checklist with blank lines', async () => {
+		const listWithGaps = [
+			'- A',
+			'',
+			'- B',
+			'',
+			'- C',
+		].join('\n');
+
+		const expectedAfterToggle = [
+			'- [ ] A',
+			'',
+			'- [ ] B',
+			'',
+			'- [ ] C',
+		].join('\n');
+
+		const editor = await createTestEditor(
+			listWithGaps,
+			EditorSelection.range(0, listWithGaps.length),
+			['BulletList'],
+		);
+
+		toggleList(ListType.CheckList)(editor);
+		expect(editor.state.doc.toString()).toBe(expectedAfterToggle);
 	});
 });

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -269,6 +269,10 @@ export const toggleList = (listType: ListType): Command => {
 		});
 
 		view.dispatch(changes);
+		// Fix any selected lists. Do this as a separate .dispatch
+		// so that it can be undone separately.
+		view.dispatch(renumberSelectedLists(view.state));
+
 		return true;
 	};
 };

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -179,6 +179,7 @@ export const toggleList = (listType: ListType): Command => {
 					continue; // skip blank lines
 				}
 
+				// Content excluding the block quote start
 				const lineContentFrom = line.to - origLineContent.length;
 				const indentation = origLineContent.match(startingSpaceRegex)?.[0] || '';
 				const currentIndent = indentation.length;

--- a/packages/editor/CodeMirror/markdown/markdownCommands.ts
+++ b/packages/editor/CodeMirror/markdown/markdownCommands.ts
@@ -205,7 +205,7 @@ export const toggleList = (listType: ListType): Command => {
 			const firstLine = getFirstBaselineIndentLine(fromLine, toLine);
 
 			const currentListType = getContainerType(firstLine);
-			if (!currentListType) {
+			if (currentListType === null) {
 				return ListAction.AddList;
 			} else if (currentListType === listType) {
 				return ListAction.RemoveList;

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
@@ -138,6 +138,49 @@ describe('renumberSelectedLists', () => {
 				'\t5. test',
 			].join('\n'),
 		},
+		{ // Should handle mixed number/bullet lists
+			before: [
+				'1. This',
+				'\t- is',
+				'\t\t',
+				'',
+				'\t\t1. Test',
+				'\t1. A test',
+				'- Test',
+			].join('\n'),
+			after: [
+				'1. This',
+				'\t- is',
+				'\t\t',
+				'',
+				'\t\t1. Test',
+				'\t1. A test',
+				'- Test',
+			].join('\n'),
+		},
+		{ // Should handle non-tight lists
+			before: [
+				'1. This',
+				'   ![](./test.png)',
+				'',
+				'\t1. is',
+				'\t3. a test',
+				'\t4. a test',
+				'',
+				'1. A test',
+			].join('\n'),
+			after: [
+				'1. This',
+				'   ![](./test.png)',
+				'',
+				'\t1. is',
+				'\t2. a test',
+				'\t3. a test',
+				'',
+				'2. A test',
+			].join('\n'),
+		},
+
 	])('should handle nested lists (case %#)', async ({ before, after }) => {
 		const suffix = '\n\n# End';
 		before += suffix;

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
@@ -39,14 +39,17 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 			prevLineNumber = line.number;
 
 			const filteredText = stripBlockquote(line);
+			if (!filteredText.trim()) continue;
+
 			const match = filteredText.match(listItemRegex);
 
 			// Skip lines that aren't the correct type (e.g. blank lines)
-			if (!match) {
-				continue;
+			let indentation;
+			if (match) {
+				indentation = match[1];
+			} else {
+				indentation = filteredText.match(/^\s+/)?.[0] ?? '';
 			}
-
-			const indentation = match[1];
 
 			const indentationLen = tabsToSpaces(state, indentation).length;
 			let currentGroupIndentLength = tabsToSpaces(state, currentGroupIndentation).length;
@@ -78,19 +81,20 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 				}
 
 			}
-
 			currentGroupIndentation = indentation;
 
-			const from = line.to - filteredText.length;
-			const to = from + match[0].length;
-			const inserted = `${indentation}${nextListNumber}. `;
-			nextListNumber++;
+			if (match) {
+				const from = line.to - filteredText.length;
+				const to = from + match[0].length;
+				const inserted = `${indentation}${nextListNumber}. `;
+				nextListNumber++;
 
-			changes.push({
-				from,
-				to,
-				insert: inserted,
-			});
+				changes.push({
+					from,
+					to,
+					insert: inserted,
+				});
+			}
 		}
 
 		return changes;

--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.ts
@@ -62,7 +62,9 @@ const renumberSelectedLists = (state: EditorState): TransactionSpec => {
 				});
 				nextListNumber = 1;
 			} else if (indentDecreased) {
-				nextListNumber = parseInt(match[2], 10);
+				if (match) {
+					nextListNumber = parseInt(match[2], 10);
+				}
 
 				// Handle the case where we deindent multiple times. For example,
 				// 1. test

--- a/packages/editor/CodeMirror/markdown/utils/stripBlockquote.ts
+++ b/packages/editor/CodeMirror/markdown/utils/stripBlockquote.ts
@@ -1,6 +1,6 @@
 import { Line } from '@codemirror/state';
 
-const blockQuoteRegex = /^>\s/;
+const blockQuoteRegex = /^>(\s|$)/;
 
 export const stripBlockquote = (line: Line): string => {
 	const match = line.text.match(blockQuoteRegex);

--- a/packages/editor/CodeMirror/testUtil/createTestEditor.ts
+++ b/packages/editor/CodeMirror/testUtil/createTestEditor.ts
@@ -12,16 +12,18 @@ import MarkdownHighlightExtension from '../markdown/MarkdownHighlightExtension';
 // until all syntax tree tags in `expectedSyntaxTreeTags` exist.
 const createTestEditor = async (
 	initialText: string,
-	initialSelection: SelectionRange,
+	initialSelection: SelectionRange|SelectionRange[],
 	expectedSyntaxTreeTags: string[],
 	extraExtensions: Extension[] = [],
 	addMarkdownKeymap = true,
 ): Promise<EditorView> => {
 	await loadLanguages();
 
+	initialSelection = Array.isArray(initialSelection) ? initialSelection : [initialSelection];
+
 	const editor = new EditorView({
 		doc: initialText,
-		selection: EditorSelection.create([initialSelection]),
+		selection: EditorSelection.create(initialSelection),
 		extensions: [
 			markdown({
 				extensions: [MarkdownMathExtension, MarkdownHighlightExtension, GithubFlavoredMarkdownExt],


### PR DESCRIPTION
# Summary

> [!NOTE]
>
> Most of the work in this pull request was done by @j-scheitler1 in #12047.

This pull request is a version of #12047 with a few adjustments:
- Fixes an issue related to toggling a list containing multiple cursors and adds a test case.
    - See e2a2022cec8a9554f6110ef311a3191da5fd4abd and 96361f1c471d3d27222f21a90dadd6971bb75adc — in part, this was done by restoring a call to `renumberSelectedLists` after changing the list type and fixing a previously-existing bug in `renumberSelectedLists`.
- Fixes an issue where certain lists in blockquotes could cause numbers to be inserted before the `>`s at the beginning of lines.

Resolves #11845.

This pull request includes automated tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->