### PR TITLE
Chore: `shim.mobilePlatform`: Use a stronger return type 

### DIFF
--- a/packages/app-cli/tests/services/plugins/PluginService.ts
+++ b/packages/app-cli/tests/services/plugins/PluginService.ts
@@ -2,7 +2,7 @@ import PluginRunner from '../../../app/services/plugins/PluginRunner';
 import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
 import MdToHtml from '@joplin/renderer/MdToHtml';
-import shim from '@joplin/lib/shim';
+import shim, { MobilePlatform } from '@joplin/lib/shim';
 import Setting from '@joplin/lib/models/Setting';
 import * as fs from 'fs-extra';
 import Note from '@joplin/lib/models/Note';
@@ -310,7 +310,7 @@ describe('services_PluginService', () => {
 
 		let resetPlatformMock = () => {};
 		if (!isDesktop) {
-			resetPlatformMock = mockMobilePlatform('android').reset;
+			resetPlatformMock = mockMobilePlatform(MobilePlatform.Android).reset;
 		}
 
 		try {

--- a/packages/app-mobile/components/FeedbackBanner.test.tsx
+++ b/packages/app-mobile/components/FeedbackBanner.test.tsx
@@ -7,6 +7,7 @@ import createMockReduxStore from '../utils/testing/createMockReduxStore';
 import setupGlobalStore from '../utils/testing/setupGlobalStore';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import FeedbackBanner from './FeedbackBanner';
+import { MobilePlatform } from '@joplin/lib/shim';
 
 interface WrapperProps { }
 
@@ -84,7 +85,7 @@ describe('FeedbackBanner', () => {
 		setupGlobalStore(store);
 
 		jest.useFakeTimers({ advanceTimers: true });
-		mockMobilePlatform('web');
+		mockMobilePlatform(MobilePlatform.Web);
 	});
 
 	afterEach(() => {
@@ -93,9 +94,9 @@ describe('FeedbackBanner', () => {
 	});
 
 	test.each([
-		{ platform: 'android', shouldShow: false },
-		{ platform: 'web', shouldShow: true },
-		{ platform: 'ios', shouldShow: false },
+		{ platform: MobilePlatform.Android, shouldShow: false },
+		{ platform: MobilePlatform.Web, shouldShow: true },
+		{ platform: MobilePlatform.Ios, shouldShow: false },
 	])('should correctly show/hide the feedback banner on %s', ({ platform, shouldShow }) => {
 		mockMobilePlatform(platform);
 

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.installed.test.tsx
@@ -6,7 +6,7 @@ import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../../
 import PluginService, { PluginSettings, defaultPluginSetting } from '@joplin/lib/services/plugins/PluginService';
 import { writeFile } from 'fs-extra';
 import { join } from 'path';
-import shim from '@joplin/lib/shim';
+import shim, { MobilePlatform } from '@joplin/lib/shim';
 import { resetRepoApi } from './utils/useRepoApi';
 import { Store } from 'redux';
 import { AppState } from '../../../../utils/types';
@@ -59,7 +59,7 @@ describe('PluginStates.installed', () => {
 		mockPluginServiceSetup(reduxStore);
 		resetRepoApi();
 
-		await mockMobilePlatform('android');
+		await mockMobilePlatform(MobilePlatform.Android);
 		await mockRepositoryApiConstructor();
 
 		// Fake timers are necessary to prevent a warning.
@@ -73,8 +73,8 @@ describe('PluginStates.installed', () => {
 	});
 
 	it.each([
-		'android',
-		'ios',
+		MobilePlatform.Android,
+		MobilePlatform.Ios,
 	])('should not allow updating a plugin that is not recommended on iOS, but should on Android (on %s)', async (platform) => {
 		await mockMobilePlatform(platform);
 		expect(shim.mobilePlatform()).toBe(platform);

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginStates.search.test.tsx
@@ -10,6 +10,7 @@ import { Store } from 'redux';
 import mockRepositoryApiConstructor from './testUtils/mockRepositoryApiConstructor';
 import { resetRepoApi } from './utils/useRepoApi';
 import mockPluginServiceSetup from '../../../../utils/testing/mockPluginServiceSetup';
+import { MobilePlatform } from '@joplin/lib/shim';
 
 const expectSearchResultCountToBe = async (count: number) => {
 	await waitFor(() => {
@@ -38,7 +39,7 @@ describe('PluginStates.search', () => {
 		await switchClient(0);
 		reduxStore = createMockReduxStore();
 		mockPluginServiceSetup(reduxStore);
-		mockMobilePlatform('android');
+		mockMobilePlatform(MobilePlatform.Android);
 		resetRepoApi();
 
 		await mockRepositoryApiConstructor();
@@ -70,7 +71,7 @@ describe('PluginStates.search', () => {
 
 	it('should only show recommended plugin search results on iOS-like environments', async () => {
 		// iOS uses restricted install mode
-		mockMobilePlatform('ios');
+		mockMobilePlatform(MobilePlatform.Ios);
 		await mockRepositoryApiConstructor();
 
 		const wrapper = render(<WrappedPluginStates initialPluginSettings={{}} store={reduxStore}/>);

--- a/packages/app-mobile/utils/shim-init-react/index.ts
+++ b/packages/app-mobile/utils/shim-init-react/index.ts
@@ -1,6 +1,6 @@
 import shimInitShared from './shimInitShared';
 
-import shim from '@joplin/lib/shim';
+import shim, { MobilePlatform } from '@joplin/lib/shim';
 const { GeolocationReact } = require('../geolocation-react.js');
 import RNFetchBlob from 'rn-fetch-blob';
 import { generateSecureRandom } from 'react-native-securerandom';
@@ -165,7 +165,7 @@ export default function shimInit() {
 	};
 
 	shim.mobilePlatform = () => {
-		return Platform.OS;
+		return Platform.OS as MobilePlatform;
 	};
 
 	shim.isAppleSilicon = () => {

--- a/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
+++ b/packages/app-mobile/utils/shim-init-react/shimInitShared.ts
@@ -9,7 +9,7 @@ import * as mimeUtils from '@joplin/lib/mime-utils';
 import Resource from '@joplin/lib/models/Resource';
 import { getLocales } from 'react-native-localize';
 import type Setting from '@joplin/lib/models/Setting';
-import shim from '@joplin/lib/shim';
+import shim, { MobilePlatform } from '@joplin/lib/shim';
 import { closestSupportedLocale, defaultLocale, setLocale } from '@joplin/lib/locale';
 
 const shimInitShared = () => {
@@ -76,7 +76,7 @@ const shimInitShared = () => {
 	};
 
 	shim.mobilePlatform = () => {
-		return Platform.OS;
+		return Platform.OS as MobilePlatform;
 	};
 
 	shim.platformArch = () => {

--- a/packages/lib/shim.ts
+++ b/packages/lib/shim.ts
@@ -54,6 +54,13 @@ export interface ShowMessageBoxOptions {
 	cancelId?: number;
 }
 
+export enum MobilePlatform {
+	None = '',
+	Android = 'android',
+	Ios = 'ios',
+	Web = 'web',
+}
+
 let isTestingEnv_ = false;
 
 // We need to ensure that there's only one instance of React being used by all
@@ -190,8 +197,8 @@ const shim = {
 	},
 
 	// "ios" or "android", or "" if not on mobile
-	mobilePlatform: () => {
-		return ''; // Default if we're not on mobile (React Native)
+	mobilePlatform: (): MobilePlatform => {
+		return MobilePlatform.None; // Default if we're not on mobile (React Native)
 	},
 
 	// https://github.com/cheton/is-electron

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -6,7 +6,7 @@ import Setting, { AppType, Env } from '../models/Setting';
 import BaseService from '../services/BaseService';
 import FsDriverNode from '../fs-driver-node';
 import time from '../time';
-import shim from '../shim';
+import shim, { MobilePlatform } from '../shim';
 import uuid from '../uuid';
 import ResourceService from '../services/ResourceService';
 import KeymapService from '../services/KeymapService';
@@ -1119,7 +1119,7 @@ export const newOcrService = () => {
 	return new OcrService([driver]);
 };
 
-export const mockMobilePlatform = (platform: string) => {
+export const mockMobilePlatform = (platform: MobilePlatform) => {
 	const originalMobilePlatform = shim.mobilePlatform;
 	const originalIsNode = shim.isNode;
 


### PR DESCRIPTION
# Summary

This pull request updates `shim.mobilePlatform`'s return type to a `MobilePlatform` enum value, rather than a string. With this change, TypeScript marks `shim.mobilePlatform() === 'typo here'` as an error.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->