### PR TITLE
Desktop: Clarify handwritten text transcription setting

### DIFF
--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -557,7 +557,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		},
 
 		'ocr.handwrittenTextDriverEnabled': {
-			value: true,
+			value: false,
 			type: SettingItemType.Bool,
 			public: true,
 			appTypes: [AppType.Desktop],

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -562,7 +562,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			public: true,
 			appTypes: [AppType.Desktop],
 			label: () => _('Enable handwritten transcription'),
-			description: () => 'Allows selecting specific attachments for higher-quality on-server OCR. When enabled, the right-click menu for an attachment includes an option to send an attachment for off-device processing.\n\nExperimental! It may not work at all. Requires Joplin Server or Cloud.',
+			description: () => 'Allows selecting specific attachments for higher-quality on-server OCR. When enabled, the right-click menu for an attachment includes an option to send an attachment to Joplin Cloud/Server for off-device processing.\n\nExperimental! It may not work at all. Requires Joplin Server or Cloud.',
 			storage: SettingStorage.File,
 			isGlobal: true,
 			advanced: true,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -562,7 +562,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			public: true,
 			appTypes: [AppType.Desktop],
 			label: () => _('Enable handwritten transcription'),
-			description: () => 'Experimental! It may not work at all. Note that the resource to be transcribed will be sent unencrypted to Joplin Cloud/Server.',
+			description: () => 'Allows selecting specific attachments for higher-quality on-server OCR. When enabled, the right-click menu for an attachment includes an option to send an attachment for off-device processing.\n\nExperimental! It may not work at all. Requires Joplin Server or Cloud.',
 			storage: SettingStorage.File,
 			isGlobal: true,
 			advanced: true,


### PR DESCRIPTION
# Summary

This pull request updates the description for the handwritten text transcription setting:
- Tries to clarify that enabling "handwritten text transcription" doesn't directly enable handwritten text transcription for resources. When "handwritten text transcription" is enabled, resources must be manually selected for transcription through a right-click menu.
- Removes "will be sent unencrypted to Joplin Cloud/Server" — with Joplin Cloud, resources should be encrypted using HTTPS/TLS during transport. However, resources selected for handwritten text transcription will be decrypted on the server for processing.

# Notes

- This pull request targets `release-3.4`.
- At least for now, it could make sense to set `ocr.handwrittenTextDriverEnabled` to `false` by default:
   - Doing so may help prevent confusion about what the setting does.
   - When disabled, the right-click menu item for queuing a resource for higher-quality OCR will still be present. However, when activated, the user is [given instructions for enabling `ocr.handwrittenTextDriverEnabled`](https://github.com/laurent22/joplin/blob/bc2832e78fd6f76cb3543fd38096a50e918b86c1/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts#L151).
- If `ocr.handwrittenTextDriverEnabled` is kept as `true`, it may make sense to [update the message shown by this confirmation dialog](https://github.com/laurent22/joplin/blob/bc2832e78fd6f76cb3543fd38096a50e918b86c1/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts#L151).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->