### PR TITLE
Desktop: Fixes #12653: Fix the cursor performance when click a parent li element

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -767,6 +767,30 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				text_patterns_lookup: (ctx: TextPatternContext) => textPatternsLookupRef.current(ctx),
 
 				setup: (editor: Editor) => {
+					editor.on('mousedown', (event) => {
+						const li = event.target;
+						const childList = li.querySelector('ul,ol');
+						if (!childList) return;
+						let textNode = null;
+						for (const node of li.childNodes) {
+							if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+								textNode = node;
+								break;
+							}
+						}
+						if (!textNode) { return; }
+
+						textNode = event.target.firstChild;
+						if (textNode && textNode.nodeType === Node.TEXT_NODE) {
+							const range = document.createRange();
+							range.setStart(textNode, textNode.nodeValue.length);
+							range.collapse(false);
+							editor.selection.setRng(range);
+						}
+
+						event.preventDefault();
+					}, true);
+
 					editor.addCommand('joplinMath', async () => {
 						const katex = editor.selection.getContent();
 						const md = `$${katex}$`;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
### Issue
When clicking on a parent `<li>` that contains nested `<ul>` or `<ol>`, TinyMCE’s default behavior failed to place the text cursor at the end of the list item’s text (in TinyMCE editor).

### Implementation
This PR adds a custom `mousedown` handler in the TinyMCE `setup` callback to:

1. Detect clicks on `<li>` elements that have a child list.
2. Locate the first non-empty TEXT_NODE within that `<li>`.
3. Collapse the selection to the end of that text node if the clicked point is out of the range of the text node.
4. Prevent TinyMCE’s default mouse handling to avoid race conditions and set capture to true.

### Test
I didn’t find any TinyMCE-specific test files, so I only performed manual testing by clicking various nested list items in large notes—caret now jumps immediately to the correct position.

### Related issues
Fixes #12653
