### PR TITLE
Chore: Web: Skip secondary single-instance check in dev mode

### DIFF
--- a/packages/app-mobile/utils/lockToSingleInstance.ts
+++ b/packages/app-mobile/utils/lockToSingleInstance.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 
 const lockToSingleInstance = async () => {
 	if (Platform.OS !== 'web') return;
+	if (__DEV__) return;
 
 	const channel = new BroadcastChannel('single-instance-lock');
 	channel.postMessage('app-opened');


### PR DESCRIPTION
# Summary

This pull request skips the secondary single instance check when the web app is running in dev mode. When auto-reloaded by Webpack, this single instance check would often fail. As a result, an `alert` dialog was shown, pausing script execution. On some platforms (e.g. MacOS with the Chrome browser), this caused focus to move to the web app browser tab (and away from the IDE). This made developing with the web app more difficult.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->