### PR TITLE
Desktop: Disable console wrapper

### DIFF
--- a/packages/app-desktop/main-html.js
+++ b/packages/app-desktop/main-html.js
@@ -39,32 +39,6 @@ window.React = React;
 
 
 const main = async () => {
-	if (bridge().env() === 'dev') {
-		const newConsole = function(oldConsole) {
-			const output = {};
-			const fnNames = ['assert', 'clear', 'context', 'count', 'countReset', 'debug', 'dir', 'dirxml', 'error', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'memory', 'profile', 'profileEnd', 'table', 'time', 'timeEnd', 'timeLog', 'timeStamp', 'trace', 'warn'];
-			for (const fnName of fnNames) {
-				if (fnName === 'warn') {
-					output.warn = function(...text) {
-						const s = [...text].join('');
-						// React spams the console with walls of warnings even outside of strict mode, and even after having renamed
-						// unsafe methods to UNSAFE_xxxx, so we need to hack the console to remove them...
-						if (s.indexOf('Warning: componentWillReceiveProps has been renamed, and is not recommended for use') === 0) return;
-						if (s.indexOf('Warning: componentWillUpdate has been renamed, and is not recommended for use.') === 0) return;
-						oldConsole.warn(...text);
-					};
-				} else {
-					output[fnName] = function(...text) {
-						return oldConsole[fnName](...text);
-					};
-				}
-			}
-			return output;
-		}(window.console);
-
-		window.console = newConsole;
-	}
-
 	// eslint-disable-next-line no-console
 	console.info(`Environment: ${bridge().env()}`);
 


### PR DESCRIPTION
# Summary

This pull request disables a wrapper around `console.*` methods. This wrapper made it more difficult to determine where error messages came from in the development tools.

**Does not** completely resolve #12451, since the full-page error modals still have incorrect stack traces.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->