### PR TITLE
Desktop: Resolves #13586: Preserve scroll when switching between Markdown and Rich Text Editors

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -919,8 +919,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 					editor.on('SetContent', () => {
 						preprocessContent();
-
-						props_onMessage.current({ channel: 'noteRenderComplete' });
 					});
 				},
 			});
@@ -1130,6 +1128,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					resourceInfos: props.resourceInfos,
 					contentKey: props.contentKey,
 				};
+				props_onMessage.current({ channel: 'noteRenderComplete' });
 			}
 
 			const allAssetsOptions: NoteStyleOptions = {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.ts
@@ -1,9 +1,9 @@
 import { useEffect, useCallback, useRef } from 'react';
 import shim from '@joplin/lib/shim';
+import { Editor } from 'tinymce';
 
 interface HookDependencies {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	editor: any;
+	editor: Editor;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onScroll: Function;
 }

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useScroll.ts
@@ -1,9 +1,9 @@
 import { useEffect, useCallback, useRef } from 'react';
 import shim from '@joplin/lib/shim';
-import { Editor } from 'tinymce';
 
 interface HookDependencies {
-	editor: Editor;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+	editor: any;
 	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 	onScroll: Function;
 }

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -335,6 +335,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		selectedNoteHash: props.selectedNoteHash,
 		lastEditorScrollPercents: props.lastEditorScrollPercents,
 		editorRef,
+		editorName: props.bodyEditor,
 	});
 	const onMessage = useMessageHandler(scrollWhenReadyRef, clearScrollWhenReady, windowId, editorRef, setLocalSearchResultCount, props.dispatch, formNote, htmlToMarkdown, markupToHtml);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useScrollWhenReadyOptions.ts
@@ -6,21 +6,25 @@ import useNowEffect from '@joplin/lib/hooks/useNowEffect';
 
 interface Props {
 	noteId: string;
+	editorName: string;
 	selectedNoteHash: string;
 	lastEditorScrollPercents: NoteIdToScrollPercent;
 	editorRef: RefObject<NoteBodyEditorRef>;
 }
 
-const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollPercents, editorRef }: Props) => {
+const useScrollWhenReadyOptions = ({ noteId, editorName, selectedNoteHash, lastEditorScrollPercents, editorRef }: Props) => {
 	const scrollWhenReadyRef = useRef<ScrollOptions|null>(null);
 
 	const previousNoteId = usePrevious(noteId);
+	const noteIdChanged = noteId !== previousNoteId;
+	const previousEditor = usePrevious(editorName);
+	const editorChanged = editorName !== previousEditor;
 	const lastScrollPercentsRef = useRef<NoteIdToScrollPercent>(null);
 	lastScrollPercentsRef.current = lastEditorScrollPercents;
 
 	// This needs to be a nowEffect to prevent race conditions
 	useNowEffect(() => {
-		if (noteId === previousNoteId) return () => {};
+		if (!editorChanged && !noteIdChanged) return () => {};
 
 		if (editorRef.current) {
 			editorRef.current.resetScroll();
@@ -32,7 +36,7 @@ const useScrollWhenReadyOptions = ({ noteId, selectedNoteHash, lastEditorScrollP
 			value: selectedNoteHash ? selectedNoteHash : lastScrollPercent,
 		};
 		return () => {};
-	}, [noteId, previousNoteId, selectedNoteHash, editorRef]);
+	}, [editorChanged, noteIdChanged, noteId, selectedNoteHash, editorRef]);
 
 	const clearScrollWhenReady = useCallback(() => {
 		scrollWhenReadyRef.current = null;


### PR DESCRIPTION
# Summary

This pull request restores the last scroll position when switching between the Markdown and Rich Text Editors. Previously, this scroll position was only restored when switching notes.

Fixes #13586.

# Screen recording

[Screencast from 2025-10-31 08-52-40.webm](https://github.com/user-attachments/assets/e8449533-4ef0-4189-b7bb-3022c49e14cd)

The above screen recording shows:
- Switching between notes with the Rich Text Editor enabled. The scroll position for each note is restored.
- Opening a longer note and scrolling to the end, then switching editors. In both, the note is initially scrolled to the end of the document.
- Scrolling to the top of a note in the Markdown editor, then switching to the Rich Text Editor. The Rich Text Editor is initially scrolled to the top of the document.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->