### PR TITLE
Android: Fix shadow shown above the screen header

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -101,11 +101,23 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const styleObject: any = {
-			container: {
+			outerContainer: {
 				flexDirection: 'column',
+			},
+			innerContainer: {
+				flexDirection: 'row',
+				alignItems: 'center',
 				backgroundColor: theme.backgroundColor2,
 				shadowColor: '#000000',
 				elevation: 5,
+			},
+			// A small border above the header: Covers the part of the shadow that would otherwise
+			// be shown above the header on Android.
+			aboveHeader: {
+				backgroundColor: '#323640',
+				paddingBottom: 6,
+				marginTop: -6,
+				zIndex: 2,
 			},
 			sideMenuButton: {
 				flex: 1,
@@ -678,8 +690,9 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 			);
 
 		return (
-			<View style={this.styles().container}>
-				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
+			<View style={this.styles().outerContainer}>
+				<View style={this.styles().aboveHeader}/>
+				<View style={this.styles().innerContainer}>
 					{sideMenuComp}
 					{backButtonComp}
 					{renderUndoButton()}


### PR DESCRIPTION
# Summary

This pull request removes a probably-undesired shadow from above the screen header on Android. This shadow is darker on some screens and lighter on others.

This regression was likely introduced as part of https://github.com/laurent22/joplin/pull/12785.

> [!IMPORTANT]
>
> This pull request targets `release-3.4`, since the shadow is a behavior change in the 3.4 branch. However, the change is stylistic and shouldn't impact the core Joplin functionality. As such, it may make more sense for this pull request to target `dev`.


# Screenshots

## Android 15 emulator

**Before**:
<img width="959" height="515" alt="Screenshot: Dark shadow visible above the screen header on the note screen" src="https://github.com/user-attachments/assets/0dabe842-d340-4cc9-b562-3bff70f38188" />

**After**:
<img width="959" height="515" alt="Screenshot: No shadow visible above the screen header on the note screen" src="https://github.com/user-attachments/assets/8961de90-ada3-4374-acfd-97c9ff6f0891" />

### iPadOS 18.4 simulator

On iOS, no shadow is shown.

| Before | After |
|--------|-------|
|<img width="856" height="603" alt="Screenshot: No shadow visible above or below the header" src="https://github.com/user-attachments/assets/3a5296dc-aed0-47d1-8c3b-71324b4d008a" />| <img width="856" height="603" alt="Screenshot: No shadow visible above or below the header" src="https://github.com/user-attachments/assets/cacce2e0-2464-4614-8e36-fb498916ef63" />|



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->