### PR TITLE
Transcribe: Fixes #12862: Add log statement signaling that the startup has finished

### DIFF
--- a/packages/transcribe/src/api/app.ts
+++ b/packages/transcribe/src/api/app.ts
@@ -39,7 +39,7 @@ const init = async (logger: LoggerWrapper) => {
 
 	logger.info('Starting worker');
 	await jobProcessor.init();
-	logger.info('Finished startup');
+	logger.info('Server started successfully');
 };
 
 const checkServerConfigurations = (envVariables: EnvVariables) => {

--- a/packages/transcribe/src/api/app.ts
+++ b/packages/transcribe/src/api/app.ts
@@ -1,6 +1,6 @@
 require('dotenv').config();
 import * as Koa from 'koa';
-import Logger from '@joplin/utils/Logger';
+import Logger, { LoggerWrapper } from '@joplin/utils/Logger';
 import koaBody from 'koa-body';
 import initiateLogger from '../services/initiateLogger';
 import createQueue from '../services/createQueue';
@@ -10,12 +10,11 @@ import env, { EnvVariables } from '../env';
 import HtrCli from '../core/HtrCli';
 import JobProcessor from '../workers/JobProcessor';
 
-initiateLogger();
-const logger = Logger.create('api/app');
 
-const init = async () => {
+const init = async (logger: LoggerWrapper) => {
 	const envVariables = env();
 
+	logger.info('Checking configurations');
 	await checkServerConfigurations(envVariables);
 
 	const app = new Koa();
@@ -26,6 +25,7 @@ const init = async () => {
 
 	await router(app, envVariables.API_KEY);
 
+	logger.info('Creating queue');
 	const queue = await createQueue(envVariables, true);
 
 	const fileStorage = new FileStorage();
@@ -39,6 +39,7 @@ const init = async () => {
 
 	logger.info('Starting worker');
 	await jobProcessor.init();
+	logger.info('Finished startup');
 };
 
 const checkServerConfigurations = (envVariables: EnvVariables) => {
@@ -46,12 +47,13 @@ const checkServerConfigurations = (envVariables: EnvVariables) => {
 };
 
 const main = async () => {
+	initiateLogger();
+	const logger = Logger.create('api/app');
 	logger.info('Starting...');
-	await init();
+	await init(logger);
 };
 
 main().catch(error => {
 	console.error(error);
-	logger.error(error);
 	process.exit(1);
 });


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12862

# Summary

Improving startup logging for transcribe by moving `initiateLogger` inside the main function and adding a message when start up is finished.

Logs now:

```
js@mint:~/Desktop/joplin/fork/packages/transcribe$ yarn start
2025-08-04 16:06:08: api/app: Starting...
2025-08-04 16:06:08: api/app: Checking configurations
2025-08-04 16:06:08: api/app: Listening on http://localhost:4567
2025-08-04 16:06:08: api/app: Creating queue
2025-08-04 16:06:08: createQueue: Choosing queue
2025-08-04 16:06:09: createQueue: Starting
2025-08-04 16:06:09: SqliteQueue: Starting sqlite-queue
2025-08-04 16:06:09: JobProcessor: Created JobProcessor
2025-08-04 16:06:09: api/app: Starting worker
2025-08-04 16:06:09: HtrCli: Loading
2025-08-04 16:06:11: HtrCli: Finished loading:  0.0.2: Pulling from joplin/htr-cli
Digest: sha256:942c69279ed71e3f30a493ef83d8116274c19d37c68f212967c8d3887ab19a2a
Status: Image is up to date for joplin/htr-cli:0.0.2
docker.io/joplin/htr-cli:0.0.2
2025-08-04 16:06:11: api/app: Server started successfully
```