### PR TITLE
Desktop: Fixes #12419: Ensure min and max validation is enforced when setting is not yet present (old)

### DIFF
--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -456,4 +456,18 @@ describe('models/Setting', () => {
 			await Setting.saveAll();
 		}
 	});
+
+	test('should enforce min and max values for when the setting is already in the cache and when it is not', async () => {
+		await Setting.reset();
+		Setting.setValue('revisionService.ttlDays', 0);
+		expect(Setting.value('revisionService.ttlDays')).toBe(1);
+		Setting.setValue('revisionService.ttlDays', 100000);
+		expect(Setting.value('revisionService.ttlDays')).toBe(99999);
+
+		await Setting.reset();
+		Setting.setValue('revisionService.ttlDays', 100000);
+		expect(Setting.value('revisionService.ttlDays')).toBe(99999);
+		Setting.setValue('revisionService.ttlDays', 0);
+		expect(Setting.value('revisionService.ttlDays')).toBe(1);
+	});
 });

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -694,6 +694,12 @@ class Setting extends BaseModel {
 			}
 		}
 
+		const md = this.settingMetadata(key);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied
+		if ('minimum' in md && value < md.minimum) value = md.minimum as any;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied
+		if ('maximum' in md && value > md.maximum) value = md.maximum as any;
+
 		this.cache_.push({
 			key: key,
 			value: this.formatValue(key, value),


### PR DESCRIPTION
This PR fixes an issue whereby the min / max value validation is not enforced for integer type settings, when the value is not currently present in the settings.json file. Currently, the validation is only enforced if the setting has been changed before and therefor is present. This change fixes a gap in the validation logic, which will align the behaviour to be the same for insert and update of setting values. I have manually tested this resolves the issue, as well as adding a test unit

This fixes https://github.com/laurent22/joplin/issues/12419