### PR TITLE
Desktop: Fixes #13561: Upgrade to Electron 39

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -258,6 +258,13 @@ fi
 if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.*|.*sway.* ]] || [[ `command -v update-desktop-database` ]]; then
   DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
   DESKTOP_FILE_LOCATION="$DATA_HOME/applications"
+
+  # Joplin has a different startup WM class on Wayland and X11:
+  STARTUP_WM_CLASS=Joplin
+  if [[ $XDG_SESSION_TYPE = "wayland" ]]; then
+    STARTUP_WM_CLASS=@joplin/app-desktop
+  fi
+
   # Only delete the desktop file if it will be replaced
   rm -f "$DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop"
 
@@ -272,7 +279,9 @@ Name=Joplin
 Comment=Joplin for Desktop
 Exec=env APPIMAGELAUNCHER_DISABLE=TRUE "${INSTALL_DIR}/Joplin.AppImage" ${SANDBOXPARAM} %u
 Icon=joplin
-StartupWMClass=Joplin
+# This will be different between Wayland and X11. On Wayland, the startup
+# WM class is "@joplin/app-desktop". On X11, it's "Joplin".
+StartupWMClass=${STARTUP_WM_CLASS}
 Type=Application
 Categories=Office;
 MimeType=x-scheme-handler/joplin;

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -67,6 +67,45 @@ showHelp() {
   fi
 }
 
