### PR TITLE
Mobile: Rich Text Editor: Fix adding headings moves the cursor to the next line

### DIFF
--- a/packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.ts
+++ b/packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.ts
@@ -4,51 +4,6 @@ import extractSelectedLinesTo from './extractSelectedLinesTo';
 import schema from '../schema';
 
 describe('extractSelectedLinesTo', () => {
-	test('should extract multiple lines in the same paragraph to a new paragraph', () => {
-		const view = createTestEditor({
-			html: '<p>Line 1<br>Line 2<br>Line 3<br>Line 4</p>',
-		});
-		view.dispatch(view.state.tr.setSelection(
-			TextSelection.create(
-				view.state.doc,
-				// ...from the middle of the second line...
-				'<Line 1|Line'.length,
-				// ...to the end of the third line
-				'<Line 1|Line 2|Line 3'.length,
-			),
-		));
-
-		const { transaction } = extractSelectedLinesTo(
-			{ type: schema.nodes.paragraph, attrs: { } },
-			view.state.tr,
-			view.state.selection,
-		);
-
-		view.dispatch(transaction);
-
-		// The section of the document containing the cursor should now be a new line
-		expect(view.state.doc.toJSON()).toMatchObject({
-			content: [
-				{
-					type: 'paragraph',
-					content: [{ type: 'text', text: 'Line 1' }],
-				},
-				{
-					type: 'paragraph',
-					content: [
-						{ type: 'text', text: 'Line 2' },
-						{ type: 'hard_break' },
-						{ type: 'text', text: 'Line 3' },
-					],
-				},
-				{
-					type: 'paragraph',
-					content: [{ type: 'text', text: 'Line 4' }],
-				},
-			],
-		});
-	});
-
 	test.each([
 		{
 			label: 'should extract a single line containing the cursor to a heading',
@@ -176,5 +131,50 @@ describe('extractSelectedLinesTo', () => {
 		// All of the tests in this group expect a single cursor
 		expect(view.state.selection.empty).toBe(true);
 		expect(view.state.selection.from).toBe(expected.cursorPosition);
+	});
+
+	test('should extract multiple lines in the same paragraph to a new paragraph', () => {
+		const view = createTestEditor({
+			html: '<p>Line 1<br>Line 2<br>Line 3<br>Line 4</p>',
+		});
+		view.dispatch(view.state.tr.setSelection(
+			TextSelection.create(
+				view.state.doc,
+				// ...from the middle of the second line...
+				'<Line 1|Line'.length,
+				// ...to the end of the third line
+				'<Line 1|Line 2|Line 3'.length,
+			),
+		));
+
+		const { transaction } = extractSelectedLinesTo(
+			{ type: schema.nodes.paragraph, attrs: { } },
+			view.state.tr,
+			view.state.selection,
+		);
+
+		view.dispatch(transaction);
+
+		// The section of the document containing the cursor should now be a new line
+		expect(view.state.doc.toJSON()).toMatchObject({
+			content: [
+				{
+					type: 'paragraph',
+					content: [{ type: 'text', text: 'Line 1' }],
+				},
+				{
+					type: 'paragraph',
+					content: [
+						{ type: 'text', text: 'Line 2' },
+						{ type: 'hard_break' },
+						{ type: 'text', text: 'Line 3' },
+					],
+				},
+				{
+					type: 'paragraph',
+					content: [{ type: 'text', text: 'Line 4' }],
+				},
+			],
+		});
 	});
 });

--- a/packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.ts
+++ b/packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.ts
@@ -4,49 +4,6 @@ import extractSelectedLinesTo from './extractSelectedLinesTo';
 import schema from '../schema';
 
 describe('extractSelectedLinesTo', () => {
-	test('should extract a single line containing the cursor to a heading', () => {
-		const view = createTestEditor({
-			html: '<p>Line 1<br>Line 2<br>Line 3</p>',
-		});
-		view.dispatch(view.state.tr.setSelection(
-			// Put the cursor in the middle of the second line
-			TextSelection.create(view.state.doc, '<Line 1|Line'.length),
-		));
-
-		const { transaction } = extractSelectedLinesTo(
-			{ type: schema.nodes.heading, attrs: { level: 1 } },
-			view.state.tr,
-			view.state.selection,
-		);
-
-		view.dispatch(transaction);
-
-		// The section of the document containing the cursor should now be a new line
-		expect(view.state.doc.toJSON()).toMatchObject({
-			content: [
-				{
-					type: 'paragraph',
-					content: [{ type: 'text', text: 'Line 1' }],
-				},
-				{
-					type: 'heading',
-					attrs: { level: 1 },
-					content: [{ type: 'text', text: 'Line 2' }],
-				},
-				{
-					type: 'paragraph',
-					content: [{ type: 'text', text: 'Line 3' }],
-				},
-			],
-		});
-
-		// The selection should still be in the heading
-		expect(view.state.selection.$anchor.parent.toJSON()).toMatchObject({
-			type: 'heading',
-			attrs: { level: 1 },
-		});
-	});
-
 	test('should extract multiple lines in the same paragraph to a new paragraph', () => {
 		const view = createTestEditor({
 			html: '<p>Line 1<br>Line 2<br>Line 3<br>Line 4</p>',
@@ -90,5 +47,134 @@ describe('extractSelectedLinesTo', () => {
 				},
 			],
 		});
+	});
+
+	test.each([
+		{
+			label: 'should extract a single line containing the cursor to a heading',
+			initial: {
+				docHtml: '<p>Line 1<br>Line 2<br>Line 3</p>',
+				// Put the cursor in the middle of the second line
+				cursorPosition: '<Line 1|Line'.length,
+			},
+			convertTo: { type: schema.nodes.heading, attrs: { level: 1 } },
+			expected: {
+				// The section of the document containing the cursor should now be a new line
+				docJson: [
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 1' }],
+					},
+					{
+						type: 'heading',
+						attrs: { level: 1 },
+						content: [{ type: 'text', text: 'Line 2' }],
+					},
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 3' }],
+					},
+				],
+				// The cursor should move to the end of the extracted line
+				cursorPosition: '<Line 1><Line 2'.length,
+			},
+		},
+		{
+			label: 'should convert an empty paragraph to a heading',
+			initial: {
+				docHtml: '<p>Line 1</p><p></p><p>Line 3</p>',
+				cursorPosition: '<Line 1><'.length,
+			},
+			convertTo: { type: schema.nodes.heading },
+			expected: {
+				docJson: [
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 1' }],
+					},
+					{
+						type: 'heading',
+					},
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 3' }],
+					},
+				],
+				cursorPosition: '<Line 1><'.length,
+			},
+		},
+		{
+			label: 'should convert the last line in a paragraph to a heading',
+			initial: {
+				docHtml: '<p>Line 1<br/></p><p>End</p>',
+				cursorPosition: '<Line 1|'.length,
+			},
+			convertTo: { type: schema.nodes.heading },
+			expected: {
+				docJson: [
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 1' }],
+					},
+					{
+						type: 'heading',
+					},
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'End' }],
+					},
+				],
+				cursorPosition: '<Line 1><'.length,
+			},
+		},
+		{
+			label: 'should convert the first line in a paragraph to a heading',
+			initial: {
+				docHtml: '<p><br/>Line 1</p><p>End</p>',
+				cursorPosition: '<'.length,
+			},
+			convertTo: { type: schema.nodes.heading },
+			expected: {
+				docJson: [
+					{
+						type: 'heading',
+					},
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'Line 1' }],
+					},
+					{
+						type: 'paragraph',
+						content: [{ type: 'text', text: 'End' }],
+					},
+				],
+				cursorPosition: '<'.length,
+			},
+		},
+	])('$label', ({ initial, expected, convertTo }) => {
+		const view = createTestEditor({
+			html: initial.docHtml,
+		});
+		view.dispatch(view.state.tr.setSelection(
+			TextSelection.create(
+				view.state.doc,
+				initial.cursorPosition,
+			),
+		));
+
+		const { transaction } = extractSelectedLinesTo(
+			{ type: convertTo.type, attrs: convertTo.attrs ?? { } },
+			view.state.tr,
+			view.state.selection,
+		);
+		view.dispatch(transaction);
+
+		expect(view.state.doc.toJSON()).toMatchObject({
+			content: expected.docJson,
+		});
+
+		// All of the tests in this group expect a single cursor
+		expect(view.state.selection.empty).toBe(true);
+		expect(view.state.selection.from).toBe(expected.cursorPosition);
 	});
 });

