### PR TITLE
Desktop, Mobile: Resolves #12097: Add delete all history button

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -746,6 +746,7 @@ packages/app-mobile/components/plugins/types.js
 packages/app-mobile/components/plugins/utils/createOnLogHandler.js
 packages/app-mobile/components/plugins/utils/useOnDevPluginsUpdated.js
 packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.js
+packages/app-mobile/components/screens/ConfigScreen/DeleteAllHistoryButton.js
 packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.js
 packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.js
 packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.js

--- a/.gitignore
+++ b/.gitignore
@@ -720,6 +720,7 @@ packages/app-mobile/components/plugins/types.js
 packages/app-mobile/components/plugins/utils/createOnLogHandler.js
 packages/app-mobile/components/plugins/utils/useOnDevPluginsUpdated.js
 packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.js
+packages/app-mobile/components/screens/ConfigScreen/DeleteAllHistoryButton.js
 packages/app-mobile/components/screens/ConfigScreen/FileSystemPathSelector.js
 packages/app-mobile/components/screens/ConfigScreen/JoplinCloudConfig.js
 packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/ExportDebugReportButton.js

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -20,6 +20,7 @@ import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 import SettingComponent, { UpdateSettingValueEvent } from './controls/SettingComponent';
 import shim from '@joplin/lib/shim';
+import RevisionService from '@joplin/lib/services/RevisionService';
 
 
 interface Font {
@@ -292,6 +293,26 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					</div>,
 				);
 			}
+		}
+
+		if (section.name === 'revisionService') {
+			const deleteAllHistoryAction = async () => {
+				const response = await shim.showMessageBox(_('Are you sure you want to delete all note history? This cannot be undone.'), {
+					buttons: [_('Yes'), _('No')],
+				});
+				if (response === 0) {
+					await RevisionService.instance_.deleteOldRevisions(0);
+				}
+			};
+			settingComps.push(
+				<div key="delete_all_history_button" style={this.rowStyle_}>
+					<Button
+						title={_('Delete All History')}
+						level={ButtonLevel.Primary}
+						onClick={deleteAllHistoryAction}
+					/>
+				</div>,
+			);
 		}
 
 		let advancedSettingsButton = null;

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -19,8 +19,9 @@ import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/conf
 import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 import SettingComponent, { UpdateSettingValueEvent } from './controls/SettingComponent';
