### PR TITLE
Chore: Mobile: Fix Note.test.tsx warnings

### DIFF
--- a/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
+++ b/packages/app-mobile/components/NoteEditor/CodeMirror/CodeMirror.ts
@@ -15,6 +15,18 @@ import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
 import WebViewToRNMessenger from '../../../utils/ipc/WebViewToRNMessenger';
 import { WebViewToEditorApi } from '../types';
 import { focus } from '@joplin/lib/utils/focusHandler';
+import Logger, { TargetType } from '@joplin/utils/Logger';
+
+let loggerCreated = false;
+export const setUpLogger = () => {
+	if (!loggerCreated) {
+		const logger = new Logger();
+		logger.addTarget(TargetType.Console);
+		logger.setLevel(Logger.LEVEL_WARN);
+		Logger.initializeGlobalLogger(logger);
+		loggerCreated = true;
+	}
+};
 
 export const initCodeMirror = (
 	parentElement: HTMLElement,

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -387,6 +387,7 @@ function NoteEditor(props: Props, ref: any) {
 
 			try {
 				${shim.injectedJs('codeMirrorBundle')};
+				codeMirrorBundle.setUpLogger();
 
 				const parentElement = document.getElementsByClassName('CodeMirror')[0];
 				// On Android, injectJavaScript is run twice -- once before the parent element exists.

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -292,7 +292,7 @@ describe('screens/Note', () => {
 		const deleteButton = await screen.findByText('Delete');
 		expect(deleteButton).toBeDisabled();
 
-		cleanup();
+		act(() => cleanup());
 	});
 
 	it.each([


### PR DESCRIPTION
# Summary

This pull request fixes two warnings observed in Note.test.tsx:
- An "uninitialized global logger" warning -- fixed by initializing the global logger within the webview.
- A "wrap state modifications in act()" -- fixed by wrapping cleanup code in act().

Fixes https://github.com/laurent22/joplin/issues/12442, https://github.com/laurent22/joplin/issues/11127.

# Testing plan

**Web**: 
1. Open a note.
2. Switch to the note editor.
3. Click just below the note editor.
4. Check the console for an "uninitialized global logger" warning.
    - **Note**: There may be other warnings related to "`BackHandler` is not supported on web" or the runtime `fsDriver` tests. I plan to fix these in a follow-up pull request.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->