### PR TITLE
Chore: Mobile: Fix "missing `act()`" warning

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -143,6 +143,12 @@ const openEditor = async () => {
 	await expectToBeEditing(true);
 };
 
+const runEditorCommand = async (commandName: string) => {
+	await act(() => {
+		return CommandService.instance().execute(commandName);
+	});
+};
+
 describe('screens/Note', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
@@ -340,9 +346,9 @@ describe('screens/Note', () => {
 		render(<WrappedNoteScreen />);
 
 		await expectToBeEditing(false);
-		await CommandService.instance().execute('toggleVisiblePanes');
+		await runEditorCommand('toggleVisiblePanes');
 		await expectToBeEditing(true);
-		await CommandService.instance().execute('toggleVisiblePanes');
+		await runEditorCommand('toggleVisiblePanes');
 		await expectToBeEditing(false);
 	});
 });


### PR DESCRIPTION
# Summary

This pull request wraps calls to the state-changing `toggleVisiblePanes` editor command in `act`. This should fix the warnings identified in #12472. 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->