### PR TITLE
Cli: Add commands for publishing and unpublishing notes with Joplin Server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -117,6 +117,8 @@ packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js
 packages/app-cli/app/command-mv.js
+packages/app-cli/app/command-publish.test.js
+packages/app-cli/app/command-publish.js
 packages/app-cli/app/command-ren.js
 packages/app-cli/app/command-restore.js
 packages/app-cli/app/command-rmbook.test.js
@@ -129,6 +131,8 @@ packages/app-cli/app/command-share.test.js
 packages/app-cli/app/command-share.js
 packages/app-cli/app/command-sync.js
 packages/app-cli/app/command-testing.js
+packages/app-cli/app/command-unpublish.test.js
+packages/app-cli/app/command-unpublish.js
 packages/app-cli/app/command-use.js
 packages/app-cli/app/command-version.js
 packages/app-cli/app/gui/FolderListWidget.js

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js
 packages/app-cli/app/command-mv.js
+packages/app-cli/app/command-publish.test.js
+packages/app-cli/app/command-publish.js
 packages/app-cli/app/command-ren.js
 packages/app-cli/app/command-restore.js
 packages/app-cli/app/command-rmbook.test.js
@@ -102,6 +104,8 @@ packages/app-cli/app/command-share.test.js
 packages/app-cli/app/command-share.js
 packages/app-cli/app/command-sync.js
 packages/app-cli/app/command-testing.js
+packages/app-cli/app/command-unpublish.test.js
+packages/app-cli/app/command-unpublish.js
 packages/app-cli/app/command-use.js
 packages/app-cli/app/command-version.js
 packages/app-cli/app/gui/FolderListWidget.js

--- a/packages/app-cli/app/command-publish.test.ts
+++ b/packages/app-cli/app/command-publish.test.ts
@@ -1,0 +1,60 @@
+import ShareService from '@joplin/lib/services/share/ShareService';
+import mockShareService from '@joplin/lib/testing/share/mockShareService';
+import { setupDatabaseAndSynchronizer, switchClient, waitFor } from '@joplin/lib/testing/test-utils';
+import { setupApplication, setupCommandForTesting } from './utils/testUtils';
+import Note from '@joplin/lib/models/Note';
+import Folder from '@joplin/lib/models/Folder';
+import Setting from '@joplin/lib/models/Setting';
+const Command = require('./command-publish');
+
+
+describe('command-publish', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		await setupApplication();
+
+		mockShareService({
+			getShares: async () => {
+				return { items: [] };
+			},
+			postShares: async () => ({ id: 'test-id' }),
+			getShareInvitations: async () => null,
+		}, ShareService.instance());
+	});
+
+	test('should publish a note', async () => {
+		const onStdout = jest.fn();
+		const command = setupCommandForTesting(Command, onStdout);
+
+		const testFolder = await Folder.save({ title: 'Test' });
+		const testNote = await Note.save({ title: 'test', parent_id: testFolder.id });
+
+		await command.action({
+			note: testNote.id,
+			options: {
+				force: true,
+			},
+		});
+
+		// Should be shared
+		await waitFor(async () => {
+			expect(await Note.load(testNote.id)).toMatchObject({
+				is_shared: 1,
+			});
+		});
+	});
+
+	test('should be enabled for Joplin Server and Cloud sync targets', async () => {
+		const command = setupCommandForTesting(Command, ()=>{});
+
+		Setting.setValue('sync.target', 1);
+		expect(command.enabled()).toBe(false);
+
+		const supportedSyncTargets = [9, 10, 11];
+		for (const id of supportedSyncTargets) {
+			Setting.setValue('sync.target', id);
+			expect(command.enabled()).toBe(true);
+		}
+	});
+});

--- a/packages/app-cli/app/command-publish.test.ts
+++ b/packages/app-cli/app/command-publish.test.ts
@@ -1,12 +1,18 @@
 import ShareService from '@joplin/lib/services/share/ShareService';
 import mockShareService from '@joplin/lib/testing/share/mockShareService';
