### PR TITLE
Server: Fix unique constraint error when multiple `createSharedFolderUserItems` are run concurrently

### DIFF
--- a/packages/server/src/models/ShareModel.test.ts
+++ b/packages/server/src/models/ShareModel.test.ts
@@ -202,13 +202,13 @@ describe('ShareModel', () => {
 			},
 		});
 
-		expect((await models().userItem().byUserId(user3.id)).length).toBe(0);
+		expect(await models().userItem().byUserId(user3.id)).toHaveLength(0);
 		await Promise.all([
 			models().share().createSharedFolderUserItems(share.id, user3.id),
 			models().share().createSharedFolderUserItems(share.id, user3.id),
 			models().share().createSharedFolderUserItems(share.id, user3.id),
 		]);
-		expect((await models().userItem().byUserId(user3.id)).length).toBe(4);
+		expect(await models().userItem().byUserId(user3.id)).toHaveLength(4);
 	});
 
 });

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -421,7 +421,10 @@ export default class ShareModel extends BaseModel<Share> {
 	// errors, but re-assigning all items to a user.
 	public async createSharedFolderUserItems(shareId: Uuid, userId: Uuid) {
 		const query = this.models().item().byShareIdQuery(shareId, { fields: ['id', 'name'] });
-		await this.models().userItem().addMulti(userId, query);
+		await this.models().userItem().addMulti(
+			// Don't throw if a (user_id, item_id) pair already exists to avoid race conditions.
+			userId, query, { ignoreAlreadyExists: true },
+		);
 	}
 
 	public async shareFolder(owner: User, folderId: string, masterKeyId: string): Promise<Share> {

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -139,12 +139,12 @@ export default class UserItemModel extends BaseModel<UserItem> {
 		const items: Item[] = Array.isArray(itemsQuery) ? itemsQuery : await itemsQuery.whereNotIn('id', this.db('user_items').select('item_id').where('user_id', '=', userId));
 		if (!items.length) return;
 
-		await this.withTransaction(async () => {
-			perfTimer.push(`Processing ${items.length} items`);
+		perfTimer.push(`Processing ${items.length} items`);
 
-			for (const item of items) {
-				if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
+		for (const item of items) {
+			if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
 
+			await this.withTransaction(async () => {
 				try {
 					await super.save({
 						user_id: userId,
@@ -166,10 +166,10 @@ export default class UserItemModel extends BaseModel<UserItem> {
 						throw error;
 					}
 				}
-			}
+			}, 'UserItemModel::addMulti');
+		}
 
-			perfTimer.pop();
-		}, 'UserItemModel::addMulti');
+		perfTimer.pop();
 
 		perfTimer.pop();
 	}

--- a/packages/server/src/models/UserItemModel.ts
+++ b/packages/server/src/models/UserItemModel.ts
@@ -5,6 +5,7 @@ import { ErrorNotFound } from '../utils/errors';
 import { Knex } from 'knex';
 import { PerformanceTimer } from '../utils/time';
 import Logger from '@joplin/utils/Logger';
+import { isUniqueConstraintError } from '../db';
 
 const logger = Logger.create('UserItemModel');
 
@@ -21,6 +22,12 @@ export interface UserItemDeleteOptions extends DeleteOptions {
 	byUserItemIds?: number[];
 	byShare?: DeleteByShare;
 	recordChanges?: boolean;
+}
+
+interface UserItemSaveOptions extends SaveOptions {
+	// Ignore unique constraint errors if a (user_id, item_id) pair already
+	// exists.
+	ignoreAlreadyExists?: boolean;
 }
 
 export default class UserItemModel extends BaseModel<UserItem> {
@@ -116,7 +123,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 		await this.deleteBy({ byShareId: shareId, byUserId: userId });
 	}
 
-	public async add(userId: Uuid, itemId: Uuid, options: SaveOptions = {}): Promise<void> {
+	public async add(userId: Uuid, itemId: Uuid, options: UserItemSaveOptions = {}): Promise<void> {
 		const item = await this.models().item().load(itemId, { fields: ['id', 'name'] });
 		if (!item) {
 			throw new ErrorNotFound(`No such item: ${itemId}`);
@@ -124,7 +131,7 @@ export default class UserItemModel extends BaseModel<UserItem> {
 		await this.addMulti(userId, [item], options);
 	}
 
-	public async addMulti(userId: Uuid, itemsQuery: Knex.QueryBuilder | Item[], options: SaveOptions = {}): Promise<void> {
+	public async addMulti(userId: Uuid, itemsQuery: Knex.QueryBuilder | Item[], options: UserItemSaveOptions = {}): Promise<void> {
 		const perfTimer = new PerformanceTimer(logger, 'addMulti');
 
 		perfTimer.push('Main');
@@ -138,20 +145,26 @@ export default class UserItemModel extends BaseModel<UserItem> {
 			for (const item of items) {
 				if (!('name' in item) || !('id' in item)) throw new Error('item.id and item.name must be set');
 
-				await super.save({
-					user_id: userId,
-					item_id: item.id,
-				}, options);
-
-				if (this.models().item().shouldRecordChange(item.name)) {
-					await this.models().change().save({
-						item_type: ItemType.UserItem,
-						item_id: item.id,
-						item_name: item.name,
-						type: ChangeType.Create,
-						previous_item: '',
+				try {
+					await super.save({
 						user_id: userId,
-					});
+						item_id: item.id,
+					}, options);
+
+					if (this.models().item().shouldRecordChange(item.name)) {
+						await this.models().change().save({
+							item_type: ItemType.UserItem,
+							item_id: item.id,
+							item_name: item.name,
+							type: ChangeType.Create,
+							previous_item: '',
+							user_id: userId,
+						});
+					}
+				} catch (error) {
+					if (!options.ignoreAlreadyExists || !isUniqueConstraintError(error)) {
+						throw error;
+					}
 				}
 			}
 


### PR DESCRIPTION
# Summary

This pull request ignores "unique constraint" thrown while adding `(user_id, item_id)` pairs to `user_items` while accepting a share. (See [comment](https://github.com/laurent22/joplin/issues/12075#issuecomment-3246245206)).

May partially resolve https://github.com/laurent22/joplin/issues/12075.

# Testing

This pull request includes an automated test that runs `createSharedFolderUserItems` multiple times concurrently (as could happen if the same share is accepted multiple times concurrently).

With this change, the sync fuzzer fails after 22 steps, with conflicts (currently expected, see https://github.com/laurent22/joplin/pull/12993).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->