### PR TITLE
Chore: Windows: Tests: Fix Rust OneNote importer tests fail

### DIFF
--- a/packages/onenote-converter/parser-utils/src/file_api/native_driver.rs
+++ b/packages/onenote-converter/parser-utils/src/file_api/native_driver.rs
@@ -1,6 +1,7 @@
 use super::ApiResult;
 use super::FileApiDriver;
 use std::fs;
+use std::path;
 use std::path::Path;
 
 pub struct FileApiDriverImpl {}
@@ -62,8 +63,8 @@ impl FileApiDriver for FileApiDriverImpl {
     fn join(&self, path_1: &str, path_2: &str) -> String {
         // Remove the / prefix prior to joining: Match the behavior of the
         // WASM/NodeJS file API.
-        let path_2 = if path_2.starts_with("/") {
-            path_2.strip_prefix("/").unwrap()
+        let path_2 = if path_2.starts_with(path::MAIN_SEPARATOR) {
+            path_2.strip_prefix(path::MAIN_SEPARATOR).unwrap()
         } else {
             path_2
         };


### PR DESCRIPTION
# Summary

This pull request fixes an issue in the `file_api/native_driver.rs` file (only used for tests) that caused the renderer tests to fail when run on Windows.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->