### PR TITLE
Server: Fixes #13686: Fix items can be incorrectly unshared on conflicting update

### DIFF
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -2,7 +2,6 @@ import { Knex } from 'knex';
 import Logger from '@joplin/utils/Logger';
 import { DbConnection, SqliteMaxVariableNum, isPostgres } from '../db';
 import { Change, ChangeType, Item, Uuid } from '../services/database/types';
-import { md5 } from '../utils/crypto';
 import { ErrorResyncRequired } from '../utils/errors';
 import { Day, formatDateTime } from '../utils/time';
 import BaseModel, { SaveOptions } from './BaseModel';
@@ -416,7 +415,9 @@ export default class ChangeModel extends BaseModel<Change> {
 			const previous = itemChanges[itemId];
 
 			if (change.type === ChangeType.Update) {
-				const key = md5(itemId + change.previous_item);
+				// HACK: Work around a bug in ShareModel.updateSharedItems3.
+				const prev = change.previous_item ? JSON.parse(change.previous_item).jop_share_id : '';
+				const key = `${itemId}-${prev}`;
 				if (!uniqueUpdateChanges[itemId]) uniqueUpdateChanges[itemId] = {};
 				uniqueUpdateChanges[itemId][key] = change;
 			}

--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 import Logger from '@joplin/utils/Logger';
 import { DbConnection, SqliteMaxVariableNum, isPostgres } from '../db';
 import { Change, ChangeType, Item, Uuid } from '../services/database/types';
+import { md5 } from '../utils/crypto';
 import { ErrorResyncRequired } from '../utils/errors';
 import { Day, formatDateTime } from '../utils/time';
 import BaseModel, { SaveOptions } from './BaseModel';
@@ -415,9 +416,7 @@ export default class ChangeModel extends BaseModel<Change> {
 			const previous = itemChanges[itemId];
 
 			if (change.type === ChangeType.Update) {
-				// HACK: Work around a bug in ShareModel.updateSharedItems3.
-				const prev = change.previous_item ? JSON.parse(change.previous_item).jop_share_id : '';
-				const key = `${itemId}-${prev}`;
+				const key = md5(itemId + change.previous_item);
 				if (!uniqueUpdateChanges[itemId]) uniqueUpdateChanges[itemId] = {};
 				uniqueUpdateChanges[itemId][key] = change;
 			}

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -232,9 +232,7 @@ export default class ShareModel extends BaseModel<Share> {
 			const previousShareId = previousItem.jop_share_id;
 			const shareId = share ? share.id : '';
 
-			if (previousShareId === shareId) {
-				return;
-			}
+			if (previousShareId === shareId) return;
 
 			perfTimer.push('handleUpdated');
 

--- a/packages/server/src/models/ShareModel.ts
+++ b/packages/server/src/models/ShareModel.ts
@@ -324,7 +324,7 @@ export default class ShareModel extends BaseModel<Share> {
 			perfTimer.push('Get paginated changes');
 			const paginatedChanges = await this.models().change().allFromId(latestProcessedChange || '', {
 				// Ignore all updates that don't change the share_id
-				updatesEquivalent: (a, b) => {
+				updatesEqual: (a, b) => {
 					const previousShareId = (change: Change) => {
 						return this.models().change().unserializePreviousItem(change.previous_item).jop_share_id;
 					};

--- a/packages/server/src/routes/api/shares.folder.test.ts
+++ b/packages/server/src/routes/api/shares.folder.test.ts
@@ -1,4 +1,4 @@
-import { ChangeType, Share, ShareType, ShareUser, ShareUserStatus } from '../../services/database/types';
+import { ChangeType, Session, Share, ShareType, ShareUser, ShareUserStatus } from '../../services/database/types';
 import { beforeAllDb, afterAllTests, beforeEachDb, createUserAndSession, models, createNote, createFolder, updateItem, createItemTree, makeNoteSerializedBody, updateNote, expectHttpError, createResource, expectNotThrow } from '../../utils/testing/testUtils';
 import { postApi, patchApi, getApi, deleteApi } from '../../utils/testing/apiUtils';
 import { PaginatedDeltaChanges } from '../../models/ChangeModel';
@@ -8,6 +8,67 @@ import { ErrorForbidden } from '../../utils/errors';
 import { resourceBlobPath, serializeJoplinItem, unserializeJoplinItem } from '../../utils/joplinUtils';
 import { PaginatedItems } from '../../models/ItemModel';
 import { NoteEntity } from '@joplin/lib/services/database/types';
+
+const createSingleFolderShare = async (session1: Session, session2: Session) => {
+	const folderItem = await createFolder(session1.id, { title: 'created by sharer' });
+
+	// ----------------------------------------------------------------
+	// Create the file share object
+	// ----------------------------------------------------------------
+	const share = await postApi<Share>(session1.id, 'shares', {
+		type: ShareType.Folder,
+		folder_id: folderItem.jop_id,
+	});
+
+	// ----------------------------------------------------------------
+	// Once the share object has been created, the client can add folders
+	// and notes to it. This is done by setting the share_id property,
+	// which we simulate here.
+	// ----------------------------------------------------------------
+	await models().item().saveForUser(session1.user_id, {
+		id: folderItem.id,
+		jop_parent_id: '',
+		jop_share_id: share.id,
+	});
+
+	// ----------------------------------------------------------------
+	// Send the share to a user
+	// ----------------------------------------------------------------
+	const user2 = await models().user().load(session2.user_id);
+	let shareUser = await postApi(session1.id, `shares/${share.id}/users`, {
+		email: user2.email,
+	}) as ShareUser;
+
+	shareUser = await models().shareUser().load(shareUser.id);
+	expect(shareUser.share_id).toBe(share.id);
+	expect(shareUser.user_id).toBe(user2.id);
+	expect(shareUser.status).toBe(ShareUserStatus.Waiting);
+
+	// ----------------------------------------------------------------
+	// On the sharee side, accept the share
+	// ----------------------------------------------------------------
+	await patchApi<ShareUser>(session2.id, `share_users/${shareUser.id}`, { status: ShareUserStatus.Accepted });
+
+	{
+		shareUser = await models().shareUser().load(shareUser.id);
+		expect(shareUser.status).toBe(ShareUserStatus.Accepted);
+	}
+
+	await models().share().updateSharedItems3();
+
+	// ----------------------------------------------------------------
+	// On the sharee side, check that the file is present
+	// and with the right content.
+	// ----------------------------------------------------------------
+	const results = await getApi<PaginatedItems>(session2.id, 'items/root/children');
+	expect(results.items.length).toBe(1);
+	expect(results.items[0].name).toBe(folderItem.name);
+
+	const itemContent = await getApi<Buffer>(session2.id, `items/root:/${folderItem.name}:/content`);
+	expect(itemContent.toString().includes('created by sharer')).toBe(true);
+
+	return { folderItem, itemContent, share };
+};
 
 describe('shares.folder', () => {
 
@@ -24,62 +85,15 @@ describe('shares.folder', () => {
 	});
 
 	test('should share a folder with another user', async () => {
-		const { user: user1, session: session1 } = await createUserAndSession(1);
-		const { user: user2, session: session2 } = await createUserAndSession(2);
-		const folderItem = await createFolder(session1.id, { title: 'created by sharer' });
+		const { session: session1 } = await createUserAndSession(1);
+		const { session: session2 } = await createUserAndSession(2);
+		await createSingleFolderShare(session1, session2);
+	});
 
-		// ----------------------------------------------------------------
-		// Create the file share object
-		// ----------------------------------------------------------------
-		const share = await postApi<Share>(session1.id, 'shares', {
-			type: ShareType.Folder,
-			folder_id: folderItem.jop_id,
-		});
-
-		// ----------------------------------------------------------------
-		// Once the share object has been created, the client can add folders
-		// and notes to it. This is done by setting the share_id property,
-		// which we simulate here.
-		// ----------------------------------------------------------------
-		await models().item().saveForUser(user1.id, {
-			id: folderItem.id,
-			jop_share_id: share.id,
-		});
-
-		// ----------------------------------------------------------------
-		// Send the share to a user
-		// ----------------------------------------------------------------
-		let shareUser = await postApi(session1.id, `shares/${share.id}/users`, {
-			email: user2.email,
-		}) as ShareUser;
-
-		shareUser = await models().shareUser().load(shareUser.id);
-		expect(shareUser.share_id).toBe(share.id);
-		expect(shareUser.user_id).toBe(user2.id);
-		expect(shareUser.status).toBe(ShareUserStatus.Waiting);
-
-		// ----------------------------------------------------------------
-		// On the sharee side, accept the share
-		// ----------------------------------------------------------------
-		await patchApi<ShareUser>(session2.id, `share_users/${shareUser.id}`, { status: ShareUserStatus.Accepted });
-
-		{
-			shareUser = await models().shareUser().load(shareUser.id);
-			expect(shareUser.status).toBe(ShareUserStatus.Accepted);
-		}
-
-		await models().share().updateSharedItems3();
-
-		// ----------------------------------------------------------------
-		// On the sharee side, check that the file is present
-		// and with the right content.
-		// ----------------------------------------------------------------
-		const results = await getApi<PaginatedItems>(session2.id, 'items/root/children');
-		expect(results.items.length).toBe(1);
-		expect(results.items[0].name).toBe(folderItem.name);
-
-		const itemContent = await getApi<Buffer>(session2.id, `items/root:/${folderItem.name}:/content`);
-		expect(itemContent.toString().includes('created by sharer')).toBe(true);
+	test('sharer should see change if item is changed by sharee', async () => {
+		const { session: session1 } = await createUserAndSession(1);
+		const { session: session2 } = await createUserAndSession(2);
+		const { folderItem, itemContent } = await createSingleFolderShare(session1, session2);
 
 		// ----------------------------------------------------------------
 		// If file is changed by sharee, sharer should see the change too
@@ -95,6 +109,30 @@ describe('shares.folder', () => {
 			const modContent = await getApi<Buffer>(session1.id, `items/root:/${folderItem.name}:/content`);
 			expect(modContent.toString().includes('modified by recipient')).toBe(true);
 		}
+	});
+
+	test('should not delete an item on unshare', async () => {
+		const { session: session1 } = await createUserAndSession(1);
+		const { session: session2 } = await createUserAndSession(2);
+		const { folderItem, share } = await createSingleFolderShare(session1, session2);
+
+		await models().item().saveForUser(session2.user_id, {
+			id: folderItem.id,
+			jop_parent_id: 'changed',
+			jop_share_id: share.id,
+		});
+
+		await models().item().saveForUser(session1.user_id, {
+			id: folderItem.id,
+			jop_parent_id: 'changed',
+			jop_share_id: '',
+		});
+
+		await models().share().updateSharedItems3();
+
+		const user1HasAccess = !!await models().userItem().byUserAndItemId(session1.user_id, folderItem.id);
+		const user2HasAccess = !!await models().userItem().byUserAndItemId(session2.user_id, folderItem.id);
+		expect({ user1HasAccess, user2HasAccess }).toEqual({ user1HasAccess: true, user2HasAccess: false });
 	});
 
 	test('should share a folder and all its children', async () => {


### PR DESCRIPTION
# Summary

This pull request:
- Changes `ChangeModel.compressChanges` to allow callers to specify when updates should be compressed (default: Don't compress updates).
- Updates `updateSharedItems3` to request that all updates that don't change the `share_id` be compressed.

Fixes #13686.

# Testing plan

In addition to the automated test added by this pull request, I have verified that the sync fuzzer can run for > 20 steps (includes a `shareFolder` action in step 6).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->