### PR TITLE
All: Fixes #13531: When creating a conflict, ensure the latest note contents are used to create the conflict

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1643,6 +1643,7 @@ packages/lib/services/synchronizer/Synchronizer.sharing.test.js
 packages/lib/services/synchronizer/Synchronizer.tags.test.js
 packages/lib/services/synchronizer/Synchronizer.tools.test.js
 packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.js
+packages/lib/services/synchronizer/handleConflictAction.test.js
 packages/lib/services/synchronizer/migrations/1.js
 packages/lib/services/synchronizer/migrations/2.js
 packages/lib/services/synchronizer/migrations/3.js

--- a/.gitignore
+++ b/.gitignore
@@ -1616,6 +1616,7 @@ packages/lib/services/synchronizer/Synchronizer.sharing.test.js
 packages/lib/services/synchronizer/Synchronizer.tags.test.js
 packages/lib/services/synchronizer/Synchronizer.tools.test.js
 packages/lib/services/synchronizer/gui/useSyncTargetUpgrade.js
+packages/lib/services/synchronizer/handleConflictAction.test.js
 packages/lib/services/synchronizer/migrations/1.js
 packages/lib/services/synchronizer/migrations/2.js
 packages/lib/services/synchronizer/migrations/3.js

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -13,6 +13,8 @@ describe('handleConflictAction', () => {
 
 	test('create a note conflict', async () => {
 		const local = await Note.save({ title: 'Test' });
+		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
+		const changedLocal = { ...local, title: 'TestChanged' };
 		const remoteContent = { ...local, title: 'TestRemote' };
 		const initialSyncItem = await BaseItem.syncItem(1, local.id);
 		await handleConflictAction(
@@ -20,7 +22,7 @@ describe('handleConflictAction', () => {
 			Note,
 			true,
 			remoteContent,
-			local,
+			changedLocal,
 			1,
 			false,
 			(action) => (action),

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -12,7 +12,7 @@ describe('handleConflictAction', () => {
 	});
 
 	test('note conflict is created', async () => {
-		const local = await Note.save({ title: 'Test' });
+		const local = await Note.save({ title: 'Test', body: 'body' });
 		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
 		const changedLocal = { ...local, title: 'TestChanged' };
 		const remoteContent = { ...local, title: 'TestRemote' };
@@ -31,19 +31,22 @@ describe('handleConflictAction', () => {
 
 		const createdSyncItem = await BaseItem.syncItem(1, local.id);
 		const updatedLocal = await Note.load(local.id);
+		const notes = await Note.all();
 		const conflictNote = await Note.loadByTitle('Test');
 
 		expect(initialSyncItem).toBeUndefined();
 		expect(createdSyncItem).toBeDefined();
 		expect(updatedLocal.title).toBe('TestRemote');
+		expect(notes.length).toBe(2);
 		expect(conflictNote.id).not.toBe(local.id);
 	});
 
 	test('note conflict is not created when remote and local contents match', async () => {
-		const local = await Note.save({ title: 'Test' });
+		const local = await Note.save({ title: 'Test', body: 'body' });
 		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
 		const changedLocal = { ...local, title: 'TestChanged' };
-		const remoteContent = { ...local, title: 'Test' };
+		const remoteContent = local;
+		const initialSyncItem = await BaseItem.syncItem(1, local.id);
 
 		await handleConflictAction(
 			SyncAction.NoteConflict,
@@ -56,11 +59,11 @@ describe('handleConflictAction', () => {
 			(action) => (action),
 		);
 
-		const noteWithSavedTitle = await Note.loadByTitle('Test');
-		const noteWithUnsavedTitle = await Note.loadByTitle('TestChanged');
-
-		expect(noteWithSavedTitle).toBeUndefined();
-		expect(noteWithUnsavedTitle).toBeUndefined();
+		const createdSyncItem = await BaseItem.syncItem(1, local.id);
+		const notes = await Note.all();
+		expect(initialSyncItem).toBeUndefined();
+		expect(createdSyncItem).toBeDefined();
+		expect(notes.length).toBe(1);
 	});
 
 });

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -43,7 +43,7 @@ describe('handleConflictAction', () => {
 
 	test('note conflict is not created when remote and local contents match', async () => {
 		const local = await Note.save({ title: 'Test', body: 'body' });
-		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
+		// Pass the local note with unsaved changes to verify that the note is reloaded before checking if eligible to create a conflict
 		const changedLocal = { ...local, title: 'TestChanged' };
 		const remoteContent = local;
 		const initialSyncItem = await BaseItem.syncItem(1, local.id);

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -1,0 +1,39 @@
+import BaseItem from '../../models/BaseItem';
+import Note from '../../models/Note';
+import { setupDatabaseAndSynchronizer, switchClient } from '../../testing/test-utils';
+import handleConflictAction from './utils/handleConflictAction';
+import { SyncAction } from './utils/types';
+
+describe('handleConflictAction', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	test('create a note conflict', async () => {
+		const local = await Note.save({ title: 'Test' });
+		const remoteContent = { ...local, title: 'TestRemote' };
+		const initialSyncItem = await BaseItem.syncItem(1, local.id);
+		await handleConflictAction(
+			SyncAction.NoteConflict,
+			Note,
+			true,
+			remoteContent,
+			local,
+			1,
+			false,
+			(action) => (action),
+		);
+
+		const createdSyncItem = await BaseItem.syncItem(1, local.id);
+		const updatedLocal = await Note.load(local.id);
+		const conflictNote = await Note.loadByTitle('Test');
+
+		expect(initialSyncItem).toBeUndefined();
+		expect(createdSyncItem).toBeDefined();
+		expect(updatedLocal.title).toBe('TestRemote');
+		expect(conflictNote.id).not.toBe(local.id);
+	});
+
+});

--- a/packages/lib/services/synchronizer/handleConflictAction.test.ts
+++ b/packages/lib/services/synchronizer/handleConflictAction.test.ts
@@ -11,12 +11,13 @@ describe('handleConflictAction', () => {
 		await switchClient(1);
 	});
 
-	test('create a note conflict', async () => {
+	test('note conflict is created', async () => {
 		const local = await Note.save({ title: 'Test' });
 		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
 		const changedLocal = { ...local, title: 'TestChanged' };
 		const remoteContent = { ...local, title: 'TestRemote' };
 		const initialSyncItem = await BaseItem.syncItem(1, local.id);
+
 		await handleConflictAction(
 			SyncAction.NoteConflict,
 			Note,
@@ -36,6 +37,30 @@ describe('handleConflictAction', () => {
 		expect(createdSyncItem).toBeDefined();
 		expect(updatedLocal.title).toBe('TestRemote');
 		expect(conflictNote.id).not.toBe(local.id);
+	});
+
+	test('note conflict is not created when remote and local contents match', async () => {
+		const local = await Note.save({ title: 'Test' });
+		// Pass the local note with unsaved changes to verify that the note is reloaded before creating the conflict
+		const changedLocal = { ...local, title: 'TestChanged' };
+		const remoteContent = { ...local, title: 'Test' };
+
+		await handleConflictAction(
+			SyncAction.NoteConflict,
+			Note,
+			true,
+			remoteContent,
+			changedLocal,
+			1,
+			false,
+			(action) => (action),
+		);
+
+		const noteWithSavedTitle = await Note.loadByTitle('Test');
+		const noteWithUnsavedTitle = await Note.loadByTitle('TestChanged');
+
+		expect(noteWithSavedTitle).toBeUndefined();
+		expect(noteWithUnsavedTitle).toBeUndefined();
 	});
 
 });

--- a/packages/lib/services/synchronizer/utils/handleConflictAction.ts
+++ b/packages/lib/services/synchronizer/utils/handleConflictAction.ts
@@ -38,6 +38,9 @@ export default async (action: SyncAction, ItemClass: typeof BaseItem, remoteExis
 			});
 		}
 	} else if (action === SyncAction.NoteConflict) {
+		// Reload the note, to ensure the latest version is used to create the conflict
+		local = await Note.load(local.id);
+
 		// ------------------------------------------------------------------------------
 		// First find out if the conflict matters. For example, if the conflict is on the title or body
 		// we want to preserve all the changes. If it's on todo_completed it doesn't really matter


### PR DESCRIPTION
The conflict resolution process handles conflicts for notes by creating a conflict using the local note contents and then replaces the local note with the remote note. Currently, the process will select the local note contents during the upload step of the Synchroniser code. This means that if there are many uploads queued, it is possible that if a conflict is created for a note which is currently being edited by a user, an outdated version of the note will be used to create the conflicting note, and some text which the user has just typed may be lost.

**Reproduction steps (this is easier to reproduce on desktop, due to the 15 second delay for sync as you type):**
1. Setup 2 Joplin clients syncing with OneDrive, with the default Welcome notebook. Have them both open
2. Create a new note called 'Test' with the body '123'
3. Sync both clients
4. On client A, add 'a' to the end of the note body for note 'Test', then sync the change
5. On client B, do not click sync. Duplicate the 5 default notes in the Welcome notebook twice
6. Then, quickly add 'b' to the end of the note body for note 'Test'
7. Wait until the sync automatically triggers. As soon as it triggers, quickly type '12345678901234567890' at the end of the note body for note 'Test'
8. Once the sync completes, a conflict is created for note 'Test', but the note body only contains '123b'. It should contain '123b12345678901234567890'

In order to remedy this, this PR re-selects the local note immediately before creating the note conflict, so that the latest contents will be used.

This fixes https://github.com/laurent22/joplin/issues/13531

### Limitations

Note that if the user is typing continuously and they type faster than the debounce interval for the note editor (100ms desktop and 500ms on mobile), some changes may still be lost because they are not currently saved when the note is reloaded. Also, if the user happens to be typing just at the point when the conflict is created, the replacement of the local note contents with the remote contents may not have time to re-render, and therefore they are lost to the local version, due to a local save overwriting the change made by the conflict resolution. I'm not sure how this can be prevented to be honest, but it should be a rarer occurrence than the bug which this PR does address.

### Testing

See videos following the reproduction steps.

**Before:**

https://github.com/user-attachments/assets/b6ef4650-534b-47d8-bb67-33ab8c7ce2ce

**After:**

https://github.com/user-attachments/assets/bdcb6cee-78e0-4095-9bb2-be0ebabf66fb