### PR TITLE
Chore: Sync fuzzer: Fix "DecryptionWorker: Cannot start because..." warning

### DIFF
--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -8,6 +8,7 @@ import shim from '../shim';
 import KvStore from './KvStore';
 import EncryptionService from './e2ee/EncryptionService';
 import PerformanceLogger from '../PerformanceLogger';
+import AsyncActionQueue from '../AsyncActionQueue';
 
 const EventEmitter = require('events');
 const perfLogger = PerformanceLogger.create();
@@ -44,7 +45,7 @@ export default class DecryptionWorker {
 	private eventEmitter_: any;
 	private kvStore_: KvStore = null;
 	private maxDecryptionAttempts_ = 2;
-	private startCalls_: boolean[] = [];
+	private taskQueue_: AsyncActionQueue = new AsyncActionQueue();
 	private encryptionService_: EncryptionService = null;
 
 	public constructor() {
@@ -328,15 +329,25 @@ export default class DecryptionWorker {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public async start(options: any = {}) {
-		this.startCalls_.push(true);
-		const startTask = perfLogger.taskStart('DecryptionWorker/start');
+	public async start(options: any = {}): Promise<DecryptionResult> {
 		let output = null;
-		try {
-			output = await this.start_(options);
-		} finally {
-			this.startCalls_.pop();
-			startTask.onEnd();
+		let lastError: Error;
+
+		// Use taskQueue_ to ensure that only one decryption task is running at a time.
+		this.taskQueue_.push(async () => {
+			const startTask = perfLogger.taskStart('DecryptionWorker/start');
+			try {
+				output = await this.start_(options);
+			} catch (error) {
+				lastError = error;
+			} finally {
+				startTask.onEnd();
+			}
+		});
+		await this.taskQueue_.processAllNow();
+
+		if (lastError) {
+			throw lastError;
 		}
 		return output;
 	}
@@ -350,13 +361,6 @@ export default class DecryptionWorker {
 		this.eventEmitter_ = null;
 		DecryptionWorker.instance_ = null;
 
-		return new Promise((resolve) => {
-			const iid = shim.setInterval(() => {
-				if (!this.startCalls_.length) {
-					shim.clearInterval(iid);
-					resolve(null);
-				}
-			}, 100);
-		});
+		await this.taskQueue_.waitForAllDone();
 	}
 }


### PR DESCRIPTION
# Summary

This pull request adds additional logic to `DecryptionWorker.ts` to ensure that calling `.start` does not attempt to run multiple instances of the decryption worker logic at the same time.

# Notes

- **Old behavior**: Before this pull request, calling `DecryptionWorker.start` if the `DecryptionWorker` was already running in the background would result in a `Error: DecryptionWorker: cannot start because state is "started"` error. This could happen while running the sync fuzzer when attempting to force decryption to finish with the `e2ee decrypt` command.
    - The `DecryptionWorker` was likely [started in the background here](https://github.com/laurent22/joplin/blob/bfd5bfc00466c9953504236d0acfbe76229eda65/packages/lib/components/shared/reduxSharedMiddleware.ts#L52).
- **New behavior**: Calling `DecryptionWorker.start` waits for any ongoing decryption task to complete before starting decryption.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->