### PR TITLE
Desktop, Mobile: Markdown editor: Fix image rendering is disabled unless markup rendering is also enabled

### DIFF
--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -17,6 +17,7 @@ import insertNewlineContinueMarkup from './editorCommands/insertNewlineContinueM
 import renderingExtension from './extensions/rendering/renderingExtension';
 import { RenderedContentContext } from './extensions/rendering/types';
 import highlightActiveLineExtension from './extensions/highlightActiveLineExtension';
+import renderBlockImages from './extensions/rendering/renderBlockImages';
 
 const configFromSettings = (settings: EditorSettings, context: RenderedContentContext) => {
 	const languageExtension = (() => {
@@ -88,9 +89,11 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 	}
 
 	if (settings.inlineRenderingEnabled) {
-		extensions.push(renderingExtension(context, {
-			renderImages: settings.imageRenderingEnabled,
-		}));
+		extensions.push(renderingExtension());
+	}
+
+	if (settings.imageRenderingEnabled) {
+		extensions.push(renderBlockImages(context));
 	}
 
 	if (settings.highlightActiveLine) {

--- a/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
@@ -1,22 +1,15 @@
 import addFormattingClasses from './addFormattingClasses';
-import renderBlockImages from './renderBlockImages';
 import replaceBulletLists from './replaceBulletLists';
 import replaceCheckboxes from './replaceCheckboxes';
 import replaceDividers from './replaceDividers';
 import replaceFormatCharacters from './replaceFormatCharacters';
-import { RenderedContentContext } from './types';
 
-interface Options {
-	renderImages: boolean;
-}
-
-export default (context: RenderedContentContext, options: Options) => {
+export default () => {
 	return [
 		replaceCheckboxes,
 		replaceBulletLists,
 		replaceFormatCharacters,
 		replaceDividers,
 		addFormattingClasses,
-		...(options.renderImages ? [renderBlockImages(context)] : []),
 	];
 };


### PR DESCRIPTION
# Summary

Previously, the `imageRenderingEnabled` setting had no effect unless `inlineRenderingEnabled` was also enabled.

# Testing plan

1. Start the desktop app.
2. Attach an image to a note.
3. Open settings and enable "Markdown editor: Render images", while keeping "Markdown editor: Render markup in editor" disabled.
4. Apply changes and close settings.
5. Verify that the image is rendered in the Markdown editor.
6. Enable "Markdown editor: Render markup in editor"
7. Verify that the image is still rendered in the Markdown editor.
8. Add a heading to the note.
9. Verify that the `#` at the beginning of the heading is hidden when the cursor is on a different line.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->