### PR TITLE
Cli: Remove setting default value for Setting not used by the CLI

### DIFF
--- a/packages/app-cli/app/app.ts
+++ b/packages/app-cli/app/app.ts
@@ -8,7 +8,7 @@ import Note from '@joplin/lib/models/Note';
 import Tag from '@joplin/lib/models/Tag';
 import Setting from '@joplin/lib/models/Setting';
 import { reg } from '@joplin/lib/registry.js';
-import { dirname, fileExtension } from '@joplin/lib/path-utils';
+import { fileExtension } from '@joplin/lib/path-utils';
 import { splitCommandString } from '@joplin/utils';
 import { _ } from '@joplin/lib/locale';
 import { pathExists, readFile, readdirSync } from 'fs-extra';
@@ -397,11 +397,6 @@ class Application extends BaseApplication {
 	}
 
 	public async start(argv: string[]) {
-		// TODO: Currently, `pluginAssetDir` needs to be set differently for each platform and requires
-		// a call to Setting.setConstant. Ideally, this would be done in a way that requires users to
-		// set this constant on startup.
-		Setting.setConstant('pluginAssetDir', `${dirname(require.resolve('@joplin/renderer'))}/assets`);
-
 		const keychainEnabled = this.checkIfKeychainEnabled(argv);
 		argv = await super.start(argv, { keychainEnabled });
 

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -68,7 +68,6 @@ import OcrService from '../services/ocr/OcrService';
 import { createWorker } from 'tesseract.js';
 import { reg } from '../registry';
 import { Store } from 'redux';
-import { dirname } from '@joplin/utils/path';
 import SyncTargetJoplinServerSAML from '../SyncTargetJoplinServerSAML';
 
 // Each suite has its own separate data and temp directory so that multiple
@@ -199,7 +198,6 @@ Setting.setConstant('tempDir', baseTempDir);
 Setting.setConstant('cacheDir', baseTempDir);
 Setting.setConstant('resourceDir', baseTempDir);
 Setting.setConstant('pluginDataDir', `${profileDir}/profile/plugin-data`);
-Setting.setConstant('pluginAssetDir', `${dirname(require.resolve('@joplin/renderer'))}/assets`);
 Setting.setConstant('profileDir', profileDir);
 Setting.setConstant('rootProfileDir', rootProfileDir);
 Setting.setConstant('env', Env.Dev);


### PR DESCRIPTION
# Summary

In the [Desktop: Performance: Faster startup and smaller application size](https://github.com/laurent22/joplin/pull/12366) it was introduced a new constant `pluginAssetDir`, which seems to be causing some issue with the desktop configure, like related in the parent issue.

While trying to find a solution, I didn't find a reason why the constant needed to be set on `app-cli` as doesn't seems to be used anywhere there since we don't support the HTML exporter there and neither plugins.

# Testing

To test the change I run all automated tests and made some manual ones like:

## Test 1

1. Remove the `~/.config/joplindev` directory
2. Starting the `app-cli` application
3. Create notebook, note, edit note, etc.

## Test 2

1. Remove the `~/.config/joplindev` directory
2. Starting the `app-cli` application
3. Create notebook, note, edit note, etc.
4. Export the note to `md`, `jex` and `raw` format