### PR TITLE
Desktop: Fixes #13196: Fixed red close button not working on macOS 26

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -407,7 +407,17 @@ export default class ElectronAppWrapper {
 					isGoingToExit = true;
 				} else {
 					event.preventDefault();
-					this.hide();
+
+					const w = this.win_;
+					if (!w) return;
+
+					if (w.isFullScreen()) {
+						// leave fullscreen, then hide
+						w.once('leave-full-screen', () => w.hide());
+						w.setFullScreen(false);
+					} else {
+						w.hide();
+					}
 				}
 			} else {
 				const hasBackgroundWindows = this.secondaryWindows_.size > 0;


### PR DESCRIPTION
### Summary
On macOS 26, the red close button did not close the main Joplin window.
Users had to force quit the app. This PR fixes the issue.

### Fix
- Prevent default close event and properly hide the main window.
- Handle fullscreen exit before hiding to ensure consistent behavior.

### Testing
- Verified on macOS 26 (Apple M2).
- Confirmed that the red close button now hides the app window as expected.

### Demo
Before: Clicking the red close button did not close the window (macOS 26).
After: The window now hides correctly when the red close button is clicked.

https://github.com/user-attachments/assets/3c75908b-2927-4f70-acd1-c0d6b590c6ad

Fixes #13196