### PR TITLE
Chore: Desktop: Remove unused dependency

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -160,7 +160,6 @@
     "codemirror": "5.65.9",
     "color": "3.2.1",
     "compare-versions": "6.1.1",
-    "countable": "3.0.1",
     "debounce": "1.2.1",
     "electron": "39.0.0",
     "electron-builder": "24.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10231,7 +10231,6 @@ __metadata:
     codemirror: "npm:5.65.9"
     color: "npm:3.2.1"
     compare-versions: "npm:6.1.1"
-    countable: "npm:3.0.1"
     debounce: "npm:1.2.1"
     electron: "npm:39.0.0"
     electron-builder: "npm:24.13.3"
@@ -23235,13 +23234,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/8bdf1dfbb6fdb3755195b6886dc0649a3c742ec75afa4cb8da7b070936aed22a4f4e5b7359faafe03180358f311dbc300d248fd6586c458203d376a40cc77826
-  languageName: node
-  linkType: hard
-
-"countable@npm:3.0.1":
-  version: 3.0.1
-  resolution: "countable@npm:3.0.1"
-  checksum: 10/4ace30b6922e6672116a97c756d80094201f5a57879873bad18e166f7688230d7ccff63af79e974ae636fe5a278914169172b539d45e4c674433d664b416776e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Removes the [`countable`](https://www.npmjs.com/package/countable) dependency from the desktop app, which is no longer used (since 6d7b856d1de288f1110156e03812aa625f57809b). Word counting in the note viewer uses [`lib/countable/Countable.js`](https://github.com/laurent22/joplin/blob/dev/packages/lib/countable/Countable.js).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->