### PR TITLE
Desktop: Fixes #13537: Fix adding a new user to a share creates an unused E2EE key

### DIFF
--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -120,7 +120,7 @@ export default class ShareService {
 			}
 
 			if (folder.master_key_id) {
-				logger.debug(`Folder ${folderId}'s already has a master key. Not creating a new one.`);
+				logger.info(`Folder ${folderId}'s already has a master key. Not creating a new one.`);
 			} else {
 				// TODO: handle "undefinedMasterPassword" error - show master password dialog
 				folderMasterKey = await this.encryptionService_.generateMasterKey(getMasterPassword());

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -22,6 +22,7 @@ const perfLogger = PerformanceLogger.create();
 export interface ApiShare {
 	id: string;
 	master_key_id: string;
+	folder_id: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -118,11 +119,15 @@ export default class ShareService {
 				throw new Error('The local public private key pair uses an unsupported algorithm. It may be necessary to upgrade Joplin or share from a different device.');
 			}
 
-			// TODO: handle "undefinedMasterPassword" error - show master password dialog
-			folderMasterKey = await this.encryptionService_.generateMasterKey(getMasterPassword());
-			folderMasterKey = await MasterKey.save(folderMasterKey);
+			if (folder.master_key_id) {
+				logger.debug(`Folder ${folderId}'s already has a master key. Not creating a new one.`);
+			} else {
+				// TODO: handle "undefinedMasterPassword" error - show master password dialog
+				folderMasterKey = await this.encryptionService_.generateMasterKey(getMasterPassword());
+				folderMasterKey = await MasterKey.save(folderMasterKey);
 
-			addMasterKey(syncInfo, folderMasterKey);
+				addMasterKey(syncInfo, folderMasterKey);
+			}
 		}
 
 		const newFolderProps: FolderEntity = {};
@@ -162,6 +167,11 @@ export default class ShareService {
 		// First, delete the share - which in turns is going to remove the items
 		// for all users, except the owner.
 		await this.deleteShare(share.id);
+
+		// Clear the master_key_id so that the folder uses a new master key if
+		// shared again.
+		// TODO: Remove the now-unused master key from local sync info.
+		await Folder.save({ id: folderId, master_key_id: '' });
 
 		// Then reset the "share_id" field for the folder and all sub-items.
 		// This could potentially be done server-side, when deleting the share,


### PR DESCRIPTION
# Summary

Fixes an issue that caused unused E2EE keys to be created in some cases.

Fixes #13537.

# Details

Currently, when a user adds a new recipient to a share:
- `ShareService::shareFolder` re-runs. When the folder is already shared, this should just return the share. Previously, however, the E2EE setup for the folder ran each time `ShareService::shareFolder` was called, regardless of whether the folder was already shared.
- The recipient is added to the share with `ShareService::addRecipient` (see [E2EE: Notebook Share](https://joplinapp.org/help/dev/spec/e2ee/workflow/#e2ee-notebook-share) for what this step does).

See #13537 for additional information.

Fixes #13537.

# Testing

## Manual testing

On Fedora 42, Linux:
1. Start Joplin Server. Create two users: `self@localhost` and `self2@localhost`.
2. Enable encryption for both users.
3. Share a notebook from `self@localhost` to `self2@localhost`.
4. Accept the share from `self2@localhost`.
5. Verify that the shared notebook is visible.
6. Unshare and reshare the notebook from `self@localhost`.
7. Accept the share from `self2@localhost`.
8. Verify that the shared notebook briefly shows an "encrypted" icon while accepting the share.
9. Verify that the shared notebook is visible.
10. Verify that there are three encryption keys present in settings > encryption. (One for `self2@localhost`, one for the share accepted in (4) and one for the share accepted in (7)).

## Automated testing

In addition to the existing share tests that run in CI, this pull request adds the following two automated tests:
- [`should not update the folder\'s master_key_id when shareFolder is called multiple times`](https://github.com/laurent22/joplin/blob/2d76628c27415af896bf0a0c7b677d2649627f69/packages/lib/services/share/ShareService.test.ts#L281)
- [`should use a different master key when folders are unshared, then shared again`](https://github.com/laurent22/joplin/blob/2d76628c27415af896bf0a0c7b677d2649627f69/packages/lib/services/share/ShareService.test.ts#L305)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->