### PR TITLE
Mobile: Add the ability to search on the tag list screen

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -851,6 +851,7 @@ packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.test.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.js
 packages/app-mobile/components/screens/Notes/Notes.js
+packages/app-mobile/components/screens/SearchScreen/SearchBar.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.test.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.js
 packages/app-mobile/components/screens/SearchScreen/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -823,6 +823,7 @@ packages/app-mobile/components/screens/NoteTagsDialog.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.test.js
 packages/app-mobile/components/screens/Notes/NewNoteButton.js
 packages/app-mobile/components/screens/Notes/Notes.js
+packages/app-mobile/components/screens/SearchScreen/SearchBar.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.test.js
 packages/app-mobile/components/screens/SearchScreen/SearchResults.js
 packages/app-mobile/components/screens/SearchScreen/index.js

--- a/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { _ } from '@joplin/lib/locale';
+import { StyleSheet, TextInput, View } from 'react-native';
+import { themeStyle } from '../../global-style';
+import IconButton from '../../IconButton';
+import { useMemo } from 'react';
+
+interface Props {
+	themeId: number;
+	value: string;
+	autoFocus: boolean;
+	placeholder?: string;
+	onChangeText: (text: string)=> void;
+	onClearButtonPress: ()=> void;
+	onSubmitEditing?: ()=> void;
+}
+
+const useStyles = (themeId: number) => {
+	return useMemo(() => {
+		const theme = themeStyle(themeId);
+		return StyleSheet.create({
+			searchContainer: {
+				flexDirection: 'row',
+				alignItems: 'center',
+				borderWidth: 1,
+				borderColor: theme.dividerColor,
+			},
+			searchTextInput: {
+				...theme.lineInput,
+				paddingLeft: theme.marginLeft,
+				flex: 1,
+				backgroundColor: theme.backgroundColor,
+				color: theme.color,
+			},
+			clearIcon: {
+				...theme.icon,
+				color: theme.colorFaded,
+				paddingRight: theme.marginRight,
+				backgroundColor: theme.backgroundColor,
+			},
+		});
+	}, [themeId]);
+};
+
+const SearchBar: React.FC<Props> = ({ themeId, value, autoFocus, placeholder, onChangeText, onClearButtonPress, onSubmitEditing }) => {
+	const theme = themeStyle(themeId);
+	const styles = useStyles(themeId);
+
+	return (
+		<View style={styles.searchContainer}>
+			<TextInput
+				style={styles.searchTextInput}
+				autoFocus={autoFocus}
+				underlineColorAndroid="#ffffff00"
+				onChangeText={onChangeText}
+				onSubmitEditing={onSubmitEditing}
+				placeholder={placeholder}
+				placeholderTextColor={theme.colorFaded}
+				value={value}
+				selectionColor={theme.textSelectionColor}
+				keyboardAppearance={theme.keyboardAppearance}
+			/>
+			<IconButton
+				themeId={themeId}
+				iconStyle={styles.clearIcon}
+				iconName='ionicon close-circle'
+				onPress={onClearButtonPress}
+				description={_('Clear')}
+			/>
+		</View>
+	);
+};
+
+export default SearchBar;

--- a/packages/app-mobile/components/screens/SearchScreen/index.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { StyleSheet, View, TextInput } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { connect } from 'react-redux';
 import ScreenHeader from '../../ScreenHeader';
 import { _ } from '@joplin/lib/locale';
@@ -8,10 +8,10 @@ import { ThemeStyle, themeStyle } from '../../global-style';
 import { AppState } from '../../../utils/types';
 import { Dispatch } from 'redux';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import IconButton from '../../IconButton';
 import SearchResults from './SearchResults';
 import AccessibleView from '../../accessibility/AccessibleView';
 import { ComplexTerm } from '@joplin/lib/services/search/SearchEngine';
