### PR TITLE
Chore: Desktop: Share folder dialog: Remove duplicate "refreshShares" call

### DIFF
--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -147,7 +147,7 @@ function ShareFolderDialog(props: Props) {
 
 	useEffect(() => {
 		void ShareService.instance().refreshShares();
-	}, [props.folderId]);
+	}, []);
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		await synchronize(event);

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -147,7 +147,7 @@ function ShareFolderDialog(props: Props) {
 
 	useEffect(() => {
 		void ShareService.instance().refreshShares();
-	}, []);
+	}, [props.folderId]);
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		await synchronize(event);
@@ -176,10 +176,6 @@ function ShareFolderDialog(props: Props) {
 		if (!sus) return;
 		setShareUsers(sus);
 	}, [share, props.shareUsers]);
-
-	useEffect(() => {
-		void ShareService.instance().refreshShares();
-	}, [props.folderId]);
 
 	const permissionsFromString = (p: string): SharePermissions => {
 		return {


### PR DESCRIPTION
# Summary

This pull request removes a duplicate call to `void ShareService.instance().refreshShares();` from `ShareFolderDialog.tsx`.

# Testing plan

Desktop (Fedora 42 Linux):
1. Navigate to a previously unshared folder.
2. Right-click on the folder, click "Share".
3. In the "Share notebook", add a recipient using the "Recipients" field.
4. Verify that sync completes successfully.
5. Share the notebook with a different user.
6. Verify that it's possible to accept the share from a Joplin client synced with one of the share recipients' accounts.
7. Remove the user from step 7 from the share.
8. Sync the Joplin client that was removed from the share.
9. Verify that the previously-shared notebook has been removed from the notebook list.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->