### PR TITLE
Server: Save and query less data when creating and updating items

### DIFF
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -30,9 +30,6 @@ export interface ChangePagination {
 }
 
 export interface ChangePreviousItem {
-	name: string;
-	jop_parent_id: string;
-	jop_resource_ids: string[];
 	jop_share_id: string;
 }
 


### PR DESCRIPTION
# Summary

Avoids saving unused information in the `previous_item` field of the `changes` table.

As commented in https://github.com/laurent22/joplin/pull/13730, most fields (e.g. `resourceIds`) in `previous_item` seem to be unused. Not saving these fields allows:
- One less database query: The `itemResource().byItemId` query is no longer necessary. Previously, it ran on each item update.
- Querying fewer fields when loading the `beforeSaveItem`.
- Writing less data when saving each update to the database.

# Performance impact

Testing with an otherwise empty SQLite database, in a Jest testing environment, this change **doesn't seem to significantly impact the performance** of the `api/items` route.

In the future, this change *may* improve the performance of the `delta` query, since `delta` currently loads the `previous_item` field. Since this change makes `previous_item` smaller for new `Update`s, the `delta` logic may be faster (particularly when querying notes with many attached resources).

<details><summary><code>api/items</code>: Note with an empty body: Roughly the same before and after</summary>

<details><summary>diff</summary>

```diff
diff --git a/packages/server/src/routes/api/items.test.ts b/packages/server/src/routes/api/items.test.ts
index 380857410..748b96954 100644
--- a/packages/server/src/routes/api/items.test.ts
+++ b/packages/server/src/routes/api/items.test.ts
@@ -8,6 +8,8 @@ import { shareFolderWithUser } from '../../utils/testing/shareApiUtils';
 import { resourceBlobPath } from '../../utils/joplinUtils';
 import { ErrorForbidden, ErrorPayloadTooLarge } from '../../utils/errors';
 import { PaginatedResults } from '../../models/utils/pagination';
+import { remove } from 'fs-extra';
+import uuid from '@joplin/lib/uuid';
 
 describe('api/items', () => {
 
@@ -441,4 +443,39 @@ describe('api/items', () => {
 		// Should not have deleted the other item
 		expect(await models().item().loadByJopId(user1.id, '00000000000000000000000000000003')).toBeTruthy();
 	});
+
+	test('benchmark: should modify an item', async () => {
+		const { session } = await createUserAndSession(1, true);
+
+		const noteId = '00000000000000000000000000000001';
+		const filename = `${noteId}.md`;
+		const item = await createItem(session.id, `root:/${filename}:`, makeNoteSerializedBody({
+			id: noteId,
+		}));
+
+		const trials = 200;
+		let total = 0;
+		const totals = [];
+		for (let i = 0; i < trials; i++) {
+			const tempFilePath = await makeTempFileWithContent(makeNoteSerializedBody({
+				...item,
+				parent_id: uuid.create(),
+				title: 'new title',
+			}));
+
+			const start = performance.now();
+			await putApi(session.id, `items/root:/${filename}:/content`, null, { filePath: tempFilePath });
+			const end = performance.now();
+			total += end - start;
+			totals.push(end - start);
+
+			await remove(tempFilePath);
+		}
+		const mean = total / trials;
+		// variance: 𝔼(x - μ)²
+		const variance = totals.reduce((prev, current) => {
+			return prev + Math.pow(current - mean, 2);
+		}, 0) / trials;
+		console.log(mean, ',', Math.sqrt(variance));
+	});
 });
```

</details>

Roughly the same before and after, averaged over 200 trials.

**Before**: μ = 78.22316307499996 ms , σ = 6.388570363423622 ms
**After**: μ = 78.09694113000006 ms, σ = 8.814652139683615 ms

</details>

<details><summary><code>api/items</code>: Updating a note with several attached resources: Roughly the same before and after</summary>


<details><summary>diff</summary>

