### PR TITLE
Chore: Migrate `urlUtils` from deprecated `url.parse` to `URL`

### DIFF
--- a/packages/lib/htmlUtils2.test.ts
+++ b/packages/lib/htmlUtils2.test.ts
@@ -58,24 +58,31 @@ describe('htmlUtils', () => {
 		}
 	}));
 
-	it.each([
-		[
-			'<a href="a.html">Something</a>',
-			'http://test.com',
-			'<a href="http://test.com/a.html">Something</a>',
-		],
-		[
-			'<a href="a.html">a</a> <a href="b.html">b</a>',
-			'http://test.com',
-			'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
-		],
-		[
-			'<a href="a.html">a</a> <a href="b.html">b</a>',
-			'http://test.com',
-			'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
-		],
-	])('should prepend a base URL (html: %j, baseUrl: %j)', (html, baseUrl, expected) => {
-		expect(htmlUtils.prependBaseUrl(html, baseUrl)).toBe(expected);
-	});
+	it('should prepend a base URL', (async () => {
+		const testCases = [
+			[
+				'<a href="a.html">Something</a>',
+				'http://test.com',
+				'<a href="http://test.com/a.html">Something</a>',
+			],
+			[
+				'<a href="a.html">a</a> <a href="b.html">b</a>',
+				'http://test.com',
+				'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
+			],
+			[
+				'<a href="a.html">a</a> <a href="b.html">b</a>',
+				'http://test.com',
+				'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
+			],
+		];
+
+		for (let i = 0; i < testCases.length; i++) {
+			const html = testCases[i][0];
+			const baseUrl = testCases[i][1];
+			const expected = testCases[i][2];
+			expect(htmlUtils.prependBaseUrl(html, baseUrl)).toBe(expected);
+		}
+	}));
 
 });

--- a/packages/lib/htmlUtils2.test.ts
+++ b/packages/lib/htmlUtils2.test.ts
@@ -58,31 +58,24 @@ describe('htmlUtils', () => {
 		}
 	}));
 
-	it('should prepend a base URL', (async () => {
-		const testCases = [
-			[
-				'<a href="a.html">Something</a>',
-				'http://test.com',
-				'<a href="http://test.com/a.html">Something</a>',
-			],
-			[
-				'<a href="a.html">a</a> <a href="b.html">b</a>',
-				'http://test.com',
-				'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
-			],
-			[
-				'<a href="a.html">a</a> <a href="b.html">b</a>',
-				'http://test.com',
-				'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
-			],
-		];
-
-		for (let i = 0; i < testCases.length; i++) {
-			const html = testCases[i][0];
-			const baseUrl = testCases[i][1];
-			const expected = testCases[i][2];
-			expect(htmlUtils.prependBaseUrl(html, baseUrl)).toBe(expected);
-		}
-	}));
+	it.each([
+		[
+			'<a href="a.html">Something</a>',
+			'http://test.com',
+			'<a href="http://test.com/a.html">Something</a>',
+		],
+		[
+			'<a href="a.html">a</a> <a href="b.html">b</a>',
+			'http://test.com',
+			'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
+		],
+		[
+			'<a href="a.html">a</a> <a href="b.html">b</a>',
+			'http://test.com',
+			'<a href="http://test.com/a.html">a</a> <a href="http://test.com/b.html">b</a>',
+		],
+	])('should prepend a base URL (html: %j, baseUrl: %j)', (html, baseUrl, expected) => {
+		expect(htmlUtils.prependBaseUrl(html, baseUrl)).toBe(expected);
+	});
 
 });

--- a/packages/lib/urlUtils.test.js
+++ b/packages/lib/urlUtils.test.js
@@ -91,4 +91,22 @@ describe('urlUtils', () => {
 		}
 	}));
 