+# Accepts two versions in symver (a.b.c).
+# Echos -1 if the first version is less than the second,
+#        0 if they're equal,
+#        1 if the first version is greater than second.
+compareVersions() {
+  V_MAJOR1=$(echo "$1"|cut -d. -f1)
+  V_MAJOR2=$(echo "$2"|cut -d. -f1)
+
+  if [[ $V_MAJOR1 -lt $V_MAJOR2 ]] ; then
+    echo -1
+    return
+  elif [[ $V_MAJOR1 -gt $V_MAJOR2 ]] ; then
+    echo 1
+    return
+  fi
+
+  V_MINOR1=$(echo "$1"|cut -d. -f2)
+  V_MINOR2=$(echo "$2"|cut -d. -f2)
+
+  if [[ $V_MINOR1 -lt $V_MINOR2 ]] ; then
+    echo -1
+    return
+  elif [[ $V_MINOR1 -gt $V_MINOR2 ]] ; then
+    echo 1
+    return
+  fi
+
+  V_PATCH1=$(echo "$1"|cut -d. -f3)
+  V_PATCH2=$(echo "$2"|cut -d. -f3)
+
+  if [[ $V_PATCH1 -lt $V_PATCH2 ]] ; then
+    echo -1
+  elif [[ $V_PATCH1 -gt $V_PATCH2 ]] ; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
 #-----------------------------------------------------
 # Setup Download Helper: DL
 #-----------------------------------------------------
@@ -259,9 +298,11 @@ if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cin
   DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
   DESKTOP_FILE_LOCATION="$DATA_HOME/applications"
 
+  # Only later versions of Joplin default to Wayland
+  IS_WAYLAND_BY_DEFAULT=$(compareVersions "$RELEASE_VERSION" "3.5.6")
   # Joplin has a different startup WM class on Wayland and X11:
   STARTUP_WM_CLASS=Joplin
-  if [[ $XDG_SESSION_TYPE = "wayland" ]]; then
+  if [[ $XDG_SESSION_TYPE != "x11" && $IS_WAYLAND_BY_DEFAULT == "1" ]]; then
     STARTUP_WM_CLASS=@joplin/app-desktop
   fi
 

--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -258,13 +258,6 @@ fi
 if [[ $DESKTOP =~ .*gnome.*|.*kde.*|.*xfce.*|.*mate.*|.*lxqt.*|.*unity.*|.*x-cinnamon.*|.*deepin.*|.*pantheon.*|.*lxde.*|.*i3.*|.*sway.* ]] || [[ `command -v update-desktop-database` ]]; then
   DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
   DESKTOP_FILE_LOCATION="$DATA_HOME/applications"
-
-  # Joplin has a different startup WM class on Wayland and X11:
-  STARTUP_WM_CLASS=Joplin
-  if [[ $XDG_SESSION_TYPE = "wayland" ]]; then
-    STARTUP_WM_CLASS=@joplin/app-desktop
-  fi
-
   # Only delete the desktop file if it will be replaced
   rm -f "$DESKTOP_FILE_LOCATION/appimagekit-joplin.desktop"
 
@@ -279,9 +272,7 @@ Name=Joplin
 Comment=Joplin for Desktop
 Exec=env APPIMAGELAUNCHER_DISABLE=TRUE "${INSTALL_DIR}/Joplin.AppImage" ${SANDBOXPARAM} %u
 Icon=joplin
-# This will be different between Wayland and X11. On Wayland, the startup
-# WM class is "@joplin/app-desktop". On X11, it's "Joplin".
-StartupWMClass=${STARTUP_WM_CLASS}
+StartupWMClass=Joplin
 Type=Application
 Categories=Office;
 MimeType=x-scheme-handler/joplin;

--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -64,7 +64,8 @@ export default class InteropServiceHelper {
 
 			const windowOptions: BrowserWindowConstructorOptions = {
 				// Work around a printing issue: As of Electron 39, if the window is initially hidden, printing crashes the app.
-				show: true,
+				// This only seems to be necessary on Linux.
+				show: shim.isLinux(),
 			};
 
 			win = bridge().newBrowserWindow(windowOptions);

--- a/packages/app-desktop/InteropServiceHelper.ts
+++ b/packages/app-desktop/InteropServiceHelper.ts
@@ -11,7 +11,7 @@ import Setting from '@joplin/lib/models/Setting';
 import Note from '@joplin/lib/models/Note';
 const { friendlySafeFilename } = require('@joplin/lib/path-utils');
 import time from '@joplin/lib/time';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
 const md5 = require('md5');
 const url = require('url');
 
@@ -62,8 +62,9 @@ export default class InteropServiceHelper {
 
 			htmlFile = await this.exportNoteToHtmlFile(noteId, exportOptions);
 
-			const windowOptions = {
-				show: false,
+			const windowOptions: BrowserWindowConstructorOptions = {
+				// Work around a printing issue: As of Electron 39, if the window is initially hidden, printing crashes the app.
+				show: true,
 			};
 
 			win = bridge().newBrowserWindow(windowOptions);
@@ -120,6 +121,9 @@ export default class InteropServiceHelper {
 							//
 							// 2025-05-03: Windows and MacOS also need the window.print() workaround.
 							// See https://github.com/electron/electron/pull/46937.
+							//
+							// 2025-10-30: window.print() now causes a crash on Linux -- switch back to the
+							// other method.
 
 							const applyWorkaround = true;
 							if (applyWorkaround) {

--- a/packages/app-desktop/main.ts
+++ b/packages/app-desktop/main.ts
@@ -13,18 +13,13 @@ const packageInfo = require('./packageInfo.js');
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import determineBaseAppDirs from '@joplin/lib/determineBaseAppDirs';
 import registerCustomProtocols from './utils/customProtocols/registerCustomProtocols';
-import shim from '@joplin/lib/shim';
 
 // Electron takes the application name from package.json `name` and
 // displays this in the tray icon toolip and message box titles, however in
 // our case it's a string like "@joplin/app-desktop". It's also supposed to
 // check the productName key but is not doing it, so here set the
 // application name to the right string.
-//
-// 2025-11-03: On Linux, this needs to be 'Joplin' to match the 'StartupWMClass' used
-// in the AppImage launcher. In the future, it may make sense to adjust the app name
-// for the other platforms as well.
-electronApp.setName(shim.isLinux() ? 'Joplin' : packageInfo.name);
+electronApp.setName(packageInfo.name);
 
 process.on('unhandledRejection', (reason, p) => {
 	console.error('Unhandled promise rejection', p, 'reason:', reason);

--- a/packages/app-desktop/main.ts
+++ b/packages/app-desktop/main.ts
@@ -13,13 +13,18 @@ const packageInfo = require('./packageInfo.js');
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import determineBaseAppDirs from '@joplin/lib/determineBaseAppDirs';
 import registerCustomProtocols from './utils/customProtocols/registerCustomProtocols';
+import shim from '@joplin/lib/shim';
 
 // Electron takes the application name from package.json `name` and
 // displays this in the tray icon toolip and message box titles, however in
 // our case it's a string like "@joplin/app-desktop". It's also supposed to
 // check the productName key but is not doing it, so here set the
 // application name to the right string.
-electronApp.setName(packageInfo.name);
+//
+// 2025-11-03: On Linux, this needs to be 'Joplin' to match the 'StartupWMClass' used
+// in the AppImage launcher. In the future, it may make sense to adjust the app name
+// for the other platforms as well.
+electronApp.setName(shim.isLinux() ? 'Joplin' : packageInfo.name);
 
 process.on('unhandledRejection', (reason, p) => {
 	console.error('Unhandled promise rejection', p, 'reason:', reason);

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -161,7 +161,7 @@
     "compare-versions": "6.1.1",
     "countable": "3.0.1",
     "debounce": "1.2.1",
-    "electron": "37.7.0",
+    "electron": "39.0.0",
     "electron-builder": "24.13.3",
     "electron-updater": "6.6.2",
     "electron-window-state": "5.0.3",

--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -119,7 +119,8 @@
       "category": "Office",
       "desktop": {
         "Icon": "joplin",
-        "MimeType": "x-scheme-handler/joplin;"
+        "MimeType": "x-scheme-handler/joplin;",
+        "StartupWMClass": "@joplin/app-desktop"
       },
       "target": [
         "AppImage",

--- a/packages/app-desktop/tools/electronRebuild.js
+++ b/packages/app-desktop/tools/electronRebuild.js
@@ -25,7 +25,7 @@ async function main() {
 	// wrong one. However it means it will have to be manually upgraded for each
 	// new Electron release. Some ABI map there:
 	// https://github.com/electron/node-abi/tree/master/test
-	const forceAbiArgs = '--force-abi 138';
+	const forceAbiArgs = '--force-abi 142';
 
 	if (isWindows()) {
 		// Cannot run this in parallel, or the 64-bit version might end up

--- a/packages/lib/utils/processStartFlags.ts
+++ b/packages/lib/utils/processStartFlags.ts
@@ -192,6 +192,13 @@ const processStartFlags = async (argv: string[], setDefaults = true) => {
 			continue;
 		}
 
+		if (arg === '--force-renderer-accessibility') {
+			// Electron-specific flag - ignore it
+			// Allows users to force-enable accessibility support
+			argv.splice(0, 1);
+			continue;
+		}
+
 		if (arg === '--updated') {
 			// Electron-specific flag - ignore it
 			// Allows to restart with the updated application after the update option is selected by the user

--- a/yarn.lock
+++ b/yarn.lock
@@ -8988,7 +8988,7 @@ __metadata:
     compare-versions: "npm:6.1.1"
     countable: "npm:3.0.1"
     debounce: "npm:1.2.1"
-    electron: "npm:37.7.0"
+    electron: "npm:39.0.0"
     electron-builder: "npm:24.13.3"
     electron-updater: "npm:6.6.2"
     electron-window-state: "npm:5.0.3"
@@ -23995,16 +23995,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:37.7.0":
-  version: 37.7.0
-  resolution: "electron@npm:37.7.0"
+"electron@npm:39.0.0":
+  version: 39.0.0
+  resolution: "electron@npm:39.0.0"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/90d65ac676770662442f7f473791ed7488c2186f42d516e1cebe1deac64a8259a67cef1126787a729309c25801ee6f53a312127e71696d86a51c056d3b6a6646
+  checksum: 10/c2bb9f84bd06d12a90c650b2741ee618426e1ce20be18ff3708bf5f373e942e75e6a8cade94c15d96a06077f7f1fae6709b95f53784456d1db09f493928b47f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request upgrades to [Electron 39.0.0](https://releases.electronjs.org/release/v39.0.0) from [Electron 37.7.0](https://releases.electronjs.org/release/v37.7.0).

Fixes #13561 (see [comment](https://github.com/laurent22/joplin/issues/13561#issuecomment-3464137868)).


# Notes

- With Electron 38.4.0, 38.5.0: Joplin freezes shortly after startup (Fedora 42/GNOME+Wayland). I haven't observed this issue with Electron 39.0.0.

## Breaking changes

A list of related breaking changes can be found on the Electron "breaking changes" page for Electron [v38](https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-380) and [v39](https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-390). The most likely to affect Joplin are:
Known breaking changes that affect Joplin:
- Linux: Native Wayland support is now enabled by default. (Fixes #13561).
- MacOS 11 is no longer supported.

## Accessibility workaround

Electron 39 includes an [accessibility regression](https://issues.chromium.org/issues/431257156) that affects the Markdown editor on Linux. With Electron 39 (testing with Fedora 42/GNOME+Wayland), the up/down arrow keys in the markdown editor cause Orca to re-read the **entire note**. The up/down arrow keys should instead read the content of the line the cursor is moved to.

This pull request includes a workaround (based on [this comment](https://issues.chromium.org/issues/431257156#comment2)) that:
1. Checks if Orca is running (with `ps -C orca`), then
2. Force-enables accessibility support.

This pull request also exposes the Electron `--force-renderer-accessibility` flag, which provides another workaround, should the above check for Orca fail.

See also:
- [Chromium code responsible for detecting Orca](https://chromium.googlesource.com/chromium/src/+/8c180647165a5cece5f9590b5cc9367c4e25532d/content/browser/accessibility/browser_accessibility_state_impl_auralinux.cc#57).

## Printing bug workaround

This pull request was originally a draft due to a printing bug. Originally, file > print causes Joplin to crash:

[Screencast from 2025-10-29 16-13-22.webm](https://github.com/user-attachments/assets/2289a773-09c8-41d9-b469-d0f312923eb3)

This crash only seems to happen on Linux.

This pull request works around the printing issue by showing the window with the to-be-printed content. This isn't ideal, but it avoids the crash.

# Testing

**Automated testing**: Tests in [packages/app-desktop/integration-tests](https://github.com/laurent22/joplin/tree/dev/packages/app-desktop/integration-tests) are run in CI (on Windows, MacOS, and Linux), but run with a development version of Joplin.

## Manual testing

**Plan**: The following should be tested on each platform:
- Startup: The application starts in release mode
- Screen reader support: Verify that it's possible for the screen reader to interact with the note editor
- External editing
- Notifications
- Attaching files
- Printing

The following should be tested on at least one platform:
- Secondary windows: Check that changes from one window are reflected in the others.
- Folder editor: Verify that it's possible to add an emoji to a folder.
- Tag editor: It's possible to associate tags with a note using the tag dropdown.
- Drawing tool: It's possible to insert and edit drawings.

---

- [x] MacOS 26:
  - [x] Create a new task, set a notification for a few minutes in the future. Verify that the notification triggers.
  - [x] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [x] Start the external editor for a note. Verify that changing the note title from the external editor updates the note.
  - [x] Enable Markdown editor spellchecking in settings. Verify that an intentionally misspelled word is marked as misspelled. 
  - [x] Verify that it's possible to add a tag from the secondary window.
  - [x] Verify that it's possible to attach a drawing from the secondary window.
  - [x] Attach a PDF file using the "attach" button. Verify that 1) it renders and 2) the print dialog can be opened using the "print" button from the note viewer.
  - [x] Create a new subnotebook using the right-click menu.
  - [x] Convert a note to PDF (`:exportPdf` from the command palette).
  - [x] Verify that it's possible to print a note to PDF using file > print.
  - [x] Enable VoiceOver. Verify that VoiceOver reads the content of the line containing the cursor within the Markdown editor.
- [x] Linux (Fedora 43/GNOME + AppImage)
  - [x] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [x] Verify that it's possible to open the print dialog and print to a file.
  - [x] Attach a PDF file using the "attach" button. Verify that it renders and can be printed to PDF from the note viewer.
  - [x] Enable the compose key in system settings > keyboard > "Compose key". Verify that it's possible to use the compose key to add a "☺" to a note.
  - [x] Drag and drop a file from file explorer into the Rich Text editor in a new note.
  - [x] Create a new subnotebook using the right-click menu.
  - [x] Open a note in an external editor. Make a change and save. Verify that the note updates based on the external change.
  - [x] Verify that it's possible to add an emoji as a folder icon through right-click > edit.
  - [x] Verify that clicking a resource link opens it in an external application.
  - [x] Create a task with an alarm set for one minute in the future. Verify that the alarm causes a desktop notification to be shown.
  - [x] Verify that the `.deb` package can still be built and installed.
  - [x] Enable the Orca screen reader (and restart Joplin).
      - [x] Verify that Orca can read the note editor's content.
      - [x] Verify that moving focus to the notebook list and changing the selected notebook reads the title of the newly-selected notebook.
      <!-- - [ ] Verify that moving screen reader focus cancels the previous announcement. Can't easily test this with the current Orca setup. -->
      - [x] Verify that focusing the editor, then pressing the down arrow key reads only the line that gains focus.
- [x] Windows 11
  - [x] Fix large app size increase. Locally, the built application size is roughly 700 MB.
     - **Update**: Running `git clean -dXi`, then doing a full rebuild seems to have fixed the issue. I suspect that old test output, or some other artifact of past development work was being included in the built application.
  - [x] Create a new task, set a notification for a few minutes in the future. Verify that the notification triggers.
  - [x] Open a note in a new window (Markdown editor). Verify that editing the note updates the main window.
  - [x] Verify that it's possible to add a tag from the secondary window.
  - [x] Convert a note to PDF through file > print.
  - [x] Attach a PDF file using the "attach" button. Verify that it renders and can be printed to PDF from the note viewer.
  - [x] Enable NVDA. Place the cursor in the Markdown editor. Move the cursor up until it reaches the top of the note. Verify that NVDA reads each line.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->