### PR TITLE
Desktop: Fix "insecure content security policy" warning

### DIFF
--- a/.yarn/patches/depd-npm-1.1.2-b0c8414da7.patch
+++ b/.yarn/patches/depd-npm-1.1.2-b0c8414da7.patch
@@ -1,0 +1,36 @@
+# Patch to remove eval. This allows using depd in an environment with
+# a strict Content-Security-Policy.
+# Ref: https://github.com/dougwilson/nodejs-depd/pull/33
+diff --git a/index.js b/index.js
+index d758d3c8f58a60bf27ef377ad77639bf10ce7854..2bad40d4eeba553d3bcfb206873eac059067ae3b 100644
+--- a/index.js
++++ b/index.js
+@@ -399,19 +399,20 @@ function wrapfunction (fn, message) {
+     throw new TypeError('argument fn must be a function')
+   }
+ 
+-  var args = createArgumentsString(fn.length)
+-  var deprecate = this // eslint-disable-line no-unused-vars
+   var stack = getStack()
+   var site = callSiteLocation(stack[1])
+ 
+   site.name = fn.name
+ 
+-   // eslint-disable-next-line no-eval
+-  var deprecatedfn = eval('(function (' + args + ') {\n' +
+-    '"use strict"\n' +
+-    'log.call(deprecate, message, site)\n' +
+-    'return fn.apply(this, arguments)\n' +
+-    '})')
++  var deprecatedfn
++  var self = this
++  deprecatedfn = function () {
++    'use strict'
++    log.call(self, message, site)
++    return fn.apply(this, arguments)
++  }
++  Object.defineProperty(deprecatedfn, 'length', { value: fn.length })
++  Object.defineProperty(deprecatedfn, 'name', { value: fn.name })
+ 
+   return deprecatedfn
+ }

--- a/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch
+++ b/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch
@@ -1,0 +1,35 @@
+# Patch to remove eval. This allows using depd in an environment with
+# a strict Content-Security-Policy.
+# Ref: https://github.com/dougwilson/nodejs-depd/pull/33
+diff --git a/index.js b/index.js
+index 1bf2fcfdeffc984e5ad792eec08744c29d4a4590..1b24aa2414458bc651abfdded81b103c131efeaa 100644
+--- a/index.js
++++ b/index.js
+@@ -415,19 +415,19 @@ function wrapfunction (fn, message) {
+     throw new TypeError('argument fn must be a function')
+   }
+ 
+-  var args = createArgumentsString(fn.length)
+   var stack = getStack()
+   var site = callSiteLocation(stack[1])
+ 
+   site.name = fn.name
+ 
+-  // eslint-disable-next-line no-new-func
+-  var deprecatedfn = new Function('fn', 'log', 'deprecate', 'message', 'site',
+-    '"use strict"\n' +
+-    'return function (' + args + ') {' +
+-    'log.call(deprecate, message, site)\n' +
+-    'return fn.apply(this, arguments)\n' +
+-    '}')(fn, log, this, message, site)
++  var self = this
++  var deprecatedfn = function () {
++    'use strict'
++    log.call(self, message, site)
++    return fn.apply(this, arguments)
++  }
++  Object.defineProperty(deprecatedfn, 'length', { value: fn.length })
++  Object.defineProperty(deprecatedfn, 'name', { value: fn.name })
+ 
+   return deprecatedfn
+ }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,12 @@
     "pdfjs-dist@*": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch",
     "pdfjs-dist@3.11.174": "patch:pdfjs-dist@npm%3A3.11.174#./.yarn/patches/pdfjs-dist-npm-3.11.174-67f2fee6d6.patch",
     "canvas@npm:^2.11.2": "link:./.yarn/joplin-empty-package/",
