### PR TITLE
Desktop: Feat: Add useToast hook and refactor TrashNotification to use it

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -519,6 +519,7 @@ packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js
 packages/app-desktop/gui/hooks/useMarkupToHtml.js
 packages/app-desktop/gui/hooks/usePrevious.js
 packages/app-desktop/gui/hooks/usePropsDebugger.js
+packages/app-desktop/gui/hooks/useToast.js
 packages/app-desktop/gui/lib/SearchInput/SearchInput.js
 packages/app-desktop/gui/lib/ToggleButton/ToggleButton.js
 packages/app-desktop/gui/menuCommandNames.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -519,7 +519,7 @@ packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js
 packages/app-desktop/gui/hooks/useMarkupToHtml.js
 packages/app-desktop/gui/hooks/usePrevious.js
 packages/app-desktop/gui/hooks/usePropsDebugger.js
-packages/app-desktop/gui/hooks/useToast.js
+packages/app-desktop/gui/hooks/useToastNotifier.js
 packages/app-desktop/gui/lib/SearchInput/SearchInput.js
 packages/app-desktop/gui/lib/ToggleButton/ToggleButton.js
 packages/app-desktop/gui/menuCommandNames.js

--- a/.gitignore
+++ b/.gitignore
@@ -492,6 +492,7 @@ packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js
 packages/app-desktop/gui/hooks/useMarkupToHtml.js
 packages/app-desktop/gui/hooks/usePrevious.js
 packages/app-desktop/gui/hooks/usePropsDebugger.js
+packages/app-desktop/gui/hooks/useToast.js
 packages/app-desktop/gui/lib/SearchInput/SearchInput.js
 packages/app-desktop/gui/lib/ToggleButton/ToggleButton.js
 packages/app-desktop/gui/menuCommandNames.js

--- a/.gitignore
+++ b/.gitignore
@@ -492,7 +492,7 @@ packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js
 packages/app-desktop/gui/hooks/useMarkupToHtml.js
 packages/app-desktop/gui/hooks/usePrevious.js
 packages/app-desktop/gui/hooks/usePropsDebugger.js
-packages/app-desktop/gui/hooks/useToast.js
+packages/app-desktop/gui/hooks/useToastNotifier.js
 packages/app-desktop/gui/lib/SearchInput/SearchInput.js
 packages/app-desktop/gui/lib/ToggleButton/ToggleButton.js
 packages/app-desktop/gui/menuCommandNames.js

--- a/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
+++ b/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { _ } from '@joplin/lib/locale';
 import { Dispatch } from 'redux';
-import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import { NotificationType } from '../PopupNotification/types';
+import useToast from '../../gui/hooks/useToast';
 
 interface Props {
 	noteId: string;
@@ -11,18 +11,21 @@ interface Props {
 }
 
 export default (props: Props) => {
-	const popupManager = useContext(PopupNotificationContext);
+	const toast = useToast();
 
 	useEffect(() => {
 		if (!props.noteId || props.noteId === '') return;
 
 		props.dispatch({ type: 'NOTE_HTML_TO_MARKDOWN_DONE', value: '' });
 
-		const notification = popupManager.createPopup(() => (
-			<div>{_('The note has been converted to Markdown and the original note has been moved to the trash')}</div>
-		), { type: NotificationType.Success });
-		notification.scheduleDismiss();
-	}, [props.dispatch, popupManager, props.noteId]);
+		toast(
+			_('The note has been converted to Markdown and the original note has been moved to the trash'),
+			{
+				type: NotificationType.Success,
+				delay: 4000,
+			},
+		);
+	}, [props.dispatch, props.noteId, toast]);
 
 	return <div style={{ display: 'none' }}/>;
 };

--- a/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
+++ b/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { _ } from '@joplin/lib/locale';
 import { Dispatch } from 'redux';
 import { NotificationType } from '../PopupNotification/types';
