### PR TITLE
Transcribe: Fixes #12765: Removes file from temporary folder after storing it

### DIFF
--- a/packages/transcribe/src/services/FileStorage.test.ts
+++ b/packages/transcribe/src/services/FileStorage.test.ts
@@ -11,8 +11,8 @@ describe('FileStorage', () => {
 		const name = await fs.store('./test_file.png');
 
 		const destination = join('images', name);
-		const fileStillExists = await exists(destination);
-		expect(fileStillExists).toBe(true);
+		const destinationStillExists = await exists(destination);
+		expect(destinationStillExists).toBe(true);
 
 		await remove(destination);
 	});
@@ -24,8 +24,8 @@ describe('FileStorage', () => {
 		const fs = new FileStorage();
 		const name = await fs.store('./test_file.png');
 
-		const fileStillExists = await exists('./test_file.png');
-		expect(fileStillExists).toBe(false);
+		const originalStillExists = await exists('./test_file.png');
+		expect(originalStillExists).toBe(false);
 
 		await remove(join('images', name));
 	});

--- a/packages/transcribe/src/services/FileStorage.test.ts
+++ b/packages/transcribe/src/services/FileStorage.test.ts
@@ -1,0 +1,34 @@
+import { copyFile, exists, remove } from 'fs-extra';
+import { join } from 'path';
+import FileStorage from './FileStorage';
+
+describe('FileStorage', () => {
+
+	it('should move file to storage folder', async () => {
+		await copyFile('./images/htr_sample.png', './test_file.png');
+
+		const fs = new FileStorage();
+		const name = await fs.store('./test_file.png');
+
+		const destination = join('images', name);
+		const fileStillExists = await exists(destination);
+		expect(fileStillExists).toBe(true);
+
+		await remove(destination);
+	});
+
+
+	it('should remove the original file', async () => {
+		await copyFile('./images/htr_sample.png', './test_file.png');
+
+		const fs = new FileStorage();
+		const name = await fs.store('./test_file.png');
+
+		const fileStillExists = await exists('./test_file.png');
+		expect(fileStillExists).toBe(false);
+
+		await remove(join('images', name));
+	});
+
+});
+

--- a/packages/transcribe/src/services/FileStorage.ts
+++ b/packages/transcribe/src/services/FileStorage.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { copyFile } from 'fs-extra';
+import { copyFile, remove } from 'fs-extra';
 import { randomBytes } from 'crypto';
 import { ContentStorage } from '../types';
 
@@ -8,6 +8,7 @@ export default class FileStorage implements ContentStorage {
 	public async store(filepath: string) {
 		const randomName = randomBytes(16).toString('hex');
 		await copyFile(filepath, join('images', randomName));
+		await remove(filepath);
 		return randomName;
 	}
 }

--- a/packages/transcribe/src/services/FileStorage.ts
+++ b/packages/transcribe/src/services/FileStorage.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { copyFile, remove } from 'fs-extra';
+import { move } from 'fs-extra';
 import { randomBytes } from 'crypto';
 import { ContentStorage } from '../types';
 
@@ -7,8 +7,7 @@ export default class FileStorage implements ContentStorage {
 
 	public async store(filepath: string) {
 		const randomName = randomBytes(16).toString('hex');
-		await copyFile(filepath, join('images', randomName));
-		await remove(filepath);
+		await move(filepath, join('images', randomName));
 		return randomName;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12765

# Summary

At current transcribe implementation we are not cleaning up the file that comes from the request.

# Testing

I added test to createJob and FileStorage, while the responsability seems to belong only to FileStorage, I thought it was important for createJob to have a test like this in case the storage implementation changes.