### PR TITLE
Desktop,Cli: Fix data API failure when including both conflicts and deleted notes in results

### DIFF
--- a/packages/lib/models/utils/paginatedFeed.ts
+++ b/packages/lib/models/utils/paginatedFeed.ts
@@ -20,7 +20,7 @@ export interface WhereQuery {
 export default async function(db: any, tableName: string, pagination: Pagination, whereQuery: WhereQuery = null, fields: string[] = null): Promise<ModelFeedPage> {
 	fields = fields ? fields.slice() : ['id'];
 
-	const where = whereQuery ? [whereQuery.sql] : [];
+	const where = whereQuery && whereQuery.sql ? [whereQuery.sql] : [];
 	const sqlParams = whereQuery && whereQuery.params ? whereQuery.params.slice() : [];
 
 	if (!pagination.order.length) throw new Error('Pagination order must be provided');


### PR DESCRIPTION
# Summary

This pull request fixes an error in the data API when both `include_conflicts` is set to `1` and `include_deleted` is set to `1`. Previously, this would result in invalid SQL, resulting in an API server error.

# Details

If `include_conflicts` and `include_deleted` were both `1`, then `sql` would be `[]` below:

https://github.com/laurent22/joplin/blob/13711c6a9c48b4950d09246b0180687a6940e548/packages/lib/services/rest/routes/notes.ts#L487

As a result, the `sql` option would be `''` in `paginatedFeed.ts`:

https://github.com/laurent22/joplin/blob/cada200575392d9812e460d7a0f79501e8817717/packages/lib/models/utils/paginatedFeed.ts#L23

This would then generate SQL similar to the following:
```
SELECT `id`,`parent_id`,`title`,`deleted_time` FROM `notes`
                WHERE 
                ORDER BY `updated_time` COLLATE NOCASE ASC, `id` ASC
                LIMIT 3
                OFFSET 0
```

This would then result in an error similar to:

```
    Error: SQLITE_ERROR: near "ORDER": syntax error: 
                SELECT `id`,`parent_id`,`title`,`deleted_time` FROM `notes`
                WHERE 
                ORDER BY `updated_time` COLLATE NOCASE ASC, `id` ASC
                LIMIT 3
                OFFSET 0
```

# Testing

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->