### PR TITLE
Desktop: Fixes #12683: Fix web clipper fails to clip pages that include comments in inline styles

### DIFF
--- a/packages/app-cli/tests/html_to_md/comments_in_style.html
+++ b/packages/app-cli/tests/html_to_md/comments_in_style.html
@@ -1,0 +1,1 @@
+<p><span style="/* Comment */ text-decoration: underline;">Test</span>. In the past, <span style="font-size: auto;/* Test! */">comments</span> in CSS have caused issues.</p>

--- a/packages/app-cli/tests/html_to_md/comments_in_style.md
+++ b/packages/app-cli/tests/html_to_md/comments_in_style.md
@@ -1,0 +1,1 @@
+<ins>Test</ins>. In the past, comments in CSS have caused issues.

--- a/packages/turndown/src/utilities.js
+++ b/packages/turndown/src/utilities.js
@@ -124,6 +124,8 @@ export function getStyleProp(node, name) {
 
   const o = css.parse('div {' + style + '}');
   if (!o.stylesheet.rules.length) return null;
-  const prop = o.stylesheet.rules[0].declarations.find(d => d.property.toLowerCase() === name);
+  const prop = o.stylesheet.rules[0].declarations.find(d => {
+    return d.type === 'declaration' && d.property.toLowerCase() === name;
+  });
   return prop ? prop.value : null;
 }


### PR DESCRIPTION
# Summary

Fixes an issue where the web clipper could fail to clip certain pages due to inline comments in `style=""` attributes.

Fixes #12683.

# Testing

**Automated testing**: This pull request includes an automated test. It has been verified that this test fails without the changes to [utilities.js](https://github.com/laurent22/joplin/compare/dev...personalizedrefrigerator:pr/clipper/fix-style-comment-bug?expand=1#diff-1c9b6202336878240334ffc8ef251745b7b4b2fadcbd03a9746069419938f581) applied.

**Manual testing**:
1. Load the web clipper extension in development mode.
2. Start a development version of Joplin desktop.
3. Verify that it is possible to clip the blog from #12683 with "Clip complete page (Markdown)".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->