### PR TITLE
Chore: Mobile: Increase test `waitFor` timeouts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -915,6 +915,7 @@ packages/app-mobile/utils/testing/createMockReduxStore.js
 packages/app-mobile/utils/testing/getWebViewDomById.js
 packages/app-mobile/utils/testing/getWebViewWindowById.js
 packages/app-mobile/utils/testing/setupGlobalStore.js
+packages/app-mobile/utils/testing/testingLibrary.js
 packages/app-mobile/utils/types.js
 packages/app-mobile/web/serviceWorker.js
 packages/app-mobile/web/webpack.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -891,6 +891,7 @@ packages/app-mobile/utils/testing/createMockReduxStore.js
 packages/app-mobile/utils/testing/getWebViewDomById.js
 packages/app-mobile/utils/testing/getWebViewWindowById.js
 packages/app-mobile/utils/testing/setupGlobalStore.js
+packages/app-mobile/utils/testing/testingLibrary.js
 packages/app-mobile/utils/types.js
 packages/app-mobile/web/serviceWorker.js
 packages/app-mobile/web/webpack.config.js

--- a/packages/app-mobile/components/CameraView/CameraView.test.tsx
+++ b/packages/app-mobile/components/CameraView/CameraView.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import CameraView from './CameraView';
 import { CameraResult } from './types';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '../../utils/testing/testingLibrary';
 import createMockReduxStore from '../../utils/testing/createMockReduxStore';
 import TestProviderStack from '../testing/TestProviderStack';
 

--- a/packages/app-mobile/components/Dropdown.test.tsx
+++ b/packages/app-mobile/components/Dropdown.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Text } from 'react-native';
 
 import { describe, it, expect, jest } from '@jest/globals';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '../utils/testing/testingLibrary';
 
 import Dropdown, { DropdownListItem } from './Dropdown';
 

--- a/packages/app-mobile/components/EditorToolbar/EditorToolbar.test.tsx
+++ b/packages/app-mobile/components/EditorToolbar/EditorToolbar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '../../utils/testing/testingLibrary';
 
 import { Store } from 'redux';
 import { AppState } from '../../utils/types';

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.test.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { describe, it, beforeEach } from '@jest/globals';
-import { render, screen, waitFor } from '@testing-library/react-native';
+import { render, screen, waitFor } from '../../utils/testing/testingLibrary';
 
 
 import NoteBodyViewer from './NoteBodyViewer';

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, waitFor } from '../../utils/testing/testingLibrary';
 
 import NoteEditor from './NoteEditor';
 import Setting from '@joplin/lib/models/Setting';

--- a/packages/app-mobile/components/NoteEditor/hooks/useEditorCommandHandler.test.ts
+++ b/packages/app-mobile/components/NoteEditor/hooks/useEditorCommandHandler.test.ts
@@ -4,7 +4,7 @@ import CommandService from '@joplin/lib/services/CommandService';
 import useEditorCommandHandler from './useEditorCommandHandler';
 import commandDeclarations from '../commandDeclarations';
 import createTestEditorControl from '@joplin/editor/CodeMirror/testUtil/createEditorControl';
-import { renderHook } from '@testing-library/react-native';
+import { renderHook } from '../../../utils/testing/testingLibrary';
 import { defaultState } from '@joplin/lib/reducer';
 
 

--- a/packages/app-mobile/components/ScreenHeader/WarningBanner.test.tsx
+++ b/packages/app-mobile/components/ScreenHeader/WarningBanner.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { WarningBannerComponent } from './WarningBanner';
 import Setting from '@joplin/lib/models/Setting';
 import NavService from '@joplin/lib/services/NavService';
-import { render, screen, userEvent } from '@testing-library/react-native';
+import { render, screen, userEvent } from '../../utils/testing/testingLibrary';
 import { ShareInvitation, ShareUserStatus } from '@joplin/lib/services/share/reducer';
 import makeShareInvitation from '@joplin/lib/testing/share/makeMockShareInvitation';
 

