### PR TITLE
Desktop: Fix secondary window controls greyed out when first opened

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -343,6 +343,14 @@ export default class ElectronAppWrapper {
 			}, 1000);
 		}
 
+		const sendWindowFocused = (focusedWebContents: WebContents) => {
+			const joplinId = this.windowIdFromWebContents(focusedWebContents);
+
+			if (joplinId !== null) {
+				this.win_.webContents.send('window-focused', joplinId);
+			}
+		};
+
 		const addWindowEventHandlers = (webContents: WebContents) => {
 			// will-frame-navigate is fired by clicking on a link within the BrowserWindow.
 			webContents.on('will-frame-navigate', event => {
@@ -376,13 +384,10 @@ export default class ElectronAppWrapper {
 				addWindowEventHandlers(event.webContents);
 			});
 
-			webContents.on('focus', () => {
-				const joplinId = this.windowIdFromWebContents(webContents);
-
-				if (joplinId !== null) {
-					this.win_.webContents.send('window-focused', joplinId);
-				}
-			});
+			const onFocus = () => {
+				sendWindowFocused(webContents);
+			};
+			webContents.on('focus', onFocus);
 		};
 		addWindowEventHandlers(this.win_.webContents);
 
@@ -454,6 +459,10 @@ export default class ElectronAppWrapper {
 					this.win_.close();
 				}
 			});
+
+			if (window.isFocused()) {
+				sendWindowFocused(window.webContents);
+			}
 		});
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied


### PR DESCRIPTION
# Summary

This pull request fixes an issue where secondary window controls would be greyed out when first opened. The issue persisted until focus was switched away from then back to the secondary window.


This issue was caused by a race condition in registering the secondary window ID and the timing of the first `focus` event.


Possible regression from: 945b309

# Testing plan

1. Open a secondary window by double-clicking on an item in the note list.
2. Verify that the controls in the secondary window are not greyed out.
3. Move focus back to the main window.
4. Repeat steps 1-2.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->