### PR TITLE
Desktop: Fixes #13267: Fixed image load failure when path contains '#' (#13267)

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -27,6 +27,7 @@ const toRelative = require('relative');
 const timers = require('timers');
 const zlib = require('zlib');
 const dgram = require('dgram');
+const { toFileProtocolPath } = require('./path-utils');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const proxySettings: any = {};
@@ -236,7 +237,7 @@ function shimInit(options: ShimInitOptions = null) {
 			// original code).
 
 			const image = new Image();
-			image.src = filePath;
+			image.src = toFileProtocolPath(filePath);
 			await new Promise<void>((resolve, reject) => {
 				image.onload = () => resolve();
 				image.onerror = () => reject(new Error(`Image at ${filePath} failed to load.`));

--- a/packages/utils/path.ts
+++ b/packages/utils/path.ts
@@ -1,4 +1,5 @@
 /* eslint no-useless-escape: 0*/
+import { pathToFileURL } from 'url';
 
 export function dirname(path: string) {
 	if (!path) throw new Error('Path is empty');
@@ -59,17 +60,10 @@ export function safeFilename(e: string, maxLength: number|null = null, allowSpac
 	return output.substring(0, maxLength);
 }
 
-export function toFileProtocolPath(filePathEncode: string, os: string|null = null) {
-	if (os === null) os = process.platform;
-
-	if (os === 'win32') {
-		filePathEncode = filePathEncode.replace(/\\/g, '/'); // replace backslash in windows pathname with slash e.g. c:\temp to c:/temp
-		filePathEncode = `/${filePathEncode}`; // put slash in front of path to comply with windows fileURL syntax
-	}
-
-	filePathEncode = encodeURI(filePathEncode);
-	filePathEncode = filePathEncode.replace(/\+/g, '%2B'); // escape '+' with unicode
-	return `file://${filePathEncode.replace(/\'/g, '%27')}`; // escape '(single quote) with unicode, to prevent crashing the html view
+export function toFileProtocolPath(filePathEncode: string) {
+	// pathToFileURL normalizes slashes and percent-encodes reserved chars (#, ?, [, ])
+	// and returns a proper file:// URL (with the right number of leading slashes on Windowns and Mac).
+	return pathToFileURL(filePathEncode).href;
 }
 
 export function toSystemSlashes(path: string, os: string|null = null) {


### PR DESCRIPTION
### Description

This pull request fixes [#13267](https://github.com/laurent22/joplin/issues/13267), where images fail to load if the file path includes a # character.

### Cause:
In shim-init-node.ts, the Image.src property was assigned directly from a raw file path. When a path includes #, the browser/Electron interprets it as a URL fragment, resulting in a “failed to load” error.

### Fix:
Updated toFileProtocolPath in path.ts to use Node’s built-in pathToFileURL() helper instead of manual encoding.
Replaced the direct path assignment in shim-init-node.ts with a call to toFileProtocolPath.

pathToFileURL() automatically normalizes slashes and percent-encodes reserved characters (#, ?, [, ]), producing a valid file:// URL across Windows and macOS.

### Result:
Images now load correctly when dragged or attached from folders containing # in their names.

https://github.com/user-attachments/assets/506d8331-be8d-4fd5-beca-3fb586c5c30f

