### PR TITLE
Cli,Mobile,Desktop: Shared folders: Fix moving shared subfolder to toplevel briefly marks it as a toplevel share

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -955,6 +955,8 @@ export default class Folder extends BaseItem {
 			// When a shared subfolder is converted to a toplevel folder, clear its share_id
 			// as soon as possible. Without this, modifiedFolder would be incorrectly treated
 			// as a root shared folder by some logic.
+			// Since the folder's children aren't toplevel, they won't be considered root
+			// shared folders and are updated later.
 			modifiedFolder.share_id = '';
 		}
 

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -938,13 +938,13 @@ export default class Folder extends BaseItem {
 	public static async moveToFolder(folderId: string, targetFolderId: string) {
 		if (!(await this.canNestUnder(folderId, targetFolderId))) throw new Error(_('Cannot move notebook to this location'));
 
-		// When moving a note to a different folder, the user timestamp is not updated.
-		// However updated_time is updated so that the note can be synced later on.
 		const original = await this.load(folderId);
-
 		const modifiedFolder: FolderEntity = {
 			id: folderId,
 			parent_id: targetFolderId,
+
+			// When moving a note to a different folder, the user timestamp is not updated.
+			// However updated_time is updated so that the note can be synced later on.
 			updated_time: time.unixMs(),
 			share_id: original.share_id,
 		};

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -953,8 +953,8 @@ export default class Folder extends BaseItem {
 		const movedToTopLevel = original.parent_id !== '' && targetFolderId === '';
 		if (wasShared && movedToTopLevel) {
 			// When a shared subfolder is converted to a toplevel folder, clear its share_id
-			// as soon as possible (prevent it from being recognised as a toplevel shared
-			// folder).
+			// as soon as possible. Without this, modifiedFolder would be incorrectly treated
+			// as a root shared folder by some logic.
 			modifiedFolder.share_id = '';
 		}
 


### PR DESCRIPTION
# Summary

Prior to this change, the following did not work:
1. Create a folder (folder A) with a subfolder (folder B).
2. Share folder A with another user.
3. Convert folder B to a toplevel folder.
4. Immediately move folder B back into folder A.

Repeating step 4 after a sync would work, however.

The issue came from how a toplevel shared folder is identified -- any toplevel folder with a `share_id` is considered by `isRootSharedFolder` to be a share root. Share roots are prevented from being moved into other folders. As a result, since step 3 did not clear folder B's `share_id`, in step 4, folder B was considered to be a share root, and thus prevented from being moved into folder A.

Note that this pull request only clears the `share_id` of the moved subfolder (and not items in the subfolder).

# Possible alternatives

- Call `Folder.updateAllShareIds` in `Folder.moveToFolder` if a previously-shared folder is converted to a toplevel folder.
- If the current behavior is by design, adjust the sync fuzzer to call `Folder.updateAllShareIds` after each `moveTo` action.

# Testing

## ...with the sync fuzzer

1. Run `git merge pr/sync/clear-share-id-on-folder-move` from `pr/chore/sync-fuzzer/support-add-remove-share-recipients`.
2. Rebuild
3. Run the sync fuzzer.
4. Verify that the sync fuzzer completes step 5 successfully.
   - With the current seed and actions available in `pr/chore/sync-fuzzer/support-add-remove-share-recipients`, step 5 involves 1) moving a folder to toplevel, 2) creating a new note, and 3) moving the folder from step 1 back into a shared folder.
   - **Note**: Currently, the sync fuzzer fails on **step 8**, in which 1) a subfolder of a shared folder is moved to toplevel and 2) that toplevel folder is immediately shared with a different client.

## ...with automated tests

This pull request adds an automated test that verifies that the `share_id` is cleared after converting a subfolder of a shared folder to a toplevel folder. 

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->