### PR TITLE
Chore: Web: Fix build

### DIFF
--- a/packages/app-mobile/web/webpack.config.ts
+++ b/packages/app-mobile/web/webpack.config.ts
@@ -45,6 +45,7 @@ const buildSharedConfig = (hotReload: boolean): webpack.Configuration => {
 	};
 
 	const emptyLibraryMock = path.resolve(__dirname, 'mocks/empty.js');
+	const throwOnLoadLibraryMock = path.resolve(__dirname, 'mocks/throwOnLoad.js');
 
 	return {
 		output: {
@@ -78,6 +79,8 @@ const buildSharedConfig = (hotReload: boolean): webpack.Configuration => {
 				'@react-native-documents/picker': emptyLibraryMock,
 				'react-native-exit-app': emptyLibraryMock,
 				'expo-camera': emptyLibraryMock,
+				// Remove this after upgrading react-native-vector-icons.
+				'@react-native-vector-icons/material-design-icons': throwOnLoadLibraryMock,
 
 				// Workaround for applying serviceworker types to a single file.
 				// See https://joshuatz.com/posts/2021/strongly-typed-service-workers/.


### PR DESCRIPTION
# Summary

Resolves a build issue related to https://github.com/laurent22/joplin/commit/cac93e9f9cdd86946fb2fe92bfcfd954570b342b. See [the related upstream code](https://github.com/callstack/react-native-paper/blob/ff0df5454eb13d6e8e2d8f1c87c0bca8bb3635f0/src/components/MaterialCommunityIcon.tsx#L42). 

# Notes

Despite the problematic upstream code including `require`s for both `@react-native-vector-icons/material-design-icons` and `@expo/vector-icons/MaterialCommunityIcons`, it only seems necessary to add override for `@react-native-vector-icons/material-design-icons`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->