### PR TITLE
All: Fix #13328 Implement the config check for Joplin Server with SAML enabled

### DIFF
--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -87,10 +87,14 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 
 				// Check if we got an error message
 				if (result.headers.get('Content-Type').includes('application/json')) {
-					const json = await result.json();
+					try {
+						const json = await result.json();
 
-					if (json.error) {
-						message = json.error;
+						if (json.error) {
+							message = json.error;
+						}
+					} catch (e) {
+						message = 'Not a valid JSON response';
 					}
 				}
 

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -72,6 +72,35 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 		return false;
 	}
 
+	public static override async checkConfig(fileApi: FileApiOptions) {
+		try {
+			// Simulate a login request
+			const result = await fetch(`${fileApi.path()}/api/saml`);
+
+			if (result.status === 200) { // The server successfully responded, SAML is enabled
+				return {
+					ok: true,
+					errorMessage: '',
+				};
+			} else if (result.status === 403) { // The server responded with a forbidden response, SAML is disabled
+				return {
+					ok: false,
+					errorMessage: _('SAML is not enabled on this server.'),
+				};
+			} else { // Unknown error
+				return {
+					ok: false,
+					errorMessage: _('Failed to connect to the server'),
+				};
+			}
+		} catch (e) {
+			return {
+				ok: false,
+				errorMessage: e.message,
+			};
+		}
+	}
+
 	protected override async initFileApi() {
 		return initFileApi(SyncTargetJoplinServerSAML.id(), this.logger(), {
 			path: () => Setting.value('sync.11.path'),

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -77,20 +77,27 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 			// Simulate a login request
 			const result = await fetch(`${fileApi.path()}/api/saml`);
 
+			// SAML seems to be enabled
 			if (result.status === 200) { // The server successfully responded, SAML is enabled
 				return {
 					ok: true,
 					errorMessage: '',
 				};
-			} else if (result.status === 403) { // The server responded with a forbidden response, SAML is disabled
+			} else { // SAML is disabled or an error occurred
+				let message = result.statusText;
+
+				// Check if we got an error message
+				if (result.headers.get('Content-Type').includes('application/json')) {
+					const json = await result.json();
+
+					if (json.error) {
+						message = json.error;
+					}
+				}
+
 				return {
 					ok: false,
-					errorMessage: _('SAML is not enabled on this server.'),
-				};
-			} else { // Unknown error
-				return {
-					ok: false,
-					errorMessage: _('Failed to connect to the server'),
+					errorMessage: `Could not connect to server: Error ${result.status}: ${message}`,
 				};
 			}
 		} catch (e) {

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -77,7 +77,6 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 			// Simulate a login request
 			const result = await fetch(`${fileApi.path()}/api/saml`);
 
-			// SAML seems to be enabled
 			if (result.status === 200) { // The server successfully responded, SAML is enabled
 				return {
 					ok: true,

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -83,19 +83,18 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 					errorMessage: '',
 				};
 			} else { // SAML is disabled or an error occurred
-				let message = result.statusText;
+				const text = await result.text();
+				let message = text; // Use the textual body as the default message
 
 				// Check if we got an error message
 				if (result.headers.get('Content-Type').includes('application/json')) {
 					try {
-						const json = await result.json();
+						const json = JSON.parse(text);
 
 						if (json.error) {
 							message = json.error;
 						}
-					} catch (e) {
-						message = 'Not a valid JSON response';
-					}
+					} catch (_e) {} // eslint-disable-line no-empty -- Keep the plain text response as the error message, ignore the parsing exception
 				}
 
 				return {


### PR DESCRIPTION
This PR fixes #13328 by implementing a proper config check for SAML users.

The check simply verifies that fetching `/api/saml` returns a 200 HTTP status code by faking a login request, since if SAML is disabled by the server administrator a 403 error code is returned instead.