### PR TITLE
Server: Periodically delete old backups for archived accounts

### DIFF
--- a/packages/server/src/models/BackupItemModel.test.ts
+++ b/packages/server/src/models/BackupItemModel.test.ts
@@ -29,16 +29,15 @@ describe('BackupItemModel', () => {
 		jest.advanceTimersByTime(61 * Day);
 		await backupModel.add(BackupItemType.UserAccount, 'key4', 'value');
 
-		const toKeys = (items: BackupItem[]) => items.map(item => item.key);
-		expect(
-			toKeys(await backupModel.all()).sort(),
-		).toEqual(['key1', 'key2', 'key3', 'key4']);
+		const sortedKeys = (items: BackupItem[]) => items.map(item => item.key).sort();
+		expect(sortedKeys(await backupModel.all())).toEqual(['key1', 'key2', 'key3', 'key4']);
 
 		await backupModel.deleteOldAccountBackups();
+		expect(sortedKeys(await backupModel.all())).toEqual(['key3', 'key4']);
 
-		expect(
-			toKeys(await backupModel.all()).sort(),
-		).toEqual(['key3', 'key4']);
+		// Re-running, should not delete items newer than 90 days
+		await backupModel.deleteOldAccountBackups();
+		expect(sortedKeys(await backupModel.all())).toEqual(['key3', 'key4']);
 	});
 
 });

--- a/packages/server/src/models/BackupItemModel.test.ts
+++ b/packages/server/src/models/BackupItemModel.test.ts
@@ -1,0 +1,44 @@
+import { beforeAllDb, afterAllTests, beforeEachDb, models } from '../utils/testing/testUtils';
+import { BackupItem, BackupItemType } from '../services/database/types';
+import { Day } from '../utils/time';
+
+describe('BackupItemModel', () => {
+
+	beforeAll(async () => {
+		await beforeAllDb('BackupItemModel');
+		jest.useFakeTimers({ advanceTimers: true });
+	});
+
+	afterAll(async () => {
+		await afterAllTests();
+	});
+
+	beforeEach(async () => {
+		await beforeEachDb();
+	});
+
+	test('should delete archived account backups older than 90 days', async () => {
+		const backupModel = models().backupItem();
+
+		// Items older than 90 days
+		await backupModel.add(BackupItemType.UserAccount, 'key1', 'value');
+		await backupModel.add(BackupItemType.UserAccount, 'key2', 'value');
+		jest.advanceTimersByTime(30 * Day);
+		// Items newer than 90 days
+		await backupModel.add(BackupItemType.UserAccount, 'key3', 'value');
+		jest.advanceTimersByTime(61 * Day);
+		await backupModel.add(BackupItemType.UserAccount, 'key4', 'value');
+
+		const toKeys = (items: BackupItem[]) => items.map(item => item.key);
+		expect(
+			toKeys(await backupModel.all()).sort(),
+		).toEqual(['key1', 'key2', 'key3', 'key4']);
+
+		await backupModel.deleteOldAccountBackups();
+
+		expect(
+			toKeys(await backupModel.all()).sort(),
+		).toEqual(['key3', 'key4']);
+	});
+
+});

--- a/packages/server/src/models/BackupItemModel.ts
+++ b/packages/server/src/models/BackupItemModel.ts
@@ -1,5 +1,9 @@
+import { Day } from '@joplin/utils/time';
 import { BackupItem, BackupItemType } from '../services/database/types';
 import BaseModel from './BaseModel';
+import Logger from '@joplin/utils/Logger';
+
+const logger = Logger.create('BackupItemModel');
 
 export default class BackupItemModel extends BaseModel<BackupItem> {
 
@@ -25,6 +29,16 @@ export default class BackupItemModel extends BaseModel<BackupItem> {
 		};
 
 		return this.save(item);
+	}
+
+	public async deleteOldAccountBackups() {
+		const cutOffDate = Date.now() - 90 * Day;
+		const deletedCount = await this
+			.db(this.tableName)
+			.where('type', '=', BackupItemType.UserAccount)
+			.where('created_time', '<', cutOffDate)
+			.delete();
+		logger.info('Deleted', deletedCount, 'archived account record(s)');
 	}
 
 }

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -34,7 +34,7 @@ export const taskIdToLabel = (taskId: TaskId): string => {
 		[TaskId.LogHeartbeatMessage]: 'Log heartbeat message',
 		[TaskId.DeleteOldEvents]: 'Delete old events',
 		[TaskId.DeleteExpiredAuthCodes]: 'Delete expired authentication codes',
-		[TaskId.DeleteArchivedBackups]: 'Delete archived backups',
+		[TaskId.DeleteArchivedBackups]: 'Delete archived account backups',
 	};
 
 	const s = strings[taskId];

--- a/packages/server/src/services/TaskService.ts
+++ b/packages/server/src/services/TaskService.ts
@@ -34,6 +34,7 @@ export const taskIdToLabel = (taskId: TaskId): string => {
 		[TaskId.LogHeartbeatMessage]: 'Log heartbeat message',
 		[TaskId.DeleteOldEvents]: 'Delete old events',
 		[TaskId.DeleteExpiredAuthCodes]: 'Delete expired authentication codes',
+		[TaskId.DeleteArchivedBackups]: 'Delete archived backups',
 	};
 
 	const s = strings[taskId];

--- a/packages/server/src/services/database/types.ts
+++ b/packages/server/src/services/database/types.ts
@@ -138,6 +138,7 @@ export enum TaskId {
 	LogHeartbeatMessage,
 	DeleteOldEvents,
 	DeleteExpiredAuthCodes,
+	DeleteArchivedBackups,
 }
 
 // AUTO-GENERATED-TYPES

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -83,6 +83,13 @@ export default async function(env: Env, models: Models, config: Config, services
 			schedule: '*/15 * * * *',
 			run: (models: Models) => models.user().deleteExpiredAuthCodes(),
 		},
+
+		{
+			id: TaskId.DeleteArchivedBackups,
+			description: taskIdToLabel(TaskId.DeleteArchivedBackups),
+			schedule: '0 0 */2 * *',
+			run: (models: Models) => models.backupItem().deleteOldAccountBackups(),
+		},
 	];
 
 	if (config.DELETE_EXPIRED_SESSIONS_SCHEDULE) {

--- a/packages/server/src/utils/setupTaskService.ts
+++ b/packages/server/src/utils/setupTaskService.ts
@@ -87,7 +87,7 @@ export default async function(env: Env, models: Models, config: Config, services
 		{
 			id: TaskId.DeleteArchivedBackups,
 			description: taskIdToLabel(TaskId.DeleteArchivedBackups),
-			schedule: '0 0 */2 * *',
+			schedule: '0 0 * * *',
 			run: (models: Models) => models.backupItem().deleteOldAccountBackups(),
 		},
 	];


### PR DESCRIPTION
# Summary

Adds a task that deletes items in the `item_backups` table that are older than 90 days.

# Testing

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->