### PR TITLE
Mobile: Rich Text Editor: Accessibility: Fix font size setting not respected

### DIFF
--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -127,8 +127,8 @@ const useSource = (props: UseSourceProps) => {
 				${rendererCss}
 				${markdownEditorCss}
 
+				/* Increase the size of the editor to make it easier to focus the editor. */
 				.prosemirror-editor {
-					/* Increase the size of the editor to make it easier to focus the editor. */
 					min-height: 75vh;
 				}
 			`,

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -48,7 +48,9 @@ const useMessenger = (props: UseMessengerProps) => {
 		themeId: props.themeId,
 		highlightedKeywords: [],
 		resources: props.noteResources,
-		themeOverrides: {},
+		themeOverrides: {
+			noteViewerFontSize: `${props.settings.themeData.fontSize}${props.settings.themeData.fontSizeUnits}`,
+		},
 		noteHash: '',
 		initialScroll: 0,
 		pluginAssetContainerSelector: null,
@@ -128,10 +130,6 @@ const useSource = (props: UseSourceProps) => {
 				.prosemirror-editor {
 					/* Increase the size of the editor to make it easier to focus the editor. */
 					min-height: 75vh;
-
-					/* -apple-system-body allows for correct font scaling on iOS devices */
-					font: -apple-system-body;
-					font-family: var(--joplin-font-family, sans-serif);
 				}
 			`,
 			js: `

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -125,9 +125,13 @@ const useSource = (props: UseSourceProps) => {
 				${rendererCss}
 				${markdownEditorCss}
 
-				/* Increase the size of the editor to make it easier to focus the editor. */
 				.prosemirror-editor {
+					/* Increase the size of the editor to make it easier to focus the editor. */
 					min-height: 75vh;
+
+					/* -apple-system-body allows for correct font scaling on iOS devices */
+					font: -apple-system-body;
+					font-family: var(--joplin-font-family, sans-serif);
 				}
 			`,
 			js: `

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -44,12 +44,13 @@ const useMessenger = (props: UseMessengerProps) => {
 	onAttachRef.current = props.onAttachFile;
 
 	const markupRenderingSettings = useRef<RenderOptions>(null);
+	const baseTheme = props.settings.themeData;
 	markupRenderingSettings.current = {
 		themeId: props.themeId,
 		highlightedKeywords: [],
 		resources: props.noteResources,
 		themeOverrides: {
-			noteViewerFontSize: `${props.settings.themeData.fontSize}${props.settings.themeData.fontSizeUnits}`,
+			noteViewerFontSize: `${baseTheme.fontSize}${baseTheme.fontSizeUnits ?? 'px'}`,
 		},
 		noteHash: '',
 		initialScroll: 0,

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -148,7 +148,7 @@ export enum EditorKeymap {
 export interface EditorTheme extends Theme {
 	themeId: number;
 	fontFamily: string;
-	fontSize?: number;
+	fontSize: number;
 	fontSizeUnits?: string;
 	isDesktop?: boolean;
 	monospaceFont?: string;


### PR DESCRIPTION
# Summary

This pull request fixes an issue in which the mobile Rich Text Editor's font size matched neither the viewer nor the editor and was instead fixed at 16px. With this change, the mobile Rich Text Editor uses the "Editor font size" setting to set the base font size.

# Testing plan

On web (Chromium 140):
1. Set the editor font size to a large value (e.g. 50) in settings > appearance.
2. Save changes and re-open the Rich Text Editor.
3. Verify that the Rich Text Editor uses a very large font size.
4. Switch to the Markdown editor.
5. Verify that the Markdown editor uses roughly the same size.
6. Set the editor font size to a small value (e.g. 5) in settings > appearance.
7. Open the Rich Text Editor.
8. Verify that text in the Rich Text Editor is now very small.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->