### PR TITLE
Chore: CI: Upgrade NodeJS to v24

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -21,9 +21,9 @@ jobs:
           
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'yarn'
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -9,11 +9,9 @@ jobs:
 
       - uses: actions/checkout@v4
       - uses: olegtarasov/get-tag@v2.1.4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          # We need to pin the version to 18.15, because 18.16+ fails with this error:
-          # https://github.com/facebook/react-native/issues/36440
-          node-version: '18.20.8'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install Yarn

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -147,9 +147,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - name: Free disk space
         if: runner.os == 'Linux'

--- a/.github/workflows/shared/setup-build-environment/action.yml
+++ b/.github/workflows/shared/setup-build-environment/action.yml
@@ -51,9 +51,9 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
       if: ${{ runner.os != 'Windows' }}
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: '18.20.8'
+        node-version: '24'
         # Disable the cache on ARM runners. For now, we don't run "yarn install" on these
         # environments and this breaks actions/setup-node.
         # See https://github.com/laurent22/joplin/commit/47d0d3eb9e89153a609fb5441344da10904c6308#commitcomment-159577783.


### PR DESCRIPTION
# Summary

- Upgrades CI from Node v18 to Node v24. [Node v18 is EOL](https://nodejs.org/en/blog/announcements/node-18-eol-support#the-support-landscape-has-changedand-security-issues-are-real).
- Upgrades `actions/setup-node` from v4 to v6. v5 or later may be necessary for Node v24 support (see https://github.com/actions/setup-node/pull/1325).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->