### PR TITLE
Transcribe: #12883: Disable JobProcessor tests by default

### DIFF
--- a/packages/transcribe/README.md
+++ b/packages/transcribe/README.md
@@ -29,7 +29,13 @@ For further customization look at `.env-sample-transcribe`
 
 ## Testing
 
-The integration tests that require the full model to run **don't run on the CI**. It is necessary to be extra careful when changing the model or the prompt because of that. The specific test that has been disabled is at `workers/JobProcessor.test.ts`
+The integration tests that require the full model to run **don't run by default, including on CI**. It is necessary to be extra careful when changing the model or the prompt because of that. The specific test that has been disabled is at `workers/JobProcessor.test.ts`
+
+To run all tests, use the command:
+
+```
+yarn test-all
+```
 
 ## Setup up the database
 

--- a/packages/transcribe/package.json
+++ b/packages/transcribe/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/src/api/app.js",
     "tsc": "tsc --project tsconfig.json",
     "test": "jest --verbose=false",
+    "test-all": "TRANSCRIBE_RUN_ALL=1 jest --verbose=false",
     "test-ci": "yarn test",
     "clean": "gulp clean",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json"

--- a/packages/transcribe/src/workers/JobProcessor.test.ts
+++ b/packages/transcribe/src/workers/JobProcessor.test.ts
@@ -12,7 +12,7 @@ const cleanUpResult = (result: string) => {
 	return result.replace('“', '"').replace('”', '"');
 };
 
-const skipIfCI = process.env.IS_CONTINUOUS_INTEGRATION ? it.skip : it;
+const skipByDefault = (process.env.IS_CONTINUOUS_INTEGRATION || process.env.TRANSCRIBE_RUN_ALL !== '1') ? it.skip : it;
 
 describe('JobProcessor', () => {
 	let queue: BaseQueue;
@@ -31,7 +31,7 @@ describe('JobProcessor', () => {
 		await cleanUpDb('./JobProcessor.test.sqlite3');
 	});
 
-	skipIfCI('should execute work on job in the queue', async () => {
+	skipByDefault('should execute work on job in the queue', async () => {
 		jest.useRealTimers();
 		const tw = new JobProcessor(queue, new HtrCli('joplin/htr-cli:0.0.2', 'images'), 1000);
 		await tw.init();
@@ -53,7 +53,7 @@ describe('JobProcessor', () => {
 		}
 	}, 6 * Minute);
 
-	skipIfCI('should execute work on job in the queue even if one fails', async () => {
+	skipByDefault('should execute work on job in the queue even if one fails', async () => {
 		jest.useRealTimers();
 		const tw = new JobProcessor(queue, new HtrCli('joplin/htr-cli:0.0.2', 'images'), 1000);
 		await tw.init();


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12883

# Summary

Disabling tests on JobProcessor by default, since they take a long time to run.

I also added a new script on package.json to allow running all tests, this one included

I thought about removing the `IS_CONTINUOUS_INTEGRATION` check, but I thought it was better to let here since it is explicit about skipping tests on CI too.

# Testing

Running `yarn test` skip Jobprocessors tests
Running `yarn test-all` run Jobprocessors tests