### PR TITLE
Mobile: Resolves #11521: Remember the viewing / editing mode

### DIFF
--- a/packages/app-mobile/components/ScreenHeader/index.tsx
+++ b/packages/app-mobile/components/ScreenHeader/index.tsx
@@ -71,6 +71,9 @@ interface ScreenHeaderProps {
 	showContextMenuButton?: boolean;
 	showPluginEditorButton?: boolean;
 	showBackButton?: boolean;
+	showViewToggleButton?: boolean;
+	onViewTogglePress?: OnPressCallback;
+	viewToggleIconName?: string;
 
 	saveButtonDisabled?: boolean;
 	showSaveButton?: boolean;
@@ -370,6 +373,16 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 				description: _('Redo'),
 				onPress: this.props.onRedoButtonPress,
 				visible: this.props.showRedoButton,
+			});
+		};
+
+		const renderViewToggleButton = () => {
+			if (!this.props.showViewToggleButton || !this.props.onViewTogglePress || !this.props.viewToggleIconName) return null;
+			return renderTopButton({
+				iconName: this.props.viewToggleIconName,
+				description: _('Toggle view/edit'),
+				onPress: this.props.onViewTogglePress,
+				visible: true,
 			});
 		};
 
@@ -706,6 +719,7 @@ class ScreenHeaderComponent extends PureComponent<ScreenHeaderProps, ScreenHeade
 						this.props.showSaveButton === true,
 					)}
 					{titleComp}
+					{renderViewToggleButton()}
 					{selectAllButtonComp}
 					{searchButtonComp}
 					{deleteButtonComp}

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -149,6 +149,18 @@ const runEditorCommand = async (commandName: string) => {
 	});
 };
 
+const setupNoteWithPanes = async (panes: string[], noteTitle = 'Test note') => {
+	store.dispatch({
+		type: 'NOTE_VISIBLE_PANES_SET',
+		panes: panes,
+	});
+	await openNewNote({ title: noteTitle, body: 'Test body' });
+	const renderResult = render(<WrappedNoteScreen />);
+	// HACK: Wait for component to finish loading
+	await screen.findByDisplayValue(noteTitle);
+	return renderResult;
+};
+
 describe('screens/Note', () => {
 	beforeEach(async () => {
 		await setupDatabaseAndSynchronizer(1);
@@ -350,5 +362,114 @@ describe('screens/Note', () => {
 		await expectToBeEditing(true);
 		await runEditorCommand('toggleVisiblePanes');
 		await expectToBeEditing(false);
+	});
+
+	it.each([
+		[['viewer']],
+		[['editor']],
+	])('should initialize in the correct mode when noteVisiblePanes is %j', async (panes) => {
+		await setupNoteWithPanes(panes);
+		await expectToBeEditing(panes.includes('editor'));
+	});
+
+	it('should show toggle button', async () => {
+		await setupNoteWithPanes(['viewer']);
+		const toggleButton = await screen.findByLabelText('Toggle view/edit');
+		expect(toggleButton).toBeVisible();
+	});
+
+	it.each([
+		[['viewer']],
+		[['editor']],
+	])('should switch modes when toggle button is pressed', async (panes) => {
+		const initialEditing = panes.includes('editor');
+		const expectedEditing = !initialEditing;
+		await setupNoteWithPanes(panes);
+		await expectToBeEditing(initialEditing);
+		const toggleButton = await screen.findByLabelText('Toggle view/edit');
+		fireEvent.press(toggleButton);
+		await expectToBeEditing(expectedEditing);
+	});
+
+	it('should always start in edit mode for provisional notes regardless of noteVisiblePanes', async () => {
+		store.dispatch({
+			type: 'NOTE_VISIBLE_PANES_SET',
+			panes: ['viewer'],
+		});
+		const noteId = await openNewNote({ title: 'Provisional note', body: 'Test body' });
+		// Mark note as provisional by dispatching NOTE_UPDATE_ONE with provisional flag
+		const note = await Note.load(noteId);
+		store.dispatch({
+			type: 'NOTE_UPDATE_ONE',
+			note: note,
+			provisional: true,
+		});
+		render(<WrappedNoteScreen />);
+		// Wait for component to finish loading
+		await screen.findByDisplayValue('Provisional note');
+		await expectToBeEditing(true);
+	});
+
+	it.each([
+		[['viewer']],
+		[['editor']],
+	])('should preserve noteVisiblePanes state when leaving and returning to the same note', async (panes) => {
+		const firstRender = await setupNoteWithPanes(panes);
+		await expectToBeEditing(panes.includes('editor'));
+		// Navigate away
+		await act(async () => {
+			store.dispatch({
+				type: 'NAV_GO',
+				routeName: 'Notes',
+			});
+		});
+		firstRender.unmount();
+
+		// Navigate back to the same note
+		const currentState = store.getState();
+		const noteId = currentState.selectedNoteIds[0];
+		await act(async () => {
+			await openExistingNote(noteId);
+		});
+		render(<WrappedNoteScreen />);
+		await screen.findByDisplayValue('Test note');
+
+		// Should still be in the same mode
+		await expectToBeEditing(panes.includes('editor'));
+		expect(store.getState().noteVisiblePanes).toEqual(panes);
+	});
+
+	it.each([
+		[['viewer']],
+		[['editor']],
+	])('should preserve noteVisiblePanes state when navigating from note 1 to note 2', async (panes) => {
+		// Open note 1
+		await act(async () => {
+			store.dispatch({
+				type: 'NOTE_VISIBLE_PANES_SET',
+				panes: panes,
+			});
+		});
+		await act(async () => {
+			return await openNewNote({ title: 'Note 1', body: 'Test body 1' });
+		});
+		const render1 = render(<WrappedNoteScreen />);
+		await screen.findByDisplayValue('Note 1');
+		await expectToBeEditing(panes.includes('editor'));
+		render1.unmount();
+
+		// Open note 2
+		const note2Id = await act(async () => {
+			return await openNewNote({ title: 'Note 2', body: 'Test body 2' });
+		});
+		await act(async () => {
+			await openExistingNote(note2Id);
+		});
+		render(<WrappedNoteScreen />);
+		await screen.findByDisplayValue('Note 2');
+
+		// Note 2 should be in the same mode
+		await expectToBeEditing(panes.includes('editor'));
+		expect(store.getState().noteVisiblePanes).toEqual(panes);
 	});
 });

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -156,8 +156,8 @@ const setupNoteWithPanes = async (panes: string[], noteTitle = 'Test note') => {
 	});
 	await openNewNote({ title: noteTitle, body: 'Test body' });
 	const renderResult = render(<WrappedNoteScreen />);
-	// HACK: Wait for component to finish loading
-	await screen.findByDisplayValue(noteTitle);
+	const titleInput = await screen.findByDisplayValue(noteTitle);
+	expect(titleInput).toBeVisible();
 	return renderResult;
 };
 
