### PR TITLE
Desktop,Mobile: Fixes #12573: Markdown editor: Make list indentation size equivalent to four spaces

### DIFF
--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -107,13 +107,6 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			marginRight: `${theme.marginRight}px`,
 		},
 
-		'& .cm-listItem': {
-			// Needs to be !important because the tab-size is directly set on the element style
-			// attribute by CodeMirror. And the `EditorState.tabSize` function only accepts a
-			// number, while we need a "em" value to make it match the viewer tab size.
-			tabSize: `${theme.listTabSize} !important`,
-		},
-
 		'&.cm-focused .cm-cursor': baseCursorStyle,
 
 		// The desktop app sets the font for these elements to a specific font.


### PR DESCRIPTION
# Summary

This pull request reverts #11940, fixing #12573.

> [!NOTE]
>
> As suggested by @bwat47 in #12573, an alternate (but more complicated) solution would be to also override the indentation size when indented with spaces. This would probably involve a custom [CodeMirror replacement decoration](https://codemirror.net/examples/decoration/) for each list item indent. As https://github.com/laurent22/joplin/pull/12747 uses similar APIs, it may make sense to implement @bwat47's suggestion as a part of https://github.com/laurent22/joplin/pull/12747.

# Screenshot comparison

| Before | After |
|--------|-------|
| <img width="1259" height="462" alt="screenshot: A bulleted list in the Markdown editor with one toplevel item and two nested items. The two nested items appear to have different indentation depths, but are shown to render to two items of the same depth." src="https://github.com/user-attachments/assets/6867855c-5ba2-48bb-993a-ac3d97c2e5d3" /> | <img width="1259" height="462" alt="screenshot: Same bulleted list as before, except now the second list item has the same indentation as the first." src="https://github.com/user-attachments/assets/618619c0-3f2e-4c8d-b0a0-b154a5ba213a" /> |



# Testing plan

1. Start Joplin in development mode.
2. Create a new note in the Rich Text Editor.
    - The Rich Text Editor uses spaces for list indentation when converting back into Markdown.
3. Add an unordered list.
4. Increase the level of the last list item.
5. Switch to the Markdown editor.
6. Add an item to the nested unordered list.
7. Verify that the items in the nested unordered list have the same indentation.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->