### PR TITLE
Mobile: Fixes #13151: Reset the state of undo and redo buttons which switching exiting edit mode or switching editor type

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -657,6 +657,26 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				type: 'NOTE_EDITOR_VISIBLE_CHANGE',
 				visible: this.state.mode === 'edit' && !this.state.showCamera && !this.state.showImageEditor,
 			});
+
+			// Reset undo/redo button state when switching modes since the editor is recreated and loses its undo/redo history
+			if (this.state.mode === 'edit') {
+				this.setState({
+					undoRedoButtonState: {
+						canUndo: false,
+						canRedo: false,
+					},
+				});
+			}
+		}
+
+		// Reset undo/redo button state when switching between markdown and rich text editors since the editor is recreated and loses its undo/redo history
+		if (prevProps.editorType !== this.props.editorType && this.state.mode === 'edit') {
+			this.setState({
+				undoRedoButtonState: {
+					canUndo: false,
+					canRedo: false,
+				},
+			});
 		}
 
 		if (prevProps.noteId && this.props.noteId && prevProps.noteId !== this.props.noteId) {

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -657,20 +657,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				type: 'NOTE_EDITOR_VISIBLE_CHANGE',
 				visible: this.state.mode === 'edit' && !this.state.showCamera && !this.state.showImageEditor,
 			});
-
-			// Reset undo/redo button state when switching modes since the editor is recreated and loses its undo/redo history
-			if (this.state.mode === 'edit') {
-				this.setState({
-					undoRedoButtonState: {
-						canUndo: false,
-						canRedo: false,
-					},
-				});
-			}
 		}
 
-		// Reset undo/redo button state when switching between markdown and rich text editors since the editor is recreated and loses its undo/redo history
-		if (prevProps.editorType !== this.props.editorType && this.state.mode === 'edit') {
+		// Reset undo/redo button state when switching to edit mode or when switching between markdown and rich text editors, since the editor is
+		// recreated and loses its undo/redo history
+		if (this.state.mode === 'edit' && (prevState.mode !== this.state.mode || prevProps.editorType !== this.props.editorType)) {
 			this.setState({
 				undoRedoButtonState: {
 					canUndo: false,


### PR DESCRIPTION
Currently on mobile, when exiting edit mode of a note, or switching between the markdown and rich text editor, the undo / redo history is lost, but the state of the undo / redo buttons is not reset. This PR ensures that the state is cleared in both scenarios, and the new history can be created following this.

This fixes https://github.com/laurent22/joplin/issues/13151

### Testing

See video (note that the back button becoming invisible when switching between editor types is an existing issue):

https://github.com/user-attachments/assets/b0d11dc5-fef8-4daa-afab-38327ac2b8dc