+import SearchBar from './SearchBar';
 
 interface Props {
 	themeId: number;
@@ -28,25 +28,6 @@ const useStyles = (theme: ThemeStyle, visible: boolean) => {
 		return StyleSheet.create({
 			body: {
 				flex: 1,
-			},
-			searchContainer: {
-				flexDirection: 'row',
-				alignItems: 'center',
-				borderWidth: 1,
-				borderColor: theme.dividerColor,
-			},
-			searchTextInput: {
-				...theme.lineInput,
-				paddingLeft: theme.marginLeft,
-				flex: 1,
-				backgroundColor: theme.backgroundColor,
-				color: theme.color,
-			},
-			clearIcon: {
-				...theme.icon,
-				color: theme.colorFaded,
-				paddingRight: theme.marginRight,
-				backgroundColor: theme.backgroundColor,
 			},
 			rootStyle: visible ? theme.rootStyle : theme.hiddenRootStyle,
 		});
@@ -118,26 +99,14 @@ const SearchScreenComponent: React.FC<Props> = props => {
 				showSearchButton={false}
 			/>
 			<View style={styles.body}>
-				<View style={styles.searchContainer}>
-					<TextInput
-						style={styles.searchTextInput}
-						autoFocus={props.visible}
-						underlineColorAndroid="#ffffff00"
-						onChangeText={setQuery}
-						onSubmitEditing={onOverridePause}
-						value={query}
-						selectionColor={theme.textSelectionColor}
-						keyboardAppearance={theme.keyboardAppearance}
-					/>
-					<IconButton
-						themeId={props.themeId}
-						iconStyle={styles.clearIcon}
-						iconName='ionicon close-circle'
-						onPress={clearButton_press}
-						description={_('Clear')}
-					/>
-				</View>
-
+				<SearchBar
+					themeId={props.themeId}
+					autoFocus={props.visible}
+					value={query}
+					onChangeText={setQuery}
+					onSubmitEditing={onOverridePause}
+					onClearButtonPress={clearButton_press}
+				/>
 				<SearchResults
 					query={query}
 					paused={paused}

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { View, Text, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
 import { connect } from 'react-redux';
 import Tag from '@joplin/lib/models/Tag';
 import { themeStyle } from '../global-style';
@@ -10,8 +10,9 @@ import { AppState } from '../../utils/types';
 import { TagEntity } from '@joplin/lib/services/database/types';
 import { useCallback, useMemo, useState } from 'react';
 import { Dispatch } from 'redux';
-import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
+import useQueuedAsyncEffect from '@joplin/lib/hooks/useQueuedAsyncEffect';
 import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getCollator';
+import IconButton from '../IconButton';
 
 interface Props {
 	dispatch: Dispatch;
@@ -39,6 +40,25 @@ const useStyles = (themeId: number) => {
 				fontSize: theme.fontSize,
 			},
 			rootStyle: theme.rootStyle,
+			searchContainer: {
+				flexDirection: 'row',
+				alignItems: 'center',
+				borderWidth: 1,
+				borderColor: theme.dividerColor,
+			},
+			searchTextInput: {
+				...theme.lineInput,
+				paddingLeft: theme.marginLeft,
+				flex: 1,
+				backgroundColor: theme.backgroundColor,
+				color: theme.color,
+			},
+			clearIcon: {
+				...theme.icon,
+				color: theme.colorFaded,
+				paddingRight: theme.marginRight,
+				backgroundColor: theme.backgroundColor,
+			},
 		});
 	}, [themeId]);
 };
