### PR TITLE
Chore: CI: Disable accessibility scanner tests that cause a crash in CI

### DIFF
--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
-import SettingsScreen from './models/SettingsScreen';
 import AxeBuilder from '@axe-core/playwright';
 import { Page } from '@playwright/test';
 
@@ -39,24 +38,25 @@ const expectNoViolations = async (page: Page) => {
 };
 
 test.describe('wcag', () => {
-	for (const tabName of ['General', 'Plugins']) {
-		test(`should not detect significant issues in the settings screen ${tabName} tab`, async ({ electronApp, mainWindow }) => {
-			const mainScreen = await new MainScreen(mainWindow).setup();
-			await mainScreen.waitFor();
-
-			await mainScreen.openSettings(electronApp);
-
-			// Should be on the settings screen
-			const settingsScreen = new SettingsScreen(mainWindow);
-			await settingsScreen.waitFor();
-
-			const tabLocator = settingsScreen.getTabLocator(tabName);
-			await tabLocator.click();
-			await expect(tabLocator).toBeFocused();
-
-			await expectNoViolations(mainWindow);
-		});
-	}
+	// Disabled due to random failure in CI:
+// for (const tabName of ['General', 'Plugins']) {
+// 	test(`should not detect significant issues in the settings screen ${tabName} tab`, async ({ electronApp, mainWindow }) => {
+// 		const mainScreen = await new MainScreen(mainWindow).setup();
+// 		await mainScreen.waitFor();
+//
+// 		await mainScreen.openSettings(electronApp);
+//
+// 		// Should be on the settings screen
+// 		const settingsScreen = new SettingsScreen(mainWindow);
+// 		await settingsScreen.waitFor();
+//
+// 		const tabLocator = settingsScreen.getTabLocator(tabName);
+// 		await tabLocator.click();
+// 		await expect(tabLocator).toBeFocused();
+//
+// 		await expectNoViolations(mainWindow);
+// 	});
+// }
 
 	test('should not detect significant issues in the main screen with an open note', async ({ mainWindow }) => {
 		const mainScreen = await new MainScreen(mainWindow).setup();


### PR DESCRIPTION
# Summary

At present, some of the accessibility scanner-related tests are failing in CI (seeming due to a variable name conflict). This pull request disables the relevant tests.

**Note**: See https://github.com/laurent22/joplin/pull/12415 for a potential fix that does not require disabling tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->