### PR TITLE
Added instructions for setting sync target to dropbox.md

### DIFF
--- a/readme/apps/sync/dropbox.md
+++ b/readme/apps/sync/dropbox.md
@@ -4,4 +4,4 @@ When syncing with Dropbox, Joplin creates a sub-directory in Dropbox, in `/Apps/
 
 In the **desktop application** or **mobile application**, select "Dropbox" as the synchronisation target in the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md) (it is selected by default). Then, to initiate the synchronisation process, click on the "Synchronise" button in the sidebar and follow the instructions.
 
-In the **terminal application**, to initiate the synchronisation process, type `:sync`. You will be asked to follow a link to authorise the application.
+In the **terminal application**, set the `sync.target` config variable with `:config sync.target N`, where "N" is the corresponding number. To get a list of each number and its corresponding application, type `:config sync.target`. After setting the sync target, initiate the synchronisation process by typing `:sync`. You will be asked to follow a link to authorise the application.


### PR DESCRIPTION
A description of how to set the config variable sync.target has been added as this step is necessary for setting up sync in the terminal application. This information was already included on the pages explaining other sync methods, but was not included for Dropbox.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->