### PR TITLE
Chore: Refactor WebViewController

### DIFF
--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -72,4 +72,10 @@ export default class MainScreen {
 		await setFilePickerResponse(electronApp, [path]);
 		await activateMainMenuItem(electronApp, 'HTML - HTML document (Directory)', 'Import');
 	}
+
+	public async pluginPanelLocator(pluginId: string) {
+		return this.page.locator(
+			`iframe[id^=${JSON.stringify(`plugin-view-${pluginId}`)}]`,
+		);
+	}
 }

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -128,12 +128,24 @@ test.describe('pluginApi', () => {
 		const mainScreen = await new MainScreen(mainWindow).setup();
 		await mainScreen.createNewNote('Test note (panels)');
 
+		const panelLocator = await mainScreen.pluginPanelLocator('org.joplinapp.plugins.example.panels');
+
 		const noteEditor = mainScreen.noteEditor;
 		await mainScreen.goToAnything.runCommand(app, 'testShowPanel');
 		await expect(noteEditor.codeMirrorEditor).toHaveText('visible');
 
+		// Panel should be visible
+		await expect(panelLocator).toBeVisible();
+		// The panel should have the expected content
+		const panelContent = panelLocator.contentFrame();
+		await expect(
+			panelContent.getByRole('heading', { name: 'Panel content' }),
+		).toBeAttached();
+
 		await mainScreen.goToAnything.runCommand(app, 'testHidePanel');
 		await expect(noteEditor.codeMirrorEditor).toHaveText('hidden');
+
+		await expect(panelLocator).not.toBeVisible();
 	});
 });
 

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -122,5 +122,18 @@ test.describe('pluginApi', () => {
 		await msleep(Second);
 		await expect(noteEditor.codeMirrorEditor).toHaveText(expectedUpdatedText);
 	});
+
+	test('should support hiding and showing panels', async ({ startAppWithPlugins }) => {
+		const { mainWindow, app } = await startAppWithPlugins(['resources/test-plugins/panels.js']);
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('Test note (panels)');
+
+		const noteEditor = mainScreen.noteEditor;
+		await mainScreen.goToAnything.runCommand(app, 'testShowPanel');
+		await expect(noteEditor.codeMirrorEditor).toHaveText('visible');
+
+		await mainScreen.goToAnything.runCommand(app, 'testHidePanel');
+		await expect(noteEditor.codeMirrorEditor).toHaveText('hidden');
+	});
 });
 

--- a/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
@@ -47,5 +47,22 @@ joplin.plugins.register({
 				}));
 			},
 		});
+
+		await joplin.commands.register({
+			name: 'getTestDialogVisibility',
+			label: 'Returns the dialog visibility state',
+			execute: async () => {
+				// panels.visible should also work for dialogs.
+				const visible = await joplin.views.panels.visible(dialogHandle);
+				// For dialogs, isActive should return the visibility.
+				// (Prefer panels.visible for dialogs).
+				const active = await joplin.views.panels.isActive(dialogHandle);
+
+				await joplin.commands.execute('editor.setText', JSON.stringify({
+					visible,
+					active,
+				}));
+			},
+		});
 	},
 });

--- a/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
@@ -1,0 +1,71 @@
+// Allows referencing the Joplin global:
+/* eslint-disable no-undef */
+
+// Allows the `joplin-manifest` block comment:
+/* eslint-disable multiline-comment-style */
+
+/* joplin-manifest:
+{
+	"id": "org.joplinapp.plugins.example.panels",
+	"manifest_version": 1,
+	"app_min_version": "3.1",
+	"name": "JS Bundle test",
+	"description": "JS Bundle Test plugin",
+	"version": "1.0.0",
+	"author": "",
+	"homepage_url": "https://joplinapp.org"
+}
+*/
+
+const waitFor = async (condition) => {
+	const wait = () => {
+		return new Promise(resolve => {
+			setTimeout(() => resolve(), 100);
+		});
+	};
+	for (let i = 0; i < 100; i++) {
+		if (await condition()) {
+			return;
+		}
+
+		// Pause for a brief delay
+		await wait();
+	}
+
+	throw new Error('Condition was never true');
+};
+
+joplin.plugins.register({
+	onStart: async function() {
+		const panels = joplin.views.panels;
+		const view = await panels.create('panelTestView');
+		await panels.setHtml(view, '<h1>Test</h1><p>Test</p>');
+		await panels.hide(view);
+
+
+		await joplin.commands.register({
+			name: 'testShowPanel',
+			label: 'Test panel visibility',
+			execute: async () => {
+				await panels.show(view);
+				await waitFor(async () => {
+					return await panels.visible(view);
+				});
+				await joplin.commands.execute('editor.setText', 'visible');
+			},
+		});
+
+		await joplin.commands.register({
+			name: 'testHidePanel',
+			label: 'Test: Hide the panel',
+			execute: async () => {
+				await panels.hide(view);
+				await waitFor(async () => {
+					return !await panels.visible(view);
+				});
+
+				await joplin.commands.execute('editor.setText', 'hidden');
+			},
+		});
+	},
+});

