### PR TITLE
Desktop: Fixes #12531: Fix the order of attached images (#12531)

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -15,6 +15,7 @@ const joplinRendererUtils = require('@joplin/renderer').utils;
 const { clipboard } = require('electron');
 import * as mimeUtils from '@joplin/lib/mime-utils';
 import bridge from '../../../services/bridge';
+import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getCollator';
 const md5 = require('md5');
 const path = require('path');
 
@@ -42,6 +43,12 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 		});
 		if (!filePaths || !filePaths.length) return null;
 	}
+
+	const collatorLocale = getCollatorLocale();
+	const collator = getCollator(collatorLocale);
+	filePaths = filePaths.sort((a, b) => {
+		return collator.compare(a, b);
+	});
 
 	let pos = options.position ?? 0;
 

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -43,7 +43,7 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 		if (!filePaths || !filePaths.length) return null;
 	}
 
-	for (let i = 0; i < filePaths.length; i++) {
+	for (let i = filePaths.length - 1; i >= 0; i--) {
 		const filePath = filePaths[i];
 		try {
 			logger.info(`Attaching ${filePath}`);
@@ -51,7 +51,7 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 				createFileURL: options.createFileURL,
 				resizeLargeImages: Setting.value('imageResizing'),
 				markupLanguage: options.markupLanguage,
-				resourceSuffix: i > 0 ? ' ' : '',
+				resourceSuffix: i >= 0 && i < filePaths.length - 1 ? ' ' : '',
 			});
 
 			if (!newBody) {

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -43,22 +43,24 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 		if (!filePaths || !filePaths.length) return null;
 	}
 
-	for (let i = filePaths.length - 1; i >= 0; i--) {
+	let pos = options.position ?? 0;
+
+	for (let i = 0; i < filePaths.length; i++) {
 		const filePath = filePaths[i];
+		const beforeLen = body.length;
 		try {
 			logger.info(`Attaching ${filePath}`);
-			const newBody = await shim.attachFileToNoteBody(body, filePath, options.position, {
+			const newBody = await shim.attachFileToNoteBody(body, filePath, pos, {
 				createFileURL: options.createFileURL,
 				resizeLargeImages: Setting.value('imageResizing'),
 				markupLanguage: options.markupLanguage,
-				resourceSuffix: i >= 0 && i < filePaths.length - 1 ? ' ' : '',
+				resourcePrefix: i > 0 ? ' ' : '',
 			});
-
 			if (!newBody) {
 				logger.info('File attachment was cancelled');
 				return null;
 			}
-
+			pos += newBody.length - beforeLen;
 			body = newBody;
 			logger.info('File was attached.');
 		} catch (error) {
@@ -66,7 +68,6 @@ export async function commandAttachFileToBody(body: string, filePaths: string[] 
 			bridge().showErrorMessageBox(error.message);
 		}
 	}
-
 	return body;
 }
 


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
### What it does
Fixes an off-by-one error in the attachments loop that caused images to render in reverse order.
Insert white space in the expected area.

### How to test
1. Open a note with multiple attachments in the desktop app.  
2. Verify that they now appear in the order they were added.  
3. All existing automated tests pass (`yarn test resourceHandlingt`).

### Related issues
Fixes #12531