### PR TITLE
All: Fixes #13319: Treat unclosed quotes as fully quoted search terms, to prevent malformed match expression error

### DIFF
--- a/packages/lib/services/search/filterParser.test.ts
+++ b/packages/lib/services/search/filterParser.test.ts
@@ -157,4 +157,15 @@ describe('filterParser should be correct filter for keyword', () => {
 		expect(() => filterParser(searchString)).toThrow(new Error('iscompleted can\'t be negated'));
 
 	});
+
+	it('unclosed quote in search query', () => {
+		const searchString = '"hello';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('text', '"hello"', false, true));
+	});
+
+	it('unclosed quote in multi term search query', () => {
+		const searchString = '"hello" "you';
+		expect(filterParser(searchString)).toContainEqual(makeTerm('text', '"hello"', false, true));
+		expect(filterParser(searchString)).toContainEqual(makeTerm('text', '"you"', false, true));
+	});
 });

--- a/packages/lib/services/search/filterParser.ts
+++ b/packages/lib/services/search/filterParser.ts
@@ -63,6 +63,7 @@ const getTerms = (query: string, validFilters: Set<string>): Term[] => {
 
 		currentTerm += c;
 	}
+	if (inQuote) currentTerm += '"'; // Treat unclosed quotes as fully quoted search terms, to get partial matches while the user types the search term
 	if (currentTerm) terms.push(makeTerm(currentCol, currentTerm));
 	return terms;
 };


### PR DESCRIPTION
In order to avoid malformed match expression errors when the user is currently typing a quoted search term and has not yet closed the quotes, treat unclosed quotes as fully quoted search terms, to get partial matches while the user types the search term

This fixes https://github.com/laurent22/joplin/issues/13319

### Testing

See video:

https://github.com/user-attachments/assets/230568d1-3bf9-4efc-a45d-baf1077e4de1