### PR TITLE
Mobile: Resolves: #12823: Disable auto-search for 1-2 character searches

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -844,6 +844,7 @@ packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.test.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.js
 packages/app-mobile/components/screens/Notes/Notes.js
+packages/app-mobile/components/screens/SearchScreen/SearchResults.test.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.js
 packages/app-mobile/components/screens/SearchScreen/index.js
 packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.js

--- a/.gitignore
+++ b/.gitignore
@@ -817,6 +817,7 @@ packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.test.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.js
 packages/app-mobile/components/screens/Notes/Notes.js
+packages/app-mobile/components/screens/SearchScreen/SearchResults.test.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.js
 packages/app-mobile/components/screens/SearchScreen/index.js
 packages/app-mobile/components/screens/ShareManager/AcceptedShareItem.js

--- a/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchResults.test.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { AppState } from '../../../utils/types';
+import { Store } from 'redux';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+import createMockReduxStore from '../../../utils/testing/createMockReduxStore';
+import setupGlobalStore from '../../../utils/testing/setupGlobalStore';
+import Note from '@joplin/lib/models/Note';
+import { render, screen } from '../../../utils/testing/testingLibrary';
+import SearchResults from './SearchResults';
+import SearchEngine from '@joplin/lib/services/search/SearchEngine';
+import Folder from '@joplin/lib/models/Folder';
+import TestProviderStack from '../../testing/TestProviderStack';
+
+const createNotes = async (count: number) => {
+	const folder = await Folder.save({ title: 'Test Note' });
+	for (let i = 0; i < count; i++) {
+		await Note.save({ title: `abcd ${i}`, body: 'body', parent_id: folder.id });
+	}
+	await SearchEngine.instance().syncTables();
+};
+
+let store: Store<AppState>;
+
+interface WrapperProps {
+	query: string;
+	paused: boolean;
+}
+const WrappedSearchResults: React.FC<WrapperProps> = props => (
+	<TestProviderStack store={store}>
+		<SearchResults paused={props.paused} query={props.query} onHighlightedWordsChange={() => { }} ftsEnabled={1} />
+	</TestProviderStack>
+);
+
+describe('SearchResult', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		store = createMockReduxStore();
+		setupGlobalStore(store);
+	});
+
+	test('should show results when unpaused', async () => {
+		const noteCount = 8;
+		await createNotes(noteCount);
+
+		render(<WrappedSearchResults query='abcd' paused={false}/>);
+		const items = await screen.findAllByText(/abcd \d\d?\d?/);
+		expect(items.length).toBe(noteCount);
+	});
+});

--- a/packages/app-mobile/components/screens/SearchScreen/SearchResults.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchResults.tsx
@@ -13,6 +13,7 @@ import shim from '@joplin/lib/shim';
 
 interface Props {
 	query: string;
+	paused: boolean;
 	onHighlightedWordsChange: (highlightedWords: (ComplexTerm | string)[])=> void;
 
 	ftsEnabled: number;
@@ -28,7 +29,7 @@ const useResults = (props: Props) => {
 		let notes: NoteEntity[] = [];
 		setIsProcessing(true);
 		try {
-			if (query) {
+			if (query && !props.paused) {
 				if (ftsEnabled) {
 					const r = await SearchEngineUtils.notesForQuery(query, true, { appendWildCards: true });
 					notes = r.notes;
@@ -57,7 +58,7 @@ const useResults = (props: Props) => {
 		} finally {
 			setIsProcessing(false);
 		}
-	}, [query, ftsEnabled], { interval: 200 });
+	}, [query, props.paused, ftsEnabled], { interval: 200 });
 
 	return {
 		notes,

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -71,6 +71,7 @@ import { Store } from 'redux';
 import { dirname } from '@joplin/utils/path';
 import SyncTargetJoplinServerSAML from '../SyncTargetJoplinServerSAML';
 import { MarkupLanguage } from '@joplin/renderer';
+import SearchEngine from '../services/search/SearchEngine';
 
 // Each suite has its own separate data and temp directory so that multiple
 // suites can be run at the same time. suiteName is what is used to
@@ -287,6 +288,7 @@ async function switchClient(id: number, options: any = null) {
 	currentClient_ = id;
 	BaseModel.setDb(databases_[id]);
 	KvStore.instance().setDb(databases_[id]);
+	SearchEngine.instance().setDb(databases_[id]);
 
 	BaseItem.encryptionService_ = encryptionServices_[id];
 	Resource.encryptionService_ = encryptionServices_[id];


### PR DESCRIPTION
# Summary

This pull request is an alternative to https://github.com/laurent22/joplin/pull/12969 that implements the following suggestion from #12823:
> Or: we don't support auto-type for the first two letters - the user needs to press Enter. But we do for the next ones

(This option was selected after discussion with @laurent22).

Unlike #12969, this pull request preserves the order of results ([see comment](https://github.com/laurent22/joplin/pull/12969#issuecomment-3407456059)).

Resolves #12823.

# Problems with this pull request

- This pull request causes the search screen to behave differently for searches of different lengths with different starting patterns. This may be confusing to users.
- There's no UI to indicate that the user needs to press <kbd>enter</kbd> or the "search"/submit/enter button on the software keyboard.
- This does not fix the performance issue for longer searches that have many occurrences.

# Testing

The following manual testing has been done on web:
1. Create a large number of notes:
    - This was done by running
      ```
      for (let i = 0; i < 500; i++) {
          await joplin.Note.save({ title: `A test note (${i})`, parent_id: '', markup_language: 1, body: `# test notes ${i} ${i + 1}\n\nThis note can be searched for.\n${'test **testing** '.repeat(i)}`, deleted_time: 0 })
      }
      ```
      from the browser development tools.
2. Open the search screen.
3. Search for `t`.
4. Verify that no results are shown.
5. Press <kbd>enter</kbd>.
6. Verify that the in-progress indicator is shown.
7. Verify that results are shown.
8. Search for `te`.
9. Verify that no results are shown.
10. Press <kbd>enter</kbd> and verify that, after a delay, results are shown.
11. Search for a medium-length (>2 character) word not in the notes from step 1, but known to be in another note (e.g. "Joplin").
12. Verify that search happens automatically.

At present, all manual testing has been on web. Manual testing on Android is planned.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->