### PR TITLE
Mobile: Change revisions to be presented in reverse order in the dropdown

### DIFF
--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -46,7 +46,7 @@ const useRevisions = (noteId: string) => {
 
 		const revisions = await Revision.allByType(ModelType.Note, noteId);
 		if (event.cancelled) return;
-		setRevisions(revisions);
+		setRevisions(revisions.slice().reverse());
 	}, [noteId]);
 
 	return revisions;

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -46,7 +46,7 @@ const useRevisions = (noteId: string) => {
 
 		const revisions = await Revision.allByType(ModelType.Note, noteId);
 		if (event.cancelled) return;
-		setRevisions(revisions.slice().reverse());
+		setRevisions(revisions);
 	}, [noteId]);
 
 	return revisions;
@@ -118,7 +118,8 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 
 	const options = useMemo(() => {
 		const result = [];
-		for (const revision of revisions) {
+		const reversedRevisions = revisions.slice().reverse();
+		for (const revision of reversedRevisions) {
 			const stats = Revision.revisionPatchStatsText(revision);
 			result.push({
 				label: `${formatMsToLocal(revision.item_updated_time)} (${stats})`,


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/12305 introduced a revision viewer for mobile. I noticed that the list of revisions in the dropdown are presented in ascending order (oldest to newest) which is not logical, particularly if there are a lot of revisions for a note. On desktop, the revisions are presented in descending order, so this change aligns the behaviour to be the same.

I have tested this works for a note with and without any revisions.

Screenshot after the code change:
![fix](https://github.com/user-attachments/assets/4a8f4cc3-9f7d-47f0-9a2e-ea57a6f151bb)
