### PR TITLE
Desktop: Fix: Hide 'Start application minimised' unless tray icon is enabled

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -510,16 +510,6 @@ class Application extends BaseApplication {
 			Setting.dispatchUpdateAll();
 		});
 
-		addTask('app/override setting metadata', () => {
-			const meta = Setting.settingMetadata('startMinimized');
-			Setting.registerSetting('startMinimized', {
-				...meta,
-				show: (settings: any) => {
-					return !!settings['showTrayIcon'];
-				},
-			});
-		});
-
 		addTask('app/update folders and tags', async () => {
 			await refreshFolders((action) => this.dispatch(action), '');
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -510,6 +510,16 @@ class Application extends BaseApplication {
 			Setting.dispatchUpdateAll();
 		});
 
+		addTask('app/override setting metadata', () => {
+			const meta = Setting.settingMetadata('startMinimized');
+			Setting.registerSetting('startMinimized', {
+				...meta,
+				show: (settings: any) => {
+					return !!settings['showTrayIcon'];
+				},
+			});
+		});
+
 		addTask('app/update folders and tags', async () => {
 			await refreshFolders((action) => this.dispatch(action), '');
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1132,7 +1132,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop],
 		},
 
-		startMinimized: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Start application minimised in the tray icon') },
+		startMinimized: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Start application minimised in the tray icon'), show: settings => !!settings['showTrayIcon'] },
 
 		collapsedFolderIds: { value: [] as string[], type: SettingItemType.Array, public: false },
 


### PR DESCRIPTION
**Context**

Currently, the “Start application minimised in the tray icon” setting is logically tied to the “Show tray icon” option. The minimised-start behaviour only works when “Show tray icon” is enabled.
If the tray icon is disabled, ticking “Start application minimised” has no effect — the app will still open normally — which can confuse users.

From the settings screen alone, users cannot see this dependency. As a result, they may think the minimise feature is broken when in fact it requires the tray icon to be enabled.

**Change**

This PR makes the “Start application minimised” option dependent on the “Show tray icon” setting.
	•	When “Show tray icon” is checked, the “Start application minimised” checkbox will appear.
	•	When “Show tray icon” is unchecked, the “Start application minimised” option will be hidden.

This prevents user confusion and makes the relationship between the two settings clear in the UI.

Pls check the below video to see the behaviour after the change.

https://github.com/user-attachments/assets/e69e2897-cce7-401f-aa4d-27db0ae3c6e9

This change relates to #13088.

Question:
	•	Does this behaviour look reasonable to you?
	•	Do you think it would improve clarity if the “Start application minimised” option was slightly indented under the “Show tray icon” setting (to visually show the dependency)?