### PR TITLE
Desktop: Add write() method to Plugin Clipboard API

### DIFF
--- a/packages/lib/services/plugins/api/JoplinClipboard.ts
+++ b/packages/lib/services/plugins/api/JoplinClipboard.ts
@@ -69,13 +69,13 @@ export default class JoplinClipboard {
 	 *
 	 * @example
 	 * ```typescript
-	 * await joplin.clipboard.writeMultiple({
+	 * await joplin.clipboard.write({
 	 *   text: 'Plain text version',
 	 *   html: '<strong>HTML version</strong>'
 	 * });
 	 * ```
 	 */
-	public async writeMultiple(content: ClipboardContent): Promise<void> {
+	public async write(content: ClipboardContent): Promise<void> {
 		const clipboardData: Record<string, unknown> = {};
 
 		if (content.text !== undefined) {

--- a/packages/lib/services/plugins/api/JoplinClipboard.ts
+++ b/packages/lib/services/plugins/api/JoplinClipboard.ts
@@ -90,7 +90,10 @@ export default class JoplinClipboard {
 			clipboardData.image = this.electronNativeImage_.createFromDataURL(content.image);
 		}
 
-		this.electronClipboard_.write(clipboardData);
+		// Only write to clipboard if there's actually data to write
+		if (Object.keys(clipboardData).length > 0) {
+			this.electronClipboard_.write(clipboardData);
+		}
 	}
 
 }

--- a/packages/lib/services/plugins/api/JoplinClipboard.ts
+++ b/packages/lib/services/plugins/api/JoplinClipboard.ts
@@ -1,5 +1,7 @@
 /* eslint-disable multiline-comment-style */
 
+import { ClipboardContent } from './types';
+
 export default class JoplinClipboard {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -57,6 +59,38 @@ export default class JoplinClipboard {
 	 */
 	public async availableFormats(): Promise<string[]> {
 		return this.electronClipboard_.availableFormats();
+	}
+
+	/**
+	 * Writes multiple formats to the clipboard simultaneously.
+	 * This allows setting both text/plain and text/html at the same time.
+	 *
+	 * <span class="platform-desktop">desktop</span>
+	 *
+	 * @example
+	 * ```typescript
+	 * await joplin.clipboard.writeMultiple({
+	 *   text: 'Plain text version',
+	 *   html: '<strong>HTML version</strong>'
+	 * });
+	 * ```
+	 */
+	public async writeMultiple(content: ClipboardContent): Promise<void> {
+		const clipboardData: Record<string, unknown> = {};
+
+		if (content.text !== undefined) {
+			clipboardData.text = content.text;
+		}
+
+		if (content.html !== undefined) {
+			clipboardData.html = content.html;
+		}
+
+		if (content.image !== undefined) {
+			clipboardData.image = this.electronNativeImage_.createFromDataURL(content.image);
+		}
+
+		this.electronClipboard_.write(clipboardData);
 	}
 
 }

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -589,6 +589,30 @@ export interface SettingSection {
 export type Path = string[];
 
 // =================================================================
+// Clipboard API types
+// =================================================================
+
+/**
+ * Represents content that can be written to the clipboard in multiple formats.
+ */
+export interface ClipboardContent {
+	/**
+	 * Plain text representation of the content
+	 */
+	text?: string;
+
+	/**
+	 * HTML representation of the content
+	 */
+	html?: string;
+
+	/**
+	 * Image in [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) format
+	 */
+	image?: string;
+}
+
+// =================================================================
 // Content Script types
 // =================================================================
 


### PR DESCRIPTION
## Summary

Adds a new `write()` method to the plugin clipboard API that allows writing multiple formats (text/plain, text/html, and image) to the clipboard simultaneously.

Background: see forum thread: https://discourse.joplinapp.org/t/is-it-possible-to-populate-both-text-html-and-text-plain-at-the-same-time-with-joplin-clipboard/46968

## Overview

Currently, the plugin API provides writeText() and writeHtml() methods, but each call overwrites the previous clipboard content. This limitation prevents plugins from setting both plain text and HTML formats at the same time.

## Changes

### 1\. New ClipboardContent Interface (types.ts)

- Added new interface with optional text, html, and image properties
- Placed in new "Clipboard API types" section for organization

### 2\. New write() Method (JoplinClipboard.ts)

- Accepts a ClipboardContent object
- Writes all provided formats atomically using Electron's clipboard.write() API
- Includes JSDoc with usage example
- Tagged as `<span class="platform-desktop">desktop</span>` (Electron-only)
- Named write() to indicate that this is a generic method to write any supported format(s) to clipboard.

## Usage Example

```ts
await joplin.clipboard.write({
  text: 'A red circle',
  html: '<div><p>A red circle</p><img src="data:image/png;base64,iVBORw0KGg..." alt="Red circle"></div>',
  image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA...'
});
```

## Testing

- Tested via my Copy as HTML plugin and verified that I could successfully write text/plain, text/html and image to clipboard via joplin.clipboard.write
- Tested with text/html and text/plain (no image) and with all three formats
- Pasting into a rich text editor pastes text/html as expected, and using ctrl + shift + v pastes text/plain as expected
- Pasting into paint pastes the image as expected
- Example clipboard output with all three formats:
- <img width="1836" height="1630" alt="image" src="https://github.com/user-attachments/assets/ef8d87ca-94e5-405a-8b97-d2c56560fa61" />

## Backward Compatibility

This change is fully backward compatible:

- Existing writeText(), writeHtml(), and writeImage() methods remain unchanged
- Tested backwards compatibility via the current release version of my Copy as HTML plugin and verified that writeText and writeHtml still work as they did before. Also tested writeImage (via rich markdown plugin copy image context menu option).