### PR TITLE
Chore: Sync fuzzer: Fix incorrect expected state after removing the last user from a share

### DIFF
--- a/packages/tools/fuzzer/ActionTracker.ts
+++ b/packages/tools/fuzzer/ActionTracker.ts
@@ -1,10 +1,13 @@
 import { strict as assert } from 'assert';
 import { ActionableClient, FolderData, FuzzContext, ItemId, NoteData, ShareOptions, TreeItem, assertIsFolder, isFolder } from './types';
-import type Client from './Client';
 import FolderRecord from './model/FolderRecord';
 
 interface ClientData {
 	childIds: ItemId[];
+}
+
+interface ClientInfo {
+	email: string;
 }
 
 class ActionTracker {
@@ -87,7 +90,7 @@ class ActionTracker {
 		}
 	}
 
-	public track(client: { email: string }) {
+	public track(client: ClientInfo) {
 		const clientId = client.email;
 		// If the client's remote account already exists, continue using it:
 		if (!this.tree_.has(clientId)) {
@@ -271,6 +274,23 @@ class ActionTracker {
 			}
 		};
 
+		const removeFromShare = (id: ItemId, shareWith: ClientInfo) => {
+			const targetItem = this.idToItem_.get(id);
+			assertIsFolder(targetItem);
+
+			assert.ok(targetItem.isSharedWith(shareWith.email), `Folder ${id} should be shared with ${shareWith.email}`);
+
+			const otherSubTree = this.tree_.get(shareWith.email);
+			this.tree_.set(shareWith.email, {
+				...otherSubTree,
+				childIds: otherSubTree.childIds.filter(childId => childId !== id),
+			});
+
+			this.idToItem_.set(id, targetItem.withRemovedFromShare(shareWith.email));
+
+			this.checkRep_();
+		};
+
 		const tracker: ActionableClient = {
 			createNote: (data: NoteData) => {
 				assertWriteable(data.parentId);
@@ -311,6 +331,7 @@ class ActionTracker {
 					childIds: getChildIds(data.id),
 					sharedWith: [],
 					ownedByEmail: clientId,
+					isShared: false,
 				}));
 				addChild(data.parentId, data.id);
 
@@ -330,7 +351,7 @@ class ActionTracker {
 				this.checkRep_();
 				return Promise.resolve();
 			},
-			shareFolder: (id: ItemId, shareWith: Client, options: ShareOptions) => {
+			shareFolder: (id: ItemId, shareWith: ClientInfo, options: ShareOptions) => {
 				const itemToShare = this.idToItem_.get(id);
 				assertIsFolder(itemToShare);
 
@@ -354,19 +375,16 @@ class ActionTracker {
 				this.checkRep_();
 				return Promise.resolve();
 			},
-			removeFromShare: (id: ItemId, shareWith: Client) => {
+			removeFromShare: (id, client) => Promise.resolve(removeFromShare(id, client)),
+			deleteAssociatedShare: (id: ItemId) => {
 				const targetItem = this.idToItem_.get(id);
 				assertIsFolder(targetItem);
 
-				assert.ok(targetItem.isSharedWith(shareWith.email), `Folder ${id} should be shared with ${shareWith.label}`);
+				for (const recipient of targetItem.shareRecipients) {
+					removeFromShare(id, { email: recipient });
+				}
 
-				const otherSubTree = this.tree_.get(shareWith.email);
-				this.tree_.set(shareWith.email, {
-					...otherSubTree,
-					childIds: otherSubTree.childIds.filter(childId => childId !== id),
-				});
-
-				this.idToItem_.set(id, targetItem.withUnshared(shareWith.email));
+				this.idToItem_.set(id, targetItem.withUnshared());
 
 				this.checkRep_();
 				return Promise.resolve();

--- a/packages/tools/fuzzer/Client.ts
+++ b/packages/tools/fuzzer/Client.ts
@@ -567,6 +567,12 @@ class Client implements ActionableClient {
 		await other.sync();
 	}
 
+	public async deleteAssociatedShare(id: string) {
+		await this.tracker_.deleteAssociatedShare(id);
+		logger.info('Unshare', id, '(from', this.label, ')');
+		await this.execCliCommand_('share', 'delete', '-f', id);
+	}
+
 	public async moveItem(itemId: ItemId, newParentId: ItemId) {
 		logger.info('Move', itemId, 'to', newParentId);
 		await this.tracker_.moveItem(itemId, newParentId);

--- a/packages/tools/fuzzer/sync-fuzzer.ts
+++ b/packages/tools/fuzzer/sync-fuzzer.ts
@@ -172,11 +172,15 @@ const doRandomAction = async (context: FuzzContext, client: Client, clientPool: 
 			});
 			if (!target) return false;
 
-			const recipientIndex = context.randInt(0, target.shareRecipients.length);
-			const recipientEmail = target.shareRecipients[recipientIndex];
-			const recipient = clientPool.clientsByEmail(recipientEmail)[0];
-			assert.ok(recipient, `invalid state -- recipient ${recipientEmail} should exist`);
-			await client.removeFromShare(target.id, recipient);
+			const recipientIndex = context.randInt(-1, target.shareRecipients.length);
+			if (recipientIndex === -1) { // Completely remove the share
+				await client.deleteAssociatedShare(target.id);
+			} else {
+				const recipientEmail = target.shareRecipients[recipientIndex];
+				const recipient = clientPool.clientsByEmail(recipientEmail)[0];
+				assert.ok(recipient, `invalid state -- recipient ${recipientEmail} should exist`);
+				await client.removeFromShare(target.id, recipient);
+			}
 			return true;
 		},
 		deleteFolder: async () => {

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -67,6 +67,7 @@ export interface ActionableClient {
 	createFolder(data: FolderData): Promise<void>;
 	shareFolder(id: ItemId, shareWith: Client, options: ShareOptions): Promise<void>;
 	removeFromShare(id: string, shareWith: Client): Promise<void>;
+	deleteAssociatedShare(id: string): Promise<void>;
 	deleteFolder(id: ItemId): Promise<void>;
 	createNote(data: NoteData): Promise<void>;
 	updateNote(data: NoteData): Promise<void>;


### PR DESCRIPTION
# Summary

Prior to this pull request, when the sync fuzzer deleted the last user in a share, `checkState` would fail, expecting the shared folder to no longer be shared. However, Joplin allows folders to be marked as shared even if the share has no recipients. This pull request adjusts the fuzzer's expected state accordingly.

# Testing

I've verified that the sync fuzzer runs for 42 steps before failing with unexpected conflicts. The conflict-related issue should be fixed by #12993.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->