### PR TITLE
Mobile: Performance: Improve Rich Text Editor startup performance

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -873,7 +873,8 @@ packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useContentScripts.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.test.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.js
-packages/app-mobile/contentScripts/richTextEditorBundle/contentScript.js
+packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/convertHtmlToMarkdown.js
+packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.js
 packages/app-mobile/contentScripts/richTextEditorBundle/types.js
 packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.js
 packages/app-mobile/contentScripts/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -846,7 +846,8 @@ packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useContentScripts.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.test.js
 packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.js
-packages/app-mobile/contentScripts/richTextEditorBundle/contentScript.js
+packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/convertHtmlToMarkdown.js
+packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.js
 packages/app-mobile/contentScripts/richTextEditorBundle/types.js
 packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.js
 packages/app-mobile/contentScripts/types.js

--- a/packages/app-cli/tests/MarkupToHtml.ts
+++ b/packages/app-cli/tests/MarkupToHtml.ts
@@ -1,6 +1,6 @@
 
-import MarkupToHtml, { MarkupLanguage } from '@joplin/renderer/MarkupToHtml';
-import { RenderResult } from '@joplin/renderer/types';
+import MarkupToHtml from '@joplin/renderer/MarkupToHtml';
+import { RenderResult, MarkupLanguage } from '@joplin/renderer/types';
 
 describe('MarkupToHtml', () => {
 

--- a/packages/app-mobile/contentScripts/rendererBundle/types.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/types.ts
@@ -1,6 +1,6 @@
-import type { FsDriver as RendererFsDriver, RenderResult, ResourceInfos } from '@joplin/renderer/types';
+import type { MarkupLanguage, FsDriver as RendererFsDriver, RenderResult, ResourceInfos } from '@joplin/renderer/types';
 import type Renderer from './contentScript/Renderer';
-import { MarkupLanguage, PluginOptions } from '@joplin/renderer/MarkupToHtml';
+import { PluginOptions } from '@joplin/renderer/MarkupToHtml';
 
 // Joplin settings (as from Setting.value(...)) that should
 // remain constant during editing.

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/convertHtmlToMarkdown.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/convertHtmlToMarkdown.ts
@@ -1,0 +1,32 @@
+const TurndownService = require('@joplin/turndown');
+const turndownPluginGfm = require('@joplin/turndown-plugin-gfm').gfm;
+
+// Avoid using @joplin/lib/HtmlToMd here. HtmlToMd may cause several megabytes
+// of additional JavaScript and supporting data to be included.
+
+const convertHtmlToMarkdown = (html: string|HTMLElement) => {
+	const turndownOpts = {
+		headingStyle: 'atx',
+		codeBlockStyle: 'fenced',
+		preserveImageTagsWithSize: true,
+		preserveNestedTables: true,
+		preserveColorStyles: true,
+		bulletListMarker: '-',
+		emDelimiter: '*',
+		strongDelimiter: '**',
+		allowResourcePlaceholders: true,
+
+		// If soft-breaks are enabled, lines need to end with two or more spaces for
+		// trailing <br/>s to render. See
+		// https://github.com/laurent22/joplin/issues/8430
+		br: '  ',
+	};
+	const turndown = new TurndownService(turndownOpts);
+	turndown.use(turndownPluginGfm);
+	turndown.remove('script');
+	turndown.remove('style');
+	const md = turndown.turndown(html);
+	return md;
+};
+
+export default convertHtmlToMarkdown;

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.ts
@@ -1,12 +1,12 @@
-import '../utils/polyfills';
+import '../../utils/polyfills';
 import { createEditor } from '@joplin/editor/ProseMirror';
-import { EditorProcessApi, EditorProps, MainProcessApi } from './types';
-import WebViewToRNMessenger from '../../utils/ipc/WebViewToRNMessenger';
-import { MarkupLanguage } from '@joplin/renderer';
+import { EditorProcessApi, EditorProps, MainProcessApi } from '../types';
+import WebViewToRNMessenger from '../../../utils/ipc/WebViewToRNMessenger';
+import { MarkupLanguage } from '@joplin/renderer/types';
 import '@joplin/editor/ProseMirror/styles';
-import HtmlToMd from '@joplin/lib/HtmlToMd';
-import readFileToBase64 from '../utils/readFileToBase64';
+import readFileToBase64 from '../../utils/readFileToBase64';
 import { EditorLanguageType } from '@joplin/editor/types';
+import convertHtmlToMarkdown from './convertHtmlToMarkdown';
 
 const postprocessHtml = (html: HTMLElement) => {
 	// Fix resource URLs
@@ -45,11 +45,10 @@ const wrapHtmlForMarkdownConversion = (html: HTMLElement) => {
 };
 
 
-const htmlToMd = new HtmlToMd();
 const htmlToMarkdown = (html: HTMLElement): string => {
 	html = postprocessHtml(html);
 
-	return htmlToMd.parse(html, { preserveColorStyles: true });
+	return convertHtmlToMarkdown(html);
 };
 
 export const initialize = async ({
@@ -127,5 +126,5 @@ export const initialize = async ({
 	return editor;
 };
 
-export { default as setUpLogger } from '../utils/setUpLogger';
+export { default as setUpLogger } from '../../utils/setUpLogger';
 

--- a/packages/lib/markupLanguageUtils.ts
+++ b/packages/lib/markupLanguageUtils.ts
@@ -1,11 +1,12 @@
 import markdownUtils from './markdownUtils';
 import Setting from './models/Setting';
 import shim from './shim';
-import MarkupToHtml, { MarkupLanguage, Options } from '@joplin/renderer/MarkupToHtml';
+import MarkupToHtml, { Options } from '@joplin/renderer/MarkupToHtml';
 
 import htmlUtils from './htmlUtils';
 import Resource from './models/Resource';
 import { PluginStates } from './services/plugins/reducer';
+import { MarkupLanguage } from '@joplin/renderer';
 
 export class MarkupLanguageUtils {
 

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -1,4 +1,4 @@
-import { rtrimSlashes, toFileProtocolPath } from './path-utils';
+import { rtrimSlashes, toFileProtocolPath } from '@joplin/utils/path';
 import { urlDecode } from './string-utils';
 
 export const hash = (url: string) => {

--- a/packages/lib/urlUtils.ts
+++ b/packages/lib/urlUtils.ts
@@ -1,4 +1,4 @@
-import { rtrimSlashes, toFileProtocolPath } from '@joplin/utils/path';
+import { rtrimSlashes, toFileProtocolPath } from './path-utils';
 import { urlDecode } from './string-utils';
 
 export const hash = (url: string) => {

--- a/packages/renderer/MarkupToHtml.ts
+++ b/packages/renderer/MarkupToHtml.ts
@@ -3,15 +3,9 @@ import HtmlToHtml from './HtmlToHtml';
 import htmlUtils from './htmlUtils';
 import { Options as NoteStyleOptions } from './noteStyle';
 import { AllHtmlEntities } from 'html-entities';
-import { FsDriver, MarkupRenderer, MarkupToHtmlConverter, OptionsResourceModel, RenderOptions, RenderResult } from './types';
+import { FsDriver, MarkupLanguage, MarkupRenderer, MarkupToHtmlConverter, OptionsResourceModel, RenderOptions, RenderResult } from './types';
 import defaultResourceModel from './defaultResourceModel';
 const MarkdownIt = require('markdown-it');
-
-export enum MarkupLanguage {
-	Markdown = 1,
-	Html = 2,
-	Any = 3,
-}
 
 export interface PluginOptions {
 	[id: string]: { enabled: boolean };

--- a/packages/renderer/index.ts
+++ b/packages/renderer/index.ts
@@ -1,4 +1,4 @@
-import MarkupToHtml, { MarkupLanguage } from './MarkupToHtml';
+import MarkupToHtml from './MarkupToHtml';
 import MdToHtml from './MdToHtml';
 import HtmlToHtml from './HtmlToHtml';
 import * as utils from './utils';
@@ -6,6 +6,7 @@ import setupLinkify from './MdToHtml/setupLinkify';
 import validateLinks from './MdToHtml/validateLinks';
 import headerAnchor from './headerAnchor';
 import assetsToHeaders from './assetsToHeaders';
+import { MarkupLanguage } from './types';
 
 export {
 	MarkupToHtml,

--- a/packages/renderer/types.ts
+++ b/packages/renderer/types.ts
@@ -1,5 +1,10 @@
-import { MarkupLanguage } from './MarkupToHtml';
 import { Options as NoteStyleOptions } from './noteStyle';
+
+export enum MarkupLanguage {
+	Markdown = 1,
+	Html = 2,
+	Any = 3,
+}
 
 export type ItemIdToUrlHandler = (resourceId: string, urlParameters?: string)=> string;
 


### PR DESCRIPTION
# Summary

This pull request should improve the Rich Text Editor's startup performance on mobile. It significantly **reduces the Rich Text Editor bundle size**. In particular, before this pull request, the bundled and processed JavaScript was roughly 11 MB in `app-mobile/lib/rnInjectedJs`. With this change, the same file is only about 600 KB.

Previously:
- `@joplin/renderer` was included in the bundle through `@joplin/lib/HtmlToMd`. This added > 1 MB to the bundle (before converting to base64).
   - This was addressed by using Turndown directly.
- The Joplin localization data was included in the bundle through a file indirectly imported by `@joplin/lib/HtmlToMd`. This added > 4 MB to the bundle (before converting to base64).
   - This was also addressed by using Turndown directly.

# Testing plan

**Note**: These changes are partially covered by [RichTextEditor.test.tsx](https://github.com/laurent22/joplin/blob/dev/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx).

This change was tested manually on an Android emulator by:
1. Creating a new note.
2. Opening the Rich Text Editor.
3. Adding a level two heading.
4. Creating a new line.
5. Attaching an image.
6. Adding a new line after the image.
7. Typing "test".
8. Pressing <kbd>enter</kbd> four times.
9. Typing "test".
10. Switching to the Markdown editor.
11. Verifying that the note's Markdown is similar to:
  ```
  ## Test
  
  ![image.png](:/3939bde81c5e451d8ce3fbff82a40a4d)
  
  &nbsp;
  
  &nbsp;
  
  test
  ```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->