### PR TITLE
Server: Improve error when attempting to load certain routes that do not exist

### DIFF
--- a/packages/server/src/routes/default.ts
+++ b/packages/server/src/routes/default.ts
@@ -8,6 +8,7 @@ import { AppContext, RouteType } from '../utils/types';
 import { localFileFromUrl } from '../utils/joplinUtils';
 import { homeUrl, loginUrl } from '../utils/urlUtils';
 import * as mime from '@joplin/lib/mime-utils';
+import { hasOwnProperty } from '@joplin/utils/object';
 
 const publicDir = `${dirname(dirname(__dirname))}/public`;
 
@@ -33,7 +34,7 @@ async function findLocalFile(path: string): Promise<string> {
 	const appFilePath = await localFileFromUrl(path);
 	if (appFilePath) return appFilePath;
 
-	if (path in pathToFileMap) return pathToFileMap[path];
+	if (hasOwnProperty(pathToFileMap, path)) return pathToFileMap[path];
 	// For now a bit of a hack to load FontAwesome fonts.
 	if (path.indexOf('css/fontawesome/webfonts/fa-') === 0) return `node_modules/@fortawesome/fontawesome-free/${path.substr(16)}`;
 

--- a/packages/server/src/utils/routeUtils.ts
+++ b/packages/server/src/utils/routeUtils.ts
@@ -7,6 +7,7 @@ import { URL } from 'url';
 import { csrfCheck } from './csrf';
 import { contextSessionId } from './requestUtils';
 import { stripOffQueryParameters } from './urlUtils';
+import { hasOwnProperty } from '@joplin/utils/object';
 
 const { ltrimSlashes, rtrimSlashes } = require('@joplin/lib/path-utils');
 
@@ -262,7 +263,7 @@ export function findMatchingRoute(path: string, routes: Routers): MatchedRoute {
 		// Create the base path, eg. "api/files", to match it to one of the
 		// routes.
 		const basePath = `${namespace ? `${namespace}/` : ''}${splittedPath[0]}/${splittedPath[1]}`;
-		if (routes[basePath]) {
+		if (hasOwnProperty(routes, basePath)) {
 			// Remove the base path from the array so that parseSubPath() can
 			// extract the ID and link from the URL. So the array will contain
 			// at this point: ['SOME_ID', 'content'].
@@ -278,7 +279,7 @@ export function findMatchingRoute(path: string, routes: Routers): MatchedRoute {
 	// Paths such as "/users/:id" or "/apps/joplin/notes/:id" will get here
 	const basePath = splittedPath[0];
 	const basePathNS = (namespace ? `${namespace}/` : '') + basePath;
-	if (routes[basePathNS]) {
+	if (hasOwnProperty(routes, basePathNS)) {
 		splittedPath.splice(0, 1);
 		return {
 			route: routes[basePathNS],

--- a/packages/utils/object.ts
+++ b/packages/utils/object.ts
@@ -15,3 +15,7 @@ export function checkObjectHasProperties(object: any, properties: string[]) {
 		if (!(prop in object)) throw new Error(`Missing property "${prop}": ${JSON.stringify(object)}`);
 	}
 }
+
+export const hasOwnProperty = (object: object, property: string): boolean => {
+	return !!object && Object.prototype.hasOwnProperty.call(object, property);
+};


### PR DESCRIPTION
# Summary

This change improves the error message shown to the user when attempting to load a non-existent route that matches a reserved name.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->