### PR TITLE
Mobile: Upgrade react-native-quick-crypto to v0.7.17

### DIFF
--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -64,7 +64,7 @@
     "react-native-paper": "5.13.5",
     "react-native-popup-menu": "0.17.0",
     "react-native-quick-actions": "0.3.13",
-    "react-native-quick-crypto": "0.7.13",
+    "react-native-quick-crypto": "0.7.17",
     "react-native-rsa-native": "2.0.5",
     "react-native-safe-area-context": "5.4.1",
     "react-native-securerandom": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9300,7 +9300,7 @@ __metadata:
     react-native-paper: "npm:5.13.5"
     react-native-popup-menu: "npm:0.17.0"
     react-native-quick-actions: "npm:0.3.13"
-    react-native-quick-crypto: "npm:0.7.13"
+    react-native-quick-crypto: "npm:0.7.17"
     react-native-rsa-native: "npm:2.0.5"
     react-native-safe-area-context: "npm:5.4.1"
     react-native-securerandom: "npm:1.0.1"
@@ -41816,16 +41816,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-quick-crypto@npm:0.7.13":
-  version: 0.7.13
-  resolution: "react-native-quick-crypto@npm:0.7.13"
+"react-native-quick-crypto@npm:0.7.17":
+  version: 0.7.17
+  resolution: "react-native-quick-crypto@npm:0.7.17"
   dependencies:
     "@craftzdog/react-native-buffer": "npm:^6.0.5"
     events: "npm:^3.3.0"
     readable-stream: "npm:^4.5.2"
     string_decoder: "npm:^1.3.0"
     util: "npm:^0.12.5"
-  checksum: 10/065ad3d8d539235a33b29ac7ba4beb9272bd8c9cb39633574ec7c702c9e538886a385de8557272444f982c05c226fb68f1f7066ae65b1192c5d7b4f11f31016d
+  checksum: 10/3a51c4cdee05c2906f12be28f983873598325284e0f06d5248000b49cd57afe53de318ad53fec0e10923b31540a7506ca57764eca7869f0948996165a990d6a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades `react-native-quick-crypto` to v0.7.17, bringing Joplin closer to [support for devices with 16 KB pages](https://github.com/laurent22/joplin/issues/13113).

# Testing plan

I've started Joplin in development mode on both an iOS 18 simulator and an Android 16 emulator and verified that the startup tests pass.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->