### PR TITLE
Desktop: Accessibility: Fix last items in note actions menu cannot be accessed on small screens

### DIFF
--- a/packages/app-desktop/gui/MultiNoteActions.tsx
+++ b/packages/app-desktop/gui/MultiNoteActions.tsx
@@ -22,12 +22,6 @@ interface MultiNoteActionsProps {
 function styles_(props: MultiNoteActionsProps) {
 	return buildStyle('MultiNoteActions', props.themeId, (theme: ThemeStyle) => {
 		return {
-			root: {
-				display: 'inline-flex',
-				justifyContent: 'center',
-				paddingTop: theme.marginTop,
-				width: '100%',
-			},
 			itemList: {
 				display: 'flex',
 				flexDirection: 'column',
@@ -90,7 +84,7 @@ export default function MultiNoteActions(props: MultiNoteActionsProps) {
 	}
 
 	return (
-		<div style={styles.root}>
+		<div style={styles.root} className='multi-note-actions'>
 			<div style={styles.itemList}>{itemComps}</div>
 		</div>
 	);

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -18,3 +18,4 @@
 @use './joplin-cloud-sign-up.scss';
 @use './popup-notification-list.scss';
 @use './popup-notification-item.scss';
+@use './multi-note-actions.scss';

--- a/packages/app-desktop/gui/styles/multi-note-actions.scss
+++ b/packages/app-desktop/gui/styles/multi-note-actions.scss
@@ -1,0 +1,8 @@
+
+.multi-note-actions {
+	display: inline-flex;
+	justify-content: center;
+	padding-top: var(--joplin-margin-top);
+	width: 100%;
+	overflow-y: auto;
+}


### PR DESCRIPTION
# Summary

Allows the note actions list to scroll, when low on vertical space.

Related: [WCAG 2.2 SC 1.4.10](https://www.w3.org/TR/WCAG22/#reflow).

# Screenshots

## Before
<img width="2098" height="410" alt="screenshot: Items in multi-note actions below 'move to notebook' are offscreen and cannot be scrolled to" src="https://github.com/user-attachments/assets/b82f0c8c-94e6-437e-bea8-1eaa90b814df" />

## After
<img width="2098" height="410" alt="screenshot: Items in multi-note actions below 'move to note' are offscreen, but there is also a vertical scrollbar" src="https://github.com/user-attachments/assets/dd2ccd2b-0aa0-4eab-a88b-8f5dcedbff4e" />


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->