### PR TITLE
All: Resolves #13254: Always fully encode URL for the Nextcloud and WebDAV

### DIFF
--- a/packages/lib/SyncTargetNextcloud.js
+++ b/packages/lib/SyncTargetNextcloud.js
@@ -42,11 +42,12 @@ class SyncTargetNextcloud extends BaseSyncTarget {
 	}
 
 	async initFileApi() {
-		let syncPath = Setting.value('sync.5.path');
+		const syncPath = Setting.value('sync.5.path');
 		// the syncPath might contain non-ASCII characters
 		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
 		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
-		const syncPathUrl = RegExp(/[^\u0021-\u00ff]/).exec(syncPath) !== null ? encodeURI(syncPath) : syncPath;
+		const charsReg = /[^\u0021-\u00ff]/;
+		const syncPathUrl = charsReg.exec(syncPath) !== null ? encodeURI(syncPath) : syncPath;
 		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetNextcloud.id(), {
 			path: () => syncPathUrl,
 			username: () => Setting.value('sync.5.username'),

--- a/packages/lib/SyncTargetNextcloud.js
+++ b/packages/lib/SyncTargetNextcloud.js
@@ -42,14 +42,8 @@ class SyncTargetNextcloud extends BaseSyncTarget {
 	}
 
 	async initFileApi() {
-		const syncPath = Setting.value('sync.5.path');
-		// the syncPath might contain non-ASCII characters
-		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
-		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
-		const charsReg = /[^\u0021-\u00ff]/;
-		const syncPathUrl = charsReg.exec(syncPath) !== null ? encodeURI(syncPath) : syncPath;
 		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetNextcloud.id(), {
-			path: () => syncPathUrl,
+			path: () => Setting.value('sync.5.path'),
 			username: () => Setting.value('sync.5.username'),
 			password: () => Setting.value('sync.5.password'),
 			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),

--- a/packages/lib/SyncTargetNextcloud.js
+++ b/packages/lib/SyncTargetNextcloud.js
@@ -42,8 +42,13 @@ class SyncTargetNextcloud extends BaseSyncTarget {
 	}
 
 	async initFileApi() {
+		let syncPath = Setting.value('sync.5.path');
+		// the syncPath might contain non-ASCII characters
+		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
+		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
+		const syncPathUrl = RegExp(/[^\u0021-\u00ff]/).exec(syncPath) !== null ? encodeURI(syncPath) : syncPath;
 		const fileApi = await SyncTargetWebDAV.newFileApi_(SyncTargetNextcloud.id(), {
-			path: () => Setting.value('sync.5.path'),
+			path: () => syncPathUrl,
 			username: () => Setting.value('sync.5.username'),
 			password: () => Setting.value('sync.5.password'),
 			ignoreTlsErrors: () => Setting.value('net.ignoreTlsErrors'),

--- a/packages/lib/SyncTargetWebDAV.js
+++ b/packages/lib/SyncTargetWebDAV.js
@@ -6,6 +6,7 @@ const Synchronizer = require('./Synchronizer').default;
 const WebDavApi = require('./WebDavApi');
 const { FileApiDriverWebDav } = require('./file-api-driver-webdav');
 const checkProviderIsSupported = require('./utils/webDAVUtils').default;
+const urlUtils = require('./utils/urlUtils');
 
 class SyncTargetWebDAV extends BaseSyncTarget {
 	static id() {
@@ -41,7 +42,7 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
 		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
 		const charsReg = /[^\u0021-\u00ff]/;
-		const pathUrl = charsReg.exec(options.path()) !== null ? encodeURI(options.path()) : options.path();
+		const pathUrl = charsReg.exec(options.path()) !== null ? urlUtils.safe_encodeURI(options.path()) : options.path();
 		const apiOptions = {
 			baseUrl: () => pathUrl,
 			username: () => options.username(),

--- a/packages/lib/SyncTargetWebDAV.js
+++ b/packages/lib/SyncTargetWebDAV.js
@@ -37,8 +37,13 @@ class SyncTargetWebDAV extends BaseSyncTarget {
 	}
 
 	static async newFileApi_(syncTargetId, options) {
+		// the syncPath might contain non-ASCII characters
+		// /[^\u0021-\u00ff]/ is used in Node.js to detect the unescaped characters.
+		// See https://github.com/nodejs/node/blob/bbbf97b6dae63697371082475dc8651a6a220336/lib/_http_client.js#L176
+		const charsReg = /[^\u0021-\u00ff]/;
+		const pathUrl = charsReg.exec(options.path()) !== null ? encodeURI(options.path()) : options.path();
 		const apiOptions = {
-			baseUrl: () => options.path(),
+			baseUrl: () => pathUrl,
 			username: () => options.username(),
 			password: () => options.password(),
 			ignoreTlsErrors: () => options.ignoreTlsErrors(),

--- a/packages/lib/utils/urlUtils.js
+++ b/packages/lib/utils/urlUtils.js
@@ -1,0 +1,34 @@
+// Safely encodes URI with avoiding of the double-encoding of already encoded parts
+function safe_encodeURI(path) {
+    let out = "";
+    let encodeRanges = []
+    let begin = 0;
+    let i;
+
+    if (path == undefined || path === null || path.length == 0)
+        return path;
+
+    // Collecting ranges that should be encoded
+    for (i = 0; i < path.length; ) {
+        // If valid percent encoding is detected, don't encode it again!
+        if(path[i] === '%' && i + 3 < path.length && /[a-fA-F0-9]{2}/.test(path.substring(i + 1, i + 3)))
+        {
+            if(begin != i)
+                out += encodeURI(path.substring(begin, i))
+
+            out += path.substring(i, i + 3)
+            begin = i + 3;
+            i += 3;
+        } else {
+            ++i;
+        }
+    }
+
+    // If it's a piece at end of string that can be encoded too
+    if (begin < i)
+        out += encodeURI(path.substring(begin, i))
+
+    return out;
+}
+
+module.exports = { safe_encodeURI: safe_encodeURI }

--- a/packages/lib/utils/urlUtils.js
+++ b/packages/lib/utils/urlUtils.js
@@ -1,34 +1,36 @@
 // Safely encodes URI with avoiding of the double-encoding of already encoded parts
 function safe_encodeURI(path) {
-    let out = "";
-    let encodeRanges = []
-    let begin = 0;
-    let i;
+	let out = '';
+	let begin = 0;
+	let i;
 
-    if (path == undefined || path === null || path.length == 0)
-        return path;
+	if (path == undefined || path === null || path.length === 0) {
+		return path;
+	}
 
-    // Collecting ranges that should be encoded
-    for (i = 0; i < path.length; ) {
-        // If valid percent encoding is detected, don't encode it again!
-        if(path[i] === '%' && i + 3 < path.length && /[a-fA-F0-9]{2}/.test(path.substring(i + 1, i + 3)))
-        {
-            if(begin != i)
-                out += encodeURI(path.substring(begin, i))
+	// Collecting ranges that should be encoded
+	for (i = 0; i < path.length; ) {
+		// If valid percent encoding is detected, don't encode it again!
+		if (path[i] === '%' && i + 3 < path.length && /[a-fA-F0-9]{2}/.test(path.substring(i + 1, i + 3)))
+		{
+			if (begin !== i) {
+				out += encodeURI(path.substring(begin, i));
+			}
 
-            out += path.substring(i, i + 3)
-            begin = i + 3;
-            i += 3;
-        } else {
-            ++i;
-        }
-    }
+			out += path.substring(i, i + 3);
+			begin = i + 3;
+			i += 3;
+		} else {
+			++i;
+		}
+	}
 
-    // If it's a piece at end of string that can be encoded too
-    if (begin < i)
-        out += encodeURI(path.substring(begin, i))
+	// If it's a piece at end of string that can be encoded too
+	if (begin < i) {
+		out += encodeURI(path.substring(begin, i));
+	}
 
-    return out;
+	return out;
 }
 
-module.exports = { safe_encodeURI: safe_encodeURI }
+module.exports = { safe_encodeURI: safe_encodeURI };

--- a/packages/lib/utils/urlUtils.js
+++ b/packages/lib/utils/urlUtils.js
@@ -4,15 +4,14 @@ function safe_encodeURI(path) {
 	let begin = 0;
 	let i;
 
-	if (path == undefined || path === null || path.length === 0) {
+	if (path === undefined || path === null || path.length === 0) {
 		return path;
 	}
 
 	// Collecting ranges that should be encoded
-	for (i = 0; i < path.length; ) {
+	for (i = 0; i < path.length;) {
 		// If valid percent encoding is detected, don't encode it again!
-		if (path[i] === '%' && i + 3 < path.length && /[a-fA-F0-9]{2}/.test(path.substring(i + 1, i + 3)))
-		{
+		if (path[i] === '%' && i + 3 < path.length && /[a-fA-F0-9]{2}/.test(path.substring(i + 1, i + 3))) {
 			if (begin !== i) {
 				out += encodeURI(path.substring(begin, i));
 			}


### PR DESCRIPTION
This is the similar fix to #7868 done for OneDrive, but it's fully suitable for the Nextcloud too, allowing Unicode paths used normally. URL field at the UI expected to support unicode paths, and they should be URL-encoded and Punycoded at the backend during the work. Without making unexpected situations like described in the #13254 and other similar.

<img width="480" height="114" alt="Image" src="https://github.com/user-attachments/assets/e5837752-013d-4f96-b38a-0c34e48e4d72" />

<img width="737" height="156" alt="Image" src="https://github.com/user-attachments/assets/4d6d95a8-510d-461d-90ae-fc590b705490" />

---
I have read the CLA Document and I hereby sign the CLA

---

recheck