### PR TITLE
Desktop: Fixes #12816: Accessibility: Fix dismissing the alarm dialog by pressing escape

### DIFF
--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -251,8 +251,6 @@ export default class PromptDialog extends React.Component<Props, any> {
 				} else {
 					onClose(true);
 				}
-			} else if (event.key === 'Escape') {
-				onClose(false);
 			}
 		};
 
@@ -309,7 +307,7 @@ export default class PromptDialog extends React.Component<Props, any> {
 		}
 
 		return (
-			<Dialog className='prompt-dialog' contentStyle={styles.dialog}>
+			<Dialog className='prompt-dialog' contentStyle={styles.dialog} onCancel={() => onClose(false, 'cancel')}>
 				<label style={styles.label}>{this.props.label ? this.props.label : ''}</label>
 				<div style={{ display: 'inline-block', color: 'black', backgroundColor: theme.backgroundColor }}>
 					{inputComp}


### PR DESCRIPTION
# Summary

This pull request fixes #12816. Previously, dismissing the "set alarm" with <kbd>escape</kbd> prevented it from being opened again.

# Testing plan

On Fedora 42:
1. Start Joplin
2. Open the alarm dialog.
3. Dismiss the alarm dialog by pressing <kbd>escape</kbd>.
4. Verify that it's possible to open the alarm dialog.
5. Verify that it's possible to dismiss the alarm dialog by pressing <kbd>escape</kbd>.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->