### PR TITLE
Mobile: Fixes #12957: Avoid dismissing the keyboard when tapping markdown toolbar buttons with the title in focus

### DIFF
--- a/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
+++ b/packages/app-mobile/components/EditorToolbar/EditorToolbar.tsx
@@ -132,6 +132,7 @@ const EditorToolbar: React.FC<Props> = props => {
 			style={styles.content}
 			contentContainerStyle={styles.contentContainer}
 			onLayout={onContainerLayout}
+			keyboardShouldPersistTaps="always"
 		>
 			{buttonInfos.map(renderButton)}
 			<View style={styles.spacer}/>


### PR DESCRIPTION
Currently, tapping markdown toolbar buttons only dismiss the keyboard on the first press (it does not perform the intended action), when the on screen keyboard is open and focus is on the title field. This PR makes it so that the keyboard is not dismissed, but the intended action is performed immediately, to be consistent with the behaviour if the note body were in focus instead.

This fixes https://github.com/laurent22/joplin/issues/12957

### Testing

See video:

https://github.com/user-attachments/assets/1a60a2a7-ebec-4c96-a82e-d62a0617175e