### PR TITLE
CLI: new feature: add collapsible notebooks functionality

### DIFF
--- a/packages/app-cli/app/app-gui.js
+++ b/packages/app-cli/app/app-gui.js
@@ -380,6 +380,13 @@ class AppGui {
 		this.widget('noteList').toggleShowIds();
 	}
 
+	toggleFolderCollapse() {
+		const folderList = this.widget('folderList');
+		if (folderList && folderList.toggleFolderCollapse) {
+			folderList.toggleFolderCollapse();
+		}
+	}
+
 	widget(name) {
 		if (name === 'root') return this.rootWidget_;
 		return this.rootWidget_.childByName(name);
@@ -506,6 +513,8 @@ class AppGui {
 			this.toggleNoteMetadata();
 		} else if (cmd === 'toggle_ids') {
 			this.toggleFolderIds();
+		} else if (cmd === 'toggle_folder_collapse') {
+			this.toggleFolderCollapse();
 		} else if (cmd === 'enter_command_line_mode') {
 			const cmd = await this.widget('statusBar').prompt();
 			if (!cmd) return;

--- a/packages/app-cli/app/app.ts
+++ b/packages/app-cli/app/app.ts
@@ -222,6 +222,7 @@ class Application extends BaseApplication {
 		return { ...this.commandMetadata_ };
 	}
 
+
 	public hasGui() {
 		return this.gui() && !this.gui().isDummy();
 	}
@@ -332,6 +333,7 @@ class Application extends BaseApplication {
 			{ keys: ['mb'], type: 'prompt', command: 'mkbook ""', cursorPosition: -2 },
 			{ keys: ['yn'], type: 'prompt', command: 'cp $n ""', cursorPosition: -2 },
 			{ keys: ['dn'], type: 'prompt', command: 'mv $n ""', cursorPosition: -2 },
+			{ keys: ['z'], type: 'function', command: 'toggle_folder_collapse' },
 		];
 
 		// Filter the keymap item by command so that items in keymap.json can override

--- a/packages/app-cli/app/command-use.ts
+++ b/packages/app-cli/app/command-use.ts
@@ -2,6 +2,7 @@ import BaseCommand from './base-command';
 import app from './app';
 import { _ } from '@joplin/lib/locale';
 import BaseModel from '@joplin/lib/BaseModel';
+import Folder from '@joplin/lib/models/Folder';
 
 class Command extends BaseCommand {
 	public override usage() {
@@ -20,6 +21,18 @@ class Command extends BaseCommand {
 	public override async action(args: any) {
 		const folder = await app().loadItem(BaseModel.TYPE_FOLDER, args['notebook']);
 		if (!folder) throw new Error(_('Cannot find "%s".', args['notebook']));
+
+		// Auto-expand parent folders in GUI if present
+		if (app().gui() && app().gui().widget && app().gui().widget('folderList')) {
+			const folderListWidget = app().gui().widget('folderList');
+			if (folderListWidget.expandToFolder) {
+				// Get all folders to pass to expandToFolder
+				const folders = await Folder.all();
+				folderListWidget.folders = folders; // Ensure widget has current folders
+				folderListWidget.expandToFolder(folder.id);
+			}
+		}
+
 		app().switchCurrentFolder(folder);
 	}
 }

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -311,19 +311,4 @@ export default class FolderListWidget extends ListWidget {
 		this.updateItems_ = true;
 		this.invalidate();
 	}
-
-	public collapseAll() {
-		const foldersWithChildren = this.folders
-			.filter(folder => this.folderHasChildren_(this.folders, folder.id))
-			.map(folder => folder.id);
-		Setting.setValue('cli.folderCollapseState', foldersWithChildren);
-		this.updateItems_ = true;
-		this.invalidate();
-	}
-
-	public expandAll() {
-		Setting.setValue('cli.folderCollapseState', []);
-		this.updateItems_ = true;
-		this.invalidate();
-	}
 }

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -52,11 +52,7 @@ export default class FolderListWidget extends ListWidget {
 				}
 				output.push(Folder.displayTitle(item));
 
-				if (
-					Setting.value('showNoteCounts') &&
-          !item.deleted_time &&
-          item.id !== getTrashFolderId()
-				) {
+				if (Setting.value('showNoteCounts') && !item.deleted_time && item.id !== getTrashFolderId()) {
 					let noteCount = item.note_count;
 					if (this.folderHasChildren_(this.folders, item.id)) {
 						for (let i = 0; i < this.folders.length; i++) {
@@ -261,11 +257,7 @@ export default class FolderListWidget extends ListWidget {
 
 	public toggleFolderCollapse() {
 		const item = this.currentItem;
-		if (
-			item &&
-      item.type_ === Folder.modelType() &&
-      this.folderHasChildren_(this.folders, item.id)
-		) {
+		if (item && item.type_ === Folder.modelType() && this.folderHasChildren_(this.folders, item.id)) {
 			const collapsedFolders = Setting.value('collapsedFolderIds');
 			const isCollapsed = collapsedFolders.includes(item.id);
 			if (isCollapsed) {

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -40,7 +40,7 @@ export default class FolderListWidget extends ListWidget {
 				// Add collapse/expand indicator
 				const hasChildren = this.folderHasChildren_(this.folders, item.id);
 				if (hasChildren) {
-					const collapsedFolders = Setting.value('cli.folderCollapseState');
+					const collapsedFolders = Setting.value('collapsedFolderIds');
 					const isCollapsed = collapsedFolders.includes(item.id);
 					output.push(isCollapsed ? '[+] ' : '[-] ');
 				} else {
@@ -208,7 +208,7 @@ export default class FolderListWidget extends ListWidget {
 						newItems.push(f);
 						// Only recurse into children if the folder is not collapsed
 						if (this.folderHasChildren_(this.folders, f.id)) {
-							const collapsedFolders = Setting.value('cli.folderCollapseState');
+							const collapsedFolders = Setting.value('collapsedFolderIds');
 							if (!collapsedFolders.includes(f.id)) {
 								orderFolders(f.id);
 							}
@@ -266,13 +266,13 @@ export default class FolderListWidget extends ListWidget {
       item.type_ === Folder.modelType() &&
       this.folderHasChildren_(this.folders, item.id)
 		) {
-			const collapsedFolders = Setting.value('cli.folderCollapseState');
+			const collapsedFolders = Setting.value('collapsedFolderIds');
 			const isCollapsed = collapsedFolders.includes(item.id);
 			if (isCollapsed) {
 				const newCollapsed = collapsedFolders.filter((id: string) => id !== item.id);
-				Setting.setValue('cli.folderCollapseState', newCollapsed);
+				Setting.setValue('collapsedFolderIds', newCollapsed);
 			} else {
-				Setting.setValue('cli.folderCollapseState', [...collapsedFolders, item.id]);
+				Setting.setValue('collapsedFolderIds', [...collapsedFolders, item.id]);
 			}
 			this.updateItems_ = true;
 			this.invalidate();
@@ -304,9 +304,9 @@ export default class FolderListWidget extends ListWidget {
 		}
 
 		// Expand all parent folders
-		const collapsedFolders = Setting.value('cli.folderCollapseState');
+		const collapsedFolders = Setting.value('collapsedFolderIds');
 		const newCollapsed = collapsedFolders.filter((id: string) => !parentsToExpand.includes(id));
-		Setting.setValue('cli.folderCollapseState', newCollapsed);
+		Setting.setValue('collapsedFolderIds', newCollapsed);
 
 		this.updateItems_ = true;
 		this.invalidate();

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -10,91 +10,9 @@ import {
 } from '@joplin/lib/services/trash';
 const ListWidget = require('tkwidgets/ListWidget.js');
 
-// Service for managing folder collapse states
-class FolderCollapseService {
-	private static instance_: FolderCollapseService;
-	private collapsedFolders_: Set<string> = new Set();
-
-	public static instance(): FolderCollapseService {
-		if (!this.instance_) {
-			this.instance_ = new FolderCollapseService();
-			this.instance_.loadFromSettings();
-		}
-		return this.instance_;
-	}
-
-	public isCollapsed(folderId: string): boolean {
-		return this.collapsedFolders_.has(folderId);
-	}
-
-	public setCollapsed(folderId: string, collapsed: boolean) {
-		if (collapsed) {
-			this.collapsedFolders_.add(folderId);
-		} else {
-			this.collapsedFolders_.delete(folderId);
-		}
-		this.saveToSettings();
-	}
-
-	public toggleCollapsed(folderId: string): boolean {
-		const newState = !this.isCollapsed(folderId);
-		this.setCollapsed(folderId, newState);
-		return newState;
-	}
-
-	public expandToFolder(folderId: string, folders: FolderEntity[]) {
-		// Find all parent folders and expand them
-		const parentsToExpand: string[] = [];
-		let currentId = folderId;
-
-		while (currentId) {
-			const folder = BaseModel.byId(folders, currentId);
-			if (!folder) break;
-
-			const parentId = getDisplayParentId(
-				folder,
-				folders.find((f) => f.id === folder.parent_id),
-			);
-			if (parentId) {
-				parentsToExpand.unshift(parentId);
-				currentId = parentId;
-			} else {
-				break;
-			}
-		}
-
-		// Expand all parent folders
-		for (const parentId of parentsToExpand) {
-			this.setCollapsed(parentId, false);
-		}
-	}
-
-	private loadFromSettings() {
-		try {
-			const stored = Setting.value('cli.folderCollapseState');
-			if (stored && typeof stored === 'string') {
-				const folderIds = JSON.parse(stored);
-				this.collapsedFolders_ = new Set(folderIds);
-			}
-		} catch (error) {
-			// If there's an error loading, start with empty state
-			this.collapsedFolders_ = new Set();
-		}
-	}
-
-	private saveToSettings() {
-		try {
-			const folderIds = Array.from(this.collapsedFolders_);
-			Setting.setValue('cli.folderCollapseState', JSON.stringify(folderIds));
-		} catch (error) {
-			// Silently ignore save errors
-		}
-	}
-}
 
 export default class FolderListWidget extends ListWidget {
 	private folders_: FolderEntity[] = [];
-	private collapseService_: FolderCollapseService;
 
 	public constructor() {
 		super();
@@ -109,7 +27,6 @@ export default class FolderListWidget extends ListWidget {
 		this.updateItems_ = false;
 		this.trimItemTitle = false;
 		this.showIds = false;
-		this.collapseService_ = FolderCollapseService.instance();
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.itemRenderer = (item: any) => {
@@ -123,7 +40,8 @@ export default class FolderListWidget extends ListWidget {
 				// Add collapse/expand indicator
 				const hasChildren = this.folderHasChildren_(this.folders, item.id);
 				if (hasChildren) {
-					const isCollapsed = this.collapseService_.isCollapsed(item.id);
+					const collapsedFolders = Setting.value('collapsedFolderIds');
+					const isCollapsed = collapsedFolders.includes(item.id);
 					output.push(isCollapsed ? '[+] ' : '[-] ');
 				} else {
 					output.push('  '); // Space for alignment
@@ -289,11 +207,11 @@ export default class FolderListWidget extends ListWidget {
 					if (folderParentId === parentId) {
 						newItems.push(f);
 						// Only recurse into children if the folder is not collapsed
-						if (
-							this.folderHasChildren_(this.folders, f.id) &&
-              !this.collapseService_.isCollapsed(f.id)
-						) {
-							orderFolders(f.id);
+						if (this.folderHasChildren_(this.folders, f.id)) {
+							const collapsedFolders = Setting.value('collapsedFolderIds');
+							if (!collapsedFolders.includes(f.id)) {
+								orderFolders(f.id);
+							}
 						}
 					}
 				}
@@ -348,7 +266,14 @@ export default class FolderListWidget extends ListWidget {
       item.type_ === Folder.modelType() &&
       this.folderHasChildren_(this.folders, item.id)
 		) {
-			this.collapseService_.toggleCollapsed(item.id);
+			const collapsedFolders = Setting.value('collapsedFolderIds');
+			const isCollapsed = collapsedFolders.includes(item.id);
+			if (isCollapsed) {
+				const newCollapsed = collapsedFolders.filter((id: string) => id !== item.id);
+				Setting.setValue('collapsedFolderIds', newCollapsed);
+			} else {
+				Setting.setValue('collapsedFolderIds', [...collapsedFolders, item.id]);
+			}
 			this.updateItems_ = true;
 			this.invalidate();
 			return true;
@@ -356,33 +281,33 @@ export default class FolderListWidget extends ListWidget {
 		return false;
 	}
 
-	// Getter for external access to collapse service
-	public get collapseService() {
-		return this.collapseService_;
-	}
 
 	public expandToFolder(folderId: string) {
-		this.collapseService_.expandToFolder(folderId, this.folders);
-		this.updateItems_ = true;
-		this.invalidate();
-	}
+		// Find all parent folders and expand them
+		const parentsToExpand: string[] = [];
+		let currentId = folderId;
 
-	public collapseAll() {
-		for (const folder of this.folders) {
-			if (this.folderHasChildren_(this.folders, folder.id)) {
-				this.collapseService_.setCollapsed(folder.id, true);
+		while (currentId) {
+			const folder = BaseModel.byId(this.folders, currentId);
+			if (!folder) break;
+
+			const parentId = getDisplayParentId(
+				folder,
+				this.folders.find((f) => f.id === folder.parent_id),
+			);
+			if (parentId) {
+				parentsToExpand.unshift(parentId);
+				currentId = parentId;
+			} else {
+				break;
 			}
 		}
-		this.updateItems_ = true;
-		this.invalidate();
-	}
 
-	public expandAll() {
-		for (const folder of this.folders) {
-			if (this.folderHasChildren_(this.folders, folder.id)) {
-				this.collapseService_.setCollapsed(folder.id, false);
-			}
-		}
+		// Expand all parent folders
+		const collapsedFolders = Setting.value('collapsedFolderIds');
+		const newCollapsed = collapsedFolders.filter((id: string) => !parentsToExpand.includes(id));
+		Setting.setValue('collapsedFolderIds', newCollapsed);
+
 		this.updateItems_ = true;
 		this.invalidate();
 	}

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -10,91 +10,9 @@ import {
 } from '@joplin/lib/services/trash';
 const ListWidget = require('tkwidgets/ListWidget.js');
 
-// Service for managing folder collapse states
-class FolderCollapseService {
-	private static instance_: FolderCollapseService;
-	private collapsedFolders_: Set<string> = new Set();
-
-	public static instance(): FolderCollapseService {
-		if (!this.instance_) {
-			this.instance_ = new FolderCollapseService();
-			this.instance_.loadFromSettings();
-		}
-		return this.instance_;
-	}
-
-	public isCollapsed(folderId: string): boolean {
-		return this.collapsedFolders_.has(folderId);
-	}
-
-	public setCollapsed(folderId: string, collapsed: boolean) {
-		if (collapsed) {
-			this.collapsedFolders_.add(folderId);
-		} else {
-			this.collapsedFolders_.delete(folderId);
-		}
-		this.saveToSettings();
-	}
-
-	public toggleCollapsed(folderId: string): boolean {
-		const newState = !this.isCollapsed(folderId);
-		this.setCollapsed(folderId, newState);
-		return newState;
-	}
-
-	public expandToFolder(folderId: string, folders: FolderEntity[]) {
-		// Find all parent folders and expand them
-		const parentsToExpand: string[] = [];
-		let currentId = folderId;
-
-		while (currentId) {
-			const folder = BaseModel.byId(folders, currentId);
-			if (!folder) break;
-
-			const parentId = getDisplayParentId(
-				folder,
-				folders.find((f) => f.id === folder.parent_id),
-			);
-			if (parentId) {
-				parentsToExpand.unshift(parentId);
-				currentId = parentId;
-			} else {
-				break;
-			}
-		}
-
-		// Expand all parent folders
-		for (const parentId of parentsToExpand) {
-			this.setCollapsed(parentId, false);
-		}
-	}
-
-	private loadFromSettings() {
-		try {
-			const stored = Setting.value('cli.folderCollapseState');
-			if (stored && typeof stored === 'string') {
-				const folderIds = JSON.parse(stored);
-				this.collapsedFolders_ = new Set(folderIds);
-			}
-		} catch (error) {
-			// If there's an error loading, start with empty state
-			this.collapsedFolders_ = new Set();
-		}
-	}
-
-	private saveToSettings() {
-		try {
-			const folderIds = Array.from(this.collapsedFolders_);
-			Setting.setValue('cli.folderCollapseState', JSON.stringify(folderIds));
-		} catch (error) {
-			// Silently ignore save errors
-		}
-	}
-}
 
 export default class FolderListWidget extends ListWidget {
 	private folders_: FolderEntity[] = [];
-	private collapseService_: FolderCollapseService;
 
 	public constructor() {
 		super();
@@ -109,7 +27,6 @@ export default class FolderListWidget extends ListWidget {
 		this.updateItems_ = false;
 		this.trimItemTitle = false;
 		this.showIds = false;
-		this.collapseService_ = FolderCollapseService.instance();
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.itemRenderer = (item: any) => {
@@ -123,7 +40,8 @@ export default class FolderListWidget extends ListWidget {
 				// Add collapse/expand indicator
 				const hasChildren = this.folderHasChildren_(this.folders, item.id);
 				if (hasChildren) {
-					const isCollapsed = this.collapseService_.isCollapsed(item.id);
+					const collapsedFolders = Setting.value('cli.folderCollapseState');
+					const isCollapsed = collapsedFolders.includes(item.id);
 					output.push(isCollapsed ? '[+] ' : '[-] ');
 				} else {
 					output.push('  '); // Space for alignment
@@ -289,11 +207,11 @@ export default class FolderListWidget extends ListWidget {
 					if (folderParentId === parentId) {
 						newItems.push(f);
 						// Only recurse into children if the folder is not collapsed
-						if (
-							this.folderHasChildren_(this.folders, f.id) &&
-              !this.collapseService_.isCollapsed(f.id)
-						) {
-							orderFolders(f.id);
+						if (this.folderHasChildren_(this.folders, f.id)) {
+							const collapsedFolders = Setting.value('cli.folderCollapseState');
+							if (!collapsedFolders.includes(f.id)) {
+								orderFolders(f.id);
+							}
 						}
 					}
 				}
@@ -348,7 +266,14 @@ export default class FolderListWidget extends ListWidget {
       item.type_ === Folder.modelType() &&
       this.folderHasChildren_(this.folders, item.id)
 		) {
-			this.collapseService_.toggleCollapsed(item.id);
+			const collapsedFolders = Setting.value('cli.folderCollapseState');
+			const isCollapsed = collapsedFolders.includes(item.id);
+			if (isCollapsed) {
+				const newCollapsed = collapsedFolders.filter((id: string) => id !== item.id);
+				Setting.setValue('cli.folderCollapseState', newCollapsed);
+			} else {
+				Setting.setValue('cli.folderCollapseState', [...collapsedFolders, item.id]);
+			}
 			this.updateItems_ = true;
 			this.invalidate();
 			return true;
@@ -356,33 +281,48 @@ export default class FolderListWidget extends ListWidget {
 		return false;
 	}
 
-	// Getter for external access to collapse service
-	public get collapseService() {
-		return this.collapseService_;
-	}
 
 	public expandToFolder(folderId: string) {
-		this.collapseService_.expandToFolder(folderId, this.folders);
+		// Find all parent folders and expand them
+		const parentsToExpand: string[] = [];
+		let currentId = folderId;
+
+		while (currentId) {
+			const folder = BaseModel.byId(this.folders, currentId);
+			if (!folder) break;
+
+			const parentId = getDisplayParentId(
+				folder,
+				this.folders.find((f) => f.id === folder.parent_id),
+			);
+			if (parentId) {
+				parentsToExpand.unshift(parentId);
+				currentId = parentId;
+			} else {
+				break;
+			}
+		}
+
+		// Expand all parent folders
+		const collapsedFolders = Setting.value('cli.folderCollapseState');
+		const newCollapsed = collapsedFolders.filter((id: string) => !parentsToExpand.includes(id));
+		Setting.setValue('cli.folderCollapseState', newCollapsed);
+
 		this.updateItems_ = true;
 		this.invalidate();
 	}
 
 	public collapseAll() {
-		for (const folder of this.folders) {
-			if (this.folderHasChildren_(this.folders, folder.id)) {
-				this.collapseService_.setCollapsed(folder.id, true);
-			}
-		}
+		const foldersWithChildren = this.folders
+			.filter(folder => this.folderHasChildren_(this.folders, folder.id))
+			.map(folder => folder.id);
+		Setting.setValue('cli.folderCollapseState', foldersWithChildren);
 		this.updateItems_ = true;
 		this.invalidate();
 	}
 
 	public expandAll() {
-		for (const folder of this.folders) {
-			if (this.folderHasChildren_(this.folders, folder.id)) {
-				this.collapseService_.setCollapsed(folder.id, false);
-			}
-		}
+		Setting.setValue('cli.folderCollapseState', []);
 		this.updateItems_ = true;
 		this.invalidate();
 	}

--- a/packages/app-cli/app/gui/FolderListWidget.ts
+++ b/packages/app-cli/app/gui/FolderListWidget.ts
@@ -4,12 +4,97 @@ import BaseModel from '@joplin/lib/BaseModel';
 import Setting from '@joplin/lib/models/Setting';
 import { _ } from '@joplin/lib/locale';
 import { FolderEntity } from '@joplin/lib/services/database/types';
-import { getDisplayParentId, getTrashFolderId } from '@joplin/lib/services/trash';
+import {
+	getDisplayParentId,
+	getTrashFolderId,
+} from '@joplin/lib/services/trash';
 const ListWidget = require('tkwidgets/ListWidget.js');
 
-export default class FolderListWidget extends ListWidget {
+// Service for managing folder collapse states
+class FolderCollapseService {
+	private static instance_: FolderCollapseService;
+	private collapsedFolders_: Set<string> = new Set();
 
+	public static instance(): FolderCollapseService {
+		if (!this.instance_) {
+			this.instance_ = new FolderCollapseService();
+			this.instance_.loadFromSettings();
+		}
+		return this.instance_;
+	}
+
+	public isCollapsed(folderId: string): boolean {
+		return this.collapsedFolders_.has(folderId);
+	}
+
+	public setCollapsed(folderId: string, collapsed: boolean) {
+		if (collapsed) {
+			this.collapsedFolders_.add(folderId);
+		} else {
+			this.collapsedFolders_.delete(folderId);
+		}
+		this.saveToSettings();
+	}
+
+	public toggleCollapsed(folderId: string): boolean {
+		const newState = !this.isCollapsed(folderId);
+		this.setCollapsed(folderId, newState);
+		return newState;
+	}
+
+	public expandToFolder(folderId: string, folders: FolderEntity[]) {
+		// Find all parent folders and expand them
+		const parentsToExpand: string[] = [];
+		let currentId = folderId;
+
+		while (currentId) {
+			const folder = BaseModel.byId(folders, currentId);
+			if (!folder) break;
+
+			const parentId = getDisplayParentId(
+				folder,
+				folders.find((f) => f.id === folder.parent_id),
+			);
+			if (parentId) {
+				parentsToExpand.unshift(parentId);
+				currentId = parentId;
+			} else {
+				break;
+			}
+		}
+
+		// Expand all parent folders
+		for (const parentId of parentsToExpand) {
+			this.setCollapsed(parentId, false);
+		}
+	}
+
+	private loadFromSettings() {
+		try {
+			const stored = Setting.value('cli.folderCollapseState');
+			if (stored && typeof stored === 'string') {
+				const folderIds = JSON.parse(stored);
+				this.collapsedFolders_ = new Set(folderIds);
+			}
+		} catch (error) {
+			// If there's an error loading, start with empty state
+			this.collapsedFolders_ = new Set();
+		}
+	}
+
+	private saveToSettings() {
+		try {
+			const folderIds = Array.from(this.collapsedFolders_);
+			Setting.setValue('cli.folderCollapseState', JSON.stringify(folderIds));
+		} catch (error) {
+			// Silently ignore save errors
+		}
+	}
+}
+
+export default class FolderListWidget extends ListWidget {
 	private folders_: FolderEntity[] = [];
+	private collapseService_: FolderCollapseService;
 
 	public constructor() {
 		super();
@@ -24,6 +109,7 @@ export default class FolderListWidget extends ListWidget {
 		this.updateItems_ = false;
 		this.trimItemTitle = false;
 		this.showIds = false;
+		this.collapseService_ = FolderCollapseService.instance();
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.itemRenderer = (item: any) => {
@@ -31,14 +117,28 @@ export default class FolderListWidget extends ListWidget {
 			if (item === '-') {
 				output.push('-'.repeat(this.innerWidth));
 			} else if (item.type_ === Folder.modelType()) {
-				output.push(' '.repeat(this.folderDepth(this.folders, item.id)));
+				const depth = this.folderDepth(this.folders, item.id);
+				output.push(' '.repeat(depth));
+
+				// Add collapse/expand indicator
+				const hasChildren = this.folderHasChildren_(this.folders, item.id);
+				if (hasChildren) {
+					const isCollapsed = this.collapseService_.isCollapsed(item.id);
+					output.push(isCollapsed ? '[+] ' : '[-] ');
+				} else {
+					output.push('  '); // Space for alignment
+				}
 
 				if (this.showIds) {
 					output.push(Folder.shortId(item.id));
 				}
 				output.push(Folder.displayTitle(item));
 
-				if (Setting.value('showNoteCounts') && !item.deleted_time && item.id !== getTrashFolderId()) {
+				if (
+					Setting.value('showNoteCounts') &&
+          !item.deleted_time &&
+          item.id !== getTrashFolderId()
+				) {
 					let noteCount = item.note_count;
 					if (this.folderHasChildren_(this.folders, item.id)) {
 						for (let i = 0; i < this.folders.length; i++) {
@@ -65,7 +165,10 @@ export default class FolderListWidget extends ListWidget {
 		let output = 0;
 		while (true) {
 			const folder = BaseModel.byId(folders, folderId);
-			const folderParentId = getDisplayParentId(folder, folders.find(f => f.id === folder.parent_id));
+			const folderParentId = getDisplayParentId(
+				folder,
+				folders.find((f) => f.id === folder.parent_id),
+			);
 			if (!folder || !folderParentId) return output;
 			output++;
 			folderId = folderParentId;
@@ -153,7 +256,10 @@ export default class FolderListWidget extends ListWidget {
 	public folderHasChildren_(folders: FolderEntity[], folderId: string) {
 		for (let i = 0; i < folders.length; i++) {
 			const folder = folders[i];
-			const folderParentId = getDisplayParentId(folder, folders.find(f => f.id === folder.parent_id));
+			const folderParentId = getDisplayParentId(
+				folder,
+				folders.find((f) => f.id === folder.parent_id),
+			);
 			if (folderParentId === folderId) return true;
 		}
 		return false;
@@ -161,7 +267,12 @@ export default class FolderListWidget extends ListWidget {
 
 	public render() {
 		if (this.updateItems_) {
-			this.logger().debug('Rebuilding items...', this.notesParentType, this.selectedJoplinItemId, this.selectedSearchId);
+			this.logger().debug(
+				'Rebuilding items...',
+				this.notesParentType,
+				this.selectedJoplinItemId,
+				this.selectedSearchId,
+			);
 			const wasSelectedItemId = this.selectedJoplinItemId;
 			const previousParentType = this.notesParentType;
 
@@ -170,12 +281,20 @@ export default class FolderListWidget extends ListWidget {
 			const orderFolders = (parentId: string) => {
 				for (let i = 0; i < this.folders.length; i++) {
 					const f = this.folders[i];
-					const originalParent = this.folders_.find(f => f.id === f.parent_id);
+					const originalParent = this.folders_.find(
+						(f) => f.id === f.parent_id,
+					);
 
 					const folderParentId = getDisplayParentId(f, originalParent); // f.parent_id ? f.parent_id : '';
 					if (folderParentId === parentId) {
 						newItems.push(f);
-						if (this.folderHasChildren_(this.folders, f.id)) orderFolders(f.id);
+						// Only recurse into children if the folder is not collapsed
+						if (
+							this.folderHasChildren_(this.folders, f.id) &&
+              !this.collapseService_.isCollapsed(f.id)
+						) {
+							orderFolders(f.id);
+						}
 					}
 				}
 			};
@@ -220,5 +339,51 @@ export default class FolderListWidget extends ListWidget {
 		if (itemId === null) itemId = this.selectedJoplinItemId;
 		const index = this.itemIndexByKey('id', itemId);
 		this.currentIndex = index >= 0 ? index : 0;
+	}
+
+	public toggleFolderCollapse() {
+		const item = this.currentItem;
+		if (
+			item &&
+      item.type_ === Folder.modelType() &&
+      this.folderHasChildren_(this.folders, item.id)
+		) {
+			this.collapseService_.toggleCollapsed(item.id);
+			this.updateItems_ = true;
+			this.invalidate();
+			return true;
+		}
+		return false;
+	}
+
+	// Getter for external access to collapse service
+	public get collapseService() {
+		return this.collapseService_;
+	}
+
+	public expandToFolder(folderId: string) {
+		this.collapseService_.expandToFolder(folderId, this.folders);
+		this.updateItems_ = true;
+		this.invalidate();
+	}
+
+	public collapseAll() {
+		for (const folder of this.folders) {
+			if (this.folderHasChildren_(this.folders, folder.id)) {
+				this.collapseService_.setCollapsed(folder.id, true);
+			}
+		}
+		this.updateItems_ = true;
+		this.invalidate();
+	}
+
+	public expandAll() {
+		for (const folder of this.folders) {
+			if (this.folderHasChildren_(this.folders, folder.id)) {
+				this.collapseService_.setCollapsed(folder.id, false);
+			}
+		}
+		this.updateItems_ = true;
+		this.invalidate();
 	}
 }

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1660,6 +1660,15 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'cli.folderCollapseState': {
+			value: '[]',
+			type: SettingItemType.String,
+			public: false,
+			appTypes: [AppType.Cli],
+			storage: SettingStorage.File,
+			isGlobal: true,
+		},
+
 		'syncInfoCache': {
 			value: '',
 			type: SettingItemType.String,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1660,14 +1660,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
-		'cli.folderCollapseState': {
-			value: '[]',
-			type: SettingItemType.String,
-			public: false,
-			appTypes: [AppType.Cli],
-			storage: SettingStorage.File,
-			isGlobal: true,
-		},
 
 		'syncInfoCache': {
 			value: '',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1660,7 +1660,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
-
 		'syncInfoCache': {
 			value: '',
 			type: SettingItemType.String,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1660,14 +1660,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
-		'cli.folderCollapseState': {
-			value: [] as string[],
-			type: SettingItemType.Array,
-			public: false,
-			appTypes: [AppType.Cli],
-			storage: SettingStorage.File,
-			isGlobal: true,
-		},
 
 		'syncInfoCache': {
 			value: '',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1661,8 +1661,8 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		},
 
 		'cli.folderCollapseState': {
-			value: '[]',
-			type: SettingItemType.String,
+			value: [] as string[],
+			type: SettingItemType.Array,
 			public: false,
 			appTypes: [AppType.Cli],
 			storage: SettingStorage.File,


### PR DESCRIPTION
- Allows to collapse notebooks with nested notebooks
- Visual indicator for collapsed [+] and expanded [-] notebooks
- Collapse states persistent across restarts (cli.folderCollapseState setting)
- Keyboard shortcut 'z' toggles between collase/expand

Partially resolves #6475

<img width="1282" height="225" alt="collapsed2" src="https://github.com/user-attachments/assets/ea82fbcf-ed42-4f5a-a32e-de8ab476719a" />
<img width="1279" height="174" alt="collapsed1" src="https://github.com/user-attachments/assets/14137f96-10d2-4762-bc27-d4cdf52f74d3" />
