### PR TITLE
All: Fixes 12810: Ensure the sync shows an error when the server is down, when using a local WebDAV server

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -20,7 +20,7 @@ import JoplinError from './JoplinError';
 import ShareService from './services/share/ShareService';
 import TaskQueue from './TaskQueue';
 import ItemUploader from './services/synchronizer/ItemUploader';
-import { FileApi, getSupportsDeltaWithItems, PaginatedList, RemoteItem } from './file-api';
+import { FileApi, getSupportsDeltaWithItems, isLocalServer, PaginatedList, RemoteItem } from './file-api';
 import JoplinDatabase from './JoplinDatabase';
 import { checkIfCanSync, fetchSyncInfo, checkSyncTargetIsValid, getActiveMasterKey, localSyncInfo, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyHasBeenUsed, SyncInfo, syncInfoEquals, uploadSyncInfo } from './services/synchronizer/syncInfoUtils';
 import { getMasterPassword, setupAndDisableEncryption, setupAndEnableEncryption } from './services/e2ee/utils';
@@ -32,6 +32,7 @@ import syncDeleteStep from './services/synchronizer/utils/syncDeleteStep';
 import { ErrorCode } from './errors';
 import { SyncAction } from './services/synchronizer/utils/types';
 import checkDisabledSyncItemsNotification from './services/synchronizer/utils/checkDisabledSyncItemsNotification';
+import SyncTargetRegistry from './SyncTargetRegistry';
 const { sprintf } = require('sprintf-js');
 const { Dirnames } = require('./services/synchronizer/utils/types');
 
