### PR TITLE
Add Linux import instructions for ENEX files

### DIFF
--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -18,6 +18,8 @@ In the **desktop application**, open File > Import > ENEX and select your file. 
 
 In the **terminal application**, in [command-line mode](https://github.com/laurent22/joplin/blob/dev/readme/apps/terminal.md#command-line-mode), type `import /path/to/file.enex`. This will import the notes into a new notebook named after the filename.
 
+**From Linux**, where not desktop app is available, you can use [evernote-backup](https://github.com/vzhd1701/evernote-backup). The process to export the notes is very easy. While importing choose "ENEX - Evernote Export Files (Directory, as Markdown)"
+
 In both cases you can either import a single file or a directory that contains multiple ENEX files.
 
 - If you import a single file, a notebook with the same name will be created, and all notes will be imported in this notebook.


### PR DESCRIPTION
Added instructions for importing ENEX files from Linux using evernote-backup.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->