### PR TITLE
Android: Fixes #13079: Fix dropdown menus are offset on Android 15+

### DIFF
--- a/packages/app-mobile/components/Dropdown.tsx
+++ b/packages/app-mobile/components/Dropdown.tsx
@@ -112,9 +112,15 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 	};
 
 	private renderWithInsets(insets: EdgeInsets) {
+		let offsetHeight = 0;
+
+		if (Platform.OS === 'android' && Platform.Version >= 35) {
+			offsetHeight = insets.bottom;
+		}
+
 		const items = this.props.items;
 		const itemHeight = 60;
-		const windowHeight = Dimensions.get('window').height - 50;
+		const windowHeight = Dimensions.get('window').height - 50 - offsetHeight;
 		const windowWidth = Dimensions.get('window').width;
 
 		// Dimensions doesn't return quite the right dimensions so leave an extra gap to make

--- a/packages/app-mobile/components/Dropdown.tsx
+++ b/packages/app-mobile/components/Dropdown.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { TouchableOpacity, TouchableWithoutFeedback, Dimensions, Text, Modal, View, LayoutRectangle, ViewStyle, TextStyle, FlatList } from 'react-native';
+import { TouchableOpacity, TouchableWithoutFeedback, Dimensions, Text, Modal, View, LayoutRectangle, ViewStyle, TextStyle, FlatList, Platform } from 'react-native';
 import { Component, ReactElement } from 'react';
 import { _ } from '@joplin/lib/locale';
+import { EdgeInsets, SafeAreaInsetsContext } from 'react-native-safe-area-context';
 
 type ValueType = string;
 export interface DropdownListItem {
@@ -56,25 +57,43 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 		};
 	}
 
