### PR TITLE
Chore: Mobile: Fix expo-related warnings in tests

### DIFF
--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -105,6 +105,13 @@ jest.mock('react-native-zip-archive', () => {
 
 jest.mock('@react-native-documents/picker', () => ({ default: { } }));
 
+
+jest.doMock('@expo/vector-icons/MaterialCommunityIcons', () => {
+	return {
+		default: {},
+	};
+});
+
 // Used by the renderer
 jest.doMock('react-native-vector-icons/Ionicons', () => {
 	return {

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -105,11 +105,11 @@ jest.mock('react-native-zip-archive', () => {
 
 jest.mock('@react-native-documents/picker', () => ({ default: { } }));
 
-
+// This is one of the icon libraries that react-native-paper attempts to use.
+// Throwing an Error causes react-native-paper to select a different icon library
+// that better supports our automated testing environment.
 jest.doMock('@expo/vector-icons/MaterialCommunityIcons', () => {
-	return {
-		default: {},
-	};
+	throw new Error('Not supported in testing environments.');
 });
 
 // Used by the renderer


### PR DESCRIPTION
# Summary

This pull request fixes an issue in which two warnings were logged at the start of many mobile app tests:
```
The "EXNativeModulesProxy" native module is not exported through NativeModules; verify that expo-modules-core's native code is linked properly
The global process.env.EXPO_OS is not defined. This should be inlined by babel-preset-expo during transformation.
```

This seems to be related to the `react-native-paper` upgrade in https://github.com/laurent22/joplin/commit/cac93e9f9cdd86946fb2fe92bfcfd954570b342b.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->