### PR TITLE
Chore: Testing: Add test coverage (MC/DC) for Note.mustHandleConflict

### DIFF
--- a/packages/lib/models/NoteConflict.test.js
+++ b/packages/lib/models/NoteConflict.test.js
@@ -1,0 +1,50 @@
+const Note = require('./Note.js').default;
+
+describe('Note.mustHandleConflict', () => {
+
+	const createNoteMock = (id, title, body, encryption_cipher_text) => {
+		return {
+			id,
+			title,
+			body,
+			encryption_cipher_text,
+		};
+	};
+
+	it('should throw an error if note IDs are different', () => {
+		const localNote = createNoteMock('id1', 'title', 'body', '');
+		const remoteNote = createNoteMock('id2', 'title', 'body', '');
+		expect(() => Note.mustHandleConflict(localNote, remoteNote)).toThrow('Cannot handle conflict for two different notes');
+	});
+
+	it('should return true if only the local note is encrypted', () => {
+		const localNote = createNoteMock('id1', 'title', 'body', 'encrypted_text');
+		const remoteNote = createNoteMock('id1', 'title', 'body', '');
+		expect(Note.mustHandleConflict(localNote, remoteNote)).toBe(true);
+	});
+
+	it('should return true if only the remote note is encrypted', () => {
+		const localNote = createNoteMock('id1', 'title', 'body', '');
+		const remoteNote = createNoteMock('id1', 'title', 'body', 'encrypted_text');
+		expect(Note.mustHandleConflict(localNote, remoteNote)).toBe(true);
+	});
+
+
+	it('should return true if titles are different', () => {
+		const localNote = createNoteMock('id1', 'local title', 'body', '');
+		const remoteNote = createNoteMock('id1', 'remote title', 'body', '');
+		expect(Note.mustHandleConflict(localNote, remoteNote)).toBe(true);
+	});
+
+	it('should return true if bodies are different', () => {
+		const localNote = createNoteMock('id1', 'title', 'local body', '');
+		const remoteNote = createNoteMock('id1', 'title', 'remote body', '');
+		expect(Note.mustHandleConflict(localNote, remoteNote)).toBe(true);
+	});
+
+	it('should return false if there are no relevant differences', () => {
+		const localNote = createNoteMock('id1', 'title', 'body', '');
+		const remoteNote = createNoteMock('id1', 'title', 'body', '');
+		expect(Note.mustHandleConflict(localNote, remoteNote)).toBe(false);
+	});
+});


### PR DESCRIPTION
### Description

This PR introduces a unit test suite for the `Note.mustHandleConflict` method (located in `packages/lib/models/Note.ts`), which previously had no dedicated test coverage.

#### What this PR does:

This PR follows the contribution guidelines by adding automated tests for existing business logic.

The `mustHandleConflict` method is responsible for critical business logic during synchronization, deciding when a note conflict should be created. The lack of tests represented a risk of regression.

#### Explanation of Changes:

1.  **MC/DC Test Creation:** Six new test cases were created in a separate file (`NoteConflict.test.js`) to ensure compatibility with the `@joplin/lib` sub-package's test environment.
2.  **Logic Coverage:** The tests cover all 4 decisions within the method, including the independence pairs for the multi-condition decision (line 981), as required by the MC/DC criterion.
3.  **Focus:** This PR is focused on this single issue, as guided by the contribution rules.

#### Manual Testing Plan (for the reviewer):

While the automated tests validate the logic, the following manual steps can be used to confirm execution:

1.  **Verify Test Execution:**
    > Run the command:
    > ```bash
    > yarn workspace @joplin/lib test -- --coverage NoteConflict.test.js
    > ```
    > **Expected Result:** All 6 tests should pass successfully.

2.  **Verify Coverage:**
    > Open the generated coverage report at `packages/lib/coverage/lcov-report/index.html`.
    >
    > Navigate to `packages/lib/models/Note.ts`.
    >
    > **Expected Result:** A measurable increase in the "Branches" and "Functions" coverage percentages for the `Note.ts` file will be visible, proving the effectiveness of the new tests.