### PR TITLE
Cli: Refresh shares when running the sync command

### DIFF
--- a/packages/app-cli/app/command-sync.ts
+++ b/packages/app-cli/app/command-sync.ts
@@ -17,6 +17,7 @@ import { pathExists, writeFile } from 'fs-extra';
 import { checkIfLoginWasSuccessful, generateApplicationConfirmUrl } from '@joplin/lib/services/joplinCloudUtils';
 import Logger from '@joplin/utils/Logger';
 import { uuidgen } from '@joplin/lib/uuid';
+import ShareService from '@joplin/lib/services/share/ShareService';
 
 const logger = Logger.create('command-sync');
 
@@ -229,6 +230,10 @@ class Command extends BaseCommand {
 
 				return cleanUp();
 			}
+
+			// Refresh share invitations -- if running without a GUI, some of the
+			// maintenance tasks may otherwise be skipped.
+			await ShareService.instance().maintenance();
 
 			this.stdout(_('Starting synchronisation...'));
 


### PR DESCRIPTION
# Summary

This pull request extracts a change from the sync fuzzer pull request (#12592). Previously, the `sync` command in the CLI app did not refresh shares, causing issues with the sync fuzzer.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->