### PR TITLE
All: Fixes #12363: Fix Yinxiang HTML imported notes being enclosed by a open anchor tag

### DIFF
--- a/packages/app-cli/tests/support/test_notes/md/self-closing-anchor.html
+++ b/packages/app-cli/tests/support/test_notes/md/self-closing-anchor.html
@@ -1,0 +1,4 @@
+<body>
+<a name="519"/>
+<h1>Second note</h1>
+</body>

--- a/packages/lib/services/interop/InteropService_Importer_Md.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md.test.ts
@@ -25,6 +25,21 @@ describe('InteropService_Importer_Md', () => {
 		const allNotes: NoteEntity[] = await Note.all();
 		return allNotes[0];
 	}
+	async function importHTMLNote(path: string) {
+		const newFolder = await Folder.save({ title: 'folder' });
+		const importer = new InteropService_Importer_Md();
+		await importer.init(path, {
+			format: 'html',
+			outputFormat: 'html',
+			path,
+			destinationFolder: newFolder,
+			destinationFolderId: newFolder.id,
+		});
+		importer.setMetadata({ fileExtensions: ['md'] });
+		await importer.exec({ warnings: [] });
+		const allNotes: NoteEntity[] = await Note.all();
+		return allNotes[0];
+	}
 	async function importNoteDirectory(path: string) {
 		const importer = new InteropService_Importer_Md();
 		await importer.init(path, {
@@ -203,5 +218,43 @@ describe('InteropService_Importer_Md', () => {
 		expect(itemIds.length).toBe(0);
 		// The malformed link is imported as-is
 		expect(note.body).toContain('![malformed link](https://malformed_uri/%E0%A4%A.jpg)');
+	});
+
+	it.each([
+		['<a name="525"/>', '<a name="525"></a>'],
+		['<a name="525" id="test" class="link"/>', '<a name="525" id="test" class="link"></a>'],
+		['<a name="test@#$%^&*()" data-value="hello&world"/>', '<a name="test@#$%^&*()" data-value="hello&world"></a>'],
+		['<a name="525 href="#test"/>', '<a name="525 href="#test"></a>'],
+		['<a name="525" <!-- comment --> href="#"/>', '<a name="525" <!-- comment --> href="#"></a>'],
+		['<a name="525" title="a > b"/>', '<a name="525" title="a > b"></a>'],
+
+		// Shouldn't break anything
+		['<a/><a></a>', '<a/><a></a>'],
+		['<a><br/></a>', '<a><br/></a>'],
+		['<a><span>test</span></a>', '<a><span>test</span></a>'],
+		['<a name="525"></a>', '<a name="525"></a>'],
+		['<a>test</a>', '<a>test</a>'],
+		[
+			'<div><a href=":/0be7f50730194dd9b7d3b2834b8bfd58" rev="en_rl_none">First note</a> </div>',
+			'<div><a href=":/0be7f50730194dd9b7d3b2834b8bfd58" rev="en_rl_none">First note</a> </div>',
+		],
+		[
+			`<a name="525">
+</a>`,
+			`<a name="525">
+</a>`,
+		],
+	])('should transform self closing a tag into two', async (original: string, result: string) => {
+		const importer = new InteropService_Importer_Md();
+
+		expect(importer.applyImportFixes(original)).toBe(result);
+	});
+
+	it('should import apply import fix on note imported from Yinxiang', async () => {
+		const note = await importHTMLNote(`${supportDir}/test_notes/md/self-closing-anchor.html`);
+		expect(note.body).toContain(`<body>
+<a name="519"></a>
+<h1>Second note</h1>
+</body>`);
 	});
 });

--- a/packages/tools/cspell/dictionary3.txt
+++ b/packages/tools/cspell/dictionary3.txt
@@ -389,6 +389,7 @@ Xmark
 xzvf
 Yaniv
 yarg
+Yinxiang
 yosay
 Yousafzai
 yufzkns


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12363

# Summary

Yinxiang HTML exports include a `<a>` tag at the start of the body that is self-closing. Because how we sanitize the content to be displayed, the `<a/>` get turned into a `<a>` (see rendere/htmlUtils.sanitezeHtml).

Since we couldn't find a easy way to fix this there, we agreed upon adding a clean up step during the import that should catch such edge cases.

**The current implementation is not meant to fix all `<a ... />` cases**, such task would just increase complexity, I tried to add a rule that followed some constrains that seems to apply to all cases: 
- The faulty tag would be at the start of the line
- The end of the tag will be at the end of the line

# Testing

I added unit tests to the newly added function and a integration test with a case similar to what happens in the exported HTML.