-import { setupDatabaseAndSynchronizer, switchClient, waitFor } from '@joplin/lib/testing/test-utils';
+import { createFolderTree, setupDatabaseAndSynchronizer, switchClient, waitFor } from '@joplin/lib/testing/test-utils';
 import { setupApplication, setupCommandForTesting } from './utils/testUtils';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
 import Setting from '@joplin/lib/models/Setting';
 const Command = require('./command-publish');
 
+const setUpCommand = () => {
+	const onStdout = jest.fn();
+	const command = setupCommandForTesting(Command, onStdout);
+
+	return { command, onStdout };
+};
 
 describe('command-publish', () => {
 	beforeEach(async () => {
@@ -24,8 +30,7 @@ describe('command-publish', () => {
 	});
 
 	test('should publish a note', async () => {
-		const onStdout = jest.fn();
-		const command = setupCommandForTesting(Command, onStdout);
+		const { command, onStdout } = setUpCommand();
 
 		const testFolder = await Folder.save({ title: 'Test' });
 		const testNote = await Note.save({ title: 'test', parent_id: testFolder.id });
@@ -43,10 +48,14 @@ describe('command-publish', () => {
 				is_shared: 1,
 			});
 		});
+
+		// Should have logged a share URL
+		expect(onStdout).toHaveBeenCalled();
+		expect(onStdout.mock.lastCall[0]).toMatch(/Share URL:/);
 	});
 
-	test('should be enabled for Joplin Server and Cloud sync targets', async () => {
-		const command = setupCommandForTesting(Command, ()=>{});
+	test('should be enabled for Joplin Server and Cloud sync targets', () => {
+		const { command } = setUpCommand();
 
 		Setting.setValue('sync.target', 1);
 		expect(command.enabled()).toBe(false);
@@ -56,5 +65,40 @@ describe('command-publish', () => {
 			Setting.setValue('sync.target', id);
 			expect(command.enabled()).toBe(true);
 		}
+	});
+
+	test('should not ask for confirmation if a note is already published', async () => {
+		const { command } = setUpCommand();
+
+		const promptMock = jest.fn(() => true);
+		command.setPrompt(promptMock);
+
+		await createFolderTree('', [
+			{
+				title: 'folder 1',
+				children: [
+					{
+						title: 'note 1',
+						body: 'test',
+					},
+				],
+			},
+		]);
+		const noteId = (await Note.loadByTitle('note 1')).id;
+
+		// Should ask for confirmation when first sharing
+		await command.action({
+			note: noteId,
+			options: { },
+		});
+		expect(promptMock).toHaveBeenCalledTimes(1);
+		expect(await Note.load(noteId)).toMatchObject({ is_shared: 1 });
+
+		// Should not ask for confirmation if called again for the same note
+		await command.action({
+			note: noteId,
+			options: { },
+		});
+		expect(promptMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/app-cli/app/command-publish.test.ts
+++ b/packages/app-cli/app/command-publish.test.ts
@@ -49,9 +49,9 @@ describe('command-publish', () => {
 			});
 		});
 
-		// Should have logged a share URL
+		// Should have logged the publication URL
 		expect(onStdout).toHaveBeenCalled();
-		expect(onStdout.mock.lastCall[0]).toMatch(/Share URL:/);
+		expect(onStdout.mock.lastCall[0]).toMatch(/Published at URL:/);
 	});
 
 	test('should be enabled for Joplin Server and Cloud sync targets', () => {

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -53,7 +53,7 @@ class Command extends BaseCommand {
 
 		const userId = ShareService.instance().userId;
 		const shareUrl = ShareService.instance().shareUrl(userId, share);
-		this.stdout(_('Share URL:', shareUrl));
+		this.stdout(_('Published at URL:', shareUrl));
 	}
 }
 

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -6,6 +6,7 @@ import ShareService from '@joplin/lib/services/share/ShareService';
 import { ModelType } from '@joplin/lib/BaseModel';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 import Setting from '@joplin/lib/models/Setting';
+import { reg } from '@joplin/lib/registry';
 
 const logger = Logger.create('command-publish');
 
@@ -50,6 +51,9 @@ class Command extends BaseCommand {
 
 		logger.info('Share note: ', targetNote.id);
 		const share = await ShareService.instance().shareNote(targetNote.id, false);
+
+		this.stdout(_('Syncing...'));
+		await reg.waitForSyncFinishedThenSync();
 
 		const userId = ShareService.instance().userId;
 		const shareUrl = ShareService.instance().shareUrl(userId, share);

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -52,7 +52,7 @@ class Command extends BaseCommand {
 		logger.info('Share note: ', targetNote.id);
 		const share = await ShareService.instance().shareNote(targetNote.id, false);
 
-		this.stdout(_('Syncing...'));
+		this.stdout(_('Synchronising...'));
 		await reg.waitForSyncFinishedThenSync();
 
 		const userId = ShareService.instance().userId;

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -1,0 +1,59 @@
+import { _ } from '@joplin/lib/locale';
+import BaseCommand from './base-command';
+import app from './app';
+import Logger from '@joplin/utils/Logger';
+import ShareService from '@joplin/lib/services/share/ShareService';
+import { ModelType } from '@joplin/lib/BaseModel';
+import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
+import Setting from '@joplin/lib/models/Setting';
+
+const logger = Logger.create('command-publish');
+
+type Args = {
+	note: string;
+	options: {
+		force?: boolean;
+	};
+};
+
+
+class Command extends BaseCommand {
+	public usage() {
+		return 'publish [note]';
+	}
+
+	public description() {
+		return _('Publishes a note to Joplin Server or Joplin Cloud');
+	}
+
+	public options() {
+		return [
+			['-f, --force', _('Do not ask for user confirmation.')],
+		];
+	}
+
+	public enabled() {
+		return SyncTargetRegistry.isJoplinServerOrCloud(Setting.value('sync.target'));
+	}
+
+	public async action(args: Args) {
+		const targetNote = await app().loadItemOrFail(ModelType.Note, args.note);
+		const parent = await app().loadItem(ModelType.Folder, targetNote.parent_id);
+
+		const force = args.options.force;
+		const ok = force ? true : await this.prompt(
+			_('Publish note "%s" (in notebook "%s")?', targetNote.title, parent.title ?? '<root>'),
+			{ booleanAnswerDefault: 'n' },
+		);
+		if (!ok) return;
+
+		logger.info('Share note: ', targetNote.id);
+		const share = await ShareService.instance().shareNote(targetNote.id, false);
+
+		const userId = ShareService.instance().userId;
+		const shareUrl = ShareService.instance().shareUrl(userId, share);
+		this.stdout(_('Share URL:', shareUrl));
+	}
+}
+
+module.exports = Command;

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -53,7 +53,7 @@ class Command extends BaseCommand {
 
 		const userId = ShareService.instance().userId;
 		const shareUrl = ShareService.instance().shareUrl(userId, share);
-		this.stdout(_('Published at URL:', shareUrl));
+		this.stdout(_('Published at URL: %s', shareUrl));
 	}
 }
 

--- a/packages/app-cli/app/command-publish.ts
+++ b/packages/app-cli/app/command-publish.ts
@@ -41,7 +41,8 @@ class Command extends BaseCommand {
 		const parent = await app().loadItem(ModelType.Folder, targetNote.parent_id);
 
 		const force = args.options.force;
-		const ok = force ? true : await this.prompt(
+		const alreadyShared = !!targetNote.is_shared;
+		const ok = force || alreadyShared ? true : await this.prompt(
 			_('Publish note "%s" (in notebook "%s")?', targetNote.title, parent.title ?? '<root>'),
 			{ booleanAnswerDefault: 'n' },
 		);

--- a/packages/app-cli/app/command-unpublish.test.ts
+++ b/packages/app-cli/app/command-unpublish.test.ts
@@ -4,7 +4,7 @@ import { setupDatabaseAndSynchronizer, switchClient, waitFor } from '@joplin/lib
 import { setupApplication, setupCommandForTesting } from './utils/testUtils';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
-const Command = require('./command-publish');
+const Command = require('./command-unpublish');
 
 
 describe('command-unpublish', () => {

--- a/packages/app-cli/app/command-unpublish.test.ts
+++ b/packages/app-cli/app/command-unpublish.test.ts
@@ -1,0 +1,43 @@
+import ShareService from '@joplin/lib/services/share/ShareService';
+import mockShareService from '@joplin/lib/testing/share/mockShareService';
+import { setupDatabaseAndSynchronizer, switchClient, waitFor } from '@joplin/lib/testing/test-utils';
+import { setupApplication, setupCommandForTesting } from './utils/testUtils';
+import Note from '@joplin/lib/models/Note';
+import Folder from '@joplin/lib/models/Folder';
+const Command = require('./command-publish');
+
+
+describe('command-unpublish', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		await setupApplication();
+
+		mockShareService({
+			getShares: async () => {
+				return { items: [{ id: 'test-id' }] };
+			},
+			postShares: async () => {
+				throw new Error('Unexpected call to postShares');
+			},
+			getShareInvitations: async () => null,
+		}, ShareService.instance());
+	});
+
+	test('should unpublish a note', async () => {
+		const command = setupCommandForTesting(Command, ()=>{});
+
+		const testFolder = await Folder.save({ title: 'Test' });
+		const testNote = await Note.save({ title: 'test', parent_id: testFolder.id, is_shared: 1 });
+
+		await command.action({
+			note: testNote.id,
+		});
+
+		await waitFor(async () => {
+			expect(await Note.load(testNote.id)).toMatchObject({
+				is_shared: 0,
+			});
+		});
+	});
+});

--- a/packages/app-cli/app/command-unpublish.ts
+++ b/packages/app-cli/app/command-unpublish.ts
@@ -1,0 +1,53 @@
+import { _ } from '@joplin/lib/locale';
+import BaseCommand from './base-command';
+import app from './app';
+import Logger from '@joplin/utils/Logger';
+import ShareService from '@joplin/lib/services/share/ShareService';
+import { ModelType } from '@joplin/lib/BaseModel';
+import Note from '@joplin/lib/models/Note';
+import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
+import Setting from '@joplin/lib/models/Setting';
+
+const logger = Logger.create('command-unpublish');
+
+type Args = {
+	note: string;
+};
+
+class Command extends BaseCommand {
+	public usage() {
+		return 'publish [note]';
+	}
+
+	public description() {
+		return _('Publishes a note to Joplin Server or Joplin Cloud');
+	}
+
+	public options() {
+		return [
+			['-f, --force', _('Do not ask for user confirmation.')],
+		];
+	}
+
+	public enabled() {
+		return SyncTargetRegistry.isJoplinServerOrCloud(Setting.value('sync.target'));
+	}
+
+	public async action(args: Args) {
+		const targetNote = await app().loadItemOrFail(ModelType.Note, args.note);
+
+		if (!targetNote.is_shared) {
+			throw new Error(_('Note not published: %s', targetNote.title));
+		}
+
+		logger.info('Unshare note: ', targetNote.id);
+		await ShareService.instance().unshareNote(targetNote.id);
+
+		const note = await Note.load(targetNote.id);
+		if (note.is_shared) {
+			throw new Error('Assertion failure: The note is still shared.');
+		}
+	}
+}
+
+module.exports = Command;

--- a/packages/app-cli/app/command-unpublish.ts
+++ b/packages/app-cli/app/command-unpublish.ts
@@ -7,6 +7,7 @@ import { ModelType } from '@joplin/lib/BaseModel';
 import Note from '@joplin/lib/models/Note';
 import SyncTargetRegistry from '@joplin/lib/SyncTargetRegistry';
 import Setting from '@joplin/lib/models/Setting';
+import { reg } from '@joplin/lib/registry';
 
 const logger = Logger.create('command-unpublish');
 
@@ -47,6 +48,9 @@ class Command extends BaseCommand {
 		if (note.is_shared) {
 			throw new Error('Assertion failure: The note is still shared.');
 		}
+
+		this.stdout(_('Synchronising...'));
+		await reg.waitForSyncFinishedThenSync();
 	}
 }
 


### PR DESCRIPTION
# Summary

This pull request adds commands for publishing and unpublishing notes to the CLI app.

# Screen recording


https://github.com/user-attachments/assets/dd1dad46-a4bf-43a6-8674-c36dd8c30cf3

The above screen recording shows:
1. Publishing a note with `publish $n`.
2. Opening the sharable link in a browser.
3. Unpublishing the note with `unpublish $n`.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->