### PR TITLE
Mobile: Improve tag dialog performance with long tags and many tags

### DIFF
--- a/packages/app-mobile/components/ComboBox.tsx
+++ b/packages/app-mobile/components/ComboBox.tsx
@@ -254,6 +254,8 @@ const SearchResult: React.FC<SearchResultProps> = ({
 		<View style={[styles.optionContent, selected && styles.optionContentSelected]}>
 			{icon}
 			<Text
+				ellipsizeMode='tail'
+				numberOfLines={1}
 				style={styles.optionLabel}
 			>{text}</Text>
 		</View>

--- a/packages/app-mobile/components/NestableFlatList.tsx
+++ b/packages/app-mobile/components/NestableFlatList.tsx
@@ -84,7 +84,7 @@ const NestableFlatList = function<T>({
 	}, []);
 
 	const bufferSize = 10;
-	const visibleStartIndex = Math.floor(scroll / itemHeight);
+	const visibleStartIndex = Math.min(Math.floor(scroll / itemHeight), data.length);
 	const visibleEndIndex = Math.ceil((scroll + listHeight) / itemHeight);
 	const startIndex = Math.max(0, visibleStartIndex - bufferSize);
 	const maximumIndex = data.length - 1;

--- a/packages/app-mobile/components/TagEditor.tsx
+++ b/packages/app-mobile/components/TagEditor.tsx
@@ -44,6 +44,7 @@ const useStyles = (themeId: number, headerStyle: TextStyle|undefined) => {
 			tagText: {
 				color: theme.color3,
 				fontSize: theme.fontSize,
+				flexShrink: 1,
 			},
 			removeTagButton: {
 				color: theme.color3,

--- a/packages/app-mobile/components/TagEditor.tsx
+++ b/packages/app-mobile/components/TagEditor.tsx
@@ -38,6 +38,7 @@ const useStyles = (themeId: number, headerStyle: TextStyle|undefined) => {
 				color: theme.color3,
 				flexDirection: 'row',
 				alignItems: 'center',
+				maxWidth: '100%',
 				gap: 4,
 			},
 			tagText: {
@@ -122,7 +123,11 @@ const TagCard: React.FC<TagChipProps> = props => {
 		style={props.styles.tag}
 		role='listitem'
 	>
-		<Text style={props.styles.tagText}>{props.title}</Text>
+		<Text
+			ellipsizeMode='tail'
+			numberOfLines={1}
+			style={props.styles.tagText}
+		>{props.title}</Text>
 		<IconButton
 			pressableRef={removeButtonRef}
 			themeId={props.themeId}


### PR DESCRIPTION
# Summary

This pull request:
- Ellipsizes long tags (rather than clipping/overlapping other content).
   - Fixes an issue where the "x" button for long tags was not visible.
- Fixes a scroll issue where if 1) scroll is near the end of the tag search results and 2) the number of search results significantly decreases, then the scroll would remain below the last search result.
   - See [comment](https://github.com/laurent22/joplin/issues/13116#issuecomment-3249801663).

May fix #13116.

# Tasks

Some testing has been done with the web version of the mobile app. However, this change also needs to be tested on Android/iOS:

- [x] Test on an Android emulator/device (tested on Android 16).
   - Steps:
     1. Creating a large number of tags with a common prefix (with a script).
         - After this step, the test device has 704 tags.
     2. Opening the tag dialog for a note.
     3. Searching for the tag prefix.
     4. Verifying that a large number of tags are visible in the search results.
   - Screen recording:
     
     [Screen recording: Shows steps listed above](https://github.com/user-attachments/assets/31db736e-f0e8-4960-8f69-3b94d3c433da)

- [x] Test on an iOS device. Testing was done by:
   1. Creating a large number of tags with a common prefix (with a script).
   2. Opening the tag dialog for a note.
   6. Scrolling to the end of the tag list.
   7. Typing part of the common prefix.
   8. Verifying that tags are visible in the results list.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->