### PR TITLE
Desktop,Mobile: Add support for rendering html images when "Markdown editor: Render images" is enabled

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.ts
@@ -146,4 +146,17 @@ describe('renderBlockImages', () => {
 		expect(images[0].style.width).toBe(''); // markdown - no width
 		expect(images[1].style.width).toBe('400px'); // HTML with width
 	});
+
+	test('should render HTML img tags with single-quoted attributes', async () => {
+		const editor = await createEditor(
+			// eslint-disable-next-line quotes
+			"<img src=':/0123456789abcdef0123456789abcdef' alt='test' width='250' />",
+			false,
+		);
+
+		const images = findImages(editor);
+		expect(images).toHaveLength(1);
+		expect(images[0].ariaLabel).toBe('test');
+		expect(images[0].style.width).toBe('250px');
+	});
 });

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.ts
@@ -88,4 +88,62 @@ describe('renderBlockImages', () => {
 			':/b123456789abcdef0123456789abcde2?r=1',
 		]);
 	});
+
+	test.each([
+		{ spaceBefore: '', spaceAfter: '\n\n', alt: 'test', width: null },
+		{ spaceBefore: '', spaceAfter: '', alt: 'This is a test!', width: null },
+		{ spaceBefore: '   ', spaceAfter: ' ', alt: 'test', width: null },
+		{ spaceBefore: '', spaceAfter: '', alt: '!!!!', width: '500' },
+	])('should render HTML img tags (case %#)', async ({ spaceBefore, spaceAfter, alt, width }) => {
+		const widthAttr = width ? ` width="${width}"` : '';
+		const editor = await createEditor(
+			`${spaceBefore}<img src=":/0123456789abcdef0123456789abcdef" alt="${alt}"${widthAttr} />${spaceAfter}`,
+			false,
+		);
+
+		const images = findImages(editor);
+		expect(images).toHaveLength(1);
+		expect(images[0].role).toBe('image');
+		expect(images[0].ariaLabel).toBe(alt);
+
+		if (width) {
+			expect(images[0].style.width).toBe(`${width}px`);
+			expect(images[0].style.height).toBe('auto');
+		} else {
+			expect(images[0].style.width).toBe('');
+		}
+	});
+
+	test('should render non-self-closing HTML img tags', async () => {
+		const editor = await createEditor(
+			'<img src=":/0123456789abcdef0123456789abcdef" alt="test" width="300">',
+			false,
+		);
+
+		const images = findImages(editor);
+		expect(images).toHaveLength(1);
+		expect(images[0].style.width).toBe('300px');
+	});
+
+	test('should not render HTML img tags with web URLs', async () => {
+		const editor = await createEditor(
+			'<img src="https://example.com/test.png" alt="test" />',
+			false,
+		);
+
+		const images = findImages(editor);
+		expect(images).toHaveLength(0);
+	});
+
+	test('should render both markdown and HTML images in same document', async () => {
+		const editor = await createEditor(
+			'![markdown](:/a123456789abcdef0123456789abcdef)\n\n<img src=":/b123456789abcdef0123456789abcde2" alt="html" width="400" />',
+			true,
+		);
+
+		const images = findImages(editor);
+		expect(images).toHaveLength(2);
+		expect(images[0].style.width).toBe(''); // markdown - no width
+		expect(images[1].style.width).toBe('400px'); // HTML with width
+	});
 });

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -166,20 +166,38 @@ const renderBlockImages = (context: RenderedContentContext) => [
 	}),
 	makeBlockReplaceExtension({
 		createDecoration: (node, state) => {
-			// Handle markdown images
-			if (node.name === 'Image') {
+			// Handle both markdown images and HTML img tags
+			if (node.name === 'Image' || node.name === 'HTMLTag' || node.name === 'HTMLBlock') {
 				const lineFrom = state.doc.lineAt(node.from);
 				const lineTo = state.doc.lineAt(node.to);
 				const textBefore = state.sliceDoc(lineFrom.from, node.from);
 				const textAfter = state.sliceDoc(node.to, lineTo.to);
+
+				// Only render images on their own line
 				if (textBefore.trim() === '' && textAfter.trim() === '') {
-					const src = getImageSrc(node, state);
-					const alt = getImageAlt(node, state);
+					let src: string | null = null;
+					let alt: string | null = null;
+					let width: string | null = null;
+
+					// Parse image data based on node type
+					if (node.name === 'Image') {
+						// Markdown image: ![alt](src)
+						src = getImageSrc(node, state);
+						alt = getImageAlt(node, state);
+					} else {
+						// HTML img tag: <img src="..." alt="..." width="..." />
+						const imageInfo = parseHtmlImage(node, state);
+						if (imageInfo) {
+							src = imageInfo.src;
+							alt = imageInfo.alt;
+							width = imageInfo.width;
+						}
+					}
 
 					if (src) {
 						const isLastLine = lineTo.number === state.doc.lines;
 						return Decoration.widget({
-							widget: new ImageWidget(context, src, alt, imageToRefreshCounters.get(src) ?? 0, null),
+							widget: new ImageWidget(context, src, alt, imageToRefreshCounters.get(src) ?? 0, width),
 							// "side: -1": In general, when the cursor is at the widget's location, it should be at
 							// the start of the next line (and so "side" should be -1).
 							//
@@ -188,32 +206,6 @@ const renderBlockImages = (context: RenderedContentContext) => [
 							// position from being outside the document, which would break CodeMirror).
 							// This means that we need "side: 1" to put the cursor before the widget
 							// when at the end of the document.
-							side: isLastLine ? 1 : -1,
-							block: true,
-						});
-					}
-				}
-			}
-
-			// Handle HTML img tags (both HTMLTag for self-closing and HTMLBlock for non-self-closing)
-			if (node.name === 'HTMLTag' || node.name === 'HTMLBlock') {
-				const lineFrom = state.doc.lineAt(node.from);
-				const lineTo = state.doc.lineAt(node.to);
-				const textBefore = state.sliceDoc(lineFrom.from, node.from);
-				const textAfter = state.sliceDoc(node.to, lineTo.to);
-				if (textBefore.trim() === '' && textAfter.trim() === '') {
-					const imageInfo = parseHtmlImage(node, state);
-
-					if (imageInfo) {
-						const isLastLine = lineTo.number === state.doc.lines;
-						return Decoration.widget({
-							widget: new ImageWidget(
-								context,
-								imageInfo.src,
-								imageInfo.alt ?? '',
-								imageToRefreshCounters.get(imageInfo.src) ?? 0,
-								imageInfo.width,
-							),
 							side: isLastLine ? 1 : -1,
 							block: true,
 						});

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -66,15 +66,6 @@ class ImageWidget extends WidgetType {
 		const image = document.createElement('img');
 		image.classList.add('image');
 
-		// Apply width if specified, otherwise clear it
-		if (this.width_) {
-			image.style.width = `${this.width_}px`;
-			image.style.height = 'auto';
-		} else {
-			image.style.width = '';
-			image.style.height = '';
-		}
-
 		container.appendChild(image);
 		this.updateDOM(container);
 

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -30,10 +30,13 @@ class ImageWidget extends WidgetType {
 		image.ariaLabel = this.alt_;
 		image.role = 'image';
 
-		// Apply width if specified
+		// Apply width if specified, otherwise clear it
 		if (this.width_) {
 			image.style.width = `${this.width_}px`;
 			image.style.height = 'auto';
+		} else {
+			image.style.width = '';
+			image.style.height = '';
 		}
 
 		const updateImageUrl = () => {
@@ -63,10 +66,13 @@ class ImageWidget extends WidgetType {
 		const image = document.createElement('img');
 		image.classList.add('image');
 
-		// Apply width if specified
+		// Apply width if specified, otherwise clear it
 		if (this.width_) {
 			image.style.width = `${this.width_}px`;
 			image.style.height = 'auto';
+		} else {
+			image.style.width = '';
+			image.style.height = '';
 		}
 
 		container.appendChild(image);

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -114,22 +114,22 @@ const parseHtmlImage = (node: SyntaxNodeRef, state: EditorState): HtmlImageInfo 
 		return null;
 	}
 
-	// Extract src (only Joplin resource images with double quotes)
-	const srcMatch = nodeText.match(/src="(:\/[a-zA-Z0-9]{32})"/i);
+	// Extract src (only Joplin resource images, accepts single or double quotes)
+	const srcMatch = nodeText.match(/src=(["'])(:\/[a-zA-Z0-9]{32})\1/i);
 	if (!srcMatch) {
 		return null;
 	}
 
-	// Extract alt attribute (optional)
-	const altMatch = nodeText.match(/alt="([^"]*)"/i);
+	// Extract alt attribute (optional, accepts single or double quotes)
+	const altMatch = nodeText.match(/alt=(["'])([^"']*)\1/i);
 
-	// Extract width attribute (optional)
-	const widthMatch = nodeText.match(/width="(\d+)"/i);
+	// Extract width attribute (optional, accepts single or double quotes)
+	const widthMatch = nodeText.match(/width=(["'])(\d+)\1/i);
 
 	return {
-		src: srcMatch[1],
-		alt: altMatch ? altMatch[1] : null,
-		width: widthMatch ? widthMatch[1] : null,
+		src: srcMatch[2],
+		alt: altMatch ? altMatch[2] : null,
+		width: widthMatch ? widthMatch[2] : null,
 	};
 };
 

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -14,12 +14,13 @@ class ImageWidget extends WidgetType {
 		private readonly src_: string,
 		private readonly alt_: string,
 		private readonly reloadCounter_ = 0,
+		private readonly width_: string | null = null,
 	) {
 		super();
 	}
 
 	public eq(other: ImageWidget) {
-		return this.src_ === other.src_ && this.alt_ === other.alt_ && this.reloadCounter_ === other.reloadCounter_;
+		return this.src_ === other.src_ && this.alt_ === other.alt_ && this.reloadCounter_ === other.reloadCounter_ && this.width_ === other.width_;
 	}
 
 	public updateDOM(dom: HTMLElement): boolean {
@@ -28,6 +29,12 @@ class ImageWidget extends WidgetType {
 
 		image.ariaLabel = this.alt_;
 		image.role = 'image';
+
+		// Apply width if specified
+		if (this.width_) {
+			image.style.width = `${this.width_}px`;
+			image.style.height = 'auto';
+		}
 
 		const updateImageUrl = () => {
 			if (this.resolvedSrc_) {
@@ -55,6 +62,12 @@ class ImageWidget extends WidgetType {
 
 		const image = document.createElement('img');
 		image.classList.add('image');
+
+		// Apply width if specified
+		if (this.width_) {
+			image.style.width = `${this.width_}px`;
+			image.style.height = 'auto';
+		}
 
 		container.appendChild(image);
 		this.updateDOM(container);
@@ -90,6 +103,39 @@ const getImageAlt = (node: SyntaxNodeRef, state: EditorState) => {
 	}
 };
 
+interface HtmlImageInfo {
+	src: string;
+	alt: string | null;
+	width: string | null;
+}
+
+const parseHtmlImage = (node: SyntaxNodeRef, state: EditorState): HtmlImageInfo | null => {
+	const nodeText = state.sliceDoc(node.from, node.to);
+
+	// Check if this is an img tag (handles both /> and > closing styles)
+	if (!nodeText.match(/<img\s/i)) {
+		return null;
+	}
+
+	// Extract src (only Joplin resource images with double quotes)
+	const srcMatch = nodeText.match(/src="(:\/[a-zA-Z0-9]{32})"/i);
+	if (!srcMatch) {
+		return null;
+	}
+
+	// Extract alt attribute (optional)
+	const altMatch = nodeText.match(/alt="([^"]*)"/i);
+
+	// Extract width attribute (optional)
+	const widthMatch = nodeText.match(/width="(\d+)"/i);
+
+	return {
+		src: srcMatch[1],
+		alt: altMatch ? altMatch[1] : null,
+		width: widthMatch ? widthMatch[1] : null,
+	};
+};
+
 // In Electron: To work around browser caching, these counters should continue to increase even if an old
 // editor is destroyed and a new one is created in the same window.
 const imageToRefreshCounters = new Map<string, number>();
@@ -114,6 +160,7 @@ const renderBlockImages = (context: RenderedContentContext) => [
 	}),
 	makeBlockReplaceExtension({
 		createDecoration: (node, state) => {
+			// Handle markdown images
 			if (node.name === 'Image') {
 				const lineFrom = state.doc.lineAt(node.from);
 				const lineTo = state.doc.lineAt(node.to);
@@ -126,7 +173,7 @@ const renderBlockImages = (context: RenderedContentContext) => [
 					if (src) {
 						const isLastLine = lineTo.number === state.doc.lines;
 						return Decoration.widget({
-							widget: new ImageWidget(context, src, alt, imageToRefreshCounters.get(src) ?? 0),
+							widget: new ImageWidget(context, src, alt, imageToRefreshCounters.get(src) ?? 0, null),
 							// "side: -1": In general, when the cursor is at the widget's location, it should be at
 							// the start of the next line (and so "side" should be -1).
 							//
@@ -141,6 +188,33 @@ const renderBlockImages = (context: RenderedContentContext) => [
 					}
 				}
 			}
+
+			// Handle HTML img tags (both HTMLTag for self-closing and HTMLBlock for non-self-closing)
+			if (node.name === 'HTMLTag' || node.name === 'HTMLBlock') {
+				const lineFrom = state.doc.lineAt(node.from);
+				const lineTo = state.doc.lineAt(node.to);
+				const textBefore = state.sliceDoc(lineFrom.from, node.from);
+				const textAfter = state.sliceDoc(node.to, lineTo.to);
+				if (textBefore.trim() === '' && textAfter.trim() === '') {
+					const imageInfo = parseHtmlImage(node, state);
+
+					if (imageInfo) {
+						const isLastLine = lineTo.number === state.doc.lines;
+						return Decoration.widget({
+							widget: new ImageWidget(
+								context,
+								imageInfo.src,
+								imageInfo.alt ?? '',
+								imageToRefreshCounters.get(imageInfo.src) ?? 0,
+								imageInfo.width,
+							),
+							side: isLastLine ? 1 : -1,
+							block: true,
+						});
+					}
+				}
+			}
+
 			return null;
 		},
 		getDecorationRange: (node, state) => {


### PR DESCRIPTION
Related to: #12959

This pr adds support for rendering html `<img>` embeds when "Markdown editor: Render images" is enabled.

## Changes

- Extended ImageWidget to accept optional width parameter
- Added parseHtmlImage() function to extract src, alt, and width from HTML img tags
- Updated createDecoration() to handle HTMLTag and HTMLBlock nodes in addition to markdown Image nodes
- Consolidated decoration logic for markdown/html into single code path

## Details

- Renders both self-closing (<img ... />) and non-self-closing (<img ... >) formats
- Supports width attribute for custom image sizing, like the rich markdown plugin
- **Note:** Height is always auto-calculated, for behavior consistent with markdown viewer and rich text editor
- Images without width render at natural size consistent with markdown images
- Accepts both single and double-quoted attributes, consistent with markdown viewer
- Only renders Joplin resources (:\/[a-zA-Z0-9]{32}), blocks external URLs, consistent with existing implementation for markdown images
- same max-width and centering as markdown images
- width changes reflect immediately in editor

## Testing

> [!note]
> I've only tested this on desktop, I'm not sure how to get a mobile dev build going

1. Verified all existing renderBlockImages tests still pass
2. Added new test cases:
- HTML img tags with various spacing and width attributes
- Non-self-closing tag syntax
- Single-quoted attributes
- Should not render web images (consistent behavior with markdown images)
- Mixed markdown and HTML images in same document
3. Manually tested all of the above in the markdown editor

## Example

https://github.com/user-attachments/assets/05468ea3-9661-4035-b56e-6041578bc535


