### PR TITLE
Chore: Editor: Retry list tests on failure

### DIFF
--- a/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
+++ b/packages/editor/CodeMirror/markdown/utils/renumberSelectedLists.test.ts
@@ -3,6 +3,8 @@ import createTestEditor from '../../testUtil/createTestEditor';
 import renumberSelectedLists from './renumberSelectedLists';
 
 describe('renumberSelectedLists', () => {
+	jest.retryTimes(2);
+
 	it('should correctly renumber a list with multiple selections in that list', async () => {
 		const listText = [
 			'1. This',


### PR DESCRIPTION
# Summary

A day or two ago, I observed a CI failure in `renumberSelectedLists`. To make similar CI failures less likely, this pull request retries tests in `renumberSelectedLists`.

**Note**: Other list-related tests [already have `jest.retryTimes(2)`](https://github.com/laurent22/joplin/blob/ca46df562799e4ebd11068f707e29aafaf20298f/packages/editor/CodeMirror/markdown/markdownCommands.bulletedVsChecklist.test.ts#L8).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->