### PR TITLE
Mobile: Fixes #13116: Fix tag association screen no longer searches case insensitively or searches tag endings

### DIFF
--- a/packages/app-mobile/components/ComboBox.tsx
+++ b/packages/app-mobile/components/ComboBox.tsx
@@ -66,7 +66,7 @@ const useSearchResults = ({
 }: UseSearchResultsOptions) => {
 	const results = useMemo(() => {
 		return options
-			.filter(option => option.title.startsWith(search))
+			.filter(option => option.title.toLowerCase().includes(search))
 			.sort((a, b) => {
 				if (a.title === b.title) return 0;
 				// Full matches should go first


### PR DESCRIPTION
Since the introduction of the new tag association screen in Joplin 3.4, on the tag association screen it is no longer possible to search case insensitively or search via tag endings. This PR restores this behaviour

This fixes https://github.com/laurent22/joplin/issues/13116

### Testing

Current:

https://github.com/user-attachments/assets/df00dea5-fcd6-4d1b-92f3-8636c4bd163f

New:

https://github.com/user-attachments/assets/7f878da0-15a2-4f55-9f03-4b4046a7f99e