### PR TITLE
All: Update frontMatter parser to not output blank titles

### DIFF
--- a/packages/lib/utils/frontMatter.ts
+++ b/packages/lib/utils/frontMatter.ts
@@ -187,10 +187,13 @@ export const parse = (note: string): ParsedMeta => {
 
 	const md = toLowerCase(yaml.load(header, { schema: yaml.FAILSAFE_SCHEMA }) ?? {});
 	const metadata: NoteEntity = {
-		title: md['title'] || '',
 		source_url: md['source'] || '',
 		is_todo: ('completed?' in md) ? 1 : 0,
 	};
+
+	if ('title' in md) {
+		metadata['title'] = md.title;
+	}
 
 	if ('id' in md && typeof md['id'] === 'string' && md.id.match(/^[0-9a-zA-Z]{32}$/)) {
 		metadata['id'] = md.id;


### PR DESCRIPTION
This PR fixes the issue raised here:

https://discourse.joplinapp.org/t/imported-frontmatter-md-has-untitled-as-title/34105

I also ran into this issue importing my Obsidian Vault. Obsidian uses the filename to be the title of the note. This is also the expected behavior in Joplin: the importer should fall back to the file basename if no `title: ` is present in the frontmatter.

In the markdown with frontmatter importer, we have:
https://github.com/laurent22/joplin/blob/8b4ad0aaf75b7ac0f4c975cfed4f62119f52e8ea/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts#L14

This overwrites the default value for `title` with the frontmatter value if one is returned from the frontmatter helper.  Unfortunately the frontmatter helper is returning an empty `title` when one doesn't exist in the frontmatter and this clobbers the default from the filename.

The PR fixes the issue by having the frontmatter helper not return any title value if one is not present in the frontmatter.
