### PR TITLE
Chore: Desktop: Allow access to more Joplin APIs from the desktop development tools in dev mode

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -689,6 +689,7 @@ class Application extends BaseApplication {
 					Note,
 					Folder,
 					Resource,
+					Setting,
 					ocrService: () => this.ocrService_,
 				};
 			});

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -63,6 +63,8 @@ import { refreshFolders } from '@joplin/lib/folders-screen-utils';
 import initializeCommandService from './utils/initializeCommandService';
 import OcrDriverBase from '@joplin/lib/services/ocr/OcrDriverBase';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
+import Note from '@joplin/lib/models/Note';
+import Resource from '@joplin/lib/models/Resource';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -683,6 +685,10 @@ class Application extends BaseApplication {
 					debug: new DebugService(reg.db()),
 					resourceService: ResourceService.instance(),
 					searchEngine: SearchEngine.instance(),
+					shim,
+					Note,
+					Folder,
+					Resource,
 					ocrService: () => this.ocrService_,
 				};
 			});


### PR DESCRIPTION
# Summary

This allows access to `Resource`, `Note`, `Folder`, and `shim` from the development tools (through the `joplin` variable) when Joplin is running in development mode.

This change was used in the "manual testing" section of https://github.com/laurent22/joplin/pull/13051.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->