### PR TITLE
Web: Fixes #13153: Fix installing certain plugins

### DIFF
--- a/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
+++ b/packages/app-mobile/utils/fs-driver/fs-driver-rn.web.worker.ts
@@ -236,15 +236,20 @@ export class WorkerApi {
 		const folderName = removeReservedWords(basename(path));
 
 		let handle: FileSystemDirectoryHandle;
-		try {
-			handle = await parent.getDirectoryHandle(folderName, { create });
-			this.directoryHandleCache_.set(path, handle);
-		} catch (error) {
-			if (!isNotFoundError(error)) {
-				throw error;
-			}
-
+		if (!parent) {
+			logger.debug('Parent not found for path', path);
 			handle = null;
+		} else {
+			try {
+				handle = await parent.getDirectoryHandle(folderName, { create });
+				this.directoryHandleCache_.set(path, handle);
+			} catch (error) {
+				if (!isNotFoundError(error)) {
+					throw error;
+				}
+
+				handle = null;
+			}
 		}
 
 		return handle;


### PR DESCRIPTION
# Summary

Fixes an issue in the web file system driver where `pathToDirectoryHandle_` would fail if a parent directory doesn't exist. In general, `pathToDirectoryHandle_` should return `null` when directories don't exist.

Fixes #13153.

# Testing plan

1. Start the web app.
2. Navigate to settings > plugins.
3. Install the "Diff view" plugin.
4. Open a note.
5. Verify that it's possible to use "Diff view" from the Markdown editor to show a diff with another note.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->