### PR TITLE
Mobile: Fixes #13637: Fix incorrect zebra striping on tables in the rich text editor

### DIFF
--- a/packages/editor/ProseMirror/styles/table.css
+++ b/packages/editor/ProseMirror/styles/table.css
@@ -9,3 +9,8 @@ table .selectedCell {
 th > p:only-child, td > p:only-child {
 	margin: unset;
 }
+
+/* Tables used with ProseMirror do not have a thead, so zebra striping needs be styled separately to the global noteStyle css */
+table tr:nth-child(odd) {
+	background-color: var(--joplin-table-background-color);
+}

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -344,7 +344,7 @@ export default function(theme: any, options: Options = null) {
 		}
 
 		.jop-tinymce table tr:nth-child(even),
-		table tr:nth-child(even) {
+		table:has(thead) tr:nth-child(even) {
 			background-color: ${theme.tableBackgroundColor};
 		}
 


### PR DESCRIPTION
On the Rich Text Editor on mobile, the zebra striping on tables is applied incorrectly. Both the header and first row are grey, instead of the header being grey, and the first row white. This is due to the th row of tables in the ProseMirror schema being inside a tbody instead of thead tag (thead is absent). This means that the first row of table is actually an even row instead of an odd row in the tbody, and the global styling applies the grey stripe to both the header and the first row of data. This PR addresses the issue by preventing the tr:nth-child(even) css rule from executing where the table containing it does not include a thead, and then separate zebra stripe styling is applied the ProseMirror editor, for a result consistent with the other views.

This fixes https://github.com/laurent22/joplin/issues/13637

### Testing

Tested using the Windows and Web client. See screenshots:

**Mobile (view mode):**

<img width="128" height="426" alt="tablemobileview" src="https://github.com/user-attachments/assets/6a8721f9-4c36-46e7-88df-3c4da2d00e5b" />

**Mobile (RTE):**

<img width="257" height="554" alt="tablemobilerte" src="https://github.com/user-attachments/assets/4c929e97-1358-4baa-85fc-d3af04de9493" />

**Desktop (Markdown split view):**

<img width="1421" height="296" alt="tabledesktopview" src="https://github.com/user-attachments/assets/55484974-853c-48c5-a4c6-2e96516524b9" />

**Desktop (RTE):**

<img width="1422" height="288" alt="tabledesktoprte" src="https://github.com/user-attachments/assets/8d0b2096-4541-4d93-b594-d9d0e3d782ab" />