### PR TITLE
Android: Fixes #12781: Fix editor becomes blank after dismissing search

### DIFF
--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -136,6 +136,13 @@ const useStyles = (theme: Theme) => {
 				justifyContent: 'center',
 				marginLeft: 10,
 			},
+			panelContainer: {
+				// Workaround for the editor disappearing when dismissing search on Android.
+				// See https://github.com/laurent22/joplin/issues/12781
+				//
+				// It may be possible to remove this line after upgrading to React Native's New Architecture.
+				borderColor: 'transparent',
+			},
 		});
 	}, [theme]);
 };
@@ -366,7 +373,9 @@ export const SearchPanel = (props: SearchPanelProps) => {
 		return null;
 	}
 
-	return showingAdvanced ? advancedLayout : simpleLayout;
+	return <View style={styles.panelContainer}>
+		{showingAdvanced ? advancedLayout : simpleLayout}
+	</View>;
 };
 
 export default SearchPanel;


### PR DESCRIPTION
# Summary

This pull request adds a zero-width, transparent border around the search panel. This seems to fix an issue in which dismissing search by pressing the Android back button would cause the editor to go blank.

Fixes #12781.

# Testing plan

1. Start Joplin in development mode on an Android emulator.
2. Open the Rich Text Editor.
3. Open the search bar.
4. Dismiss search by pressing "Back" in the emulator's controls.
5. Verify that the search panel has been hidden.

If the `borderColor: 'transparent',` line is commented out, the editor becomes blank after step 4.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->