### PR TITLE
Mobile: Rich Text Editor: Add basic support for collapsible <details> blocks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1082,6 +1082,8 @@ packages/editor/ProseMirror/commands.test.js
 packages/editor/ProseMirror/commands.js
 packages/editor/ProseMirror/createEditor.js
 packages/editor/ProseMirror/index.js
+packages/editor/ProseMirror/plugins/detailsPlugin.test.js
+packages/editor/ProseMirror/plugins/detailsPlugin.js
 packages/editor/ProseMirror/plugins/inputRulesPlugin.js
 packages/editor/ProseMirror/plugins/joplinEditablePlugin/createEditorDialog.js
 packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1055,6 +1055,8 @@ packages/editor/ProseMirror/commands.test.js
 packages/editor/ProseMirror/commands.js
 packages/editor/ProseMirror/createEditor.js
 packages/editor/ProseMirror/index.js
+packages/editor/ProseMirror/plugins/detailsPlugin.test.js
+packages/editor/ProseMirror/plugins/detailsPlugin.js
 packages/editor/ProseMirror/plugins/inputRulesPlugin.js
 packages/editor/ProseMirror/plugins/joplinEditablePlugin/createEditorDialog.js
 packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.test.js

--- a/packages/editor/ProseMirror/createEditor.ts
+++ b/packages/editor/ProseMirror/createEditor.ts
@@ -25,6 +25,7 @@ import { RendererControl } from './types';
 import resourcePlaceholderPlugin, { onResourceDownloaded } from './plugins/resourcePlaceholderPlugin';
 import getFileFromPasteEvent from '../utils/getFileFromPasteEvent';
 import { RenderResult } from '../../renderer/types';
+import detailsPlugin from './plugins/detailsPlugin';
 
 const createEditor = async (
 	parentElement: HTMLElement,
@@ -73,6 +74,7 @@ const createEditor = async (
 				gapCursor(),
 				dropCursor(),
 				history(),
+				detailsPlugin,
 				searchPlugin,
 				joplinEditablePlugin,
 				markupTracker,

--- a/packages/editor/ProseMirror/plugins/detailsPlugin.test.ts
+++ b/packages/editor/ProseMirror/plugins/detailsPlugin.test.ts
@@ -29,4 +29,36 @@ describe('detailsPlugin', () => {
 			markupToHtml.stateToMarkup(view.state).trim(),
 		).toBe(expectedState);
 	});
+
+	it.each([
+		{ initialOpen: false },
+		{ initialOpen: true },
+	])('toggling the details element should update its state (%j)', ({ initialOpen }) => {
+		const view = createTestEditor({
+			html: `
+				<details${initialOpen ? ' open' : ''}><summary>Test summary</summary>
+					<p>Test content.</p>
+				</details>
+			`,
+			plugins: [detailsPlugin],
+		});
+
+		const details = view.dom.querySelector('details');
+		details.open = !initialOpen;
+		details.dispatchEvent(new Event('toggle'));
+
+		// The changes to the DOM should be reflected in the editor state
+		expect(view.state.doc.toJSON()).toMatchObject({
+			content: [
+				{
+					type: 'details',
+					attrs: { open: !initialOpen },
+					content: [
+						{ type: 'details_summary' },
+						{ type: 'paragraph' },
+					],
+				},
+			],
+		});
+	});
 });

--- a/packages/editor/ProseMirror/plugins/detailsPlugin.test.ts
+++ b/packages/editor/ProseMirror/plugins/detailsPlugin.test.ts
@@ -1,0 +1,32 @@
+import createTestEditor from '../testing/createTestEditor';
+import detailsPlugin from './detailsPlugin';
+import originalMarkupPlugin from './originalMarkupPlugin';
+
+describe('detailsPlugin', () => {
+	it('should add jop-noMdConv attributes to <details> and <summary>', () => {
+		const serializer = new XMLSerializer();
+		const markupToHtml = originalMarkupPlugin(node => serializer.serializeToString(node));
+		const view = createTestEditor({
+			html: `
+				<details><summary>Test</summary>
+					<p>Test...</p>
+				</details>
+			`,
+			plugins: [detailsPlugin, markupToHtml.plugin],
+		});
+
+		// Serialize, then parse to normalize the HTML (for comparison
+		// with the HTML serialized by markupToHtml).
+		const expectedState = serializer.serializeToString(
+			new DOMParser().parseFromString([
+				'<details class="jop-noMdConv"><summary class="jop-noMdConv">Test</summary>',
+				'<p>Test...</p>',
+				'</details>',
+			].join(''), 'text/html').querySelector('details'),
+		);
+
+		expect(
+			markupToHtml.stateToMarkup(view.state).trim(),
+		).toBe(expectedState);
+	});
+});

