### PR TITLE
Mobile: Plugins: Fix plugin panel buttons are offscreen on recent versions of Android

### DIFF
--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -27,11 +27,23 @@ export interface ModalElementProps extends ModalProps {
 const useStyles = (hasScrollView: boolean, backgroundColor: string|undefined) => {
 	const safeAreaPadding = useSafeAreaPadding();
 	return useMemo(() => {
+		// On Android, the top-level container seems to need to be absolutely positioned
+		// to prevent it from being larger than the screen size:
+		const absoluteFill = {
+			position: 'absolute',
+			top: 0,
+			left: 0,
+			right: 0,
+			bottom: 0,
+		} satisfies ViewStyle;
+
 		return StyleSheet.create({
 			modalBackground: {
 				...safeAreaPadding,
-				flexGrow: 1,
-				flexShrink: 1,
+				...(hasScrollView ? {
+					flexGrow: 1,
+					flexShrink: 1,
+				} : absoluteFill),
 
 				// When hasScrollView, the modal background is wrapped in a ScrollView. In this case, it's
 				// possible to scroll content outside the background into view. To prevent the edge of the
@@ -40,6 +52,7 @@ const useStyles = (hasScrollView: boolean, backgroundColor: string|undefined) =>
 				backgroundColor: hasScrollView ? null : backgroundColor,
 			},
 			keyboardAvoidingView: {
+				...absoluteFill,
 				flex: 1,
 			},
 			modalScrollView: {


### PR DESCRIPTION
# Summary

Fixes an issue where plugin panel tab buttons were offscreen on Android 15 and 16.

Ref: [Forum post `plugin-system-failure-on-android/47111`](https://discourse.joplinapp.org/t/plugin-system-failure-on-android/47111).

> [!NOTE]
>
> This pull request targets `release-3.4`.

# Testing

This change affects Joplin's custom `<Modal>` component, which is used by many Joplin dialogs. 
The attached screen recording shows opening and closing various dialogs on web (Chromium), an Android 15 emulator, and an iOS 18.4 simulator.

https://github.com/user-attachments/assets/0dd37098-f911-4b06-840c-26d4d091662a




<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->