@@ -405,8 +405,8 @@ describe('screens/Note', () => {
 			provisional: true,
 		});
 		render(<WrappedNoteScreen />);
-		// Wait for component to finish loading
-		await screen.findByDisplayValue('Provisional note');
+		const titleInput = await screen.findByDisplayValue('Provisional note');
+		expect(titleInput).toBeVisible();
 		await expectToBeEditing(true);
 	});
 
@@ -432,8 +432,8 @@ describe('screens/Note', () => {
 			await openExistingNote(noteId);
 		});
 		render(<WrappedNoteScreen />);
-		await screen.findByDisplayValue('Test note');
-
+		const titleInput = await screen.findByDisplayValue('Test note');
+		expect(titleInput).toBeVisible();
 		// Should still be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);
@@ -454,7 +454,8 @@ describe('screens/Note', () => {
 			return await openNewNote({ title: 'Note 1', body: 'Test body 1' });
 		});
 		const render1 = render(<WrappedNoteScreen />);
-		await screen.findByDisplayValue('Note 1');
+		const titleInput1 = await screen.findByDisplayValue('Note 1');
+		expect(titleInput1).toBeVisible();
 		await expectToBeEditing(panes.includes('editor'));
 		render1.unmount();
 
@@ -466,8 +467,8 @@ describe('screens/Note', () => {
 			await openExistingNote(note2Id);
 		});
 		render(<WrappedNoteScreen />);
-		await screen.findByDisplayValue('Note 2');
-
+		const titleInput2 = await screen.findByDisplayValue('Note 2');
+		expect(titleInput2).toBeVisible();
 		// Note 2 should be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -115,6 +115,7 @@ interface Props extends BaseProps {
 	pluginHtmlContents: PluginHtmlContents;
 	editorNoteReloadTimeRequest: number;
 	canPublish: boolean;