-	private updateHeaderCoordinates = () => {
+	private updateHeaderCoordinates = (insets: EdgeInsets) => {
 		if (!this.headerRef) return;
 
 		// https://stackoverflow.com/questions/30096038/react-native-getting-the-position-of-an-element
 		this.headerRef.measure((_fx, _fy, width, height, px, py) => {
 			const lastLayout = this.state.headerSize;
+			let offsetX = 0;
+			let offsetY = 0;
+
+			// The opening position of the dropdown must be offset to cater for insets, on newer versions of Android which use edge to edge by default
+			// If the dropdown fills the full height of the screen, the offset gets ignored and does not cause anything to be truncated
+			if (Platform.OS === 'android' && Platform.Version >= 35) {
+				const windowHeight = Dimensions.get('window').height;
+				const windowWidth = Dimensions.get('window').width;
+				const isLandscape = windowWidth > windowHeight;
+
+				if (isLandscape) {
+					offsetX = insets.left;
+					offsetY = insets.top;
+				} else {
+					offsetY = insets.top;
+				}
+			}
+
 			if (px !== lastLayout.x || py !== lastLayout.y || width !== lastLayout.width || height !== lastLayout.height) {
 				this.setState({
-					headerSize: { x: px, y: py, width: width, height: height },
+					headerSize: { x: px - offsetX, y: py - offsetY, width: width, height: height },
 				});
 			}
 		});
 	};
 
-	private onOpenList = () => {
+	private onOpenList = (insets: EdgeInsets) => {
 		// On iOS, we need to re-measure just before opening the list. Measurements from just after
 		// onLayout can be inaccurate in some cases (in the past, this had caused the menu to be
 		// drawn far offscreen).
-		this.updateHeaderCoordinates();
+		this.updateHeaderCoordinates(insets);
 		this.setState({ listVisible: true });
 	};
 	private onCloseList = () => {
@@ -92,7 +111,7 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 		}
 	};
 
-	public render() {
+	private renderWithInsets(insets: EdgeInsets) {
 		const items = this.props.items;
 		const itemHeight = 60;
 		const windowHeight = Dimensions.get('window').height - 50;
@@ -205,13 +224,13 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 			<View style={{ flex: 1, flexDirection: 'column' }}>
 				<View
 					style={{ flexDirection: 'row', flex: 1, alignItems: 'center' }}
-					onLayout={this.updateHeaderCoordinates}
+					onLayout={() => this.updateHeaderCoordinates(insets)}
 					ref={ref => { this.headerRef = ref; } }
 				>
 					<TouchableOpacity
 						style={headerWrapperStyle}
 						disabled={this.props.disabled}
-						onPress={this.onOpenList}
+						onPress={() => this.onOpenList(insets)}
 						accessibilityRole='button'
 						accessibilityHint={[this.props.accessibilityHint, _('Opens dropdown')].join(' ')}
 					>
@@ -266,6 +285,14 @@ class Dropdown extends Component<DropdownProps, DropdownState> {
 					{screenReaderCloseMenuButton}
 				</Modal>
 			</View>
+		);
+	}
+
+	public render() {
+		return (
+			<SafeAreaInsetsContext.Consumer>
+				{(insets) => this.renderWithInsets(insets)}
+			</SafeAreaInsetsContext.Consumer>
 		);
 	}
 }


### PR DESCRIPTION
On Android 15+, due to the default use of edge to edge support, insets now need to be considered, for components to have the correct alignment, as has been addressed by a number of PR's since the upgrade to API level 35 in Joplin 3.4. Starting with Android 15, anywhere that the Dropdown component is used is offset incorrectly, due to not considering the status bar and/or navigation bar inset, depending on the orientation. This PR addresses the issue by considering these insets, but only targets the Android platform where API level is 35 or above, to avoid causing issues on other platforms. I have verified that with these changes, the alignments now match the way they look when running on Android 14.

Note that if the on-screen keyboard is open when you open a dropdown, it will be dismissed while the dropdown is open. Therefore testing the change with different keyboard states is out of scope. For the notebook selection dropdown, it will remain open if you rotate the screen with it open. I have verified that the dropdown is correctly re-aligned when doing so.

This fixes https://github.com/laurent22/joplin/issues/13079

## Testing

Screenshots on Android 16 emulator, with the change:

### 3 button navigation:

<img width="412" height="899" alt="portrait" src="https://github.com/user-attachments/assets/92490ea3-dd26-4862-92e8-e74aa57a6247" />
<img width="410" height="899" alt="portrait" src="https://github.com/user-attachments/assets/7de311b9-ca20-48f4-b783-723acc38873b" />
<img width="414" height="896" alt="portrait2" src="https://github.com/user-attachments/assets/aaa6ef37-e173-41ac-8cdb-01823538b45a" />
<img width="1920" height="822" alt="landscape" src="https://github.com/user-attachments/assets/6c2eca83-a718-4076-a250-5f02618eae7a" />
<img width="412" height="898" alt="notebookdropdown" src="https://github.com/user-attachments/assets/9e5b8dc0-1ba3-43fb-84ec-cfbc781f146d" />
<img width="1920" height="814" alt="notebookdropdownoverflow" src="https://github.com/user-attachments/assets/bdd61e19-4b94-4342-a630-4513d3f89dc0" />
<img width="1920" height="818" alt="landscape" src="https://github.com/user-attachments/assets/3aa299f6-f257-47f8-a868-d152e164e7d4" />

### Gesture navigation:

<img width="412" height="896" alt="portraitgesture" src="https://github.com/user-attachments/assets/2f1cd308-168c-4a76-89e3-87c359584888" />
<img width="413" height="899" alt="portraitgesture" src="https://github.com/user-attachments/assets/56dc6306-1645-4f58-a7e2-cd946d048697" />
<img width="413" height="901" alt="portraitgesture2" src="https://github.com/user-attachments/assets/360f03b2-06fc-470f-ab59-74bad7da779c" />
<img width="1920" height="824" alt="landscapegesture" src="https://github.com/user-attachments/assets/6d3f5f41-823a-4d47-9b16-9a13d3da8bd4" />
<img width="1920" height="820" alt="landscapegesture" src="https://github.com/user-attachments/assets/7f12fe85-2066-48c5-81ec-1e9f4e952a34" />
