### PR TITLE
Mobile: Fixes #13457: Prevent toggling of multiline mode from clearing the title field on iOS

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -690,6 +690,10 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		if (prevState.note.body !== this.state.note.body) {
 			this.emitEditorPluginUpdate_();
 		}
+
+		if (prevState.multiline !== this.state.multiline && this.titleTextFieldRef.current) {
+			focus('Note::focusUpdate::title', this.titleTextFieldRef.current);
+		}
 	}
 
 	public componentWillUnmount() {
@@ -1703,6 +1707,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			<View style={titleContainerStyle}>
 				{isTodo && <Checkbox style={this.styles().checkbox} checked={!!Number(note.todo_completed)} onChange={this.todoCheckbox_change} />}
 				<TextInput
+					key={this.state.multiline ? 'multiLine' : 'singleLine'}
 					ref={this.titleTextFieldRef}
 					underlineColorAndroid="#ffffff00"
 					autoCapitalize="sentences"


### PR DESCRIPTION
The toggle multiline mode for the title field of the mobile app, which was introduced in https://github.com/laurent22/joplin/pull/13016, does not work correctly on iOS. When pressing the toggle button, the title field is cleared (if exiting the note and returning to it, the original value is still present).

According to ChatGPT, there is a discrepancy on iOS compared to Android for the following reason:
In iOS, a single-line `TextInput` is backed by a `UITextField`, whereas a multi-line `TextInput` is backed by a `UITextView` (or some variant). These two native components have different capabilities and implementations. When you toggle `multiline`, React Native may need to switch between different native views or reconfigure internal state. Because the native component underneath changes, React Native may **unmount** the old native view and **mount** a new one (or reinitialize many internal properties). During that process, unless the JS side carefully preserves the text and pushes it into the freshly mounted native view, you can lose the content.

In order to address this issue, I have added a conditional key attribute to the TextInput, so that the single line and multi line versions of the TextInput will be rendered as separate components. This does have the side effect that focus is lost on the field, but this can be re-obtained programmatically. In order to keep the logic for this simple though, I have kept the default behaviour for regaining focus, which means when pressing the multi line toggle, the cursor position will move to the end of the title field on both iOS and Android. This seems an acceptable compromise though, in order for the feature to be properly supported on iOS as well.

This fixes https://github.com/laurent22/joplin/issues/13457

### Testing

I have tested the change using iOS 17 simulator. As I only have temporary access to the Mac, I did not make a recording, but I did equivalent testing as is shown in the following video, which I recorded on Android emulator using this code:

https://github.com/user-attachments/assets/49e14bd0-c18a-4b9f-a7b3-57325af6afe3