### PR TITLE
Desktop: OneNote importer: Simplify reporting import issues to the forum

### DIFF
--- a/packages/onenote-converter/src/lib.rs
+++ b/packages/onenote-converter/src/lib.rs
@@ -3,7 +3,7 @@ use color_eyre::eyre::{eyre, Result};
 use std::panic;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
-use crate::utils::{fs_driver, get_current_page, utils::log};
+use crate::utils::{fs_driver, get_current_page, set_current_page, utils::log};
 
 mod notebook;
 mod page;
@@ -19,6 +19,7 @@ extern crate web_sys;
 #[allow(non_snake_case)]
 pub fn oneNoteConverter(input: &str, output: &str, base_path: &str) -> Result<(), JsError> {
     panic::set_hook(Box::new(console_error_panic_hook::hook));
+    set_current_page("[None]".into());
 
     if let Err(e) = _main(input, output, base_path) {
         let message = format!("Error: {:?} (near page {})", e, get_current_page());

--- a/packages/onenote-converter/src/lib.rs
+++ b/packages/onenote-converter/src/lib.rs
@@ -1,9 +1,9 @@
 pub use crate::parser::Parser;
 use color_eyre::eyre::{eyre, Result};
 use std::panic;
-use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
-use crate::utils::{fs_driver, utils::{log, log_warn}};
+use crate::utils::{fs_driver, get_current_page, utils::log};
 
 mod notebook;
 mod page;
@@ -17,11 +17,14 @@ extern crate web_sys;
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
-pub fn oneNoteConverter(input: &str, output: &str, base_path: &str) {
+pub fn oneNoteConverter(input: &str, output: &str, base_path: &str) -> Result<(), JsError> {
     panic::set_hook(Box::new(console_error_panic_hook::hook));
 
     if let Err(e) = _main(input, output, base_path) {
-        log_warn!("{:?}", e);
+        let message = format!("Error: {:?} (near page {})", e, get_current_page());
+        Err(JsError::new(&message))
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Summary

This change simplifies reporting OneNote import issues. Previously, no feedback was shown when the importer failed to process a OneNote file. With this change, the "Please consider sending a bug report to the forum" dialog is also shown for OneNote imports.

# Testing plan

On MacOS 26.0.1:
1. Download [OneWithFileData.one](https://github.com/OfficeDev/Interop-TestSuites/blob/master/FileSyncandWOPI/Setup/SUT/OneWithFileData.one) (a `.one` file in an unsupported format).
2. Create a new `.zip` file containing `OneWithFileData.one`.
3. Import the `.zip` file using Joplin's File > Import > "ZIP - OneNote notebook".
4. Verify that the import failure dialog is shown.
5. Click "Send bug report".
6. Verify that the "Send bug report" button links to the Joplin forum, with a pre-filled support request template.
7. Dismiss the "Send bug report" dialog.
8. Import the [corrupted_attachment.zip](https://github.com/laurent22/joplin/blob/dev/packages/app-cli/tests/support/onenote/corrupted_attachment.zip) test OneNote file.
9. Verify that the import process completes successfully (without showing the "Send bug report" dialog).
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->