### PR TITLE
Docs: Resolves #13591: Update terminal.md (readme) to mention 'z' shortcut

### DIFF
--- a/readme/apps/terminal.md
+++ b/readme/apps/terminal.md
@@ -242,7 +242,7 @@ As an example, this is the default keymap, but read below for a detailed explana
 	{ "keys": ["mb"], "type": "prompt", "command": "mkbook \"\"", "cursorPosition": -2 },
 	{ "keys": ["yn"], "type": "prompt", "command": "cp $n \"\"", "cursorPosition": -2 },
 	{ "keys": ["dn"], "type": "prompt", "command": "mv $n \"\"", "cursorPosition": -2 },
-    { "keys": ["z"], "command": "toggle_folder_collapse" }
+	{ "keys": ["z"], "command": "toggle_folder_collapse" }
 ]
 ```
 

--- a/readme/apps/terminal.md
+++ b/readme/apps/terminal.md
@@ -213,6 +213,7 @@ There are two types of shortcuts: those that manipulate the user interface direc
 	mb                mkbook ""
 	yn                cp $n ""
 	dn                mv $n ""
+	z                 toggle_folder_collapse
 
 Shortcut can be configured by adding a keymap file to the profile directory in `~/.config/joplin/keymap.json`. The content of this file is a JSON array with each entry defining a command and the keys associated with it.
 
@@ -240,7 +241,8 @@ As an example, this is the default keymap, but read below for a detailed explana
 	{ "keys": ["mt"], "type": "prompt", "command": "mktodo \"\"", "cursorPosition": -2 },
 	{ "keys": ["mb"], "type": "prompt", "command": "mkbook \"\"", "cursorPosition": -2 },
 	{ "keys": ["yn"], "type": "prompt", "command": "cp $n \"\"", "cursorPosition": -2 },
-	{ "keys": ["dn"], "type": "prompt", "command": "mv $n \"\"", "cursorPosition": -2 }
+	{ "keys": ["dn"], "type": "prompt", "command": "mv $n \"\"", "cursorPosition": -2 },
+    { "keys": ["z"], "command": "toggle_folder_collapse" }
 ]
 ```
 
@@ -271,6 +273,7 @@ activate | Activates the selected item. If the item is a note for example it wil
 delete | Deletes the selected item
 toggle_console | Toggle the console
 toggle_metadata | Toggle note metadata
+toggle_folder_collapse | Toggle display of sub-notebooks of current notebook in the notebooks pane
 
 ## Commands
 


### PR DESCRIPTION
Added mention of `z` shortcut for `toggle_folder_collapse` to the documentation for the terminal application. Said command is mentioned in `:help keymaps` but not currently here.

This is my first time making a pull request, so I apologize if I made a faux paux anywhere. 

<!--

Please prefix the title with the platform you are targeting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->