### PR TITLE
Desktop: Fixes #9593: Rich Text Editor: Fix including `$`s creates math blocks on save

### DIFF
--- a/packages/app-cli/tests/html_to_md/escaped_format_characters.html
+++ b/packages/app-cli/tests/html_to_md/escaped_format_characters.html
@@ -1,0 +1,1 @@
+<p>Some **format** characters $need$ to be `escaped`, if the characters were included directly in HTML.</p>

--- a/packages/app-cli/tests/html_to_md/escaped_format_characters.md
+++ b/packages/app-cli/tests/html_to_md/escaped_format_characters.md
@@ -1,0 +1,1 @@
+Some \*\*format\*\* characters \$need\$ to be \`escaped\`, if the characters were included directly in HTML.

--- a/packages/turndown/src/turndown.js
+++ b/packages/turndown/src/turndown.js
@@ -18,7 +18,8 @@ var escapes = [
   [/^>/g, '\\>'],
   // A list of valid \p values can be found here: https://unicode.org/reports/tr44/#GC_Values_Table
   [/(^|\p{Punctuation}|\p{Separator}|\p{Symbol})_(\P{Separator})/ug, '$1\\_$2'],
-  [/^(\d+)\. /g, '$1\\. ']
+  [/^(\d+)\. /g, '$1\\. '],
+  [/\$/g, '\\$$'], // Math
 ]
 
 export default function TurndownService (options) {


### PR DESCRIPTION
# Summary

This pull request adds `$`s to the list of characters that need to be escaped when saving content from the Rich Text Editor.

Fixes #9593.

# Testing

In addition to the automated test added by this pull request, this change has been tested manually by:
1. Creating a new note in the Markdown editor with the following content:
   ```markdown
   \$not math\$
   Also \$not\$ \$ math \$.
   
   $\KaTeX$
   $$\sin x^2$$
  
   \$\$Also not math\$\$
   ```
2. Switching to the Rich Text Editor.
3. Changing the first "Also" to "also".
4. Switching back to the Markdown editor.
5. Verifying that the note has the following content:
   ```markdown
   \$not math\$  
   also \$not\$ \$ math \$.
   
   $\KaTeX$
   
   $$
   \sin x^2
   $$
   
   \$\$Also not math\$\$
   ```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->