### PR TITLE
Desktop: Fixes #12239: Prevent the default cut action handler to avoid double deletion

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1393,10 +1393,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		async function onCut(event: any) {
+			event.preventDefault();
 			const selectedContent = editor.selection.getContent();
 			copyHtmlToClipboard(selectedContent);
 			editor.insertContent('');
-			event.preventDefault();
 			onChangeHandler();
 		}
 
@@ -1444,7 +1444,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		// `compositionend` means that a user has finished entering a Chinese
 		// (or other languages that require IME) character.
 		editor.on(TinyMceEditorEvents.CompositionEnd, onChangeHandler);
-		editor.on(TinyMceEditorEvents.Cut, onCut);
+		editor.on(TinyMceEditorEvents.Cut, onCut, true);
 		editor.on(TinyMceEditorEvents.JoplinChange, onChangeHandler);
 		editor.on(TinyMceEditorEvents.Undo, onChangeHandler);
 		editor.on(TinyMceEditorEvents.Redo, onChangeHandler);


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

## What does this PR do:
I noticed that the issue seems to come from both TinyMCE’s built-in cut handling and Joplin’s custom handling running at the same time. This overlap causes the unexpected behavior described here, and it’s also related to #12554.

To address this, I disabled TinyMCE’s default cut behavior so that only Joplin’s custom logic is applied. After updating the code, I tested the scenarios from this issue and from #12554. Everything now works as expected: only the selected content is cut and copied, the clipboard content is correct, and the undo stack matches the deletion.

## Test gif:
### Before:
![Before](https://github.com/user-attachments/assets/c95c258b-ab49-4599-bc94-72a6fa75bf78)

### After:
![After](https://github.com/user-attachments/assets/ce5e3c4d-f39f-4350-96de-f02058d567fb)

## Related issue:
Related to #12239
