### PR TITLE
Mobile: Remove the "beta" warning from the plugin settings screen

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SectionSelector/SectionTab.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SectionSelector/SectionTab.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ConfigScreenStyles } from '../configScreenStyles';
 import Icon from '../../../Icon';
-import BetaChip from '../../../BetaChip';
 import { TouchableRipple, Text } from 'react-native-paper';
 import { View } from 'react-native';
 import Setting, { AppType, SettingMetadataSection } from '@joplin/lib/models/Setting';
@@ -20,9 +19,6 @@ const SectionTab: React.FC<Props> = ({ styles, onPress, selected, section }) => 
 
 	const styleSheet = styles.styleSheet;
 	const titleStyle = selected ? styleSheet.sidebarSelectedButtonText : styleSheet.sidebarButtonMainText;
-
-	const isBeta = section.name === 'plugins';
-	const betaChip = isBeta ? <BetaChip size={10}/> : null;
 
 	return (
 		<TouchableRipple
@@ -47,8 +43,6 @@ const SectionTab: React.FC<Props> = ({ styles, onPress, selected, section }) => 
 						>
 							{label}
 						</Text>
-
-						{betaChip}
 					</View>
 					<Text
 						style={styleSheet.sidebarButtonDescriptionText}

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.tsx
@@ -12,7 +12,6 @@ import useRepoApi from './utils/useRepoApi';
 import RepositoryApi from '@joplin/lib/services/plugins/RepositoryApi';
 import PluginInfoModal from './PluginInfoModal';
 import usePluginCallbacks from './utils/usePluginCallbacks';
-import BetaChip from '../../../BetaChip';
 import SectionLabel from './SectionLabel';
 
 interface Props {
@@ -191,10 +190,6 @@ const PluginStates: React.FC<Props> = props => {
 	return (
 		<View>
 			{renderRepoApiStatus()}
-			<Banner visible={true} elevation={0} icon={() => <BetaChip size={13}/>}>
-				<Text>Plugin support on mobile is still in beta. Plugins may cause performance issues. Some have only partial support for Joplin mobile.</Text>
-			</Banner>
-			<Divider/>
 
 			{showSearch ? searchSection : null}
 			<View style={styles.installedPluginsContainer}>


### PR DESCRIPTION
# Summary

This pull request removes the "beta" warning and banner from the mobile plugin settings screen. At this point, the mobile app has had plugin support for plugins for several versions — since https://github.com/laurent22/joplin/pull/10086. No significant changes to the mobile plugin API are planned for the near future.

**Note**: It may make sense to keep the "some have only partial support for Joplin mobile" part of the beta message — this is still true.

# Screenshot

**Before**:
<img width="1177" height="782" alt="Screenshot: A 'Plugin support on mobile is still in beta. Plugins may cause performance issues. Some have only partial support for Joplin mobile." src="https://github.com/user-attachments/assets/5529465c-216e-4cc8-967e-00d566c3757e" />


**After**: 
<img width="1177" height="782" alt="Screenshot: The 'search for plugins' input is now at the top of the screen. Like before, both the web and Android versions are shown." src="https://github.com/user-attachments/assets/2e7d3983-e056-46c2-ba57-7b563e9ef201" />


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->