### PR TITLE
Server: Fixes #12983: Not handling correctly non JSON error responses from Transcribe

### DIFF
--- a/packages/server/src/routes/api/transcribe.test.ts
+++ b/packages/server/src/routes/api/transcribe.test.ts
@@ -18,6 +18,23 @@ type JobWithResult = {
 	state: string;
 };
 
+type TranscribeJobResponse = {
+	jobId: string;
+};
+
+type TranscribeResponse = TranscribeJobResponse | JobWithResult | string;
+
+type FetchResponse = {
+	json?: ()=> Promise<TranscribeResponse>;
+	text?: ()=> Promise<string>;
+	status: number;
+};
+
+const fetchSpyOn = (response: FetchResponse) => {
+	jest.spyOn(global, 'fetch').mockImplementation(
+		jest.fn(() => Promise.resolve(response)) as jest.Mock,
+	);
+};
 
 describe('api_transcribe', () => {
 
@@ -41,16 +58,12 @@ describe('api_transcribe', () => {
 
 	test('should create job', async () => {
 		const { session } = await createUserAndSession(1);
-
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					json: () => Promise.resolve(
-						{ jobId: '608626f1-cad9-4b07-a02e-ec427c47147f' },
-					),
-					status: 200,
-				})) as jest.Mock,
-		);
+		fetchSpyOn({
+			json: () => Promise.resolve(
+				{ jobId: '608626f1-cad9-4b07-a02e-ec427c47147f' },
+			),
+			status: 200,
+		});
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);
 		const response = await postApi<TranscribeJob>(session.id, 'transcribe', {},
@@ -65,15 +78,12 @@ describe('api_transcribe', () => {
 	test('should create job and return response eventually', async () => {
 		const { session } = await createUserAndSession(1);
 
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					json: () => Promise.resolve(
-						{ jobId: '608626f1-cad9-4b07-a02e-ec427c47147f' },
-					),
-					status: 200,
-				})) as jest.Mock,
-		);
+		fetchSpyOn({
+			json: () => Promise.resolve(
+				{ jobId: '608626f1-cad9-4b07-a02e-ec427c47147f' },
+			),
+			status: 200,
+		});
 
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);
@@ -85,19 +95,16 @@ describe('api_transcribe', () => {
 
 		expect(postResponse.jobId).not.toBe(undefined);
 
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
+		fetchSpyOn({
+			json: () => Promise.resolve(
 				{
-					json: (): Promise<JobWithResult> => Promise.resolve(
-						{
-							id: '608626f1-cad9-4b07-a02e-ec427c47147f',
-							state: 'completed',
-							result: { result: 'transcription' },
-						},
-					),
-					status: 200,
-				})) as jest.Mock,
-		);
+					id: '608626f1-cad9-4b07-a02e-ec427c47147f',
+					state: 'completed',
+					result: { result: 'transcription' },
+				},
+			),
+			status: 200,
+		});
 
 		const getResponse = await getApi<JobWithResult>(session.id, `transcribe/${postResponse.jobId}`, {});
 		expect(getResponse.id).toBe(postResponse.jobId);
