### PR TITLE
Android: Voice typing: Fix memory leak

### DIFF
--- a/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/whisperWrapper.cpp
@@ -75,7 +75,7 @@ extern "C"
 JNIEXPORT void JNICALL
 Java_net_cozic_joplin_audio_NativeWhisperLib_00024Companion_free(JNIEnv *env, jobject thiz,
 																 jlong pointer) {
-	std::free(reinterpret_cast<WhisperSession *>(pointer));
+	delete reinterpret_cast<WhisperSession *>(pointer);
 }
 
 extern "C"


### PR DESCRIPTION
# Summary

Fixes a potentially severe memory leak caused by a mismatched new/free. Among other issues, `std::free` doesn't call the destructor of the object created with `new`. In this case, this prevented the internal whisper.cpp voice typing session from being freed. 

> [!IMPORTANT]
>
> This pull request targets `release-3.3`.

# Testing plan


**Android 13** (before changing the base branch to `release-3.3`):
1. Run `adb shell top -h` to display the system memory usage.
1. Start voice typing.
2. Read the first paragraph of [Wikipedia: The Four Color Theorem](https://en.wikipedia.org/wiki/Four_color_theorem) out loud.
3. Stop voice typing.
4. Repeat steps 2-3 three more times.
5. Verify that the app hasn't crashed.
6. Verify that the memory/swap usage is similar to what it was in step 1.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->