### PR TITLE
Desktop: Accessibility: Improve dialog keyboard handling

### DIFF
--- a/packages/app-desktop/gui/DialogButtonRow.tsx
+++ b/packages/app-desktop/gui/DialogButtonRow.tsx
@@ -51,7 +51,15 @@ export default function DialogButtonRow(props: Props) {
 		if (props.onClick) props.onClick(event);
 	}, [props.onClick]);
 
-	const onKeyDown = useKeyboardHandler({ onOkButtonClick, onCancelButtonClick });
+	const okButtonShow = props.okButtonShow ?? true;
+	const cancelButtonShow = props.cancelButtonShow ?? true;
+	const canClickOk = okButtonShow && !props.okButtonDisabled;
+	const canClickCancel = cancelButtonShow && !props.cancelButtonDisabled;
+
+	const onKeyDown = useKeyboardHandler({
+		onOkButtonClick: canClickOk ? onOkButtonClick : null,
+		onCancelButtonClick: canClickCancel ? onCancelButtonClick : null,
+	});
 
 	const buttonComps = [];
 
@@ -65,7 +73,7 @@ export default function DialogButtonRow(props: Props) {
 		}
 	}
 
-	if (props.okButtonShow !== false) {
+	if (okButtonShow) {
 		buttonComps.push(
 			<button disabled={props.okButtonDisabled} key="ok" style={buttonStyle} onClick={onOkButtonClick} ref={props.okButtonRef} onKeyDown={onKeyDown}>
 				{props.okButtonLabel ? props.okButtonLabel : _('OK')}
@@ -73,7 +81,7 @@ export default function DialogButtonRow(props: Props) {
 		);
 	}
 
-	if (props.cancelButtonShow !== false) {
+	if (cancelButtonShow) {
 		buttonComps.push(
 			<button disabled={props.cancelButtonDisabled} key="cancel" style={{ ...buttonStyle }} onClick={onCancelButtonClick}>
 				{props.cancelButtonLabel ? props.cancelButtonLabel : _('Cancel')}

--- a/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
+++ b/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
@@ -3,10 +3,8 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { isInsideContainer } from '@joplin/lib/dom';
 
 interface Props {
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onOkButtonClick: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onCancelButtonClick: Function;
+	onOkButtonClick: null|(()=> void);
+	onCancelButtonClick: null|(()=> void);
 }
 
 const globalKeydownHandlers: string[] = [];
@@ -48,15 +46,17 @@ export default (props: Props) => {
 
 		if (!isTopDialog() || isInSubModal(event.target)) return;
 
-		if (event.keyCode === 13) {
+		if (event.keyCode === 13 && props.onOkButtonClick) {
 			if ('nodeName' in event.target && event.target.nodeName === 'INPUT') {
 				const target = event.target as HTMLInputElement;
 
 				if (target.type !== 'button' && target.type !== 'checkbox') {
+					event.preventDefault();
 					props.onOkButtonClick();
 				}
 			}
-		} else if (event.keyCode === 27) {
+		} else if (event.keyCode === 27 && props.onCancelButtonClick) {
+			event.preventDefault();
 			props.onCancelButtonClick();
 		}
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied

--- a/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
+++ b/packages/app-desktop/gui/DialogButtonRow/useKeyboardHandler.ts
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { isInsideContainer } from '@joplin/lib/dom';
 
+type OnButtonClick = ()=> void;
 interface Props {
-	onOkButtonClick: null|(()=> void);
-	onCancelButtonClick: null|(()=> void);
+	onOkButtonClick: null|OnButtonClick;
+	onCancelButtonClick: null|OnButtonClick;
 }
 
 const globalKeydownHandlers: string[] = [];

--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -172,7 +172,12 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 			<div style={{ ...labelCompStyle, marginTop: 10 }}>
 				{readTimeLabel}
 			</div>
-			<DialogButtonRow themeId={props.themeId} onClick={buttonRow_click} okButtonShow={false} cancelButtonLabel={_('Close')}/>
+			<DialogButtonRow
+				themeId={props.themeId}
+				onClick={buttonRow_click}
+				okButtonShow={false}
+				cancelButtonLabel={_('Close')}
+			/>
 		</Dialog>
 	);
 }

--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -501,7 +501,12 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 				<div role='table' aria-labelledby='note-properties-dialog-title'>
 					{noteComps}
 				</div>
-				<DialogButtonRow themeId={this.props.themeId} okButtonShow={!this.isReadOnly()} okButtonRef={this.okButton} onClick={this.buttonRow_click}/>
+				<DialogButtonRow
+					themeId={this.props.themeId}
+					okButtonShow={!this.isReadOnly()}
+					okButtonRef={this.okButton}
+					onClick={this.buttonRow_click}
+				/>
 			</Dialog>
 		);
 	}


### PR DESCRIPTION
# Summary

This pull request improves how keyboard events are handled in dialogs. This:
- Fixes an issue where **various dialogs couldn't be re-opened after being closed with <kbd>escape</kbd>**.
   - This was fixed by preventing the default behavior in the custom <kbd>escape</kbd> handler for dialogs.
- Fixes an issue where pressing <kbd>enter</kbd> in the "share note" dialog's "email" field dismissed the dialog, rather than adding the user to the share.
   - With this change, pressing <kbd>enter</kbd> from the "email" field does nothing (focus must be moved to the "share" button). However, this is better than incorrectly dismissing the dialog.
   - This was fixed by avoiding triggering the "onClick({ buttonName: 'ok' })" action for the button bar when pressing <kbd>enter</kbd> when the "OK" button is hidden.

# Testing plan

Fedora 42 (Desktop):
1. Open the "Share Notebook" dialog using right-click > "share notebook..." on a top-level notebook.
2. Move focus to the "add recipient" field.
3. Press <kbd>enter</kbd>. Verify that the dialog remains open.
4. Press <kbd>escape</kbd>. Verify that the dialog closes.
5. Right-click on the current notebook and click "Share notebook...".
6. Verify that the "Share Notebook" dialog opens.
7. Dismiss the "Share" dialog with <kbd>Escape</kbd>.
8. Open the "Edit" dialog for a notebook.
9. Change the title.
10. Press <kbd>enter</kbd>. Verify that this dismisses the "Edit" dialog and changes the folder title.
11. Re-open the edit dialog.
12. Press <kbd>escape</kbd>. Verify that this dismisses the "Edit" dialog.
13. Open the "note properties" dialog. Adjust the "Created" date.
14. Press <kbd>enter</kbd>. Verify that this dismisses the "Note properties" dialog.
15. Re-open the "Note properties" dialog. Verify that the adjusted "Created date" was applied.
16. Press <kbd>escape</kbd>. Verify that this dismisses the dialog.
17. Open the "Manage master password" dialog from settings > encryption.
18. Press <kbd>escape</kbd>. Verify that this dismisses the dialog.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->