### PR TITLE
Desktop,Mobile: Markdown editor: Toggle checkboxes on ctrl-click

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1004,6 +1004,8 @@ packages/editor/CodeMirror/editorCommands/sortSelectedLines.test.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/extensions/biDirectionalTextExtension.js
+packages/editor/CodeMirror/extensions/ctrlClickActionExtension.js
+packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.js
 packages/editor/CodeMirror/extensions/keyUpHandlerExtension.js
 packages/editor/CodeMirror/extensions/links/ctrlClickLinksExtension.js
 packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.test.js
@@ -1074,9 +1076,11 @@ packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/allLanguages.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/defaultLanguage.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/lookUpLanguage.js
+packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.test.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.js
 packages/editor/CodeMirror/utils/markdown/stripBlockquote.js
+packages/editor/CodeMirror/utils/markdown/toggleCheckboxAt.js
 packages/editor/CodeMirror/utils/setupVim.js
 packages/editor/ProseMirror/commands.test.js
 packages/editor/ProseMirror/commands.js

--- a/.gitignore
+++ b/.gitignore
@@ -977,6 +977,8 @@ packages/editor/CodeMirror/editorCommands/sortSelectedLines.test.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
 packages/editor/CodeMirror/extensions/biDirectionalTextExtension.js
+packages/editor/CodeMirror/extensions/ctrlClickActionExtension.js
+packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.js
 packages/editor/CodeMirror/extensions/keyUpHandlerExtension.js
 packages/editor/CodeMirror/extensions/links/ctrlClickLinksExtension.js
 packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.test.js
@@ -1047,9 +1049,11 @@ packages/editor/CodeMirror/utils/isInSyntaxNode.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/allLanguages.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/defaultLanguage.js
 packages/editor/CodeMirror/utils/markdown/codeBlockLanguages/lookUpLanguage.js
+packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.test.js
 packages/editor/CodeMirror/utils/markdown/renumberSelectedLists.js
 packages/editor/CodeMirror/utils/markdown/stripBlockquote.js
+packages/editor/CodeMirror/utils/markdown/toggleCheckboxAt.js
 packages/editor/CodeMirror/utils/setupVim.js
 packages/editor/ProseMirror/commands.test.js
 packages/editor/ProseMirror/commands.js

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -39,6 +39,7 @@ import selectedNoteIdExtension, { setNoteIdEffect } from './extensions/selectedN
 import ctrlKeyStateClassExtension from './extensions/modifierKeyCssExtension';
 import ctrlClickLinksExtension from './extensions/links/ctrlClickLinksExtension';
 import { RenderedContentContext } from './extensions/rendering/types';
+import ctrlClickCheckboxExtension from './extensions/ctrlClickCheckboxExtension';
 
 // Newer versions of CodeMirror by default use Chrome's EditContext API.
 // While this might be stable enough for desktop use, it causes significant
