### PR TITLE
Desktop,Mobile,Cli: Fixes #12648: Fix unshare action requires two syncs to be reflected locally

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -445,6 +445,16 @@ export default class Synchronizer {
 			logger.error('Error indexing resources:', error);
 		}
 
+		// Before syncing, we run the share service maintenance, which is going
+		// to fetch share invitations and clear share_ids for unshared items, if any.
+		if (this.shareService_) {
+			try {
+				await this.shareService_.maintenance();
+			} catch (error) {
+				logger.error('Could not run share service maintenance:', error);
+			}
+		}
+
 		// Before synchronising make sure all share_id properties are set
 		// correctly so as to share/unshare the right items.
 		try {
@@ -1156,16 +1166,6 @@ export default class Synchronizer {
 		if (this.cancelling()) {
 			logger.info('Synchronisation was cancelled.');
 			this.cancelling_ = false;
-		}
-
-		// After syncing, we run the share service maintenance, which is going
-		// to fetch share invitations, if any.
-		if (this.shareService_) {
-			try {
-				await this.shareService_.maintenance();
-			} catch (error) {
-				logger.error('Could not run share service maintenance:', error);
-			}
 		}
 
 		this.progressReport_.completedTime = time.unixMs();


### PR DESCRIPTION
# Summary

This pull request resolves an issue identified in https://github.com/laurent22/joplin/pull/12993 and #12648 — it sometimes takes two synchronizations for an unshare to be fully processed.

This also fixes the "share not found" error referenced in #12648.

Combined with https://github.com/laurent22/joplin/pull/12993, this fixes #12648.

# Notes

- This pull request moves the call to `this.shareService_.maintenance` just before the main sync logic. Previously, it ran just after.
   - In addition to fetching share invitations, `this.shareService_.maintenance` clears the `share_id`s for unshared items. Clearing these IDs changes how the next sync behaves. As a result, clearing `this.shareService_.maintenance` **after** synchronization can result in more unsynced changes.

# Testing plan

1. Start two instances of the desktop app, each using a different account for sync.
2. Choose one of the two to be the share recipient.
3. Share a notebook from one client to the other and accept the share.
4. Stop Joplin Server.
5. Create a new note from the share recipient's instance.
6. Pause the share recipient's instance from the developer tools.
7. Start Joplin Server and unshare the notebook.
8. Clear the console in the share recipient's instance.
9. Resume the share recipient's instance and sync.
10. Verify that all items are moved to the "Conflicts" folder.
11. Check the console for errors & check that sync finishes successfully.
   - Found errors: "File not found" GET requests: `GET http://localhost:22300/api/items/root:/ba0b8c9ee1a34955a5ad25abecf9a439.md: 404 (Not Found)`. However, 1) this error comes from `.stat` and [should be handled](https://github.com/laurent22/joplin/blob/432b0ca870b541510711e38a240363a46efc4c5f/packages/lib/file-api-driver-joplinServer.ts#L91) and 2) sync continues and completes successfully. 
   - The error message described in #12648 is not present.

<details><summary>Checking that the testing plan reproduces the error without this change</summary>

Additional testing was done to check that the error referenced in #12648 happens if "ShareService.maintenance" is again moved below the main sync logic:
1. Move the "shareService_.maintenance" call back to below the main sync logic.
2. Rebuild.
3. Start two instances of the desktop app, each using a different account for sync.
4. Choose one of the two to be the share recipient.
5. Share a notebook from one client to the other and accept the share.
6. Stop Joplin Server.
7. Create a new note from the share recipient's instance.
8. Pause the share recipient's instance from the developer tools.
9. Start Joplin Server and unshare the notebook.
10. Clear the console in the share recipient's instance.
11. Resume the share recipient's instance and sync.
12. Verify that all items are moved to the "Conflicts" folder.
13. Observe that sync fails
14. Check the console for errors/warnings.
    - Found errors:
      ```
      Logger.ts:317 09:39:59: Synchronizer: There was some errors:
      log @ Logger.ts:317
      warn @ Logger.ts:145
      logSyncSummary @ Synchronizer.ts:280
      Logger.ts:317 09:39:59: Synchronizer: Ilt: share not found: w6DKPDY6A01tsMApQASeNR
        at vAt.serializeAndUploadItem (file:///home/self/Documents/joplin/packages/lib/services/synchronizer/ItemUploader.ts:50:22)
        at e.start (file:///home/self/Documents/joplin/packages/lib/Synchronizer.ts:764:28)
        at Timeout.timeoutCallback [as _onTimeout] (file:///home/self/Documents/joplin/packages/lib/registry.ts:190:27)
      ```

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->