### PR TITLE
Android: Accessibility: Fix tag search input loses focus when submitted by pressing "enter"

### DIFF
--- a/packages/app-mobile/utils/focusView.ts
+++ b/packages/app-mobile/utils/focusView.ts
@@ -26,13 +26,6 @@ const focusView = (source: string, view: View|HTMLElement) => {
 			} else {
 				logger.warn('Couldn\'t find a view to focus.');
 			}
-
-			// Also set keyboard focus if called, for example, with a TextInput.
-			// eslint-disable-next-line no-restricted-properties
-			if ('focus' in view && typeof view.focus === 'function') {
-				// eslint-disable-next-line no-restricted-properties -- Already within a call to focus()
-				view.focus();
-			}
 		}
 	};
 

--- a/packages/app-mobile/utils/focusView.ts
+++ b/packages/app-mobile/utils/focusView.ts
@@ -26,6 +26,13 @@ const focusView = (source: string, view: View|HTMLElement) => {
 			} else {
 				logger.warn('Couldn\'t find a view to focus.');
 			}
+
+			// Also set keyboard focus if called, for example, with a TextInput.
+			// eslint-disable-next-line no-restricted-properties
+			if ('focus' in view && typeof view.focus === 'function') {
+				// eslint-disable-next-line no-restricted-properties -- Already within a call to focus()
+				view.focus();
+			}
 		}
 	};
 


### PR DESCRIPTION
# Summary

Previously,
- Pressing <kbd>enter</kbd> when the tag search input has focus would cause keyboard focus to jump to the start of the tag editor dialog.
- Pressing the "submit" button on the software keyboard would dismiss the keyboard in addition to adding a tag.

With this pull request,
- The search input in the tag dialog retains focus after adding a tag by pressing <kbd>enter</kbd>.
- The software keyboard remains open after adding a tag with the "done" button.

# Screen recording

**Android 15 emulator**: Shows 1) adding a tag using the onscreen keyboard 2) the keyboard remaining visible after clicking the "✅" button.

https://github.com/user-attachments/assets/40bfd11e-d2ba-43b5-aa21-412708533d69



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->