### PR TITLE
Mobile: Fixes #12783: Improve usability of inline search in notes

### DIFF
--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -116,6 +116,7 @@ const useStyles = (theme: Theme) => {
 				backgroundColor: theme.backgroundColor3,
 			},
 			input: {
+				flexBasis: 0,
 				flexGrow: 1,
 				height: buttonSize,
 				backgroundColor: theme.backgroundColor4,
@@ -171,6 +172,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 				returnKeyType='search'
 				blurOnSubmit={false}
 				onSubmitEditing={control.findNext}
+				selectTextOnFocus={true}
 			/>
 		);
 	};

--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -116,6 +116,7 @@ const useStyles = (theme: Theme) => {
 				backgroundColor: theme.backgroundColor3,
 			},
 			input: {
+				flexBasis: 0,
 				flexGrow: 1,
 				height: buttonSize,
 				backgroundColor: theme.backgroundColor4,
@@ -193,13 +194,13 @@ export const SearchPanel = (props: SearchPanelProps) => {
 
 
 	const themeId = props.editorSettings.themeId;
-	const closeButton = (
+	const clearButton = (
 		<ActionButton
 			themeId={themeId}
 			styles={styles}
-			iconName="close"
-			onPress={control.hideSearch}
-			title={_('Close')}
+			iconName="close-circle"
+			onPress={() => updateSearchState({ searchText: '' })}
+			title={_('Clear')}
 		/>
 	);
 
@@ -335,7 +336,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 
 	const simpleLayout = (
 		<View style={{ flexDirection: 'row' }}>
-			{ closeButton }
+			{ clearButton }
 			{ searchTextInput }
 			{ showDetailsButton }
 			{ toPrevButton }
@@ -346,7 +347,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 	const advancedLayout = (
 		<View style={{ flexDirection: 'column', alignItems: 'center' }}>
 			<View style={{ flexDirection: 'row' }}>
-				{ closeButton }
+				{ clearButton }
 				{ labeledSearchInput }
 				{ hideDetailsButton }
 				{ toPrevButton }

--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -116,7 +116,6 @@ const useStyles = (theme: Theme) => {
 				backgroundColor: theme.backgroundColor3,
 			},
 			input: {
-				flexBasis: 0,
 				flexGrow: 1,
 				height: buttonSize,
 				backgroundColor: theme.backgroundColor4,
@@ -194,13 +193,13 @@ export const SearchPanel = (props: SearchPanelProps) => {
 
 
 	const themeId = props.editorSettings.themeId;
-	const clearButton = (
+	const closeButton = (
 		<ActionButton
 			themeId={themeId}
 			styles={styles}
-			iconName="close-circle"
-			onPress={() => updateSearchState({ searchText: '' })}
-			title={_('Clear')}
+			iconName="close"
+			onPress={control.hideSearch}
+			title={_('Close')}
 		/>
 	);
 
@@ -336,7 +335,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 
 	const simpleLayout = (
 		<View style={{ flexDirection: 'row' }}>
-			{ clearButton }
+			{ closeButton }
 			{ searchTextInput }
 			{ showDetailsButton }
 			{ toPrevButton }
@@ -347,7 +346,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 	const advancedLayout = (
 		<View style={{ flexDirection: 'column', alignItems: 'center' }}>
 			<View style={{ flexDirection: 'row' }}>
-				{ clearButton }
+				{ closeButton }
 				{ labeledSearchInput }
 				{ hideDetailsButton }
 				{ toPrevButton }


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/12291 introduced a feature to auto-fill the editor search input with the global search to comply with WCAG. While this may be useful, in some cases it is unhelpful to auto fill the search bar. For example, the user may enter a global search query such as 'tag:this is a long tag name' which likely will not yield any results within the note. Using a touch screen, the user either needs to hold the backspace button on the virtual keyboard, or long press the text to select it, expand the selection and then press backspace. In both of these cases it may take a few seconds to remove the input text, which can cause user frustration in cases where the auto filled text is unwanted.

In order to alleviate frustration in this scenario, and improve usability for the search on mobile in general, I have made the search and replace inputs on the search bar have selectTextOnFocus set to true, which means the full text is highlighted on focus (but you can unselect it for editing by tapping it once more), allowing the user to clear the search by just pressing backspace once.

In addition to allowing the search bar inputs to be quickly cleared, there is an existing issue with the search bar which means if you enter a long search query, the buttons on the bar will shrink until they eventually are hidden. I have addressed this issue also so that the text inputs do not change based on the size of the content (the text inputs are horizontally scrollable, so this is ok). These screenshots show the issue (it affects the replace input also, not just the search input):

<img src="https://github.com/user-attachments/assets/d581da0a-c098-4855-9261-f988e46958ee" width="200" />
<img src="https://github.com/user-attachments/assets/273ad06b-67ba-44b9-93b3-13f9a1591e64" width="200" />

### Testing

Here is a video demonstrating the changes made in this PR:

https://github.com/user-attachments/assets/c58d8ec6-167e-4334-bec3-f236ace13a33

This fixes https://github.com/laurent22/joplin/issues/12783