-import shim from '@joplin/lib/shim';
-import RevisionService from '@joplin/lib/services/RevisionService';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
+import Revision from '@joplin/lib/models/Revision';
+import CommandService from '@joplin/lib/services/CommandService';
 
 
 interface Font {
@@ -298,10 +299,21 @@ class ConfigScreenComponent extends React.Component<any, any> {
 		if (section.name === 'revisionService') {
 			const deleteAllHistoryAction = async () => {
 				const response = await shim.showMessageBox(_('Are you sure you want to delete all note history? This cannot be undone.'), {
+					title: _('Warning'),
 					buttons: [_('Yes'), _('No')],
+					type: MessageBoxType.Confirm,
 				});
 				if (response === 0) {
-					await RevisionService.instance_.deleteOldRevisions(0);
+					void CommandService.instance().execute('showModalMessage', _('Deleting note history. Please wait...'));
+
+					try {
+						await Revision.deleteOldRevisions(0);
+					} catch (error) {
+						console.error(error);
+						bridge().showErrorMessageBox(_('Note history deletion failed: %s', error.message));
+					}
+
+					void CommandService.instance().execute('hideModalMessage');
 				}
 			};
 			settingComps.push(

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -37,7 +37,7 @@ import JoplinCloudConfig, { emailToNoteDescription, emailToNoteLabel } from './J
 import shim from '@joplin/lib/shim';
 import SettingsToggle from './SettingsToggle';
 import { UpdateSettingValueCallback } from './types';
-import RevisionService from '@joplin/lib/services/RevisionService';
+import DeleteAllHistoryButton, { deleteAllHistoryButtonDefaultTitle, deleteAllHistoryButtonDescription } from './DeleteAllHistoryButton';
 
 interface ConfigScreenState {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -125,15 +125,6 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 	private e2eeConfig_ = () => {
 		void NavService.go('EncryptionConfig');
-	};
-
-	private deleteAllHistoryAction_ = async () => {
-		const response = await shim.showMessageBox(_('Are you sure you want to delete all note history? This cannot be undone.'), {
-			buttons: [_('Yes'), _('No')],
-		});
-		if (response === 0) {
-			await RevisionService.instance_.deleteOldRevisions(0);
-		}
 	};
 
 	private saveButton_press = async () => {
@@ -559,7 +550,10 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 		}
 
 		if (section.name === 'revisionService') {
-			addSettingButton('delete_all_history_button', _('Delete All History'), this.deleteAllHistoryAction_);
+			addSettingComponent(
+				<DeleteAllHistoryButton key='delete_all_history_button' styles={this.styles()}/>,
+				[deleteAllHistoryButtonDefaultTitle(), deleteAllHistoryButtonDescription()],
+			);
 		}
 
 		if (section.name === 'joplinCloud') {

--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -37,6 +37,7 @@ import JoplinCloudConfig, { emailToNoteDescription, emailToNoteLabel } from './J
 import shim from '@joplin/lib/shim';
 import SettingsToggle from './SettingsToggle';
 import { UpdateSettingValueCallback } from './types';
+import RevisionService from '@joplin/lib/services/RevisionService';
 
 interface ConfigScreenState {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -124,6 +125,15 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 	private e2eeConfig_ = () => {
 		void NavService.go('EncryptionConfig');
+	};
+
+	private deleteAllHistoryAction_ = async () => {
+		const response = await shim.showMessageBox(_('Are you sure you want to delete all note history? This cannot be undone.'), {
+			buttons: [_('Yes'), _('No')],
+		});
+		if (response === 0) {
+			await RevisionService.instance_.deleteOldRevisions(0);
+		}
 	};
 
 	private saveButton_press = async () => {
@@ -546,6 +556,10 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 
 		if (section.name === 'sync') {
 			addSettingButton('e2ee_config_button', _('Encryption Config'), this.e2eeConfig_);
+		}
+
+		if (section.name === 'revisionService') {
+			addSettingButton('delete_all_history_button', _('Delete All History'), this.deleteAllHistoryAction_);
 		}
 
 		if (section.name === 'joplinCloud') {

--- a/packages/app-mobile/components/screens/ConfigScreen/DeleteAllHistoryButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/DeleteAllHistoryButton.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { _ } from '@joplin/lib/locale';
+import Logger from '@joplin/utils/Logger';
+import { FunctionComponent } from 'react';
+import { ConfigScreenStyles } from './configScreenStyles';
+import shim from '@joplin/lib/shim';
+import TaskButton, { OnProgressCallback, TaskStatus } from './NoteExportSection/TaskButton';
+import Revision from '@joplin/lib/models/Revision';
+
+const logger = Logger.create('DeleteAllHistoryButton');
+
+interface Props {
+	styles: ConfigScreenStyles;
+}
+
+// Exported for search filtering
+export const deleteAllHistoryButtonDefaultTitle = () => _('Delete all history');
+export const deleteAllHistoryButtonDescription = () => _('Delete history for all notes.');
+
+const getTitle = (taskStatus: TaskStatus) => {
+	if (taskStatus === TaskStatus.InProgress) {
+		return _('Deleting note history...');
+	} else {
+		return deleteAllHistoryButtonDefaultTitle();
+	}
+};
+
+const runTask = async (
+	_onProgress: OnProgressCallback,
+) => {
+	const response = await shim.showMessageBox(_('Are you sure you want to delete all note history? This cannot be undone.'), {
+		title: _('Warning'),
+		buttons: [_('Yes'), _('No')],
+	});
+	if (response === 0) {
+		try {
+			await Revision.deleteOldRevisions(0);
+			logger.info('Note history deletion completed');
+			return { success: true, warnings: [] as string[] };
+		} catch (error) {
+			logger.error('Note history deletion failed with error', error);
+			throw new Error(_('Note history deletion failed.\nDetails: %s', error.toString()));
+		}
+	} else {
+		logger.info('Canceled.');
+		return { success: false, warnings: [] };
+	}
+};
+
+const DeleteAllHistoryButton: FunctionComponent<Props> = props => {
+	return (
+		<TaskButton
+			taskName={deleteAllHistoryButtonDefaultTitle()}
+			description={deleteAllHistoryButtonDescription()}
+			buttonLabel={getTitle}
+			finishedLabel={_('Note history deletion completed!')}
+			styles={props.styles}
+			onRunTask={runTask}
+		/>
+	);
+};
+
+export default DeleteAllHistoryButton;


### PR DESCRIPTION
This PR adds the ability to delete all note history for all notes, by adding a button to the note history configuration screen on both desktop and mobile, which prompts the user to confirm the action before executing it:

![desktop](https://github.com/user-attachments/assets/66b823c4-d740-4df4-8899-10d0d3b211db)
![mobile](https://github.com/user-attachments/assets/f6807a49-88c7-4c3c-8842-e418ec281b6b)

This partially implements https://github.com/laurent22/joplin/issues/12097 by providing a button to delete all note history for all notes on desktop and mobile. The issue however, also requests the ability to delete all history for an individual note, which is not implemented in this PR.

**Testing:**

I have manually tested the confirmation dialog for the button on Windows and Android emulator, and verified the UI waits for the action to complete, to show it is in progress. As I have very little history in my test profile, I added an explicit 5 second wait in the Revision.deleteOldRevisions function (during testing only), in order to see the in progress behaviour. I have recorded videos showing this. On desktop, I have also verified that cancelling the prompt does not touch any revisions, and confirming the prompt does indeed delete all revisions (including ones created the same day), as shown by the sync status screen.

Desktop:
https://github.com/user-attachments/assets/5b2f93e8-b341-424a-bee8-2f87fddeebe2

Mobile:
https://github.com/user-attachments/assets/c1388404-85e9-46e7-aeba-ab1fb0c007b6