### PR TITLE
Chore: Remove unused type definition dependency

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -52,7 +52,6 @@
     "@joplin/turndown": "^4.0.82",
     "@joplin/turndown-plugin-gfm": "^1.0.64",
     "@joplin/utils": "^3.5.1",
-    "@types/nanoid": "3.0.0",
     "adm-zip": "0.5.16",
     "async-mutex": "0.5.0",
     "base-64": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10578,7 +10578,6 @@ __metadata:
     "@types/jsdom": "npm:21.1.7"
     "@types/markdown-it": "npm:13.0.9"
     "@types/mustache": "npm:4.2.6"
-    "@types/nanoid": "npm:3.0.0"
     "@types/node": "npm:18.19.130"
     "@types/node-rsa": "npm:1.1.4"
     "@types/react": "npm:18.3.23"
@@ -16326,15 +16325,6 @@ __metadata:
   version: 4.2.6
   resolution: "@types/mustache@npm:4.2.6"
   checksum: 10/56a9b979a9984d4f8b370ccdf04b54ae07f055b9e7326a526cf86b2fac73b04576cc71c83edaceaaf80038817520cbe2405f73623200a8ce03dcdd1e578e5016
-  languageName: node
-  linkType: hard
-
-"@types/nanoid@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@types/nanoid@npm:3.0.0"
-  dependencies:
-    nanoid: "npm:*"
-  checksum: 10/6e84d71ce2b8a2e23b20a018249a2e6a1c36b4ea0f45ff0265e8db514010ccf13141d87d6892f35b8e50ca5832d1d04ddc27062b5e69f91db2d5b3c5321c8c56
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

[`@types/nanoid`](https://www.npmjs.com/package/@types/nanoid) is documented with:
> nanoid provides its own type definitions, so you don't need `@types/nanoid` installed!

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->