### PR TITLE
Web: Fixes #13241: Fix find and replace toolbar in the note editor is not sized correctly

### DIFF
--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -121,6 +121,7 @@ const useStyles = (theme: Theme) => {
 				height: buttonSize,
 				backgroundColor: theme.backgroundColor4,
 				color: theme.color4,
+				margin: 2,
 			},
 			buttonText: buttonTextStyle,
 			activeButtonText: {
@@ -352,7 +353,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 	);
 
 	const advancedLayout = (
-		<View style={{ flexDirection: 'column', alignItems: 'center' }}>
+		<View style={{ flexDirection: 'column' }}>
 			<View style={{ flexDirection: 'row' }}>
 				{ closeButton }
 				{ labeledSearchInput }


### PR DESCRIPTION
When using the Web client, the find and replace bar in the note editor is not sized correctly. Also on Android, using it in portrait orientation may result in some of the buttons being partially cut off. See https://github.com/laurent22/joplin/issues/13241 for original screenshots.

This PR addresses the issue with the find and replace bar width on the web app, and also fixes the border being clipped when the inputs are in focus. The styling changes also affect the native app. These changes could be made to effect the web app only, but the difference is so minor it seems fine to make them global (see screenshots)

This fixes https://github.com/laurent22/joplin/issues/13241

### Testing

Web app, using Firefox (also tested on Chrome, looks basically equivalent) on Windows:

<img width="1920" height="928" alt="searcha1" src="https://github.com/user-attachments/assets/90ae43fc-af22-4ddd-9a5b-f9271059ccf6" />
<img width="1919" height="927" alt="searcha2" src="https://github.com/user-attachments/assets/f22c4b60-9e95-4cbf-9b24-be421643baed" />
<img width="1920" height="926" alt="searcha3" src="https://github.com/user-attachments/assets/528171fc-ead8-4de7-8017-fb14920e0aca" />

Using mobile viewport:

<img width="359" height="695" alt="searcha4" src="https://github.com/user-attachments/assets/d9187956-8155-4398-8dd0-815dceff1ff0" />
<img width="358" height="693" alt="searcha5" src="https://github.com/user-attachments/assets/1315df1f-779e-4746-b345-04101d8961bb" />
<img width="358" height="689" alt="searcha6" src="https://github.com/user-attachments/assets/26171f74-7723-49fa-8e59-0b90d2ba1928" />

Before / After on Android emulator on the native app:

<img width="350" height="898" alt="searchbefore" src="https://github.com/user-attachments/assets/fb89703f-e331-4dc5-8ae3-845aa580309b" />
<img width="350" height="897" alt="searchafter" src="https://github.com/user-attachments/assets/50dc7fad-a659-4f1f-a8b9-922b26768fa2" />