### PR TITLE
Desktop: Disallow unsharing a folder while sharing is in progress

### DIFF
--- a/packages/app-desktop/gui/DialogButtonRow.tsx
+++ b/packages/app-desktop/gui/DialogButtonRow.tsx
@@ -7,6 +7,7 @@ import useKeyboardHandler from './DialogButtonRow/useKeyboardHandler';
 export interface ButtonSpec {
 	name: string;
 	label: string;
+	disabled?: boolean;
 }
 
 export interface ClickEvent {
@@ -58,7 +59,7 @@ export default function DialogButtonRow(props: Props) {
 	if (props.customButtons) {
 		for (const b of props.customButtons) {
 			buttonComps.push(
-				<button key={b.name} style={buttonStyle} onClick={() => onCustomButtonClick({ buttonName: b.name })} onKeyDown={onKeyDown}>
+				<button key={b.name} style={buttonStyle} onClick={() => onCustomButtonClick({ buttonName: b.name })} disabled={b.disabled} onKeyDown={onKeyDown}>
 					{b.label}
 				</button>,
 			);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearchExtension.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useEditorSearchExtension.ts
@@ -8,6 +8,139 @@ const logger = Logger.create('useEditorSearch');
 // Registers a helper CodeMirror extension to be used with
 // useEditorSearchHandler.
 
+type Mark = { clear: ()=> void };
+interface SearchHighlightState {
+	previousKeywordValue: string;
+	previousIndex: number;
+	previousSearchTimestamp: number;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied
+	overlayTimeoutRef: { current: any };
+	clearMarkers(): void;
+	clearOverlay(editor: CodeMirror5Emulation): void;
+	getSearchTerm(keyword: string): RegExp;
+	highlightSearch(cm: CodeMirror5Emulation, searchTerm: RegExp, index: number, scrollTo: boolean, withSelection: boolean): Mark;
+	setMarkers(marker: Mark[]): void;
+	setPreviousIndex(index: number): void;
+	setPreviousSearchTimestamp(timestamp: number): void;
+	setPreviousKeywordValue(value: string): void;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied
+	setScrollbarMarks(marks: any): void;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of old code before rule was applied
+	setOverlay(overlay: any): void;
+	setOverlayTimeout(timeout: number): void;
+}
+
+
+// Modified from codemirror/addons/search/search.js
+const searchOverlay = (query: RegExp) => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+	return { token: function(stream: any) {
+		query.lastIndex = stream.pos;
+		const match = query.exec(stream.string);
+		if (match && match.index === stream.pos) {
+			stream.pos += match[0].length || 1;
+			return 'search-marker';
+		} else if (match) {
+			stream.pos = match.index;
+		} else {
+			stream.skipToEnd();
+		}
+		return null;
+	} };
+};
+
+const addCodeMirrorExtension = (CodeMirror: CodeMirror5Emulation) => {
+	CodeMirror.defineOption('joplin.search-highlight-state', null, ()=>{});
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+	CodeMirror?.defineExtension('setMarkers', function(keywords: any, options: any) {
+		// Pass arguments in via options to allow the extension to work if multiple editors are open simultaneously
+		// See https://github.com/laurent22/joplin/issues/13399.
+		const state: SearchHighlightState = this.getOption('joplin.search-highlight-state');
+		if (!options) {
+			options = { selectedIndex: 0, searchTimestamp: 0 };
+		}
+
+		if (options.showEditorMarkers === false) {
+			state.clearMarkers();
+			state.clearOverlay(this);
+			return;
+		}
+
+		state.clearMarkers();
+
+		// HIGHLIGHT KEYWORDS
+		// When doing a global search it's possible to have multiple keywords
+		// This means we need to highlight each one
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		const marks: any = [];
+		for (let i = 0; i < keywords.length; i++) {
+			const keyword = keywords[i];
+
+			if (keyword.value === '') continue;
+
+			const searchTerm = state.getSearchTerm(keyword);
+
+			// We only want to scroll the first keyword into view in the case of a multi keyword search
+			const scrollTo = i === 0 && (state.previousKeywordValue !== keyword.value || state.previousIndex !== options.selectedIndex || options.searchTimestamp !== state.previousSearchTimestamp);
+
+			try {
+				const match = state.highlightSearch(this, searchTerm, options.selectedIndex, scrollTo, !!options.withSelection);
+				if (match) marks.push(match);
+			} catch (error) {
+				if (error.name !== 'SyntaxError') {
+					throw error;
+				}
+				// An error of 'Regular expression too large' might occur in the markJs library
+				// when the input is really big, this catch is here to avoid the application crashing
+				// https://github.com/laurent22/joplin/issues/7634
+				console.error('Error while trying to highlight words from search: ', error);
+			}
+		}
+
+		state.setMarkers(marks);
+		state.setPreviousIndex(options.selectedIndex);
+		state.setPreviousSearchTimestamp(options.searchTimestamp);
+
+		// SEARCHOVERLAY
+		// We only want to highlight all matches when there is only 1 search term
+		if (keywords.length !== 1 || keywords[0].value === '') {
+			state.clearOverlay(this);
+			const prev = keywords.length > 1 ? keywords[0].value : '';
+			state.setPreviousKeywordValue(prev);
+			return 0;
+		}
+
+		const searchTerm = state.getSearchTerm(keywords[0]);
+
+		// Determine the number of matches in the source, this is passed on
+		// to the NoteEditor component
+		const regexMatches = this.getValue().match(searchTerm);
+		const nMatches = regexMatches ? regexMatches.length : 0;
+
+		// Don't bother clearing and re-calculating the overlay if the search term
+		// hasn't changed
+		if (keywords[0].value === state.previousKeywordValue) return nMatches;
+
+		state.clearOverlay(this);
+		state.setPreviousKeywordValue(keywords[0].value);
+
+		// These operations are pretty slow, so we won't add use them until the user
+		// has finished typing, 500ms is probably enough time
+		const timeout = shim.setTimeout(() => {
+			const scrollMarks = this.showMatchesOnScrollbar?.(searchTerm, true, 'cm-search-marker-scrollbar');
+			const overlay = searchOverlay(searchTerm);
+			this.addOverlay(overlay);
+			state.setOverlay(overlay);
+			state.setScrollbarMarks(scrollMarks);
+		}, 500);
+
+		state.setOverlayTimeout(timeout);
+		state.overlayTimeoutRef.current = timeout;
+
+		return nMatches;
+	});
+};
+
 export default function useEditorSearchExtension(CodeMirror: CodeMirror5Emulation) {
 
 	const [markers, setMarkers] = useState([]);
@@ -48,23 +181,6 @@ export default function useEditorSearchExtension(CodeMirror: CodeMirror5Emulatio
 		setOverlayTimeout(null);
 	}, [scrollbarMarks, overlay, overlayTimeout]);
 
-	// Modified from codemirror/addons/search/search.js
-	const searchOverlay = useCallback((query: RegExp) => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		return { token: function(stream: any) {
-			query.lastIndex = stream.pos;
-			const match = query.exec(stream.string);
-			if (match && match.index === stream.pos) {
-				stream.pos += match[0].length || 1;
-				return 'search-marker';
-			} else if (match) {
-				stream.pos = match.index;
-			} else {
-				stream.skipToEnd();
-			}
-			return null;
-		} };
-	}, []);
 
 	// Highlights the currently active found work
 	// It's possible to get tricky with this functions and just use findNext/findPrev
@@ -115,89 +231,25 @@ export default function useEditorSearchExtension(CodeMirror: CodeMirror5Emulatio
 		};
 	}, []);
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	CodeMirror?.defineExtension('setMarkers', function(keywords: any, options: any) {
-		if (!options) {
-			options = { selectedIndex: 0, searchTimestamp: 0 };
-		}
-
-		if (options.showEditorMarkers === false) {
-			clearMarkers();
-			clearOverlay(this);
-			return;
-		}
-
-		clearMarkers();
-
-		// HIGHLIGHT KEYWORDS
-		// When doing a global search it's possible to have multiple keywords
-		// This means we need to highlight each one
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const marks: any = [];
-		for (let i = 0; i < keywords.length; i++) {
-			const keyword = keywords[i];
-
-			if (keyword.value === '') continue;
-
-			const searchTerm = getSearchTerm(keyword);
-
-			// We only want to scroll the first keyword into view in the case of a multi keyword search
-			const scrollTo = i === 0 && (previousKeywordValue !== keyword.value || previousIndex !== options.selectedIndex || options.searchTimestamp !== previousSearchTimestamp);
-
-			try {
-				const match = highlightSearch(this, searchTerm, options.selectedIndex, scrollTo, !!options.withSelection);
-				if (match) marks.push(match);
-			} catch (error) {
-				if (error.name !== 'SyntaxError') {
-					throw error;
-				}
-				// An error of 'Regular expression too large' might occur in the markJs library
-				// when the input is really big, this catch is here to avoid the application crashing
-				// https://github.com/laurent22/joplin/issues/7634
-				console.error('Error while trying to highlight words from search: ', error);
-			}
-		}
-
-		setMarkers(marks);
-		setPreviousIndex(options.selectedIndex);
-		setPreviousSearchTimestamp(options.searchTimestamp);
-
-		// SEARCHOVERLAY
-		// We only want to highlight all matches when there is only 1 search term
-		if (keywords.length !== 1 || keywords[0].value === '') {
-			clearOverlay(this);
-			const prev = keywords.length > 1 ? keywords[0].value : '';
-			setPreviousKeywordValue(prev);
-			return 0;
-		}
-
-		const searchTerm = getSearchTerm(keywords[0]);
-
-		// Determine the number of matches in the source, this is passed on
-		// to the NoteEditor component
-		const regexMatches = this.getValue().match(searchTerm);
-		const nMatches = regexMatches ? regexMatches.length : 0;
-
-		// Don't bother clearing and re-calculating the overlay if the search term
-		// hasn't changed
-		if (keywords[0].value === previousKeywordValue) return nMatches;
-
-		clearOverlay(this);
-		setPreviousKeywordValue(keywords[0].value);
-
-		// These operations are pretty slow, so we won't add use them until the user
-		// has finished typing, 500ms is probably enough time
-		const timeout = shim.setTimeout(() => {
-			const scrollMarks = this.showMatchesOnScrollbar?.(searchTerm, true, 'cm-search-marker-scrollbar');
-			const overlay = searchOverlay(searchTerm);
-			this.addOverlay(overlay);
-			setOverlay(overlay);
-			setScrollbarMarks(scrollMarks);
-		}, 500);
-
-		setOverlayTimeout(timeout);
-		overlayTimeoutRef.current = timeout;
-
-		return nMatches;
-	});
+	if (CodeMirror) {
+		const state: SearchHighlightState = {
+			previousKeywordValue,
+			previousIndex,
+			previousSearchTimestamp,
+			overlayTimeoutRef,
+			clearMarkers,
+			clearOverlay,
+			getSearchTerm,
+			highlightSearch,
+			setMarkers,
+			setPreviousIndex,
+			setPreviousSearchTimestamp,
+			setPreviousKeywordValue,
+			setScrollbarMarks,
+			setOverlay,
+			setOverlayTimeout,
+		};
+		addCodeMirrorExtension(CodeMirror);
+		CodeMirror.setOption('joplin.search-highlight-state', state);
+	}
 }

