### PR TITLE
Mobile: Plugins: Improve handling of invalid toolbar button enabled conditions

### DIFF
--- a/packages/lib/services/commands/ToolbarButtonUtils.ts
+++ b/packages/lib/services/commands/ToolbarButtonUtils.ts
@@ -2,7 +2,9 @@ import CommandService from '../CommandService';
 import { stateUtils } from '../../reducer';
 import focusEditorIfEditorCommand from './focusEditorIfEditorCommand';
 import { WhenClauseContext } from './stateToWhenClauseContext';
+import Logger from '@joplin/utils/Logger';
 
+const logger = Logger.create('ToolbarButtonUtils');
 
 export interface ToolbarButtonInfo {
 	type: 'button';
@@ -94,7 +96,11 @@ export default class ToolbarButtonUtils {
 				continue;
 			}
 
-			output.push(this.commandToToolbarButton(commandName, whenClauseContext));
+			try {
+				output.push(this.commandToToolbarButton(commandName, whenClauseContext));
+			} catch (error) {
+				logger.error('Unable to add toolbar button for command', commandName, '. Error: ', error);
+			}
 		}
 
 		return stateUtils.selectArrayShallow({ array: output }, commandNames.join('_'));


### PR DESCRIPTION
# Summary

This pull request wraps `commandToToolbarButton` in a `try/catch`, preventing `commandToToolbarButton` failures from breaking the toolbar.

> [!NOTE]
>
> Targets `dev`.

# Known issues

- Although the error is logged to the console, it isn't associated with the plugin. As such, an invalid enabled condition won't cause an "error" badge to be shown for a plugin.
   - Fixing this will likely require a larger change than this PR and may make more sense for `release-3.5`.

# Testing plan

On Android 13:
1. Install the "Collapsible Blocks" plugin (if not already installed).
2. Open the Rich Text editor.
3. Verify that the Rich Text editor opens and that the toolbar is displayed.
4. Verify that an error is logged in the console: "Unable to add toolbar button for command insertCollapsibleBlock".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->