### PR TITLE
Desktop: Fixes #13528: Prevent OCR service from saving changes to a deleted resource

### DIFF
--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -186,9 +186,9 @@ export default class OcrService {
 			const processedResourceIds: string[] = [];
 
 			// Queue all resources for processing
-			let lastProcessedResourceIdsLength = -1;
-			while (processedResourceIds.length > lastProcessedResourceIdsLength) {
-				lastProcessedResourceIdsLength = processedResourceIds.length;
+			let lastProcessedCount = -1;
+			while (processedResourceIds.length > lastProcessedCount) {
+				lastProcessedCount = processedResourceIds.length;
 
 				const resources = await Resource.needOcr(supportedMimeTypes, skippedResourceIds.concat(processedResourceIds), 100, {
 					fields: [


### PR DESCRIPTION
# Summary

This pull request adds an additional check to the OCR service to prevent `Resource.save` from being called for deleted resources.

May fix #13528.




<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->