-import useToast from '../../gui/hooks/useToast';
+import useToastNotifier from '../../gui/hooks/useToast';
 
 interface Props {
 	noteId: string;
@@ -11,21 +11,21 @@ interface Props {
 }
 
 export default (props: Props) => {
-	const toast = useToast();
+	const notify = useToastNotifier();
 
 	useEffect(() => {
 		if (!props.noteId || props.noteId === '') return;
 
 		props.dispatch({ type: 'NOTE_HTML_TO_MARKDOWN_DONE', value: '' });
 
-		toast(
+		notify(
 			_('The note has been converted to Markdown and the original note has been moved to the trash'),
 			{
 				type: NotificationType.Success,
 				delay: 4000,
 			},
 		);
-	}, [props.dispatch, props.noteId, toast]);
+	}, [props.dispatch, props.noteId, notify]);
 
 	return <div style={{ display: 'none' }}/>;
 };

--- a/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
+++ b/packages/app-desktop/gui/ConversionNotification/ConversionNotification.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import { _ } from '@joplin/lib/locale';
 import { Dispatch } from 'redux';
-import { NotificationType } from '../PopupNotification/types';
-import useToastNotifier from '../../gui/hooks/useToast';
+import useToastNotifier from '../hooks/useToastNotifier';
 
 interface Props {
 	noteId: string;
@@ -18,13 +17,7 @@ export default (props: Props) => {
 
 		props.dispatch({ type: 'NOTE_HTML_TO_MARKDOWN_DONE', value: '' });
 
-		notify(
-			_('The note has been converted to Markdown and the original note has been moved to the trash'),
-			{
-				type: NotificationType.Success,
-				delay: 4000,
-			},
-		);
+		notify(_('The note has been converted to Markdown and the original note has been moved to the trash.'));
 	}, [props.dispatch, props.noteId, notify]);
 
 	return <div style={{ display: 'none' }}/>;

--- a/packages/app-desktop/gui/PopupNotification/types.ts
+++ b/packages/app-desktop/gui/PopupNotification/types.ts
@@ -17,6 +17,12 @@ export interface PopupOptions {
 	type?: NotificationType;
 }
 
+export interface ToastOptions {
+	delay?: number;
+	type?: NotificationType;
+	persistent?: boolean;
+}
+
 export interface PopupControl {
 	createPopup(content: NotificationContentCallback, props?: PopupOptions): PopupHandle;
 }

--- a/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
+++ b/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
@@ -7,7 +7,7 @@ import { ModelType } from '@joplin/lib/BaseModel';
 import { Dispatch } from 'redux';
 import { NotificationType } from '../PopupNotification/types';
 import TrashNotificationMessage from './TrashNotificationMessage';
-import useToast from '../../gui/hooks/useToast';
+import useToastNotifier from '../../gui/hooks/useToast';
 
 interface Props {
 	lastDeletion: StateLastDeletion;
@@ -27,7 +27,7 @@ const onCancelClick = async (lastDeletion: StateLastDeletion) => {
 };
 
 export default (props: Props) => {
-	const toast = useToast();
+	const notify = useToastNotifier();
 
 	const lastDeletionNotificationTimeRef = useRef<number>(props.lastDeletionNotificationTime);
 	lastDeletionNotificationTimeRef.current = props.lastDeletionNotificationTime;
@@ -51,7 +51,7 @@ export default (props: Props) => {
 			notification.remove();
 			void onCancelClick(props.lastDeletion);
 		};
-		const notification = toast(
+		const notification = notify(
 			<TrashNotificationMessage message={msg} onCancel={handleCancelClick} />,
 			{
 				delay: 4000,
@@ -59,7 +59,7 @@ export default (props: Props) => {
 				persistent: false,
 			},
 		);
-	}, [props.lastDeletion, props.dispatch, toast]);
+	}, [props.lastDeletion, props.dispatch, notify]);
 
 	return <div style={{ display: 'none' }}/>;
 };

