### PR TITLE
Desktop: Fixes #13707: Fix text contrast issues with Aritim, Dracula, and Nord themes

### DIFF
--- a/packages/lib/themes/aritimDark.ts
+++ b/packages/lib/themes/aritimDark.ts
@@ -8,22 +8,22 @@ const theme: Theme = {
 	backgroundColorTransparent: 'rgba(16, 21, 26, 0.9)', //
 	oddBackgroundColor: '#141a21',
 	color: '#d3dae3', // For regular text (everything except notebooks)
-	colorError: '#9a2f2f',
+	colorError: '#4a2608',
 	colorWarn: '#d66500',
 	colorFaded: '#666a73', // For less important text (e.g. not selected menu in settings)
 	dividerColor: '#141a21', // Borders, I wish I could remove them
 	selectedColor: '#2b5278', // Selected note
-	urlColor: '#356693', // Links to external sites (e.g. in settings)
+	urlColor: '#5a95c5', // Links to external sites (e.g. in settings)
 
 	backgroundColor2: '#141a21', // Notebooks main background
 	color2: '#d3dae3', // Notebook sidebar text color
 	selectedColor2: '#10151a', // Selected notebook (or settings icon in settings)
-	colorError2: '#9a2f2f',
+	colorError2: '#4a2608',
 
 	raisedBackgroundColor: '#2b5278', // Table, hover
 	raisedColor: '#141a21',
 
-	warningBackgroundColor: '#9a2f2f', // Info / Warning boxes bg color
+	warningBackgroundColor: '#4a2608', // Info / Warning boxes bg color
 
 	tableBackgroundColor: '#141a21', // Table (even) background color
 	codeBackgroundColor: '#141a21', // Single line code bg

--- a/packages/lib/themes/dracula.ts
+++ b/packages/lib/themes/dracula.ts
@@ -9,7 +9,7 @@ const theme: Theme = {
 	oddBackgroundColor: '#282a36',
 	color: '#f8f8f2', // For regular text
 	colorError: '#ff5555',
-	colorWarn: '#ffb86c',
+	colorWarn: '#a65a2e',
 	colorFaded: '#6272a4', // For less important text;
 	dividerColor: '#bd93f9',
 	selectedColor: '#44475a',
@@ -23,7 +23,7 @@ const theme: Theme = {
 	raisedBackgroundColor: '#44475a',
 	raisedColor: '#bd93f9',
 
-	warningBackgroundColor: '#ffb86c',
+	warningBackgroundColor: '#a65a2e',
 
 	tableBackgroundColor: '#6272a4',
 	codeBackgroundColor: '#44475a',

--- a/packages/lib/themes/nord.ts
+++ b/packages/lib/themes/nord.ts
@@ -1,7 +1,7 @@
 import { Theme } from './type';
 import theme_dark from './dark';
 
-const nord = ['#2e3440', '#3b4252', '#434c5e', '#4c566a', '#d8dee9', '#e5e9f0', '#eceff4', '#8fbcbb', '#88c0d0', '#81a1c1', '#5e81ac', '#bf616a', '#d08770', '#ebcb8b', '#a3be8c', '#b48ead'];
+const nord = ['#2e3440', '#3b4252', '#434c5e', '#4c566a', '#d8dee9', '#e5e9f0', '#eceff4', '#8fbcbb', '#88c0d0', '#81a1c1', '#5e81ac', '#bf616a', '#d08770', '#ebcb8b', '#a3be8c', '#b48ead', '#8f503b'];
 
 // DOCUMENTATION of Nord as of Oct 3
 // 0 #2e3440 :     Base component color of "Polar Night".
@@ -46,6 +46,9 @@ const nord = ['#2e3440', '#3b4252', '#434c5e', '#4c566a', '#d8dee9', '#e5e9f0', 
 // 15 #b48ead :    Colorful component color.
 // Used for numbers.
 // 2e3440 === rbga(46, 52, 64, 1)
+// 16 #8f503b :    Colorful component color.
+// Darkened version of nord[12] to avoid white text on light background.
+// Used for warning backgrounds.
 
 const theme: Theme = {
 	...theme_dark,
@@ -69,7 +72,7 @@ const theme: Theme = {
 	raisedBackgroundColor: nord[2],
 	raisedColor: nord[7],
 
-	warningBackgroundColor: nord[13],
+	warningBackgroundColor: nord[16],
 
 	tableBackgroundColor: nord[0],
 	codeBackgroundColor: nord[0],


### PR DESCRIPTION
## Overview

Slight color adjustments to fix constrast issues in Aritim, Dracula, and Nord themes to address #13707 

Aritim:

- Adjusted colorError, colorError2, and warningBackgroundColor to #4a2608 (darkened version of the #d66500 colorWarn color)
- Slightly lightened urlColor

Dracula:

- Adjusted colorWarn and warningBackgroundColor to #a65a2e (desaturated version of the original color)

Nord:

- Added nord[16] color: #8f503b (darkened version of nord[12])
- Set warningBackgroundColor to nord[16]
- Added as new color to avoid changing codeColor which also used nord[13] (and the new orange looked too dark for that)

## Screenshots:

### Aritim:

<img width="3020" height="326" alt="Screenshot 2025-11-19 182626" src="https://github.com/user-attachments/assets/a23ca848-c1f1-43a0-86d6-c6a8b55d6857" />
<img width="2046" height="1300" alt="Screenshot 2025-11-19 190358" src="https://github.com/user-attachments/assets/c31ed4b9-afb8-4365-9a25-75065b3f1149" />
<img width="2078" height="562" alt="Screenshot 2025-11-19 190432" src="https://github.com/user-attachments/assets/e0996cdf-4274-4f9b-bbd8-11ae815c7372" />

### Dracula

<img width="2724" height="160" alt="Screenshot 2025-11-19 180937" src="https://github.com/user-attachments/assets/46131062-721b-4364-9693-b348591038ac" />
<img width="3012" height="212" alt="Screenshot 2025-11-19 180954" src="https://github.com/user-attachments/assets/a102fa0a-29b4-4958-8181-0cc827e12e1b" />
<img width="2066" height="332" alt="Screenshot 2025-11-19 181042" src="https://github.com/user-attachments/assets/8a84ae56-5d10-4df1-806c-c6782451ca24" />
<img width="2092" height="610" alt="Screenshot 2025-11-19 181130" src="https://github.com/user-attachments/assets/5ce24bd5-801c-44c5-a17b-c6636e02bb13" />

### Nord

<img width="2586" height="560" alt="Screenshot 2025-11-19 190502" src="https://github.com/user-attachments/assets/b9d79021-6ebb-491a-9c70-22cf4aad535b" />
<img width="3030" height="330" alt="Screenshot 2025-11-19 190524" src="https://github.com/user-attachments/assets/f661e81f-560c-486d-b7d9-1dd6ea7c95f4" />
<img width="2056" height="556" alt="Screenshot 2025-11-19 190539" src="https://github.com/user-attachments/assets/f315eb9b-eb23-4e13-bc24-7acb42168ab0" />
