### PR TITLE
Chore: Remove no-longer-necessary `Promise` polyfill

### DIFF
--- a/packages/lib/database-driver-node.js
+++ b/packages/lib/database-driver-node.js
@@ -1,5 +1,4 @@
 const shim = require('./shim').default;
-const Promise = require('promise');
 
 class DatabaseDriverNode {
 	open(options) {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -85,7 +85,6 @@
     "node-notifier": "10.0.1",
     "node-persist": "3.1.3",
     "node-rsa": "1.1.1",
-    "promise": "8.3.0",
     "query-string": "7.1.3",
     "re-reselect": "4.0.1",
     "redux": "4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10619,7 +10619,6 @@ __metadata:
     node-persist: "npm:3.1.3"
     node-rsa: "npm:1.1.1"
     pdfjs-dist: "npm:3.11.174"
-    promise: "npm:8.3.0"
     query-string: "npm:7.1.3"
     re-reselect: "npm:4.0.1"
     react: "npm:18.3.1"
@@ -42460,21 +42459,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise@npm:8.3.0, promise@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "promise@npm:8.3.0"
-  dependencies:
-    asap: "npm:~2.0.6"
-  checksum: 10/55e9d0d723c66810966bc055c6c77a3658c0af7e4a8cc88ea47aeaf2949ca0bd1de327d9c631df61236f5406ad478384fa19a77afb3f88c0303eba9e5eb0a8d8
-  languageName: node
-  linkType: hard
-
 "promise@npm:^7.1.1":
   version: 7.3.1
   resolution: "promise@npm:7.3.1"
   dependencies:
     asap: "npm:~2.0.3"
   checksum: 10/37dbe58ca7b0716cc881f0618128f1fd6ff9c46cdc529a269fd70004e567126a449a94e9428e2d19b53d06182d11b45d0c399828f103e06b2bb87643319bd2e7
+  languageName: node
+  linkType: hard
+
+"promise@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "promise@npm:8.3.0"
+  dependencies:
+    asap: "npm:~2.0.6"
+  checksum: 10/55e9d0d723c66810966bc055c6c77a3658c0af7e4a8cc88ea47aeaf2949ca0bd1de327d9c631df61236f5406ad478384fa19a77afb3f88c0303eba9e5eb0a8d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Removes an unnecessary `Promise` polyfill in `database-driver-node.js`. The `Promise` global should be available in [NodeJS >= 0.12](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#browser_compatibility).


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->