### PR TITLE
Desktop: Fixes #13694: Fix settings aren't saved before opening the SAML login screen

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -261,7 +261,10 @@ class ConfigScreenComponent extends React.Component<any, any> {
 				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServerSaml')) {
 					const server = settings['sync.11.path'] as string;
 
-					const goToSamlLogin = () => {
+					const goToSamlLogin = async () => {
+						// Save settings to allow SAML auth with the correct URL.
+						await shared.saveSettings(this);
+
 						this.props.dispatch({
 							type: 'NAV_GO',
 							routeName: 'JoplinServerSamlLogin',

--- a/packages/lib/components/shared/SamlShared.ts
+++ b/packages/lib/components/shared/SamlShared.ts
@@ -1,3 +1,4 @@
+import { _ } from '../../locale';
 import Setting from '../../models/Setting';
 import shim from '../../shim';
 import { authenticateWithCode } from '../../SyncTargetJoplinServerSAML';
@@ -8,7 +9,7 @@ export default class SamlShared implements SsoScreenShared {
 	public openLoginPage() {
 		const samlUrl = Setting.value('sync.11.path');
 		if (!samlUrl) {
-			const message = 'No URL for SAML authentication set.';
+			const message = _('No URL for SAML authentication set.');
 			void shim.showErrorDialog(message);
 
 			throw new Error(message);

--- a/packages/lib/components/shared/SamlShared.ts
+++ b/packages/lib/components/shared/SamlShared.ts
@@ -6,7 +6,15 @@ import SsoScreenShared from './SsoScreenShared';
 
 export default class SamlShared implements SsoScreenShared {
 	public openLoginPage() {
-		shim.openUrl(`${prefixWithHttps(Setting.value('sync.11.path'))}/login/sso-saml-app`);
+		const samlUrl = Setting.value('sync.11.path');
+		if (!samlUrl) {
+			const message = 'No URL for SAML authentication set.';
+			void shim.showErrorDialog(message);
+
+			throw new Error(message);
+		}
+
+		shim.openUrl(`${prefixWithHttps(samlUrl)}/login/sso-saml-app`);
 		return Promise.resolve();
 	}
 


### PR DESCRIPTION
# Summary

- On desktop, saves settings before opening the SAML login screen. This is similar to what's currently done on mobile.
- Displays an error dialog if attempting to open a blank authentication URL.

Fixes #13694.

# Testing

[Screencast from 2025-11-13 10-55-23.webm](https://github.com/user-attachments/assets/fbe20ef3-c9f8-4d46-9fbf-ab478abdee6d)

The above screen recording shows:

1. Setting the sync target to "Joplin Server (SAML)"
2. Setting the "Joplin Server URL" to `https://example.com/`.
3. Clicking "Connect using your organisation account".
4. Clicking "Log in with your web browser".
5. A web browser opening `https://example.com//login/sso-saml-app`.
6. Navigating back to Joplin's settings screen and clearing the "Joplin Server URL" setting.
7. Saving settings.
8. Closing settings.
9. Clicking "sync".
10. The SAML login screen opening.
11. Clicking "Log in with your web browser".
12. An error message: "No URL for SAML authentication set".

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->