### PR TITLE
Server: Performance: Improve performance of requests-per-minute logger

### DIFF
--- a/packages/server/src/middleware/routeHandler.ts
+++ b/packages/server/src/middleware/routeHandler.ts
@@ -115,7 +115,7 @@ export default async function(ctx: AppContext) {
 			if (error.code) r.code = error.code;
 			ctx.response.body = r;
 		}
+	} finally {
+		onRequestComplete(requestId);
 	}
-
-	onRequestComplete(requestId);
 }


### PR DESCRIPTION
# Summary

Improves the performance of:
- The heartbeat task.
- The request handler (by optimizing `metrics.onRequestStart`).

# Details

- Uses a `Map` and `Set` rather than JavaScript `Object`s to track the number of active requests.
   - Since [`Map` iteration is done in insertion order](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#description), `deleteRequestInfoOlderThan` no longer needs to iterate over all entries.
- Uses a `} finally {` block to ensure that request completion is logged even if, for example, an error occurs while rendering a view.

# Benchmark

<details><summary>Script</summary>

```diff
# Run with cd packages/server && yarn test metrics.bench -t 'benchmark' --verbose
diff --git a/packages/server/src/utils/metrics.bench.test.ts b/packages/server/src/utils/metrics.bench.test.ts
new file mode 100644
index 000000000..d350c3a13
--- /dev/null
+++ b/packages/server/src/utils/metrics.bench.test.ts
@@ -0,0 +1,36 @@
+import { clearMetrics, onRequestComplete, onRequestStart } from "./metrics";
+import { Minute } from "./time";
+
+describe('metrics.bench', () => {
+	it('benchmark', async () => {
+		jest.useFakeTimers();
+		const sendRequests = (totalSimulatedDuration: number, timePerRequest: number) => {
+			const prefix = String(Math.random());
+			const count = Math.round(totalSimulatedDuration / timePerRequest);
+			for (let i = 0; i < count; i++) {
+				onRequestStart(`${prefix}-${i}`);
+				jest.advanceTimersByTime(timePerRequest); // ms
+			}
+
+			for (let i = 0; i < count; i++) {
+				onRequestComplete(`${prefix}-${i}`);
+			}
+		};
+
+		console.log('trial,duration (ms)');
+		const trials = 10;
+		let totalDuration = 0;
+		for (let i = 0; i < trials; i++) {
+			clearMetrics();
+			const startTime = jest.getRealSystemTime();
+			// Send 15 minutes worth of requests (1 request every 10 ms), but not in real time
+			sendRequests(15 * Minute, 10);
+
+			const timeDeltaMs = jest.getRealSystemTime() - startTime;
+			console.log(i, ',', timeDeltaMs);
+			totalDuration += timeDeltaMs;
+		}
+
+		console.log('Average:', totalDuration / trials);
+	});
+});
```

</details>

The above script adds a test file that benchmarks `onRequestStart` and `onRequestComplete` by:
1. Resetting the `metrics.ts` state.
2. Calling `onRequestStart` 90,000 times, with different IDs.
    - After each call, the script simulates a pause by calling `jest.advanceTimersByTime` with `10` ms.
    - This simulates 15 minutes of requests, at 1 request every 10 ms.
3. Calling `onRequestComplete` for each of the IDs from (2).
4. Logging the system time steps 1-3 took to complete.
5. Repeating steps 1-4 nine additional times, for 10 total trials.

<details><summary>Results: Before (on average, 7s per trial)</summary>

```
trial,duration (ms)
0 , 6474
1 , 6504
2 , 6828
3 , 6920
4 , 7147
5 , 7150
6 , 7296
7 , 7296
8 , 7256
9 , 7228
Average: 7009.9
```

$$7009.9 ms \approx 7 s$$

</details>


<details><summary>Results: After (on average, 0.1s per trial)</summary>

```
trial,duration (ms)
0 , 113
1 , 103
2 , 101
3 , 108
4 , 107
5 , 105
6 , 104
7 , 102
8 , 107
9 , 122
Average: 107.2
```

$$107.2 ms \approx 0.1 s$$

</details>

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->