### PR TITLE
Desktop: Fixes #13481: Accessibility: Prevent sidebar header text from moving: Don't change the header icon on hover

### DIFF
--- a/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/HeaderItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { StyledHeader, StyledHeaderIcon, StyledHeaderLabel } from '../styles';
 import { HeaderId, HeaderListItem } from '../types';
 import bridge from '../../../services/bridge';
@@ -25,8 +25,6 @@ const HeaderItem: React.FC<Props> = props => {
 	const item = props.item;
 	const onItemClick = item.onClick;
 	const itemId = item.id;
-	const [isHovered, setIsHovered] = useState(false);
-	const expanded = item.expanded;
 
 	const onClick: React.MouseEventHandler<HTMLElement> = useCallback(event => {
 		if (onItemClick) {
@@ -46,14 +44,6 @@ const HeaderItem: React.FC<Props> = props => {
 		}
 	}, [itemId]);
 
-	const handleMouseEnter = useCallback(() => {
-		setIsHovered(true);
-	}, []);
-
-	const handleMouseLeave = useCallback(() => {
-		setIsHovered(false);
-	}, []);
-
 	return (
 		<ListItemWrapper
 			containerRef={props.anchorRef}
@@ -70,10 +60,8 @@ const HeaderItem: React.FC<Props> = props => {
 		>
 			<StyledHeader
 				onClick={onClick}
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
 			>
-				<StyledHeaderIcon aria-hidden='true' role='img' className={isHovered ? `fas ${expanded ? 'fa-caret-down' : 'fa-caret-right'}` : item.iconName}/>
+				<StyledHeaderIcon aria-hidden='true' role='img' className={item.iconName}/>
 				<StyledHeaderLabel>{item.label}</StyledHeaderLabel>
 			</StyledHeader>
 		</ListItemWrapper>


### PR DESCRIPTION
# Summary

Partially reverts #12292. With this pull request, the background color of the sidebar headers changes on hover, but the icon doesn't change.

Fixes #13481 (see that issue for context).

# Notes

- **Accessibility guidelines**: This *might* be related to [WCAG 2.2 SC 1.4.13](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->