### PR TITLE
Mobile: Fixes #13138: Rich Text Editor: Fix image size lost on change

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
@@ -452,6 +452,8 @@ describe('RichTextEditor', () => {
 		'==highlight==ed',
 		'<sup>Super</sup>script',
 		'<sub>Sub</sub>script',
+		'![image](data:image/svg+xml;utf8,test)',
+		'<img src="data:image/svg+xml;utf8,test" width="120">',
 	])('should preserve inline markup on edit (case %#)', async (initialBody) => {
 		initialBody += 'test'; // Ensure that typing will add new content outside the formatting
 		let body = initialBody;

--- a/packages/editor/ProseMirror/schema.ts
+++ b/packages/editor/ProseMirror/schema.ts
@@ -167,6 +167,8 @@ const nodes = addDefaultToplevelAttributes({
 			title: { default: '', validate: 'string' },
 			fromMd: { default: false, validate: 'boolean' },
 			resourceId: { default: null as string|null, validate: 'string|null' },
+			width: { default: '', validate: 'string' },
+			height: { default: '', validate: 'string' },
 		},
 		parseDOM: [
 			{
@@ -174,6 +176,8 @@ const nodes = addDefaultToplevelAttributes({
 				getAttrs: node => ({
 					src: node.getAttribute('src'),
 					alt: node.getAttribute('alt'),
+					width: node.getAttribute('width') ?? '',
+					height: node.getAttribute('height') ?? '',
 					title: node.getAttribute('title'),
 					fromMd: node.hasAttribute('data-from-md'),
 					resourceId: node.getAttribute('data-resource-id') || null,
@@ -181,7 +185,7 @@ const nodes = addDefaultToplevelAttributes({
 			},
 		],
 		toDOM: node => {
-			const { src, alt, title, fromMd, resourceId } = node.attrs;
+			const { src, alt, title, width, height, fromMd, resourceId } = node.attrs;
 			const outputAttrs: Record<string, unknown> = { src, alt, title };
 
 			if (fromMd) {
@@ -189,6 +193,12 @@ const nodes = addDefaultToplevelAttributes({
 			}
 			if (resourceId) {
 				outputAttrs['data-resource-id'] = resourceId;
+			}
+			if (width) {
+				outputAttrs.width = width;
+			}
+			if (height) {
+				outputAttrs.height = height;
 			}
 
 			return [


### PR DESCRIPTION
# Summary

This pull request adds `width` and `height` to the list of preserved image attributes.

Fixes #13138.

# Testing plan

(Web/Chrome 140):
1. Open a note as Markdown.
2. Attach an image.
3. Set the image size using the HTML `width` and `height` attributes.
4. Switch to the Rich Text Editor.
5. Add content to the line containing the image.
6. Switch back to the Markdown editor.
7. Verify that both `width` and `height` are still present.
   - **Note**: Possible related issue — when converted back to image HTML, a `data-resource-id` attribute is also added.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->