### PR TITLE
Server: Fixes #13400: Fix password fields are always disabled

### DIFF
--- a/packages/server/src/routes/index/users.ts
+++ b/packages/server/src/routes/index/users.ts
@@ -107,7 +107,7 @@ router.get('users/:id', async (path: SubPath, ctx: AppContext, formUser: User = 
 	view.content.hasFlags = !!userFlagViews.length;
 	view.content.userFlagViews = userFlagViews;
 	view.content.stripePortalUrl = stripePortalUrl();
-	view.content.isUsingExternalAuth = isUsingExternalAuth(config());
+	view.content.disabledIfExternalAuth = isUsingExternalAuth(config()) ? 'disabled' : '';
 
 	view.jsFiles.push('zxcvbn');
 	view.cssFiles.push('index/user');

--- a/packages/server/src/views/index/user.mustache
+++ b/packages/server/src/views/index/user.mustache
@@ -10,20 +10,20 @@
 		<div class="field">
 			<label class="label">Full name</label>
 			<div class="control">
-				<input disabled="{{isUsingExternalAuth}}" class="input" type="text" name="full_name" value="{{user.full_name}}"/>
+				<input {{disabledIfExternalAuth}} class="input" type="text" name="full_name" value="{{user.full_name}}"/>
 			</div>
 		</div>
 		<div class="field">
 			<label class="label">Email</label>
 			<div class="control">
-				<input disabled="{{isUsingExternalAuth}}" class="input" type="email" name="email" value="{{user.email}}"/>
+				<input {{disabledIfExternalAuth}} class="input" type="email" name="email" value="{{user.email}}"/>
 			</div>
 		</div>
 
 		<div class="field">
 			<label class="label">Password</label>
 			<div class="control">
-				<input disabled="{{isUsingExternalAuth}}" id="password" class="input" type="password" name="password" autocomplete="new-password"/>
+				<input {{disabledIfExternalAuth}} id="password" class="input" type="password" name="password" autocomplete="new-password"/>
 			</div>
 			<p id="password_strength" class="help"></p>
 		</div>
@@ -31,7 +31,7 @@
 		<div class="field">
 			<label class="label">Repeat password</label>
 			<div class="control">
-				<input disabled="{{isUsingExternalAuth}}" class="input" type="password" name="password2" autocomplete="new-password"/>
+				<input {{disabledIfExternalAuth}} class="input" type="password" name="password2" autocomplete="new-password"/>
 			</div>
 		</div>
 


### PR DESCRIPTION
# Summary

With cd5bb575c8bcd0d13ee33e1d947026788ae40487, the fields on the "Your profile" screen have `disabled="true"` in certain cases. However, when these fields should be editable, they are assigned `disabled="false"`. Confusingly, [setting disabled="false" disables HTML inputs](https://stackoverflow.com/a/32745315).

This pull request updates the `user.mustache` template to only include the `disabled` attribute when inputs should be disabled.

Fixes #13400.

# Testing plan

1. Start Joplin Server with `yarn start-dev`.
2. Open the "Your profile" screen for the admin account.
3. Change the password.
4. Replace `isUsingExternalAuth(config())` with `true` in `index/routes/users.ts`. Fix the "unused import" build error and recompile.
5. Restart Joplin Server.
6. Verify that the inputs on the "Your profile" screen are disabled.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->