### PR TITLE
Android: Fixes #12960: Rich Text Editor: Fix pressing enter does nothing in some cases

### DIFF
--- a/packages/editor/ProseMirror/plugins/keymapPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/keymapPlugin.ts
@@ -60,8 +60,10 @@ const isInEmptyParagraph = (state: EditorState) => {
 		selectionParent.content.size === 0;
 };
 
-// Handling "Enter" key events directly with a Plugin prevents the cursor from getting stuck
-// on Android. As such, double hard-breaks are replaced separately from the main keymap() plugins.
+// Handle double-hard-break -> paragraph conversion with a Plugin to work around
+// a bug on Android. If convertDoubleHardBreakToNewParagraph is handled with the
+// main keymap logic (with a keymap() extension), then it's possible for the cursor
+// to get stuck in some cases.
 // See https://github.com/laurent22/joplin/issues/12960.
 const replaceDoubleHardBreaksOnEnter = new Plugin({
 	props: {


### PR DESCRIPTION
# Summary

Fixes an issue where pressing <kbd>enter</kbd> on the line just before a paragraph (if that line ended in a hard break) did nothing.

Fixes #12960.

# Testing

1. Create a note where a paragraph starts with an empty line (i.e. starts with a `<br/>` element).
2. Move the cursor to that empty line.
3. Press <kbd>enter</kbd>.
4. Verify that a new line has been added.
5. Press <kbd>enter</kbd>.
6. Verify that another new line has been added.


## Screen recording (before)

**Android 15 emulator**


https://github.com/user-attachments/assets/492ee010-04ec-4d49-8e90-9632b54c5af9

The above screen recording demonstrates running the testing plan without this change applied. Observe that pressing the enter key on the software keyboard doesn't add new lines when the cursor is placed just before the `<br/>` at the start of the last `<p>` element.

## Screen recording (after)

**Android 15 emulator**:

https://github.com/user-attachments/assets/a79dbae4-75b4-4dc6-bea9-9df3fe67fc87



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->