### PR TITLE
Mobile: Add missing title to the revision viewer for mobile

### DIFF
--- a/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
+++ b/packages/app-mobile/components/screens/NoteRevisionViewer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, SafeAreaView, ScrollView } from 'react-native';
 import { AppState } from '../../utils/types';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import Revision from '@joplin/lib/models/Revision';
@@ -102,6 +102,30 @@ const useStyles = (themeId: number) => {
 			root: {
 				...theme.rootStyle,
 			},
+			titleContainer: {
+				paddingLeft: theme.marginLeft,
+				paddingRight: theme.marginRight,
+				borderTopColor: theme.dividerColor,
+				borderTopWidth: 1,
+				borderBottomColor: theme.dividerColor,
+				borderBottomWidth: 1,
+			},
+			titleViewContainer: {
+				flex: 0,
+				flexDirection: 'row',
+				flexBasis: 'auto',
+			},
+			titleText: {
+				flex: 1,
+				marginTop: 0,
+				paddingLeft: 0,
+				color: theme.color,
+				backgroundColor: theme.backgroundColor,
+				fontWeight: 'bold',
+				fontSize: theme.fontSize,
+				paddingTop: 10,
+				paddingBottom: 10,
+			},
 		});
 	}, [themeId]);
 };
@@ -188,6 +212,16 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 		>{restoreButtonTitle}</PrimaryButton>
 	);
 
+	const titleComponent = (
+		<SafeAreaView style={styles.titleContainer}>
+			<ScrollView horizontal showsHorizontalScrollIndicator={false}>
+				<View style={styles.titleViewContainer}>
+					<Text style={styles.titleText}>{note?.title ?? ''}</Text>
+				</View>
+			</ScrollView>
+		</SafeAreaView>
+	);
+
 	return <View style={styles.root}>
 		<ScreenHeader menuOptions={menuOptions} title={_('Note history')} />
 		<View style={styles.controls}>
@@ -212,6 +246,7 @@ const NoteRevisionViewer: React.FC<Props> = props => {
 				onPress={onHelpPress}
 			/>
 		</View>
+		{note ? titleComponent : ''}
 		<NoteBodyViewer
 			style={styles.noteViewer}
 			noteBody={note?.body ?? _('No revision selected')}


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/12305 introduced a revision viewer for mobile. On the desktop app, the revision viewer includes the note title in addition to the note contents, which is currently missing on the revision viewer on mobile. As there are no undo / redo commands available on mobile for changes to note titles, it could be useful to be able to see this information on mobile as well. This PR adds this functionality to mobile.

Please note, it is not possible to make a disabled TextInput component horizontally scrollable, therefore I have implemented the note title section of the screen using a Text component wrapped in ScrollView in order to ensure that the full note title can be viewed for notes with a title which is longer than the width of the screen.

For todo notes, the desktop app does not indicate in the revision viewer whether it was checked / unchecked when the revision was created, so therefore I have not included this in the implementation for mobile.

Screenshots (tested on Android):
![revisiontitle1](https://github.com/user-attachments/assets/7bf2b13f-9fa1-4d78-9b44-9d6449d7efd1)
![revisiontitle2](https://github.com/user-attachments/assets/033b561a-00ea-49fd-bbd5-a52a99a02c44)
![landscape1](https://github.com/user-attachments/assets/67d65c73-e8e2-4721-84c4-0ff90efbbeac)
![landscape2](https://github.com/user-attachments/assets/74878e9c-9de2-4610-b486-4303edf6e0e1)