+	noteVisiblePanes: string[];
 }
 
 interface ComponentProps extends Props {
@@ -195,9 +196,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	public constructor(props: ComponentProps) {
 		super(props);
 
+		const initialMode = props.noteVisiblePanes?.includes('editor') ? 'edit' : 'view';
+
 		this.state = {
 			note: Note.new(),
-			mode: 'view',
+			mode: initialMode,
 			readOnly: false,
 			folder: null,
 			lastSavedNote: null,
@@ -270,14 +273,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 			if (this.state.mode === 'edit') {
 				Keyboard.dismiss();
-
-				this.setState({
-					mode: 'view',
-				});
-
 				await this.undoRedoService_.reset();
-
-				return true;
 			}
 
 			if (this.state.fromShare) {
@@ -369,6 +365,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 				setMode: (mode: 'view'|'edit') => {
 					this.setState({ mode });
 				},
+				dispatch: this.props.dispatch,
 			},
 			commands,
 			true,
@@ -1404,6 +1401,14 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		await this.saveOneProperty('todo_completed', checked ? time.unixMs() : 0);
 	}
 
+	private toggleVisiblePanes = () => {
+		const isSwitchingToEdit = this.state.mode === 'view';
+		void CommandService.instance().execute('toggleVisiblePanes');
+		if (isSwitchingToEdit) {
+			this.doFocusUpdate_ = true;
+		}
+	};
+
 	public scheduleFocusUpdate() {
 		if (this.focusUpdateIID_) shim.clearInterval(this.focusUpdateIID_);
 
@@ -1686,11 +1691,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			const editButton = {
 				label: _('Edit'),
 				icon: 'create',
-				onPress: () => {
-					this.setState({ mode: 'edit' });
-
-					this.doFocusUpdate_ = true;
-				},
+				onPress: this.toggleVisiblePanes,
 			};
 
 			if (this.state.mode === 'edit') return null;
@@ -1778,6 +1779,9 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 					undoButtonDisabled={!this.state.undoRedoButtonState.canUndo && this.state.undoRedoButtonState.canRedo}
 					onUndoButtonPress={this.screenHeader_undoButtonPress}
 					onRedoButtonPress={this.screenHeader_redoButtonPress}
+					showViewToggleButton={!!this.state.note && !this.state.note.deleted_time}
+					viewToggleIconName={this.state.mode === 'edit' ? 'ionicon eye' : 'ionicon create'}
+					onViewTogglePress={this.toggleVisiblePanes}
 					title={getDisplayParentTitle(this.state.note, this.state.folder)}
 				/>
 				{titleComp}
@@ -1833,6 +1837,7 @@ const NoteScreen = connect((state: AppState) => {
 		plugins: state.pluginService.plugins,
 		pluginHtmlContents: state.pluginService.pluginHtmlContents,
 		editorNoteReloadTimeRequest: state.editorNoteReloadTimeRequest,
+		noteVisiblePanes: state.noteVisiblePanes,
 
 		editorType: state.settings['editor.codeView'] ? EditorType.Markdown : EditorType.RichText,
 

--- a/packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.ts
+++ b/packages/app-mobile/components/screens/Note/commands/toggleVisiblePanes.ts
@@ -10,8 +10,11 @@ export const declaration: CommandDeclaration = {
 export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 	return {
 		execute: async (_context: CommandContext) => {
-			// For now, the only two "panes" on mobile are view and edit.
-			const newMode = props.getMode() === 'edit' ? 'view' : 'edit';
+			props.dispatch({
+				type: 'NOTE_VISIBLE_PANES_TOGGLE',
+			});
+			const currentMode = props.getMode();
+			const newMode = currentMode === 'edit' ? 'view' : 'edit';
 			props.setMode(newMode);
 		},
 	};

--- a/packages/app-mobile/components/screens/Note/types.ts
+++ b/packages/app-mobile/components/screens/Note/types.ts
@@ -1,5 +1,6 @@
 import { ResourceEntity } from '@joplin/lib/services/database/types';
 import { DialogControl } from '../../DialogManager';
+import { Dispatch } from 'redux';
 
 export interface PickerResponse {
 	uri?: string;
@@ -20,4 +21,5 @@ export interface CommandRuntimeProps {
 	setTagDialogVisible(visible: boolean): void;
 	setAudioRecorderVisible(visible: boolean): void;
 	dialogs: DialogControl;
+	dispatch: Dispatch;
 }

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -227,6 +227,10 @@ const generalMiddleware = (store: any) => (next: any) => async (action: any) => 
 		void ResourceFetcher.instance().autoAddResources();
 	}
 
+	if (['NOTE_VISIBLE_PANES_TOGGLE', 'NOTE_VISIBLE_PANES_SET'].indexOf(action.type) >= 0) {
+		Setting.setValue('noteVisiblePanes', newState.noteVisiblePanes);
+	}
+
 	if (doRefreshFolders) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		await scheduleRefreshFolders((action: any) => storeDispatch(action), newState.selectedFolderId);

--- a/packages/app-mobile/utils/appDefaultState.ts
+++ b/packages/app-mobile/utils/appDefaultState.ts
@@ -18,6 +18,7 @@ const appDefaultState: AppState = {
 	showPanelsDialog: false,
 	noteEditorVisible: false,
 	syncWizardVisible: false,
+	noteVisiblePanes: ['viewer'],
 	...defaultState,
 
 	// On mobile, it's possible to select notes that aren't in the selected folder/tag/etc.

--- a/packages/app-mobile/utils/appReducer.ts
+++ b/packages/app-mobile/utils/appReducer.ts
@@ -204,6 +204,20 @@ const appReducer = (state = appDefaultState, action: any) => {
 		case 'SYNC_WIZARD_VISIBLE_CHANGE':
 			newState = { ...state, syncWizardVisible: action.visible };
 			break;
+
+		case 'NOTE_VISIBLE_PANES_TOGGLE':
+			newState = {
+				...state,
+				noteVisiblePanes: state.noteVisiblePanes.includes('editor') ? ['viewer'] : ['editor'],
+			};
+			break;
+
+		case 'NOTE_VISIBLE_PANES_SET':
+			newState = {
+				...state,
+				noteVisiblePanes: action.panes,
+			};
+			break;
 		}
 	} catch (error) {
 		error.message = `In reducer: ${error.message} Action: ${JSON.stringify(action)}`;

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -367,6 +367,13 @@ const buildStartupTasks = (
 			ids: Setting.value('collapsedFolderIds'),
 		});
 	});
+	addTask('buildStartupTasks/initialize note visible panes', async () => {
+		const panes = Setting.value('noteVisiblePanes') || ['viewer'];
+		dispatch({
+			type: 'NOTE_VISIBLE_PANES_SET',
+			panes: panes,
+		});
+	});
 	addTask('buildStartupTasks/load tags', async () => {
 		const tags = await Tag.allWithNotes();
 

--- a/packages/app-mobile/utils/types.ts
+++ b/packages/app-mobile/utils/types.ts
@@ -12,4 +12,5 @@ export interface AppState extends State {
 	disableSideMenuGestures: boolean;
 	noteEditorVisible: boolean;
 	syncWizardVisible: boolean;
+	noteVisiblePanes: string[];
 }

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -29,6 +29,7 @@ export interface Props {
 	noteId: string;
 	folders: FolderEntity[];
 	sharedData: SharedData|undefined;
+	noteVisiblePanes: string[];
 }
 
 export interface BaseState {
@@ -293,7 +294,8 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 
 	const note = await Note.load(comp.props.noteId);
 
-	let mode = 'view';
+	const panes = comp.props.noteVisiblePanes;
+	let mode = panes[0] === 'editor' ? 'edit' : 'view';
 
 	if (isProvisionalNote && !comp.props.sharedData) {
 		mode = 'edit';

--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -295,7 +295,7 @@ shared.reloadNote = async (comp: BaseNoteScreenComponent) => {
 	const note = await Note.load(comp.props.noteId);
 
 	const panes = comp.props.noteVisiblePanes;
-	let mode = panes[0] === 'editor' ? 'edit' : 'view';
+	let mode = panes.includes('editor') ? 'edit' : 'view';
 
 	if (isProvisionalNote && !comp.props.sharedData) {
 		mode = 'edit';


### PR DESCRIPTION
# Summary

Makes the mobile note editor remember the editing mode ('view' or 'edit') across different notes and sessions, like on desktop. Suggested here #11521. Makes it much faster to open > edit > exit existing notes. 

- Notes open in the mode that was last used instead of always opening in 'view' mode
- Adds a view toggle button to the right side of the top bar
- The back button now exits the note editor without going trough 'view' mode first

## Demo

https://github.com/user-attachments/assets/7cb91431-a4e3-4a74-a6ab-62fad47116f1