### PR TITLE
Chore: CI: Desktop: Re-run the accessibility scanner on failure

### DIFF
--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -32,19 +32,11 @@ const expectNoViolations = async (page: Page) => {
 
 	// Retry the accessibility scanner on failure to prevent
 	// random failure in CI.
-	let lastViolations;
-	const maxRetries = 2;
-	for (let i = 0; i < maxRetries; i++) {
+	await expect.poll(async () => {
 		const results = await scanner.analyze();
-		lastViolations = results.violations;
-
-		if (lastViolations.length === 0) {
-			return;
-		}
-	}
-	expect(lastViolations).toEqual([]);
+		return results.violations;
+	}).toEqual([]);
 };
-
 
 test.describe('wcag', () => {
 	for (const tabName of ['General', 'Plugins']) {

--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -28,8 +28,21 @@ const waitForAnimationsToEnd = (page: Page) => {
 
 const expectNoViolations = async (page: Page) => {
 	await waitForAnimationsToEnd(page);
-	const results = await createScanner(page).analyze();
-	expect(results.violations).toEqual([]);
+	const scanner = createScanner(page);
+
+	// Retry the accessibility scanner on failure to prevent
+	// random failure in CI.
+	let lastViolations;
+	const maxRetries = 2;
+	for (let i = 0; i < maxRetries; i++) {
+		const results = await scanner.analyze();
+		lastViolations = results.violations;
+
+		if (lastViolations.length === 0) {
+			return;
+		}
+	}
+	expect(lastViolations).toEqual([]);
 };
 
 


### PR DESCRIPTION
# Summary

This pull request re-runs the `@axe-core/playwright` accessibility scanner on failure without restarting the full test. 

These tests were observed failing in CI [here](https://github.com/laurent22/joplin/actions/runs/15492250406/job/43620304124) and [here](https://github.com/laurent22/joplin/actions/runs/15514881896/job/43680533448?pr=12407).

<details><summary>Output</summary>

```
Error: expect(received).toEqual(expected) // deep equality

    - Expected  -  1
    + Received  + 70

    - Array []
    + Array [
    +   Object {
    +     "description": "Ensure the document has a main landmark",
    +     "help": "Document should have one main landmark",
    +     "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/landmark-one-main?application=playwright",
    +     "id": "landmark-one-main",
    +     "impact": "moderate",
    +     "nodes": Array [
    +       Object {
    +         "all": Array [
    +           Object {
    +             "data": null,
    +             "id": "page-has-main",
    +             "impact": "moderate",
    +             "message": "Document does not have a main landmark",
    +             "relatedNodes": Array [],
    +           },
    +         ],
    +         "any": Array [],
    +         "failureSummary": "Fix all of the following:
    +   Document does not have a main landmark",
    +         "html": "<html lang=\"en-GB\">",
    +         "impact": "moderate",
    +         "none": Array [],
    +         "target": Array [
    +           "html",
    +         ],
    +       },
    +     ],
    +     "tags": Array [
    +       "cat.semantics",
    +       "best-practice",
    +     ],
    +   },
    +   Object {
    +     "description": "Ensure all page content is contained by landmarks",
    +     "help": "All page content should be contained by landmarks",
    +     "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/region?application=playwright",
    +     "id": "region",
    +     "impact": "moderate",
    +     "nodes": Array [
    +       Object {
    +         "all": Array [],
    +         "any": Array [
    +           Object {
    +             "data": Object {
    +               "isIframe": false,
    +             },
    +             "id": "region",
    +             "impact": "moderate",
    +             "message": "Some page content is not contained by landmarks",
    +             "relatedNodes": Array [],
    +           },
    +         ],
    +         "failureSummary": "Fix any of the following:
    +   Some page content is not contained by landmarks",
    +         "html": "<div id=\"react-root\">",
    +         "impact": "moderate",
    +         "none": Array [],
    +         "target": Array [
    +           "#react-root",
    +         ],
    +       },
    +     ],
    +     "tags": Array [
    +       "cat.keyboard",
    +       "best-practice",
    +     ],
    +   },
    + ]

      30 | 	await waitForAnimationsToEnd(page);
      31 | 	const results = await createScanner(page).analyze();
    > 32 | 	expect(results.violations).toEqual([]);
         | 	                           ^
      33 | };
      34 |
      35 |
        at expectNoViolations (/home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/wcag.spec.ts:32:29)
        at /home/runner/work/joplin/joplin/packages/app-desktop/integration-tests/wcag.spec.ts:52:4

```

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->