### PR TITLE
Chore: Work around test failure in newer NodeJS versions

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
     "generatePluginTypes": "rm -rf ./plugin_types && yarn tsc --declaration --declarationDir ./plugin_types --project tsconfig.json",
-    "test": "node --security-revert=CVE-2023-46809 ./node_modules/.bin/jest --verbose=false",
+    "test": "jest",
     "test-ci": "yarn test"
   },
   "devDependencies": {

--- a/packages/lib/services/e2ee/RSA.node.ts
+++ b/packages/lib/services/e2ee/RSA.node.ts
@@ -6,6 +6,9 @@ const nodeRSAOptions: NodeRSA.Options = {
 	// app when decrypted by RN-RSA.
 	// https://github.com/amitaymolko/react-native-rsa-native/issues/66#issuecomment-932768139
 	encryptionScheme: 'pkcs1',
+
+	// Allows NodeRSA to work with pkcs1-v1.5 in newer NodeJS versions:
+	environment: 'browser',
 };
 
 const rsa: RSA = {


### PR DESCRIPTION
# Summary

This pull request manually sets the `node-rsa` environment to `browser`, working around an automated test failure.

**Note**: In the desktop app, `node-rsa`'s environment was previously auto-detected to `browser`. As a result, this pull request should make the E2EE automated tests more closely align with the behavior of the desktop app.

Related: https://github.com/laurent22/joplin/pull/12829

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->