### PR TITLE
Desktop: Fixes #12763: skip copy event in TinyMCE if no content is selected.

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1387,6 +1387,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		async function onCopy(event: any) {
 			const copiedContent = editor.selection.getContent();
+			if (!copiedContent) return;
 			copyHtmlToClipboard(copiedContent);
 			event.preventDefault();
 		}


### PR DESCRIPTION


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

## What it does

This issue appears to occur only in the WYSIWYG (TinyMCE) editor.
In the Markdown editor, the default behavior is to copy the entire line when there is no selection, so no change is needed there.
I’ve limited the fix to TinyMCE: on copy, we first check whether there is a selection; if not, we do nothing.


## How to test

Manual testing: before the change, the issue is reproducible; after the change, the behavior matches expectations—empty (no-selection) copies have no effect.

## Test gif

### Before:
![Before](https://github.com/user-attachments/assets/cc1ec873-6b7a-4eb8-a896-9b6b9c92a912)

### After:
![After](https://github.com/user-attachments/assets/1fd2cced-7b89-4028-b093-69ca36f6d1be)

## Related issues

Fixes #12763