@@ -255,6 +256,7 @@ const createEditor = (
 				ctrlClickLinksExtension(link => {
 					props.onEvent({ kind: EditorEventType.FollowLink, link });
 				}),
+				ctrlClickCheckboxExtension(),
 
 				highlightSpecialChars(),
 				indentOnInput(),

--- a/packages/editor/CodeMirror/extensions/ctrlClickActionExtension.ts
+++ b/packages/editor/CodeMirror/extensions/ctrlClickActionExtension.ts
@@ -1,0 +1,33 @@
+import { EditorView } from '@codemirror/view';
+import { Prec } from '@codemirror/state';
+
+const hasMultipleCursors = (view: EditorView) => {
+	return view.state.selection.ranges.length > 1;
+};
+
+type OnCtrlClick = (view: EditorView, event: MouseEvent)=> boolean;
+
+const ctrlClickActionExtension = (onCtrlClick: OnCtrlClick) => {
+	return [
+		Prec.high([
+			EditorView.domEventHandlers({
+				mousedown: (event: MouseEvent, view: EditorView) => {
+					const hasModifier = event.ctrlKey || event.metaKey;
+					// The default CodeMirror action for ctrl-click is to add another cursor
+					// to the document. If the user already has multiple cursors, assume that
+					// the ctrl-click action is intended to add another.
+					if (hasModifier && !hasMultipleCursors(view)) {
+						const handled = onCtrlClick(view, event);
+						if (handled) {
+							event.preventDefault();
+							return true;
+						}
+					}
+					return false;
+				},
+			}),
+		]),
+	];
+};
+
+export default ctrlClickActionExtension;

--- a/packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.ts
+++ b/packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.ts
@@ -1,0 +1,30 @@
+import { EditorView } from '@codemirror/view';
+import modifierKeyCssExtension from './modifierKeyCssExtension';
+import { syntaxTree } from '@codemirror/language';
+import getCheckboxAtPosition from '../utils/markdown/getCheckboxAtPosition';
+import toggleCheckboxAt from '../utils/markdown/toggleCheckboxAt';
+import ctrlClickActionExtension from './ctrlClickActionExtension';
+
+
+const ctrlClickCheckboxExtension = () => {
+	return [
+		modifierKeyCssExtension,
+		EditorView.theme({
+			'&.-ctrl-or-cmd-pressed .cm-taskMarker': {
+				cursor: 'pointer',
+			},
+		}),
+		ctrlClickActionExtension((view, event) => {
+			const target = view.posAtCoords(event);
+			const taskMarker = getCheckboxAtPosition(target, syntaxTree(view.state));
+
+			if (taskMarker) {
+				toggleCheckboxAt(target)(view);
+				return true;
+			}
+			return false;
+		}),
+	];
+};
+
+export default ctrlClickCheckboxExtension;

--- a/packages/editor/CodeMirror/extensions/links/ctrlClickLinksExtension.ts
+++ b/packages/editor/CodeMirror/extensions/links/ctrlClickLinksExtension.ts
@@ -4,11 +4,9 @@ import modifierKeyCssExtension from '../modifierKeyCssExtension';
 import openLink from './utils/openLink';
 import getUrlAtPosition from './utils/getUrlAtPosition';
 import { syntaxTree } from '@codemirror/language';
-import { Prec } from '@codemirror/state';
-
+import ctrlClickActionExtension from '../ctrlClickActionExtension';
 
 type OnOpenLink = (url: string, view: EditorView)=> void;
-
 
 const ctrlClickLinksExtension = (onOpenExternalLink: OnOpenLink) => {
 	return [
@@ -19,27 +17,16 @@ const ctrlClickLinksExtension = (onOpenExternalLink: OnOpenLink) => {
 				cursor: 'pointer',
 			},
 		}),
-		Prec.high([
-			EditorView.domEventHandlers({
-				mousedown: (event: MouseEvent, view: EditorView) => {
-					if (event.ctrlKey || event.metaKey) {
-						const target = view.posAtCoords(event);
-						const url = getUrlAtPosition(target, syntaxTree(view.state), view.state);
-						const hasMultipleCursors = view.state.selection.ranges.length > 1;
+		ctrlClickActionExtension((view: EditorView, event: MouseEvent) => {
+			const target = view.posAtCoords(event);
+			const url = getUrlAtPosition(target, syntaxTree(view.state), view.state);
 
-						// The default CodeMirror action for ctrl-click is to add another cursor
-						// to the document. If the user already has multiple cursors, assume that
-						// the ctrl-click action is intended to add another.
-						if (url && !hasMultipleCursors) {
-							openLink(url.url, view, onOpenExternalLink);
-							event.preventDefault();
-							return true;
-						}
-					}
-					return false;
-				},
-			}),
-		]),
+			if (url) {
+				openLink(url.url, view, onOpenExternalLink);
+				return true;
+			}
+			return false;
+		}),
 	];
 };
 

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -1,30 +1,10 @@
 import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 import { SyntaxNodeRef } from '@lezer/common';
 import makeReplaceExtension from './utils/makeInlineReplaceExtension';
+import toggleCheckboxAt from '../../utils/markdown/toggleCheckboxAt';
 
 const checkboxClassName = 'cm-ext-checkbox-toggle';
 
