### PR TITLE
Chore: Silence expected warning while running tests in lib/

### DIFF
--- a/packages/lib/models/Folder.test.ts
+++ b/packages/lib/models/Folder.test.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from '../errors';
 import { FolderEntity } from '../services/database/types';
-import { createNTestNotes, setupDatabaseAndSynchronizer, sleep, switchClient, checkThrowAsync, createFolderTree, simulateReadOnlyShareEnv, expectThrow } from '../testing/test-utils';
+import { createNTestNotes, setupDatabaseAndSynchronizer, sleep, switchClient, checkThrowAsync, createFolderTree, simulateReadOnlyShareEnv, expectThrow, withWarningSilenced } from '../testing/test-utils';
 import Folder from './Folder';
 import Note from './Note';
 
@@ -174,8 +174,10 @@ describe('models/Folder', () => {
 		await Folder.save({ id: f1.id, parent_id: f3.id });
 
 		const folders = await Folder.all();
-		// Should not loop indefinitely:
-		await Folder.addNoteCounts(folders);
+		// Should not loop indefinitely, okay to warn:
+		await withWarningSilenced(/has itself as a parent/, async () => {
+			await Folder.addNoteCounts(folders);
+		});
 		// Note count may be incorrect
 		expect(folders.find(folder => folder.id === f1.id)).toHaveProperty('note_count');
 	});

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -1190,4 +1190,22 @@ export const runWithFakeTimers = async (callback: ()=> Promise<void>) => {
 	}
 };
 
+export const withWarningSilenced = async <T> (warningRegex: RegExp, task: ()=> Promise<T>): Promise<T> => {
+	// See https://jestjs.io/docs/jest-object#spied-methods-and-the-using-keyword, which
+	// shows how to use .spyOn to hide warnings
+	let warningMock;
+	try {
+		warningMock = jest.spyOn(console, 'warn');
+		warningMock.mockImplementation((message, ...args) => {
+			const fullMessage = [message, ...args].join(' ');
+			if (!fullMessage.match(warningRegex)) {
+				console.error(`Unexpected warning: ${message}`, ...args);
+			}
+		});
+		return await task();
+	} finally {
+		warningMock.mockRestore();
+	}
+};
+
 export { supportDir, createNoteAndResource, createTempFile, createTestShareData, simulateReadOnlyShareEnv, waitForFolderCount, afterAllCleanUp, exportDir, synchronizerStart, afterEachCleanUp, syncTargetName, setSyncTargetName, syncDir, createTempDir, isNetworkSyncTarget, kvStore, expectThrow, logger, expectNotThrow, resourceService, resourceFetcher, tempFilePath, allSyncTargetItemsEncrypted, msleep, setupDatabase, revisionService, setupDatabaseAndSynchronizer, db, synchronizer, fileApi, sleep, clearDatabase, switchClient, syncTargetId, objectsEqual, checkThrowAsync, checkThrow, encryptionService, loadEncryptionMasterKey, fileContentEqual, decryptionWorker, currentClientId, id, ids, sortedIds, at, createNTestNotes, createNTestFolders, createNTestTags, TestApp };


### PR DESCRIPTION
This pull request silences a warning using `.spyOn`. See [the relevant Jest documentation](https://jestjs.io/docs/jest-object#spied-methods-and-the-using-keyword).

Fixes https://github.com/laurent22/joplin/issues/12441

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->