### PR TITLE
Desktop: Rich Text Editor: Auto-format "---", "***" and "___" as dividers

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -44,7 +44,7 @@ import useDocument from '../../../hooks/useDocument';
 import useEditDialog from './utils/useEditDialog';
 import useEditDialogEventListeners from './utils/useEditDialogEventListeners';
 import Setting from '@joplin/lib/models/Setting';
-import useTextPatternsLookup from './utils/useTextPatternsLookup';
+import useTextPatternsLookup, { TextPatternContext } from './utils/useTextPatternsLookup';
 import { toFileProtocolPath } from '@joplin/utils/path';
 import { RenderResultPluginAsset } from '@joplin/renderer/types';
 
@@ -764,7 +764,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					forecolor: { inline: 'span', styles: { color: '%value' }, remove_similar: true },
 				},
 				text_patterns: [],
-				text_patterns_lookup: () => textPatternsLookupRef.current(),
+				text_patterns_lookup: (ctx: TextPatternContext) => textPatternsLookupRef.current(ctx),
 
 				setup: (editor: Editor) => {
 					editor.addCommand('joplinMath', async () => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
@@ -1,12 +1,17 @@
 import { useRef } from 'react';
 
+export interface TextPatternContext {
+	readonly text: string;
+	readonly block: Element;
+}
+
 interface TextPatternOptions {
 	enabled: boolean;
 	enableMath: boolean;
 }
 
 const useTextPatternsLookup = ({ enabled, enableMath }: TextPatternOptions) => {
-	const getTextPatterns = () => {
+	const getTextPatterns = (ctx: TextPatternContext) => {
 		if (!enabled) return [];
 
 		return [
@@ -27,6 +32,8 @@ const useTextPatternsLookup = ({ enabled, enableMath }: TextPatternOptions) => {
 			{ start: '1.', cmd: 'InsertOrderedList' },
 			{ start: '*', cmd: 'InsertUnorderedList' },
 			{ start: '-', cmd: 'InsertUnorderedList' },
+			// Only do <hr/> replacements if the full line is an <hr/>
+			['---', '***'].includes(ctx.text) && { start: ctx.text, replacement: '<hr/>' },
 		].filter(pattern => !!pattern);
 	};
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
@@ -33,7 +33,7 @@ const useTextPatternsLookup = ({ enabled, enableMath }: TextPatternOptions) => {
 			{ start: '*', cmd: 'InsertUnorderedList' },
 			{ start: '-', cmd: 'InsertUnorderedList' },
 			// To more closely match Markdown, only do <hr/> replacements if the full line matches the pattern.
-			['---', '***'].includes(ctx.text) && { start: ctx.text, replacement: '<hr/>' },
+			['---', '***', '___'].includes(ctx.text) && { start: ctx.text, replacement: '<hr/>' },
 		].filter(pattern => !!pattern);
 	};
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useTextPatternsLookup.ts
@@ -32,7 +32,7 @@ const useTextPatternsLookup = ({ enabled, enableMath }: TextPatternOptions) => {
 			{ start: '1.', cmd: 'InsertOrderedList' },
 			{ start: '*', cmd: 'InsertUnorderedList' },
 			{ start: '-', cmd: 'InsertUnorderedList' },
-			// Only do <hr/> replacements if the full line is an <hr/>
+			// To more closely match Markdown, only do <hr/> replacements if the full line matches the pattern.
 			['---', '***'].includes(ctx.text) && { start: ctx.text, replacement: '<hr/>' },
 		].filter(pattern => !!pattern);
 	};

--- a/readme/apps/rich_text_editor.md
+++ b/readme/apps/rich_text_editor.md
@@ -40,6 +40,7 @@ By default, the following patterns are replaced:
 - `## Heading 3`: Creates a level 3 heading.
 - `- List`: Creates a bulleted list.
 - `1. List`: Creates a numbered list.
+- `---` or `***`: Creates a horizontal rule.
 
 Most replacements require pressing the <kbd>space</kbd> or <kbd>enter</kbd> key after the closing formatting character. For example, typing `==test==` does not highlight "test", but pressing a space after the last `=` does.
 

--- a/readme/apps/rich_text_editor.md
+++ b/readme/apps/rich_text_editor.md
@@ -40,7 +40,7 @@ By default, the following patterns are replaced:
 - `## Heading 3`: Creates a level 3 heading.
 - `- List`: Creates a bulleted list.
 - `1. List`: Creates a numbered list.
-- `---` or `***`: Creates a horizontal rule.
+- `---`, `___`, or `***`: Creates a horizontal rule.
 
 Most replacements require pressing the <kbd>space</kbd> or <kbd>enter</kbd> key after the closing formatting character. For example, typing `==test==` does not highlight "test", but pressing a space after the last `=` does.
 


### PR DESCRIPTION
# Summary

Partially implements a feature requested [on the forum](https://discourse.joplinapp.org/t/impossible-to-create-horizontal-rule-or-block-quote-via-keyboard-shortcuts-in-rich-text-editor/45747). With this change, creating a line containing either `---` or `***` then pressing <kbd>enter</kbd> or <kbd>space</kbd> creates a horizontal rule in the Rich Text Editor when the auto-format setting is enabled.

# Testing plan

**Fedora 42 (GNOME)**:
1. Create a new note in the Rich Text Editor.
2. Type `***`.
3. Press <kbd>enter</kbd>.
4. Verify that a horizontal rule has been added.
5. Type "Test ", then type `***`.
6. Press <kbd>enter</kbd>.
7. Verify that another horizontal rule has not been added.
8. Create a new, empty line.
9. Repeat steps 2-7 for `---`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->