### PR TITLE
Chore: Fix intermittent revision test failure attempt 2

### DIFF
--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -613,31 +613,40 @@ describe('services/RevisionService', () => {
 	});
 
 	it('should create 2 revisions (old and new content), after the first change to a note without existing revisions, where the oldNoteInterval has passed since the last change. Then create 1 revision on the next change', async () => {
-		Setting.setValue('revisionService.oldNoteInterval', 50);
+		Setting.setValue('revisionService.oldNoteInterval', 0);
 
 		const note = await Note.save({ title: 'test', body: 'Start' }); // REV 1
 		await revisionService().collectRevisions(); // No revision created because change type is CREATE
-		jest.advanceTimersByTime(100);
+		jest.advanceTimersByTime(500);
 
 		await Note.save({ id: note.id, title: 'test', body: 'StartA' });
 		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'StartAB' });
+		await ItemChange.waitForAllSaved();
 		await Note.save({ id: note.id, title: 'test', body: 'StartABC' }); // REV 2
 		await revisionService().collectRevisions(); // Create revisions for old and new content
 
-		Setting.setValue('revisionService.oldNoteInterval', 10_000);
+		let revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBe(2);
 
-		// To verify the oldNotesCache_ for a note is cleared when collecting revisions, make a change without waiting for the intervalBetweenRevisions
-		// period to pass, which we expect no revision to be created for
+		Setting.setValue('revisionService.intervalBetweenRevisions', 10_000);
+
 		await Note.save({ id: note.id, title: 'test', body: 'IgnoredChange' });
-		jest.advanceTimersByTime(100);
+		await revisionService().collectRevisions(); // No revision created
+
+		revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		expect(revisions.length).toBe(2);
+
+		Setting.setValue('revisionService.oldNoteInterval', 10_000);
+		Setting.setValue('revisionService.intervalBetweenRevisions', 0);
+		jest.advanceTimersByTime(500);
 
 		await Note.save({ id: note.id, title: 'test', body: 'StartABCD' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartABCDE' });
 		await Note.save({ id: note.id, title: 'test', body: 'StartABCDEF' }); // REV 3
 		await revisionService().collectRevisions();
 
-		const revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
+		revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
 		expect(revisions.length).toBe(3);
 		expect(revisions[0].body_diff).toBe('[{"diffs":[[1,"Start"]],"start1":0,"start2":0,"length1":0,"length2":5}]');
 		expect(revisions[1].body_diff).toBe('[{"diffs":[[0,"Start"],[1,"ABC"]],"start1":0,"start2":0,"length1":5,"length2":8}]');
@@ -718,6 +727,8 @@ describe('services/RevisionService', () => {
 		await revisionService().collectRevisions(); // Collect initial revision
 		expect((await Revision.allByType(BaseModel.TYPE_NOTE, note.id)).length).toBe(1);
 
+		// To verify the oldNotesCache_ for a note is cleared when collecting revisions, make a change without waiting for the intervalBetweenRevisions
+		// period to pass, which we expect no revision to be created for
 		await Note.save({ id: note.id, title: 'test', body: 'ABCD' });
 		await Note.save({ id: note.id, title: 'test', body: 'ABCDE' }); // REV 1
 		await revisionService().collectRevisions(); // No revisions are collected, but item_changes are processed and deleted

--- a/packages/lib/services/RevisionService.test.ts
+++ b/packages/lib/services/RevisionService.test.ts
@@ -627,7 +627,8 @@ describe('services/RevisionService', () => {
 		await revisionService().collectRevisions(); // Create revisions for old and new content
 
 		let revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
-		expect(revisions.length).toBe(2);
+		expect(revisions[0].body_diff).toBe('[{"diffs":[[1,"Start"]],"start1":0,"start2":0,"length1":0,"length2":5}]');
+		expect(revisions[1].body_diff).toBe('[{"diffs":[[0,"Start"],[1,"ABC"]],"start1":0,"start2":0,"length1":5,"length2":8}]');
 
 		Setting.setValue('revisionService.intervalBetweenRevisions', 10_000);
 
@@ -648,8 +649,6 @@ describe('services/RevisionService', () => {
 
 		revisions = await Revision.allByType(BaseModel.TYPE_NOTE, note.id);
 		expect(revisions.length).toBe(3);
-		expect(revisions[0].body_diff).toBe('[{"diffs":[[1,"Start"]],"start1":0,"start2":0,"length1":0,"length2":5}]');
-		expect(revisions[1].body_diff).toBe('[{"diffs":[[0,"Start"],[1,"ABC"]],"start1":0,"start2":0,"length1":5,"length2":8}]');
 		expect(revisions[2].body_diff).toBe('[{"diffs":[[0,"StartABC"],[1,"DEF"]],"start1":0,"start2":0,"length1":8,"length2":11}]');
 
 		// The updated time of the revision created for the original note contents must be before the first revision created for the current contents, but only 1 ms in the past


### PR DESCRIPTION
Despite the change in https://github.com/laurent22/joplin/pull/13458, the same Revision test is still intermittently failing (see https://github.com/laurent22/joplin/actions/runs/19064537890/job/54451803670). I'm unable to determine what exactly is causing the failure, so I've instead made some general changes to reduce the likelihood of possible race conditions in the relevant test.

**Changes:**
1. Increased the interval in usages of advanceTimersByTime from 100 ms to 500 ms
2. Set the oldNoteInterval to zero, for the revision collection which creates the 'old note' revision
3. Added ItemChange.waitForAllSaved() between all saves, prior to the collection which creates the 'old note' revision (the revision collection already calls this, so a call is not needed after the last save)
4. Added assertions after each collection, so that if we still get test failures, we can determine which revision specifically is missing
5. Changed the 'check oldNotesCache_ for a note is cleared' verification to do what is it is supposed to do. Originally the comment was not correct, as it should actually verify an old note revision is not created when the old note interval has not passed (and a revision collection after the 'ignored change' is required for that check to work correctly). The check that the comment specifies is actually done in one of the other tests, so I have moved the comment to there