### PR TITLE
Chore: Transcribe: Make logic for starting transcription workers safer

### DIFF
--- a/packages/transcribe/src/core/HtrCli.ts
+++ b/packages/transcribe/src/core/HtrCli.ts
@@ -1,5 +1,5 @@
 import Logger from '@joplin/utils/Logger';
-import { execCommand } from '@joplin/utils';
+import { commandToString, execCommand } from '@joplin/utils';
 import { WorkHandler } from '../types';
 
 const logger = Logger.create('HtrCli');
@@ -16,15 +16,15 @@ export default class HtrCli implements WorkHandler {
 
 	public async init() {
 		logger.info('Loading');
-		const result = await execCommand(`docker pull ${this.htrCliDockerImage}`, { quiet: true });
+		const result = await execCommand(['docker', 'pull', this.htrCliDockerImage], { quiet: true });
 		logger.info('Finished loading: ', result);
 	}
 
 	public async run(imageName: string) {
-		const command = `docker run --rm -t -v "${this.htrCliImagesFolder}:/images" ${this.htrCliDockerImage} ${imageName}`;
+		const command = ['docker', 'run', '--rm', '-t', '-v', `${this.htrCliImagesFolder}:/images`, this.htrCliDockerImage, imageName];
 
 		logger.info('Running transcription...');
-		logger.info(`Command: ${command}`);
+		logger.info(`Command: ${commandToString(command[0], command.slice(1))}`);
 		const result = await execCommand(command, { quiet: true });
 
 		logger.info('Finished transcription');


### PR DESCRIPTION
# Summary

This pull request updates `HtrCli.ts` to use a safer pattern for executing commands. This should help prevent command execution if the transcription server is refactored in the future such that `imageName` or other command inputs are no longer trusted.

# Testing

Prior to rebasing on the latest `dev`, I verified that `yarn test` completes successfully when run from the `packages/transcribe` directory with `TRANSCRIBE_RUN_ALL` set to `1`.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->