### PR TITLE
Desktop: Fixes #13411: Fix header links only work if the note viewer is visible

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -270,6 +270,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.js
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.js
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -167,9 +167,8 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			},
 			scrollTo: (options: ScrollOptions) => {
 				if (options.type === ScrollOptionTypes.Hash) {
-					if (!webviewRef.current) return;
 					const hash: string = options.value;
-					webviewRef.current.send('scrollToHash', hash);
+					webviewRef.current?.send('scrollToHash', hash);
 					editorRef.current.jumpToHash(hash);
 				} else if (options.type === ScrollOptionTypes.Percent) {
 					const percent = options.value as number;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -31,6 +31,7 @@ import CommandService from '@joplin/lib/services/CommandService';
 import useRefocusOnVisiblePaneChange from './utils/useRefocusOnVisiblePaneChange';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
 import eventManager, { EventName, ResourceChangeEvent } from '@joplin/lib/eventManager';
+import useSyncEditorValue from './utils/useSyncEditorValue';
 
 const logger = Logger.create('CodeMirror6');
 const logDebug = (message: string) => logger.debug(message);
@@ -399,15 +400,13 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 		props.tabMovesFocus,
 	]);
 
-	// Update the editor's value
-	useEffect(() => {
-		// Include the noteId in the update props to give plugins access
-		// to the current note ID.
-		const updateProps = { noteId: props.noteId };
-		if (editorRef.current?.updateBody(props.content, updateProps)) {
-			editorRef.current?.clearHistory();
-		}
-	}, [props.content, props.noteId]);
+	useSyncEditorValue({
+		content: props.content,
+		visiblePanes: props.visiblePanes,
+		onMessage: props.onMessage,
+		editorRef,
+		noteId: props.noteId,
+	});
 
 	const renderEditor = () => {
 		return (

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
@@ -28,11 +28,7 @@ const useSyncEditorValue = ({ content, visiblePanes, onMessage, editorRef, noteI
 			// If the viewer isn't visible, the content should be considered rendered
 			// after the editor has finished updating:
 			if (!visiblePanesRef.current.includes('viewer')) {
-				// TODO: This needs to be in a setTimeout so that it runs after all useEffects have
-				// finished. This should be refactored to remove the need for a setTimeout.
-				setTimeout(() => {
-					onMessageRef.current({ channel: 'noteRenderComplete' });
-				}, 10);
+				onMessageRef.current({ channel: 'noteRenderComplete' });
 			}
 		}
 	}, [content, noteId, editorRef]);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, RefObject } from 'react';
+import { OnMessage } from '../../../../utils/types';
+import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
+
+interface Props {
+	content: string;
+
+	visiblePanes: string[];
+	onMessage: OnMessage;
+	editorRef: RefObject<CodeMirrorControl>;
+	noteId: string;
+}
+
+// Updates the editor's value as necessary
+const useSyncEditorValue = ({ content, visiblePanes, onMessage, editorRef, noteId }: Props) => {
+	const visiblePanesRef = useRef(visiblePanes);
+	visiblePanesRef.current = visiblePanes;
+	const onMessageRef = useRef(onMessage);
+	onMessageRef.current = onMessage;
+
+	useEffect(() => {
+		// Include the noteId in the update props to give plugins access
+		// to the current note ID.
+		const updateProps = { noteId: noteId };
+		if (editorRef.current?.updateBody(content, updateProps)) {
+			editorRef.current?.clearHistory();
+
+			// If the viewer isn't visible, the content should be considered rendered
+			// after the editor has finished updating:
+			if (!visiblePanesRef.current.includes('viewer')) {
+				// TODO: This needs to be in a setTimeout so that it runs after all useEffects have
+				// finished. This should be refactored to remove the need for a setTimeout.
+				setTimeout(() => {
+					onMessageRef.current({ channel: 'noteRenderComplete' });
+				}, 10);
+			}
+		}
+	}, [content, noteId, editorRef]);
+};
+
+export default useSyncEditorValue;

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -329,13 +329,13 @@ function NoteEditorContent(props: NoteEditorProps) {
 		});
 	}, [formNote, setFormNote, handleProvisionalFlag, props.dispatch]);
 
