### PR TITLE
Desktop: Fixes #13267: Fixed image load failure when path contains '#' (13267)

### DIFF
--- a/packages/lib/shim-init-node.ts
+++ b/packages/lib/shim-init-node.ts
@@ -18,6 +18,7 @@ import * as mimeUtils from './mime-utils';
 import BaseItem from './models/BaseItem';
 import { Size } from '@joplin/utils/types';
 import { cpus } from 'os';
+import { pathToFileURL } from 'url';
 import type PdfJs from './utils/types/pdfJs';
 const { _ } = require('./locale');
 const http = require('http');
@@ -236,7 +237,7 @@ function shimInit(options: ShimInitOptions = null) {
 			// original code).
 
 			const image = new Image();
-			image.src = filePath;
+			image.src = pathToFileURL(filePath).href;
 			await new Promise<void>((resolve, reject) => {
 				image.onload = () => resolve();
 				image.onerror = () => reject(new Error(`Image at ${filePath} failed to load.`));


### PR DESCRIPTION
### Description

This pull request fixes [#13267](https://github.com/laurent22/joplin/issues/13267), where images failed to load if their file path contained the # character.

### Problem
When dragging an image from a folder whose name includes #, the app displayed an error such as:
Image at /Users/Example/Pictures/foo#bar/image.png failed to load.

This happened because the Image.src property in shim-init-node.ts was assigned a raw file system path.
Electron’s Image element treated # as a URL fragment, causing the load failure.

### Fix
Updated packages/lib/shim-init-node.ts to use Node’s built-in pathToFileURL() when assigning Image.src.

pathToFileURL() correctly normalizes slashes and percent-encodes reserved characters (#, ?, [, ]), preventing them from being misinterpreted as URL fragments.

### Result
Images now load correctly when their file path or parent folder contains #, both works on my macOS and Windows.

https://github.com/user-attachments/assets/fb004e26-82e9-4856-bc98-68b4894f05fb
