### PR TITLE
Web: Fix multi-page document creation action fails for non-JPEG images

### DIFF
--- a/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
+++ b/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
@@ -116,8 +116,7 @@ const shimInitShared = () => {
 		const resourceId = defaultProps.id ? defaultProps.id : uuid.create();
 
 		const ext = fileExtension(filePath);
-		let mimeType = mimeUtils.fromFileExtension(ext);
-		if (!mimeType) mimeType = 'image/jpeg';
+		const mimeType = defaultProps.mime ?? mimeUtils.fromFileExtension(ext) ?? 'image/jpeg';
 
 		let resource = Resource.new();
 		resource.id = resourceId;


### PR DESCRIPTION
# Summary

This pull request fixes an issue where all images created by the document scanner workflow on web were marked as JPEG images. This resulted in notes that failed to render if the user selected images that are not JPEGs.

# Testing plan

Web:
1. Open the document scanner using the "scan notebook" action in the "new note" menu.
2. Select a PNG image.
3. Click "next", then "create note".
4. Verify that the just-created note includes the PNG image and that the PNG image renders successfully.
5. Repeat for a JPEG image.

Android 16 emulator:
1. Open the document scanner using the "scan notebook" action in the "new note" menu.
2. Take two photos.
3. Click "next", then "create note".
4. Verify that the just-created note includes two images.
