### PR TITLE
Mobile: Increase space available for revisions dropdown

### DIFF
--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -152,6 +152,13 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 	const styles = useStyles(props.themeId);
 	const dropdownLabelText = _('Revision:');
 
+	const restoreButton = (
+		<PrimaryButton
+			onPress={onRestore}
+			disabled={restoring || !note}
+		>{restoreButtonTitle}</PrimaryButton>
+	);
+
 	return <View style={styles.root}>
 		<ScreenHeader title={_('Note history')} />
 		<View style={styles.controls}>
@@ -165,11 +172,11 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 				itemStyle={styles.dropdownItemStyle}
 				accessibilityHint={dropdownLabelText}
 				defaultHeaderLabel={_('Select a revision...')}
+				// Hides the restore button when the dropdown is open. This
+				// is important on small screens where otherwise it's difficult
+				// to read the content of the revision dropdown.
+				coverableChildrenRight={restoreButton}
 			/>
-			<PrimaryButton
-				onPress={onRestore}
-				disabled={restoring || !note}
-			>{restoreButtonTitle}</PrimaryButton>
 			<IconButton
 				icon='help-circle-outline'
 				accessibilityLabel={_('Help')}


### PR DESCRIPTION
# Summary

This pull request hides the "Revisions" button when the revisions dropdown is open. Previously, little space was available for the dropdown's content on small screens:
<img alt="screenshot: The dropdown is open and restricted to the space between the 'dropdown' label and the 'restore' button. This results in little room for the content of the dropdown. The labels are ellipsized." src="https://github.com/user-attachments/assets/d4f38090-c1d6-4010-a1c7-ee0abb35cc9c" width="340"/>

This change allows the dropdown to hide the "Restore" button when open, increasing the space available for the dropdown's content.

<img alt="screenshot: The dropdown is open and has somewhat more space available than in the previous screenshot, since the 'restore' button is no longer visible" src="https://github.com/user-attachments/assets/220a69db-28cf-483b-b472-237664b0c990" width="340"/>

# Screen recording

**From Joplin web (running in Chromium)**:

[Screencast: opening and closing the dropdown](https://github.com/user-attachments/assets/ecf77522-231b-406d-bf73-1a1df1e1286b)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->