### PR TITLE
Mobile: Improve tag screen usability to allow add or remove tag with a single press, when the keyboard is open

### DIFF
--- a/packages/app-mobile/components/ComboBox.tsx
+++ b/packages/app-mobile/components/ComboBox.tsx
@@ -540,6 +540,7 @@ const ComboBox: React.FC<Props> = ({
 	};
 	const activeId = `${baseId}-${selectedIndex}`;
 	const searchResults = <NestableFlatList
+		keyboardShouldPersistTaps="handled"
 		ref={listRef}
 		data={results}
 		{...searchResultProps}

--- a/packages/app-mobile/components/SearchInput.tsx
+++ b/packages/app-mobile/components/SearchInput.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import TextInput from './TextInput';
-import { View, StyleSheet, TextInputProps, ViewStyle, TextInput as ReactNativeTextInput } from 'react-native';
+import { View, StyleSheet, TextInputProps, ViewStyle, TextInput as ReactNativeTextInput, Keyboard } from 'react-native';
 import { _ } from '@joplin/lib/locale';
 import { Ref, useCallback, useMemo } from 'react';
 import { themeStyle } from './global-style';
 import IconButton from './IconButton';
-import Icon from './Icon';
 
 
 interface SearchInputProps extends TextInputProps {
@@ -58,11 +57,12 @@ const SearchInput: React.FC<SearchInputProps> = ({ inputRef, themeId, value, con
 	}, [onChangeText]);
 
 	return <View style={[styles.root, containerStyle]}>
-		<Icon
-			aria-hidden={true}
-			name='material magnify'
-			accessibilityLabel={null}
-			style={styles.icon}
+		<IconButton
+			iconName='material magnify'
+			onPress={() => Keyboard.dismiss()}
+			description={_('Hide keyboard')}
+			iconStyle={styles.icon}
+			themeId={themeId}
 		/>
 		<TextInput
 			ref={inputRef}

--- a/packages/app-mobile/components/TagEditor.tsx
+++ b/packages/app-mobile/components/TagEditor.tsx
@@ -171,6 +171,7 @@ const TagsBox: React.FC<TagsBoxProps> = props => {
 	return <View style={props.styles.tagBoxRoot}>
 		<Text style={props.styles.header} role='heading'>{_('Associated tags:')}</Text>
 		<ScrollView
+			keyboardShouldPersistTaps="handled"
 			style={props.styles.tagBoxScrollView}
 			// On web, specifying aria-live here announces changes to the associated tags.
 			// However, on Android (and possibly iOS), this breaks focus behavior:


### PR DESCRIPTION
Currently on the tag association screen on mobile, when the on screen keyboard is opened, if you tap the cross on an associated tag pill, or if you tap a search result / the add new tag entry, the keyboard will be dismissed, rather than the associated action being applied. This can make it easy to accidentally not apply changes to tag associations (personally, I have done this many times when using this screen), because the user may not notice that nothing was applied, particularly when adding a tag to a note which already has many tags associated with it.

In order to remedy this, I have changed the associated tag section and the search result section, so that tapping them does not dismiss the keyboard, causing the action to be applied on the first press. In order to provide a way that the keyboard can still be dismissed without needing to press the device back button, I have changed the search icon on the screen to be an IconButton, which dismisses the keyboard when pressed. Also tapping a blank section of the associated tag panel will also dismiss the keyboard.

### Testing

See video demonstrating the new behaviour:

https://github.com/user-attachments/assets/57bad572-894b-4a7a-89fe-58da22ce179c

