### PR TITLE
Chore: Fix CI: Disable yarn install cache on ARM runners

### DIFF
--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -52,7 +52,10 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: '18.18.0'
-        cache: 'yarn'
+        # Disable the cache on ARM runners. For now, we don't run "yarn install" on these
+        # environments and this breaks actions/setup-node.
+        # See https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577783.
+        cache: ${{ (contains(runner.os, 'arm')) && '') || 'yarn' }}
 
     - name: Install Yarn
       shell: bash

--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -55,7 +55,7 @@ runs:
         # Disable the cache on ARM runners. For now, we don't run "yarn install" on these
         # environments and this breaks actions/setup-node.
         # See https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577783.
-        cache: ${{ (contains(runner.os, 'arm')) && '') || 'yarn' }}
+        cache: ${{ ((contains(runner.os, 'arm')) && '') || 'yarn' }}
 
     - name: Install Yarn
       shell: bash

--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -55,7 +55,7 @@ runs:
         # Disable the cache on ARM runners. For now, we don't run "yarn install" on these
         # environments and this breaks actions/setup-node.
         # See https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577783.
-        cache: ${{ ((contains(runner.os, 'arm')) && '') || 'yarn' }}
+        cache: ${{ (!contains(runner.os, 'arm') && 'yarn') || '' }}
 
     - name: Install Yarn
       shell: bash


### PR DESCRIPTION
# Summary

In CI, we often don't run `yarn install` on the ARM-based runners. This [seems to cause `actions/node` to break](https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577218) when the cache option is set to `yarn`.

This pull request sets `cache` to the empty string on ARM-based runners.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->