### PR TITLE
Chore: Sync fuzzer: Fix failures related to publishing/unpublishing notes

### DIFF
--- a/packages/tools/fuzzer/Client.ts
+++ b/packages/tools/fuzzer/Client.ts
@@ -583,6 +583,8 @@ class Client implements ActionableClient {
 	public async publishNote(id: ItemId) {
 		await this.tracker_.publishNote(id);
 
+		await this.sync();
+
 		logger.info('Publish note', id, 'in', this.label);
 		const publishOutput = await this.execCliCommand_('publish', '-f', id);
 		const publishUrl = publishOutput.stdout.match(/http[s]?:\/\/\S+/);
@@ -599,7 +601,7 @@ class Client implements ActionableClient {
 	}
 
 	public async unpublishNote(id: ItemId) {
-		await this.tracker_.publishNote(id);
+		await this.tracker_.unpublishNote(id);
 
 		logger.info('Unpublish note', id, 'in', this.label);
 		await this.execCliCommand_('unpublish', id);


### PR DESCRIPTION
# Summary

This pull request fixes two sync fuzzer failures observed while running the fuzzer locally:
- `unpublishNote` always failed with an assertion failure.
- `publish` failed to publish just-created, unsynced notes.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->