### PR TITLE
Desktop: Fixes #13600: Don't initially maximize the window on Linux

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -218,6 +218,10 @@ export default class ElectronAppWrapper {
 			defaultWidth: Math.round(0.8 * screen.getPrimaryDisplay().workArea.width),
 			defaultHeight: Math.round(0.8 * screen.getPrimaryDisplay().workArea.height),
 			file: `window-state-${this.env_}.json`,
+			// Work around a bug on certain Linux desktops: If the window is initially maximized, there
+			// may be rendering issues.
+			// See https://github.com/laurent22/joplin/issues/13561, https://github.com/laurent22/joplin/issues/13600
+			maximize: !shim.isLinux(),
 		};
 
 		if (this.profilePath_) stateOptions.path = this.profilePath_;


### PR DESCRIPTION
# Summary

A number of users are reporting startup issues when `isMaximized` is `true` in the window state config file. This pull request disables setting the initial window state to maximized on Linux.

This pull request *may* fix #13600.

# Notes

- This pull request works around an issue observed when running Joplin with recent versions of KDE Plasma (6.5.0 and 6.5.1). An Electron upgrade (https://github.com/laurent22/joplin/pull/13567) may also resolve this issue.
- Per [comment](https://github.com/laurent22/joplin/issues/13561#issuecomment-3477970800), I don't think this will resolve #13561.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->