### PR TITLE
Chore: Mobile: Add test to verify that content scripts load in the note viewer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -813,7 +813,6 @@ packages/app-mobile/components/screens/ConfigScreen/plugins/buttons/InstallButto
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/WrappedPluginStates.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/mockRepositoryApiConstructor.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/newRepoApi.js
-packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/pluginServiceSetup.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/openWebsiteForPlugin.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginItem.js
@@ -971,6 +970,7 @@ packages/app-mobile/utils/shim-init-react/shimInitShared.js
 packages/app-mobile/utils/testing/createMockReduxStore.js
 packages/app-mobile/utils/testing/getWebViewDomById.js
 packages/app-mobile/utils/testing/getWebViewWindowById.js
+packages/app-mobile/utils/testing/mockPluginServiceSetup.js
 packages/app-mobile/utils/testing/setupGlobalStore.js
 packages/app-mobile/utils/testing/testingLibrary.js
 packages/app-mobile/utils/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -786,7 +786,6 @@ packages/app-mobile/components/screens/ConfigScreen/plugins/buttons/InstallButto
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/WrappedPluginStates.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/mockRepositoryApiConstructor.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/newRepoApi.js
-packages/app-mobile/components/screens/ConfigScreen/plugins/testUtils/pluginServiceSetup.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/openWebsiteForPlugin.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginCallbacks.js
 packages/app-mobile/components/screens/ConfigScreen/plugins/utils/usePluginItem.js
@@ -944,6 +943,7 @@ packages/app-mobile/utils/shim-init-react/shimInitShared.js
 packages/app-mobile/utils/testing/createMockReduxStore.js
 packages/app-mobile/utils/testing/getWebViewDomById.js
 packages/app-mobile/utils/testing/getWebViewWindowById.js
+packages/app-mobile/utils/testing/mockPluginServiceSetup.js
 packages/app-mobile/utils/testing/setupGlobalStore.js
 packages/app-mobile/utils/testing/testingLibrary.js
 packages/app-mobile/utils/types.js

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -4,7 +4,6 @@ import { createTempDir, mockMobilePlatform, setupDatabaseAndSynchronizer, switch
 import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../../utils/testing/testingLibrary';
 
 import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
-import pluginServiceSetup from './testUtils/pluginServiceSetup';
 import { writeFile } from 'fs-extra';
 import { join } from 'path';
 import shim from '@joplin/lib/shim';
@@ -15,6 +14,7 @@ import createMockReduxStore from '../../../../utils/testing/createMockReduxStore
 import WrappedPluginStates from './testUtils/WrappedPluginStates';
 import mockRepositoryApiConstructor from './testUtils/mockRepositoryApiConstructor';
 import Setting from '@joplin/lib/models/Setting';
+import mockPluginServiceSetup from '../../../../utils/testing/mockPluginServiceSetup';
 
 
 let reduxStore: Store<AppState> = null;
@@ -56,7 +56,7 @@ describe('PluginStates.installed', () => {
 		await setupDatabaseAndSynchronizer(0);
 		await switchClient(0);
 		reduxStore = createMockReduxStore();
-		pluginServiceSetup(reduxStore);
+		mockPluginServiceSetup(reduxStore);
 		resetRepoApi();
 
 		await mockMobilePlatform('android');

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
@@ -3,13 +3,13 @@ import { mockMobilePlatform, setupDatabaseAndSynchronizer, switchClient } from '
 
 import { render, screen, userEvent, waitFor } from '../../../../utils/testing/testingLibrary';
 
-import pluginServiceSetup from './testUtils/pluginServiceSetup';
 import createMockReduxStore from '../../../../utils/testing/createMockReduxStore';
 import WrappedPluginStates from './testUtils/WrappedPluginStates';
 import { AppState } from '../../../../utils/types';
 import { Store } from 'redux';
 import mockRepositoryApiConstructor from './testUtils/mockRepositoryApiConstructor';
 import { resetRepoApi } from './utils/useRepoApi';
+import mockPluginServiceSetup from '../../../../utils/testing/mockPluginServiceSetup';
 
 const expectSearchResultCountToBe = async (count: number) => {
 	await waitFor(() => {
@@ -37,7 +37,7 @@ describe('PluginStates.search', () => {
 		await setupDatabaseAndSynchronizer(0);
 		await switchClient(0);
 		reduxStore = createMockReduxStore();
-		pluginServiceSetup(reduxStore);
+		mockPluginServiceSetup(reduxStore);
 		mockMobilePlatform('android');
 		resetRepoApi();
 

--- a/packages/app-mobile/utils/testing/mockPluginServiceSetup.ts
+++ b/packages/app-mobile/utils/testing/mockPluginServiceSetup.ts
@@ -7,11 +7,11 @@ class MockPluginRunner extends BasePluginRunner {
 	public override async stop() {}
 }
 
-const pluginServiceSetup = (store: Store) => {
+const mockPluginServiceSetup = (store: Store) => {
 	const runner = new MockPluginRunner();
 	PluginService.instance().initialize(
 		'2.14.0', { joplin: {} }, runner, store,
 	);
 };
 
-export default pluginServiceSetup;
+export default mockPluginServiceSetup;


### PR DESCRIPTION
# Summary

This pull request:
- Adds a new test to help verify that the mobile note viewer loads renderer plugins correctly. The test:
  1. Loads a minimal [Markdown-it plugin](https://github.com/laurent22/joplin/blob/dev/packages/app-cli/tests/support/plugins/markdownItTestPlugin.js) in the note viewer.
  2. Checks that the plugin produces the expected output.
- Includes refactoring changes to simplify adding similar future tests.

A useful follow-up change might be to also test loading a renderer plugin that uses the `settingValue` renderer plugin API. Such a test would help prevent [this issue](https://github.com/laurent22/joplin/pull/13078) from reoccurring.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->