### PR TITLE
Chore: VSCode workspace: Default to tab indentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-	"cSpell.enabled": true
+	"cSpell.enabled": true,
+	"editor.insertSpaces": false
 }


### PR DESCRIPTION
# Summary

Most of Joplin's source code uses tab indentation, rather than space indentation. This pull request updates Joplin's VSCode workspace file to use tab indentation for new files.

See also: [Description of the `editor.insertSpaces` setting](https://github.com/microsoft/vscode/blob/202f02381bfb70de8e7717daa3d440e429a8967c/src/vs/editor/common/config/editorConfigurationSchema.ts#L49).
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->