### PR TITLE
Chore: Mobile: Fix warning

### DIFF
--- a/packages/app-mobile/components/DialogManager/index.tsx
+++ b/packages/app-mobile/components/DialogManager/index.tsx
@@ -66,7 +66,6 @@ const DialogManager: React.FC<Props> = props => {
 	const dialogComponents: React.ReactNode[] = [];
 	for (const dialog of dialogModels) {
 		const dialogProps = {
-			key: dialog.key,
 			containerStyle: styles.dialogContainer,
 			themeId: props.themeId,
 		};
@@ -75,6 +74,7 @@ const DialogManager: React.FC<Props> = props => {
 				<PromptDialog
 					dialog={dialog}
 					{...dialogProps}
+					key={dialog.key}
 				/>,
 			);
 		} else if (dialog.type === DialogType.TextInput) {
@@ -82,6 +82,7 @@ const DialogManager: React.FC<Props> = props => {
 				<TextInputDialog
 					dialog={dialog}
 					{...dialogProps}
+					key={dialog.key}
 				/>,
 			);
 		} else {


### PR DESCRIPTION
# Summary

This pull request fixes the following warning shown when opening certain dialogs:
```
A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, dialog: ..., containerStyle: ..., themeId: ...};
  <PromptDialog {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {dialog: ..., containerStyle: ..., themeId: ...};
  <PromptDialog key={someKey} {...props} /> Error Component Stack:
    at DialogManager
```

# Testing plan

**Android 15**
1. Create a new note.
2. Open the "Attach" menu.
3. Verify that no key-related error or warning is shown in the development console.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->