### PR TITLE
Chore: Trying to fix GitHub Actions size issue

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -32,6 +32,7 @@ jobs:
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
       - name: Free disk space
+        if: runner.os == 'Linux'
         run: |
           sudo rm -rf /usr/local/lib/android || true
           sudo rm -rf /usr/share/dotnet || true
@@ -132,6 +133,7 @@ jobs:
           node-version: '18'
 
       - name: Free disk space
+        if: runner.os == 'Linux'
         run: |
           sudo rm -rf /usr/local/lib/android || true
           sudo rm -rf /usr/share/dotnet || true

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -31,6 +31,15 @@ jobs:
           sudo apt-get update || true
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          docker system prune -af || true
+          docker builder prune -af || true
+          sudo rm -rf /var/lib/docker/tmp/* || true
+
       # Login to Docker only if we're on a server release tag. If we run this on
       # a pull request it will fail because the PR doesn't have access to
       # secrets

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -131,6 +131,15 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          docker system prune -af || true
+          docker builder prune -af || true
+          sudo rm -rf /var/lib/docker/tmp/* || true
+
       - name: Install Yarn
         run: |
           # https://yarnpkg.com/getting-started/install


### PR DESCRIPTION
GitHub started complaining about the Docker image size from this commit, even though nothing important was changed: https://github.com/laurent22/joplin/commit/6705712f80409a9a8bc86dc0be63ff2adab23385  It might be that GitHub changed the max allowed size