### PR TITLE
Chore: Fix CI

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -26,14 +26,14 @@ jobs:
           node-version: '18'
           cache: 'yarn'
 
-      - uses: dtolnay/rust-toolchain@stable
-
       - name: Install Yarn
         run: |
           corepack enable
 
       - name: Install
         run:  yarn install
+        env:
+          SKIP_ONENOTE_CONVERTER_BUILD: 1
 
       - name: Assemble Android Release
         run: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,6 +34,11 @@ jobs:
         run:  yarn install
         env:
           SKIP_ONENOTE_CONVERTER_BUILD: 1
+      
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
 
       - name: Assemble Android Release
         run: |


### PR DESCRIPTION
# Summary

Attempts to fix a "No space left on device" error when running the "react-native-android-build-apk / AssembleRelease (pull_request)" CI workflow.