### PR TITLE
Desktop: Resolves #13096: Prefer user-specified CSS page sizing when printing to PDF

### DIFF
--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -86,8 +86,14 @@ export default class InteropServiceHelper {
 								// pdfs.
 								// https://github.com/laurent22/joplin/issues/6254.
 								await win.webContents.executeJavaScript('document.querySelectorAll(\'details\').forEach(el=>el.setAttribute(\'open\',\'\'))');
-								// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-								const data = await win.webContents.printToPDF(options as any);
+								const data = await win.webContents.printToPDF({
+									...options,
+									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code before rule was applied
+									pageSize: options.pageSize as any,
+									// Allows users to override the CSS page size.
+									// See https://github.com/laurent22/joplin/issues/13096
+									preferCSSPageSize: true,
+								});
 								resolve(data);
 							} catch (error) {
 								reject(error);


### PR DESCRIPTION
# Summary

Resolves #13096 by instructing Electron to prefer `@page` styles (if provided) when exporting to PDF.

# Testing

1. Set the paper size in settings to "A5".
2. Create a new note.
3. Convert the note to a PDF using the `exportPdf` command.
4. Verify that the exported PDF is in landscape mode and is A5 sized (Chromium reports: 8.28 × 5.83 in (landscape)).
5. Add page styling to the note:
   ```
   <style>
   @page { size: a5 landscape; }
   </style>
   ```
6. Export to PDF.
7. Verify that the exported PDF is no longer in landscape mode (Chromium reports 5.83 × 8.28 in (portrait)).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->