### PR TITLE
Fix: Allow creating top-level notebooks on mobile by adding 'None' option

### DIFF
--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -64,7 +64,7 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 		let output: DropdownListItem[] = [];
 		if (mustSelect) {
 			output.push({ label: placeholder || _('Move to notebook...'), value: '' });
-			
+
 			// Add option for creating top-level notebooks when showRootOption is true
 			if (showRootOption) {
 				output.push({ label: _('None (create top-level notebook)'), value: 'root' });

--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -14,6 +14,7 @@ interface FolderPickerProps {
 	selectedFolderId?: string;
 	onValueChange?: OnValueChangedListener;
 	mustSelect?: boolean;
+	showRootOption?: boolean; // New prop to control when to show the 'root' option
 	folders: FolderEntity[];
 	placeholder?: string;
 	darkText?: boolean;
@@ -28,6 +29,7 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 	selectedFolderId,
 	onValueChange,
 	mustSelect,
+	showRootOption = false, // Default to false for backward compatibility
 	folders,
 	placeholder,
 	darkText,
@@ -57,13 +59,16 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 		return pickerItems;
 	};
 
-	const titlePickerItems = (mustSelect: boolean) => {
+	const titlePickerItems = (mustSelect: boolean, showRootOption: boolean) => {
 		const folderList = folders.filter(f => f.id !== Folder.conflictFolderId());
-		let output = [];
+		let output: DropdownListItem[] = [];
 		if (mustSelect) {
 			output.push({ label: placeholder || _('Move to notebook...'), value: '' });
 			
-			output.push({ label: _('None (create top-level notebook)'), value: 'root' });
+			// Add option for creating top-level notebooks when showRootOption is true
+			if (showRootOption) {
+				output.push({ label: _('None (create top-level notebook)'), value: 'root' });
+			}
 		}
 		const folderTree = Folder.buildTree(folderList);
 		output = addFolderChildren(folderTree, output, 0);
@@ -80,7 +85,7 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 
 	const dropdown = (
 		<Dropdown
-			items={titlePickerItems(!!mustSelect)}
+			items={titlePickerItems(!!mustSelect, showRootOption)}
 			accessibilityHint={_('Selects a notebook')}
 			disabled={disabled}
 			labelTransform="trim"

--- a/packages/app-mobile/components/FolderPicker.tsx
+++ b/packages/app-mobile/components/FolderPicker.tsx
@@ -60,7 +60,11 @@ const FolderPicker: FunctionComponent<FolderPickerProps> = ({
 	const titlePickerItems = (mustSelect: boolean) => {
 		const folderList = folders.filter(f => f.id !== Folder.conflictFolderId());
 		let output = [];
-		if (mustSelect) output.push({ label: placeholder || _('Move to notebook...'), value: '' });
+		if (mustSelect) {
+			output.push({ label: placeholder || _('Move to notebook...'), value: '' });
+			
+			output.push({ label: _('None (create top-level notebook)'), value: 'root' });
+		}
 		const folderTree = Folder.buildTree(folderList);
 		output = addFolderChildren(folderTree, output, 0);
 		return output;

--- a/packages/app-mobile/components/screens/folder.js
+++ b/packages/app-mobile/components/screens/folder.js
@@ -113,6 +113,7 @@ class FolderScreenComponent extends BaseScreenComponent {
 						selectedFolderId={this.state.folder.parent_id}
 						onValueChange={newValue => this.parent_changeValue(newValue)}
 						mustSelect
+						showRootOption
 						darkText
 					/>
 				</View>

--- a/packages/app-mobile/components/screens/folder.js
+++ b/packages/app-mobile/components/screens/folder.js
@@ -62,7 +62,9 @@ class FolderScreenComponent extends BaseScreenComponent {
 	}
 
 	parent_changeValue(parent) {
-		this.folderComponent_change('parent_id', parent);
+		// Handle the special 'root' value for creating top-level notebooks
+		const parentId = parent === 'root' ? '' : parent;
+		this.folderComponent_change('parent_id', parentId);
 	}
 
 


### PR DESCRIPTION
## Fix: Allow creating top-level notebooks on mobile

### Issue
Fixes #13483 - Users cannot create top-level parent notebooks on Android mobile (version 3.4.7). The issue forces users to select an existing parent notebook instead of allowing creation of new top-level notebooks.

### Solution
This PR adds a "None (create top-level notebook)" option to the FolderPicker component when creating new notebooks on mobile, allowing users to create top-level notebooks without requiring a parent selection.

### Changes
1. Modified `packages/app-mobile/components/FolderPicker.tsx` to add a new option "None (create top-level notebook)" when [mustSelect](file://f:\jop\joplin\packages\app-mobile\components\FolderPicker.tsx#L15-L15) is true
2. Updated `packages/app-mobile/components/screens/folder.js` to handle the 'root' value correctly by setting parent_id to empty string

### Testing
- Verified that users can now create top-level notebooks on mobile
- Confirmed that existing functionality for selecting parent notebooks still works
- Tested that the new option appears only when appropriate (during notebook creation)

### Technical Details
The issue was in the mobile app's FolderPicker component where users were forced to select a parent notebook when creating a new notebook, with no option to create a top-level notebook. The [mustSelect](file://f:\jop\joplin\packages\app-mobile\components\FolderPicker.tsx#L15-L15) prop was set to `true` in the folder creation screen, which only provided a "Move to notebook..." placeholder but no option for creating a top-level notebook.

This fix adds a new dropdown item with value 'root' and label 'None (create top-level notebook)' when mustSelect is true. The folder screen was updated to handle the 'root' value by converting it to an empty string, which creates a top-level notebook.