--- a/packages/app-mobile/components/accessibility/AccessibleView.test.tsx
+++ b/packages/app-mobile/components/accessibility/AccessibleView.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import FocusControl from './FocusControl/FocusControl';
-import { render } from '@testing-library/react-native';
+import { render } from '../../utils/testing/testingLibrary';
 import AccessibleView from './AccessibleView';
 import { AccessibilityInfo } from 'react-native';
 import ModalWrapper from './FocusControl/ModalWrapper';

--- a/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/NoteExportSection/NoteExportButton.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { _ } from '@joplin/lib/locale';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '../../../../utils/testing/testingLibrary';
 import { expect, describe, beforeEach, test, jest } from '@jest/globals';
 import { createNTestNotes, setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 import Folder from '@joplin/lib/models/Folder';

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createTempDir, mockMobilePlatform, setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 
-import { act, fireEvent, render, screen, userEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../../utils/testing/testingLibrary';
 
 import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import pluginServiceSetup from './testUtils/pluginServiceSetup';

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mockMobilePlatform, setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 
-import { render, screen, userEvent, waitFor } from '@testing-library/react-native';
+import { render, screen, userEvent, waitFor } from '../../../../utils/testing/testingLibrary';
 
 import pluginServiceSetup from './testUtils/pluginServiceSetup';
 import createMockReduxStore from '../../../../utils/testing/createMockReduxStore';

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { describe, it, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, screen, userEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../utils/testing/testingLibrary';
 
 import NoteScreen from './Note';
 import { setupDatabaseAndSynchronizer, switchClient, simulateReadOnlyShareEnv, supportDir, synchronizerStart, resourceFetcher, runWithFakeTimers } from '@joplin/lib/testing/test-utils';

--- a/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.test.tsx
@@ -6,7 +6,7 @@ import NoteRevisionViewer from './NoteRevisionViewer';
 import { setupDatabaseAndSynchronizer, switchClient, revisionService } from '@joplin/lib/testing/test-utils';
 import createMockReduxStore from '../../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../../utils/testing/setupGlobalStore';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '../../utils/testing/testingLibrary';
 import Note from '@joplin/lib/models/Note';
 import { useMemo } from 'react';
 import Revision from '@joplin/lib/models/Revision';

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.test.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.test.tsx
@@ -5,7 +5,7 @@ import { AppState } from '../../../utils/types';
 import { Store } from 'redux';
 import createMockReduxStore from '../../../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../../../utils/testing/setupGlobalStore';
-import { act, render, screen, waitFor } from '@testing-library/react-native';
+import { act, render, screen, waitFor } from '../../../utils/testing/testingLibrary';
 import { AccessibilityActionInfo } from 'react-native';
 import { setupDatabaseAndSynchronizer } from '@joplin/lib/testing/test-utils';
 import Folder from '@joplin/lib/models/Folder';

--- a/packages/app-mobile/components/screens/ShareManager/index.test.tsx
+++ b/packages/app-mobile/components/screens/ShareManager/index.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ShareManagerComponent } from './index';
 import Setting from '@joplin/lib/models/Setting';
 import mockShareService from '@joplin/lib/testing/share/mockShareService';
-import { act, render, screen, userEvent, waitFor } from '@testing-library/react-native';
+import { act, render, screen, userEvent, waitFor } from '../../../utils/testing/testingLibrary';
 import { ShareInvitation, ShareUserStatus } from '@joplin/lib/services/share/reducer';
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 import ShareService from '@joplin/lib/services/share/ShareService';

--- a/packages/app-mobile/components/screens/ShareNoteDialog.test.tsx
+++ b/packages/app-mobile/components/screens/ShareNoteDialog.test.tsx
@@ -8,7 +8,7 @@ import TestProviderStack from '../testing/TestProviderStack';
 import ShareNoteDialog from './ShareNoteDialog';
 import Note from '@joplin/lib/models/Note';
 import mockShareService from '@joplin/lib/testing/share/mockShareService';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, screen, waitFor } from '../../utils/testing/testingLibrary';
 import Folder from '@joplin/lib/models/Folder';
 import ShareService from '@joplin/lib/services/share/ShareService';
 

--- a/packages/app-mobile/components/screens/encryption-config.test.tsx
+++ b/packages/app-mobile/components/screens/encryption-config.test.tsx
@@ -7,7 +7,7 @@ import { loadEncryptionMasterKey, setupDatabaseAndSynchronizer, switchClient, sy
 import createMockReduxStore from '../../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../../utils/testing/setupGlobalStore';
 import { getActiveMasterKeyId, setEncryptionEnabled, setMasterKeyEnabled } from '@joplin/lib/services/synchronizer/syncInfoUtils';
-import { act, render, screen } from '@testing-library/react-native';
+import { act, render, screen } from '../../utils/testing/testingLibrary';
 
 interface WrapperProps { }
 

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -12,6 +12,7 @@ const uuid = require('@joplin/lib/uuid').default;
 const Setting = require('@joplin/lib/models/Setting').default;
 const sqlite3 = require('sqlite3');
 const React = require('react');
+const { configure: configureTestingLibrary } = require('@testing-library/react-native');
 require('../../jest.base-setup.js')();
 
 import { setImmediate } from 'timers';
@@ -124,6 +125,9 @@ shim.fsDriver().getCacheDirectoryPath = () => {
 
 beforeAll(async () => {
 	await mkdir(tempDirectoryPath);
+
+	// The default timeout of 1_000 ms is often too low in CI.
+	configureTestingLibrary({ asyncUtilTimeout: 5_000 });
 });
 
 afterEach(async () => {

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -12,7 +12,6 @@ const uuid = require('@joplin/lib/uuid').default;
 const Setting = require('@joplin/lib/models/Setting').default;
 const sqlite3 = require('sqlite3');
 const React = require('react');
-const { configure: configureTestingLibrary } = require('@testing-library/react-native');
 require('../../jest.base-setup.js')();
 
 import { setImmediate } from 'timers';
@@ -125,9 +124,6 @@ shim.fsDriver().getCacheDirectoryPath = () => {
 
 beforeAll(async () => {
 	await mkdir(tempDirectoryPath);
-
-	// The default timeout of 1_000 ms is often too low in CI.
-	configureTestingLibrary({ asyncUtilTimeout: 5_000 });
 });
 
 afterEach(async () => {

--- a/packages/app-mobile/utils/testing/getWebViewWindowById.ts
+++ b/packages/app-mobile/utils/testing/getWebViewWindowById.ts
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react-native';
+import { screen, waitFor } from './testingLibrary';
 
 const getWebViewWindowById = async (id: string): Promise<Window> => {
 	const webviewContent = await screen.findByTestId(id);

--- a/packages/app-mobile/utils/testing/testingLibrary.ts
+++ b/packages/app-mobile/utils/testing/testingLibrary.ts
@@ -1,0 +1,12 @@
+import * as testingLibrary from '@testing-library/react-native';
+
+// This file wraps @testing-library/react-native to allow configuring it
+// only if it's going to be used. Attempting to do this with a jest.mock
+// fails with "Cannot add a hook after tests have started running. Hooks must be defined synchronously."
+// Calling .configure for all tests causes jsdom-based tests to fail.
+testingLibrary.configure({
+	// The default timeout of 1_000 ms is often too low in CI.
+	asyncUtilTimeout: 5_000,
+});
+
+export * from '@testing-library/react-native';


### PR DESCRIPTION
# Summary

This pull request increases the default `waitFor` timeout from 1s to 5s. Partially resolves #12472.

# Notes

- Calling `.configure` for all tests caused [test failures](https://github.com/laurent22/joplin/actions/runs/15588534680/job/43901162081). This pull request wraps `@testing-library/react-native` with `utils/testing/testingLibrary.ts`. This file calls `.configure` when imported and thus only affects `@testing-library/`-related tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->