--- a/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
+++ b/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
@@ -5,9 +5,8 @@ import { _, _n } from '@joplin/lib/locale';
 import restoreItems from '@joplin/lib/services/trash/restoreItems';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { Dispatch } from 'redux';
-import { NotificationType } from '../PopupNotification/types';
 import TrashNotificationMessage from './TrashNotificationMessage';
-import useToastNotifier from '../../gui/hooks/useToast';
+import useToastNotifier from '../hooks/useToastNotifier';
 
 interface Props {
 	lastDeletion: StateLastDeletion;
@@ -52,12 +51,7 @@ export default (props: Props) => {
 			void onCancelClick(props.lastDeletion);
 		};
 		const notification = notify(
-			<TrashNotificationMessage message={msg} onCancel={handleCancelClick} />,
-			{
-				delay: 4000,
-				type: NotificationType.Success,
-				persistent: false,
-			},
+			<TrashNotificationMessage message={msg} onCancel={handleCancelClick}/>,
 		);
 	}, [props.lastDeletion, props.dispatch, notify]);
 

--- a/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
+++ b/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
@@ -53,8 +53,11 @@ export default (props: Props) => {
 		};
 		const notification = toast(
 			<TrashNotificationMessage message={msg} onCancel={handleCancelClick} />,
-			4000,
-			NotificationType.Success,
+			{
+				delay: 4000,
+				type: NotificationType.Success,
+				persistent: false,
+			},
 		);
 	}, [props.lastDeletion, props.dispatch, toast]);
 

--- a/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
+++ b/packages/app-desktop/gui/TrashNotification/TrashNotification.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { useContext, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { StateLastDeletion } from '@joplin/lib/reducer';
 import { _, _n } from '@joplin/lib/locale';
 import restoreItems from '@joplin/lib/services/trash/restoreItems';
 import { ModelType } from '@joplin/lib/BaseModel';
 import { Dispatch } from 'redux';
-import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import { NotificationType } from '../PopupNotification/types';
 import TrashNotificationMessage from './TrashNotificationMessage';
+import useToast from '../../gui/hooks/useToast';
 
 interface Props {
 	lastDeletion: StateLastDeletion;
@@ -27,7 +27,7 @@ const onCancelClick = async (lastDeletion: StateLastDeletion) => {
 };
 
 export default (props: Props) => {
-	const popupManager = useContext(PopupNotificationContext);
+	const toast = useToast();
 
 	const lastDeletionNotificationTimeRef = useRef<number>(props.lastDeletionNotificationTime);
 	lastDeletionNotificationTimeRef.current = props.lastDeletionNotificationTime;
@@ -51,11 +51,12 @@ export default (props: Props) => {
 			notification.remove();
 			void onCancelClick(props.lastDeletion);
 		};
-		const notification = popupManager.createPopup(() => (
-			<TrashNotificationMessage message={msg} onCancel={handleCancelClick}/>
-		), { type: NotificationType.Success });
-		notification.scheduleDismiss();
-	}, [props.lastDeletion, props.dispatch, popupManager]);
+		const notification = toast(
+			<TrashNotificationMessage message={msg} onCancel={handleCancelClick} />,
+			4000,
+			NotificationType.Success,
+		);
+	}, [props.lastDeletion, props.dispatch, toast]);
 
 	return <div style={{ display: 'none' }}/>;
 };

--- a/packages/app-desktop/gui/hooks/useToast.ts
+++ b/packages/app-desktop/gui/hooks/useToast.ts
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { useContext, useCallback } from 'react';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import { ToastOptions, NotificationType } from '../PopupNotification/types';
-import type { PopupHandle } from '../PopupNotification/types';
 
