### PR TITLE
Docs: Fix lower half of Markdown documentation is marked as a code block

### DIFF
--- a/packages/tools/website/processDocs.ts
+++ b/packages/tools/website/processDocs.ts
@@ -39,6 +39,7 @@ interface Context {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	currentLinkAttrs?: any;
 	inFence?: boolean;
+	fenceStarting?: string;
 	processedFiles?: string[];
 	isNews?: boolean;
 	donateLinks?: string;
@@ -159,7 +160,8 @@ const processToken = (token: any, output: string[], context: Context): void => {
 		}
 	} else if (type === 'fence') {
 		context.inFence = true;
-		content.push(`\`\`\`${token.info || ''}\n`);
+		context.fenceStarting = token.markup;
+		content.push(`${token.markup}${token.info || ''}\n`);
 	} else if (type === 'html_block') {
 		contentProcessed = true;
 		content.push(parseHtml(token.content.trim()));
@@ -252,7 +254,7 @@ const processToken = (token: any, output: string[], context: Context): void => {
 	}
 
 	if (type === 'fence') {
-		content.push('```');
+		content.push(context.fenceStarting);
 		content.push(paragraphBreak);
 		context.inFence = false;
 	}

--- a/readme/apps/markdown.md
+++ b/readme/apps/markdown.md
@@ -122,10 +122,12 @@ Joplin can renders [ABC notation](https://abcnotation.com) into sheet music. You
 
 <!-- cSpell:disable -->
 
-	```abc
-	K:F
-	!f!(fgag-g2c2)|
-	```
+````md
+```abc
+K:F
+!f!(fgag-g2c2)|
+```
+````
 
 <!-- cSpell:enable -->
 
@@ -150,20 +152,20 @@ You can also activate options for a particular sheet music. To do so, add a head
 For example, this would add violin tablatures to the sheet music:
 
 <!-- cSpell:disable -->
+````md
+```abc
+{tablature: [{instrument: 'violin'}]}
+---
 
-	```abc
-	{tablature: [{instrument: 'violin'}]}
-	---
-
-	X:1
-	T: Cooley's
-	M: 4/4
-	L: 1/8
-	R: reel
-	K: G
-	|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|
-	```
-
+X:1
+T: Cooley's
+M: 4/4
+L: 1/8
+R: reel
+K: G
+|:D2|EB{c}BA B2 EB|~B2 AB dBAG|FDAD BDAD|FDAD dAFD|
+```
+````
 <!-- cSpell:enable -->
 
 ![Sheet music and guitar tablature for the Irish reel "Cooley's" in D major](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/md_plugins/abc/Tablature.png)

--- a/readme/apps/markdown.md
+++ b/readme/apps/markdown.md
@@ -127,7 +127,7 @@ Joplin can renders [ABC notation](https://abcnotation.com) into sheet music. You
 	!f!(fgag-g2c2)|
 	```
 
-`<!-- cSpell:enable -->
+<!-- cSpell:enable -->
 
 For example:
 


### PR DESCRIPTION
# Summary

Fixes an issue that caused much of Joplin's Markdown guide to be marked as a code block.

# Screenshots

**Before**:
<img width="1222" height="730" alt="screenshot: Everything below 'musical notation' is marked as a code block" src="https://github.com/user-attachments/assets/cb7200b1-de8d-4942-92e3-bea7fc04ed5a" />


**After**:
<img width="1222" height="730" alt="screenshot: Content no longer marked as a code block" src="https://github.com/user-attachments/assets/1cb1f8b7-db66-40de-8d0f-03005fc3b266" />


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->