### PR TITLE
Android: Fixes #13193: Fix Markdown toolbar buttons sometimes don't work

### DIFF
--- a/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
@@ -57,7 +57,7 @@ const useWebViewSetup = ({
 	` : '';
 
 	const injectedJavaScript = useMemo(() => `
-		if (typeof markdownEditorBundle === 'undefined') {
+		if (typeof window.markdownEditorBundle === 'undefined') {
 			${shim.injectedJs('markdownEditorBundle')};
 			window.markdownEditorBundle = markdownEditorBundle;
 			markdownEditorBundle.setUpLogger();


### PR DESCRIPTION
# Summary

Fixes #13193 by improving a check. Previously, the Markdown editor setup script would run multiple times on Android devices (see the [related react-native-webview bug](https://github.com/react-native-webview/react-native-webview/issues/3656)), which sometimes broke parts of main-process-to-editor communication.

> [!NOTE]
>
> Since this is a regression, this pull request targets `release-3.4`. The regression was most likely caused by https://github.com/laurent22/joplin/commit/af5c0135dc4af94fb3ece2dcd82a1d05fc65308a.

# Details

If the second time the setup script ran was **after** the first editor was initialized, then an [editor reference](https://github.com/laurent22/joplin/blob/9fc76f4e4ce1e0525ee1950a17256bf9e5a68b08/packages/app-mobile/contentScripts/markdownEditorBundle/contentScript.ts#L15) was reset to `null`. This reference was used to [call `supportsCommand`](https://github.com/laurent22/joplin/blob/9fc76f4e4ce1e0525ee1950a17256bf9e5a68b08/packages/app-mobile/components/NoteEditor/hooks/useEditorCommandHandler.ts#L25) in the editor command handler. As a result, `supportsCommand` would fail (throw an `Error`). Interestingly, this error not included in Joplin's logfile (or logged to the console). I suspect that there is an issue with Joplin's [unhandled promise rejection logic](https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event), or that logic for logging unhandled promise rejections is missing on mobile.

# Testing plan

Android 16 emulator:
1. Start Joplin on a device or emulator that could previously consistently reproduce the issue.
2. Create a new note with title "a".
3. In the Markdown editor, type "bcd".
4. Select "bcd".
5. Click "bold".
6. Verify that "bcd" is now surrounded by `**`s.
7. Repeat steps 2-6 three more times.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->