### PR TITLE
Web: Fix find and replace toolbar in note editor is too squashed on small mobile screens

### DIFF
--- a/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
+++ b/packages/app-mobile/components/NoteEditor/SearchPanel.tsx
@@ -122,6 +122,7 @@ const useStyles = (theme: Theme) => {
 				backgroundColor: theme.backgroundColor4,
 				color: theme.color4,
 				margin: 2,
+				width: 90, // Reduce the min width for mobile screens in portrait
 			},
 			buttonText: buttonTextStyle,
 			activeButtonText: {
@@ -343,7 +344,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 	);
 
 	const simpleLayout = (
-		<View style={{ flexDirection: 'row' }}>
+		<View style={{ flexDirection: 'row', flexShrink: 1 }}>
 			{ closeButton }
 			{ searchTextInput }
 			{ showDetailsButton }
@@ -353,7 +354,7 @@ export const SearchPanel = (props: SearchPanelProps) => {
 	);
 
 	const advancedLayout = (
-		<View style={{ flexDirection: 'column' }}>
+		<View style={{ flexDirection: 'column', flexShrink: 1 }}>
 			<View style={{ flexDirection: 'row' }}>
 				{ closeButton }
 				{ labeledSearchInput }


### PR DESCRIPTION
In followup to PR https://github.com/laurent22/joplin/issues/13241, despite dynamic resizing of the find and replace toolbar now working correctly on the web app, input boxes seem to have a default minimum width within a flex box, which may be too large when using the web app on a mobile screen in portrait mode on some devices. At a viewport with of 320 px, the buttons in the replace section of the bar are visibly crowded together and barely usable. This PR reduces the minimum size of the search bar inputs to 90 pixels (minWidth does not work, width has to be used to set a minimum width, but it does still resize dynamically), so that the find and replace bar is usable with minimal squashing for a viewport width of 320 pixels (the general recommended supported min width), even being usable at a viewport of 300 pixels.

### Testing

Tested on a real Android device and on Windows. See screenshots (all on Windows).

**Before (300px width):**

<img width="319" height="574" alt="replacebeforemain" src="https://github.com/user-attachments/assets/cf29afa8-48f9-4de2-acf2-02fb43ca1b8c" />

<img width="322" height="580" alt="replacebefore" src="https://github.com/user-attachments/assets/189767a1-ea9a-4792-8e18-34bfcbd02c7c" />

**After (300px width):**

<img width="324" height="614" alt="replaceaftermain" src="https://github.com/user-attachments/assets/c48a868f-3a8d-40d3-989b-ff7208242d26" />

<img width="316" height="601" alt="replaceafter" src="https://github.com/user-attachments/assets/88ba4928-fd30-4b96-8ca2-c2f929b446d2" />

**After (wide width):**

<img width="1630" height="615" alt="replacelargeaftermain" src="https://github.com/user-attachments/assets/b65cf769-1ec7-406c-89d6-3aa40eafe257" />

<img width="1628" height="618" alt="replacelargeafter" src="https://github.com/user-attachments/assets/1dd3be02-a008-4dc9-bee4-7f38ede95ffa" />
