### PR TITLE
MacOS: Fix startup failure when unable to access the keychain

### DIFF
--- a/packages/lib/services/keychain/KeychainServiceDriver.electron.ts
+++ b/packages/lib/services/keychain/KeychainServiceDriver.electron.ts
@@ -31,12 +31,14 @@ export default class KeychainServiceDriver extends KeychainServiceDriverBase {
 		if (canUseSafeStorage()) {
 			logger.debug('Saving password with electron safe storage. ID: ', name);
 
+			let encrypted;
 			try {
-				const encrypted = await shim.electronBridge().safeStorage.encryptString(password);
-				await KvStore.instance().setValue(`${kvStorePrefix}${name}`, encrypted);
+				encrypted = await shim.electronBridge().safeStorage.encryptString(password);
 			} catch (error) {
 				logger.warn('Encrypting a setting failed. Missing keychain permission?', error);
+				return false;
 			}
+			await KvStore.instance().setValue(`${kvStorePrefix}${name}`, encrypted);
 		} else {
 			// Unsupported.
 			return false;

--- a/packages/lib/services/keychain/KeychainServiceDriver.electron.ts
+++ b/packages/lib/services/keychain/KeychainServiceDriver.electron.ts
@@ -31,8 +31,12 @@ export default class KeychainServiceDriver extends KeychainServiceDriverBase {
 		if (canUseSafeStorage()) {
 			logger.debug('Saving password with electron safe storage. ID: ', name);
 
-			const encrypted = await shim.electronBridge().safeStorage.encryptString(password);
-			await KvStore.instance().setValue(`${kvStorePrefix}${name}`, encrypted);
+			try {
+				const encrypted = await shim.electronBridge().safeStorage.encryptString(password);
+				await KvStore.instance().setValue(`${kvStorePrefix}${name}`, encrypted);
+			} catch (error) {
+				logger.warn('Encrypting a setting failed. Missing keychain permission?', error);
+			}
 		} else {
 			// Unsupported.
 			return false;


### PR DESCRIPTION
# Summary

This pull request adds a `try`/`catch` to handle the case where `safeStorage.encryptString` fails on MacOS. This seems to happen, for example, if a user clicks "deny" in the [keychain access prompt shown when running Joplin in development mode on MacOS](https://github.com/laurent22/joplin/issues/13005).

# Testing plan

On MacOS:
1. Delete the "Joplin Safe Storage" item from "Keychain Access"
1. Start Joplin in release mode.
2. Quit Joplin.
3. Start Joplin in development mode.
4. Click "Deny" on the keychain access prompt.
5. Verify that Joplin starts successfully.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->