### PR TITLE
Cli: Fix last change sometimes lost when not in TUI mode

### DIFF
--- a/packages/app-cli/app/app.ts
+++ b/packages/app-cli/app/app.ts
@@ -432,6 +432,7 @@ class Application extends BaseApplication {
 			}
 
 			await Setting.saveAll();
+			await this.database_.close();
 
 			// Need to call exit() explicitly, otherwise Node wait for any timeout to complete
 			// https://stackoverflow.com/questions/18050095

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -890,10 +890,6 @@ export default class BaseApplication {
 		if (!currentFolder) currentFolder = await Folder.defaultFolder();
 		Setting.setValue('activeFolderId', currentFolder ? currentFolder.id : '');
 
-		if (currentFolder && !this.hasGui()) {
-			this.currentFolder_ = currentFolder;
-		}
-
 		await setupAutoDeletion();
 
 		await MigrationService.instance().run();

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -90,8 +90,7 @@ export default class BaseApplication {
 	private eventEmitter_: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private scheduleAutoAddResourcesIID_: any = null;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private database_: any = null;
+	protected database_: JoplinDatabase = null;
 	private profileConfig_: ProfileConfig = null;
 
 	protected showStackTraces_ = false;
@@ -890,6 +889,10 @@ export default class BaseApplication {
 		if (currentFolderId) currentFolder = await Folder.load(currentFolderId);
 		if (!currentFolder) currentFolder = await Folder.defaultFolder();
 		Setting.setValue('activeFolderId', currentFolder ? currentFolder.id : '');
+
+		if (currentFolder && !this.hasGui()) {
+			this.currentFolder_ = currentFolder;
+		}
 
 		await setupAutoDeletion();
 

--- a/packages/lib/database-driver-node.js
+++ b/packages/lib/database-driver-node.js
@@ -16,6 +16,12 @@ class DatabaseDriverNode {
 		});
 	}
 
+	close() {
+		return new Promise(resolve => {
+			this.db_.close(() => resolve());
+		});
+	}
+
 	sqliteErrorToJsError(error, sql = null, params = null) {
 		const msg = [error.toString()];
 		if (sql) msg.push(sql);

--- a/packages/lib/database.ts
+++ b/packages/lib/database.ts
@@ -65,6 +65,14 @@ export default class Database {
 		this.logger().info('Database was open successfully');
 	}
 
+	public async close() {
+		try {
+			await this.driver().close?.();
+		} catch (error) {
+			this.logger().warn('Failed to close database', error);
+		}
+	}
+
 	public escapeField(field: string) {
 		if (field === '*') return '*';
 		const p = field.split('.');


### PR DESCRIPTION
# Summary

This pull request ensures that the database has been closed before force-exiting the CLI application with `process.exit`. The CLI app currently only force-exits when running in CLI mode (as opposed to TUI mode).

This issue issue was identified while [fixing the CLI app integration tests](https://github.com/laurent22/joplin/pull/13089).


# Testing

This pull request is included in https://github.com/laurent22/joplin/pull/13089. I have verified that the updated integration tests pass with this change applied. Previously, the [integration test for the `mv` command](https://github.com/laurent22/joplin/blob/78fb07d4c74f990644154d0e21352cfe1260d10b/packages/app-cli/app/cli-integration-tests.js#L209) failed consistently, with the last folder to be moved by [`mv 'note*' nb2`](https://github.com/laurent22/joplin/blob/78fb07d4c74f990644154d0e21352cfe1260d10b/packages/app-cli/app/cli-integration-tests.js#L204) remaining in in `nb1`.  



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->