### PR TITLE
Server: Slightly improve delta performance

### DIFF
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -394,9 +394,8 @@ export default class ChangeModel extends BaseModel<Change> {
 	//
 	// There's one exception for changes that include a "previous_item". This is
 	// used to save specific properties about the previous state of the item,
-	// such as "jop_parent_id" or "name", which is used by the share mechanism
-	// to know if an item has been moved from one folder to another. In that
-	// case, we need to know about each individual change, so they are not
+	// such as "jop_share_id" or "name". The share mechanism needs to know about
+	// each change to "jop_share_id", so updates that change the share ID are not
 	// compressed.
 	//
 	// The latest change, when an item goes from DELETE to CREATE seems odd but
@@ -405,7 +404,9 @@ export default class ChangeModel extends BaseModel<Change> {
 	// (CREATED), then unshared (DELETED), then shared again (CREATED). When it
 	// happens, we want the user to get the item, thus we generate a CREATE
 	// event.
-	private compressChanges_(changes: Change[]): Change[] {
+	//
+	// Public to allow testing.
+	public compressChanges_(changes: Change[]): Change[] {
 		const itemChanges = new Map<Uuid, Change>();
 
 		const itemUniqueUpdates = new Map<Uuid, Change[]>();

--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -421,15 +421,18 @@ export default class ChangeModel extends BaseModel<Change> {
 			const previous = itemChanges.get(itemId);
 
 			if (change.type === ChangeType.Update) {
-				const updates = itemUniqueUpdates.get(itemId);
 				const shareId = changeToShareId(change);
-				if (updates) {
+
+				const uniqueUpdates = itemUniqueUpdates.get(itemId);
+				if (uniqueUpdates) {
 					const lastShareId = itemToLastUpdateShareIds.get(itemId);
-					if (lastShareId === shareId) {
+					const canCompress = lastShareId === shareId;
+
+					if (canCompress) {
 						// Always keep the last change as up-to-date as possible
-						updates[updates.length - 1] = change;
+						uniqueUpdates[uniqueUpdates.length - 1] = change;
 					} else {
-						updates.push(change);
+						uniqueUpdates.push(change);
 						itemToLastUpdateShareIds.set(itemId, shareId);
 					}
 				} else {


### PR DESCRIPTION
# Summary

**Goal**: Improve the performance of `ChangeModel.compressChanges`, which is used by the `api/items/:id/delta` route.

This pull request:
- Updates `compressChanges` to compress update -> update changes in more cases.
- Improves the performance of `compressChanges` by 1) removing the need for calling `md5()` to generate a hash for each update and 2) switching from a JavaScript object to a `Map`.
- Adds additional automated tests for `compressChanges`.

Related: https://github.com/laurent22/joplin/pull/13689

# Notes

## Compressing `update->update` in more cases

Previously, `update -> update` changes weren't compressed if the changes' `previous_item`s were different.

According [to this comment](https://github.com/laurent22/joplin/blob/dev/packages/server/src/models/ChangeModel.ts#L396), this is done because of the share service. However,
- the share service's `updateSharedItems3` currently [ignores updates that don't change `previous_item.jop_share_id`](https://github.com/laurent22/joplin/blob/57a4a687d1ef7ce2e4f9198d7e7ce1a88cb073a5/packages/server/src/models/ShareModel.ts#L239) and
- `previous_item` can change even if the share ID doesn't change, e.g. if a new item is attached to a note.

As such, it should be safe to compress updates that change `previous_item`, but don't change `previous_item.jop_share_id`.

**Note**: Based on a [code search](https://github.com/search?q=repo%3Alaurent22%2Fjoplin%20previous_item&type=code), `previous_item` seems to only be read in `updateSharedItems3` and `compressChanges`.

# Benchmarks

> [!NOTE]
>
> The "After v2" tests are after adding additional caching. These tests were done with https://github.com/laurent22/joplin/pull/13730/commits/2b2ea53067eddd7a48b6dc439c706cc229cde371.

<details><summary>Large numbers of changes</summary>

<details><summary>Benchmark diff</summary>

```diff
diff --git a/packages/server/src/models/ChangeModel.test.ts b/packages/server/src/models/ChangeModel.test.ts
index 7fb4c667f..18c5dfd37 100644
--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -1,8 +1,10 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, expectThrow, createFolder, createItemTree3, expectNotThrow, createNote, updateNote, deleteNote } from '../utils/testing/testUtils';
-import { ChangeType } from '../services/database/types';
+import { Change, ChangeType } from '../services/database/types';
 import { Day, msleep } from '../utils/time';
 import { ChangePagination } from './ChangeModel';
 import { SqliteMaxVariableNum } from '../db';
+import uuid from '@joplin/lib/uuid';
+import { randomElement } from '../utils/array';
 
 describe('ChangeModel', () => {
 
@@ -343,4 +345,45 @@ describe('ChangeModel', () => {
 		expect('jopItem' in result.items[0]).toBe(false);
 	});
 
+	test('benchmark compressChanges_', () => {
+		const changes: Change[] = [];
+		const changeTypes = [ChangeType.Create, ChangeType.Update, ChangeType.Delete];
+		const itemIds = [];
+		const randomShareIds = false;
+
+		console.log('change count', ',', 'avg duration (ms)');
+		for (let changeCount = 1_000; changeCount < 100_000; changeCount += 1_000) {
+			while (changes.length < changeCount) {
+				let itemId;
+				if (!itemIds.length || changes.length % 10 === 0) {
+					itemId = uuid.create();
+					itemIds.push(itemId);
+				} else {
+					itemId = randomElement(itemIds);
+				}
+
+				changes.push({
+					counter: changes.length,
+					type: changeTypes[changes.length % 3],
+					id: uuid.create(),
+					item_id: itemId,
+					previous_item: JSON.stringify({
+						name: `${itemId}.md`,
+						jop_share_id: randomShareIds ? uuid.create() : '0000000000000000000000000000000A',
+						jop_parent_id: '000000000000000000000000000000F0',
+						jop_attachment_ids: ['000000000000000000000000000000A0', '000000000000000000000000000000A1', '000000000000000000000000000000A2'],
+					}),
+				});
+			}
+
+			const trialCount = 5;
+			let totalDuration = 0;
+			for (let trial = 0; trial < trialCount; trial++) {
+				const startTime = performance.now();
+				models().change().compressChanges_(changes);
+				totalDuration += performance.now() - startTime;
+			}
+			console.log(changeCount, ',', totalDuration / trialCount);
+		}
+	});
 });
diff --git a/packages/server/src/models/ChangeModel.ts b/packages/server/src/models/ChangeModel.ts
index f6c32d878..988bd2bb7 100644
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -405,7 +405,7 @@ export default class ChangeModel extends BaseModel<Change> {
 	// (CREATED), then unshared (DELETED), then shared again (CREATED). When it
 	// happens, we want the user to get the item, thus we generate a CREATE
 	// event.
-	private compressChanges_(changes: Change[]): Change[] {
+	public compressChanges_(changes: Change[]): Change[] {
 		const itemChanges = new Map<Uuid, Change>();
 
 		const itemUniqueUpdates = new Map<Uuid, Change[]>();
```

</details>

**Constant share ID**:

<img width="1118" height="638" alt="chart: for large values, after v2 is faster" src="https://github.com/user-attachments/assets/e5ef1efb-f1b7-47ed-a9a4-01c2c0b42fab" />


| Change count | Before (ms) | After (ms) | After v2 (ms) |
| --- | --- | --- | --- |
| 1000 | 1.03 | 0.76 | 0.63 |
| 2000 | 1.63 | 1.63 | 2.20 |
| 3000 | 1.63 | 2.00 | 1.49 |
| 4000 | 2.14 | 2.84 | 1.55 |
| 5000 | 3.79 | 2.73 | 1.86 |
| 6000 | 2.85 | 3.41 | 2.92 |
| 7000 | 4.81 | 4.00 | 2.54 |
| 8000 | 5.69 | 4.18 | 3.16 |
| 9000 | 4.37 | 5.45 | 3.90 |
| 10000 | 5.86 | 5.40 | 4.15 |
| 11000 | 6.67 | 5.60 | 4.47 |
| 12000 | 7.56 | 6.07 | 4.99 |
| 13000 | 8.00 | 6.88 | 4.63 |
| 14000 | 8.15 | 7.54 | 5.68 |
| 15000 | 8.42 | 7.63 | 5.75 |
| 16000 | 10.06 | 7.57 | 5.84 |
| 17000 | 9.65 | 8.04 | 6.52 |
| 18000 | 11.40 | 8.78 | 8.35 |
| 19000 | 11.88 | 8.95 | 9.59 |
| 20000 | 10.54 | 10.04 | 7.18 |
| 21000 | 12.81 | 9.83 | 7.84 |
| 22000 | 13.44 | 10.32 | 7.57 |
| 23000 | 12.55 | 10.61 | 7.97 |
| 24000 | 13.81 | 10.89 | 8.51 |
| 25000 | 16.56 | 11.38 | 8.55 |
| 26000 | 18.52 | 11.80 | 9.14 |
| 27000 | 19.18 | 14.18 | 9.45 |
| 28000 | 17.31 | 14.52 | 9.84 |
| 29000 | 16.75 | 15.64 | 10.73 |
| 30000 | 18.90 | 14.70 | 10.72 |
| 31000 | 18.82 | 14.57 | 11.10 |
| 32000 | 19.31 | 15.13 | 11.73 |
| 33000 | 20.99 | 15.63 | 11.71 |
| 34000 | 20.11 | 16.11 | 11.98 |
| 35000 | 21.47 | 17.20 | 12.52 |
| 36000 | 21.14 | 16.97 | 12.83 |
| 37000 | 23.22 | 17.12 | 13.76 |
| 38000 | 23.91 | 17.63 | 13.67 |
| 39000 | 23.82 | 18.03 | 13.76 |
| 40000 | 24.21 | 18.68 | 14.08 |
| 41000 | 24.13 | 19.32 | 14.64 |
| 42000 | 26.01 | 20.26 | 14.93 |
| 43000 | 27.02 | 20.00 | 15.11 |
| 44000 | 31.22 | 20.44 | 15.53 |
| 45000 | 28.73 | 21.19 | 16.66 |
| 46000 | 28.67 | 21.65 | 17.69 |
| 47000 | 28.96 | 22.11 | 17.45 |
| 48000 | 30.98 | 22.71 | 17.54 |
| 49000 | 30.53 | 23.37 | 18.25 |
| 50000 | 32.32 | 23.73 | 18.76 |
| 51000 | 31.60 | 24.64 | 20.64 |
| 52000 | 33.29 | 24.99 | 19.48 |
| 53000 | 34.70 | 25.53 | 19.47 |
| 54000 | 33.96 | 26.09 | 19.64 |
| 55000 | 37.24 | 26.75 | 20.70 |
| 56000 | 37.02 | 27.07 | 20.05 |
| 57000 | 36.84 | 27.92 | 20.24 |
| 58000 | 37.83 | 28.31 | 20.84 |
| 59000 | 38.16 | 32.02 | 20.94 |
| 60000 | 38.63 | 29.89 | 22.14 |
| 61000 | 40.72 | 30.55 | 21.86 |
| 62000 | 40.38 | 30.07 | 22.67 |
| 63000 | 41.53 | 31.84 | 24.84 |
| 64000 | 42.75 | 35.49 | 28.52 |
| 65000 | 42.40 | 31.88 | 24.99 |
| 66000 | 45.19 | 32.40 | 25.94 |
| 67000 | 45.99 | 32.88 | 25.30 |
| 68000 | 45.90 | 33.47 | 26.50 |
| 69000 | 46.99 | 33.50 | 26.36 |
| 70000 | 46.96 | 35.99 | 26.52 |
| 71000 | 46.91 | 36.13 | 27.19 |
| 72000 | 47.49 | 38.17 | 29.76 |
| 73000 | 48.07 | 36.45 | 26.56 |
| 74000 | 48.32 | 38.00 | 27.41 |
| 75000 | 49.43 | 37.81 | 28.19 |
| 76000 | 50.10 | 39.83 | 29.29 |
| 77000 | 52.03 | 40.17 | 29.46 |
| 78000 | 53.02 | 38.64 | 29.85 |
| 79000 | 52.93 | 40.06 | 29.92 |
| 80000 | 55.61 | 40.70 | 29.67 |
| 81000 | 53.57 | 41.29 | 30.32 |
| 82000 | 55.14 | 44.45 | 31.56 |
| 83000 | 56.61 | 41.16 | 31.00 |
| 84000 | 69.68 | 42.15 | 31.71 |
| 85000 | 57.70 | 42.19 | 32.49 |
| 86000 | 58.08 | 43.88 | 32.89 |
| 87000 | 59.52 | 44.54 | 33.53 |
| 88000 | 60.80 | 44.57 | 33.01 |
| 89000 | 61.07 | 45.20 | 34.73 |
| 90000 | 60.57 | 45.52 | 36.73 |
| 91000 | 60.92 | 46.49 | 36.65 |
| 92000 | 65.05 | 46.70 | 37.37 |
| 93000 | 64.09 | 47.09 | 37.66 |
| 94000 | 63.72 | 49.53 | 37.39 |
| 95000 | 66.52 | 48.53 | 37.64 |
| 96000 | 66.93 | 49.10 | 37.66 |
| 97000 | 66.82 | 49.47 | 38.33 |
| 98000 | 69.03 | 50.82 | 37.03 |
| 99000 | 68.70 | 52.06 | 37.96 |


**Random share IDs**:


<img width="1118" height="638" alt="chart: For large values, after v2 is faster" src="https://github.com/user-attachments/assets/14477455-b92c-4509-9de7-dc1e95856ce8" />

| Change count | Before (ms) | After (ms) | After v2 (ms) |
| --- | --- | --- | --- |
| 1000 | 1.37 | 0.88 | 0.92 |
| 2000 | 2.10 | 1.66 | 2.18 |
| 3000 | 1.69 | 1.59 | 1.61 |
| 4000 | 2.32 | 2.19 | 2.65 |
| 5000 | 3.58 | 2.61 | 2.61 |
| 6000 | 3.07 | 3.38 | 3.50 |
| 7000 | 3.70 | 3.50 | 3.42 |
| 8000 | 4.84 | 4.36 | 4.01 |
| 9000 | 5.53 | 5.02 | 4.69 |
| 10000 | 6.27 | 5.17 | 4.73 |
| 11000 | 6.51 | 5.73 | 5.20 |
| 12000 | 7.15 | 6.96 | 6.07 |
| 13000 | 7.79 | 6.18 | 6.26 |
| 14000 | 8.25 | 6.98 | 6.31 |
| 15000 | 8.63 | 8.47 | 7.46 |
| 16000 | 10.18 | 10.57 | 7.23 |
| 17000 | 11.25 | 8.47 | 7.10 |
| 18000 | 11.34 | 9.61 | 7.50 |
| 19000 | 11.21 | 9.58 | 9.04 |
| 20000 | 12.76 | 10.55 | 8.14 |
| 21000 | 14.08 | 11.06 | 8.14 |
| 22000 | 16.96 | 11.14 | 8.21 |
| 23000 | 17.73 | 10.98 | 8.65 |
| 24000 | 22.89 | 11.24 | 8.94 |
| 25000 | 18.60 | 12.00 | 9.76 |
| 26000 | 18.67 | 12.93 | 10.14 |
| 27000 | 24.86 | 13.31 | 10.26 |
| 28000 | 22.33 | 14.65 | 10.76 |
| 29000 | 22.87 | 15.21 | 11.08 |
| 30000 | 22.19 | 14.66 | 11.05 |
| 31000 | 24.87 | 17.58 | 13.11 |
| 32000 | 30.57 | 15.78 | 14.02 |
| 33000 | 27.99 | 16.46 | 13.58 |
| 34000 | 29.36 | 16.54 | 13.84 |
| 35000 | 27.76 | 17.23 | 13.50 |
| 36000 | 30.62 | 18.05 | 13.87 |
| 37000 | 42.55 | 17.94 | 14.42 |
| 38000 | 33.42 | 20.09 | 14.74 |
| 39000 | 30.63 | 18.80 | 15.39 |
| 40000 | 28.14 | 19.25 | 15.39 |
| 41000 | 29.30 | 19.86 | 15.88 |
| 42000 | 31.42 | 20.39 | 16.01 |
| 43000 | 30.08 | 20.81 | 18.36 |
| 44000 | 32.44 | 21.35 | 16.50 |
| 45000 | 31.80 | 22.29 | 16.51 |
| 46000 | 33.32 | 23.00 | 18.21 |
| 47000 | 34.96 | 23.29 | 17.88 |
| 48000 | 37.49 | 23.47 | 18.84 |
| 49000 | 45.49 | 24.43 | 19.34 |
| 50000 | 49.24 | 25.90 | 20.09 |
| 51000 | 42.86 | 27.00 | 19.22 |
| 52000 | 40.60 | 27.50 | 19.71 |
| 53000 | 49.31 | 27.64 | 20.17 |
| 54000 | 53.49 | 29.41 | 21.02 |
| 55000 | 48.36 | 29.20 | 21.68 |
| 56000 | 49.82 | 30.00 | 21.86 |
| 57000 | 51.25 | 35.49 | 22.57 |
| 58000 | 66.06 | 30.71 | 27.34 |
| 59000 | 52.58 | 31.46 | 24.28 |
| 60000 | 48.62 | 31.86 | 23.77 |
| 61000 | 47.98 | 31.55 | 23.84 |
| 62000 | 48.36 | 31.84 | 23.90 |
| 63000 | 51.41 | 32.51 | 24.99 |
| 64000 | 50.51 | 32.47 | 25.34 |
| 65000 | 53.60 | 40.21 | 25.61 |
| 66000 | 54.95 | 36.25 | 26.06 |
| 67000 | 58.19 | 35.80 | 26.56 |
| 68000 | 61.22 | 36.81 | 26.71 |
| 69000 | 63.05 | 35.93 | 27.00 |
| 70000 | 58.42 | 37.65 | 27.31 |
| 71000 | 61.22 | 38.80 | 27.87 |
| 72000 | 60.26 | 37.36 | 28.79 |
| 73000 | 65.45 | 40.00 | 29.72 |
| 74000 | 64.62 | 40.30 | 30.46 |
| 75000 | 64.65 | 40.38 | 29.98 |
| 76000 | 71.59 | 48.81 | 31.05 |
| 77000 | 68.22 | 42.66 | 30.52 |
| 78000 | 69.22 | 40.97 | 32.03 |
| 79000 | 68.58 | 43.11 | 32.76 |
| 80000 | 68.77 | 44.24 | 33.36 |
| 81000 | 67.80 | 44.54 | 33.27 |
| 82000 | 70.90 | 45.20 | 32.97 |
| 83000 | 83.18 | 46.29 | 33.27 |
| 84000 | 70.18 | 46.89 | 34.32 |
| 85000 | 72.83 | 48.15 | 33.76 |
| 86000 | 73.38 | 48.38 | 33.99 |
| 87000 | 74.59 | 48.85 | 34.38 |
| 88000 | 76.70 | 49.25 | 34.61 |
| 89000 | 75.82 | 50.10 | 35.34 |
| 90000 | 77.67 | 50.44 | 38.25 |
| 91000 | 77.54 | 50.40 | 36.90 |
| 92000 | 79.14 | 51.77 | 39.16 |
| 93000 | 79.14 | 52.96 | 38.21 |
| 94000 | 79.17 | 52.72 | 39.42 |
| 95000 | 82.29 | 53.91 | 40.79 |
| 96000 | 85.11 | 55.57 | 38.92 |
| 97000 | 86.76 | 55.51 | 41.41 |
| 98000 | 86.42 | 55.66 | 43.61 |
| 99000 | 88.99 | 56.45 | 43.76 |



Each duration is averaged over 5 trials.

</details>
<details><summary>Smaller numbers of changes</summary>

<details><summary>diff</summary>

```diff
diff --git a/packages/server/src/models/ChangeModel.test.ts b/packages/server/src/models/ChangeModel.test.ts
index 7fb4c667f..3933564a6 100644
--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -1,8 +1,10 @@
 import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, expectThrow, createFolder, createItemTree3, expectNotThrow, createNote, updateNote, deleteNote } from '../utils/testing/testUtils';
-import { ChangeType } from '../services/database/types';
+import { Change, ChangeType } from '../services/database/types';
 import { Day, msleep } from '../utils/time';
 import { ChangePagination } from './ChangeModel';
 import { SqliteMaxVariableNum } from '../db';
+import uuid from '@joplin/lib/uuid';
+import { randomElement } from '../utils/array';
 
 describe('ChangeModel', () => {
 
@@ -343,4 +345,45 @@ describe('ChangeModel', () => {
 		expect('jopItem' in result.items[0]).toBe(false);
 	});
 
+	test('benchmark compressChanges_', () => {
+		const changes: Change[] = [];
+		const changeTypes = [ChangeType.Create, ChangeType.Update, ChangeType.Delete];
+		const itemIds = [];
+		const randomShareIds = true;
+
+		console.log('change count', ',', 'avg duration (ms)');
+		for (let changeCount = 50; changeCount < 1000; changeCount += 50) {
+			while (changes.length < changeCount) {
+				let itemId;
+				if (!itemIds.length || changes.length % 10 === 0) {
+					itemId = uuid.create();
+					itemIds.push(itemId);
+				} else {
+					itemId = randomElement(itemIds);
+				}
+
+				changes.push({
+					counter: changes.length,
+					type: changeTypes[changes.length % 3],
+					id: uuid.create(),
+					item_id: itemId,
+					previous_item: JSON.stringify({
+						name: `${itemId}.md`,
+						jop_share_id: randomShareIds ? uuid.create() : '0000000000000000000000000000000A',
+						jop_parent_id: '000000000000000000000000000000F0',
+						jop_attachment_ids: ['000000000000000000000000000000A0', '000000000000000000000000000000A1', '000000000000000000000000000000A2'],
+					}),
+				});
+			}
+
+			const trialCount = 50;
+			let totalDuration = 0;
+			for (let trial = 0; trial < trialCount; trial++) {
+				const startTime = performance.now();
+				models().change().compressChanges_(changes);
+				totalDuration += performance.now() - startTime;
+			}
+			console.log(changeCount, ',', totalDuration / trialCount);
+		}
+	});
 });
diff --git a/packages/server/src/models/ChangeModel.ts b/packages/server/src/models/ChangeModel.ts
index f6c32d878..988bd2bb7 100644
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -405,7 +405,7 @@ export default class ChangeModel extends BaseModel<Change> {
 	// (CREATED), then unshared (DELETED), then shared again (CREATED). When it
 	// happens, we want the user to get the item, thus we generate a CREATE
 	// event.
-	private compressChanges_(changes: Change[]): Change[] {
+	public compressChanges_(changes: Change[]): Change[] {
 		const itemChanges = new Map<Uuid, Change>();
 
 		const itemUniqueUpdates = new Map<Uuid, Change[]>();
```
</details>

**Random share IDs**:
<img width="606" height="341" alt="chart: 'after v2' is usually faster than 'after' and 'before'" src="https://github.com/user-attachments/assets/3fe54459-f5fc-4ba4-ac79-c29e33134a4b" />

| Change count | Before (ms) | After (ms) | After v2 (ms) |
| --- | --- | --- | --- |
| 50  | 0.06 | 0.04 | 0.03 |
| 100 | 0.12 | 0.06 | 0.05 |
| 150 | 0.10 | 0.09 | 0.13 |
| 200 | 0.12 | 0.11 | 0.09 |
| 250 | 0.16 | 0.17 | 0.08 |
| 300 | 0.15 | 0.12 | 0.10 |
| 350 | 0.26 | 0.14 | 0.13 |
| 400 | 0.18 | 0.16 | 0.19 |
| 450 | 0.20 | 0.22 | 0.15 |
| 500 | 0.23 | 0.22 | 0.17 |
| 550 | 0.40 | 0.24 | 0.21 |
| 600 | 0.29 | 0.24 | 0.21 |
| 650 | 0.44 | 0.28 | 0.26 |
| 700 | 0.30 | 0.27 | 0.42 |
| 750 | 0.43 | 0.33 | 0.30 |
| 800 | 0.30 | 0.34 | 0.31 |
| 850 | 0.43 | 0.37 | 0.32 |
| 900 | 0.46 | 0.39 | 0.32 |
| 950 | 0.38 | 0.42 | 0.33 |

**Constant share IDs**:
<img width="606" height="341" alt="chart: After v2 is usually faster than both after and before" src="https://github.com/user-attachments/assets/f4f48d8d-0d86-4ed9-a326-dc94423e7825" />

| Change count | Before (ms) | After (ms) | After v2 (ms) |
| --- | --- | --- | --- |
| 50  | 0.06 | 0.04 | 0.11 |
| 100 | 0.09 | 0.09 | 0.08 |
| 150 | 0.20 | 0.16 | 0.12 |
| 200 | 0.14 | 0.08 | 0.08 |
| 250 | 0.12 | 0.14 | 0.16 |
| 300 | 0.15 | 0.15 | 0.11 |
| 350 | 0.27 | 0.20 | 0.14 |
| 400 | 0.18 | 0.19 | 0.14 |
| 450 | 0.20 | 0.21 | 0.18 |
| 500 | 0.21 | 0.25 | 0.21 |
| 550 | 0.36 | 0.24 | 0.49 |
| 600 | 0.23 | 0.27 | 0.26 |
| 650 | 0.40 | 0.32 | 0.30 |
| 700 | 0.33 | 0.36 | 0.36 |
| 750 | 0.49 | 0.35 | 0.29 |
| 800 | 0.29 | 0.39 | 0.30 |
| 850 | 0.47 | 0.35 | 0.32 |
| 900 | 0.39 | 0.42 | 0.32 |
| 950 | 0.57 | 0.44 | 0.37 |

Each duration is averaged over 50 trials.

</details>

# Testing

- This pull request adds new automated tests for `ChangeModel.compressChanges_`.
- It has been verified that the sync fuzzer runs successfully for >= 100 steps, with this change applied.