-const toggleCheckbox = (view: EditorView, linePos: number) => {
-	if (linePos >= view.state.doc.length) {
-		// Position out of range
-		return false;
-	}
-
-	const line = view.state.doc.lineAt(linePos);
-	const checkboxMarkup = line.text.match(/\[(x|\s)\]/);
-	if (!checkboxMarkup) {
-		// Couldn't find the checkbox
-		return false;
-	}
-
-	const isChecked = checkboxMarkup[0] === '[x]';
-	const checkboxPos = checkboxMarkup.index! + line.from;
-
-	view.dispatch({
-		changes: [{ from: checkboxPos, to: checkboxPos + 3, insert: isChecked ? '[ ]' : '[x]' }],
-	});
-	return true;
-};
 
 class CheckboxWidget extends WidgetType {
 	public constructor(private checked: boolean, private depth: number, private label: string) {
@@ -58,7 +38,7 @@ class CheckboxWidget extends WidgetType {
 		container.appendChild(checkbox);
 
 		checkbox.oninput = () => {
-			toggleCheckbox(view, view.posAtDOM(container));
+			toggleCheckboxAt(view.posAtDOM(container))(view);
 		};
 
 		this.applyContainerClasses(container);

--- a/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.ts
+++ b/packages/editor/CodeMirror/utils/markdown/getCheckboxAtPosition.ts
@@ -1,0 +1,21 @@
+import { Tree } from '@lezer/common';
+
+const getCheckboxAtPosition = (pos: number, tree: Tree) => {
+	let iterator = tree.resolveStack(pos);
+
+	while (true) {
+		if (iterator.node.name === 'TaskMarker') {
+			return iterator.node;
+		}
+
+		if (!iterator.next) {
+			break;
+		} else {
+			iterator = iterator.next;
+		}
+	}
+
+	return null;
+};
+
+export default getCheckboxAtPosition;

--- a/packages/editor/CodeMirror/utils/markdown/toggleCheckboxAt.ts
+++ b/packages/editor/CodeMirror/utils/markdown/toggleCheckboxAt.ts
@@ -1,0 +1,26 @@
+import { Command, EditorView } from '@codemirror/view';
+
+const toggleCheckbox = (linePos: number): Command => (target: EditorView) => {
+	const state = target.state;
+	if (linePos >= state.doc.length) {
+		// Position out of range
+		return false;
+	}
+
+	const line = state.doc.lineAt(linePos);
+	const checkboxMarkup = line.text.match(/\[(x|\s)\]/);
+	if (!checkboxMarkup) {
+		// Couldn't find the checkbox
+		return false;
+	}
+
+	const isChecked = checkboxMarkup[0] === '[x]';
+	const checkboxPos = checkboxMarkup.index! + line.from;
+
+	target.dispatch({
+		changes: [{ from: checkboxPos, to: checkboxPos + 3, insert: isChecked ? '[ ]' : '[x]' }],
+	});
+	return true;
+};
+
+export default toggleCheckbox;


### PR DESCRIPTION
# Summary

This pull request adds support for toggling Markdown-editor checkboxes with <kbd>ctrl</kbd>-<kbd>click</kbd>.

**Notes**:
- This feature was requested by @laurent22 as part of moving certain features from @CalebJohn's Rich Markdown plugin and the Extra Editor Settings plugin into the main application. (See https://github.com/laurent22/joplin/pull/12747).
- A version of this pull request is in the process of being deployed to https://personalizedrefrigerator.github.io/joplin/web-client/.

# Testing plan

On desktop (Fedora 42):
1. Create a new note.
2. Add a task list to the note.
3. Add a link to one of the task items.
4. While holding <kbd>ctrl</kbd>, move the mouse pointer over the first `[ ]` (or `[x]`). Verify that the cursor becomes a pointer.
5. Click.
6. Verify that the checkbox completion state has been toggled.
7. Move the mouse pointer over the link.
8. Ctrl-click.
9. Verify that the link opens.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->