-export default function useToast() {
+export default function useToastNotifier() {
 	const popupManager = useContext(PopupNotificationContext);
 
 	return useCallback(
@@ -15,14 +14,10 @@ export default function useToast() {
 				persistent = false,
 			} = options;
 
-			const handle: PopupHandle = popupManager.createPopup(() => message, { type });
+			const handle = popupManager.createPopup(() => message, { type });
 
 			if (!persistent) {
-				try {
-					handle.scheduleDismiss?.(delay);
-				} catch {
-					handle.scheduleDismiss?.();
-				}
+				handle.scheduleDismiss(delay);
 			}
 
 			return handle;

--- a/packages/app-desktop/gui/hooks/useToast.ts
+++ b/packages/app-desktop/gui/hooks/useToast.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useContext, useCallback } from 'react';
+import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
+import { NotificationType } from '../PopupNotification/types';
+import type { PopupHandle } from '../PopupNotification/types';
+
+export default function useToast() {
+	const popupManager = useContext(PopupNotificationContext);
+	type Duration = number | 'persist';
+
+	return useCallback(
+		(
+			message: React.ReactNode,
+			duration: Duration = 4000,
+			type: NotificationType = NotificationType.Info,
+		): PopupHandle => {
+			const handle = popupManager.createPopup(() => message, { type });
+
+			if (duration !== 'persist') {
+				try {
+					handle.scheduleDismiss?.(duration);
+				} catch {
+					handle.scheduleDismiss?.();
+				}
+			}
+
+			return handle;
+		},
+		[popupManager],
+	);
+}

--- a/packages/app-desktop/gui/hooks/useToast.ts
+++ b/packages/app-desktop/gui/hooks/useToast.ts
@@ -1,24 +1,25 @@
 import * as React from 'react';
 import { useContext, useCallback } from 'react';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
-import { NotificationType } from '../PopupNotification/types';
+import { ToastOptions, NotificationType } from '../PopupNotification/types';
 import type { PopupHandle } from '../PopupNotification/types';
 
 export default function useToast() {
 	const popupManager = useContext(PopupNotificationContext);
-	type Duration = number | 'persist';
 
 	return useCallback(
-		(
-			message: React.ReactNode,
-			duration: Duration = 4000,
-			type: NotificationType = NotificationType.Info,
-		): PopupHandle => {
-			const handle = popupManager.createPopup(() => message, { type });
+		(message: React.ReactNode | string, options: ToastOptions = {}) => {
+			const {
+				type = NotificationType.Info,
+				delay = 4000,
+				persistent = false,
+			} = options;
 
-			if (duration !== 'persist') {
+			const handle: PopupHandle = popupManager.createPopup(() => message, { type });
+
+			if (!persistent) {
 				try {
-					handle.scheduleDismiss?.(duration);
+					handle.scheduleDismiss?.(delay);
 				} catch {
 					handle.scheduleDismiss?.();
 				}

--- a/packages/app-desktop/gui/hooks/useToastNotifier.ts
+++ b/packages/app-desktop/gui/hooks/useToastNotifier.ts
@@ -9,7 +9,7 @@ export default function useToastNotifier() {
 	return useCallback(
 		(message: React.ReactNode | string, options: ToastOptions = {}) => {
 			const {
-				type = NotificationType.Info,
+				type = NotificationType.Success,
 				delay = 4000,
 				persistent = false,
 			} = options;


### PR DESCRIPTION
**Context**
Currently, the notification system in Joplin often requires creating a custom notification component (e.g., TrashNotification, UpdateNotification) even when the requirement is simply to display a short message. This leads to repetitive code and makes adding simple notifications less efficient.

**Changes**
This PR introduces a reusable useToast hook that provides a generic way to display notifications:
	•	Implemented useToast in packages/app-desktop/gui/hooks/useToast.ts
	•	Refactored TrashNotification to use the new hook, replacing direct popupManager.createPopup calls
	•	The hook supports:
	•	Custom message (React node)
	•	Configurable duration (number | 'persist')
	•	Notification type (Info, Success, etc.)
	•	If duration is provided, the toast automatically dismisses after the timeout.

**Result**
The TrashNotification now works exactly as before but is implemented with the new useToast hook. This paves the way for other notifications to be migrated in the future.

Related Issue: #12732