### PR TITLE
Deleted note message action Improved: Cancel -> Revert #12871

### DIFF
--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -95,7 +95,7 @@ test.describe('noteList', () => {
 		await expect(notification).toBeVisible();
 
 		// Should be possible to un-delete
-		const undeleteButton = notification.getByRole('button', { name: 'Revert' }); //Intead of cancel > change to Revert
+		const undeleteButton = notification.getByRole('button', { name: 'Revert' }); //Cancel to Revert (Rever changes is better)
 		await undeleteButton.click();
 
 		await expect(testNoteItem).toBeVisible();

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -95,7 +95,7 @@ test.describe('noteList', () => {
 		await expect(notification).toBeVisible();
 
 		// Should be possible to un-delete
-		const undeleteButton = notification.getByRole('button', { name: 'Cancel' });
+		const undeleteButton = notification.getByRole('button', { name: 'Revert' }); //Intead of cancel > change to Revert
 		await undeleteButton.click();
 
 		await expect(testNoteItem).toBeVisible();


### PR DESCRIPTION
<!--

,inor change in Button name Instead of saying cancel, Now, it is Revert. 

<img width="1423" height="130" alt="Screenshot 2025-08-13 161703" src="https://github.com/user-attachments/assets/96afa905-65a1-4034-a2a0-934706bab476" />

I HAVE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->