### PR TITLE
Chore: Remove APK alignment verification step

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -40,29 +40,4 @@ jobs:
           cd packages/app-mobile/android
           sed -i -- 's/signingConfig signingConfigs.release/signingConfig signingConfigs.debug/' app/build.gradle
           ./gradlew assembleRelease
-      
-      - name: Verify alignment
-        run: |
-          cd packages/app-mobile/android/app
-          APK_FILE="./build/outputs/apk/release/app-release.apk"
-          if test ! -f "$APK_FILE" ; then
-            echo "APK file not found."
-            exit 1
-          else
-            echo "APK file found at: $APK_FILE"
-          fi
 
-          BUILD_TOOLS_PATH="$ANDROID_HOME/build-tools/"
-          if test ! -d "$BUILD_TOOLS_PATH" ; then
-            echo "Build tools not found at $BUILD_TOOLS_PATH ($ANDROID_HOME, $BUILD_TOOLS_VERSION)"
-            exit 1
-          fi
-          # The build-tools/ directory contains different subdirectories
-          # for each build tools version. As a result, there may be multiple
-          # zipalign tools. Select one of them:
-          ZIPALIGN_PATH="$(find $BUILD_TOOLS_PATH -name "zipalign" -print | head -n1)"
-          if test ! -x "$ZIPALIGN_PATH" ; then
-            echo "zipalign not found (searching in $BUILD_TOOLS_PATH, candidate: $ZIPALIGN_PATH)"
-            exit 1
-          fi
-          "$ZIPALIGN_PATH" -c -P 16 -v 4 "$APK_FILE"


### PR DESCRIPTION
# Summary

This pull request removes the "verify alignment" step from the Android build process to fix a CI failure. Ideally, this removal will be only temporary, until the underlying issue is resolved.


# Notes

The APK alignment verification step seems to be using an old version of `zipalign` that does not support the `-P` flag. See [zipalign options](https://developer.android.com/tools/zipalign#options). The `-P 16` argument specifies that the APK should be aligned to 16 KiB pages.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->