### PR TITLE
Desktop: Change how the main content size is determined

### DIFF
--- a/packages/app-desktop/app.reducer.test.ts
+++ b/packages/app-desktop/app.reducer.test.ts
@@ -4,7 +4,7 @@ import appReducer, { createAppDefaultState } from './app.reducer';
 describe('app.reducer', () => {
 
 	it('should handle DIALOG_OPEN', async () => {
-		const state: AppState = createAppDefaultState({}, {});
+		const state: AppState = createAppDefaultState({});
 
 		let newState = appReducer(state, {
 			type: 'DIALOG_OPEN',
@@ -49,7 +49,7 @@ describe('app.reducer', () => {
 
 	it('showing a dialog in one window should hide dialogs with the same ID in background windows', () => {
 		const state: AppState = {
-			...createAppDefaultState({}, {}),
+			...createAppDefaultState({}),
 			backgroundWindows: {
 				testWindow: {
 					...createAppDefaultWindowState(),

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -54,8 +54,6 @@ export interface AppState extends State, AppWindowState {
 	route: AppStateRoute;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	navHistory: any[];
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	windowContentSize: any;
 	watchedNoteFiles: string[];
 	lastEditorScrollPercents: EditorScrollPercents;
 	focusedField: string;
@@ -81,7 +79,7 @@ export const createAppDefaultWindowState = (): AppWindowState => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function createAppDefaultState(windowContentSize: any, resourceEditWatcherDefaultState: any): AppState {
+export function createAppDefaultState(resourceEditWatcherDefaultState: any): AppState {
 	return {
 		...defaultState,
 		...createAppDefaultWindowState(),
@@ -91,7 +89,6 @@ export function createAppDefaultState(windowContentSize: any, resourceEditWatche
 			props: {},
 		},
 		navHistory: [],
-		windowContentSize, // bridge().windowContentSize(),
 		watchedNoteFiles: [],
 		lastEditorScrollPercents: {},
 		visibleDialogs: {}, // empty object if no dialog is visible. Otherwise contains the list of visible dialogs.
@@ -164,12 +161,6 @@ export default function(state: AppState, action: any) {
 					mainLayout: JSON.parse(JSON.stringify(newState.mainLayout)),
 				};
 			}
-			break;
-
-		case 'WINDOW_CONTENT_SIZE_SET':
-
-			newState = { ...state };
-			newState.windowContentSize = action.size;
 			break;
 
 		case 'NOTE_VISIBLE_PANES_TOGGLE':

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -65,10 +65,7 @@ const pluginClasses = [
 	require('./plugins/GotoAnything').default,
 ];
 
-const appDefaultState = createAppDefaultState(
-	bridge().windowContentSize(),
-	resourceEditWatcherDefaultState,
-);
+const appDefaultState = createAppDefaultState(resourceEditWatcherDefaultState);
 
 class Application extends BaseApplication {
 

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -313,13 +313,6 @@ export class Bridge {
 		return new BrowserWindow(options);
 	}
 
-	// Note: This provides the size of the main window. Prefer CSS where possible.
-	public windowContentSize() {
-		if (!this.mainWindow()) return { width: 0, height: 0 };
-		const s = this.mainWindow().getContentSize();
-		return { width: s[0], height: s[1] };
-	}
-
 	public windowSetSize(width: number, height: number) {
 		if (!this.mainWindow()) return;
 		return this.mainWindow().setSize(width, height);

--- a/packages/app-desktop/commands/exportDeletionLog.test.ts
+++ b/packages/app-desktop/commands/exportDeletionLog.test.ts
@@ -38,7 +38,7 @@ describe('exportDeletionLog', () => {
 	let state: AppState = undefined;
 
 	beforeAll(() => {
-		state = createAppDefaultState({}, {});
+		state = createAppDefaultState({});
 		jest.useFakeTimers();
 		jest.setSystemTime(new Date('2024-09-18T12:00:00Z').getTime());
 	});

--- a/packages/app-desktop/gui/Navigator.tsx
+++ b/packages/app-desktop/gui/Navigator.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Setting from '@joplin/lib/models/Setting';
 import { AppState, AppStateRoute } from '../app.reducer';
 import bridge from '../services/bridge';
-import { useContext, useEffect, useMemo, useRef } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { WindowIdContext } from './NewWindowOrIFrame';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of code from before rule was applied
@@ -55,26 +55,44 @@ const useWindowRefocusManager = (route: AppStateRoute) => {
 	}, [routeName, windowId]);
 };
 
+const useContainerSize = (container: HTMLElement|null) => {
+	const [size, setSize] = useState({ width: container?.clientWidth, height: container?.clientHeight });
+
+	useEffect(() => {
+		if (!container) return () => {};
+
+		const observer = new ResizeObserver(() => {
+			setSize({
+				width: container.clientWidth,
+				height: container.clientHeight,
+			});
+		});
+		observer.observe(container);
+		return () => {
+			observer.disconnect();
+		};
+	}, [container]);
+
+	return size;
+};
+
 const NavigatorComponent: React.FC<Props> = props => {
 	const route = props.route;
 	const screenInfo = props.screens[route?.routeName];
+	const [container, setContainer] = useState<HTMLElement|null>(null);
 
 	useWindowTitleManager(screenInfo);
 	useWindowRefocusManager(route);
+	const size = useContainerSize(container);
 
 	if (!route) throw new Error('Route must not be null');
 
 	const screenProps = route.props ? route.props : {};
 	const Screen = screenInfo.screen;
 
-	const screenStyle = {
-		width: props.style.width,
-		height: props.style.height,
-	};
-
 	return (
-		<div style={props.style} className={props.className}>
-			<Screen style={screenStyle} {...screenProps} />
+		<div ref={setContainer} style={props.style} className={props.className}>
+			<Screen style={size} {...screenProps} />
 		</div>
 	);
 };

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -39,7 +39,7 @@ describe('PerFolderSortOrderService', () => {
 	beforeEach(() => {
 		PerFolderSortOrderService.initialize();
 		Setting.setValue('notes.perFolderSortOrderEnabled', true);
-		updateAppState(createAppDefaultState({}, {}));
+		updateAppState(createAppDefaultState({}));
 		switchToFolder(folderId1);
 	});
 	afterEach(() => {


### PR DESCRIPTION
# Summary

This pull request changes how Joplin determines the size of the main application content. This **may** fix #12214.

**Note**: At present, I have been unable to reproduce #12214 locally. 

**Goal**:
- Simplify the logic that determines the main content size.
   - Uses DOM APIs rather than Electron APIs to determine the main content size.

# Notes

- [This comment](https://github.com/laurent22/joplin/issues/12214#issuecomment-2848089626) suggests that #12214 is caused by https://github.com/electron/electron/issues/42378. However, https://github.com/electron/electron/issues/42378 involves calls to `webContents.setBackgroundThrottling`, which Joplin does not seem to use.

- Prior to this pull request, Joplin fetched the window size from Electron ([with an `activeWindow().on('resize', ...)` listener](https://github.com/laurent22/joplin/blob/291ba88224763b75aba2183ccaa74632cfe60c67/packages/app-desktop/gui/Root.tsx#L69)) and stored it in the [main application redux store](https://github.com/laurent22/joplin/blob/291ba88224763b75aba2183ccaa74632cfe60c67/packages/app-desktop/app.reducer.ts#L58).

  This pull request removes the window size from the redux store and instead uses CSS and a ResizeObserver to fetch the size of the currently visible screen.



# Testing

Regression testing (Fedora 42 / GNOME):
1. Start Joplin.
2. Close the development tools (if docked to the main window).
3. Verify that the main application content fits within the window.
4. Verify that resizing the window also resizes the main application content.
5. Zoom in with <kbd>ctrl</kbd>-<kbd>+</kbd>.
6. Verify that the main application content still fits within the window.
7. Maximize the window.
6. Verify that the main application content still fits within the window.
8. Minimize then re-open the window.
9. Open settings.
10. Verify that the  main application content still fits within the window.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->