### PR TITLE
Desktop, Mobile: Resolves #13048: Auto-disable plugin settings when conflicting built-in settings are enabled

### DIFF
--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -521,4 +521,25 @@ describe('models/Setting', () => {
 		Setting.setValue('revisionService.ttlDays', 0);
 		expect(Setting.value('revisionService.ttlDays')).toBe(1);
 	});
+
+	test('should adjust settings to avoid conflicts', async () => {
+		const testSettingId = 'plugin-plugin.calebjohn.rich-markdown.inlineImages';
+		await Setting.registerSetting(testSettingId, {
+			public: true,
+			value: false,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+		});
+
+		Setting.setValue('editor.imageRendering', true);
+
+		// Setting one conflicting setting should update the other
+		Setting.setValue(testSettingId, true);
+		expect(Setting.value('editor.imageRendering')).toBe(false);
+		expect(Setting.value(testSettingId)).toBe(true);
+
+		Setting.setValue('editor.imageRendering', true);
+		expect(Setting.value('editor.imageRendering')).toBe(true);
+		expect(Setting.value(testSettingId)).toBe(false);
+	});
 });


### PR DESCRIPTION
# Summary

As suggested in #13048, this pull request adds logic to `Setting.setValue` to auto-disable settings with conflicts.

See the "Notes" section for a possible issue with this approach.

# Notes

- This approach may lead to confusing behavior. At present, if a user:
  1. Opens settings.
  2. Enables Rich Markdown's "Render images below their Markdown source".
  3. Applies changes.
  4. Switches to the "Note" tab and enables "Markdown editor: Render images".
  5. Applies changes.
  6. Switches back to the "Rich Markdown" tab.
  
  Then the "Render images below their Markdown source" checkbox is still checked. However, after closing and re-opening settings, "Render images below their Markdown source" 's checkbox **is unchecked**. This is because the settings screen maintains its own cache of setting values, which aren't updated by `setValue`.
  
  [Screen recording: Demonstrates settings appearing to change after closing and reopening settings](https://github.com/user-attachments/assets/8c180598-b147-4237-a8a3-1137f527a624)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->