### PR TITLE
Android: Improve location permission request

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -231,11 +231,11 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 			// Not implemented yet
 			return true;
 		}
-		return await checkPermissions(PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE, {
+		return await checkPermissions(PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE, { rationale: {
 			title: _('Information'),
 			message: _('In order to use file system synchronisation your permission to write to external storage is required.'),
 			buttonPositive: _('OK'),
-		});
+		} });
 	}
 
 	public UNSAFE_componentWillMount() {

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -547,9 +547,16 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				message: _('In order to associate a geo-location with the note, the app needs your permission to access your location.\n\nYou may turn off this option at any time in the Configuration screen.'),
 				title: _('Permission needed'),
 			},
-			confirmMessage: {
-				title: _('Save geolocation?'),
-				message: _('Joplin supports saving the location at which notes were saved or created. Do you want to enable it? This can be changed at any time in settings.'),
+			onRequestConfirmation: async () => {
+				const yesIndex = 0;
+				const result = await shim.showMessageBox(
+					_('Joplin supports saving the location at which notes were saved or created. Do you want to enable it? This can be changed at any time in settings.'),
+					{
+						buttons: [_('Yes'), _('No')],
+						title: _('Save geolocation?'),
+					},
+				);
+				return result === yesIndex;
 			},
 		});
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -550,7 +550,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			onRequestConfirmation: async () => {
 				const yesIndex = 0;
 				const result = await shim.showMessageBox(
-					_('Joplin supports saving the location at which notes were saved or created. Do you want to enable it? This can be changed at any time in settings.'),
+					_('Joplin supports saving the location at which notes are saved or created. Do you want to enable it? This can be changed at any time in settings.'),
 					{
 						buttons: [_('Yes'), _('No')],
 						title: _('Save geolocation?'),

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -543,10 +543,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		if (Platform.OS === 'web') return;
 
 		const response = await checkPermissions(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION, {
-			rationale: {
-				message: _('In order to associate a geo-location with the note, the app needs your permission to access your location.\n\nYou may turn off this option at any time in the Configuration screen.'),
-				title: _('Permission needed'),
-			},
 			onRequestConfirmation: async () => {
 				const yesIndex = 0;
 				const result = await shim.showMessageBox(

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -543,8 +543,14 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		if (Platform.OS === 'web') return;
 
 		const response = await checkPermissions(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION, {
-			message: _('In order to associate a geo-location with the note, the app needs your permission to access your location.\n\nYou may turn off this option at any time in the Configuration screen.'),
-			title: _('Permission needed'),
+			rationale: {
+				message: _('In order to associate a geo-location with the note, the app needs your permission to access your location.\n\nYou may turn off this option at any time in the Configuration screen.'),
+				title: _('Permission needed'),
+			},
+			confirmMessage: {
+				title: _('Save geolocation?'),
+				message: _('Joplin supports saving the location at which notes were saved or created. Do you want to enable it? This can be changed at any time in settings.'),
+			},
 		});
 
 		// If the user simply pressed "Deny", we don't automatically switch it off because they might accept

--- a/packages/app-mobile/utils/checkPermissions.ts
+++ b/packages/app-mobile/utils/checkPermissions.ts
@@ -1,10 +1,11 @@
 import { _ } from '@joplin/lib/locale';
+import shim from '@joplin/lib/shim';
 import Logger from '@joplin/utils/Logger';
 
 import { Platform, PermissionsAndroid, Permission } from 'react-native';
 const logger = Logger.create('checkPermissions');
 
-type rationale = {
+type Rationale = {
 	title: string;
 	message: string;
 	buttonPositive?: string;
@@ -12,7 +13,17 @@ type rationale = {
 	buttonNeutral?: string;
 };
 
-export default async (permissions: Permission, rationale?: rationale) => {
+interface ConfirmMessage {
+	title: string;
+	message: string;
+}
+
+interface Options {
+	rationale?: Rationale;
+	confirmMessage?: ConfirmMessage;
+}
+
+export default async (permissions: Permission, { rationale, confirmMessage }: Options = {}) => {
 	// On iOS, permissions are prompted for by the system, so here we assume it's granted.
 	if (Platform.OS !== 'android') return PermissionsAndroid.RESULTS.GRANTED;
 
@@ -21,6 +32,10 @@ export default async (permissions: Permission, rationale?: rationale) => {
 	if (granted) {
 		return PermissionsAndroid.RESULTS.GRANTED;
 	} else {
+		if (confirmMessage && !await shim.showConfirmationDialog(confirmMessage.message, { title: confirmMessage.title })) {
+			return PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
+		}
+
 		const result = await PermissionsAndroid.request(permissions, {
 			buttonPositive: _('Ok'),
 			...rationale,

--- a/packages/app-mobile/utils/checkPermissions.ts
+++ b/packages/app-mobile/utils/checkPermissions.ts
@@ -1,5 +1,4 @@
 import { _ } from '@joplin/lib/locale';
-import shim from '@joplin/lib/shim';
 import Logger from '@joplin/utils/Logger';
 
 import { Platform, PermissionsAndroid, Permission } from 'react-native';
@@ -13,17 +12,12 @@ type Rationale = {
 	buttonNeutral?: string;
 };
 
-interface ConfirmMessage {
-	title: string;
-	message: string;
-}
-
 interface Options {
 	rationale?: Rationale;
-	confirmMessage?: ConfirmMessage;
+	onRequestConfirmation?: ()=> Promise<boolean>;
 }
 
-export default async (permissions: Permission, { rationale, confirmMessage }: Options = {}) => {
+export default async (permissions: Permission, { rationale, onRequestConfirmation }: Options = {}) => {
 	// On iOS, permissions are prompted for by the system, so here we assume it's granted.
 	if (Platform.OS !== 'android') return PermissionsAndroid.RESULTS.GRANTED;
 
@@ -32,7 +26,7 @@ export default async (permissions: Permission, { rationale, confirmMessage }: Op
 	if (granted) {
 		return PermissionsAndroid.RESULTS.GRANTED;
 	} else {
-		if (confirmMessage && !await shim.showConfirmationDialog(confirmMessage.message, { title: confirmMessage.title })) {
+		if (onRequestConfirmation && !await onRequestConfirmation()) {
 			return PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
 		}
 

--- a/packages/app-mobile/utils/checkPermissions.ts
+++ b/packages/app-mobile/utils/checkPermissions.ts
@@ -1,4 +1,3 @@
-import { _ } from '@joplin/lib/locale';
 import Logger from '@joplin/utils/Logger';
 
 import { Platform, PermissionsAndroid, Permission } from 'react-native';
@@ -7,7 +6,7 @@ const logger = Logger.create('checkPermissions');
 type Rationale = {
 	title: string;
 	message: string;
-	buttonPositive?: string;
+	buttonPositive: string;
 	buttonNegative?: string;
 	buttonNeutral?: string;
 };
@@ -30,10 +29,7 @@ export default async (permissions: Permission, { rationale, onRequestConfirmatio
 			return PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
 		}
 
-		const result = await PermissionsAndroid.request(permissions, {
-			buttonPositive: _('Ok'),
-			...rationale,
-		});
+		const result = await PermissionsAndroid.request(permissions, rationale);
 		logger.info('Requested permission:', result);
 		return result;
 	}

--- a/packages/app-mobile/utils/checkPermissions.ts
+++ b/packages/app-mobile/utils/checkPermissions.ts
@@ -1,6 +1,7 @@
+import { _ } from '@joplin/lib/locale';
 import Logger from '@joplin/utils/Logger';
 
-const { Platform, PermissionsAndroid } = require('react-native');
+import { Platform, PermissionsAndroid, Permission } from 'react-native';
 const logger = Logger.create('checkPermissions');
 
 type rationale = {
@@ -11,15 +12,20 @@ type rationale = {
 	buttonNeutral?: string;
 };
 
-export default async (permissions: string, rationale?: rationale) => {
+export default async (permissions: Permission, rationale?: rationale) => {
 	// On iOS, permissions are prompted for by the system, so here we assume it's granted.
 	if (Platform.OS !== 'android') return PermissionsAndroid.RESULTS.GRANTED;
 
-	let result = await PermissionsAndroid.check(permissions);
-	logger.info('Checked permission:', result);
-	if (result !== PermissionsAndroid.RESULTS.GRANTED) {
-		result = await PermissionsAndroid.request(permissions, rationale);
+	const granted = await PermissionsAndroid.check(permissions);
+	logger.info('Checked permission:', granted);
+	if (granted) {
+		return PermissionsAndroid.RESULTS.GRANTED;
+	} else {
+		const result = await PermissionsAndroid.request(permissions, {
+			buttonPositive: _('Ok'),
+			...rationale,
+		});
 		logger.info('Requested permission:', result);
+		return result;
 	}
-	return result;
 };

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -447,8 +447,8 @@ const shim = {
 		await shim.showMessageBox(message, { type: MessageBoxType.Error });
 	},
 
-	showConfirmationDialog: async (message: string, options: ShowMessageBoxOptions = {}): Promise<boolean> => {
-		return await shim.showMessageBox(message, { type: MessageBoxType.Confirm, ...options }) === 0;
+	showConfirmationDialog: async (message: string): Promise<boolean> => {
+		return await shim.showMessageBox(message, { type: MessageBoxType.Confirm }) === 0;
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -447,8 +447,8 @@ const shim = {
 		await shim.showMessageBox(message, { type: MessageBoxType.Error });
 	},
 
-	showConfirmationDialog: async (message: string): Promise<boolean> => {
-		return await shim.showMessageBox(message, { type: MessageBoxType.Confirm }) === 0;
+	showConfirmationDialog: async (message: string, options: ShowMessageBoxOptions = {}): Promise<boolean> => {
+		return await shim.showMessageBox(message, { type: MessageBoxType.Confirm, ...options }) === 0;
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied


### PR DESCRIPTION
# Summary

This pull request improves the permissions request workflow on Android.

See: https://discourse.joplinapp.org/t/location-permission-request-without-explanation-or-prompt/47333.

# Possible alternatives

Alternatives to the approach taken by this pull request include:
- Disabling the location option by default. For now it will remain enabled (ref:@laurent22).
- Adding a setup wizard with a "geolocation" page that explains the setting and allows the user to opt in.


# Tasks

- [x] Change OK/Cancel to "Yes"/"No".
- [x] Reword the "Save geolocation" dialog's description.
- [x] The `rationale` provided to `PermissionsAndroid` does not seem to be displayed. Is it safe to remove it entirely?
    - Note: [Relevant react-native source code](https://github.com/facebook/react-native/blob/5b8827939d7c80e05eedd76f36111e24f18fda4d/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js#L248).
- [ ] This change only applies to Android. A similar change may be necessary on iOS. (On web, geolocation support is disabled by default).
- ~~Would it be better for this to target `release-3.4`?~~ [See comment.](https://github.com/laurent22/joplin/pull/13248#issuecomment-3312894466)

# Screenshot

<img width="825" height="853" alt="Dialog: Save geolocation? Joplin supports saving the location at which notes are saved or created. Do you want to enable it? This can be changed at any time in settings." src="https://github.com/user-attachments/assets/6cefadf6-0071-45b3-90be-63f7a76ca5f5" />


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->