--- a/packages/editor/ProseMirror/plugins/detailsPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/detailsPlugin.ts
@@ -1,0 +1,123 @@
+import { Plugin } from 'prosemirror-state';
+import { AttributeSpec, Node, NodeSpec } from 'prosemirror-model';
+import { EditorView, NodeView, ViewMutationRecord } from 'prosemirror-view';
+
+type NodeAttrs = Readonly<{
+	open: boolean;
+}>;
+
+const attrsSpec = {
+	open: { default: true, validate: 'boolean' },
+} satisfies Record<keyof NodeAttrs, AttributeSpec>;
+
+const detailsSpec: NodeSpec = {
+	group: 'block',
+	inline: false,
+	attrs: attrsSpec,
+	content: 'details_summary block+',
+	parseDOM: [
+		{
+			tag: 'details',
+			getAttrs: (node): NodeAttrs => {
+				return {
+					open: node.hasAttribute('open') && node.getAttribute('open') !== 'false',
+				};
+			},
+		},
+	],
+	toDOM: (node) => [
+		'details',
+		{
+			...(node.attrs.open ? { open: true } : {}),
+
+			// Allows the details element to be correctly converted back to Markdown (in Markdown notes).
+			class: 'jop-noMdConv',
+		},
+		0,
+	],
+};
+
+const detailsSummarySpec: NodeSpec = {
+	inline: false,
+	content: 'inline+',
+	parseDOM: [
+		{ tag: 'summary' },
+	],
+	toDOM: () => ['summary', { class: 'jop-noMdConv' }, 0],
+};
+
+export const nodeSpecs = {
+	details: detailsSpec,
+	details_summary: detailsSummarySpec,
+};
+
+type GetPosition = ()=> number|undefined;
+
+class DetailsView implements NodeView {
+	public readonly dom: HTMLDetailsElement;
+	public readonly contentDOM: HTMLElement;
+
+	public constructor(private node_: Node, view: EditorView, getPosition: GetPosition) {
+		this.dom = document.createElement('details');
+		this.dom.open = this.node_.attrs.open;
+		this.dom.ontoggle = () => {
+			const position = getPosition();
+			if (this.dom.open !== this.node_.attrs.open && position !== undefined) {
+				view.dispatch(view.state.tr.setNodeAttribute(
+					position, 'open', this.dom.open,
+				));
+			}
+		};
+
+		// Allow the user to click on the "summary" label's text without toggling the details
+		// element:
+		this.dom.onclick = (event) => {
+			const summaryNode = this.dom.querySelector('summary');
+			if (event.target === summaryNode) {
+				const contentRange = document.createRange();
+				contentRange.setStart(summaryNode, 0);
+				contentRange.setEnd(summaryNode, summaryNode.childNodes.length);
+				const bbox = contentRange.getBoundingClientRect();
+
+				const horizontalPadding = 10;
+				const eventIsInLabelText = (
+					event.x >= bbox.left &&
+					event.x <= bbox.left + bbox.width + horizontalPadding &&
+					event.y >= bbox.top &&
+					event.y <= bbox.top + bbox.height
+				);
+
+				if (eventIsInLabelText) {
+					event.preventDefault();
+				}
+			}
+		};
+
+		this.contentDOM = this.dom;
+	}
+
+	public ignoreMutation(mutation: ViewMutationRecord) {
+		// Prevent ProseMirror from immediately resetting the "open" attribute when toggled.
+		return mutation.target === this.dom && mutation.type === 'attributes' && mutation.attributeName === 'open';
+	}
+
+	public update(node: Node) {
+		if (node.type.spec !== this.node_.type.spec) return false;
+
+		this.node_ = node;
+		this.dom.open = node.attrs.open;
+		return true;
+	}
+}
+
+const detailsPlugin = new Plugin({
+	props: {
+		nodeViews: {
+			details: (node, view, getPos, _decorations) => {
+				return new DetailsView(node, view, getPos);
+			},
+		},
+	},
+});
+
+export default detailsPlugin;

--- a/packages/editor/ProseMirror/schema.ts
+++ b/packages/editor/ProseMirror/schema.ts
@@ -3,6 +3,7 @@ import { nodeSpecs as joplinEditableNodes } from './plugins/joplinEditablePlugin
 import { tableNodes } from 'prosemirror-tables';
 import { nodeSpecs as listNodes } from './plugins/listPlugin';
 import { nodeSpecs as resourcePlaceholderNodes } from './plugins/resourcePlaceholderPlugin';
+import { nodeSpecs as detailsNodes } from './plugins/detailsPlugin';
 
 // For reference, see:
 // - https://prosemirror.net/docs/guide/#schema
@@ -129,6 +130,7 @@ const nodes = addDefaultToplevelAttributes({
 			return result;
 		},
 	},
+	...detailsNodes,
 	...resourcePlaceholderNodes,
 	...listNodes,
 	...joplinEditableNodes,


### PR DESCRIPTION
# Summary

This pull request adds basic support for rendering and saving (but not adding) collapsible `<details>` blocks in the mobile Rich Text Editor.

**Note**: The `<details>` elements use the default browser styles (no Joplin-specific styles are added).

Related to https://github.com/laurent22/joplin/issues/12842.

# Testing plan

1. Open a note with two collapsed `<details>` elements in the Rich Text Editor.
2. Open the first `<details>` element by clicking near the ">" arrow.
3. Close the first `<details>` element.
4. Click near the middle of the first `<details>` element's title.
5. Verify that the cursor moves to the middle of the title and that the element isn't toggled.
6. Re-open the first details element.
7. Switch to the note viewer.
8. Verify that the `<details>` dropdowns are still present.
9. Verify that the first `<details>` dropdown is still expanded and the second is still collapsed.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->