### PR TITLE
Chore: Mobile: Add additional plugin panel integration tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -921,6 +921,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/buildStartupTasks.js
 packages/app-mobile/utils/checkPermissions.js

--- a/.gitignore
+++ b/.gitignore
@@ -894,6 +894,7 @@ packages/app-mobile/utils/ShareUtils.test.js
 packages/app-mobile/utils/ShareUtils.js
 packages/app-mobile/utils/TlsUtils.js
 packages/app-mobile/utils/appDefaultState.js
+packages/app-mobile/utils/appReducer.js
 packages/app-mobile/utils/autodetectTheme.js
 packages/app-mobile/utils/buildStartupTasks.js
 packages/app-mobile/utils/checkPermissions.js

--- a/packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx
+++ b/packages/app-mobile/components/plugins/dialogs/PluginPanelViewer.tsx
@@ -120,7 +120,7 @@ const PluginPanelViewer: React.FC<Props> = props => {
 		}
 
 		return (
-			<View style={styles.webViewContainer}>
+			<View style={styles.webViewContainer} testID='plugin-tab-content'>
 				<PluginUserWebView
 					key={selectedTabId}
 					themeId={props.themeId}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -14,7 +14,7 @@ import NoteScreen from './components/screens/Note/Note';
 import UpgradeSyncTargetScreen from './components/screens/UpgradeSyncTargetScreen';
 import Setting, { } from '@joplin/lib/models/Setting';
 import PoorManIntervals from '@joplin/lib/PoorManIntervals';
-import reducer, { NotesParent, serializeNotesParent } from '@joplin/lib/reducer';
+import { NotesParent, serializeNotesParent } from '@joplin/lib/reducer';
 import ShareExtension, { UnsubscribeShareListener } from './utils/ShareExtension';
 import handleShared from './utils/shareHandler';
 import { _, setLocale } from '@joplin/lib/locale';
@@ -28,7 +28,6 @@ import NetInfo, { NetInfoSubscription } from '@react-native-community/netinfo';
 const DropdownAlert = require('react-native-dropdownalert').default;
 import SafeAreaView from './components/SafeAreaView';
 const { connect, Provider } = require('react-redux');
-import fastDeepEqual = require('fast-deep-equal');
 import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
 import BackButtonService, { BackButtonHandler } from './services/BackButtonService';
 import NavService from '@joplin/lib/services/NavService';
@@ -95,7 +94,6 @@ import autodetectTheme, { onSystemColorSchemeChange } from './utils/autodetectTh
 import PluginRunnerWebView from './components/plugins/PluginRunnerWebView';
 import { refreshFolders, scheduleRefreshFolders } from '@joplin/lib/folders-screen-utils';
 import ShareManager from './components/screens/ShareManager';
-import appDefaultState from './utils/appDefaultState';
 import { setDateFormat, setTimeFormat, setTimeLocale } from '@joplin/utils/time';
 import DialogManager from './components/DialogManager';
 import { AppState } from './utils/types';
@@ -108,6 +106,7 @@ import NoteRevisionViewer from './components/screens/NoteRevisionViewer';
 import DocumentScanner from './components/screens/DocumentScanner/DocumentScanner';
 import buildStartupTasks from './utils/buildStartupTasks';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import appReducer from './utils/appReducer';
 
 const logger = Logger.create('root');
 const perfLogger = PerformanceLogger.create();
@@ -233,204 +232,6 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 	}
 
 	return result;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-const navHistory: any[] = [];
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-function historyCanGoBackTo(route: any) {
-	if (route.routeName === 'Folder') return false;
-
-	// This is an intermediate screen that acts more like a modal -- it should be skipped in the
-	// navigation history.
-	if (route.routeName === 'DocumentScanner') return false;
-
-	// There's no point going back to these screens in general and, at least in OneDrive case,
-	// it can be buggy to do so, due to incorrectly relying on global state (reg.syncTarget...)
-	if (route.routeName === 'OneDriveLogin') return false;
-	if (route.routeName === 'DropboxLogin') return false;
-
-	return true;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-const appReducer = (state = appDefaultState, action: any) => {
-	let newState = state;
-	let historyGoingBack = false;
-
-	try {
-		switch (action.type) {
-
-		case 'NAV_BACK':
-		case 'NAV_GO':
-
-			if (action.type === 'NAV_BACK') {
-				if (!navHistory.length) break;
-
-				const newAction = navHistory.pop();
-				action = newAction ? newAction : navHistory.pop();
-
-				historyGoingBack = true;
-			}
-
-			{
-				const currentRoute = state.route;
-
-				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
-					const previousRoute = navHistory.length && navHistory[navHistory.length - 1];
-					const isDifferentRoute = !previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute);
-
-					// Avoid multiple consecutive duplicate screens in the navigation history -- these can make
-					// pressing "back" seem to have no effect.
-					if (isDifferentRoute) {
-						navHistory.push(currentRoute);
-					}
-				}
-
-				if (action.clearHistory) {
-					navHistory.splice(0, navHistory.length);
-				}
-
-				newState = { ...state };
-
-				newState.selectedNoteHash = '';
-
-				if (action.routeName === 'Search') {
-					newState.notesParentType = 'Search';
-				}
-
-				if ('noteId' in action) {
-					newState.selectedNoteIds = action.noteId ? [action.noteId] : [];
-				}
-
-				if ('folderId' in action) {
-					newState.selectedFolderId = action.folderId;
-					newState.notesParentType = 'Folder';
-				}
-
-				if ('tagId' in action) {
-					newState.selectedTagId = action.tagId;
-					newState.notesParentType = 'Tag';
-				}
-
-				if ('smartFilterId' in action) {
-					newState.smartFilterId = action.smartFilterId;
-					newState.selectedSmartFilterId = action.smartFilterId;
-					newState.notesParentType = 'SmartFilter';
-				}
-
-				if ('itemType' in action) {
-					newState.selectedItemType = action.itemType;
-				}
-
-				if ('noteHash' in action) {
-					newState.selectedNoteHash = action.noteHash;
-				}
-
-				if ('sharedData' in action) {
-					newState.sharedData = action.sharedData;
-				} else {
-					newState.sharedData = null;
-				}
-
-				newState.route = action;
-				newState.historyCanGoBack = !!navHistory.length;
-
-				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
-			}
-			break;
-
-		case 'SIDE_MENU_TOGGLE':
-
-			newState = { ...state };
-			newState.showSideMenu = !newState.showSideMenu;
-			break;
-
-		case 'SIDE_MENU_OPEN':
-
-			newState = { ...state };
-			newState.showSideMenu = true;
-			break;
-
-		case 'SIDE_MENU_CLOSE':
-
-			newState = { ...state };
-			newState.showSideMenu = false;
-			break;
-
-		case 'SET_PLUGIN_PANELS_DIALOG_VISIBLE':
-			newState = { ...state };
-			newState.showPanelsDialog = action.visible;
-			break;
-
-		case 'NOTE_SELECTION_TOGGLE':
-
-			{
-				newState = { ...state };
-
-				const noteId = action.id;
-				const newSelectedNoteIds = state.selectedNoteIds.slice();
-				const existingIndex = state.selectedNoteIds.indexOf(noteId);
-
-				if (existingIndex >= 0) {
-					newSelectedNoteIds.splice(existingIndex, 1);
-				} else {
-					newSelectedNoteIds.push(noteId);
-				}
-
-				newState.selectedNoteIds = newSelectedNoteIds;
-				newState.noteSelectionEnabled = !!newSelectedNoteIds.length;
-			}
-			break;
-
-		case 'NOTE_SELECTION_START':
-
-			if (!state.noteSelectionEnabled) {
-				newState = { ...state };
-				newState.noteSelectionEnabled = true;
-				newState.selectedNoteIds = [action.id];
-			}
-			break;
-
-		case 'NOTE_SELECTION_END':
-
-			newState = { ...state };
-			newState.noteSelectionEnabled = false;
-			newState.selectedNoteIds = [];
-			break;
-
-		case 'NOTE_SIDE_MENU_OPTIONS_SET':
-
-			newState = { ...state };
-			newState.noteSideMenuOptions = action.options;
-			break;
-
-		case 'SET_SIDE_MENU_TOUCH_GESTURES_DISABLED':
-			newState = { ...state };
-			newState.disableSideMenuGestures = action.disableSideMenuGestures;
-			break;
-
-		case 'MOBILE_DATA_WARNING_UPDATE':
-
-			newState = { ...state };
-			newState.isOnMobileData = action.isOnMobileData;
-			break;
-
-		case 'KEYBOARD_VISIBLE_CHANGE':
-			newState = { ...state, keyboardVisible: action.visible };
-			break;
-
-		case 'NOTE_EDITOR_VISIBLE_CHANGE':
-			newState = { ...state, noteEditorVisible: action.visible };
-			break;
-		}
-	} catch (error) {
-		error.message = `In reducer: ${error.message} Action: ${JSON.stringify(action)}`;
-		throw error;
-	}
-
-	return reducer(newState, action) as AppState;
 };
 
 const store = createStore(appReducer, applyMiddleware(generalMiddleware));

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -1,0 +1,207 @@
+import reducer from '@joplin/lib/reducer';
+import { AppState } from './types';
+import appDefaultState from './appDefaultState';
+import fastDeepEqual = require('fast-deep-equal');
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('appReducer');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+const navHistory: any[] = [];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+function historyCanGoBackTo(route: any) {
+	if (route.routeName === 'Folder') return false;
+
+	// This is an intermediate screen that acts more like a modal -- it should be skipped in the
+	// navigation history.
+	if (route.routeName === 'DocumentScanner') return false;
+
+	// There's no point going back to these screens in general and, at least in OneDrive case,
+	// it can be buggy to do so, due to incorrectly relying on global state (reg.syncTarget...)
+	if (route.routeName === 'OneDriveLogin') return false;
+	if (route.routeName === 'DropboxLogin') return false;
+
+	return true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+const appReducer = (state = appDefaultState, action: any) => {
+	let newState = state;
+	let historyGoingBack = false;
+
+	try {
+		switch (action.type) {
+
+		case 'NAV_BACK':
+		case 'NAV_GO':
+
+			if (action.type === 'NAV_BACK') {
+				if (!navHistory.length) break;
+
+				const newAction = navHistory.pop();
+				action = newAction ? newAction : navHistory.pop();
+
+				historyGoingBack = true;
+			}
+
+			{
+				const currentRoute = state.route;
+
+				if (!historyGoingBack && historyCanGoBackTo(currentRoute)) {
+					const previousRoute = navHistory.length && navHistory[navHistory.length - 1];
+					const isDifferentRoute = !previousRoute || !fastDeepEqual(navHistory[navHistory.length - 1], currentRoute);
+
+					// Avoid multiple consecutive duplicate screens in the navigation history -- these can make
+					// pressing "back" seem to have no effect.
+					if (isDifferentRoute) {
+						navHistory.push(currentRoute);
+					}
+				}
+
+				if (action.clearHistory) {
+					navHistory.splice(0, navHistory.length);
+				}
+
+				newState = { ...state };
+
+				newState.selectedNoteHash = '';
+
+				if (action.routeName === 'Search') {
+					newState.notesParentType = 'Search';
+				}
+
+				if ('noteId' in action) {
+					newState.selectedNoteIds = action.noteId ? [action.noteId] : [];
+				}
+
+				if ('folderId' in action) {
+					newState.selectedFolderId = action.folderId;
+					newState.notesParentType = 'Folder';
+				}
+
+				if ('tagId' in action) {
+					newState.selectedTagId = action.tagId;
+					newState.notesParentType = 'Tag';
+				}
+
+				if ('smartFilterId' in action) {
+					newState.smartFilterId = action.smartFilterId;
+					newState.selectedSmartFilterId = action.smartFilterId;
+					newState.notesParentType = 'SmartFilter';
+				}
+
+				if ('itemType' in action) {
+					newState.selectedItemType = action.itemType;
+				}
+
+				if ('noteHash' in action) {
+					newState.selectedNoteHash = action.noteHash;
+				}
+
+				if ('sharedData' in action) {
+					newState.sharedData = action.sharedData;
+				} else {
+					newState.sharedData = null;
+				}
+
+				newState.route = action;
+				newState.historyCanGoBack = !!navHistory.length;
+
+				logger.debug('Navigated to route:', newState.route?.routeName, 'with notesParentType:', newState.notesParentType);
+			}
+			break;
+
+		case 'SIDE_MENU_TOGGLE':
+
+			newState = { ...state };
+			newState.showSideMenu = !newState.showSideMenu;
+			break;
+
+		case 'SIDE_MENU_OPEN':
+
+			newState = { ...state };
+			newState.showSideMenu = true;
+			break;
+
+		case 'SIDE_MENU_CLOSE':
+
+			newState = { ...state };
+			newState.showSideMenu = false;
+			break;
+
+		case 'SET_PLUGIN_PANELS_DIALOG_VISIBLE':
+			newState = { ...state };
+			newState.showPanelsDialog = action.visible;
+			break;
+
+		case 'NOTE_SELECTION_TOGGLE':
+
+			{
+				newState = { ...state };
+
+				const noteId = action.id;
+				const newSelectedNoteIds = state.selectedNoteIds.slice();
+				const existingIndex = state.selectedNoteIds.indexOf(noteId);
+
+				if (existingIndex >= 0) {
+					newSelectedNoteIds.splice(existingIndex, 1);
+				} else {
+					newSelectedNoteIds.push(noteId);
+				}
+
+				newState.selectedNoteIds = newSelectedNoteIds;
+				newState.noteSelectionEnabled = !!newSelectedNoteIds.length;
+			}
+			break;
+
+		case 'NOTE_SELECTION_START':
+
+			if (!state.noteSelectionEnabled) {
+				newState = { ...state };
+				newState.noteSelectionEnabled = true;
+				newState.selectedNoteIds = [action.id];
+			}
+			break;
+
+		case 'NOTE_SELECTION_END':
+
+			newState = { ...state };
+			newState.noteSelectionEnabled = false;
+			newState.selectedNoteIds = [];
+			break;
+
+		case 'NOTE_SIDE_MENU_OPTIONS_SET':
+
+			newState = { ...state };
+			newState.noteSideMenuOptions = action.options;
+			break;
+
+		case 'SET_SIDE_MENU_TOUCH_GESTURES_DISABLED':
+			newState = { ...state };
+			newState.disableSideMenuGestures = action.disableSideMenuGestures;
+			break;
+
+		case 'MOBILE_DATA_WARNING_UPDATE':
+
+			newState = { ...state };
+			newState.isOnMobileData = action.isOnMobileData;
+			break;
+
+		case 'KEYBOARD_VISIBLE_CHANGE':
+			newState = { ...state, keyboardVisible: action.visible };
+			break;
+
+		case 'NOTE_EDITOR_VISIBLE_CHANGE':
+			newState = { ...state, noteEditorVisible: action.visible };
+			break;
+		}
+	} catch (error) {
+		error.message = `In reducer: ${error.message} Action: ${JSON.stringify(action)}`;
+		throw error;
+	}
+
+	return reducer(newState, action) as AppState;
+};
+
+export default appReducer;

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
@@ -236,15 +236,20 @@ export class WorkerApi {
 		const folderName = removeReservedWords(basename(path));
 
 		let handle: FileSystemDirectoryHandle;
-		try {
-			handle = await parent.getDirectoryHandle(folderName, { create });
-			this.directoryHandleCache_.set(path, handle);
-		} catch (error) {
-			if (!isNotFoundError(error)) {
-				throw error;
-			}
-
+		if (!parent) {
+			logger.debug('Parent not found for path', path);
 			handle = null;
+		} else {
+			try {
+				handle = await parent.getDirectoryHandle(folderName, { create });
+				this.directoryHandleCache_.set(path, handle);
+			} catch (error) {
+				if (!isNotFoundError(error)) {
+					throw error;
+				}
+
+				handle = null;
+			}
 		}
 
 		return handle;

--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
@@ -236,20 +236,15 @@ export class WorkerApi {
 		const folderName = removeReservedWords(basename(path));
 
 		let handle: FileSystemDirectoryHandle;
-		if (!parent) {
-			logger.debug('Parent not found for path', path);
-			handle = null;
-		} else {
-			try {
-				handle = await parent.getDirectoryHandle(folderName, { create });
-				this.directoryHandleCache_.set(path, handle);
-			} catch (error) {
-				if (!isNotFoundError(error)) {
-					throw error;
-				}
-
-				handle = null;
+		try {
+			handle = await parent.getDirectoryHandle(folderName, { create });
+			this.directoryHandleCache_.set(path, handle);
+		} catch (error) {
+			if (!isNotFoundError(error)) {
+				throw error;
 			}
+
+			handle = null;
 		}
 
 		return handle;

--- a/packages/app-mobile/utils/testing/createMockReduxStore.ts
+++ b/packages/app-mobile/utils/testing/createMockReduxStore.ts
@@ -1,15 +1,16 @@
-import reducer from '@joplin/lib/reducer';
 import { createStore } from 'redux';
 import appDefaultState from '../appDefaultState';
 import Setting from '@joplin/lib/models/Setting';
 import { AppState } from '../types';
+import appReducer from '../appReducer';
 
 const testReducer = (state: AppState|undefined, action: unknown): AppState => {
 	state ??= {
 		...appDefaultState,
 		settings: Setting.toPlainObject(),
 	};
-	return { ...state, ...reducer(state, action) };
+
+	return { ...state, ...appReducer(state, action) };
 };
 
 const createMockReduxStore = () => {


### PR DESCRIPTION
# Summary

This pull request:
- Adds a test for showing a plugin panel, then hiding it.
- Moves the mobile reducer logic to a new `appReducer.ts` file to allow it to be used in tests.
   - This simplifies showing/hiding the plugin panel viewer in tests.

Related: https://github.com/laurent22/joplin/pull/13133
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->