### PR TITLE
Mobile: Fixes #12880: Fix plugin support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -739,6 +739,7 @@ packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/global-style.js
 packages/app-mobile/components/plugins/PluginNotification.js
 packages/app-mobile/components/plugins/PluginRunner.js
+packages/app-mobile/components/plugins/PluginRunnerWebView.test.js
 packages/app-mobile/components/plugins/PluginRunnerWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializeDialogWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializePluginBackgroundIframe.js
@@ -1584,6 +1585,7 @@ packages/lib/shim-init-node.js
 packages/lib/shim.js
 packages/lib/string-utils.test.js
 packages/lib/string-utils.js
+packages/lib/testing/plugins/createTestPlugin.js
 packages/lib/testing/share/makeMockShareInvitation.js
 packages/lib/testing/share/mockShareService.js
 packages/lib/testing/syncTargetUtils.js

--- a/.gitignore
+++ b/.gitignore
@@ -712,6 +712,7 @@ packages/app-mobile/components/getResponsiveValue.js
 packages/app-mobile/components/global-style.js
 packages/app-mobile/components/plugins/PluginNotification.js
 packages/app-mobile/components/plugins/PluginRunner.js
+packages/app-mobile/components/plugins/PluginRunnerWebView.test.js
 packages/app-mobile/components/plugins/PluginRunnerWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializeDialogWebView.js
 packages/app-mobile/components/plugins/backgroundPage/initializePluginBackgroundIframe.js
@@ -1557,6 +1558,7 @@ packages/lib/shim-init-node.js
 packages/lib/shim.js
 packages/lib/string-utils.test.js
 packages/lib/string-utils.js
+packages/lib/testing/plugins/createTestPlugin.js
 packages/lib/testing/share/makeMockShareInvitation.js
 packages/lib/testing/share/mockShareService.js
 packages/lib/testing/syncTargetUtils.js

--- a/packages/app-mobile/components/plugins/PluginRunnerWebView.test.tsx
+++ b/packages/app-mobile/components/plugins/PluginRunnerWebView.test.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+import { AppState } from '../../utils/types';
+import { Store } from 'redux';
+import createMockReduxStore from '../../utils/testing/createMockReduxStore';
+import setupGlobalStore from '../../utils/testing/setupGlobalStore';
+import PluginRunnerWebView from './PluginRunnerWebView';
+import TestProviderStack from '../testing/TestProviderStack';
+import { render, waitFor } from '../../utils/testing/testingLibrary';
+import createTestPlugin from '@joplin/lib/testing/plugins/createTestPlugin';
+import getWebViewDomById from '../../utils/testing/getWebViewDomById';
+import Setting from '@joplin/lib/models/Setting';
+import PluginService from '@joplin/lib/services/plugins/PluginService';
+
+let store: Store<AppState>;
+
+interface WrapperProps { }
+
+const WrappedPluginRunnerWebView: React.FC<WrapperProps> = _props => {
+	return <TestProviderStack store={store}>
+		<PluginRunnerWebView/>
+	</TestProviderStack>;
+};
+
+const defaultManifestProperties = {
+	manifest_version: 1,
+	version: '0.1.0',
+	app_min_version: '2.3.4',
+	platforms: ['desktop', 'mobile'],
+	name: 'Some plugin name',
+};
+
+describe('PluginRunnerWebView', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(0);
+		await switchClient(0);
+
+		store = createMockReduxStore();
+		setupGlobalStore(store);
+		Setting.setValue('plugins.pluginSupportEnabled', true);
+	});
+
+	test('should load a plugin that shows a dialog', async () => {
+		const testPlugin = await createTestPlugin({
+			...defaultManifestProperties,
+			id: 'org.joplinapp.dialog-test',
+		}, {
+			onStart: `
+				const dialogs = joplin.views.dialogs;
+				const dialogHandle = await dialogs.create('test-dialog');
+				await dialogs.setHtml(
+					dialogHandle,
+					'<h1>Test!</h1>',
+				);
+				await joplin.views.dialogs.open(dialogHandle)
+			`,
+		});
+		render(<WrappedPluginRunnerWebView/>);
+
+		// Should load the plugin
+		await waitFor(async () => {
+			expect(PluginService.instance().pluginById(testPlugin.manifest.id)).toBeTruthy();
+		});
+
+		// Should show the dialog
+		await waitFor(async () => {
+			const dom = await getWebViewDomById('joplin__PluginDialogWebView');
+			expect(dom.querySelector('h1').textContent).toBe('Test!');
+		});
+	});
+});

