### PR TITLE
Mobile: Fixes #13108: Use the safe area bottom padding in the useSafeAreaPadding hook when in landscape mode

### DIFF
--- a/packages/app-mobile/utils/hooks/useSafeAreaPadding.ts
+++ b/packages/app-mobile/utils/hooks/useSafeAreaPadding.ts
@@ -11,7 +11,7 @@ const useSafeAreaPadding = () => {
 			paddingRight: safeAreaInsets.right,
 			paddingLeft: safeAreaInsets.left,
 			paddingTop: safeAreaInsets.top,
-			paddingBottom: 0,
+			paddingBottom: safeAreaInsets.bottom,
 		} : {
 			paddingTop: safeAreaInsets.top,
 			paddingBottom: safeAreaInsets.bottom,


### PR DESCRIPTION
Currently, it can be difficult to scroll the Markdown toolbar on some Android devices without first showing the editor keyboard, due to the safe area view not taking into account the bottom inset when in landscape mode. This PR updates the useSafeAreaPadding hook to utilise the bottom inset in landscape mode

Fixes https://github.com/laurent22/joplin/issues/13108

### Testing

Android 16:

<img width="1472" height="893" alt="insets1" src="https://github.com/user-attachments/assets/03fa2d95-1404-46bc-89b7-cc36e458c2e0" />

Android 14:

<img width="691" height="289" alt="insets android 14" src="https://github.com/user-attachments/assets/2f008c38-1745-4812-a4b3-8195b264c80f" />

<img width="690" height="291" alt="insets android 14 gesture" src="https://github.com/user-attachments/assets/2dc80f20-6ad2-4cd1-912f-c6e82a871ab6" />

<img width="690" height="290" alt="insets android 14 gesture keyboard" src="https://github.com/user-attachments/assets/67c3fa13-60c8-403f-bc0b-7aaa8169b60d" />

<img width="690" height="290" alt="inset android 14 editor" src="https://github.com/user-attachments/assets/f67a7fd6-6bea-4e58-98b4-0ac9e4466c94" />

I also checked when I had access to iOS simulator and the result looked ok