### PR TITLE
Desktop,Mobile,Cli: Fixes #13522: Fix "cannot add an item as a child of a read-only item" error when updating share IDs

### DIFF
--- a/packages/lib/models/BaseItem.ts
+++ b/packages/lib/models/BaseItem.ts
@@ -1007,7 +1007,7 @@ export default class BaseItem extends BaseModel {
 
 		const isNew = this.isNew(o, options);
 
-		if (needsShareReadOnlyChecks(this.modelType(), options.changeSource, this.syncShareCache)) {
+		if (needsShareReadOnlyChecks(this.modelType(), options.changeSource, this.syncShareCache, options.disableReadOnlyCheck)) {
 			if (!isNew) {
 				const previousItem = await this.loadItemByTypeAndId(this.modelType(), o.id, { fields: ['id', 'share_id'] });
 				checkIfItemCanBeChanged(this.modelType(), options.changeSource, previousItem, this.syncShareCache);

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -556,7 +556,10 @@ export default class Folder extends BaseItem {
 				share_id: row.share_id || '',
 				parent_id: row.parent_id,
 				updated_time: Date.now(),
-			}, { autoTimestamp: false });
+			}, {
+				autoTimestamp: false,
+				disableReadOnlyCheck: true,
+			});
 		}
 	}
 


### PR DESCRIPTION
# Summary

This pull request fixes an error related to read-only shares by disabling a "not read-only" assertion when updating `share_id`s (e.g. if the `share_id`s were invalid due to an incomplete sync or issue elsewhere). Previously, if one `share_id` failed to update, calls to `updateAllShareIds` could fail. This prevented sharing new notebooks.

Fixes #13522.

# Testing

This pull request includes an automated test that failed previously.

I have verified that:
- It's possible to share a notebook without the "read-only share" error in my test environment.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->