### PR TITLE
Desktop: Fix Issues #12871: Change button content from "Cancel" to "Revert" as the report mentioned.

### DIFF
--- a/packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx
+++ b/packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.tsx
@@ -20,7 +20,7 @@ const TrashNotificationMessage: React.FC<Props> = props => {
 		<button
 			className="link-button"
 			onClick={onCancel}
-		>{cancelling ? _('Cancelling...') : _('Cancel')}</button>
+		>{cancelling ? _('Reverting...') : _('Revert')}</button>
 	</>;
 };
 

--- a/packages/app-desktop/integration-tests/noteList.spec.ts
+++ b/packages/app-desktop/integration-tests/noteList.spec.ts
@@ -95,7 +95,7 @@ test.describe('noteList', () => {
 		await expect(notification).toBeVisible();
 
 		// Should be possible to un-delete
-		const undeleteButton = notification.getByRole('button', { name: 'Cancel' });
+		const undeleteButton = notification.getByRole('button', { name: /Revert|Cancel/i });
 		await undeleteButton.click();
 
 		await expect(testNoteItem).toBeVisible();


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

## Description  
This PR updates the wording of the undo-delete button in the desktop app when a note is deleted.  

- The button label has been changed from **“Cancel”** to **“Revert”**.  
- The in-progress message has been updated accordingly, from **“Cancelling”** to **“Reverting”**.  

Only the text content was modified; no functional changes have been made.  

## Related Issue  
Fixes #12871