--- a/packages/editor/ProseMirror/utils/extractSelectedLinesTo.ts
+++ b/packages/editor/ProseMirror/utils/extractSelectedLinesTo.ts
@@ -33,7 +33,8 @@ const extractSelectedLinesTo = (extractTo: ExtractToOptions, transaction: Transa
 
 	const firstParagraphFrom = firstParagraphPos;
 	const lastParagraph = transaction.doc.nodeAt(lastParagraphPos);
-	const lastParagraphTo = lastParagraphPos + lastParagraph.nodeSize;
+	// -1: Exclude the end token
+	const lastParagraphTo = lastParagraphPos + lastParagraph.nodeSize - 1;
 
 	// Find the previous and next <br/>s (or the start/end of the paragraph)
 	let fromBreakPosition = firstParagraphFrom;


### PR DESCRIPTION
# Summary

This pull request fixes an issue with adding headings while using the mobile Rich Text Editor.

# Behavior comparison

## Before

Prior to this pull request, pressing <kbd>enter</kbd> after a paragraph, then pressing one of the "heading" buttons:
1. Created a heading block after the paragraph.
2. Moved the cursor to the line **just after the heading**.

As a result, unless the paragraph was at the end of the document, the cursor would not be in the just-added heading block.

Screen recording:

[Shows 1) pressing enter at the end of a paragraph 2) clicking the "H2" button 3) the cursor moving to the line after the just-added heading](https://github.com/user-attachments/assets/3e7bc1ef-5518-4119-ae54-d6378af1bd1c)


## After

With this change, the cursor remains in the just-added heading block, rather than moving to the next line.



# Testing plan

**Android 13**:
1. Create a new note.
2. Add two paragraphs.
3. Move the cursor to the end of the first paragraph.
4. Press <kbd>enter</kbd>.
5. Click "H2".
6. Verify that the cursor is now within a line that contains header formatting (rather than on the line just after).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->