### PR TITLE
fix(editor):resolve toolbar copy button not working CodeMirror editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -183,6 +183,9 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 						textCopy: () => {
 							editorCopyText();
 						},
+						'editor.copy': ()=>{
+							editorCopyText();
+						},
 						textCut: () => {
 							editorCutText();
 						},


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Title :  fix copy button not working in CodeMirror editor
## Problem 

On the Desktop app the "Copy" toolbar button  in the CodeMirror editor was not Working
the command was not being triggered because the toolbar did not correctly map the 
copy command to the editor


#fix 

Added correct command mapping so the toolbar "copy" button executes the editor's


- verified that the fix does not affect other toolbar actions.


#testing

selecting text - clicked copy - confirmed text is copied  sucessfully 

#platform
Desktop 










AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->