### PR TITLE
Desktop, Mobile: Resolves #12594: Move the conflicts folder to the top of the notebook list to improve visibility

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -357,7 +357,7 @@ export default class Folder extends BaseItem {
 
 		if (options && options.includeConflictFolder) {
 			const conflictCount = await Note.conflictedCount();
-			if (conflictCount) output.push(this.conflictFolder());
+			if (conflictCount) output.unshift(this.conflictFolder());
 		}
 
 		return output;


### PR DESCRIPTION
When a note conflict occurs, the conflicts folder appears at the bottom of the list of notebooks. If the user has many notebooks which requires scrolling to reach the bottom, the conflicts folder is not visible to the user unless they happen to look through their notebooks and scroll to the bottom. This is particularly a problem on mobile, where there is less space on the screen available.

This PR changes the ordering of the conflicts folder when it is visible, so it appears at the top of the notebook list, just below the all notebooks option, so that this will always be visible when the Joplin app starts, regardless of how many notebooks the user has.
This resolves https://github.com/laurent22/joplin/issues/12594

**Testing:**
I created a profile with many notebooks, so that it is required to scroll to the bottom of the notebook list, when the windows is below a certain size. I opened 2 Joplin clients which sync to the same sync target, and deliberately caused a conflict by changing a note in both clients without syncing between changes. I verified that the conflicts folder is added and appears the top of the notebook list, just after the all notebooks option. If I scroll down the notebook list so that the conflicts folder is not visible, when I restart Joplin, the scroll position returns to the top, and the conflicts folder is clearly visible. I then create a new notebook, and the conflicts folder retains it's position when the sorting re-applies. I have also verified that moving the on conflicting notes out of the conflicts folder makes the conflicts folder disappear. I have tested this on Windows and Android emulator

**Screenshots:**

Original behaviour:
![conflicta](https://github.com/user-attachments/assets/8bbaddf4-0f75-482c-83b1-34de23731446)
![conflictb](https://github.com/user-attachments/assets/fb92ee9a-fa21-4e51-a818-17d18bee4de4)

New behavior:
![conflicts](https://github.com/user-attachments/assets/fbadced2-87fb-4f44-89f6-5d0dcc5d9f7f)
![conflicts2](https://github.com/user-attachments/assets/10839438-7dd4-42e5-a233-8915bad4ffbe)
![conflictsmob](https://github.com/user-attachments/assets/2840d276-76fa-48d9-9367-5173e6f39763)

