### PR TITLE
All: Importer_Md_frontmatter falls back to filename for the title

### DIFF
--- a/packages/app-cli/tests/support/test_notes/yaml/filename-title.md
+++ b/packages/app-cli/tests/support/test_notes/yaml/filename-title.md
@@ -1,0 +1,7 @@
+---
+aliases:
+  - An Obsidian-style note
+---
+
+This is a note with no `title` field in the YAML Frontmatter.
+Joplin should be smart enough to pull the title from the filename in such cases.

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.test.ts
@@ -204,4 +204,10 @@ describe('InteropService_Importer_Md_frontmatter: importMetadata', () => {
 			todo_completed: 0,
 		});
 	});
+
+	it('should use the filename in cases where the frontmatter has no title', async () => {
+		const note = await importTestFile('filename-title.md');
+
+		expect(note.title).toBe('filename-title');
+	});
 });

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
@@ -12,6 +12,9 @@ export default class InteropService_Importer_Md_frontmatter extends InteropServi
 			const { metadata, tags } = parse(note.body);
 
 			const updatedNote = { ...note, ...metadata };
+			if (!metadata['title']) {
+				updatedNote['title'] = note['title'];
+			}
 
 			const noteItem = await Note.save(updatedNote, { isNew: false, autoTimestamp: false });
 

--- a/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
+++ b/packages/lib/services/interop/InteropService_Importer_Md_frontmatter.ts
@@ -11,10 +11,11 @@ export default class InteropService_Importer_Md_frontmatter extends InteropServi
 			const note = await super.importFile(filePath, parentFolderId);
 			const { metadata, tags } = parse(note.body);
 
-			const updatedNote = { ...note, ...metadata };
-			if (!metadata['title']) {
-				updatedNote['title'] = note['title'];
-			}
+			const updatedNote = {
+				...note,
+				...metadata,
+				title: metadata.title ? metadata.title : note.title,
+			};
 
 			const noteItem = await Note.save(updatedNote, { isNew: false, autoTimestamp: false });
 


### PR DESCRIPTION
This PR fixes the issue raised here:

https://discourse.joplinapp.org/t/imported-frontmatter-md-has-untitled-as-title/34105

I also ran into this issue importing my Obsidian Vault. Obsidian uses the filename to be the title of the note. This is also the expected behavior in Joplin: the importer should fall back to the file basename if no `title: ` is present in the frontmatter.

This is an alternate solution to the one proposed in https://github.com/laurent22/joplin/pull/12696