### PR TITLE
Desktop: Fixes #13303: Set default tab size to 2 spaces

### DIFF
--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -242,6 +242,7 @@ const createEditor = (
 			// See https://github.com/codemirror/basic-setup/blob/main/src/codemirror.ts
 			// for a sample configuration.
 			extensions: [
+				EditorState.tabSize.of(4),
 				keymapConfig,
 
 				dynamicConfig.of(configFromSettings(props.settings, context)),

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -242,7 +242,7 @@ const createEditor = (
 			// See https://github.com/codemirror/basic-setup/blob/main/src/codemirror.ts
 			// for a sample configuration.
 			extensions: [
-				EditorState.tabSize.of(4),
+				EditorState.tabSize.of(2),
 				keymapConfig,
 
 				dynamicConfig.of(configFromSettings(props.settings, context)),


### PR DESCRIPTION
This change sets the default tab indentation in the CodeMirror editor to 2 spaces, aligning with modern standards and workflows.

Fixes #13303

### Testing

1.  Run the desktop application.
2.  Create a new note.
3.  Press the Tab key and verify that the cursor indents by 2 spaces instead of 4.