### PR TITLE
Mobile: Fixes #13193: Fix Markdown toolbar

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -701,6 +701,7 @@ packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/autosave.js
 packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js
 packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.js
+packages/app-mobile/components/NoteEditor/MarkdownEditor.test.js
 packages/app-mobile/components/NoteEditor/MarkdownEditor.js
 packages/app-mobile/components/NoteEditor/NoteEditor.test.js
 packages/app-mobile/components/NoteEditor/NoteEditor.js

--- a/.gitignore
+++ b/.gitignore
@@ -674,6 +674,7 @@ packages/app-mobile/components/NoteEditor/ImageEditor/ImageEditor.js
 packages/app-mobile/components/NoteEditor/ImageEditor/autosave.js
 packages/app-mobile/components/NoteEditor/ImageEditor/isEditableResource.js
 packages/app-mobile/components/NoteEditor/ImageEditor/promptRestoreAutosave.js
+packages/app-mobile/components/NoteEditor/MarkdownEditor.test.js
 packages/app-mobile/components/NoteEditor/MarkdownEditor.js
 packages/app-mobile/components/NoteEditor/NoteEditor.test.js
 packages/app-mobile/components/NoteEditor/NoteEditor.js

--- a/packages/app-mobile/components/NoteEditor/MarkdownEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownEditor.test.tsx
@@ -55,12 +55,12 @@ describe('MarkdownEditor', () => {
 	// Regression test for #13193. This verifies that the editor can be reached
 	// over IPC.
 	it('should support the "textBold" command', async () => {
-		let lastBody = 'test';
+		let editorBody = 'test';
 		const editorRef = React.createRef<EditorControl|null>();
 		render(<WrappedEditor
 			ref={editorRef}
-			noteBody={lastBody}
-			onBodyChange={newValue => { lastBody = newValue; }}
+			noteBody={editorBody}
+			onBodyChange={newValue => { editorBody = newValue; }}
 		/>);
 
 		// Should mark the command as supported
@@ -70,7 +70,7 @@ describe('MarkdownEditor', () => {
 		await editorRef.current.execCommand(EditorCommandType.SelectAll);
 		await editorRef.current.execCommand(EditorCommandType.ToggleBolded);
 		await waitFor(() => {
-			expect(lastBody).toBe('**test**');
+			expect(editorBody).toBe('**test**');
 		});
 	});
 });

--- a/packages/app-mobile/components/NoteEditor/MarkdownEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/MarkdownEditor.test.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+import { describe, it, beforeEach } from '@jest/globals';
+import { render, waitFor } from '../../utils/testing/testingLibrary';
+
+import Setting from '@joplin/lib/models/Setting';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
+import TestProviderStack from '../testing/TestProviderStack';
+import createMockReduxStore from '../../utils/testing/createMockReduxStore';
+import createTestEditorProps from './testing/createTestEditorProps';
+import { EditorEvent, EditorEventType } from '@joplin/editor/events';
+import { RefObject, useCallback } from 'react';
+import { EditorCommandType, EditorControl } from '@joplin/editor/types';
+import MarkdownEditor from './MarkdownEditor';
+
+
+interface WrapperProps {
+	ref?: RefObject<EditorControl>;
+	onBodyChange: (newBody: string)=> void;
+	noteBody: string;
+}
+
+const defaultEditorProps = createTestEditorProps();
+const testStore = createMockReduxStore();
+const WrappedEditor: React.FC<WrapperProps> = (
+	{
+		noteBody,
+		onBodyChange,
+		ref,
+	}: WrapperProps,
+) => {
+	const onEvent = useCallback((event: EditorEvent) => {
+		if (event.kind === EditorEventType.Change) {
+			onBodyChange(event.value);
+		}
+	}, [onBodyChange]);
+
+	return <TestProviderStack store={testStore}>
+		<MarkdownEditor
+			{...defaultEditorProps}
+			onEditorEvent={onEvent}
+			initialText={noteBody}
+			editorRef={ref ?? defaultEditorProps.editorRef}
+		/>
+	</TestProviderStack>;
+};
+
+describe('MarkdownEditor', () => {
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(0);
+		await switchClient(0);
+		Setting.setValue('editor.codeView', true);
+	});
+
+	// Regression test for #13193. This verifies that the editor can be reached
+	// over IPC.
+	it('should support the "textBold" command', async () => {
+		let lastBody = 'test';
+		const editorRef = React.createRef<EditorControl|null>();
+		render(<WrappedEditor
+			ref={editorRef}
+			noteBody={lastBody}
+			onBodyChange={newValue => { lastBody = newValue; }}
+		/>);
+
+		// Should mark the command as supported
+		expect(await editorRef.current.supportsCommand(EditorCommandType.ToggleBolded));
+
+		// Command should run
+		await editorRef.current.execCommand(EditorCommandType.SelectAll);
+		await editorRef.current.execCommand(EditorCommandType.ToggleBolded);
+		await waitFor(() => {
+			expect(lastBody).toBe('**test**');
+		});
+	});
+});

--- a/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/useWebViewSetup.ts
@@ -61,12 +61,6 @@ const useWebViewSetup = ({
 	// Since the editor content is included in editorOptions, for large documents,
 	// creating the initial injected JS is potentially expensive.
 	afterLoadFinishedJs.current = () => `
-		if (typeof window.markdownEditorBundle === 'undefined') {
-			${shim.injectedJs('markdownEditorBundle')};
-			window.markdownEditorBundle = markdownEditorBundle;
-			markdownEditorBundle.setUpLogger();
-		}
-
 		if (!window.cm) {
 			const parentClassName = ${JSON.stringify(editorOptions?.parentElementOrClassName)};
 			const foundParent = !!parentClassName && document.getElementsByClassName(parentClassName).length > 0;
@@ -94,7 +88,7 @@ const useWebViewSetup = ({
 	`;
 
 	const injectedJavaScript = useMemo(() => `
-		if (typeof markdownEditorBundle === 'undefined') {
+		if (typeof window.markdownEditorBundle === 'undefined') {
 			${shim.injectedJs('markdownEditorBundle')};
 			window.markdownEditorBundle = markdownEditorBundle;
 			markdownEditorBundle.setUpLogger();


### PR DESCRIPTION
# Summary

This pull request fixes the Markdown toolbar, which seems to have been broken [by an incorrect merge](https://github.com/laurent22/joplin/issues/13193#issuecomment-3434141386).

Fixes #13193.

# Testing

## Automated testing

This pull request adds an automated regression test.

## Manual testing

Android 16 emulator:
1. Enable the Markdown editor, if not already enabled.
1. Create a new note with title "`abc`".
2. Set the body to "`def`".
3. Select "`def`".
4. Press the "bold" button.
5. Verify that "`def`" has been replaced with "`**def**`".
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->