### PR TITLE
revise docker compose file for joplin server for better understanding

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,12 +8,12 @@
 # APP_BASE_URL
 #
 # APP_BASE_URL: This is the base public URL where the service will be running.
-#	- If Joplin Server needs to be accessible over the internet, configure APP_BASE_URL as follows: https://example.com/joplin. 
+#	- If Joplin Server needs to be accessible over the internet, configure APP_BASE_URL as follows: https://joplin.example.com ,
+#     or https://example.com/joplin , which is expected to match that in proxy_pass command of nginx configuration file.  
 #	- If Joplin Server does not need to be accessible over the internet, set the APP_BASE_URL to your server's hostname. 
 #     For Example: http://[hostname]:22300. The base URL can include the port.
 # APP_PORT: The local port on which the Docker container will listen. 
-#	- This would typically be mapped to port to 443 (TLS) with a reverse proxy.
-#	- If Joplin Server does not need to be accessible over the internet, the port can be mapped to 22300.
+#	- This would typically be mapped to port to 443 (TLS) with a reverse proxy by nginx.
 
 version: '3'
 


### PR DESCRIPTION
The APP_BASE_URL should be identical to that of nginx proxy_pass command, and the "joplin" suffix is not always required.
Likewise, the APP_PORT should be 22300, which would be passed to 443 by nginx.