### PR TITLE
Mobile: Fixes #11468: Ensure note list is re-ordered after updating a note opened via a search

### DIFF
--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -67,7 +67,8 @@ const appReducer = (state = appDefaultState, action: any) => {
 
 				newState.selectedNoteHash = '';
 
-				if (currentRoute?.routeName === 'Search' && action.routeName === 'Notes') {
+				if (currentRoute.routeName === 'Search' && action.routeName === 'Notes') {
+					// Force a reload of the note list
 					newState.notesSource = '';
 				}
 

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -67,6 +67,10 @@ const appReducer = (state = appDefaultState, action: any) => {
 
 				newState.selectedNoteHash = '';
 
+				if (currentRoute?.routeName === 'Search' && action.routeName === 'Notes') {
+					newState.notesSource = '';
+				}
+
 				if (action.routeName === 'Search') {
 					newState.notesParentType = 'Search';
 				}


### PR DESCRIPTION
This PR fixes an issue whereby the note list usually is note re-ordered after updating a note which was opened via a note search

Fixes https://github.com/laurent22/joplin/issues/11468

### Testing

See video:

https://github.com/user-attachments/assets/edc6add6-2c5a-4add-8aad-eecaf6c8b480