### PR TITLE
Chore: Desktop: Migrate entrypoint to TypeScript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -553,6 +553,8 @@ packages/app-desktop/integration-tests/util/setSettingValue.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
 packages/app-desktop/integration-tests/wcag.spec.js
+packages/app-desktop/main-html.js
+packages/app-desktop/main.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js
 packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -528,6 +528,8 @@ packages/app-desktop/integration-tests/util/setSettingValue.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
 packages/app-desktop/integration-tests/wcag.spec.js
+packages/app-desktop/main-html.js
+packages/app-desktop/main.js
 packages/app-desktop/playwright.config.js
 packages/app-desktop/plugins/GotoAnything.js
 packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.js

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -1,36 +1,37 @@
 // This is the initialization for the Electron RENDERER process
 
+
 // Disable React message in console "Download the React DevTools for a better development experience"
 // https://stackoverflow.com/questions/42196819/disable-hide-download-the-react-devtools#42196820
-// eslint-disable-next-line no-undef
-window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+// eslint-disable-next-line no-undef, @typescript-eslint/no-explicit-any
+(window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
 	supportsFiber: true,
 	inject: function() {},
 	onCommitFiberRoot: function() {},
 	onCommitFiberUnmount: function() {},
 };
 
-require('./utils/sourceMapSetup');
-const app = require('./app').default;
-const Folder = require('@joplin/lib/models/Folder').default;
-const Resource = require('@joplin/lib/models/Resource').default;
-const BaseItem = require('@joplin/lib/models/BaseItem').default;
-const Note = require('@joplin/lib/models/Note').default;
-const Tag = require('@joplin/lib/models/Tag').default;
-const NoteTag = require('@joplin/lib/models/NoteTag').default;
-const MasterKey = require('@joplin/lib/models/MasterKey').default;
-const Setting = require('@joplin/lib/models/Setting').default;
-const Revision = require('@joplin/lib/models/Revision').default;
-const Logger = require('@joplin/utils/Logger').default;
-const FsDriverNode = require('@joplin/lib/fs-driver-node').default;
-const bridge = require('./services/bridge').default;
-const shim = require('@joplin/lib/shim').default;
+import './utils/sourceMapSetup';
+import app from './app';
+import Folder from '@joplin/lib/models/Folder';
+import Resource from '@joplin/lib/models/Resource';
+import BaseItem from '@joplin/lib/models/BaseItem';
+import Note from '@joplin/lib/models/Note';
+import Tag from '@joplin/lib/models/Tag';
+import NoteTag from '@joplin/lib/models/NoteTag';
+import MasterKey from '@joplin/lib/models/MasterKey';
+import Setting, { AppType } from '@joplin/lib/models/Setting';
+import Revision from '@joplin/lib/models/Revision';
+import Logger from '@joplin/utils/Logger';
+import FsDriverNode from '@joplin/lib/fs-driver-node';
+import bridge from './services/bridge';
+import shim from '@joplin/lib/shim';
 const { shimInit } = require('@joplin/lib/shim-init-node.js');
-const EncryptionService = require('@joplin/lib/services/e2ee/EncryptionService').default;
-const FileApiDriverLocal = require('@joplin/lib/file-api-driver-local').default;
-const React = require('react');
-const nodeSqlite = require('sqlite3');
-const initLib = require('@joplin/lib/initLib').default;
+import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
+import FileApiDriverLocal from '@joplin/lib/file-api-driver-local';
+import * as React from 'react';
+import nodeSqlite = require('sqlite3');
+import initLib from '@joplin/lib/initLib';
 const pdfJs = require('pdfjs-dist');
 const { isAppleSilicon } = require('is-apple-silicon');
 require('@sentry/electron/renderer');
