### PR TITLE
Server: Database: Adjust connection pool configuration, make connection pool size configurable

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -50,6 +50,7 @@ function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables, slav
 		name: '',
 		slowQueryLogEnabled: env.DB_SLOW_QUERY_LOG_ENABLED,
 		slowQueryLogMinDuration: env.DB_SLOW_QUERY_LOG_MIN_DURATION,
+		maxConnections: env.DB_MAX_CONNECTIONS,
 		autoMigration: env.DB_AUTO_MIGRATION,
 	};
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -56,9 +56,16 @@ export interface QueryContext {
 	noSuchTableErrorLoggingDisabled?: boolean;
 }
 
+// See https://knexjs.org/guide/#pool
+interface KnexPoolConfig {
+	min: number;
+	max: number;
+}
+
 export interface KnexDatabaseConfig {
 	client: string;
 	connection: DbConfigConnection;
+	pool: KnexPoolConfig;
 	useNullAsDefault?: boolean;
 	asyncStackTraces?: boolean;
 }
@@ -79,6 +86,7 @@ export interface Migration {
 
 export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 	const connection: DbConfigConnection = {};
+	let pool: KnexPoolConfig|undefined = undefined;
 
 	if (dbConfig.client === 'sqlite3') {
 		connection.filename = dbConfig.name;
@@ -92,12 +100,19 @@ export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 			connection.user = dbConfig.user;
 			connection.password = dbConfig.password;
 		}
+
+		// Only change the pooling setting for non-sqlite3 connections:
+		// Knex has a different default configuration for SQLite3 that seems to be
+		// a workaround for a connection-related issue.
+		// See https://knexjs.org/guide/#pool
+		pool = { min: 0, max: dbConfig.maxConnections };
 	}
 
 	return {
 		client: dbConfig.client,
 		useNullAsDefault: dbConfig.client === 'sqlite3',
 		asyncStackTraces: dbConfig.asyncStackTraces,
+		pool,
 		connection,
 	};
 }

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -68,6 +68,12 @@ const defaultEnvValues: EnvVariables = {
 	DB_ALLOW_INCOMPLETE_MIGRATIONS: false,
 	DB_USE_SLAVE: false,
 
+	// The maximum number of active database connections. Only applies to PostgreSQL.
+	// This should usually be somewhat small.
+	// See https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+	// and https://wiki.postgresql.org/wiki/Number_Of_Database_Connections.
+	DB_MAX_CONNECTIONS: 10,
+
 	POSTGRES_PASSWORD: 'joplin',
 	POSTGRES_DATABASE: 'joplin',
 	POSTGRES_USER: 'joplin',
@@ -206,6 +212,7 @@ export interface EnvVariables {
 	DB_AUTO_MIGRATION: boolean;
 	DB_ALLOW_INCOMPLETE_MIGRATIONS: boolean;
 	DB_USE_SLAVE: boolean;
+	DB_MAX_CONNECTIONS: number;
 
 	POSTGRES_PASSWORD: string;
 	POSTGRES_DATABASE: string;

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -70,6 +70,7 @@ export interface DatabaseConfig {
 	asyncStackTraces?: boolean;
 	slowQueryLogEnabled?: boolean;
 	slowQueryLogMinDuration?: number;
+	maxConnections?: number;
 	autoMigration?: boolean;
 }
 


### PR DESCRIPTION
# Summary

This pull request:
- Allows specifying the connection pool size through `DB_MAX_CONNECTIONS`.
- Sets the minimum number of connections to 0, based on guidance in the documentation ([added here](https://github.com/knex/documentation/pull/409)):
  > Note that the default value of min is 2 only for historical reasons. It can result in problems with stale connections, despite tarn's default idle connection timeout of 30 seconds, which is only applied when there are more than min active connections. It is recommended to set min: 0 so all idle connections can be terminated.
  > — https://knexjs.org/guide/#pool

  Setting the minimum number of connections to `0` also avoids having `min` > `max` if `DB_MAX_CONNECTIONS` is set to a low number.
  
See https://github.com/laurent22/joplin/issues/13631.

It has been manually verified that the sync fuzzer can run for several steps without errors, using `DB_CLIENT=pg yarn syncFuzzer start`.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->