### PR TITLE
Chore: CI: Update the windows-2019 runner to windows-2025

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
         # https://github.com/actions/runner-images/issues/6709
-        os: [macos-13, ubuntu-22.04, windows-2019, ubuntu-22.04-arm]
+        os: [macos-13, ubuntu-22.04, windows-2025, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Summary

The Windows 2019 runner is deprecated and will be removed on June 30th. There are several brownouts scheduled before then, including today (June 3rd) from 1:00 - 9:00 PM UTC. See https://github.com/actions/runner-images/issues/12045.

This pull request updates the main GitHub actions workflow from `windows-2019` to `windows-2025`. The UI tests workflow previously used `windows-2025`.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->