### PR TITLE
Chore: CI: Fix accessibility scanner sometimes fails due to name conflict

### DIFF
--- a/packages/app-desktop/gui/ErrorBoundary.tsx
+++ b/packages/app-desktop/gui/ErrorBoundary.tsx
@@ -5,8 +5,11 @@ import Setting from '@joplin/lib/models/Setting';
 import restart from '../services/restart';
 import BannerContent from './NoteEditor/WarningBanner/BannerContent';
 import { _ } from '@joplin/lib/locale';
+import Logger from '@joplin/utils/Logger';
 const packageInfo: PackageInfo = require('../packageInfo.js');
 const ipcRenderer = require('electron').ipcRenderer;
+
+const logger = Logger.create('ErrorBoundary');
 
 interface ErrorInfo {
 	componentStack: string;
@@ -83,6 +86,9 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 		}
 
 		this.setState({ error, errorInfo, pluginInfos, plugins });
+
+		logger.error('The application encountered an error:', error);
+		logger.error('Component stack', errorInfo?.componentStack);
 	}
 
 	public componentDidMount() {

--- a/packages/app-desktop/tools/bundleJs.ts
+++ b/packages/app-desktop/tools/bundleJs.ts
@@ -13,6 +13,7 @@ const makeBuildContext = (entryPoint: string, renderer: boolean, computeFileSize
 		bundle: true,
 		minify: true,
 		keepNames: true,
+		format: 'iife', // Immediately invoked function expression
 		sourcemap: true,
 		metafile: computeFileSizeStats,
 		platform: 'node',

--- a/packages/app-desktop/tools/bundleJs.ts
+++ b/packages/app-desktop/tools/bundleJs.ts
@@ -12,6 +12,7 @@ const makeBuildContext = (entryPoint: string, renderer: boolean, computeFileSize
 		outfile: `${filename(entryPoint)}.bundle.js`,
 		bundle: true,
 		minify: true,
+		keepNames: true,
 		sourcemap: true,
 		metafile: computeFileSizeStats,
 		platform: 'node',


### PR DESCRIPTION
# Summary

This pull request should fix an issue introduced by https://github.com/laurent22/joplin/pull/12366. In particular, the CI issue seems to be caused by a conflict between ESBuild's minification and the `axe/playwright` accessibility scanner. In particular:
- One of the auto-generated minified variable names was "axe".
- Somehow, `axe` is overwritten with (or not defined because of?) something specific to the `axe` accessibility scanner.
- One of the settings screens accesses the `axe` variable, but it doesn't contain the expected content, causing a crash.
- This shows the `ErrorBoundary` screen.
- The accessibility scanner detects accessibility issues in the `ErrorBoundary` screen, causing the test to fail.
   - Interestingly, the error isn't included in the logs attached to the test failure (and only shown onscreen).

To fix this, the pull request:
- Provides the [`keepNames` option](https://esbuild.github.io/api/#keep-names) to the bundler.
- Explicitly sets the output format to [`iife`](https://esbuild.github.io/api/#format-iife).

To assist in debugging, this pull request adds code to attach the error message associated with the failure to the log file.

See https://github.com/laurent22/joplin/pull/12409#issuecomment-2954296733 for a more detailed description of the issue.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->