### PR TITLE
Android: Voice typing: Improve silence detection

### DIFF
--- a/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
+++ b/packages/app-mobile/android/app/src/main/cpp/utils/WhisperSession.cpp
@@ -126,7 +126,7 @@ WhisperSession::splitAndTranscribeBefore_(int transcribeUpTo, int trimTo) {
 }
 
 bool WhisperSession::isBufferSilent_() {
-	int toleranceSamples = WHISPER_SAMPLE_RATE / 8; // 0.125s
+	int toleranceSamples = WHISPER_SAMPLE_RATE / 5; // 0.2s
 	auto silence = findLongestSilence(
 			audioBuffer_,
 			LongestSilenceOptions {
@@ -145,7 +145,7 @@ WhisperSession::transcribeNextChunk() {
 
 	// Handles a silence detected between (splitStart, splitEnd).
 	auto splitAndProcess = [&] (int splitStart, int splitEnd) {
-		int tolerance = WHISPER_SAMPLE_RATE / 20; // 0.05s
+		int tolerance = WHISPER_SAMPLE_RATE / 8; // 0.125s
 		bool isCompletelySilent = splitStart < tolerance && splitEnd > audioBuffer_.size() - tolerance;
 		LOGD("WhisperSession: Found silence range from %.2f -> %.2f", splitStart / (float) WHISPER_SAMPLE_RATE, splitEnd / (float) WHISPER_SAMPLE_RATE);
 


### PR DESCRIPTION
# Summary

This pull request increases the tolerance for silence detection both when splitting the recorded audio buffer and when determining whether the full audio buffer is silent.

This partially resolves [an issue raised while increasing the default voice typing model size](https://github.com/laurent22/joplin/pull/12352#issuecomment-2914398272).

# Testing plan

**Manual testing on Android 13**: 
1. Start voice typing and read the first paragraph from https://en.wikipedia.org/wiki/Four_color_theorem.
2. Wait 1-2 seconds.
3. Click "Done".
4. Verify that the first paragraph (and no additional unrelated lines) are transcribed.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->