### PR TITLE
Desktop: Upgrade to Electron 38.1.0

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -160,7 +160,7 @@
     "compare-versions": "6.1.1",
     "countable": "3.0.1",
     "debounce": "1.2.1",
-    "electron": "37.4.0",
+    "electron": "38.1.0",
     "electron-builder": "24.13.3",
     "electron-updater": "6.6.2",
     "electron-window-state": "5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9163,7 +9163,7 @@ __metadata:
     compare-versions: "npm:6.1.1"
     countable: "npm:3.0.1"
     debounce: "npm:1.2.1"
-    electron: "npm:37.4.0"
+    electron: "npm:38.1.0"
     electron-builder: "npm:24.13.3"
     electron-updater: "npm:6.6.2"
     electron-window-state: "npm:5.0.3"
@@ -24185,16 +24185,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:37.4.0":
-  version: 37.4.0
-  resolution: "electron@npm:37.4.0"
+"electron@npm:38.1.0":
+  version: 38.1.0
+  resolution: "electron@npm:38.1.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/762132aa324d9bec4ab04eba9f655f9e99b3324da9afd55429f6ad9900e5df8422dc2834bed3336fc675a8875df158b8f69923f15348f511b4ac144f82540ec2
+  checksum: 10/af70863af514b7a0ab929ef06db2d826ee83a6fcb4628b3599cf5160bcd943215874cd8b6f5f23fb336f22659bbc38c3735199cbf62852841928080ed0228849
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades to Electron v38.1.0.

**Note**: There's a Wayland-related regression in this release (see [comment](https://github.com/laurent22/joplin/pull/13182#issuecomment-3285858879)). This pull request will remain a draft until that regression is resolved (in the 38-x-x branch, probably by [this pull request](https://github.com/electron/electron/pull/48309)).

# Breaking Electron changes

A list of [related breaking changes](https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-380) can be found on the Electron "breaking changes" page for Electron v38. The most likely to affect Joplin are:
- MacOS 11 is no longer supported.
- Linux: May enable Wayland support by default ([`--ozone-plaftform` now defaults to `auto`](https://www.electronjs.org/blog/electron-38-0#removed-electron_ozone_platform_hint-environment-variable)).
    - Also: The `ELECTRON_OZONE_PLATFORM_HINT` environment variable has been removed.
    - Previously, there were 

# Testing

**Automated testing**: Tests in [packages/app-desktop/integration-tests](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/integration-tests) are run in CI (on Windows, MacOS, and Linux), but run with a development version of Joplin.

## Manual testing

**Plan**: The following should be tested on each platform:
- Startup: The application starts in release mode
- Screen reader support: Verify that it's possible for the screen reader to interact with the note editor
- External editing
- Notifications
- Attaching files
- Printing

The following should be tested on at least one platform:
- Secondary windows: Check that changes from one window are reflected in the others.
- Folder editor: Verify that it's possible to add an emoji to a folder.
- Tag editor: It's possible to associate tags with a note using the tag dropdown.
- Drawing tool: It's possible to insert and edit drawings.

---

- [ ] MacOS 15.6:
  - [ ] Create a new task, set a notification for a few minutes in the future. Verify that the notification triggers.
  - [ ] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [ ] Start the external editor for a note. Verify that changing the note title from the external editor updates the note.
  - [ ] Enable Markdown editor spellchecking in settings. Verify that an intentionally misspelled word is marked as misspelled. 
  - [ ] Verify that it's possible to add a tag from the secondary window.
  - [ ] Verify that it's possible to attach a drawing from the secondary window.
  - [ ] Attach a PDF file using the "attach" button. Verify that it renders and can be printed to PDF from the note viewer.
  - [ ] Convert a note to PDF and open it as a preview through file > print.
  - [ ] Create a new subnotebook using the right-click menu.
  - [ ] Enable VoiceOver. Verify that VoiceOver reads the content of the line containing the cursor within the Markdown editor.
- [ ] Linux (Fedora 42/GNOME + AppImage)
  - [x] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [x] Attach a PDF file using the "attach" button. Verify that it renders and can be printed to PDF from the note viewer.
  - [x] Enable the compose key in system settings > keyboard > "Compose key". Verify that it's possible to use the compose key to add a "☺" to a note.
  - [x] Drag and drop a file from file explorer into the Rich Text editor in a new note.
  - [x] Create a new subnotebook using the right-click menu.
  - [x] Open a note in an external editor. Make a change and save. Verify that the note updates based on the external change.
  - [x] Verify that it's possible to add an emoji as a folder icon through right-click > edit.
  - [x] Verify that clicking a resource link opens it in an external application.
  - [ ] Enable the Orca screen reader.
      - [x] Verify that Orca can read the note editor's content.
      - [ ] Verify that moving screen reader focus cancels the previous announcement.
          - So far, this seems to be fine. However, this needs further testing. So far, my testing has been done with a [speech-dispatcher module that sends output to the console](https://github.com/personalizedrefrigerator/speech-dispatcher-text-output) with very little delay between each output. With this method, it's difficult to tell whether old announcements are cancelled by focus changes.
- [ ] Windows 11
  - [ ] Create a new task, set a notification for a few minutes in the future. Verify that the notification triggers.
  - [ ] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [ ] Verify that it's possible to add a tag from the secondary window.
  - [ ] Convert a note to PDF through file > print.
  - [ ] Attach a PDF file using the "attach" button. Verify that it renders and can be printed to PDF from the note viewer.
  - [ ] Enable NVDA. Place the cursor in the Markdown editor. Move the cursor up until it reaches the top of the note. Verify that NVDA reads each line.