### PR TITLE
Desktop: Fixes #12790: Plugins: Fix importing sqlite3

### DIFF
--- a/packages/app-desktop/services/plugins/plugin_index.js
+++ b/packages/app-desktop/services/plugins/plugin_index.js
@@ -51,10 +51,8 @@
 			const modulePath = args && args.length ? args[0] : null;
 			if (!modulePath) throw new Error('No module path specified on `require` call');
 
-			// The sqlite3 is actually part of the lib package so we need to do
-			// something convoluted to get it working.
 			if (modulePath === 'sqlite3') {
-				return require('../../node_modules/@joplin/lib/node_modules/sqlite3/lib/sqlite3.js');
+				return require('sqlite3');
 			}
 
 			if (modulePath === 'fs-extra') {


### PR DESCRIPTION
# Summary

This pull request fixes a regression in Joplin 3.4.2 — plugins were unable to `joplin.require('sqlite3')`.

Fixes #12790.

# Testing plan

1. Install the Jarvis plugin.
1. Build Joplin with `yarn dist`.
2. Start the just-built AppImage.
3. Verify that the Jarvis plugin starts.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->