### PR TITLE
Desktop: Fixes #11871: Put crash dump files at the platform-compliant locations

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -8,8 +8,8 @@ import { urlDecode } from '@joplin/lib/string-utils';
 import * as Sentry from '@sentry/electron/main';
 import { homedir } from 'os';
 import { msleep } from '@joplin/utils/time';
-import { pathExists, pathExistsSync, writeFileSync } from 'fs-extra';
-import { extname, normalize } from 'path';
+import { pathExists, pathExistsSync, writeFileSync, ensureDirSync } from 'fs-extra';
+import { extname, normalize, join } from 'path';
 import isSafeToOpen from './utils/isSafeToOpen';
 import { closeSync, openSync, readSync, statSync } from 'fs';
 import { KB } from '@joplin/utils/bytes';
@@ -67,6 +67,30 @@ export class Bridge {
 		this.logFilePath_ = v;
 	}
 
+	private getCrashDumpDirectory(): string {
+		try {
+			const platformName = shim.platformName();
+			switch (platformName) {
+			case 'win32':
+				// Windows: Use %LOCALAPPDATA%\CrashDumps
+				return join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'CrashDumps');
+			case 'darwin':
+				// macOS: Use ~/Library/Logs/DiagnosticReports
+				return join(homedir(), 'Library', 'Logs', 'DiagnosticReports');
+			case 'linux':
+				// Linux: Use XDG_STATE_HOME (for logs) or fallback to ~/.local/state
+				return join(process.env.XDG_STATE_HOME || join(homedir(), '.local', 'state'), 'joplin');
+			default:
+				// For unknown platforms, default to the home directory
+				return homedir();
+			}
+		} catch (error) {
+			// If we can't get the platform name, fallback to the home directory
+			return homedir();
+		}
+
+	}
+
 	private sentryInit() {
 		const getLogLines = () => {
 			try {
@@ -109,7 +133,10 @@ export class Bridge {
 						log: logAttachment ? logAttachment.data.trim().split('\n') : [],
 					};
 
-					writeFileSync(`${homedir()}/joplin_crash_dump_${date}.json`, JSON.stringify(errorEventWithLog, null, '\t'), 'utf-8');
+					const crashDumpDir = this.getCrashDumpDirectory();
+					ensureDirSync(crashDumpDir);
+					const crashDumpPath = join(crashDumpDir, `joplin_crash_dump_${date}.json`);
+					writeFileSync(crashDumpPath, JSON.stringify(errorEventWithLog, null, '\t'), 'utf-8');
 				} catch (error) {
 					// Ignore the error since we can't handle it here
 				}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -195,3 +195,4 @@ orderedmap
 labelledby
 isTextblock
 deflt
+LOCALAPPDATA

--- a/readme/apps/debugging.md
+++ b/readme/apps/debugging.md
@@ -17,7 +17,7 @@ Make sure you disable debugging once you've finished. Leaving it enabled can cau
 
 ### Crash reports
 
-When the application crashes, a report is created in your [home directory](https://github.com/laurent22/joplin/blob/dev/readme/apps/home_directory.md) under the name `joplin_crash_dump_<DATE_TIME>.json`. If you experience a crash please share this log with the team by posting it to the [forum](https://discourse.joplinapp.org/), [GitHub](https://github.com/laurent22/joplin/issues) or [by email](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/AdresseSupport.png). You may also enable crash report auto-upload in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md) in the "Application" section.
+When the application crashes, a report is created in your [crash report directory](https://github.com/laurent22/joplin/blob/dev/readme/apps/home_directory.md) under the name `joplin_crash_dump_<DATE_TIME>.json`. If you experience a crash please share this log with the team by posting it to the [forum](https://discourse.joplinapp.org/), [GitHub](https://github.com/laurent22/joplin/issues) or [by email](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/AdresseSupport.png). You may also enable crash report auto-upload in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md) in the "Application" section.
 
 ### Safe mode
 

--- a/readme/apps/home_directory.md
+++ b/readme/apps/home_directory.md
@@ -7,3 +7,13 @@ Joplin stores some data in your home directory, such as your profile and certain
 | Windows | `C:\\Users\\(username)` | `%UserProfile%` |
 | Linux | `/home/(username)` | `$HOME` |
 | macOS | `/Users/(Username)` | `$HOME` |
+
+## Crash report directory
+
+When Joplin crashes, it generates a crash report that can help diagnose the issue. The location of these crash reports varies by operating system:
+
+| Operating System | Path | Environment Variable |
+| --- | --- | --- |
+| Windows | `C:\\Users\\(username)\\AppData\\Local\\CrashDumps` | `%LocalAppData%\CrashDumps` |
+| Linux | `/home/(username)/.local/state/joplin` | `$XDG_STATE_HOME/joplin` |
+| macOS | `/Users/(Username)/Library/Logs/DiagnosticReports` | `$HOME/Library/Logs/DiagnosticReports` |


### PR DESCRIPTION
## Background
Currently, Joplin dumps crash dump JSON files directly into the home directory. This is considered an anti-pattern on many platforms, as it creates unnecessary clutter and confusion for users.

Moreover, as #9941 has not yet been resolved, Joplin may create a crash dump in the home directory on *every* system shutdown.

## Summary
This PR addresses the issue by using the following standard, platform-specific locations for desktop environments:

- **Windows**: `%LOCALAPPDATA%\CrashDumps` (e.g., `X:/Users/user/AppData/Local/CrashDumps`). [Source](https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps)
- **macOS**: `~/Library/Logs/DiagnosticReports`. [Source](https://support.apple.com/guide/console/reports-cnsl664be99a/mac)
- **Linux**: `$XDG_STATE_HOME/joplin` (or `~/.local/state/joplin`). [Source](https://specifications.freedesktop.org/basedir-spec/latest/#variables)
- **Other/Unknown platforms**: Fallback to the home directory.

## Possible concerns
- [x] `readme/apps/debugging.md` and `readme/apps/home_directory.md` should also be changed to refer to the correct location.
- *Will this make it more difficult for novice users to locate crash dumps?* **I don't expect it to**. On both Windows and Linux, users can navigate directly to the location in their file manager by copying and pasting the path (e.g., `%LOCALAPPDATA%\CrashDumps`), so it won't become any harder. As for macOS, this location should allow them to view the error reports directly from the **Console** app.

This fixes #11871.