### PR TITLE
Mobile: Add additional checks when updating sidebar state

### DIFF
--- a/packages/app-mobile/components/SideMenu.tsx
+++ b/packages/app-mobile/components/SideMenu.tsx
@@ -166,25 +166,12 @@ const useAnimations = ({ menuWidth, isLeftMenu, open }: UseAnimationsProps) => {
 	return { setIsAnimating, animating, updateMenuPosition, menuOpenFraction, menuDragOffset };
 };
 
-// Syncs the local `open` with the `isOpen` prop. Changing the `isOpen` prop
-// updates the local `open`, but not necessarily the other way around.
-const useIsOpen = (requestedOpen: boolean) => {
-	const [open, setOpen] = useState(false);
-
-	const openRef = useRef(open);
-	openRef.current = open;
-	useEffect(() => {
-		// Compare with openRef to avoid unnecessary rerenders
-		if (requestedOpen !== openRef.current) {
-			setOpen(requestedOpen);
-		}
-	}, [requestedOpen]);
-
-	return { open, setIsOpen: setOpen };
-};
-
 const SideMenuComponent: React.FC<Props> = props => {
-	const { open, setIsOpen } = useIsOpen(props.isOpen);
+	const [open, setIsOpen] = useState(false);
+
+	useEffect(() => {
+		setIsOpen(props.isOpen);
+	}, [props.isOpen]);
 
 	const [menuWidth, setMenuWidth] = useState(0);
 	const [contentWidth, setContentWidth] = useState(0);
@@ -260,7 +247,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 				}
 			},
 		});
-	}, [isLeftMenu, menuDragOffset, menuWidth, props.toleranceX, props.toleranceY, contentWidth, open, props.disableGestures, props.edgeHitWidth, updateMenuPosition, setIsAnimating, setIsOpen]);
+	}, [isLeftMenu, menuDragOffset, menuWidth, props.toleranceX, props.toleranceY, contentWidth, open, props.disableGestures, props.edgeHitWidth, updateMenuPosition, setIsAnimating]);
 
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;
@@ -276,7 +263,7 @@ const SideMenuComponent: React.FC<Props> = props => {
 		setIsOpen(false);
 		// Set isAnimating as soon as possible to avoid components disappearing, then reappearing.
 		setIsAnimating(true);
-	}, [setIsAnimating, setIsOpen]);
+	}, [setIsAnimating]);
 
 	const styles = useStyles({ themeId: props.themeId, menuOpenFraction, menuWidth, isLeftMenu });
 

--- a/packages/app-mobile/components/buttons/FloatingActionButton.tsx
+++ b/packages/app-mobile/components/buttons/FloatingActionButton.tsx
@@ -45,10 +45,12 @@ const useIcon = (iconName: string) => {
 const FloatingActionButton = (props: ActionButtonProps) => {
 	const [open, setOpen] = useState(false);
 	const onMenuToggled = useCallback(() => {
-		props.dispatch({
-			type: 'SIDE_MENU_CLOSE',
-		});
 		const newOpen = !open;
+		if (newOpen) {
+			props.dispatch({
+				type: 'SIDE_MENU_CLOSE',
+			});
+		}
 		setOpen(newOpen);
 	}, [setOpen, open, props.dispatch]);
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -1243,13 +1243,16 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		}
 	}
 
-	private sideMenu_change(isOpen: boolean) {
+	private sideMenu_change = (isOpen: boolean) => {
 		// Make sure showSideMenu property of state is updated
 		// when the menu is open/closed.
-		this.props.dispatch({
-			type: isOpen ? 'SIDE_MENU_OPEN' : 'SIDE_MENU_CLOSE',
-		});
-	}
+		// Avoid dispatching unnecessarily. See https://github.com/laurent22/joplin/issues/12427
+		if (isOpen !== this.props.showSideMenu) {
+			this.props.dispatch({
+				type: isOpen ? 'SIDE_MENU_OPEN' : 'SIDE_MENU_CLOSE',
+			});
+		}
+	};
 
 	private getSideMenuWidth = () => {
 		const sideMenuWidth = getResponsiveValue({
@@ -1339,7 +1342,8 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 					toleranceY={20}
 					openMenuOffset={this.state.sideMenuWidth}
 					menuPosition={menuPosition}
-					onChange={(isOpen: boolean) => this.sideMenu_change(isOpen)}
+					onChange={this.sideMenu_change}
+					isOpen={this.props.showSideMenu}
 					disableGestures={disableSideMenuGestures}
 				>
 					<StatusBar barStyle={statusBarStyle} />


### PR DESCRIPTION
# Summary

This pull request adds additional checks before updating the sidemenu state. In particular, it:
- `root.tsx`: Adds a check that `props.dispatch({ type: isOpen ? 'SIDE_MENU_OPEN' : 'SIDE_MENU_CLOSE', });` is necessary before doing so.
   - This may fix the issue if the loop is related to unnecessary Redux updates.
   - To make it clearer that this check makes sense, `isOpen={this.props.showSideMenu}` is now explicitly passed to the side menu component from `root.tsx`, rather than passed through Redux.
- `FloatingActionButton.tsx`: Adds a check that the action button's menu is opening (rather than closing) before it dispatches `SIDE_MENU_CLOSE`.
    - This may fix the issue if the loop is related to the FloatingActionButton's `onMenuToggled` listener.

This **may** fix #12427.

> [!IMPORTANT]
>
> This pull request targets `release-3.3`.

# Testing plan

Manual testing (Web/Chromium 137.0.7151.68, iOS 18.1 simulator):
1. Open the side menu by clicking the "toggle sidemenu" button at the top left of the screen.
2. Close the side menu by clicking outside of the sidemenu.
3. Tap and drag from the left edge of the screen. Verify that this opens the side menu.
   - **Note**: On web, this step was done with a touchscreen.
4. Tap and drag from outside the sidemenu to the left edge of the screen. Verify that this closes the sidemenu.
5. Open the side menu and click "Configuration". Verify that this closes the side menu.

- [x] Manual testing on Android.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->