### PR TITLE
Desktop: Accessibility: Fix global keyboard shortcuts are ignored when the sidebar has focus

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -74,6 +74,8 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 		const selectedItem = listItems[selectedIndex];
 		let indexChange = 0;
 
+		const ctrlAltOrMeta = event.ctrlKey || event.altKey || event.metaKey;
+
 		if (selectedItem && isToggleShortcut(event.code, selectedItem, collapsedFolderIds)) {
 			event.preventDefault();
 
@@ -111,7 +113,7 @@ const useOnSidebarKeyDownHandler = (props: Props) => {
 		} else if (event.code === 'Enter' && !event.shiftKey) {
 			event.preventDefault();
 			void CommandService.instance().execute('focusElement', 'noteList');
-		} else if (selectedIndex && selectedIndex >= 0 && event.key.length === 1) {
+		} else if (selectedIndex && selectedIndex >= 0 && event.key.length === 1 && !ctrlAltOrMeta) {
 			const nextMatch = findNextTypeAheadMatch(selectedIndex, event.key, listItems);
 			if (nextMatch !== -1) {
 				indexChange = nextMatch - selectedIndex;


### PR DESCRIPTION
# Summary

Fixes a bug that prevented using global shortcuts (e.g. <kbd>ctrl</kbd>-<kbd>shift</kbd>-<kbd>b</kbd> = jump to note body) from the sidebar in some cases.

This pull request fixes a regression from #13469. With #13469, pressing a single, **unmodified** alphanumeric/symbol key on the keyboard should jump to the notebook, tag, or header starting with that key.

Reported in [comment](https://github.com/laurent22/joplin/issues/13185#issuecomment-3419323945).

# Testing plan

Fedora 42 Linux:
1. Create a notebook with title "B" (to match the keyboard shortcut).
2. Switch to a different notebook that contains notes.
1. Move focus to the notebook list.
3. Press <kbd>ctrl</kbd>-<kbd>shift</kbd>-<kbd>b</kbd>.
4. Verify that focus moves to the note body.
5. Move focus back to the notebook list.
6. Press <kbd>shift</kbd>-<kbd>b</kbd>.
7. Verify that focus moves to the notebook created in step 1.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->