### PR TITLE
All: Fixes #12249: Change default content-type for Webdav connector to application/octet-stream

### DIFF
--- a/packages/lib/WebDavApi.js
+++ b/packages/lib/WebDavApi.js
@@ -350,7 +350,7 @@ class WebDavApi {
 		// https://github.com/facebook/react-native/issues/30176
 		if (!headers['Content-Type']) {
 			if (method === 'PROPFIND') headers['Content-Type'] = 'text/xml';
-			if (method === 'PUT') headers['Content-Type'] = 'text/plain';
+			if (method === 'PUT') headers['Content-Type'] = 'application/octet-stream';
 		}
 
 		// React-native has caching enabled by at least on Android (see https://github.com/laurent22/joplin/issues/4706 and the related PR).


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/12249

# Summary

User reported a mismatch between the `Content-length` header and the real content size, which seems related to the header being `plain/text` when sending binary content (image, for example).

# Testing

To test the change I run the [sync-in](https://github.com/Sync-in/server) server in dev environment. Unfortunately I could not reproduce the bug yet (maybe we could wait some days to see if the original user can give us a little more context?), but the synchronization still works after the PR change.

I also test the synchronization with [The Good Cloud](https://thegood.cloud/) which is a provider of NextCloud implementation.