### PR TITLE
Desktop: OneNote importer: Resolve possible import failure related to unsupported formatting

### DIFF
--- a/packages/onenote-converter/renderer/src/page/image.rs
+++ b/packages/onenote-converter/renderer/src/page/image.rs
@@ -2,7 +2,7 @@ use crate::page::Renderer;
 use crate::utils::{AttributeSet, StyleSet, px};
 use color_eyre::Result;
 use parser::contents::Image;
-use parser_utils::{fs_driver, log};
+use parser_utils::{fs_driver, log, log_warn};
 
 impl<'a> Renderer<'a> {
     pub(crate) fn render_image(&mut self, image: &Image) -> Result<String> {
@@ -58,22 +58,22 @@ impl<'a> Renderer<'a> {
             return self.determine_filename(name);
         }
 
-        if let Some(ext) = image.extension() {
-            let mut i = 0;
+        let ext = image.extension().unwrap_or_else(|| {
+            log_warn!("Image missing extension. Defaulting to .png.");
+            ".png"
+        });
 
-            loop {
-                let filename = format!("image{}{}", i, ext);
+        let mut i = 0;
+        loop {
+            let filename = format!("image{}{}", i, ext);
 
-                if !self.section.files.contains(&filename) {
-                    self.section.files.insert(filename.clone());
+            if !self.section.files.contains(&filename) {
+                self.section.files.insert(filename.clone());
 
-                    return Ok(filename);
-                }
-
-                i += 1;
+                return Ok(filename);
             }
-        }
 
-        unimplemented!()
+            i += 1;
+        }
     }
 }

--- a/packages/onenote-converter/renderer/src/page/list.rs
+++ b/packages/onenote-converter/renderer/src/page/list.rs
@@ -3,6 +3,7 @@ use crate::utils::{AttributeSet, StyleSet, px};
 use color_eyre::Result;
 use parser::contents::{List, OutlineElement};
 use parser::property::common::ColorRef;
+use parser_utils::log_warn;
 
 const FORMAT_NUMBERED_LIST: char = '\u{fffd}';
 
@@ -89,8 +90,7 @@ impl<'a> Renderer<'a> {
                 container_style.set("list-style-type", "lower-latin".to_string())
             }
             [FORMAT_NUMBERED_LIST, c, ..] => {
-                dbg!(c);
-                unimplemented!();
+                log_warn!("Not implemented: Numbered list style: {}", c);
             }
             [c] => marker_style.set("content", format!("'{}'", c)),
             _ => {}

--- a/packages/onenote-converter/renderer/src/page/rich_text.rs
+++ b/packages/onenote-converter/renderer/src/page/rich_text.rs
@@ -298,8 +298,8 @@ impl<'a> Renderer<'a> {
                 ParagraphAlignment::Right => {
                     "right"
                 },
-                _ => {
-                    log_warn!("Unknown/unsupported text-align value");
+                other => {
+                    log_warn!("Unknown/unsupported text-align value: {:?}", other);
                     ""
                 }
             }.into());


### PR DESCRIPTION
# Summary

This pull request replaces several uses of [`unimplemented!()`](https://doc.rust-lang.org/std/macro.unimplemented.html) with either warnings or implementations (which always [terminates the import](https://doc.rust-lang.org/core/macro.panic.html)).

Previously, if unsupported formatting with an `unimplemented!()` implementation was encountered, the import would stop immediately, without processing other content.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->