### PR TITLE
Chore: Transcribe: Replace all occurrence of relative path on FileStorage with full path

### DIFF
--- a/packages/transcribe/src/services/FileStorage.test.ts
+++ b/packages/transcribe/src/services/FileStorage.test.ts
@@ -4,6 +4,8 @@ import FileStorage from './FileStorage';
 import initiateLogger from './initiateLogger';
 import Logger from '@joplin/utils/Logger';
 
+const imagesFolderPath = join(process.cwd(), 'images');
+
 describe('FileStorage', () => {
 
 	beforeAll(() => {
@@ -12,12 +14,14 @@ describe('FileStorage', () => {
 	});
 
 	it('should move file to storage folder', async () => {
-		await copyFile('./images/htr_sample.png', './test_file.png');
+		const originalFilePath = join(imagesFolderPath, 'htr_sample.png');
+		const testFilePath = join(imagesFolderPath, 'test_file.png');
+		await copyFile(originalFilePath, testFilePath);
 
 		const fs = new FileStorage();
-		const name = await fs.store('./test_file.png');
+		const name = await fs.store(testFilePath);
 
-		const destination = join('images', name);
+		const destination = join(imagesFolderPath, name);
 		const destinationStillExists = await exists(destination);
 		expect(destinationStillExists).toBe(true);
 
@@ -26,18 +30,21 @@ describe('FileStorage', () => {
 
 
 	it('should remove the original file', async () => {
-		await copyFile('./images/htr_sample.png', './test_file.png');
+		const originalFilePath = join(imagesFolderPath, 'htr_sample.png');
+		const testFilePath = join(imagesFolderPath, 'test_file.png');
+		await copyFile(originalFilePath, testFilePath);
 
 		const fs = new FileStorage();
-		const name = await fs.store('./test_file.png');
+		const name = await fs.store(testFilePath);
 
-		const originalStillExists = await exists('./test_file.png');
+		const originalStillExists = await exists(testFilePath);
 		expect(originalStillExists).toBe(false);
 
-		await remove(join('images', name));
+		await remove(join(imagesFolderPath, name));
 	});
 
 	it('should remove files that are older than the given date', async () => {
+		const originalFilePath = join(imagesFolderPath, 'htr_sample.png');
 		const mockedFilenames = [
 			`${new Date('2025-03-01 17:44').getTime()}_should_delete`,
 			`${new Date('2025-03-02 17:44').getTime()}_should_delete`,
@@ -45,17 +52,17 @@ describe('FileStorage', () => {
 		];
 		const mockedFiles = mockedFilenames.map(name => join('images', name));
 		for (const file of mockedFiles) {
-			await copyFile('./images/htr_sample.png', file);
+			await copyFile(originalFilePath, file);
 		}
 
 		const fs = new FileStorage();
 		await fs.removeOldFiles(new Date('2025-03-03 12:00'));
-		const files = await readdir('images');
+		const files = await readdir(imagesFolderPath);
 		expect(files.length).toBe(2);
 		expect(files.includes(mockedFilenames[2])).toBe(true);
 
 		for (const file of mockedFiles) {
-			await remove(file);
+			await remove(join(imagesFolderPath, file));
 		}
 	});
 });

--- a/packages/transcribe/src/services/FileStorage.ts
+++ b/packages/transcribe/src/services/FileStorage.ts
@@ -6,6 +6,8 @@ import Logger from '@joplin/utils/Logger';
 
 const logger = Logger.create('FileStorage');
 
+const imagesFolderPath = join(process.cwd(), 'images');
+
 export default class FileStorage implements ContentStorage {
 
 	private isMaintenanceRunning = false;
@@ -14,13 +16,13 @@ export default class FileStorage implements ContentStorage {
 		const time = new Date().getTime();
 		const random = randomBytes(16).toString('hex');
 		const randomName = `${time}_${random}`;
-		await move(filepath, join('images', randomName));
+		await move(filepath, join(imagesFolderPath, randomName));
 		return randomName;
 	}
 
 	public async remove(filename: string) {
 		logger.info(`Deleting: ${filename}`);
-		await remove(join('images', filename));
+		await remove(join(imagesFolderPath, filename));
 	}
 
 	public initMaintenance(retentionDuration: number, maintenanceInterval: number) {
@@ -37,7 +39,7 @@ export default class FileStorage implements ContentStorage {
 	}
 
 	public async removeOldFiles(olderThan: Date) {
-		const files = await readdir('images');
+		const files = await readdir(imagesFolderPath);
 		const filesToBeDeleted = files
 			.map(f => {
 				const datetimePart = parseInt(f.split('_')[0], 10);


### PR DESCRIPTION
# Summary

We caught a random failing test on CI related to FileStorage:

>[@joplin/transcribe]: FAIL dist/src/services/FileStorage.test.js
[@joplin/transcribe]:   ● FileStorage › should remove the original file
[@joplin/transcribe]: 
[@joplin/transcribe]:     ENOENT: no such file or directory, rename './test_file.png' -> 'images/1757611989041_30e8a9518c9803dce286cf8e0a5962dc'

The first suspect is the usage of relative path, which I'm replacing here. I change the test and the actual FileStorage implementation.

# Testing

I made sure that the automated tests are still working, that is possible to run the application on dev and that still is working on docker too.