### PR TITLE
Desktop,Mobile,Cli: Fix notes are moved to the conflict folder when a folder is unshared

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -500,7 +500,6 @@ export default class Folder extends BaseItem {
 
 			for (const child of children) {
 				if (child.share_id !== rootFolder.share_id) {
-					logger.info('Update share_id in', child.id, 'since it doesn\'t match ', rootFolder.share_id);
 					await this.save({
 						id: child.id,
 						share_id: rootFolder.share_id,
@@ -528,8 +527,6 @@ export default class Folder extends BaseItem {
 		report.unshareUpdateCount += foldersToUnshare.length;
 
 		for (const item of foldersToUnshare) {
-			logger.info('Unshare', item.id);
-
 			await this.save({
 				id: item.id,
 				share_id: '',

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -747,15 +747,13 @@ export default class Folder extends BaseItem {
 			report[tableName] = rows.length;
 
 			for (const row of rows) {
-				// Already unshared? If so, don't update the item.
-				// This prevents conflicts in the case where the item was unshared remotely.
-				// See https://github.com/laurent22/joplin/issues/12648.
-				if (row.share_id === '') continue;
-
 				const toSave: BaseItemEntity = {
 					id: row.id,
 					share_id: '',
-					updated_time: Date.now(),
+					// Don't change the updated_time.
+					// This prevents conflicts in the case where the item was unshared remotely.
+					// See https://github.com/laurent22/joplin/issues/12648
+					// updated_time: Date.now(),
 				};
 
 				if (hasParentId) {

--- a/readme/dev/spec/server_sharing.md
+++ b/readme/dev/spec/server_sharing.md
@@ -35,7 +35,7 @@ However, there are some maintenance tasks that clear `share_id` locally when a u
 3. `User1` unshares `Folder A`.
 4. `User2` locally clears the `share_id` property on the local `Folder A`.
 
-At this point, `User2` no longer has access to `Folder A` on the server. `User2` cannot sync the change to the `share_id` because `User2` no longer has access to the share.
+At this point, `User2` no longer has access to `Folder A` on the server. They cannot sync the change to `share_id` because they no longer have access to the share.
 
 ## Publishing a note via a public URL 
 

--- a/readme/dev/spec/server_sharing.md
+++ b/readme/dev/spec/server_sharing.md
@@ -27,7 +27,7 @@ On the other hand, all that information is present on the client. Whenever a not
 
 ### When are changes to `share_id` synced?
 
-In general, changes to `share_id` should be synced only if a Joplin client still has access to the remote item. For example, if `User1` adds an item to a folder shared with `User2`, then `User1` should update the `share_id` for that item.
+In general, changes to `share_id` should be synced only if a Joplin client still has access to the remote item. For example, if `User1` adds an item to a folder shared with `User2`, then `User1` should update and sync the `share_id` for that item.
 
 However, there are some maintenance tasks that clear `share_id` locally when a user no longer has access to a share. These changes should not be synced to the server because the user no longer has access to the relevant remote items. For example, if,
 1. `User1` shares `Folder A` with `User2`.

--- a/readme/dev/spec/server_sharing.md
+++ b/readme/dev/spec/server_sharing.md
@@ -25,6 +25,18 @@ Technically, the server would only need to know the root shared folder, and from
 
 On the other hand, all that information is present on the client. Whenever a notes is moved out a shared folder, or whenever a resources is attached, the changes are tracked, and that can be used to easily assign a `share_id` property. Once this is set, it makes the whole system more simple and reliable.
 
+### When are changes to `share_id` synced?
+
+In general, changes to `share_id` should be synced only if a Joplin client still has access to the remote item. For example, if `User1` adds an item to a folder shared with `User2`, then `User1` should update the `share_id` for that item.
+
+However, there are some maintenance tasks that clear `share_id` locally when a user no longer has access to a share. These changes should not be synced to the server because the user no longer has access to the relevant remote items. For example, if,
+1. `User1` shares `Folder A` with `User2`.
+2. `User2` accepts the share.
+3. `User1` unshares `Folder A`.
+4. `User2` locally clears the `share_id` property on the local `Folder A`.
+
+At this point, `User2` no longer has access to `Folder A` on the server. `User2` cannot sync the change to the `share_id` because `User2` no longer has access to the share.
+
 ## Publishing a note via a public URL 
 
 This is done by posting a note ID to `/api/shares`.


### PR DESCRIPTION
# Summary

This pull request partially resolves #12648.

Prior to this pull request, `updated_time` was set when `share_id` was cleared for share recipients. As a result, during the next sync, all items in unshared folders were marked as changed, resulting in "local has changes but remote does not exist" conflicts.

# Testing plan

## ...with the sync fuzzer

1. Merge this branch into [pr/chore/sync-fuzzer/support-add-remove-share-recipients](https://github.com/personalizedrefrigerator/joplin/tree/pr/chore/sync-fuzzer/support-add-remove-share-recipients) (locally).
2. Run `yarn syncFuzzer start --seed=1`.
3. Verify that the sync fuzzer runs for more than 20 steps.
4. **(Check that the issue happened previously)**: Re-add the `updated_time: Date.now(),` that was removed by this pull request. Rebuild.
5. Run `yarn syncFuzzer start --seed=1`.
6. Observe that the sync fuzzer fails on step 20.

## ...with the desktop app

With a shared folder that contains at least one note and two profiles syncing with different Joplin Server accounts,
1. Unshare the folder.
2. Switch to the share recipient's profile.
3. Sync once.
   - (⚠️) **Observed issue:** The notebook is still present, but no longer marked as shared. 
     This is similar to the behavior before this pull request and may be fixed by https://github.com/laurent22/joplin/pull/12999.
4. Sync again.
   - The notebook is removed from the device.
     **Note**: The expected behavior is for the notebook to be removed during the sync in step 3.

<!--

Plan:
1. Start Joplin Server in development mode.
4. Create or re-use two accounts (`self1@localhost` and `self2@localhost`).
5. Authenticate a different desktop app profile with each account.
6. Share a folder from `self1@localhost` with `self2@localhost`.
7. Accept the share from `self2@localhost`.
8. Add several notes to the folder.
9. Sync both profiles.

-->

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->