### PR TITLE
Desktop: Resolves #12224: Add an option to enable or disable search in OCR text

### DIFF
--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -579,14 +579,14 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			label: () => _('OCR: Clear cache and re-download language data files'),
 		},
 
-		'ocr.searchInContentExtracted': {
+		'ocr.searchInExtractedContent': {
 			value: true,
 			type: SettingItemType.Bool,
 			advanced: true,
 			public: true,
 			appTypes: [AppType.Desktop],
 			storage: SettingStorage.Database,
-			label: () => _('OCR: Search in content extracted via OCR'),
+			label: () => _('OCR: Search in extracted content'),
 		},
 
 		theme: {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -579,6 +579,16 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			label: () => _('OCR: Clear cache and re-download language data files'),
 		},
 
+		'ocr.searchInContentExtracted': {
+			value: true,
+			type: SettingItemType.Bool,
+			advanced: true,
+			public: true,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.Database,
+			label: () => _('OCR: Search in content extracted via OCR'),
+		},
+
 		theme: {
 			value: Setting.THEME_LIGHT,
 			type: SettingItemType.Int,

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -604,7 +604,7 @@ describe('services/SearchEngine', () => {
 			const normalized = await db().selectAll('select * from items_fts');
 			expect(normalized[0].body).toBe('hello, how are you ?');
 
-			Setting.setValue('ocr.searchInContentExtracted', isSearchEnabled);
+			Setting.setValue('ocr.searchInExtractedContent', isSearchEnabled);
 
 			const rows = await engine.search('hello', {
 				searchType: SearchEngine.SEARCH_TYPE_FTS,

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -1,8 +1,10 @@
-import { setupDatabaseAndSynchronizer, db, sleep, switchClient, msleep } from '../../testing/test-utils';
+import { setupDatabaseAndSynchronizer, db, sleep, switchClient, msleep, createNoteAndResource } from '../../testing/test-utils';
 import SearchEngine from './SearchEngine';
 import Note from '../../models/Note';
 import ItemChange from '../../models/ItemChange';
 import Setting from '../../models/Setting';
+import Resource from '../../models/Resource';
+import { ResourceOcrStatus } from '../database/types';
 
 let engine: SearchEngine = null;
 
@@ -582,5 +584,36 @@ describe('services/SearchEngine', () => {
 	// 	expect((await engine.search(n2.id))[0].id).toBe(n2.id);
 	// 	expect(await engine.search(f1.id)).toEqual([]);
 	// }));
+
+	it.each(
+		[
+			['find',		'enabled',	true,	1],
+			['not find',	'disabled',	false, 	3],
+		],
+	)('should %s resources if searching in OCR content is %s',
+		async (_testName: string, _testName2: string, isSearchEnabled: boolean, resultsFound: number) => {
+			const { resource } = await createNoteAndResource();
+			await Resource.save({
+				id: resource.id,
+				ocr_status: ResourceOcrStatus.Done,
+				ocr_text: 'héllô, hôw äre yoù ?',
+			});
+
+			await engine.syncTables();
+
+			const normalized = await db().selectAll('select * from items_fts');
+			expect(normalized[0].body).toBe('hello, how are you ?');
+
+			const searchInContextExtracted = Setting.value('ocr.searchInContentExtracted');
+			Setting.setValue('ocr.searchInContentExtracted', isSearchEnabled);
+
+			const rows = await engine.search('hello', {
+				searchType: SearchEngine.SEARCH_TYPE_FTS,
+				includeOrphanedResources: true,
+			});
+			expect(rows.length).toBe(resultsFound);
+
+			Setting.setValue('ocr.searchInContentExtracted', searchInContextExtracted);
+		});
 
 });

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -591,7 +591,7 @@ describe('services/SearchEngine', () => {
 			['not find',	'disabled',	false, 	3],
 		],
 	)('should %s resources if searching in OCR content is %s',
-		async (_testName: string, _testName2: string, isSearchEnabled: boolean, resultsFound: number) => {
+		async (_testName: string, _testName2: string, isSearchEnabled: boolean, resourcesFound: number) => {
 			const { resource } = await createNoteAndResource();
 			await Resource.save({
 				id: resource.id,
@@ -611,7 +611,7 @@ describe('services/SearchEngine', () => {
 				searchType: SearchEngine.SEARCH_TYPE_FTS,
 				includeOrphanedResources: true,
 			});
-			expect(rows.length).toBe(resultsFound);
+			expect(rows.length).toBe(resourcesFound);
 
 			Setting.setValue('ocr.searchInContentExtracted', searchInContextExtracted);
 		});

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -604,7 +604,6 @@ describe('services/SearchEngine', () => {
 			const normalized = await db().selectAll('select * from items_fts');
 			expect(normalized[0].body).toBe('hello, how are you ?');
 
-			const searchInContextExtracted = Setting.value('ocr.searchInContentExtracted');
 			Setting.setValue('ocr.searchInContentExtracted', isSearchEnabled);
 
 			const rows = await engine.search('hello', {
@@ -612,8 +611,6 @@ describe('services/SearchEngine', () => {
 				includeOrphanedResources: true,
 			});
 			expect(rows.length).toBe(resourcesFound);
-
-			Setting.setValue('ocr.searchInContentExtracted', searchInContextExtracted);
 		});
 
 });

--- a/packages/lib/services/search/SearchEngine.test.ts
+++ b/packages/lib/services/search/SearchEngine.test.ts
@@ -588,7 +588,7 @@ describe('services/SearchEngine', () => {
 	it.each(
 		[
 			['find',		'enabled',	true,	1],
-			['not find',	'disabled',	false, 	3],
+			['not find',	'disabled',	false, 	0],
 		],
 	)('should %s resources if searching in OCR content is %s',
 		async (_testName: string, _testName2: string, isSearchEnabled: boolean, resourcesFound: number) => {

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -809,7 +809,7 @@ export default class SearchEngine {
 					};
 				});
 
-				if (!queryHasFilters) {
+				if (!queryHasFilters && Setting.value('ocr.searchInContentExtracted')) {
 					const toSearch = parsedQuery.allTerms.map(t => t.value).join(' ');
 
 					let itemRows: ProcessResultsRow[] = [];

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -809,7 +809,7 @@ export default class SearchEngine {
 					};
 				});
 
-				if (!queryHasFilters && Setting.value('ocr.searchInContentExtracted')) {
+				if (!queryHasFilters && Setting.value('ocr.searchInExtractedContent')) {
 					const toSearch = parsedQuery.allTerms.map(t => t.value).join(' ');
 
 					let itemRows: ProcessResultsRow[] = [];


### PR DESCRIPTION
Resolves https://github.com/laurent22/joplin/issues/12224

# Summary

I'm adding a new setting that can disable the search engine to find notes that are associated with content that was OCR'ed. This allow users to use the search only through the notes, ignoring resources.

![image](https://github.com/user-attachments/assets/4baa831e-f6da-42af-bb99-6ad8eb5d9f64)

I was debating if it would be better to pass this setting as an option for `SearchEngine.search` or use directly where it is called, I end up using the second approach because it required less changes.

# Testing

I added two automated tests to test the on and off value.