### PR TITLE
Desktop, Mobile: Fixes #11902: Add fail-safe error for folder conflicts where the remote object no longer exists

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1492,6 +1492,7 @@ packages/lib/services/synchronizer/Synchronizer.sharing.test.js
 packages/lib/services/synchronizer/Synchronizer.tags.test.js
 packages/lib/services/synchronizer/Synchronizer.tools.test.js
 packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.js
+packages/lib/services/synchronizer/handleConflictAction.test.js
 packages/lib/services/synchronizer/migrations/1.js
 packages/lib/services/synchronizer/migrations/2.js
 packages/lib/services/synchronizer/migrations/3.js

--- a/.gitignore
+++ b/.gitignore
@@ -1467,6 +1467,7 @@ packages/lib/services/synchronizer/Synchronizer.sharing.test.js
 packages/lib/services/synchronizer/Synchronizer.tags.test.js
 packages/lib/services/synchronizer/Synchronizer.tools.test.js
 packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.js
+packages/lib/services/synchronizer/handleConflictAction.test.js
 packages/lib/services/synchronizer/migrations/1.js
 packages/lib/services/synchronizer/migrations/2.js
 packages/lib/services/synchronizer/migrations/3.js

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -1,0 +1,42 @@
+import Folder from '../../models/Folder';
+import Setting from '../../models/Setting';
+import Tag from '../../models/Tag';
+import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import handleConflictAction from './utils/handleConflictAction';
+import { SyncAction } from './utils/types';
+
+describe('handleConflictAction', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('should throw fail-safe error when a folder item conflicts and the remote object does not exist, if fail-safe is enabled', async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		const f1 = await Folder.save({ title: 'folder' });
+
+		await expect(async () => {
+			await handleConflictAction(SyncAction.ItemConflict, Folder, false, null, f1, 1, false, null);
+		}).rejects.toThrow('Fail-safe: Sync was interrupted because the notebook [folder] and all its notes and sub-notebooks are about to be deleted. To override this behaviour disable the fail-safe in the sync settings.');
+
+		expect(await Folder.load(f1.id)).not.toBeUndefined();
+	});
+
+	it('should delete local item when a folder item conflicts and the remote object does not exist, if fail-safe is not enabled', async () => {
+		Setting.setValue('sync.wipeOutFailSafe', false);
+		const f1 = await Folder.save({ title: 'folder' });
+
+		await handleConflictAction(SyncAction.ItemConflict, Folder, false, null, f1, 1, false, null);
+		expect(await Folder.load(f1.id)).toBeUndefined();
+	});
+
+	it('should delete local item when a non folder item conflicts and the remote object does not exist', async () => {
+		Setting.setValue('sync.wipeOutFailSafe', true);
+		const t1 = await Tag.save({ title: 'tag' });
+
+		await handleConflictAction(SyncAction.ItemConflict, Tag, false, null, t1, 1, false, null);
+		expect(await Tag.load(t1.id)).toBeUndefined();
+	});
+
+});

--- a/packages/lib/services/synchronizer/utils/handleConflictAction.ts
+++ b/packages/lib/services/synchronizer/utils/handleConflictAction.ts
@@ -6,6 +6,9 @@ import Note from '../../../models/Note';
 import Resource from '../../../models/Resource';
 import time from '../../../time';
 import { SyncAction, conflictActions } from './types';
+import Setting from '../../../models/Setting';
+import JoplinError from '../../../JoplinError';
+import { _ } from '../../../locale';
 
 const logger = Logger.create('handleConflictAction');
 
@@ -29,6 +32,10 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 			const syncTimeQueries = BaseItem.updateSyncTimeQueries(syncTargetId, local, time.unixMs());
 			await ItemClass.save(local, { autoTimestamp: false, changeSource: ItemChange.SOURCE_SYNC, nextQueries: syncTimeQueries });
 		} else {
+			if (ItemClass.name === 'Folder' && Setting.value('sync.wipeOutFailSafe')) {
+				throw new JoplinError(_('Fail-safe: Sync was interrupted because the notebook [%s] and all its notes and sub-notebooks are about to be deleted. To override this behaviour disable the fail-safe in the sync settings.', local.title), 'failSafe');
+			}
+
 			await ItemClass.delete(local.id, {
 				changeSource: ItemChange.SOURCE_SYNC,
 				sourceDescription: 'sync: handleConflictAction: non-note conflict',


### PR DESCRIPTION
This PR extends the capability of the fail-safe in Joplin, to protect against unexpected data loss for a scenario when a notebook conflicts and the remote object no longer exists. Although the cause of the situation is unknown, the situation can be reproduced easily by the following steps:
1. Take any notebook with some notes in it
2. Set up file system sync
3. Find the md file in the synced directory corresponding to the notebook - then delete it
4. Before the client has chance to sync, rename the notebook, then delete it
5. Run the sync - the notebook will be disappear
6. In the log file you will find non-note conflict entries

The existing behaviour happens because when this scenario occurs, Joplin will delete the notebook and all its notes and sub-notebooks without any warning. Although rare and the root cause unknown, this can cause massive data loss if it happens with a top level notebook, so ought to be protected against. Extending the existing fail-safe mechanism seems to be an appropriate avenue for doing this. With the change in this PR, if this scenario happens, the sync will be blocked with an error shown in the UI, which specifies the folder which is going to be deleted. This can be bypassed by temporarily turning off the fail-safe function, but should act as a prompt for the user to backup their data before doing so.

Caveat: The user will get the fail-safe error if they manually delete a notebook / notebook tree on one client, but then rename or move that notebook on another client without first syncing (note that if they do not rename or move the notebook on the second client, then upon syncing the notebook / notebook tree will just get deleted as normal without any user interaction). This is a similar caveat to how the user will get a fail-safe error if they intentionally delete all their notes within the Joplin client, and they must temporarily disable fail-safe to bypass it. Any other reason for this scenario to happen would be due to either a bug in Joplin or a modification to the server outside of Joplin, and this change would protect against it

This would be a sufficient fix for https://github.com/laurent22/joplin/issues/11902

**Testing:**

I have tested the change using the reproduction steps and the caveat scenario, with and without fail-safe enabled and verified the behaviour is as expected. When fail-safe is enabled, the sync will halt and show the fail-safe error, specifying the notebook to be deleted. Some new local changes will continue to be synced, but the sync process will always be prevented from deleting the conflicting notebook when it reaches that point in the sync, until fail-safe is disabled, which would then cause it to correctly delete the notebook and all of its notes and sub-notebooks

**Screenshot of the UI error:**

<img width="663" height="820" alt="Capture" src="https://github.com/user-attachments/assets/5e6a243c-dcce-4ef3-906d-404fc89d7933" />