### PR TITLE
Desktop: Resolves #12292: Add hover + expanded arrow behavior for Notebook/Tags header

### DIFF
--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { StyledHeader, StyledHeaderIcon, StyledHeaderLabel } from '../styles';
 import { HeaderId, HeaderListItem } from '../types';
 import bridge from '../../../services/bridge';
@@ -25,6 +25,8 @@ const HeaderItem: React.FC<Props> = props => {
 	const item = props.item;
 	const onItemClick = item.onClick;
 	const itemId = item.id;
+	const [isHovered, setIsHovered] = useState(false);
+	const expanded = item.expanded;
 
 	const onClick: React.MouseEventHandler<HTMLElement> = useCallback(event => {
 		if (onItemClick) {
@@ -58,8 +60,12 @@ const HeaderItem: React.FC<Props> = props => {
 			{...item.extraProps}
 			onDrop={props.onDrop}
 		>
-			<StyledHeader onClick={onClick}>
-				<StyledHeaderIcon aria-hidden='true' role='img' className={item.iconName}/>
+			<StyledHeader
+				onClick={onClick}
+				onMouseEnter={()=>setIsHovered(true)}
+				onMouseLeave={()=>setIsHovered(false)}
+			>
+				<StyledHeaderIcon aria-hidden='true' role='img' className={isHovered ? `fas ${expanded ? 'fa-caret-down' : 'fa-caret-right'}` : item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>
 		</ListItemWrapper>

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -28,6 +28,11 @@ export const StyledHeader = styled.div`
 	user-select: none;
 	text-transform: uppercase;
 	//cursor: pointer;
+	cursor: default;
+	transition: background 0.2s;
+	&:hover{
+	background: ${(props: StyleProps) => props.theme.backgroundColorHover2};
+	}
 `;
 
 export const StyledHeaderIcon = styled.i`


### PR DESCRIPTION
### What does this PR do?

- Adds hover behavior for Notebook and Tags headers
- Changes header icon to arrow when hovered:
  - Expanded → down arrow
  - Collapsed → right arrow
- Changes header background color on hover to match app theme
- Matches the style and behavior of sidebar folders

### How to test

1. Open the sidebar in the Desktop app.
2. Hover over "Notebook" and "Tags" headers.
3. Observe the following:
   - The header icon changes to an arrow.
     - Expanded → down arrow
     - Collapsed → right arrow
   - The header background color changes to match the app theme.
4. Click on the headers to expand/collapse and verify the arrow direction.
5. Make sure no other sidebar functionality is affected.

### Notes

- No other functionality is changed
- Styling uses existing theme colors for hover

### Related issues

- Related to #12292
