### PR TITLE
 All: Apache Tomcat WebDAV compatibility

### DIFF
--- a/packages/lib/WebDavApi.js
+++ b/packages/lib/WebDavApi.js
@@ -369,7 +369,7 @@ class WebDavApi {
 		// The "solution", an ugly one, is to send a purposely invalid string as eTag, which will bypass the If-None-Match check  - Seafile
 		// finds out that no resource has this ID and simply sends the requested data.
 		// Also add a random value to make sure the eTag is unique for each call.
-		if (['GET', 'HEAD'].indexOf(method) < 0) headers['If-None-Match'] = `JoplinIgnore-${Math.floor(Math.random() * 100000)}`;
+		if (['GET', 'HEAD'].indexOf(method) < 0) headers['If-None-Match'] = `"JoplinIgnore-${Math.floor(Math.random() * 100000)}"`;
 		if (!headers['User-Agent']) headers['User-Agent'] = 'Joplin/1.0';
 
 		const fetchOptions = {};


### PR DESCRIPTION
Bugfix for Apache Tomcat compatibility. Double quotes are required around entity tags, as per RFC 9110

More details regarding the issue:
https://discourse.joplinapp.org/t/webdavapi-compatibility-with-apache-tomcat/47750
https://bz.apache.org/bugzilla/show_bug.cgi?id=69869
