### PR TITLE
Mobile: Fixes #13095: Fix long note title doesn’t wrap properly for To Do type note

### DIFF
--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -60,6 +60,7 @@ const useStyles = (themeId: number) => {
 		const listItemTextWithCheckbox = { ...listItemText };
 		listItemTextWithCheckbox.marginTop = theme.itemMarginTop - 1;
 		listItemTextWithCheckbox.marginBottom = listItem.paddingBottom;
+		listItemTextWithCheckbox.paddingRight = 40;
 
 		const selectionWrapper: ViewStyle = { };
 

--- a/packages/app-mobile/components/NoteItem.tsx
+++ b/packages/app-mobile/components/NoteItem.tsx
@@ -37,6 +37,7 @@ const useStyles = (themeId: number) => {
 
 		const listItemPressable: ViewStyle = {
 			flexGrow: 1,
+			flexShrink: 1,
 			alignSelf: 'stretch',
 		};
 		const listItemPressableWithCheckbox: ViewStyle = {
@@ -60,7 +61,6 @@ const useStyles = (themeId: number) => {
 		const listItemTextWithCheckbox = { ...listItemText };
 		listItemTextWithCheckbox.marginTop = theme.itemMarginTop - 1;
 		listItemTextWithCheckbox.marginBottom = listItem.paddingBottom;
-		listItemTextWithCheckbox.paddingRight = 40;
 
 		const selectionWrapper: ViewStyle = { };
 


### PR DESCRIPTION
On mobile, when viewing notes with long titles, the note list wraps the titles to display the whole title. When notes are to do types, the wrapping does not take into account the checkbox causing some of the text to be off screen. This PR addressed this.

This fixes https://github.com/laurent22/joplin/issues/13095

### Screenshots

Before:

<img width="411" height="895" alt="beforeportrait" src="https://github.com/user-attachments/assets/28c88d0a-ddcf-4e1b-bfa1-39b9fa665d4a" />
<img width="1075" height="461" alt="beforelandscape" src="https://github.com/user-attachments/assets/6c9b1a2c-a2c1-4ccd-b992-9884e609fd93" />

After:

<img width="415" height="902" alt="portrait" src="https://github.com/user-attachments/assets/5253d49b-4b3f-4356-9f50-87263d8a265c" />
<img width="1075" height="458" alt="landscape" src="https://github.com/user-attachments/assets/514cc3dd-d259-4601-9c42-58031e2cd7f7" />