### PR TITLE
Mobile: Biometrics: Fix notebook list can still be accessed when the app is locked

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -1346,7 +1346,6 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 					isOpen={this.props.showSideMenu}
 					disableGestures={disableSideMenuGestures}
 				>
-					<StatusBar barStyle={statusBarStyle} />
 					<View style={{ flexGrow: 1, flexShrink: 1, flexBasis: '100%' }}>
 						<SafeAreaView style={{ flex: 0, backgroundColor: theme.backgroundColor2 }}/>
 						<SafeAreaView style={{ flex: 1 }}>
@@ -1355,11 +1354,6 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 							</View>
 							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied */}
 							<DropdownAlert alert={(func: any) => (this.dropdownAlert_ = func)} />
-							{ !shouldShowMainContent && <BiometricPopup
-								dispatch={this.props.dispatch}
-								themeId={this.props.themeId}
-								sensorInfo={this.state.sensorInfo}
-							/> }
 						</SafeAreaView>
 					</View>
 				</SideMenu>
@@ -1409,12 +1403,21 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 					},
 				}}>
 					<DialogManager themeId={this.props.themeId}>
+						<StatusBar barStyle={statusBarStyle} />
 						<MenuProvider
 							style={{ flex: 1 }}
 							closeButtonLabel={_('Dismiss')}
 						>
 							<FocusControl.MainAppContent style={{ flex: 1 }}>
-								{mainContent}
+								{shouldShowMainContent ? mainContent : (
+									<SafeAreaView>
+										<BiometricPopup
+											dispatch={this.props.dispatch}
+											themeId={this.props.themeId}
+											sensorInfo={this.state.sensorInfo}
+										/>
+									</SafeAreaView>
+								)}
 							</FocusControl.MainAppContent>
 						</MenuProvider>
 					</DialogManager>


### PR DESCRIPTION
# Summary

This change prevents the notebook list from rendering when the app is locked. Previously, the sidebar and its default notebook list content was rendered regardless of `shouldShowMainContent`.

# Testing plan

**Regression testing (web)**:
1. Start the app.
2. Open the sidebar.
3. Verify that the notebook list is visible.
4. Hardcode `shouldShowMainContent` to `false`.
5. Hardcode the initial value of `display` to `true` in `BiometricPopup.tsx`.
6. Refresh the web app.
7. Verify that a "TRY AGAIN" button is visible.
8. Swipe from the left edge of the screen.
9. Verify a sidemenu is not visible.

Limited manual testing has also been done on a physical Android 13 device after applying this change to [the pull request that changes the library used for biometrics](https://github.com/laurent22/joplin/pull/12682).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->