-    "node-gyp@npm:^9.0.0": "11.2.0"
+    "node-gyp@npm:^9.0.0": "11.2.0",
+    "depd@npm:^2.0.0": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch",
+    "depd@npm:~2.0.0": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch",
+    "depd@npm:~1.1.2": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch",
+    "depd@npm:2.0.0": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch",
+    "depd@npm:^1.1.2": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch",
+    "depd@npm:^1.1.0": "patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch"
   }
 }

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -2,11 +2,19 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<!--
-		No CPS because we need to allow everything due to some dependencies (eg. depd, which comes from maybe Node or Electron
-		uses 'eval'.
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'">
-		-->
+		<meta
+			http-equiv="Content-Security-Policy"
+			content="
+				default-src 'self' joplin-content://* ;
+				connect-src 'self' * http://* https://* joplin-content://* blob: ;
+				style-src 'unsafe-inline' 'self' blob: joplin-content://* https://* http://* ;
+				child-src 'self' joplin-content://* ;
+				script-src 'self' 'unsafe-inline' joplin-content://* ;
+				media-src 'self' * blob: data: https://* http://* joplin-content://* ;
+				img-src 'self' blob: data: http://* https://* joplin-content://* ;
+				font-src 'self' http://* https://* blob: data: joplin-content://* ;
+			"
+		/>
 		<title>Joplin</title>
 		<!-- Note: Add new dynamic CSS imports to style.scss to allow them to be included in secondary windows. -->
 		<link rel="stylesheet" href="style.min.css">

--- a/yarn.lock
+++ b/yarn.lock
@@ -23214,17 +23214,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0, depd@npm:^2.0.0, depd@npm:~2.0.0":
+"depd@npm:2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10/c0c8ff36079ce5ada64f46cc9d6fd47ebcf38241105b6e0c98f412e8ad91f084bcf906ff644cc3a4bd876ca27a62accb8b0fff72ea6ed1a414b89d8506f4a5ca
   languageName: node
   linkType: hard
 
-"depd@npm:^1.1.0, depd@npm:^1.1.2, depd@npm:~1.1.2":
-  version: 1.1.2
-  resolution: "depd@npm:1.1.2"
-  checksum: 10/2ed6966fc14463a9e85451db330ab8ba041efed0b9a1a472dbfc6fbf2f82bab66491915f996b25d8517dddc36c8c74e24c30879b34877f3c4410733444a51d1d
+"depd@patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch":
+  version: 2.0.0
+  resolution: "depd@patch:depd@npm%3A2.0.0#~/.yarn/patches/depd-npm-2.0.0-b6c51a4b43.patch::version=2.0.0&hash=c7e579"
+  checksum: 10/9f0be454908bcf019999d2c82f087a6b4e4fb5f31f2197d3c278ab3ba0b245e1172fd7f2f291940e79c59dfdccc590ad306bc8731fe68255544046263c3d2306
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request adds a `Content-Security-Policy` (CSP) to the desktop app that does not include `unsafe-eval`. This fixes the "Insecure content security policy" warning that was previously shown when running the desktop app in dev mode:
```
Electron Security Warning (Insecure Content-Security-Policy) This renderer process has either no Content Security
  Policy set or a policy with "unsafe-eval" enabled. This exposes users of
  this app to unnecessary security risks.

For more information and help, consult
https://electronjs.org/docs/tutorial/security.
This warning will not show up
once the app is packaged.
```

Related: [Comment](https://github.com/laurent22/joplin/pull/12396#issuecomment-2952868251) from @mrjo118 in #12396, current [Rich-Text-Editor-only CSP](https://github.com/laurent22/joplin/blob/2785b7f7d9ed2089688b2689c1e0b1c939dc70fb/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx#L735).

# Notes

- This only applies to the main application window (and secondary editor-only windows). It does not apply to plugin background windows. Additionally, due to [note viewer site isolation](https://joplinapp.org/help/dev/spec/note_viewer_isolation), this CSP will not affect content rendered in the note viewer.


# Testing

**Plugin regression testing**: I have verified that:
- In a Fedora 42 VM:
    - The "RevealJS integration" plugin can display a short note in a panel.
    - The outline plugin shows a list of header links in the sidebar.
    - The "math mode" plugin still works — adding `=4+4` to the body of a note shows `=> 8` inline.
    - The "YesYouKan" plugin can be used to create a Kanban board and add a new card to the board.
    - The "Freehand drawing" plugin can be used to add a new drawing and edit an existing drawing.
    - The "Note list (preview)" plugin renders a custom note list when "Note list style" is set to "preview".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->