### PR TITLE
Web: Show sync wizard on first start

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -10,6 +10,7 @@ import JoplinCloudIcon from './JoplinCloudIcon';
 import NavService from '@joplin/lib/services/NavService';
 import { StyleSheet, View } from 'react-native';
 import CardButton from '../buttons/CardButton';
+import Setting from '@joplin/lib/models/Setting';
 
 interface Props {
 	dispatch: Dispatch;
@@ -86,6 +87,11 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 		});
 	}, [dispatch]);
 
+	const onManualDismiss = useCallback(() => {
+		Setting.setValue('sync.wizard.autoShowOnStartup', false);
+		onDismiss();
+	}, [onDismiss]);
+
 	const onSelectJoplinCloud = useCallback(async () => {
 		onDismiss();
 		await NavService.go('JoplinCloudLogin');
@@ -99,7 +105,7 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 	return <DismissibleDialog
 		themeId={themeId}
 		visible={visible}
-		onDismiss={onDismiss}
+		onDismiss={onManualDismiss}
 		size={DialogVariant.SmallResize}
 		scrollOverflow={true}
 		heading={_('Sync')}

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -488,6 +488,14 @@ const buildStartupTasks = (
 
 		// await printTestData();
 	});
+	addTask('buildStartupTasks/optionally show sync wizard', async () => {
+		if (Setting.value('sync.wizard.autoShowOnStartup') && Setting.value('sync.target') === 0) {
+			dispatch({
+				type: 'SYNC_WIZARD_VISIBLE_CHANGE',
+				visible: true,
+			});
+		}
+	});
 
 	return startupTasks;
 };

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -111,7 +111,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 
 		'sync.wizard.autoShowOnStartup': {
 			value: mobilePlatform === 'web',
-			type: SettingItemType.Button,
+			type: SettingItemType.Bool,
 			public: false,
 			appTypes: [AppType.Mobile],
 			label: () => 'Show the sync wizard on startup if no sync target is selected',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -109,6 +109,15 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'sync',
 		},
 
+		'sync.wizard.autoShowOnStartup': {
+			value: mobilePlatform === 'web',
+			type: SettingItemType.Button,
+			public: false,
+			appTypes: [AppType.Mobile],
+			label: () => 'Show the sync wizard on startup if no sync target is selected',
+			section: 'sync',
+		},
+
 		'sync.target': {
 			value: 0,
 			type: SettingItemType.Int,


### PR DESCRIPTION
# Summary

This pull request updates the web app to:
- Show the sync wizard on the first start of the application.
- Show the sync wizard on subsequent starts if 1) the sync wizard hasn't been previously dismissed and 2) no sync target is selected.

# Testing plan

1. Open the web app.
2. Verify that the sync wizard is shown when the app finishes starting.
3. In the sync wizard, select "Other", then "File system". Save.
4. Refresh.
5. Verify that the sync wizard isn't shown.
6. Set the sync target to "None". Save.
7. Refresh.
8. Verify that the sync wizard is shown.
9. Dismiss the sync wizard by clicking the "X".
10. Refresh.
11. Verify that the sync wizard isn't shown.
12. Click the sync button.
13. Verify that the sync wizard is shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->