@@ -60,7 +61,7 @@ const main = async () => {
 	BaseItem.loadClass('Revision', Revision);
 
 	Setting.setConstant('appId', bridge().appId());
-	Setting.setConstant('appType', 'desktop');
+	Setting.setConstant('appType', AppType.Desktop);
 	Setting.setConstant('pluginAssetDir', `${__dirname}/pluginAssets`);
 
 	// eslint-disable-next-line no-console
@@ -127,6 +128,6 @@ main().catch((error) => {
 	// In dev, we give the option to leave the app open as debug statements in the
 	// console can be useful
 	const canIgnore = env === 'dev';
-	bridge().electronApp().handleAppFailure(errorMessage, canIgnore);
+	void bridge().electronApp().handleAppFailure(errorMessage, canIgnore);
 });
 

--- a/packages/app-desktop/main-html.ts
+++ b/packages/app-desktop/main-html.ts
@@ -1,6 +1,5 @@
 // This is the initialization for the Electron RENDERER process
 
-
 // Disable React message in console "Download the React DevTools for a better development experience"
 // https://stackoverflow.com/questions/42196819/disable-hide-download-the-react-devtools#42196820
 // eslint-disable-next-line no-undef, @typescript-eslint/no-explicit-any

--- a/packages/app-desktop/main.ts
+++ b/packages/app-desktop/main.ts
@@ -1,18 +1,18 @@
 // This is the basic initialization for the Electron MAIN process
 
-require('./utils/sourceMapSetup');
-const electronApp = require('electron').app;
+import './utils/sourceMapSetup';
+import { app as electronApp } from 'electron';
 require('@electron/remote/main').initialize();
-const ElectronAppWrapper = require('./ElectronAppWrapper').default;
-const { pathExistsSync, readFileSync, mkdirpSync } = require('fs-extra');
-const { initBridge } = require('./bridge');
-const Logger = require('@joplin/utils/Logger').default;
-const FsDriverNode = require('@joplin/lib/fs-driver-node').default;
+import ElectronAppWrapper from './ElectronAppWrapper';
+import { pathExistsSync, readFileSync, mkdirpSync } from 'fs-extra';
+import { initBridge } from './bridge';
+import Logger from '@joplin/utils/Logger';
+import FsDriverNode from '@joplin/lib/fs-driver-node';
 const envFromArgs = require('@joplin/lib/envFromArgs');
 const packageInfo = require('./packageInfo.js');
-const { isCallbackUrl } = require('@joplin/lib/callbackUrlUtils');
-const determineBaseAppDirs = require('@joplin/lib/determineBaseAppDirs').default;
-const registerCustomProtocols = require('./utils/customProtocols/registerCustomProtocols').default;
+import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import determineBaseAppDirs from '@joplin/lib/determineBaseAppDirs';
+import registerCustomProtocols from './utils/customProtocols/registerCustomProtocols';
 
 // Electron takes the application name from package.json `name` and
 // displays this in the tray icon toolip and message box titles, however in
@@ -26,7 +26,7 @@ process.on('unhandledRejection', (reason, p) => {
 	process.exit(1);
 });
 
-const getFlagValueFromArgs = (args, flag, defaultValue) => {
+const getFlagValueFromArgs = (args: string[], flag: string, defaultValue: string|null) => {
 	if (!args) return null;
 	const index = args.indexOf(flag);
 	if (index <= 0 || index >= args.length - 1) return defaultValue;
@@ -75,7 +75,13 @@ const wrapper = new ElectronAppWrapper(electronApp, {
 	env, profilePath: rootProfileDir, isDebugMode, initialCallbackUrl, isEndToEndTesting,
 });
 
-globalThis.joplinBridge = initBridge(wrapper, appId, appName, rootProfileDir, autoUploadCrashDumps, altInstanceId);
+
+type ExtendedGlobal = {
+	joplinBridge: unknown;
+};
+(globalThis as unknown as ExtendedGlobal).joplinBridge = (
+	initBridge(wrapper, appId, appName, rootProfileDir, autoUploadCrashDumps, altInstanceId)
+);
 
 wrapper.start().catch((error) => {
 	console.error('Electron App fatal error:');

--- a/packages/app-desktop/tools/bundleJs.ts
+++ b/packages/app-desktop/tools/bundleJs.ts
@@ -120,8 +120,8 @@ const makeBuildContext = (entryPoint: string, renderer: boolean, computeFileSize
 
 const bundleJs = async (writeStats: boolean) => {
 	const entryPoints = [
-		{ fileName: 'main.js', renderer: false },
-		{ fileName: 'main-html.js', renderer: true },
+		{ fileName: 'main.ts', renderer: false },
+		{ fileName: 'main-html.ts', renderer: true },
 	];
 	for (const { fileName, renderer } of entryPoints) {
 		const compiler = await makeBuildContext(fileName, renderer, writeStats);


### PR DESCRIPTION
# Summary

This pull request migrates the main entrypoints for the desktop app from JavaScript to TypeScript.

# Testing

In addition to the automated end-to-end testing, I have:
1. Build a release version of the desktop app (`cd packages/app-desktop && yarn dist`).
2. Verified that the release version can start successfully (`cd ./dist && ./Joplin-3.4.2.AppImage`)
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->