--- a/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
+++ b/packages/app-mobile/components/plugins/PluginRunnerWebView.tsx
@@ -158,6 +158,7 @@ const PluginRunnerWebViewComponent: React.FC<Props> = props => {
 		const injectedJs = `
 			if (!window.loadedBackgroundPage) {
 				${shim.injectedJs('pluginBackgroundPage')}
+				window.pluginBackgroundPage = pluginBackgroundPage;
 				console.log('Loaded PluginRunnerWebView.');
 
 				// Necessary, because React Native WebView can re-run injectedJs

--- a/packages/app-mobile/components/plugins/dialogs/PluginUserWebView.tsx
+++ b/packages/app-mobile/components/plugins/dialogs/PluginUserWebView.tsx
@@ -101,6 +101,8 @@ const PluginUserWebView = (props: Props) => {
 		return `
 			if (!window.backgroundPageLoaded) {
 				${shim.injectedJs('pluginBackgroundPage')}
+				window.pluginBackgroundPage = pluginBackgroundPage;
+
 				pluginBackgroundPage.initializeDialogWebView(
 					${JSON.stringify(messageChannelId)}
 				);

--- a/packages/app-mobile/components/plugins/dialogs/PluginUserWebView.tsx
+++ b/packages/app-mobile/components/plugins/dialogs/PluginUserWebView.tsx
@@ -122,6 +122,7 @@ const PluginUserWebView = (props: Props) => {
 		<ExtendedWebView
 			style={props.style}
 			baseDirectory={plugin.baseDir}
+			testID='joplin__PluginDialogWebView'
 			webviewInstanceId='joplin__PluginDialogWebView'
 			html={html}
 			hasPluginScripts={true}

--- a/packages/lib/testing/plugins/createTestPlugin.ts
+++ b/packages/lib/testing/plugins/createTestPlugin.ts
@@ -1,0 +1,49 @@
+import { join } from 'path';
+import { PluginManifest } from '../../services/plugins/utils/types';
+import Setting from '../../models/Setting';
+import { writeFile } from 'fs-extra';
+import { defaultPluginSetting } from '../../services/plugins/PluginService';
+
+
+const setPluginEnabled = (id: string, enabled: boolean) => {
+	const newPluginStates = {
+		...Setting.value('plugins.states'),
+		[id]: {
+			...defaultPluginSetting(),
+			enabled,
+		},
+	};
+	Setting.setValue('plugins.states', newPluginStates);
+};
+
+interface Options {
+	onStart?: string;
+	enabled?: boolean;
+}
+
+const createTestPlugin = async (manifest: PluginManifest, { onStart = '', enabled = true }: Options = {}) => {
+	const pluginSource = `
+		/* joplin-manifest:
+		${JSON.stringify(manifest)}
+		*/
+
+		joplin.plugins.register({
+			onStart: async function() {
+				${onStart}
+			},
+		});
+	`;
+	const pluginPath = join(Setting.value('pluginDir'), `${manifest.id}.js`);
+	await writeFile(pluginPath, pluginSource, 'utf-8');
+
+	setPluginEnabled(manifest.id, enabled);
+
+	return {
+		manifest,
+		setEnabled: (enabled: boolean) => {
+			setPluginEnabled(manifest.id, enabled);
+		},
+	};
+};
+
+export default createTestPlugin;


### PR DESCRIPTION
# Summary

This pull request fixes an issue on Android and iOS — but not web — in which plugins failed to load. This regression was introduced by a build system change in https://github.com/laurent22/joplin/pull/12748.

Fixes #12880.

# Notes

- Commit 83b5df58f73f040965987f465798c5660b4426e4 includes the fix and dce88e589434ed2acc7d255e17721ffc0aa8f26e adds a test. Since dce88e589434ed2acc7d255e17721ffc0aa8f26e is a much larger change than 83b5df58f73f040965987f465798c5660b4426e4, it could make sense to move dce88e589434ed2acc7d255e17721ffc0aa8f26e to a separate pull request.

# Testing plan

## Manual testing

On an Android emulator:
1. Enable plugin support and install the "Extra Markdown Editor Settings" plugin.
2. Close and reopen settings.
3. Verify that the settings tab for "Extra Markdown Editor Settings" is visible.
4. Open the Markdown editor.
5. Verify that line numbering added by the "Extra Markdown Editor Settings" plugin is visible.

## Automated testing

In dce88e589434ed2acc7d255e17721ffc0aa8f26e, this pull request adds a related automated test that should fail if plugin support is broken in a similar way in the future. The test does the following:
1. Enables plugin support.
2. Creates a test plugin.
   - If the plugin loads successfully, it should use the Joplin APIs to create and show a dialog.
3. Creates the `PluginRunnerWebView`.
4. Checks that the plugin is marked as loaded.
5. Checks that a plugin dialog is eventually shown with the content from step 2.

I have verified that the new test fails if I revert 83b5df58f73f040965987f465798c5660b4426e4 and rebuild.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->