### PR TITLE
Chore: Desktop: Fix layout-related warning shown in console on startup

### DIFF
--- a/packages/app-desktop/gui/Navigator.tsx
+++ b/packages/app-desktop/gui/Navigator.tsx
@@ -56,7 +56,7 @@ const useWindowRefocusManager = (route: AppStateRoute) => {
 };
 
 const useContainerSize = (container: HTMLElement|null) => {
-	const [size, setSize] = useState({ width: container?.clientWidth, height: container?.clientHeight });
+	const [size, setSize] = useState({ width: container?.clientWidth ?? 0, height: container?.clientHeight ?? 0 });
 
 	useEffect(() => {
 		if (!container) return () => {};


### PR DESCRIPTION
# Summary

This pull request fixes a warning/error shown in the console after starting the desktop app.

This warning was caused by an initially `undefined` value for the layout `height`, resulting in an initially `NaN` height for certain layout components.

# Testing

1. Start the desktop app.
2. Verify that `Warning: NaN is an invalid value for the height css style property` is not present in the console.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->