### PR TITLE
Web: Accessibility: Fix focus indicator is invisible for sync wizard options

### DIFF
--- a/packages/app-mobile/components/buttons/CardButton.tsx
+++ b/packages/app-mobile/components/buttons/CardButton.tsx
@@ -29,7 +29,8 @@ const useStyles = (disabled: boolean) => {
 				borderRadius,
 				overflow: 'hidden',
 				// Accessibility: Prevent the 'overflow: hidden' from hiding the focus indicator
-				// on web:
+				// on web. Only apply to web, as this causes the touchable ripple
+				// from being completely contained within the card on non-web platforms.
 				...(Platform.OS === 'web' ? {
 					margin: -2,
 					padding: 2,

--- a/packages/app-mobile/components/buttons/CardButton.tsx
+++ b/packages/app-mobile/components/buttons/CardButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Card, TouchableRipple } from 'react-native-paper';
 import { useMemo } from 'react';
-import { StyleSheet, View, ViewStyle } from 'react-native';
+import { Platform, StyleSheet, View, ViewStyle } from 'react-native';
 
 export enum InstallState {
 	NotInstalled,
@@ -20,16 +20,24 @@ interface Props {
 const useStyles = (disabled: boolean) => {
 	return useMemo(() => {
 		// For the TouchableRipple to work on Android, the card needs a transparent background.
-		const baseCard = { backgroundColor: 'transparent' };
+		const borderRadius = 12;
+		const baseCard = { backgroundColor: 'transparent', borderRadius };
 		return StyleSheet.create({
 			cardOuterWrapper: {
 				margin: 0,
 				padding: 0,
-				borderRadius: 12,
+				borderRadius,
 				overflow: 'hidden',
+				// Accessibility: Prevent the 'overflow: hidden' from hiding the focus indicator
+				// on web:
+				...(Platform.OS === 'web' ? {
+					margin: -2,
+					padding: 2,
+				} : {}),
 			},
 			cardInnerWrapper: {
 				width: '100%',
+				borderRadius,
 			},
 			card: disabled ? {
 				...baseCard,


### PR DESCRIPTION
# Summary

This pull request fixes an issue in which the focus indicator was hidden by an `overflow: hidden` on the sync wizard and plugin screen cards.

# Screenshots

In Chrome, where the "Joplin Cloud" sync wizard option has focus in both cases:

| Before | After |
|----|----|
| <img width="400" alt="Screenshot: Focus indicator is invisible, sync wizard screen" src="https://github.com/user-attachments/assets/8a03904b-9fe8-45d4-8ad8-30662b78c842" /> | <img width="400" alt="Screenshot: Focus indicator is visible around the first sync option" src="https://github.com/user-attachments/assets/09a2ea19-d69e-406c-865c-f62fc181cab6" /> |



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->