@@ -1164,8 +1165,11 @@ export default class Synchronizer {
 				logger.error(error);
 				if (error.details) logger.error('Details:', error.details);
 
-				// Don't save to the report errors that are due to things like temporary network errors or timeout.
-				if (!shim.fetchRequestCanBeRetried(error)) {
+				const isLocalWebDavServer = Setting.value('sync.target') === SyncTargetRegistry.nameToId('webdav') && isLocalServer(Setting.value('sync.6.path'));
+
+				// Don't save to the report errors that are due to things like temporary network errors or timeout, except if using a local WebDAV server, in which
+				// case timeout errors can occur when the server is actually down.
+				if (!shim.fetchRequestCanBeRetried(error) || isLocalWebDavServer) {
 					this.progressReport_.errors.push(error);
 					this.logLastRequests();
 				}

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1168,7 +1168,9 @@ export default class Synchronizer {
 				const isLocalWebDavServer = Setting.value('sync.target') === SyncTargetRegistry.nameToId('webdav') && isLocalServer(Setting.value('sync.6.path'));
 
 				// Don't save to the report errors that are due to things like temporary network errors or timeout, except if using a local WebDAV server, in which
-				// case timeout errors can occur when the server is actually down.
+				// case timeout errors can occur when the server is actually down. Those type of errors happen consistently when a local server is down when using
+				// the Android app in particular, but they can also happen on the desktop app in some circumstances. The usage of a local WebDAV server is most useful
+				// on Android, as it can be used as an alternative to file system sync, in order to work around performance issues related to SAF
 				if (!shim.fetchRequestCanBeRetried(error) || isLocalWebDavServer) {
 					this.progressReport_.errors.push(error);
 					this.logLastRequests();

--- a/packages/lib/file-api.test.ts
+++ b/packages/lib/file-api.test.ts
@@ -73,10 +73,11 @@ describe('file-api', () => {
 	it.each([
 		'http://localhost',
 		'http://localhost/',
-		'http://localhost:3000',
-		'https://127.0.0.1',
-		'https://127.0.0.1/',
-		'https://127.0.0.1:8080',
+		'https://localhost:8080',
+		'http://127.0.0.1',
+		'https://127.100.50.25:3000/test',
+		'http://[::1]',
+		'http://localhost/api/v1',
 	])('should detect a local server url', (url: string) => {
 		const result = isLocalServer(url);
 		expect(result).toBe(true);
@@ -85,7 +86,9 @@ describe('file-api', () => {
 	it.each([
 		'http://localhostXYZ',
 		'http://127.0.0.1foobar',
+		'http://192.168.1.1',
 		'http://example.com',
+		'https://my-localhost.com',
 	])('should detect a non local server url', (url: string) => {
 		const result = isLocalServer(url);
 		expect(result).toBe(false);

--- a/packages/lib/file-api.test.ts
+++ b/packages/lib/file-api.test.ts
@@ -1,4 +1,4 @@
-import { PaginatedList, RemoteItem, getSupportsDeltaWithItems } from './file-api';
+import { PaginatedList, RemoteItem, getSupportsDeltaWithItems, isLocalServer } from './file-api';
 
 const defaultPaginatedList = (): PaginatedList => {
 	return {
@@ -68,6 +68,27 @@ describe('file-api', () => {
 	])('should tell if the sync target supports delta with items', async (deltaResponse: PaginatedList, expected: boolean) => {
 		const actual = getSupportsDeltaWithItems(deltaResponse);
 		expect(actual).toBe(expected);
+	});
+
+	it.each([
+		'http://localhost',
+		'http://localhost/',
+		'http://localhost:3000',
+		'https://127.0.0.1',
+		'https://127.0.0.1/',
+		'https://127.0.0.1:8080',
+	])('should detect a local server url', (url: string) => {
+		const result = isLocalServer(url);
+		expect(result).toBe(true);
+	});
+
+	it.each([
+		'http://localhostXYZ',
+		'http://127.0.0.1foobar',
+		'http://example.com',
+	])('should detect a non local server url', (url: string) => {
+		const result = isLocalServer(url);
+		expect(result).toBe(false);
 	});
 
 });

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -53,6 +53,11 @@ export const getSupportsDeltaWithItems = (deltaResponse: PaginatedList) => {
 	return 'jopItem' in deltaResponse.items[0];
 };
 
+export const isLocalServer = (url: string) => {
+	const regex = /^https?:\/\/(localhost|127\.0\.0\.1)(?=[/:]|$)/;
+	return regex.test(url);
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 function requestCanBeRepeated(error: any) {
 	const errorCode = typeof error === 'object' && error.code ? error.code : null;

--- a/packages/lib/file-api.ts
+++ b/packages/lib/file-api.ts
@@ -54,7 +54,7 @@ export const getSupportsDeltaWithItems = (deltaResponse: PaginatedList) => {
 };
 
 export const isLocalServer = (url: string) => {
-	const regex = /^https?:\/\/(localhost|127\.0\.0\.1)(?=[/:]|$)/;
+	const regex = /^(https?:\/\/)?(localhost|127(?:\.\d{1,3}){3}|\[::1\])(?::\d{1,5})?(\/.*)?$/i;
 	return regex.test(url);
 };
 


### PR DESCRIPTION
When syncing with a local WebDAV server running on the same device as Joplin, if for whatever reason the server goes down, Joplin may not show any error when syncing while the server is down. This is because when using a localhost url, depending on the device and network configuration, errors which are handled as temporary errors may be thrown instead of a more terminal error code. A typical use case for using this setup is to work around the severe SAF performance limitations on Android 11+, so instead of using file system sync to sync to third party cloud providers, an app such as RoundSync is used to stream access to the provider via a local WebDAV server running locally on the device. As Android can be quite aggressive at killing background apps and services these days (even happening sometimes when battery optimisations are disabled), it is possible that the WebDAV server may get killed or suspended by the OS, and it would be beneficial to be able to see from the Joplin UI that there is a problem when this is the case.

To address this, I have changed the error handling in the synchronizer so that all error types will be reported to the UI, but only if the sync target is WebDAV and the url matches the format of a local server url.

Please note this uses the same isLocalServer function introduced in https://github.com/laurent22/joplin/pull/13054 so overlaps with the PR, but unit tests for the individual function have been added, as it has now been made into a public function.

This fixes https://github.com/laurent22/joplin/issues/12810

### Testing

See video of a previously hidden error, now showing in the UI when syncing with a localhost url with the WebDAV sync target:

https://github.com/user-attachments/assets/9cea5913-5ca7-429e-8e32-9fd98f7b5b37

