### PR TITLE
Cli: Fixes #13086: Fix "use" command when not in TUI mode

### DIFF
--- a/packages/app-cli/app/app.ts
+++ b/packages/app-cli/app/app.ts
@@ -417,8 +417,10 @@ class Application extends BaseApplication {
 		if (argv.length) {
 			this.gui_ = this.dummyGui();
 
+			const initialFolder = await Folder.load(Setting.value('activeFolderId'));
+			await this.switchCurrentFolder(initialFolder);
 			await this.applySettingsSideEffects();
-			await this.refreshCurrentFolder();
+
 			try {
 				await this.execCommand(argv);
 			} catch (error) {


### PR DESCRIPTION
# Summary

The `use` command was broken by a change to the CLI app's startup logic in https://github.com/laurent22/joplin/pull/12913. With this change, the initial folder ID was no longer loaded from the `activeFolderId` setting (unless in TUI mode).

Fixes #13086.


> [!NOTE]
>
> Since #13086 is a regression, this pull request targets `release-3.4`.
>

# Testing

## Automated testing

See https://github.com/laurent22/joplin/pull/13089.

## Manual testing

I've manually verified that running the `use` command in CLI mode changes the parent folder used by `mknote`.

<details><summary>Transcript</summary>

```
$ yarn start mkbook new-notebook
$ yarn start mkbook new-notebook-2
$ yarn start use new-notebook
$ yarn start mknote test
$ yarn start mknote test2
$ yarn start use new-notebook-2
$ yarn start mknote a
$ yarn start ls
a
$ yarn start use new-notebook
$ yarn start ls
test2
test 
$ yarn start
```

At this point, the CLI application started in TUI mode, with the `new-notebook` notebook open.

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->