@@ -46,7 +66,10 @@ const useStyles = (themeId: number) => {
 
 const TagsScreenComponent: React.FC<Props> = props => {
 	const [tags, setTags] = useState<TagEntity[]>([]);
+	const [searchQuery, setSearchQuery] = useState('');
+	const [showSearch, setShowSearch] = useState(false);
 	const styles = useStyles(props.themeId);
+	const theme = themeStyle(props.themeId);
 	const collatorLocale = getCollatorLocale();
 	const collator = useMemo(() => {
 		return getCollator(collatorLocale);
@@ -54,12 +77,42 @@ const TagsScreenComponent: React.FC<Props> = props => {
 
 	type TagItemPressEvent = { id: string };
 
-	useAsyncEffect(async () => {
-		const tags = await Tag.allWithNotes();
-		tags.sort((a, b) => {
-			return collator.compare(a.title, b.title);
-		});
-		setTags(tags);
+	useQueuedAsyncEffect(async (event) => {
+		try {
+			let fetchedTags: TagEntity[];
+
+			if (searchQuery.trim()) {
+				const searchPattern = `*${searchQuery.trim()}*`;
+				fetchedTags = await Tag.searchAllWithNotes({
+					titlePattern: searchPattern,
+				});
+			} else {
+				fetchedTags = await Tag.allWithNotes();
+			}
+
+			fetchedTags.sort((a, b) => {
+				return collator.compare(a.title, b.title);
+			});
+
+			if (!event.cancelled) {
+				setTags(fetchedTags);
+			}
+		} catch (error) {
+			if (!event.cancelled) {
+				setTags([]);
+			}
+		}
+	}, [searchQuery, collator], { interval: 200 });
+
+	const onSearchButtonPress = useCallback(() => {
+		setShowSearch(!showSearch);
+		if (showSearch) {
+			setSearchQuery('');
+		}
+	}, [showSearch]);
+
+	const clearButton_press = useCallback(() => {
+		setSearchQuery('');
 	}, []);
 
 	const onTagItemPress = useCallback((event: TagItemPressEvent) => {
@@ -89,7 +142,33 @@ const TagsScreenComponent: React.FC<Props> = props => {
 
 	return (
 		<View style={styles.rootStyle}>
-			<ScreenHeader title={_('Tags')} showSearchButton={false} />
+			<ScreenHeader
+				title={_('Tags')}
+				showSearchButton={true}
+				onSearchButtonPress={onSearchButtonPress}
+			/>
+			{showSearch && (
+				<View style={styles.searchContainer}>
+					<TextInput
+						style={styles.searchTextInput}
+						autoFocus={true}
+						underlineColorAndroid="#ffffff00"
+						onChangeText={setSearchQuery}
+						value={searchQuery}
+						placeholder={_('Search tags')}
+						placeholderTextColor={theme.colorFaded}
+						selectionColor={theme.textSelectionColor}
+						keyboardAppearance={theme.keyboardAppearance}
+					/>
+					<IconButton
+						themeId={props.themeId}
+						iconStyle={styles.clearIcon}
+						iconName='ionicon close-circle'
+						onPress={clearButton_press}
+						description={_('Clear')}
+					/>
+				</View>
+			)}
 			<FlatList style={{ flex: 1 }} data={tags} renderItem={onRenderItem} keyExtractor={tag => tag.id} />
 		</View>
 	);

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -13,6 +13,9 @@ import { Dispatch } from 'redux';
 import useQueuedAsyncEffect from '@joplin/lib/hooks/useQueuedAsyncEffect';
 import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getCollator';
 import SearchBar from './SearchScreen/SearchBar';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('tags');
 
 interface Props {
 	dispatch: Dispatch;
@@ -78,6 +81,7 @@ const TagsScreenComponent: React.FC<Props> = props => {
 				setTags(fetchedTags);
 			}
 		} catch (error) {
+			logger.error('Error fetching tags', error);
 			if (!event.cancelled) {
 				setTags([]);
 			}
@@ -86,9 +90,6 @@ const TagsScreenComponent: React.FC<Props> = props => {
 
 	const onSearchButtonPress = useCallback(() => {
 		setShowSearch(!showSearch);
-		if (showSearch) {
-			setSearchQuery('');
-		}
 	}, [showSearch]);
 
 	const clearButton_press = useCallback(() => {

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { View, Text, FlatList, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { connect } from 'react-redux';
 import Tag from '@joplin/lib/models/Tag';
 import { themeStyle } from '../global-style';
@@ -12,7 +12,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Dispatch } from 'redux';
 import useQueuedAsyncEffect from '@joplin/lib/hooks/useQueuedAsyncEffect';
 import { getCollator, getCollatorLocale } from '@joplin/lib/models/utils/getCollator';
-import IconButton from '../IconButton';
+import SearchBar from './SearchScreen/SearchBar';
 
 interface Props {
 	dispatch: Dispatch;
@@ -40,25 +40,6 @@ const useStyles = (themeId: number) => {
 				fontSize: theme.fontSize,
 			},
 			rootStyle: theme.rootStyle,
-			searchContainer: {
-				flexDirection: 'row',
-				alignItems: 'center',
-				borderWidth: 1,
-				borderColor: theme.dividerColor,
-			},
-			searchTextInput: {
-				...theme.lineInput,
-				paddingLeft: theme.marginLeft,
-				flex: 1,
-				backgroundColor: theme.backgroundColor,
-				color: theme.color,
-			},
-			clearIcon: {
-				...theme.icon,
-				color: theme.colorFaded,
-				paddingRight: theme.marginRight,
-				backgroundColor: theme.backgroundColor,
-			},
 		});
 	}, [themeId]);
 };
@@ -69,7 +50,6 @@ const TagsScreenComponent: React.FC<Props> = props => {
 	const [searchQuery, setSearchQuery] = useState('');
 	const [showSearch, setShowSearch] = useState(false);
 	const styles = useStyles(props.themeId);
-	const theme = themeStyle(props.themeId);
 	const collatorLocale = getCollatorLocale();
 	const collator = useMemo(() => {
 		return getCollator(collatorLocale);
@@ -148,26 +128,14 @@ const TagsScreenComponent: React.FC<Props> = props => {
 				onSearchButtonPress={onSearchButtonPress}
 			/>
 			{showSearch && (
-				<View style={styles.searchContainer}>
-					<TextInput
-						style={styles.searchTextInput}
-						autoFocus={true}
-						underlineColorAndroid="#ffffff00"
-						onChangeText={setSearchQuery}
-						value={searchQuery}
-						placeholder={_('Search tags')}
-						placeholderTextColor={theme.colorFaded}
-						selectionColor={theme.textSelectionColor}
-						keyboardAppearance={theme.keyboardAppearance}
-					/>
-					<IconButton
-						themeId={props.themeId}
-						iconStyle={styles.clearIcon}
-						iconName='ionicon close-circle'
-						onPress={clearButton_press}
-						description={_('Clear')}
-					/>
-				</View>
+				<SearchBar
+					themeId={props.themeId}
+					autoFocus={true}
+					placeholder={_('Search tags')}
+					value={searchQuery}
+					onChangeText={setSearchQuery}
+					onClearButtonPress={clearButton_press}
+				/>
 			)}
 			<FlatList style={{ flex: 1 }} data={tags} renderItem={onRenderItem} keyExtractor={tag => tag.id} />
 		</View>

--- a/packages/app-mobile/components/screens/tags.tsx
+++ b/packages/app-mobile/components/screens/tags.tsx
@@ -90,6 +90,11 @@ const TagsScreenComponent: React.FC<Props> = props => {
 
 	const onSearchButtonPress = useCallback(() => {
 		setShowSearch(!showSearch);
+
+		// If the search button is pressed while the search bar is open, in addition to hiding the search bar, it should clear the search
+		if (showSearch) {
+			setSearchQuery('');
+		}
 	}, [showSearch]);
 
 	const clearButton_press = useCallback(() => {


### PR DESCRIPTION
On the mobile app, the tag list screen currently does not include the ability to search for a tag. Being able to do this is useful because you might want to find all notes with a certain tag, but you don't quite remember what the tag name is. It is currently possible to search tags on the tag association screen, but that does not allow you to then find all notes which use the tag in a single tap. This PR makes that now possible.

From a performance perspective, the loading of the results should be as performant as it is currently. The filtering of the tags is done at database level, and the results are mapped to the same FlatList component, which lazy loads of the results. Also, to avoid excessive querying as it searches as you type, I have added a 200 ms debounce interval before the search occurs.

### Testing

See video:

https://github.com/user-attachments/assets/10781858-5e3d-47dd-b08b-d474f504c87e

I also verified that the existing behaviour for the note search is unaffected (including pressing enter when the search term is under 3 characters) after refactoring the search bar into a shared component.