### PR TITLE
Chore: CI: Retry opening the go-to-anything dialog on failure

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -542,6 +542,7 @@ packages/app-desktop/integration-tests/util/evaluateWithRetry.js
 packages/app-desktop/integration-tests/util/extendedExpect.js
 packages/app-desktop/integration-tests/util/getImageSourceSize.js
 packages/app-desktop/integration-tests/util/getMainWindow.js
+packages/app-desktop/integration-tests/util/retryOnFailure.js
 packages/app-desktop/integration-tests/util/setDarkMode.js
 packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/setMessageBoxResponse.js

--- a/.gitignore
+++ b/.gitignore
@@ -517,6 +517,7 @@ packages/app-desktop/integration-tests/util/evaluateWithRetry.js
 packages/app-desktop/integration-tests/util/extendedExpect.js
 packages/app-desktop/integration-tests/util/getImageSourceSize.js
 packages/app-desktop/integration-tests/util/getMainWindow.js
+packages/app-desktop/integration-tests/util/retryOnFailure.js
 packages/app-desktop/integration-tests/util/setDarkMode.js
 packages/app-desktop/integration-tests/util/setFilePickerResponse.js
 packages/app-desktop/integration-tests/util/setMessageBoxResponse.js

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -3,6 +3,7 @@ import { ElectronApplication, expect, Locator, Page } from '@playwright/test';
 import MainScreen from './MainScreen';
 import activateMainMenuItem from '../util/activateMainMenuItem';
 import { msleep } from '@joplin/utils/time';
+import retryOnFailure from '../util/retryOnFailure';
 
 export default class GoToAnything {
 	public readonly containerLocator: Locator;
@@ -19,9 +20,11 @@ export default class GoToAnything {
 
 	public async open(electronApp: ElectronApplication) {
 		await this.mainScreen.waitFor();
-		await activateMainMenuItem(electronApp, 'Goto Anything...');
-
-		return this.waitFor();
+		const openFromMenu = async () => {
+			await activateMainMenuItem(electronApp, 'Goto Anything...');
+			await this.waitFor();
+		};
+		await retryOnFailure(openFromMenu, { maxRetries: 3 });
 	}
 
 	public async openLinkToNote(electronApp: ElectronApplication) {

--- a/packages/app-desktop/integration-tests/util/evaluateWithRetry.ts
+++ b/packages/app-desktop/integration-tests/util/evaluateWithRetry.ts
@@ -2,23 +2,16 @@
 import { ElectronApplication } from '@playwright/test';
 import type { PageFunctionOn } from 'playwright-core/types/structs';
 import type * as ElectronType from 'electron';
+import retryOnFailure from './retryOnFailure';
 
 const evaluateWithRetry = async <ReturnType, Arg> (
 	app: ElectronApplication,
 	pageFunction: PageFunctionOn<typeof ElectronType, Arg, ReturnType>,
 	arg: Arg,
 ) => {
-	let lastError;
-	const maxRetries = 3;
-	for (let retryIndex = 0; retryIndex < maxRetries; retryIndex ++) {
-		try {
-			return await app.evaluate(pageFunction, arg);
-		} catch (error) {
-			console.error('app.evaluate failed:', error, `Retrying... ${retryIndex}/${maxRetries}`);
-			lastError = error;
-		}
-	}
-	throw lastError;
+	await retryOnFailure(async () => {
+		return await app.evaluate(pageFunction, arg);
+	}, { maxRetries: 3 });
 };
 
 export default evaluateWithRetry;

--- a/packages/app-desktop/integration-tests/util/retryOnFailure.ts
+++ b/packages/app-desktop/integration-tests/util/retryOnFailure.ts
@@ -1,0 +1,19 @@
+
+interface Options {
+	maxRetries: number;
+}
+
+const retryOnFailure = async <T> (callback: ()=> Promise<T>, { maxRetries }: Options): Promise<T> => {
+	let lastError: Error|null = null;
+	for (let i = 0; i < maxRetries; i++) {
+		try {
+			return await callback();
+		} catch (error) {
+			lastError = error;
+		}
+	}
+
+	throw lastError;
+};
+
+export default retryOnFailure;

--- a/packages/app-desktop/integration-tests/util/retryOnFailure.ts
+++ b/packages/app-desktop/integration-tests/util/retryOnFailure.ts
@@ -9,6 +9,7 @@ const retryOnFailure = async <T> (callback: ()=> Promise<T>, { maxRetries }: Opt
 		try {
 			return await callback();
 		} catch (error) {
+			console.error('retry failed:', error, `Retrying... ${i + 1}/${maxRetries}`);
 			lastError = error;
 		}
 	}


### PR DESCRIPTION
# Summary

This pull request retries opening the go-to-anything dialog on failure. This should make a [CI failure](https://github.com/laurent22/joplin/actions/runs/15592344926/job/43914317188) less likely.

# Notes

- Interestingly, based on the log output, the go-to-anything dialog was failing to open the **third** time through this loop, the second time through the loop (on test retry), and the third time through the loop again:

  https://github.com/laurent22/joplin/blob/ca46df562799e4ebd11068f707e29aafaf20298f/packages/app-desktop/integration-tests/goToAnything.spec.ts#L27-L28

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->