### PR TITLE
Docs: REST API: Add descriptions for "is_shared" and "share_id"

### DIFF
--- a/packages/lib/JoplinDatabase.ts
+++ b/packages/lib/JoplinDatabase.ts
@@ -264,6 +264,7 @@ export default class JoplinDatabase extends Database {
 					todo_due: sp('When the todo is due. An alarm will be triggered on that date.'),
 					todo_completed: sp('Tells whether todo is completed or not. This is a timestamp in milliseconds.'),
 					source_url: sp('The full URL where the note comes from.'),
+					is_shared: sp('Whether the note is published.'),
 				},
 				folders: {},
 				resources: {},
@@ -288,6 +289,7 @@ export default class JoplinDatabase extends Database {
 				this.tableDescriptions_[n].updated_time = sp('When the %s was last updated.', singular);
 				this.tableDescriptions_[n].user_created_time = sp('When the %s was created. It may differ from created_time as it can be manually set by the user.', singular);
 				this.tableDescriptions_[n].user_updated_time = sp('When the %s was last updated. It may differ from updated_time as it can be manually set by the user.', singular);
+				this.tableDescriptions_[n].share_id = sp('The ID of the Joplin Server/Cloud share containing the %s. Empty if not shared.', singular);
 			}
 		}
 

--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -197,8 +197,8 @@ command | 16
 | encryption_cipher_text | text  |       |
 | encryption_applied | int   |       |
 | markup_language | int   |       |
-| is_shared | int   |       |
-| share_id | text  |       |
+| is_shared | int   | Whether the note is published. |
+| share_id | text  | The ID of the Joplin Server/Cloud share containing the note. Empty if not shared. |
 | conflict_original_id | text  |       |
 | master_key_id | text  |       |
 | user_data | text  |       |
@@ -288,7 +288,7 @@ This is actually a notebook. Internally notebooks are called "folders".
 | encryption_applied | int   |       |
 | parent_id | text  |       |
 | is_shared | int   |       |
-| share_id | text  |       |
+| share_id | text  | The ID of the Joplin Server/Cloud share containing the folder. Empty if not shared. |
 | master_key_id | text  |       |
 | icon  | text  |       |
 | user_data | text  |       |
@@ -342,7 +342,7 @@ By default, the folder will be moved **to the trash**. To permanently delete it,
 | encryption_blob_encrypted | int   |       |
 | size  | int   |       |
 | is_shared | int   |       |
-| share_id | text  |       |
+| share_id | text  | The ID of the Joplin Server/Cloud share containing the resource. Empty if not shared. |
 | master_key_id | text  |       |
 | user_data | text  |       |
 | blob_updated_time | int   |       |


### PR DESCRIPTION
# Summary

This pull request documents the "is_shared" and "share_id" properties in `rest_api.md`. For now, `is_shared` is only updated for notes — I don't think `is_shared` currently has meaning for folders.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->