### PR TITLE
Mobile: Plugin API: Fix certain renderer plugins fail to load

### DIFF
--- a/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
@@ -185,7 +185,7 @@ const useWebViewSetup = (props: Props): SetUpResult<RendererControl> => {
 			};
 
 			let settingsChanged = false;
-			const settings: RenderSettings = {
+			const getSettings = (): RenderSettings => ({
 				...options,
 				codeTheme: theme.codeThemeCss,
 				// We .stringify the theme to avoid a JSON serialization error involving
@@ -220,12 +220,12 @@ const useWebViewSetup = (props: Props): SetUpResult<RendererControl> => {
 					return shim.fsDriver().fileAtPath(resolvedPath);
 				},
 				removeUnusedPluginAssets: options.removeUnusedPluginAssets,
-			};
+			});
 
 			await transferResources(options.resources);
 
 			return {
-				settings,
+				getSettings,
 				getSettingsChanged() {
 					return settingsChanged;
 				},
@@ -234,23 +234,23 @@ const useWebViewSetup = (props: Props): SetUpResult<RendererControl> => {
 
 		return {
 			rerenderToBody: async (markup, options, cancelEvent) => {
-				const { settings, getSettingsChanged } = await prepareRenderer(options);
+				const { getSettings, getSettingsChanged } = await prepareRenderer(options);
 				if (cancelEvent?.cancelled) return null;
 
-				const output = await renderer.rerenderToBody(markup, settings);
+				const output = await renderer.rerenderToBody(markup, getSettings());
 				if (cancelEvent?.cancelled) return null;
 
 				if (getSettingsChanged()) {
-					return await renderer.rerenderToBody(markup, settings);
+					return await renderer.rerenderToBody(markup, getSettings());
 				}
 				return output;
 			},
 			render: async (markup, options) => {
-				const { settings, getSettingsChanged } = await prepareRenderer(options);
-				const output = await renderer.render(markup, settings);
+				const { getSettings, getSettingsChanged } = await prepareRenderer(options);
+				const output = await renderer.render(markup, getSettings());
 
 				if (getSettingsChanged()) {
-					return await renderer.render(markup, settings);
+					return await renderer.render(markup, getSettings());
 				}
 				return output;
 			},


### PR DESCRIPTION
# Summary

This pull request fixes a regression in the mobile plugin API, affecting renderer plugins that used the `settingValue` API. The regression seems to have been caused by changes in https://github.com/laurent22/joplin/pull/12748.

> [!NOTE]
>
> This pull request targets `release-3.4`.

# Notes

- When a renderer plugin requests a setting with `settingValue`, the expected behavior is:
   - The renderer WebView completes a full render, keeping track of which settings were requested with `settingValue`. The WebView requests these settings from the main process.
   - If any settings were requested, the main process sends these settings to the WebView and starts a re-render.
       - The issue was in this second step. The plugin setting values were not being sent to the WebView. Instead, the second render was done with the old plugin settings list, which would be empty.

# Testing plan

Android 15 emulator:
1. Install the "Collapsible Blocks" plugin if not already installed.
2. Open a note with collapsible block markup in the note viewer.
3. Verify that the collapsible block renders and can be toggled open/closed.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->