### PR TITLE
Mobile: Fixes #13120: Fix truncated buttons on tag association screen

### DIFF
--- a/packages/app-mobile/components/ModalDialog.tsx
+++ b/packages/app-mobile/components/ModalDialog.tsx
@@ -48,6 +48,11 @@ const useStyles = (themeId: number) => {
 			invisibleHeading: {
 				flexGrow: 1,
 			},
+			// Use compact mode on the button and expand the padding to match the original styling, to work around an Android issue #13120
+			buttonStyle: {
+				paddingLeft: 16,
+				paddingRight: 16,
+			},
 		});
 	}, [themeId]);
 };
@@ -76,8 +81,8 @@ const ModalDialog: React.FC<Props> = props => {
 					accessible={true}
 					style={styles.invisibleHeading}
 				/>
-				<Button disabled={!props.buttonBarEnabled} onPress={props.onCancelPress}>{props.cancelTitle}</Button>
-				<PrimaryButton disabled={!props.buttonBarEnabled} onPress={props.onOkPress}>{props.okTitle}</PrimaryButton>
+				<Button compact contentStyle={styles.buttonStyle} disabled={!props.buttonBarEnabled} onPress={props.onCancelPress}>{props.cancelTitle}</Button>
+				<PrimaryButton compact contentStyle={styles.buttonStyle} disabled={!props.buttonBarEnabled} onPress={props.onOkPress}>{props.okTitle}</PrimaryButton>
 			</View>
 		</Modal>
 	);


### PR DESCRIPTION
This fixes truncation of text on the cancel and ok buttons on the tag association screen, in release builds of the mobile app

Fixes https://github.com/laurent22/joplin/issues/13120

### Testing

The tag association screen is the only screen which uses ModalDialog.tsx, so installing a release build of the change and inspecting the visual result of this screen is sufficient (and making sure the buttons work)

### Screenshots

**Before:**

<img width="413" height="895" alt="orig" src="https://github.com/user-attachments/assets/ac8c92c4-8b97-449c-91d3-c3f46127dd10" />

**After:**

<img width="414" height="897" alt="compact with wider horizontal padding" src="https://github.com/user-attachments/assets/2a68afd1-8c06-40e3-baaa-9edb2bd01dae" />

Landscape:

<img width="689" height="291" alt="landscape" src="https://github.com/user-attachments/assets/0a313502-2b33-4bbc-a5cf-ab5e87926b9d" />

In another language:

<img width="412" height="896" alt="language" src="https://github.com/user-attachments/assets/99f6aa86-5fbf-4504-b78c-737ba4c7fd0a" />