### PR TITLE
Desktop: Fixes #12855: Legacy editor: Fix plugin support

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/Editor.tsx
@@ -67,6 +67,11 @@ import 'codemirror/mode/diff/diff';
 import 'codemirror/mode/erlang/erlang';
 import 'codemirror/mode/sql/sql';
 
+interface ExtendedWindow {
+	CodeMirror?: unknown;
+}
+declare const window: ExtendedWindow;
+
 
 export interface EditorProps {
 	value: string;
@@ -99,6 +104,14 @@ function Editor(props: EditorProps, ref: any) {
 	const [editor, setEditor] = useState(null);
 	const editorParent = useRef(null);
 	const lastEditTime = useRef(NaN);
+
+	useEffect(() => {
+		window.CodeMirror = CodeMirror;
+
+		return () => {
+			window.CodeMirror = undefined;
+		};
+	}, []);
 
 	// Codemirror plugins add new commands to codemirror (or change it's behavior)
 	// This command adds the smartListIndent function which will be bound to tab

--- a/packages/app-desktop/tools/copyApplicationAssets.js
+++ b/packages/app-desktop/tools/copyApplicationAssets.js
@@ -82,7 +82,7 @@ async function main() {
 	const files = [
 		'@fortawesome/fontawesome-free/css/all.min.css',
 		'@joeattardi/emoji-button/dist/index.js',
-		'codemirror/addon/dialog/dialog.css',
+		'codemirror/addon/',
 		'codemirror/lib/codemirror.css',
 		'mark.js/dist/mark.min.js',
 		'roboto-fontface/css/roboto/roboto-fontface.css',


### PR DESCRIPTION
# Summary

Fixes an issue in which dependencies of certain legacy editor plugins weren't bundled with the application.

Fixes #12855.

> [!NOTE]
> 
> This pull request targets `release-3.4`.

# Testing plan

1. Download Rich Markdown 0.15.1 and add it to Joplin.
   - The latest version (0.16.2) includes a toplevel `require('@codemirror/language')`, which fails when running with CodeMirror 5 (in both Joplin 3.3.13 and 3.4.8).
2. Enable the legacy Markdown editor.
3. Enable "Render images below their markdown source (only for images on their own line)", "Align wrapped list items to the indent level", "Hide Markdown Elements", "Focus Mode", and "
Highlight the background of the current line".
4. Open the Markdown editor.
5. Verify that content on lines not containing the cursor is faded and images are rendered below their Markdown source.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->