### PR TITLE
Mobile: Fix light bar shown above header in dark mode

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -114,7 +114,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 			// A small border above the header: Covers the part of the shadow that would otherwise
 			// be shown above the header on Android.
 			aboveHeader: {
-				backgroundColor: '#323640',
+				backgroundColor: theme.backgroundColor2,
 				paddingBottom: 6,
 				marginTop: -6,
 				zIndex: 2,


### PR DESCRIPTION
# Summary

This pull request fixes a regression introduced by https://github.com/laurent22/joplin/pull/13074. Prior to this pull request, in dark mode, a light bar was shown under the status bar.

> [!NOTE]
>
> Since this is a regression, this pull request targets `release-3.4`.

# Screenshots (Android 16 emulator)

|     | Before | After |
|-----|--------|-------|
|Dark | <img width="200" alt="screenshot: Light bar above header (on statusbar)" src="https://github.com/user-attachments/assets/f869d6d9-9a68-41d7-9a0c-9b75bd7c1f06" /> |    <img width="200" alt="Screenshot_1757091533" src="https://github.com/user-attachments/assets/d6973f0f-08b3-463a-a0ad-90e9e95da0e4" />   |
|Light| <img width="200" alt="screenshot: Light mode screenshot, no bar above header" src="https://github.com/user-attachments/assets/24c68751-5fc9-4406-9a24-25bffed6356c" />  |       <img width="200" alt="Screenshot_1757091556" src="https://github.com/user-attachments/assets/30c09c6d-492b-488c-8971-61e9a99de854" />|

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->