### PR TITLE
Desktop: ENEX importer: Preserve folder hierarchy during import

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1465,6 +1465,7 @@ packages/lib/services/interop/InteropService_Exporter_Raw.js
 packages/lib/services/interop/InteropService_Importer_Base.js
 packages/lib/services/interop/InteropService_Importer_Custom.js
 packages/lib/services/interop/InteropService_Importer_EnexToHtml.js
+packages/lib/services/interop/InteropService_Importer_EnexToMd.test.js
 packages/lib/services/interop/InteropService_Importer_EnexToMd.js
 packages/lib/services/interop/InteropService_Importer_Jex.js
 packages/lib/services/interop/InteropService_Importer_Md.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1438,6 +1438,7 @@ packages/lib/services/interop/InteropService_Exporter_Raw.js
 packages/lib/services/interop/InteropService_Importer_Base.js
 packages/lib/services/interop/InteropService_Importer_Custom.js
 packages/lib/services/interop/InteropService_Importer_EnexToHtml.js
+packages/lib/services/interop/InteropService_Importer_EnexToMd.test.js
 packages/lib/services/interop/InteropService_Importer_EnexToMd.js
 packages/lib/services/interop/InteropService_Importer_Jex.js
 packages/lib/services/interop/InteropService_Importer_Md.test.js

--- a/packages/app-cli/tests/support/enex_nested_folders/root/Folder A/note1.enex
+++ b/packages/app-cli/tests/support/enex_nested_folders/root/Folder A/note1.enex
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20230920T212153Z" application="Evernote" version="10.60.4">
+  <note>
+    <title>Test 1</title>
+    <created>20200221T010525Z</created>
+    <updated>20230720T000138Z</updated>
+    <tag>recovery</tag>
+    <tag>Test!</tag>
+    <tag>Test</tag>
+    <tag>Sunny Acres</tag>
+    <note-attributes>
+      <source>web.clip</source>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+  <en-note><div>Test 1!</div></en-note>    ]]>
+    </content>
+  </note>
+</en-export>
+

--- a/packages/app-cli/tests/support/enex_nested_folders/root/Folder B/note1.enex
+++ b/packages/app-cli/tests/support/enex_nested_folders/root/Folder B/note1.enex
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20230920T212153Z" application="Evernote" version="10.60.4">
+  <note>
+    <title>Note 2</title>
+    <created>20200221T010525Z</created>
+    <updated>20230720T000138Z</updated>
+    <tag>recovery</tag>
+    <tag>Test!</tag>
+    <tag>Test</tag>
+    <note-attributes>
+      <source>web.clip</source>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+  <en-note><div>Test 2!</div></en-note>    ]]>
+    </content>
+  </note>
+</en-export>
+

--- a/packages/lib/services/interop/InteropService_Importer_EnexToMd.test.ts
+++ b/packages/lib/services/interop/InteropService_Importer_EnexToMd.test.ts
@@ -1,0 +1,48 @@
+import { join } from 'path';
+import Folder from '../../models/Folder';
+import { setupDatabase, supportDir, switchClient } from '../../testing/test-utils';
+import { ImportModuleOutputFormat, ImportOptions } from './types';
+import InteropService from './InteropService';
+import Note from '../../models/Note';
+
+describe('InteropService_Importer_EnexToMd', () => {
+	beforeEach(async () => {
+		await setupDatabase(1);
+		await switchClient(1);
+	});
+
+	it('should create Joplin folders based on the input folder hierarchy', async () => {
+		const folder = await Folder.save({ title: 'base' });
+		const importOptions: ImportOptions = {
+			path: join(supportDir, 'enex_nested_folders'),
+			format: 'enex',
+			destinationFolderId: folder.id,
+			outputFormat: ImportModuleOutputFormat.Markdown,
+		};
+
+		const result = await InteropService.instance().import(importOptions);
+		expect(result.warnings).toHaveLength(0);
+
+		const allFolders = await Folder.allAsTree();
+		expect(allFolders).toMatchObject([{
+			title: 'base',
+			children: [{
+				title: 'root',
+				children: [
+					{ title: 'Folder A' },
+					{ title: 'Folder B' },
+				],
+			}],
+		}]);
+
+		const folderA = await Folder.loadByTitle('Folder A');
+		const folderB = await Folder.loadByTitle('Folder B');
+
+		expect(await Note.previews(folderA.id)).toMatchObject([
+			{ title: 'Test 1' },
+		]);
+		expect(await Note.previews(folderB.id)).toMatchObject([
+			{ title: 'Note 2' },
+		]);
+	});
+});


### PR DESCRIPTION
# Summary

The goal of this pull request is to simplify the Evernote import process. Previously, the "Import" > "ENEX - Evernote Export Files (Directory)" import options only processed toplevel `.enex` files in the selected directory. For example, importing the folder "toplevel" below would result in no files being imported:
```
📁 toplevel/
|  📁 folder a/
|   | test.enex
|   | test2.enex
|  📁 folder b/
|   | a.enex
|   | b.enex
```

With this change, selecting the "toplevel" folder from the "ENEX ... (Directory)" option creates "folder a" and "folder b" in Joplin, then imports the contained `.enex` files into these new Joplin folders/notebooks.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->