+	it('urlProtocol should detect file protocol URLs', () => {
+		expect(urlUtils.urlProtocol('file:/test')).toBe('file:');
+		expect(urlUtils.urlProtocol('file://test')).toBe('file:');
+		expect(urlUtils.urlProtocol('file:///test')).toBe('file:');
+		expect(urlUtils.urlProtocol('file://C:\\Users\\test`')).toBe('file:');
+	});
+
+	it('urlProtocol should return null for non-empty URLs with no protocol', () => {
+		expect(urlUtils.urlProtocol('invalid!protocol:/test')).toBe(null);
+		expect(urlUtils.urlProtocol('!protocol:/test')).toBe(null);
+		expect(urlUtils.urlProtocol('.protocol:/test')).toBe(null);
+	});
+
+	it('urlProtocol should support protocols with uppercase characters, hyphens, and +s', () => {
+		expect(urlUtils.urlProtocol('ValidProtocol:/test')).toBe('validprotocol:');
+		expect(urlUtils.urlProtocol('valid-protocol:/test')).toBe('valid-protocol:');
+		expect(urlUtils.urlProtocol('valid+protocol:/test')).toBe('valid+protocol:');
+	});
 });

--- a/packages/lib/urlUtils.test.js
+++ b/packages/lib/urlUtils.test.js
@@ -14,6 +14,7 @@ describe('urlUtils', () => {
 		expect(urlUtils.prependBaseUrl('//somewhereelse.com/testing.html', 'http://example.com/something')).toBe('http://somewhereelse.com/testing.html');
 		expect(urlUtils.prependBaseUrl('', 'http://example.com/something')).toBe('http://example.com/something');
 		expect(urlUtils.prependBaseUrl('testing.html', '')).toBe('testing.html');
+		expect(urlUtils.prependBaseUrl('/testing.html', '')).toBe('/testing.html');
 
 		// It shouldn't prepend anything for these:
 		expect(urlUtils.prependBaseUrl('mailto:emailme@example.com', 'http://example.com')).toBe('mailto:emailme@example.com');

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -8,13 +8,19 @@ export const hash = (url: string) => {
 };
 
 export const urlWithoutPath = (url: string) => {
-	const parsed = require('url').parse(url, true);
+	const parsed = new URL(url);
 	return `${parsed.protocol}//${parsed.host}`;
 };
 
 export const urlProtocol = (url: string) => {
 	if (!url) return '';
-	const parsed = require('url').parse(url, true);
+	// Check whether the URL is missing a protocol, return null to match the behavior of the
+	// NodeJS 'url' library.
+	//
+	// See https://www.rfc-editor.org/rfc/rfc3986#section-3.1 for valid URI schemes.
+	if (!url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]+:/)) return null;
+
+	const parsed = new URL(url);
 	return parsed.protocol;
 };
 

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -14,13 +14,14 @@ export const urlWithoutPath = (url: string) => {
 
 export const urlProtocol = (url: string) => {
 	if (!url) return '';
-	// Check whether the URL is missing a protocol, return null to match the behavior of the
-	// NodeJS 'url' library.
-	//
-	// See https://www.rfc-editor.org/rfc/rfc3986#section-3.1 for valid URI schemes.
-	if (!url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]+:/)) return null;
 
-	const parsed = new URL(url);
+	let parsed;
+	try {
+		parsed = new URL(url);
+	} catch (error) {
+		// Match the NodeJS url.parse behavior in the case of an invalid URL:
+		return null;
+	}
 	return parsed.protocol;
 };
 


### PR DESCRIPTION
# Summary

This pull request migrates `urlUtils.ts` from `require('url').parse` to the [`new URL` constructor](https://nodejs.org/api/url.html#class-url).

- [`require('url').parse` is deprecated](https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost)
- https://github.com/laurent22/joplin/pull/12748 involves using `HtmlToMd.ts` on mobile (in a WebView) where `require('url')` doesn't work. Migrating to `new URL` allows this functionality to work on mobile and web.

This pull request adds additional automated tests.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->