### PR TITLE
Unclear icon: Fixes #12233: Enhance accessibility for sidebar buttons

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderListWrapper.tsx
@@ -27,7 +27,7 @@ const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
 	const icon = props.allFoldersCollapsed ? 'far fa-caret-square-right' : 'far fa-caret-square-down';
 	const label = props.allFoldersCollapsed ? _('Expand all notebooks') : _('Collapse all notebooks');
 
-	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall'>
+	return <button onClick={() => onToggleAllFolders(props.allFoldersCollapsed)} className='sidebar-header-button -collapseall' title={label}>
 		<i
 			aria-label={label}
 			role='img'
@@ -39,9 +39,11 @@ const CollapseExpandAllButton = (props: CollapseExpandAllButtonProps) => {
 const NewFolderButton = () => {
 	// To allow it to be accessed by accessibility tools, the new folder button
 	// is not included in the portion of the list with role='tree'.
-	return <button onClick={onAddFolderButtonClick} className='sidebar-header-button -newfolder'>
+	const label = _('New notebook');
+
+	return <button onClick={onAddFolderButtonClick} className='sidebar-header-button -newfolder' title={label}>
 		<i
-			aria-label={_('New notebook')}
+			aria-label={label}
 			role='img'
 			className='fas fa-plus'
 		/>


### PR DESCRIPTION
Desktop: Fixes #12233: Added tooltips to sidebar buttons by adding titles for better screen reader support

The fix specifically added title attributes to:

New Folder button (+ icon)
Collapse/Expand All button (arrow icon)
<img width="296" height="77" alt="image" src="https://github.com/user-attachments/assets/652de828-c042-471d-94b6-d8a9457898b1" />
