### PR TITLE
Server: Upgrade NodeJS to v24

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,7 @@
 # Build stage
 # =============================================================================
 
-FROM node:18 AS builder
+FROM node:24 AS builder
 
 RUN apt-get update \
     && apt-get install -y \
@@ -58,7 +58,7 @@ RUN --mount=type=cache,target=/build/.yarn/cache --mount=type=cache,target=/buil
 # from a smaller base image.
 # =============================================================================
 
-FROM node:18-slim
+FROM node:24-slim
 
 ARG user=joplin
 RUN useradd --create-home --shell /bin/bash $user


### PR DESCRIPTION
# Summary

Upgrades the server docker image from Node v18 to v24. [Node 18 is EOL](https://nodejs.org/en/blog/announcements/node-18-eol-support#the-support-landscape-has-changedand-security-issues-are-real).

See also: https://github.com/laurent22/joplin/pull/13700.

# Testing

CI testing:
- Tests pass with Node v24 (see https://github.com/laurent22/joplin/pull/13700).
- The docker image is built in CI, with Node v24.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->