### PR TITLE
Chore: Fix intermittent revision test failure

### DIFF
--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -39,6 +39,7 @@ describe('services/RevisionService', () => {
 		await setupDatabaseAndSynchronizer(1);
 		await switchClient(1);
 		Setting.setValue('revisionService.intervalBetweenRevisions', 0);
+		Setting.setValue('revisionService.oldNoteInterval', 1000 * 60 * 60 * 24 * 7);
 
 		jest.useFakeTimers({ advanceTimers: true });
 	});
@@ -621,6 +622,7 @@ describe('services/RevisionService', () => {
 		await Note.save({ id: note.id, title: 'test', body: 'StartA' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartAB' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartABC' }); // REV 2
+		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
 		await revisionService().collectRevisions(); // Create revisions for old and new content
 
 		Setting.setValue('revisionService.oldNoteInterval', 10_000);
@@ -727,7 +729,8 @@ describe('services/RevisionService', () => {
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEFG' }); // REV 2
-		await revisionService().collectRevisions();
+		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
+		await revisionService().collectRevisions(); // Create revisions for old and new content
 
 		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
 		expect(revisions.length).toBe(3);
@@ -764,7 +767,8 @@ describe('services/RevisionService', () => {
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDE' }); // REV 1
-		await revisionService().collectRevisions(); // Content is the same, create just one revision instead of two
+		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
+		await revisionService().collectRevisions(); // Content is the same for old and new content, so create just one revision instead of two
 
 		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
 		expect(revisions.length).toBe(2);

--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -620,9 +620,11 @@ describe('services/RevisionService', () => {
 		jest.advanceTimersByTime(100);
 
 		await Note.save({ id: note.id, title: 'test', body: 'StartA' });
+		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
+		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
+		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'StartAB' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartABC' }); // REV 2
-		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
 		await revisionService().collectRevisions(); // Create revisions for old and new content
 
 		Setting.setValue('revisionService.oldNoteInterval', 10_000);
@@ -728,8 +730,10 @@ describe('services/RevisionService', () => {
 		Setting.setValue('revisionService.oldNoteInterval', 50);
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
+		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
+		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
+		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEFG' }); // REV 2
-		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
 		await revisionService().collectRevisions(); // Create revisions for old and new content
 
 		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
@@ -766,8 +770,10 @@ describe('services/RevisionService', () => {
 		Setting.setValue('revisionService.oldNoteInterval', 50);
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
+		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
+		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
+		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDE' }); // REV 1
-		await msleep(100); // Avoid race condition when collecting revision for an 'old note', due to Note.save not awaiting the ItemChange.add function
 		await revisionService().collectRevisions(); // Content is the same for old and new content, so create just one revision instead of two
 
 		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);

--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -620,8 +620,6 @@ describe('services/RevisionService', () => {
 		jest.advanceTimersByTime(100);
 
 		await Note.save({ id: note.id, title: 'test', body: 'StartA' });
-		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
-		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
 		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'StartAB' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartABC' }); // REV 2
@@ -730,8 +728,6 @@ describe('services/RevisionService', () => {
 		Setting.setValue('revisionService.oldNoteInterval', 50);
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
-		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
-		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
 		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEFG' }); // REV 2
 		await revisionService().collectRevisions(); // Create revisions for old and new content
@@ -770,8 +766,6 @@ describe('services/RevisionService', () => {
 		Setting.setValue('revisionService.oldNoteInterval', 50);
 
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDEF' });
-		// The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. Wait for ItemChange.add to complete before subsequent
-		// saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves
 		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDE' }); // REV 1
 		await revisionService().collectRevisions(); // Content is the same for old and new content, so create just one revision instead of two


### PR DESCRIPTION
This attempts to fix the intermittent test failure as per the comment here https://github.com/laurent22/joplin/commit/53035839a5e20806cbe9635893e1d75fb11c889e#r168069206

I think it happens because in the Note.save function it invokes the async function ItemChange.add, but it does not await it. As this test and some of the other tests I added create the 'old note' revision in addition to the current content revision, if the item_changes record is selected before the new item_changes record has been inserted in a certain scenario, then there will be 1 less revision created at collection due to a race condition.

This PR should prevent the given race condition in affected tests, by explicitly waiting for the ItemChange.add call to be completed before allowing the item_changes record to be selected at the point where it is crucial to be available. It also resets the 'revisionService.oldNoteInterval' setting value on test initialisation, to ensure there would not be possible race conditions relating to that, due to leakage across tests.

Full details of the race condition:
The first save after a revision collection will set the beforeChangeItemJson for subsequent saves to use. When the next collection is intended to create an 'old note' revision in the test, we need to wait for ItemChange.add to complete before subsequent saves, to avoid a race condition whereby the next save selects the beforeChangeItemJson before it has been saved and then uses a null value for subsequent saves