### PR TITLE
Chore: Sync fuzzer: Add action for deleting notes

### DIFF
--- a/packages/tools/fuzzer/ActionTracker.ts
+++ b/packages/tools/fuzzer/ActionTracker.ts
@@ -351,6 +351,19 @@ class ActionTracker {
 				this.checkRep_();
 				return Promise.resolve();
 			},
+			deleteNote: (id: ItemId) => {
+				this.checkRep_();
+
+				const item = this.idToItem_.get(id);
+				if (!item) throw new Error(`Not found ${id}`);
+				assert.ok(!isFolder(item), 'should be a note');
+				assertWriteable(item);
+
+				removeItemRecursive(id);
+
+				this.checkRep_();
+				return Promise.resolve();
+			},
 			shareFolder: (id: ItemId, shareWith: ClientInfo, options: ShareOptions) => {
 				const itemToShare = this.idToItem_.get(id);
 				assertIsFolder(itemToShare);

--- a/packages/tools/fuzzer/Client.ts
+++ b/packages/tools/fuzzer/Client.ts
@@ -504,6 +504,13 @@ class Client implements ActionableClient {
 		await this.assertNoteMatchesState_(note);
 	}
 
+	public async deleteNote(id: ItemId) {
+		logger.info('Delete note', id, 'in', this.label);
+		await this.tracker_.deleteNote(id);
+
+		await this.execCliCommand_('rmnote', '--permanent', '--force', id);
+	}
+
 	public async deleteFolder(id: string) {
 		logger.info('Delete folder', id, 'in', this.label);
 		await this.tracker_.deleteFolder(id);

--- a/packages/tools/fuzzer/sync-fuzzer.ts
+++ b/packages/tools/fuzzer/sync-fuzzer.ts
@@ -144,6 +144,13 @@ const doRandomAction = async (context: FuzzContext, client: Client, clientPool: 
 
 			return true;
 		},
+		deleteNote: async () => {
+			const target = await client.randomNote({ includeReadOnly: false });
+			if (!target) return false;
+
+			await client.deleteNote(target.id);
+			return true;
+		},
 		shareFolder: async () => {
 			const other = clientPool.randomClient(c => !c.hasSameAccount(client));
 			if (!other) return false;

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -69,6 +69,7 @@ export interface ActionableClient {
 	removeFromShare(id: string, shareWith: Client): Promise<void>;
 	deleteAssociatedShare(id: string): Promise<void>;
 	deleteFolder(id: ItemId): Promise<void>;
+	deleteNote(id: ItemId): Promise<void>;
 	createNote(data: NoteData): Promise<void>;
 	updateNote(data: NoteData): Promise<void>;
 	moveItem(itemId: ItemId, newParentId: ItemId): Promise<void>;


### PR DESCRIPTION
# Summary

This pull request adds an action to the sync fuzzer for permanently deleting individual notes. Previously, the [sync fuzzer](https://github.com/laurent22/joplin/pull/12592) had an action for permanently deleting folders. However, it did not have an action for permanently deleting individual notes.

# Testing

I've verified that the sync fuzzer runs for at least 20 steps (including `deleteNote` actions in steps 2 and 15) without encountering errors.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->