### PR TITLE
Chore: Desktop: Enable source maps for error reporting by default

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -12,7 +12,7 @@
     "electronRebuild": "gulp electronRebuild",
     "tsc": "tsc --project tsconfig.json",
     "watch": "tsc --watch --preserveWatchOutput --project tsconfig.json",
-    "start": "gulp before-start && JOPLIN_SOURCE_MAP_ENABLED=1 electron . --env dev --log-level debug --open-dev-tools --no-welcome",
+    "start": "gulp before-start && electron . --env dev --log-level debug --open-dev-tools --no-welcome",
     "test": "jest",
     "test-ui": "gulp before-start && playwright test",
     "test-ci": "yarn test",

--- a/packages/app-desktop/utils/sourceMapSetup.ts
+++ b/packages/app-desktop/utils/sourceMapSetup.ts
@@ -1,6 +1,6 @@
 
 // source-map-support can add 1-3 seconds to the application startup
 // time -- disable it unless requested:
-if (process.env.JOPLIN_SOURCE_MAP_ENABLED) {
+if (!process.env.JOPLIN_SOURCE_MAP_DISABLED) {
 	require('source-map-support').install();
 }

--- a/packages/app-desktop/utils/sourceMapSetup.ts
+++ b/packages/app-desktop/utils/sourceMapSetup.ts
@@ -1,6 +1,8 @@
 
 // source-map-support can add 1-3 seconds to the application startup
-// time -- disable it unless requested:
+// time. In the future, it may make sense to either:
+// - Use Sentry for resolving source maps: https://docs.sentry.io/platforms/javascript/guides/electron/sourcemaps/
+// - Use NodeJS source map support (if https://github.com/electron/electron/issues/38875 is resolved)
 if (!process.env.JOPLIN_SOURCE_MAP_DISABLED) {
 	require('source-map-support').install();
 }


### PR DESCRIPTION
# Summary

This pull request enables source map resolution by default in release mode. Previously, source map resolution was only enabled if either:
- The `JOPLIN_SOURCE_MAP_ENABLED` environment variable was set to `1`.
- The Electron development tools were open (and in this case, only in the "console" pane).

This change will increase Joplin's startup time (based on a code comment, by 1-3 seconds). However, based on discussion with @laurent22, the the need to manually resolve stack traces in bug reports is a significant maintenance burden.

# Possible alternatives

- If possible, submit an upstream pull request for #38875: Add a way to enable NodeJS's native source map support (e.g. with `--enable-source-maps`).
   - Possible limitation: Would it be possible to enable source maps during application startup (e.g. if the user doesn't pass `--enable-source-maps`)?
- Add source map support to Joplin's logger. Don't load the source map file until the first error is logged.

# Planned follow-up tasks

- Separate pull request: Change ESBuild settings to include transitive dependency information in source maps. This will increase the size of the source map files (potentially significantly), but will provide information about errors in dependencies. For why this might be useful, see, for example, the stack trace in step 10 of the "testing" section.

# Testing

1. Create a release build of Joplin (AppImage). Verify that Joplin starts successfully.
2. Patch the application to throw an `Error` on startup to test stack trace loading in the main process.
    <details><summary>diff</summary>
   
    ```diff
    diff --git a/packages/app-desktop/ElectronAppWrapper.ts b/packages/app-desktop/ElectronAppWrapper.ts
    index 540ab3c4f..99062677d 100644
    --- a/packages/app-desktop/ElectronAppWrapper.ts
    +++ b/packages/app-desktop/ElectronAppWrapper.ts
    @@ -838,6 +838,8 @@ export default class ElectronAppWrapper {
                            event.preventDefault();
                            void this.openCallbackUrl(url);
                    });
    +
    +               throw new Error('Crash!');
            }
     
            public async openCallbackUrl(url: string) {
    ```
    </details>
3. Re-build a release version of Joplin.
4. Start the built AppImage from the terminal.
5. Verify that an error (including the stack trace with file names) is logged:
   ```
   Electron App fatal error:
   Error: Crash!
       at A6e.start (/tmp/.mount_Joplin45suqL/resources/app.asar/ElectronAppWrapper.ts:842:9)
   ```
6. Patch the application to throw an `Error` while rendering the root component to test stack traces in the renderer process:
    <details><summary>diff</summary>
   
    ```diff
    diff --git a/packages/app-desktop/gui/Root.tsx b/packages/app-desktop/gui/Root.tsx
    index 5a5ab9a44..c96ce89a1 100644
    --- a/packages/app-desktop/gui/Root.tsx
    +++ b/packages/app-desktop/gui/Root.tsx
    @@ -168,6 +168,8 @@ class RootComponent extends React.Component<Props, any> {
                            Status: { screen: StatusScreen, title: () => _('Synchronisation Status') },
                    };
     
    +               throw new Error('Crash!')
    +
                    return (
                            <StyleSheetManager disableVendorPrefixes>
                                    <ThemeProvider theme={theme}>
    ```
    </details>
7. Re-build a release version of Joplin.
8. Start the built AppImage from the terminal.
9. Verify that a "Joplin encountered a fatal error and could not continue" screen is shown.
10. Verify that the stack trace shown on that screen includes source file names and line numbers **for the Joplin source files**:
   ```
   Error: Crash!
      at xvn.render (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/gui/Root.tsx:171:9)
      at finishClassComponent (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3867:8047)
      at updateClassComponent (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3867:7545)
      at beginWork (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3869:13938)
      at beginWork$1 (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3886:2573)
      at performUnitOfWork (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3882:25989)
      at workLoopSync (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3882:25495)
      at renderRootSync (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3882:25216)
      at recoverFromConcurrentError (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3882:20906)
      at performConcurrentWorkOnRoot (file:///tmp/.mount_JoplinXfugLx/resources/app.asar/main-html.bundle.js:3882:20380)
   ```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->