### PR TITLE
All: Fixes: CI running out of space 

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -11,6 +11,13 @@ jobs:
         # https://github.com/actions/runner-images/issues/6709
         os: [macos-13, ubuntu-22.04, windows-2025, ubuntu-22.04-arm]
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
       - uses: actions/checkout@v4
 
       - name: Setup build environment


### PR DESCRIPTION
# Summary

When trying to run the tests from the new `transcribe` package, we didn't manage to download the whole model because we run out of disk space.

I'm adding a new step in the main CI file to delete unnecessary files to free more space.