### PR TITLE
Mobile: Fixes #12844: Rich Text Editor: Make initial search behavior match the Markdown editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -84,6 +84,7 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 		initialText: props.initialText,
 		noteId: props.noteId,
 		settings: props.editorSettings,
+		globalSearch: props.globalSearch,
 		webviewRef,
 		themeId: props.themeId,
 		pluginStates: props.plugins,

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/contentScript/index.ts
@@ -56,6 +56,7 @@ export const initialize = async ({
 	initialText,
 	initialNoteId,
 	parentElementClassName,
+	initialSearch,
 }: EditorProps) => {
 	const messenger = new WebViewToRNMessenger<EditorProcessApi, MainProcessApi>('rich-text-editor', null);
 	const parentElement = document.getElementsByClassName(parentElementClassName)[0];
@@ -118,6 +119,7 @@ export const initialize = async ({
 			}
 		},
 	});
+	editor.setSearchState(initialSearch);
 
 	messenger.setLocalInterface({
 		editor,

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/types.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/types.ts
@@ -1,10 +1,11 @@
 import { EditorEvent } from '@joplin/editor/events';
-import { EditorControl, EditorSettings } from '@joplin/editor/types';
+import { EditorControl, EditorSettings, SearchState } from '@joplin/editor/types';
 import { MarkupRecord, RendererControl } from '../rendererBundle/types';
 import { RenderResult } from '@joplin/renderer/types';
 
 export interface EditorProps {
 	initialText: string;
+	initialSearch: SearchState;
 	initialNoteId: string;
 	parentElementClassName: string;
 	settings: EditorSettings;

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -11,6 +11,7 @@ import shim from '@joplin/lib/shim';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import { RendererControl, RenderOptions } from '../rendererBundle/types';
 import { ResourceInfos } from '@joplin/renderer/types';
+import { defaultSearchState } from '../../components/NoteEditor/SearchPanel';
 
 const logger = Logger.create('useWebViewSetup');
 
@@ -19,6 +20,7 @@ interface Props {
 	noteId: string;
 	settings: EditorSettings;
 	parentElementClassName: string;
+	globalSearch: string;
 	themeId: number;
 	pluginStates: PluginStates;
 	noteResources: ResourceInfos;
@@ -100,6 +102,10 @@ const useSource = (props: UseSourceProps) => {
 			parentElementClassName: propsRef.current.parentElementClassName,
 			initialText: propsRef.current.initialText,
 			initialNoteId: propsRef.current.noteId,
+			initialSearch: {
+				...defaultSearchState,
+				searchText: propsRef.current.globalSearch,
+			},
 			settings: propsRef.current.settings,
 		};
 


### PR DESCRIPTION
# Summary

Fixes #12844 by making the Rich Text Editor's initial search match the global search on mobile.

# Testing plan

1. Open the web app and search for `test`
2. Open a search result.
3. Open the Rich Text Editor.
4. Open the search panel.
5. Verify that the search input has been pre-filled with `test`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->