### PR TITLE
Desktop: Resolves #12572 - Click on systray icon will show/hide Joplin main window

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -612,7 +612,11 @@ export default class ElectronAppWrapper {
 					console.warn('The window object was not available during the click event from tray icon');
 					return;
 				}
-				this.mainWindow().show();
+				if(!this.mainWindow().isVisible()){
+					this.mainWindow().show();
+				} else {
+					this.mainWindow().hide();
+				}
 			});
 		} catch (error) {
 			console.error('Cannot create tray', error);

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -612,7 +612,7 @@ export default class ElectronAppWrapper {
 					console.warn('The window object was not available during the click event from tray icon');
 					return;
 				}
-				if(!this.mainWindow().isVisible()){
+				if (!this.mainWindow().isVisible()) {
 					this.mainWindow().show();
 				} else {
 					this.mainWindow().hide();


### PR DESCRIPTION
A small but annoying UX behaviour when click on systray icon shows main window, but not hides it.
It was reported in #12572.
Proposed patch fixes it.