### PR TITLE
Chore: Mobile: Add additional logging to help debug toolbar issue

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -33,6 +33,9 @@ import { toFileExtension } from '@joplin/lib/mime-utils';
 import { MarkupLanguage } from '@joplin/renderer';
 import WarningBanner from './WarningBanner';
 import useIsScreenReaderEnabled from '../../utils/hooks/useIsScreenReaderEnabled';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('NoteEditor');
 
 type ChangeEventHandler = (event: ChangeEvent)=> void;
 type UndoRedoDepthChangeHandler = (event: UndoRedoDepthChangeEvent)=> void;
@@ -111,6 +114,7 @@ const useEditorControl = (
 			},
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			execCommand(command, ...args: any[]) {
+				logger.debug('execCommand', command);
 				return editorRef.current.execCommand(command, ...args);
 			},
 

--- a/packages/editor/CodeMirror/CodeMirrorControl.ts
+++ b/packages/editor/CodeMirror/CodeMirrorControl.ts
@@ -14,6 +14,9 @@ import getSearchState from './utils/getSearchState';
 import { noteIdFacet, setNoteIdEffect } from './extensions/selectedNoteIdExtension';
 import jumpToHash from './editorCommands/jumpToHash';
 import { resetImageResourceEffect } from './extensions/rendering/renderBlockImages';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('CodeMirrorControl');
 
 interface Callbacks {
 	onUndoRedo(): void;
@@ -59,6 +62,8 @@ export default class CodeMirrorControl extends CodeMirror5Emulation implements E
 			commandOutput = super.execCommand(name, ...args);
 		} else if (super.supportsJoplinCommand(name)) {
 			commandOutput = super.execJoplinCommand(name);
+		} else {
+			logger.warn('Unknown command', name);
 		}
 
 		if (name === EditorCommandType.Undo || name === EditorCommandType.Redo) {


### PR DESCRIPTION
# Summary

This pull request adds additional logging that may help debug #13193. In particular, if #13193 occurs in dev mode, it will be possible to check the log to verify that:
- The "bold"/"italic"/etc commands are being executed with `execCommand`.
- If the commands are being passed to the editor, the editor recognizes the commands (does not log `Unknown command`).
   - Since this is logged from the WebView, it is currently only included in the devtools console for the WebView (currently not included in Joplin's logfile).

Some manual testing has been done using the web app:
1. Open the Markdown editor.
2. Open the development tools and inspect the Markdown editor's `iframe`.
3. Run `cm.execCommand('testtest')`.
4. Verify that `10:44:43: CodeMirrorControl: Unknown command testtest` is logged to the console.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->