### PR TITLE
Chore: Trying to fix RSA error on CI

### DIFF
--- a/.github/scripts/run_ci.sh
+++ b/.github/scripts/run_ci.sh
@@ -133,7 +133,7 @@ if [ "$RUN_TESTS" == "1" ]; then
 	# Allocation failed - JavaScript heap out of memory
 	#
 	# https://stackoverflow.com/questions/38558989
-	export NODE_OPTIONS="--max-old-space-size=32768"
+	export NODE_OPTIONS="--max-old-space-size=32768 --security-revert=CVE-2023-46809"
 	yarn test-ci
 	testResult=$?
 	if [ $testResult -ne 0 ]; then

--- a/.github/scripts/run_ci.sh
+++ b/.github/scripts/run_ci.sh
@@ -133,7 +133,7 @@ if [ "$RUN_TESTS" == "1" ]; then
 	# Allocation failed - JavaScript heap out of memory
 	#
 	# https://stackoverflow.com/questions/38558989
-	export NODE_OPTIONS="--max-old-space-size=32768 --security-revert=CVE-2023-46809"
+	export NODE_OPTIONS="--max-old-space-size=32768"
 	yarn test-ci
 	testResult=$?
 	if [ $testResult -ne 0 ]; then

--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -52,7 +52,7 @@ runs:
       if: ${{ runner.os != 'Windows' }}
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.18.0'
+        node-version: '18.19.1'
         # Disable the cache on ARM runners. For now, we don't run "yarn install" on these
         # environments and this breaks actions/setup-node.
         # See https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577783.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
     "generatePluginTypes": "rm -rf ./plugin_types && yarn tsc --declaration --declarationDir ./plugin_types --project tsconfig.json",
-    "test": "jest --verbose=false",
+    "test": "node --security-revert=CVE-2023-46809 ./node_modules/.bin/jest --verbose=false",
     "test-ci": "yarn test"
   },
   "devDependencies": {


### PR DESCRIPTION
We should eventually update the padding but for now we need to fix CI

Error is:

```
[@joplin/lib]: FAIL services/e2ee/ppk.test.js
[@joplin/lib]:   ● e2ee/ppk › should encrypt a master key using PPK
[@joplin/lib]: 
[@joplin/lib]:     Error during decryption (probably incorrect key). Original error: TypeError: RSA_PKCS1_PADDING is no longer supported for private decryption, this can be reverted with --security-revert=CVE-2023-46809
[@joplin/lib]: 
[@joplin/lib]:       38 |
[@joplin/lib]:       39 | 	decrypt: async (ciphertextBase64: string, rsaKeyPair: RSAKeyPair): Promise<string> => {
[@joplin/lib]:     > 40 | 		return rsaKeyPair.decrypt(ciphertextBase64, 'utf8');
[@joplin/lib]:          | 		                  ^
[@joplin/lib]:       41 | 	},
[@joplin/lib]:       42 |
[@joplin/lib]:       43 | 	publicKey: (rsaKeyPair: RSAKeyPair): string => {
[@joplin/lib]: 
[@joplin/lib]:       at NodeRSA.Object.<anonymous>.module.exports.NodeRSA.$$decryptKey (node_modules/node-rsa/src/NodeRSA.js:301:19)
[@joplin/lib]:       at NodeRSA.Object.<anonymous>.module.exports.NodeRSA.decrypt (node_modules/node-rsa/src/NodeRSA.js:249:21)
[@joplin/lib]:       at Object.decrypt (services/e2ee/RSA.node.ts:40:21)
[@joplin/lib]:       at Object.decrypt (services/e2ee/ppk.ts:105:17)
[@joplin/lib]:       at EncryptionService.decrypt [as decryptMasterKeyContent] (services/e2ee/EncryptionService.ts:327:37)
[@joplin/lib]:       at decryptMasterKeyContent (services/e2ee/ppk.ts:126:17)
[@joplin/lib]:       at Object.<anonymous> (services/e2ee/ppk.test.ts:47:21)
```