### PR TITLE
Desktop: Fix error dialogs fail to appear in certain cases

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -217,7 +217,7 @@ function shimInit(options: ShimInitOptions = null) {
 
 	shim.showMessageBox = async (message, options = null) => {
 		if (shim.isElectron()) {
-			return shim.electronBridge().showMessageBox(message, options);
+			return shim.electronBridge().showMessageBox(message, options ?? {});
 		} else {
 			throw new Error('Not implemented');
 		}


### PR DESCRIPTION
# Summary

Prior to this pull request, calling `shim.showMessageBox` with only one argument (using the default second argument) resulted to an error logged to the console with no message shown. The error was caused by an attempt to access the `type` property on a `null` `options` object.

This error occurred when `shim.showMessageBox` passed `null`, its default `options`, to [`bridge.showMessageBox`](https://github.com/laurent22/joplin/blob/91c79b94880d37e74c332c507210721d5aa02561/packages/app-desktop/bridge.ts#L418) as `options`. In this case, the default parameter value for `options` of `{}` was not applied because JavaScript default parameters [only apply if a parameter is missing or if `undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) (rather than `null`).

`shim.showMessageBox` is called with one argument in cases including when deleting a folder fails.

# Testing

1. Update `Folder.moveToFolder` to always `throw`.
2. Move a folder using right-click > "move to notebook".
3. Verify that an error dialog is shown.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->