--- a/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
+++ b/packages/app-desktop/gui/ShareFolderDialog/ShareFolderDialog.tsx
@@ -394,7 +394,7 @@ function ShareFolderDialog(props: Props) {
 			// Don't allow unsharing the folder during the "create" action. Doing so might
 			// be able to cause issues similar to #13518 (e.g. if the "unshare" action completes while
 			// the "share" action is still in progress).
-			disabled: shareState === ShareState.Creating,
+			disabled: shareState === ShareState.Creating || shareState === ShareState.Synchronizing,
 		}] : [];
 	}, [share, shareState]);
 


### PR DESCRIPTION
# Summary

This change prevents the "Unshare" button from being clicked while a sync is in progress.

This pull request *may* resolve #13518, if #13518 is related to a conflict between the share and unshare actions or related to an outdated `jop_share_id` property on the server.

# Details

When unsharing a folder, Joplin Server determines which items to mark as deleted based on the `jop_share_id` property:
<details>

- [DEL `api/shares/:id`](https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/routes/api/shares.ts#L139) calls `models.share().delete`:
  https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/routes/api/shares.ts#L144
- ...which calls `userItem().deleteByShare`:
  https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/models/ShareModel.ts#L477
- ...which calls `UserItemModel::deleteBy`:
  https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/models/UserItemModel.ts#L111
- ...which gets items by the share ID:
  https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/models/UserItemModel.ts#L200
- ...which uses the `jop_share_id` property:
  https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/models/UserItemModel.ts#L66
- ...which is synced from the Joplin clients.

</details>

Since `jop_share_id` [comes from the Joplin clients' `share_id` property](https://github.com/laurent22/joplin/blob/94725c533cc76cdd042fa114976b5459528ad208/packages/server/src/models/ItemModel.ts#L622), the Joplin clients need to be fully synced for the results of the `... .where('items.jop_share_id', '=', shareId)` query to match the data present locally.

<!--Note: The below shows a partial example that I *don't* think would cause issues, since the sub-folder is moved by the share owner.
For example, if a Joplin account initially has this notebook hierarchy:
```
📂 folder 1 (🟠 shared)
| 📂 sub-folder (🟠)
| | 📄 item (🟠)
```
The user then moves `sub-folder` to the top level, **without syncing this change** (e.g. because there are a large number of other changes also being synced):
```
📂 folder 1 (🟠 shared)
| Empty!
📂 sub-folder (🟠)
| 📄 item (🟠)
```
Joplin then **locally** updates the `share_id` for `sub-folder`:
```
📂 folder 1 (🟠 shared)
| Empty!
📂 sub-folder
| 📄 item
```
The user then unshares `folder 1`. Since the `share_id` changes haven't been synced to the server, Joplin Server still considers `sub-folder` to be associated with the share. 
-->

# Testing plan

1. Right-click on a notebook and click "Share notebook...".
2. Add a user by email to the share.
3. Verify that 1) the "Unshare" button isn't visible until "Synchronizing..." is and 2) "Unshare" is greyed out/disabled while "Synchronizing..." is visible.

<details><summary>Screen recording</summary>

[Screencast from 2025-10-27 10-19-05.webm](https://github.com/user-attachments/assets/f5a5d386-8a35-4eda-a40e-018396673073)



</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->