### PR TITLE
Web: Image editor: Fix scrollbars sometimes incorrectly visible

### DIFF
--- a/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.tsx
@@ -60,6 +60,7 @@ const useCss = (editorTheme: Theme) => {
 			body, html {
 				padding: 0;
 				margin: 0;
+				overflow: hidden;
 			}
 
 			/* Hide the scrollbar. See scrollbar accessibility concerns


### PR DESCRIPTION
# Summary

Previously, when the image editor was running in the web app, it was possible for scrollbars to be incorrectly shown at the edges of the image editor frame.

# Screenshot comparison

| Before | After |
|--------|-------|
| ![screenshot: Vertical scrollbars shown on edges of the image editor](https://github.com/user-attachments/assets/0e239b55-eb2d-433a-b253-9eff3afee852)    | ![screenshot: No vertical scrollbars](https://github.com/user-attachments/assets/f5495a47-b5ba-4feb-aa57-51879dc7021d) |

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->