### PR TITLE
Desktop: Fixes #12377: Fix changing focused window when clicking on the note viewer

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -668,13 +668,15 @@ class Application extends BaseApplication {
 			Setting.setValue('linking.extraAllowedExtensions', newExtensions);
 		});
 
-		window.addEventListener('focus', () => {
+		ipcRenderer.on('window-focused', (_event, newWindowId) => {
 			const currentWindowId = this.store().getState().windowId;
-			this.dispatch({
-				type: 'WINDOW_FOCUS',
-				windowId: 'default',
-				lastWindowId: currentWindowId,
-			});
+			if (newWindowId !== currentWindowId) {
+				this.dispatch({
+					type: 'WINDOW_FOCUS',
+					windowId: newWindowId,
+					lastWindowId: currentWindowId,
+				});
+			}
 		});
 
 		await this.initPluginService();

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -13,7 +13,6 @@ import { SecondaryWindowApi } from '../utils/window/types';
 export const WindowIdContext = createContext(defaultWindowId);
 
 type OnCloseCallback = ()=> void;
-type OnFocusCallback = ()=> void;
 
 export enum WindowMode {
 	Iframe, NewWindow,
@@ -27,7 +26,6 @@ interface Props {
 	mode: WindowMode;
 	windowId: string;
 	onClose: OnCloseCallback;
-	onFocus?: OnFocusCallback;
 }
 
 const useDocument = (
@@ -86,10 +84,7 @@ const useDocument = (
 };
 
 type OnSetLoaded = (loaded: boolean)=> void;
-const useDocumentSetup = (doc: Document|null, setLoaded: OnSetLoaded, onFocus?: OnFocusCallback) => {
-	const onFocusRef = useRef(onFocus);
-	onFocusRef.current = onFocus;
-
+const useDocumentSetup = (doc: Document|null, setLoaded: OnSetLoaded) => {
 	useEffect(() => {
 		if (!doc) return;
 
@@ -120,14 +115,6 @@ const useDocumentSetup = (doc: Document|null, setLoaded: OnSetLoaded, onFocus?: 
 
 		doc.body.style.height = '100vh';
 
-		const containerWindow = doc.defaultView;
-		containerWindow.addEventListener('focus', () => {
-			onFocusRef.current?.();
-		});
-		if (doc.hasFocus()) {
-			onFocusRef.current?.();
-		}
-
 		setLoaded(true);
 	}, [doc, setLoaded]);
 };
@@ -137,7 +124,7 @@ const NewWindowOrIFrame: React.FC<Props> = props => {
 	const [loaded, setLoaded] = useState(false);
 
 	const doc = useDocument(props.mode, iframeRef, props.onClose);
-	useDocumentSetup(doc, setLoaded, props.onFocus);
+	useDocumentSetup(doc, setLoaded);
 
 	useEffect(() => {
 		if (!doc) return;

--- a/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
+++ b/packages/app-desktop/gui/NoteEditor/EditorWindow.tsx
@@ -20,7 +20,6 @@ interface Props {
 
 	newWindow: boolean;
 	windowId: string;
-	activeWindowId: string;
 	startupPluginsLoaded: boolean;
 }
 
@@ -57,22 +56,10 @@ const SecondaryWindow: React.FC<Props> = props => {
 		}
 	}, [props.dispatch, props.windowId, newWindow]);
 
-	const onWindowFocus = useCallback(() => {
-		// Verify that the window still has focus (e.g. to handle the case where the event was delayed).
-		if (containerRef.current?.ownerDocument.hasFocus()) {
-			props.dispatch({
-				type: 'WINDOW_FOCUS',
-				windowId: props.windowId,
-				lastWindowId: props.activeWindowId,
-			});
-		}
-	}, [props.dispatch, props.windowId, props.activeWindowId]);
-
 	return <NewWindowOrIFrame
 		mode={newWindow ? WindowMode.NewWindow : WindowMode.Iframe}
 		windowId={props.windowId}
 		onClose={onWindowClose}
-		onFocus={onWindowFocus}
 		title={windowTitle}
 	>
 		<LibraryStyleRoot>
@@ -122,7 +109,6 @@ export default connect((state: AppState, ownProps: ConnectProps) => {
 		isSafeMode: state.settings.isSafeMode,
 		codeView: windowState?.editorCodeView ?? state.settings['editor.codeView'],
 		legacyMarkdown: state.settings['editor.legacyMarkdown'],
-		activeWindowId: stateUtils.activeWindowId(state),
 		startupPluginsLoaded: state.startupPluginsLoaded,
 	};
 })(SecondaryWindow);


### PR DESCRIPTION
# Summary

This pull request fixes an issue where state could become invalid when switching between windows in a particular way.

Previously, clicking on the note viewer in an unfocused window would result in invalid application state. When multiple windows are open at the same time, Joplin previously relied on [DOM focus events](https://developer.mozilla.org/en-US/docs/Web/API/Window/focus_event) to determine the focused window. However, DOM focus events seem to not be dispatched to the parent window if the window is focused by clicking on a cross-process iframe (like the note viewer). This pull request updates Joplin to instead use Electron focus events.

Fixes #12377.

# Testing plan

**Linux (Fedora 42/GNOME)**:
1. Open two different notes ("note 1" and "note 2") in different windows ("window 1" and "window 2", respectively).
2. Show the note viewer in both windows.
3. Focus window 1 by clicking on the note title input.
4. Add a tag to the note in window 1 using the keyboard shortcut.
5. Focus window 2 by clicking on the note title input.
6. Add the same tag to the note in window 2 using the keyboard shortcut.
7. Focus window 1 by clicking in the note viewer.
8. Remove the tag from note 1 using the keyboard shortcut.
    - **Remaining issue**: Removing the tag in one window visually hides the tag in other windows with the same tag. However, re-focusing those windows fixes the tag list.
9. Verify that the tag bar in window 1 no longer lists the tag.
11. Focus window 2 by clicking in the note viewer.
10. Verify that the tag bar in window 2 still lists the tag.
12. Add a new tag to note 2 using the keyboard shortcut.
13. Verify that the tag bar in window 2 lists the new tag.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->