@@ -108,13 +115,10 @@ describe('api_transcribe', () => {
 	test('should throw a error if API returns error 400', async () => {
 		const { session } = await createUserAndSession(1);
 
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					json: () => Promise.resolve(''),
-					status: 400,
-				})) as jest.Mock,
-		);
+		fetchSpyOn({
+			json: () => Promise.resolve(''),
+			status: 400,
+		});
 
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);
@@ -131,13 +135,10 @@ describe('api_transcribe', () => {
 	test('should throw error if API returns error 500', async () => {
 		const { session } = await createUserAndSession(1);
 
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					json: () => Promise.resolve(''),
-					status: 500,
-				})) as jest.Mock,
-		);
+		fetchSpyOn({
+			json: () => Promise.resolve(''),
+			status: 500,
+		});
 
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);
@@ -153,13 +154,10 @@ describe('api_transcribe', () => {
 	test('should throw 500 error is something unexpected', async () => {
 		const { session } = await createUserAndSession(1);
 
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					json: () => Promise.reject(new Error('Something went wrong')),
-					status: 200,
-				})) as jest.Mock,
-		);
+		fetchSpyOn({
+			json: () => Promise.reject(new Error('Something went wrong')),
+			status: 200,
+		});
 
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);
@@ -179,13 +177,11 @@ describe('api_transcribe', () => {
 		['json', JSON.stringify({ error: 'Something went wrong' })],
 	])('should be able to handle %s error responses', async (_type: string, result: string) => {
 		const { session } = await createUserAndSession(1);
-		jest.spyOn(global, 'fetch').mockImplementation(
-			jest.fn(() => Promise.resolve(
-				{
-					text: () => Promise.resolve(result),
-					status: 500,
-				})) as jest.Mock,
-		);
+
+		fetchSpyOn({
+			text: () => Promise.resolve(result),
+			status: 500,
+		});
 
 		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
 		const tempFilePath = await makeTempFileWithContent(fileContent);

--- a/packages/server/src/routes/api/transcribe.test.ts
+++ b/packages/server/src/routes/api/transcribe.test.ts
@@ -174,4 +174,30 @@ describe('api_transcribe', () => {
 		expect(error.message.startsWith('POST /api/transcribe {"status":500,"body":{"error":"Something went wrong"')).toBe(true);
 	});
 
+	test.each([
+		['non-json', 'Something went wrong'],
+		['json', JSON.stringify({ error: 'Something went wrong' })],
+	])('should be able to handle %s error responses', async (_type: string, result: string) => {
+		const { session } = await createUserAndSession(1);
+		jest.spyOn(global, 'fetch').mockImplementation(
+			jest.fn(() => Promise.resolve(
+				{
+					text: () => Promise.resolve(result),
+					status: 500,
+				})) as jest.Mock,
+		);
+
+		const fileContent = await readFile(`${testAssetDir}/htr_example.png`);
+		const tempFilePath = await makeTempFileWithContent(fileContent);
+		const error = await expectThrow(() =>
+			postApi<TranscribeJob>(session.id, 'transcribe', {},
+				{
+					filePath: tempFilePath,
+				},
+			));
+
+		const body = JSON.parse(error.message.split('POST /api/transcribe ')[1]);
+		expect(error.httpCode).toBe(502);
+		expect(body.body.error).toBe('Something went wrong');
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12983

# Summary

I'm not properly parsing the 500 error message from Transcribe server because I was expecting that every response would be a JSON.

Here I'm fixing this by getting the response content as text and trying to parse as JSON, if this fails we just get the first 10000 characters

Example when the POST transcribe returns a 500 status with a text body 'asdfasdf':

```
2025-08-18 18:05:58: api/transcribe: Sending file to Transcribe Server
2025-08-18 18:06:12: [error] App: ::ffff:127.0.0.1 Error: asdfasdf
    at Object.handler (/home/js/Desktop/joplin/fork/packages/server/src/routes/api/transcribe.ts:93:10)
    at processTicksAndRejections (/home/js/Desktop/joplin/fork/packages/server/lib/internal/process/task_queues.js:105:5)
    at execRequest (/home/js/Desktop/joplin/fork/packages/server/src/utils/routeUtils.ts:235:13)
    at default_1 (/home/js/Desktop/joplin/fork/packages/server/src/middleware/routeHandler.ts:18:46)
    at cors (/home/js/Desktop/joplin/fork/packages/server/node_modules/@koa/cors/index.js:61:32)
    at /home/js/Desktop/joplin/fork/packages/server/src/app.ts:173:4 {httpCode: 502, code: undefined, details: undefined, retryAfterMs: 0, stack: 'Error: asdfasdf
    at Object.handler (/home/…/joplin/fork/packages/server/src/app.ts:173:4', …}
```

# Testing

I added an automated test that simulates the two body types possible, JSON and non JSON.

I also tested manually by creating a express server, sending a 500 response with a JSON body and a text body to see if worked.