### PR TITLE
Chore: Remove bitnami repository

### DIFF
--- a/docker-compose.db-dev.yml
+++ b/docker-compose.db-dev.yml
@@ -21,7 +21,7 @@ version: '2'
 services:
 
     postgresql-master:
-        image: 'bitnami/postgresql:17.4.0'
+        image: 'bitnamilegacy/postgresql:17.4.0'
         ports:
             - '5432:5432'
         environment:
@@ -38,7 +38,7 @@ services:
             - POSTGRESQL_EXTRA_FLAGS=-c work_mem=100000 -c log_statement=all
 
     postgresql-slave:
-        image: 'bitnami/postgresql:17.4.0'
+        image: 'bitnamilegacy/postgresql:17.4.0'
         ports:
             - '5433:5432'
         depends_on:

--- a/packages/transcribe/Dockerfile.htr-cli
+++ b/packages/transcribe/Dockerfile.htr-cli
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:bookworm
+FROM bitnamilegacy/minideb:bookworm
 
 RUN apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
Bitnami moved to a paid model but we should be able to simply use the official postgres images.

Ref: https://github.com/bitnami/containers/issues/83267

Looks like it's not a drop-in replacement so more tests will be needed.

Edit: Cannot just switch to standard Postgres because it doesn't support replication out of the box, that will need to be manually implemented. Bitnami vendor locked us properly with this, so for now we switch to bitnamilegacy which should buy us a year or two.