-	const { scrollWhenReady, clearScrollWhenReady } = useScrollWhenReadyOptions({
+	const { scrollWhenReadyRef, clearScrollWhenReady } = useScrollWhenReadyOptions({
 		noteId: formNote.id,
 		selectedNoteHash: props.selectedNoteHash,
 		lastEditorScrollPercents: props.lastEditorScrollPercents,
 		editorRef,
 	});
-	const onMessage = useMessageHandler(scrollWhenReady, clearScrollWhenReady, windowId, editorRef, setLocalSearchResultCount, props.dispatch, formNote, htmlToMarkdown, markupToHtml);
+	const onMessage = useMessageHandler(scrollWhenReadyRef, clearScrollWhenReady, windowId, editorRef, setLocalSearchResultCount, props.dispatch, formNote, htmlToMarkdown, markupToHtml);
 
 	useResourceUnwatcher({ noteId: formNote.id, windowId });
 

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -84,6 +84,13 @@ export { MarkupToHtmlOptions };
 export type MarkupToHtmlHandler = (markupLanguage: MarkupLanguage, markup: string, options: MarkupToHtmlOptions)=> Promise<RenderResult>;
 export type HtmlToMarkdownHandler = (markupLanguage: number, html: string, originalCss: string, parseOptions?: ParseOptions)=> Promise<string>;
 
+export interface MessageEvent {
+	channel: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code before rule was applied
+	args?: any[];
+}
+export type OnMessage = (event: MessageEvent)=> void;
+
 export interface NoteBodyEditorProps {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	style: any;
@@ -105,8 +112,7 @@ export interface NoteBodyEditorProps {
 	onChange(event: OnChangeEvent): void;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	onWillChange(event: any): void;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	onMessage(event: any): void;
+	onMessage: OnMessage;
 	onScroll(event: { percent: number }): void;
 	markupToHtml: MarkupToHtmlHandler;
 	htmlToMarkdown: HtmlToMarkdownHandler;

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { FormNote, HtmlToMarkdownHandler, MarkupToHtmlHandler, ScrollOptions } from './types';
+import { FormNote, HtmlToMarkdownHandler, MarkupToHtmlHandler, ScrollOptions, MessageEvent } from './types';
 import contextMenu from './contextMenu';
 import CommandService from '@joplin/lib/services/CommandService';
 import PostMessageService from '@joplin/lib/services/PostMessageService';
@@ -21,8 +21,7 @@ export default function useMessageHandler(
 	htmlToMd: HtmlToMarkdownHandler,
 	mdToHtml: MarkupToHtmlHandler,
 ) {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	return useCallback(async (event: any) => {
+	return useCallback(async (event: MessageEvent) => {
 		const msg = event.channel ? event.channel : '';
 		const args = event.args;
 		const arg0 = args && args.length >= 1 ? args[0] : null;

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { RefObject, useCallback } from 'react';
 import { FormNote, HtmlToMarkdownHandler, MarkupToHtmlHandler, ScrollOptions, MessageEvent } from './types';
 import contextMenu from './contextMenu';
 import CommandService from '@joplin/lib/services/CommandService';
@@ -8,7 +8,7 @@ import { reg } from '@joplin/lib/registry';
 import bridge from '../../../services/bridge';
 
 export default function useMessageHandler(
-	scrollWhenReady: ScrollOptions|null,
+	scrollWhenReadyRef: RefObject<ScrollOptions|null>,
 	clearScrollWhenReady: ()=> void,
 	windowId: string,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -34,8 +34,8 @@ export default function useMessageHandler(
 			s.splice(0, 1);
 			reg.logger().error(s.join(':'));
 		} else if (msg === 'noteRenderComplete') {
-			if (scrollWhenReady) {
-				const options = { ...scrollWhenReady };
+			if (scrollWhenReadyRef.current) {
+				const options = { ...scrollWhenReadyRef.current };
 				clearScrollWhenReady();
 				editorRef.current.scrollTo(options);
 			}
@@ -77,5 +77,5 @@ export default function useMessageHandler(
 			// bridge().showErrorMessageBox(_('Unsupported link or message: %s', msg));
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
-	}, [dispatch, setLocalSearchResultCount, scrollWhenReady, formNote]);
+	}, [dispatch, setLocalSearchResultCount, scrollWhenReadyRef, formNote]);
 }

--- a/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { RefObject, useCallback, useEffect, useRef } from 'react';
 import { NoteBodyEditorRef, ScrollOptions, ScrollOptionTypes } from './types';
 import usePrevious from '@joplin/lib/hooks/usePrevious';
 import type { EditorScrollPercents } from '../../../app.reducer';
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollPercents, editorRef }: Props) => {
-	const [scrollWhenReady, setScrollWhenReady] = useState<ScrollOptions|null>(null);
+	const scrollWhenReadyRef = useRef<ScrollOptions|null>(null);
 
 	const previousNoteId = usePrevious(noteId);
 	const lastScrollPercentsRef = useRef<EditorScrollPercents>(null);
@@ -25,17 +25,17 @@ const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollP
 		}
 
 		const lastScrollPercent = lastScrollPercentsRef.current[noteId] || 0;
-		setScrollWhenReady({
+		scrollWhenReadyRef.current = {
 			type: selectedNoteHash ? ScrollOptionTypes.Hash : ScrollOptionTypes.Percent,
 			value: selectedNoteHash ? selectedNoteHash : lastScrollPercent,
-		});
+		};
 	}, [noteId, previousNoteId, selectedNoteHash, editorRef]);
 
 	const clearScrollWhenReady = useCallback(() => {
-		setScrollWhenReady(null);
+		scrollWhenReadyRef.current = null;
 	}, []);
 
-	return { scrollWhenReady, clearScrollWhenReady };
+	return { scrollWhenReadyRef, clearScrollWhenReady };
 };
 
 export default useScrollWhenReadyOptions;

--- a/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
@@ -1,7 +1,8 @@
-import { RefObject, useCallback, useEffect, useRef } from 'react';
+import { RefObject, useCallback, useRef } from 'react';
 import { NoteBodyEditorRef, ScrollOptions, ScrollOptionTypes } from './types';
 import usePrevious from '@joplin/lib/hooks/usePrevious';
 import type { EditorScrollPercents } from '../../../app.reducer';
+import useNowEffect from '@joplin/lib/hooks/useNowEffect';
 
 interface Props {
 	noteId: string;
@@ -17,8 +18,9 @@ const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollP
 	const lastScrollPercentsRef = useRef<EditorScrollPercents>(null);
 	lastScrollPercentsRef.current = lastEditorScrollPercents;
 
-	useEffect(() => {
-		if (noteId === previousNoteId) return;
+	// This needs to be a nowEffect to prevent race conditions
+	useNowEffect(() => {
+		if (noteId === previousNoteId) return () => {};
 
 		if (editorRef.current) {
 			editorRef.current.resetScroll();
@@ -29,6 +31,7 @@ const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollP
 			type: selectedNoteHash ? ScrollOptionTypes.Hash : ScrollOptionTypes.Percent,
 			value: selectedNoteHash ? selectedNoteHash : lastScrollPercent,
 		};
+		return () => {};
 	}, [noteId, previousNoteId, selectedNoteHash, editorRef]);
 
 	const clearScrollWhenReady = useCallback(() => {

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -30,7 +30,7 @@ test.describe('pluginApi', () => {
 		await mainScreen.createNewNote('First note');
 
 		const editor = mainScreen.noteEditor;
-		await editor.expectToHaveText('');
+		await editor.expectToHaveText('\n');
 
 		await mainScreen.goToAnything.runCommand(app, 'showTestDialog');
 		// Wait for the iframe to load

--- a/packages/lib/services/ResourceFetcher.ts
+++ b/packages/lib/services/ResourceFetcher.ts
@@ -90,7 +90,7 @@ export default class ResourceFetcher extends BaseService {
 		});
 	}
 
-	public async markForDownload(resourceIds: string[]) {
+	public async markForDownload(resourceIds: string[]|string) {
 		if (!Array.isArray(resourceIds)) resourceIds = [resourceIds];
 
 		const fetchStatuses = await Resource.fetchStatuses(resourceIds);


### PR DESCRIPTION
# Summary

Fixes #13411 by ensuring that the `editor.jumpToHash` logic runs even when the viewer is not visible.

In particular, this pull request:
1. Updates `v6/CodeMirror.tsx`'s `scrollTo` logic to call `editor.jumpToHash` even if the viewer is not visible.
2. Updates the `NoteEditor`'s `useMessageHandler`: If the note viewer is hidden (only the Markdown editor is visible), emitting a `noteRenderComplete` after the editor's content is set. Previously, this event was not emitted at all when the viewer was hidden.
    - The `noteRenderComplete` event causes the logic that handles `scrollWhenReady` to run.
3. Updates the `NoteEditor`'s `useScrollWhenReadyOptions` logic to set the value of `scrollWhenReady` sooner, so that it is set before the `noteRenderComplete` emitted in (2).

~~This may also fix an issue in which the initial editor scroll was not set unless the note viewer was also visible.~~ **Edit**: The initial editor scroll issue will be partially fixed by https://github.com/laurent22/joplin/pull/13447.

# Testing

This pull request includes an automated Playwright test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->