### PR TITLE
API: Add a delete revisions for note API

### DIFF
--- a/packages/app-cli/app/command-apidoc.ts
+++ b/packages/app-cli/app/command-apidoc.ts
@@ -402,7 +402,17 @@ async function fetchAllNotes() {
 				lines.push('');
 			}
 
-			if (model.type === BaseModel.TYPE_NOTE || model.type === BaseModel.TYPE_FOLDER) {
+			if (model.type === BaseModel.TYPE_NOTE) {
+				lines.push(`By default, the ${singular} will be moved **to the trash**. To permanently delete it, add the query parameter \`permanent=1\``);
+				lines.push('');
+
+				lines.push('### DELETE /notes/:id/revisions');
+				lines.push('');
+				lines.push('Deletes all the revisions attached to this note.');
+				lines.push('');
+			}
+
+			if (model.type === BaseModel.TYPE_FOLDER) {
 				lines.push(`By default, the ${singular} will be moved **to the trash**. To permanently delete it, add the query parameter \`permanent=1\``);
 				lines.push('');
 			}

--- a/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
+++ b/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
@@ -1,7 +1,5 @@
 import { _ } from '../../../locale';
-import ItemChange from '../../../models/ItemChange';
 import Revision from '../../../models/Revision';
-import RevisionService from '../../../services/RevisionService';
 import shim, { MessageBoxType } from '../../../shim';
 const { useCallback } = shim.react();
 
@@ -25,12 +23,7 @@ const useDeleteHistoryClick = ({
 		if (response === 0) {
 			setDeleting(true);
 			try {
-				// Ensure that if the user explicitly deletes all revisions for a note, any new revisions created upon revision collection do not include
-				// contents which were present prior to triggering the deletion
-				await Revision.deleteHistoryForNote(noteId, { sourceDescription: 'useDeleteHistoryClick' });
-				await ItemChange.updateOldNoteContent(noteId, null);
-				RevisionService.instance().removeChangedSinceCollection(noteId);
-
+				await Revision.deleteHistoryForNote(noteId, { sourceDescription: 'useDeleteHistoryClick' }, true);
 				await shim.showMessageBox(_('Note history has been deleted.'), { type: MessageBoxType.Info });
 			} finally {
 				setDeleting(false);

--- a/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
+++ b/packages/lib/components/shared/NoteRevisionViewer/useDeleteHistoryClick.ts
@@ -23,7 +23,7 @@ const useDeleteHistoryClick = ({
 		if (response === 0) {
 			setDeleting(true);
 			try {
-				await Revision.deleteHistoryForNote(noteId, { sourceDescription: 'useDeleteHistoryClick' }, true);
+				await Revision.deleteHistoryForNote(noteId, { sourceDescription: 'useDeleteHistoryClick' });
 				await shim.showMessageBox(_('Note history has been deleted.'), { type: MessageBoxType.Info });
 			} finally {
 				setDeleting(false);

--- a/packages/lib/models/ItemChange.ts
+++ b/packages/lib/models/ItemChange.ts
@@ -150,22 +150,28 @@ export default class ItemChange extends BaseModel {
 		`, [changeId, options.limit]);
 	}
 
-	public static async oldNoteContent(noteId: string): Promise<string> {
-		const row = await this.db().selectOne(`
-			SELECT before_change_item
+	public static async itemChange(itemType: ModelType, itemId: string): Promise<ItemChangeEntity> {
+		return await this.db().selectOne(`
+			SELECT item_type, item_id, type, source, created_time, before_change_item
 			FROM item_changes
 			WHERE item_type = ? AND item_id = ?
 			ORDER BY created_time DESC
 			LIMIT 1
-		`, [ModelType.Note, noteId]);
-		return row && row.before_change_item ? row.before_change_item : null;
+		`, [itemType, itemId]);
 	}
 
-	public static async updateOldNoteContent(noteId: string, beforeChangeItemJson: string) {
-		const beforeChangeItem = beforeChangeItemJson ? beforeChangeItemJson : '';
-		return this.db().exec(`
-			UPDATE item_changes SET before_change_item = ? WHERE item_type = ? AND item_id = ?
-		`, [beforeChangeItem, ModelType.Note, noteId]);
+	public static async oldNoteContent(noteId: string): Promise<string> {
+		const itemChange = await this.itemChange(ModelType.Note, noteId);
+		return itemChange && itemChange.before_change_item ? itemChange.before_change_item : null;
+	}
+
+	public static async resetOldNoteContent(noteId: string) {
+		const itemChange = await this.itemChange(ModelType.Note, noteId);
+
+		// Only create a new item change if there is an existing item change and it has the before_change_item populated on it
+		if (itemChange && itemChange.before_change_item) {
+			await this.add(itemChange.item_type, itemChange.item_id, itemChange.type);
+		}
 	}
 
 }

--- a/packages/lib/models/Revision.ts
+++ b/packages/lib/models/Revision.ts
@@ -376,7 +376,7 @@ export default class Revision extends BaseItem {
 		}
 	}
 
-	public static async deleteHistoryForNote(noteIds: string | string[], options: DeleteOptions, resetItemChanges = false) {
+	public static async deleteHistoryForNote(noteIds: string | string[], options: DeleteOptions) {
 		const ids = Array.isArray(noteIds) ? noteIds : [noteIds];
 
 		const revisions: RevisionEntity[] = await this.modelSelectAll(
@@ -386,13 +386,11 @@ export default class Revision extends BaseItem {
 
 		await this.batchDelete(revisions.map(item => item.id), options);
 
-		if (resetItemChanges) {
-			// This ensures that any new revisions created upon revision collection do not include contents which were present prior to
-			// triggering the deletion
-			for (const noteId of ids) {
-				await ItemChange.updateOldNoteContent(noteId, null);
-				RevisionService.instance().removeChangedSinceCollection(noteId);
-			}
+		// Clear any cached content in the item_changes table and reset the state of the note in the revision service, to ensure that any new revisions created
+		// upon revision collection do not include contents which were present prior to triggering the deletion
+		for (const noteId of ids) {
+			await ItemChange.resetOldNoteContent(noteId);
+			RevisionService.instance().removeChangedSinceCollection(noteId);
 		}
 	}
 

--- a/packages/lib/models/Revision.ts
+++ b/packages/lib/models/Revision.ts
@@ -5,6 +5,8 @@ const DiffMatchPatch = require('diff-match-patch');
 import * as ArrayUtils from '../ArrayUtils';
 import JoplinError from '../JoplinError';
 import time from '../time';
+import ItemChange from './ItemChange';
+import RevisionService from '../services/RevisionService';
 const { sprintf } = require('sprintf-js');
 
 const dmp = new DiffMatchPatch();
@@ -374,7 +376,7 @@ export default class Revision extends BaseItem {
 		}
 	}
 
-	public static async deleteHistoryForNote(noteIds: string | string[], options: DeleteOptions) {
+	public static async deleteHistoryForNote(noteIds: string | string[], options: DeleteOptions, resetItemChanges = false) {
 		const ids = Array.isArray(noteIds) ? noteIds : [noteIds];
 
 		const revisions: RevisionEntity[] = await this.modelSelectAll(
@@ -383,6 +385,15 @@ export default class Revision extends BaseItem {
 		);
 
 		await this.batchDelete(revisions.map(item => item.id), options);
+
+		if (resetItemChanges) {
+			// This ensures that any new revisions created upon revision collection do not include contents which were present prior to
+			// triggering the deletion
+			for (const noteId of ids) {
+				await ItemChange.updateOldNoteContent(noteId, null);
+				RevisionService.instance().removeChangedSinceCollection(noteId);
+			}
+		}
 	}
 
 	public static async revisionExists(itemType: ModelType, itemId: string, updatedTime: number) {

--- a/packages/lib/services/rest/routes/notes.test.ts
+++ b/packages/lib/services/rest/routes/notes.test.ts
@@ -7,6 +7,8 @@ import Resource from '../../../models/Resource';
 import Api, { RequestMethod } from '../Api';
 import Note from '../../../models/Note';
 import { setupDatabase, switchClient } from '../../../testing/test-utils';
+import Revision from '../../../models/Revision';
+import { ModelType } from '../../../BaseModel';
 const md5 = require('md5');
 
 const imagePath = `${__dirname}/../../../images/SideMenuHeader.png`;
@@ -218,6 +220,15 @@ describe('routes/notes', () => {
 			const notes = await api.route(RequestMethod.GET, 'notes', { include_conflicts: '1' });
 			expect(notes.items.length).toBe(2);
 		}
+	});
+
+	test('should be able to delete revisions for a note', async () => {
+		const api = new Api();
+		const note = await Note.save({});
+		const revision = await Revision.save({ item_id: note.id, item_type: ModelType.Note, item_updated_time: note.updated_time });
+		await api.route(RequestMethod.DELETE, `notes/${note.id}/revisions`);
+
+		expect(await Revision.load(revision.id)).toBeFalsy();
 	});
 
 });

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -30,6 +30,7 @@ import { fileUriToPath } from '@joplin/utils/url';
 import { NoteEntity, ResourceEntity } from '../../database/types';
 import { DownloadController } from '../../../downloadController';
 import { FetchBlobOptions } from '../../../types';
+import Revision from '../../../models/Revision';
 
 const logger = Logger.create('routes/notes');
 
@@ -558,6 +559,13 @@ export default async function(request: Request, id: string = null, link: string 
 	}
 
 	if (request.method === RequestMethod.DELETE) {
+		if (link && link === 'revisions') {
+			await Revision.deleteHistoryForNote(id, { sourceDescription: 'api/notes/revisions DELETE' }, true);
+			return;
+		} else if (link) {
+			throw new ErrorNotFound();
+		}
+
 		await Note.delete(id, { toTrash: request.query.permanent !== '1', sourceDescription: 'api/notes DELETE' });
 		return;
 	}

--- a/packages/lib/services/rest/routes/notes.ts
+++ b/packages/lib/services/rest/routes/notes.ts
@@ -560,7 +560,7 @@ export default async function(request: Request, id: string = null, link: string 
 
 	if (request.method === RequestMethod.DELETE) {
 		if (link && link === 'revisions') {
-			await Revision.deleteHistoryForNote(id, { sourceDescription: 'api/notes/revisions DELETE' }, true);
+			await Revision.deleteHistoryForNote(id, { sourceDescription: 'api/notes/revisions DELETE' });
 			return;
 		} else if (link) {
 			throw new ErrorNotFound();

--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -270,6 +270,10 @@ Deletes the note with ID :id
 
 By default, the note will be moved **to the trash**. To permanently delete it, add the query parameter `permanent=1`
 
+### DELETE /notes/:id/revisions
+
+Deletes all the revisions attached to this note.
+
 ## Folders
 
 This is actually a notebook. Internally notebooks are called "folders".

--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -270,10 +270,6 @@ Deletes the note with ID :id
 
 By default, the note will be moved **to the trash**. To permanently delete it, add the query parameter `permanent=1`
 
-### DELETE /notes/:id/revisions
-
-Deletes all the revisions attached to this note.
-
 ## Folders
 
 This is actually a notebook. Internally notebooks are called "folders".


### PR DESCRIPTION
As per https://discourse.joplinapp.org/t/request-for-changes-in-revisions-data-api/47526 this PR implements the following API endpoint:

DELETE /notes/:id/revisions
Deletes all the revisions attached to this note

This facilities removing references to unencrypted data, including any data stored in the item_changes table (which may be used to create a revision containing old contents, when the revision collection is executed), which can be used by note encryption plugins