```diff
diff --git a/packages/server/src/routes/api/items.test.ts b/packages/server/src/routes/api/items.test.ts
index 380857410..33344879c 100644
--- a/packages/server/src/routes/api/items.test.ts
+++ b/packages/server/src/routes/api/items.test.ts
@@ -8,6 +8,26 @@ import { shareFolderWithUser } from '../../utils/testing/shareApiUtils';
 import { resourceBlobPath } from '../../utils/joplinUtils';
 import { ErrorForbidden, ErrorPayloadTooLarge } from '../../utils/errors';
 import { PaginatedResults } from '../../models/utils/pagination';
+import { remove } from 'fs-extra';
+import uuid from '@joplin/lib/uuid';
+import { testImageBuffer } from '../../utils/testing/fileApiUtils';
+
+const resourceContents = (id: string) => `Test Image
+
+id: ${id}
+mime: image/jpeg
+filename: 
+created_time: 2020-10-15T10:37:58.090Z
+updated_time: 2020-10-15T10:37:58.090Z
+user_created_time: 2020-10-15T10:37:58.090Z
+user_updated_time: 2020-10-15T10:37:58.090Z
+file_extension: jpg
+encryption_cipher_text: 
+encryption_applied: 0
+encryption_blob_encrypted: 0
+size: 2048
+is_shared: 0
+type_: 4`;
 
 describe('api/items', () => {
 
@@ -441,4 +461,48 @@ describe('api/items', () => {
 		// Should not have deleted the other item
 		expect(await models().item().loadByJopId(user1.id, '00000000000000000000000000000003')).toBeTruthy();
 	});
+
+	test.each([0, 10, 20, 40, 80, 100, 120, 140])('benchmark: should modify an item', async (imageCount) => {
+		const { session } = await createUserAndSession(1, true);
+
+		const imageIds = [];
+		for (let i = 0; i < imageCount; i++) {
+			const id = uuid.create();
+			imageIds.push(id);
+			await createItem(session.id, `root:/${id}.md:`, resourceContents(id));
+			await createItem(session.id, `root:/.resource/${id}:`, await testImageBuffer());
+		}
+
+		const noteId = '00000000000000000000000000000001';
+		const filename = `${noteId}.md`;
+		const item = await createItem(session.id, `root:/${filename}:`, makeNoteSerializedBody({
+			id: noteId,
+			body: imageIds.map((id, i) => `![image ${i}](:/${id})`).join('\n'),
+		}));
+
+		const trials = 20;
+		let total = 0;
+		const totals = [];
+		for (let i = 0; i < trials; i++) {
+			const tempFilePath = await makeTempFileWithContent(makeNoteSerializedBody({
+				...item,
+				parent_id: uuid.create(),
+				title: 'new title',
+			}));
+
+			const start = performance.now();
+			await putApi(session.id, `items/root:/${filename}:/content`, null, { filePath: tempFilePath });
+			const end = performance.now();
+			total += end - start;
+			totals.push(end - start);
+
+			await remove(tempFilePath);
+		}
+		const mean = total / trials;
+		// variance: 𝔼(x - μ)²
+		const variance = totals.reduce((prev, current) => {
+			return prev + Math.pow(current - mean, 2);
+		}, 0) / trials;
+		console.log(imageCount, ',', mean, ',', Math.sqrt(variance));
+	});
 });

```

</details>

**Before**:
```
resource count, average duration (ms), standard deviation
0 , 76.31648295000032 , 7.034391929207146
10 , 77.48864924999998 , 4.169384562853898
20 , 80.56688945000005 , 6.81883235752001
40 , 74.01783135000024 , 6.74448410264249
80 , 77.38962030000111 , 4.045733441729013
100 , 74.39159149999978 , 4.203195668531336
120 , 84.78663209999941 , 7.226834033356828
140 , 75.10038220000133 , 6.559743822882095
```

**After**:
```
resource count, average duration (ms), standard deviation
0 , 75.10773895000011 , 6.918779161239868
10 , 78.02019580000005 , 8.832531196640247
20 , 73.96141339999994 , 6.7872304945711806
40 , 74.62146179999999 , 5.54800661129185
80 , 99.97043305000007 , 35.54864996251154
100 , 74.71436200000025 , 4.437704437511033
120 , 73.9720177500014 , 6.147568208593881
140 , 74.42310315000068 , 5.798542957344372
```

</details>

# Testing

It has been verified that, with this change applied, the sync fuzzer runs successfully for > 100 steps (note: testing with the sync fuzzer [prior to this commit](https://github.com/laurent22/joplin/commit/0f4877f263a54057affb232857e131f37cbdccd1)).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->