--- a/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
@@ -39,7 +39,7 @@ joplin.plugins.register({
 	onStart: async function() {
 		const panels = joplin.views.panels;
 		const view = await panels.create('panelTestView');
-		await panels.setHtml(view, '<h1>Test</h1><p>Test</p>');
+		await panels.setHtml(view, '<h1>Panel content</h1><p>Test</p>');
 		await panels.hide(view);
 
 

--- a/packages/lib/commands/showEditorPlugin.ts
+++ b/packages/lib/commands/showEditorPlugin.ts
@@ -44,7 +44,7 @@ export const runtime = (): CommandRuntime => {
 				throw new Error(`No controller registered for editor view ${editorView.id}`);
 			}
 
-			const previousVisible = editorView.parentWindowId === windowId && controller.isVisible();
+			const previousVisible = editorView.parentWindowId === windowId && controller.visible;
 
 			if (show && previousVisible) {
 				logger.info(`Editor is already visible: ${editorViewId}`);
@@ -68,7 +68,7 @@ export const runtime = (): CommandRuntime => {
 			};
 			Setting.setValue('plugins.shownEditorViewIds', getUpdatedShownViewIds());
 
-			controller.setOpened(show);
+			void controller.setOpen(show);
 		},
 	};
 };

--- a/packages/lib/commands/showEditorPlugin.ts
+++ b/packages/lib/commands/showEditorPlugin.ts
@@ -68,7 +68,7 @@ export const runtime = (): CommandRuntime => {
 			};
 			Setting.setValue('plugins.shownEditorViewIds', getUpdatedShownViewIds());
 
-			void controller.setOpen(show);
+			await controller.setOpen(show);
 		},
 	};
 };

--- a/packages/lib/services/plugins/WebviewController.ts
+++ b/packages/lib/services/plugins/WebviewController.ts
@@ -285,9 +285,14 @@ export default class WebviewController extends ViewController {
 	}
 
 	public closeWithResponse(result: DialogResult) {
-		this.close();
-		this.closeResponse_.resolve(result);
+		const responseCallback = this.closeResponse_;
+		// Clear the closeResponse_ to prevent the default behavior
+		// (which sends a response of null).
 		this.closeResponse_ = null;
+
+		this.close();
+
+		responseCallback?.resolve(result);
 	}
 
 	public get buttons(): ButtonSpec[] {

--- a/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsDialogs.ts
@@ -125,7 +125,7 @@ export default class JoplinViewsDialogs {
 	 * On desktop, this closes any copies of the dialog open in different windows.
 	 */
 	public async open(handle: ViewHandle): Promise<DialogResult> {
-		return this.controller(handle).open();
+		return this.controller(handle).setOpen(true);
 	}
 
 	/**

--- a/packages/lib/services/plugins/api/JoplinViewsEditor.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsEditor.ts
@@ -90,7 +90,7 @@ export default class JoplinViewsEditors {
 			controller.setEditorTypeId(editorTypeId);
 			this.plugin.addViewController(controller);
 			// Restore the last open/closed state for the editor
-			controller.setOpened(Setting.value('plugins.shownEditorViewIds').includes(editorTypeId));
+			void controller.setOpen(Setting.value('plugins.shownEditorViewIds').includes(editorTypeId));
 
 			return () => {
 				this.plugin.removeViewController(controller);
@@ -271,7 +271,7 @@ export default class JoplinViewsEditors {
 	 * Tells whether the editor is active or not.
 	 */
 	public async isActive(handle: ViewHandle): Promise<boolean> {
-		return this.controller(handle).isActive();
+		return this.controller(handle).active;
 	}
 
 	/**
@@ -280,7 +280,7 @@ export default class JoplinViewsEditors {
 	 * `true`. Otherwise it will return `false`.
 	 */
 	public async isVisible(handle: ViewHandle): Promise<boolean> {
-		return this.controller(handle).isVisible();
+		return this.controller(handle).visible;
 	}
 
 }

--- a/packages/lib/services/plugins/api/JoplinViewsPanels.ts
+++ b/packages/lib/services/plugins/api/JoplinViewsPanels.ts
@@ -114,7 +114,7 @@ export default class JoplinViewsPanels {
 	 * Shows the panel
 	 */
 	public async show(handle: ViewHandle, show = true): Promise<void> {
-		await this.controller(handle).show(show);
+		await this.controller(handle).setOpen(show);
 	}
 
 	/**
@@ -136,7 +136,7 @@ export default class JoplinViewsPanels {
 	 * whether the editor plugin view supports editing the current note.
 	 */
 	public async isActive(handle: ViewHandle): Promise<boolean> {
-		return this.controller(handle).isActive();
+		return this.controller(handle).active;
 	}
 
 }


### PR DESCRIPTION
# Summary

This pull request refactors `WebViewController.ts` to reduce the number of methods with similar names specific to different WebView display types. Previously, `WebViewController` had a number of different methods that were specific to a certain WebView display type (e.g. `.visible` for panels and `.isVisible()` for editor plugin views).

This change should make issues similar to #13119 less likely to occur in the future.


# Testing

**Automated tests**: This pull request adds the following tests:
- A test that shows a plugin dialog, checks the `panels.visible` and `panels.isActive` results for the dialog, then closes the dialog.
- A test that shows a plugin panel, checks `panels.visible`, closes it, and checks `panels.visible`.

Existing automated plugin tests related to dialogs/panels can be found in [pluginApi.spec.ts](https://github.com/laurent22/joplin/blob/dev/packages/app-desktop/integration-tests/pluginApi.spec.ts) and [PluginRunnerWebView.test.tsx](https://github.com/laurent22/joplin/blob/dev/packages/app-mobile/components/plugins/PluginRunnerWebView.test.tsx).

**Manual testing**: On desktop:
1. Install or enable YesYouKan and Freehand Drawing.
2. Create a new Kanban board.
3. Open the Kanban editor.
4. Add a card to "Backlog".
5. Switch back to the Markdown editor.
6. Attach a drawing.
   - Verify that the drawing dialog can open and close.
7. Open a secondary Joplin window.
8. Edit the drawing added in step 6 in the secondary window.
9. Close the secondary window.
10. Install the "Joplin debug tool" plugin.
11. Restart Joplin.
12. Verify that the debug tool panel is visible.
13. Hide the debug tool panel with "View" > "Show/hide note info".
14. Show the debug tool panel with "View" > "Show/hide note info".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->