### PR TITLE
Desktop: Fixes #13579: Rich Text Editor: Make cursor jump during editing less likely

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -1047,7 +1047,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		return true;
 	}
 
-	const { onInitialContentSet } = useCursorPositioning({
+	const { onRestoreCursorPosition } = useCursorPositioning({
 		initialCursorLocation: props.initialCursorLocation.richText as Bookmark,
 		onCursorUpdate: props.onCursorMotion,
 		editor,
@@ -1120,8 +1120,12 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					// times would result in an empty note.
 					// https://github.com/laurent22/joplin/issues/3534
 					editor.undoManager.reset();
+
+					// Only restore the cursor position from the global state when switching notes.
+					// See https://github.com/laurent22/joplin/issues/13579
+					onRestoreCursorPosition();
 				} else {
-					// Restore the cursor location
+					// Restore the cursor location from the current note
 					editor.selection.bookmarkManager.moveToBookmark(bookmark);
 				}
 
@@ -1143,7 +1147,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 			await loadDocumentAssets(props.themeId, editor, allAssets);
 
 			dispatchDidUpdate(editor);
-			onInitialContentSet();
 		};
 
 		void loadContent();

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useCursorPositioning.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useCursorPositioning.ts
@@ -13,7 +13,7 @@ const useCursorPositioning = ({ initialCursorLocation, editor, onCursorUpdate }:
 	initialCursorLocationRef.current = initialCursorLocation;
 
 	const appliedInitialCursorLocationRef = useRef(false);
-	const onInitialContentSet = useCallback(() => {
+	const onRestoreCursorPosition = useCallback(() => {
 		if (editor) {
 			if (initialCursorLocationRef.current) {
 				editor.selection.moveToBookmark(initialCursorLocationRef.current);
@@ -25,8 +25,6 @@ const useCursorPositioning = ({ initialCursorLocation, editor, onCursorUpdate }:
 
 	useEffect(() => {
 		if (!editor) return () => {};
-
-		editor.on('ContentSet', onInitialContentSet);
 
 		const onSelectionChange = () => {
 			// Wait until the initial cursor position has been set. This avoids resetting
@@ -44,12 +42,11 @@ const useCursorPositioning = ({ initialCursorLocation, editor, onCursorUpdate }:
 		editor.on('SelectionChange', onSelectionChange);
 
 		return () => {
-			editor.off('ContentSet', onInitialContentSet);
 			editor.off('SelectionChange', onSelectionChange);
 		};
-	}, [editor, onCursorUpdate, onInitialContentSet]);
+	}, [editor, onCursorUpdate, onRestoreCursorPosition]);
 
-	return { onInitialContentSet };
+	return { onRestoreCursorPosition };
 };
 
 export default useCursorPositioning;


### PR DESCRIPTION
# Summary

This pull request adjusts when the Rich Text Editor's cursor location is restored from the global redux state. Previously, the cursor location was restored when the TinyMCE `ContentSet` event was emitted and when rendering completed. With this change, the cursor location is restored only when switching notes.

May fix #13579.

# Testing

[Screencast from 2025-10-30 10-24-49.webm](https://github.com/user-attachments/assets/e1f055e3-2a4b-4eb7-8790-bd5dba1def55)

The above screen recording demonstrates:
1. Opening a note in the Rich Text editor.
2. Selecting text.
3. Switching to a different note.
4. Switching back to the original note.
5. Verifying that the text is still selected.
6. Switching to a different note.
7. Positioning the cursor somewhere in the middle.
8. Switching to a different note, then switching back.
9. Verifying that the cursor is still positioned in the position from step 7.
10. Opening the note in a new window.
11. Focusing the editor with <kbd>ctrl</kbd>-<kbd>shift</kbd>-<kbd>b</kbd>.
12. Moving the cursor to scroll the selection into view.
13. Verifying that the cursor is positioned in roughly the position from step 7.
14. Making a change to the note (adding `...`).
15. Switching back to the main window.
16. Verifying that the cursor is positioned where it was placed in step 7 (just before the `...`s added in step 14).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->