### PR TITLE
Chore: Trying to migrate to macOS 15 on CI

### DIFF
--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Do not use unbuntu-latest because it causes `The operation was canceled` failures:
         # https://github.com/actions/runner-images/issues/6709
-        os: [macos-13, ubuntu-22.04, windows-2025, ubuntu-22.04-arm]
+        os: [macos-15-intel, ubuntu-22.04, windows-2025, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
macOS 13 image is deprecated. Since on this action we only build the Intel image, we should be able to migrate to the `macos-15-intel` image

* * *

The macOS 13 runner image will be retired by December 4th, 2025. To raise awareness of the upcoming removal, jobs using macOS 13 will temporarily fail during the scheduled brownout time periods defined below:

    November 4, 14:00 UTC - November 5, 00:00 UTC
    November 11, 14:00 UTC - November 12, 00:00 UTC
    November 18, 14:00 UTC - November 19, 00:00 UTC
    November 25, 14:00 UTC - November 26, 00:00 UTC

This deprecation includes the following labels:

    macos-13
    macos-13-large
    macos-13-xlarge

What you need to do
(Recommended) If your workflow is architecture agnostic, you can migrate to any of our arm64 labels:

    macos-15 or macos-latest
    macos-14
    macos-14-xlarge
    macos-latest-xlarge or macos-15-xlarge

For users that require the x86_64 (Intel) architecture, jobs can be migrated to one of the following labels:

    macos-15-intel (new)
    macos-14-large
    macos-latest-large or macos-15-large

You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=500bf75e7e794b73b89c2e3750c78c35&elq=9bad99ed2156469b8119250a9820fe52&elqaid=4685&elqat=1&elqak=8AF5FA1A2064F14B0FEBF83A9BFBF1C15AFCE38C69B46EC76C53BF84DFF3EFEC53E0). Please contact [GitHub Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=fb60ba11ba7c4951815e3ab69913b8b7&elq=9bad99ed2156469b8119250a9820fe52&elqaid=4685&elqat=1&elqak=8AF52094A179B394295FA0AE7A60B0CDFDEEE38C69B46EC76C53BF84DFF3EFEC53E0) if you run into any problems or need help.