### PR TITLE
Chore: CI: Windows: Skip installing Rust

### DIFF
--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -49,6 +49,7 @@ runs:
 
     - uses: olegtarasov/get-tag@v2.1.4
     - uses: dtolnay/rust-toolchain@stable
+      if: ${{ runner.os != 'Windows' }}
     - uses: actions/setup-node@v4
       with:
         node-version: '18.18.0'

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,6 +16,11 @@ jobs:
         uses: ./.github/workflows/shared/setup-build-environment
       - name: Build
         run: yarn install
+        env:
+          # The onenote-converter package uses Rust, which isn't installed on all CI
+          # runners. Since the onenote-converter doesn't have UI tests, it can be excluded
+          # from build:
+          SKIP_ONENOTE_CONVERTER_BUILD: 1
       - name: Run UI tests
         shell: bash
         run: |

--- a/packages/onenote-converter/build.js
+++ b/packages/onenote-converter/build.js
@@ -13,6 +13,13 @@ async function main() {
 		return;
 	}
 
+	// Sometimes the onenote-converter build needs to be disabled in CI.
+	if (process.env.SKIP_ONENOTE_CONVERTER_BUILD) {
+		// eslint-disable-next-line no-console
+		console.info('SKIP_ONENOTE_CONVERTER_BUILD was set. The onenote-converter package will not be built.');
+		return;
+	}
+
 	const argv = yargs.argv;
 	if (!argv.profile) throw new Error('OneNote build: profile value is missing');
 	if (!['release', 'dev'].includes(argv.profile)) throw new Error('OneNote build: profile value is invalid');


### PR DESCRIPTION
# Summary

This pull request disables the installation of the Rust toolchain (used for building the `onenote-converter` package) in the Windows CI.

**Goal**: Prevent the following CI failure (observed [here](https://github.com/laurent22/joplin/actions/runs/15596356047/job/43927536011) and in a few other CI runs):
```
info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'
error: failed to download file error=Reqwest(reqwest::Error { kind: Request, url: "https://static.rust-lang.org/dist/channel-rust-stable.toml.sha256", source: hyper_util::client::legacy::Error(Connect, ConnectError("dns error", Os { code: 11001, kind: Uncategorized, message: "No such host is known." })) })
error: could not download file from 'https://static.rust-lang.org/dist/channel-rust-stable.toml.sha256' to 'C:\Users\runneradmin\.rustup\tmp\w9w37ep3p96f3bs0_file': error downloading file: error sending request for url (https://static.rust-lang.org/dist/channel-rust-stable.toml.sha256): client error (Connect): dns error: No such host is known. (os error 11001): No such host is known. (os error 11001)
```
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->