### PR TITLE
Desktop: Fixes #12355: Auto-scroll to selected note from 'Go to Anything' search results

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -158,7 +158,7 @@ const NoteList = (props: Props) => {
 					// Only auto-scroll if the note is outside the currently visible range
 					const isNoteVisible = targetIndex >= startNoteIndex && targetIndex <= endNoteIndex;
 					if (!isNoteVisible) {
-						focusNote(selectedNoteId);
+						makeItemIndexVisible(targetIndex);
 					}
 					// Clear the pending scroll once we've found and handled the note
 					pendingAutoScrollRef.current = null;
@@ -169,8 +169,7 @@ const NoteList = (props: Props) => {
 			lastSelectedFolderRef.current = props.selectedFolderId;
 			pendingAutoScrollRef.current = null;
 		}
-	// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps
-	}, [props.selectedNoteIds, props.notes, props.selectedFolderId, focusNote]);
+	}, [props.selectedNoteIds, props.notes, props.selectedFolderId, makeItemIndexVisible, startNoteIndex, endNoteIndex]);
 
 
 	const onItemContextMenu = useOnContextMenu(

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -131,6 +131,48 @@ const NoteList = (props: Props) => {
 		};
 	}, [focusNote]);
 
+	// Auto-scroll to the selected note when selection changes (e.g., via "Go to Anything")
+	// Only trigger for single note selections to avoid interfering with multi-selection
+	const lastSelectedNoteRef = useRef<string | null>(null);
+	const lastSelectedFolderRef = useRef<string | null>(null);
+	const pendingAutoScrollRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (props.selectedNoteIds.length === 1) {
+			const selectedNoteId = props.selectedNoteIds[0];
+			const selectedFolderId = props.selectedFolderId;
+
+			// Auto-scroll if this is a new selection OR if we switched folders
+			const isNewSelection = selectedNoteId !== lastSelectedNoteRef.current;
+			const isFolderChange = selectedFolderId !== lastSelectedFolderRef.current;
+
+			if (isNewSelection || isFolderChange) {
+				lastSelectedNoteRef.current = selectedNoteId;
+				lastSelectedFolderRef.current = selectedFolderId;
+				pendingAutoScrollRef.current = selectedNoteId;
+			}
+
+			// Only auto-scroll if we have a pending scroll for this specific note
+			if (pendingAutoScrollRef.current === selectedNoteId) {
+				const targetIndex = props.notes.findIndex(note => note.id === selectedNoteId);
+				if (targetIndex > -1) {
+					// Only auto-scroll if the note is outside the currently visible range
+					const isNoteVisible = targetIndex >= startNoteIndex && targetIndex <= endNoteIndex;
+					if (!isNoteVisible) {
+						focusNote(selectedNoteId);
+					}
+					// Clear the pending scroll once we've found and handled the note
+					pendingAutoScrollRef.current = null;
+				}
+			}
+		} else {
+			lastSelectedNoteRef.current = null;
+			lastSelectedFolderRef.current = props.selectedFolderId;
+			pendingAutoScrollRef.current = null;
+		}
+	// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps
+	}, [props.selectedNoteIds, props.notes, props.selectedFolderId, focusNote]);
+
+
 	const onItemContextMenu = useOnContextMenu(
 		props.selectedNoteIds,
 		props.selectedFolderId,


### PR DESCRIPTION
## Resolves

- Resolves #12355

## Summary

When selecting a note from the "Go to Anything" search results, Joplin was not automatically scrolling the note list to show the selected note. This made it difficult for users to see which note was selected, especially in large note collections.

This fix adds a smart auto-scroll feature in  that automatically scrolls to newly selected notes only when they are not currently visible in the viewport.

## Implementation

The solution uses a **pending auto-scroll pattern** with three ref-based state trackers:

- ****: Tracks the previously selected note ID
- ****: Tracks the previously selected folder ID  
- ****: Tracks which note needs auto-scrolling

**Auto-scroll triggers when:**
1. **New note selection** (different note selected)
2. **Folder change** (switching folders via "Go to Anything")

**Auto-scroll behavior:**
- Only scrolls if the target note is **outside the visible range** ()
- Only triggers for **single note selections** (preserves multi-selection behavior)
- **One-time action**: Each selection change triggers auto-scroll at most once
- **No manual scroll interference**: Manual scrolling doesn't set pending flags

## Key Features

✅ **Smart scrolling**: Only auto-scrolls when the selected note is not visible  
✅ **Cross-folder support**: Handles "Go to Anything" navigation between folders  
✅ **Manual scroll preservation**: No interference with user scrolling  
✅ **Multi-selection support**: Preserves existing multi-selection behavior  
✅ **Performance optimized**: Uses existing  function and visibility calculations  

## Testing

1. **Go to Anything within folder**:
   - Use Ctrl+G to search for a note in the current folder that's not visible
   - Verify the note list scrolls to show the selected note

2. **Go to Anything across folders**:
   - Use Ctrl+G to search for a note in a different folder
   - Verify both folder switch and note scroll work correctly

3. **Manual scrolling**:
   - Scroll the note list manually
   - Verify no unexpected auto-scrolling occurs

4. **Arrow key navigation**:
   - Use arrow keys to navigate visible notes
   - Verify no unnecessary scrolling for visible notes

5. **Multi-selection**:
   - Select multiple notes using Ctrl+click
   - Verify auto-scroll doesn't interfere with multi-selection

This solution provides reliable auto-scrolling for "Go to Anything" while maintaining all existing navigation behaviors.

---

### Screencast show the problem
[joplin-without-fix.webm](https://github.com/user-attachments/assets/de3341c3-c6e7-44ac-b502-5e3f964d24b5)

### Screencast with the fix
[joplin-with-fix.webm](https://github.com/user-attachments/assets/21da7408-39b7-4c58-83ff-927513caf00a)
