### PR TITLE
Chore: Improve type safety

### DIFF
--- a/packages/lib/BaseModel.ts
+++ b/packages/lib/BaseModel.ts
@@ -214,7 +214,7 @@ class BaseModel {
 		return fields.indexOf(name) >= 0;
 	}
 
-	public static fieldNames(withPrefix = false) {
+	public static fieldNames(withPrefix: string|boolean = false) {
 		const output = this.db().tableFieldNames(this.tableName());
 		if (!withPrefix) return output;
 

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -596,7 +596,7 @@ export default class Synchronizer {
 						if (this.cancelling()) break;
 
 						let local = locals[i];
-						const ItemClass: typeof BaseItem = BaseItem.itemClass(local);
+						const ItemClass = BaseItem.itemClass(local);
 						const path = BaseItem.systemPath(local);
 
 						// Safety check to avoid infinite loops.

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -702,7 +702,7 @@ export default class BaseItem extends BaseModel {
 		for (let i = 0; i < classNames.length; i++) {
 			const className = classNames[i];
 			const ItemClass = this.getClass(className);
-			const fieldNames = ItemClass.fieldNames(true);
+			const fieldNames = ItemClass.fieldNames('items');
 
 			// // NEVER SYNCED:
 			// 'SELECT * FROM [ITEMS] WHERE id NOT INT (SELECT item_id FROM sync_items WHERE sync_target = ?)'

--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -125,7 +125,7 @@ export default class BaseItem extends BaseModel {
 	}
 
 	// Need to dynamically load the classes like this to avoid circular dependencies
-	public static getClass(name: string) {
+	public static getClass<T extends typeof BaseItem>(name: string): T {
 		for (let i = 0; i < BaseItem.syncItemDefinitions_.length; i++) {
 			if (BaseItem.syncItemDefinitions_[i].className === name) {
 				const classRef = BaseItem.syncItemDefinitions_[i].classRef;
@@ -702,7 +702,7 @@ export default class BaseItem extends BaseModel {
 		for (let i = 0; i < classNames.length; i++) {
 			const className = classNames[i];
 			const ItemClass = this.getClass(className);
-			const fieldNames = ItemClass.fieldNames('items');
+			const fieldNames = ItemClass.fieldNames(true);
 
 			// // NEVER SYNCED:
 			// 'SELECT * FROM [ITEMS] WHERE id NOT INT (SELECT item_id FROM sync_items WHERE sync_target = ?)'
@@ -710,8 +710,7 @@ export default class BaseItem extends BaseModel {
 			// // CHANGED:
 			// 'SELECT * FROM [ITEMS] items JOIN sync_items s ON s.item_id = items.id WHERE sync_target = ? AND'
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			let extraWhere: any = [];
+			let extraWhere: string[]|string = [];
 			if (className === 'Note') extraWhere.push('is_conflict = 0');
 			if (className === 'Resource') extraWhere.push('encryption_blob_encrypted = 0');
 			if (ItemClass.encryptionSupported()) extraWhere.push('encryption_applied = 0');
@@ -774,8 +773,7 @@ export default class BaseItem extends BaseModel {
 				changedItems = await ItemClass.modelSelectAll(sql);
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const neverSyncedItemIds = neverSyncedItem.map((it: any) => it.id);
+			const neverSyncedItemIds = neverSyncedItem.map((it: BaseItemEntity) => it.id);
 			const items = neverSyncedItem.concat(changedItems);
 
 			if (i >= classNames.length - 1) {

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -1,6 +1,7 @@
 import BaseModel, { DeleteOptions, ModelType } from '../BaseModel';
 import BaseItem from './BaseItem';
-import FolderClass from './Folder';
+import type FolderClass from './Folder';
+import type ResourceClass from './Resource';
 import ItemChange from './ItemChange';
 import Setting from './Setting';
 import shim from '../shim';
@@ -9,7 +10,6 @@ import markdownUtils from '../markdownUtils';
 import { FolderEntity, NoteEntity } from '../services/database/types';
 import Tag from './Tag';
 const { sprintf } = require('sprintf-js');
-import ResourceClass from './Resource';
 import syncDebugLog from '../services/synchronizer/syncDebugLog';
 import { toFileProtocolPath, toForwardSlashes } from '../path-utils';
 const { pregQuote, substrWithEllipsis } = require('../string-utils.js');


### PR DESCRIPTION
# Summary

This pull request:
- Replaces a few explicit and implicit `any` types in `models/Note.ts` and `models/BaseItem.ts`.
- Corrects a parameter type in `BaseModel.ts`.

These changes were originally made while debugging https://github.com/laurent22/joplin/issues/12648.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->