### PR TITLE
 Desktop,Mobile: Hide backslash escapes when "Markdown editor: Render markup in editor" is enabled

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1049,6 +1049,7 @@ packages/editor/CodeMirror/extensions/rendering/addFormattingClasses.js
 packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.js
 packages/editor/CodeMirror/extensions/rendering/renderBlockImages.js
 packages/editor/CodeMirror/extensions/rendering/renderingExtension.js
+packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.js
 packages/editor/CodeMirror/extensions/rendering/replaceBulletLists.js
 packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.js
 packages/editor/CodeMirror/extensions/rendering/replaceDividers.js

--- a/.gitignore
+++ b/.gitignore
@@ -1021,6 +1021,7 @@ packages/editor/CodeMirror/extensions/rendering/addFormattingClasses.js
 packages/editor/CodeMirror/extensions/rendering/renderBlockImages.test.js
 packages/editor/CodeMirror/extensions/rendering/renderBlockImages.js
 packages/editor/CodeMirror/extensions/rendering/renderingExtension.js
+packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.js
 packages/editor/CodeMirror/extensions/rendering/replaceBulletLists.js
 packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.js
 packages/editor/CodeMirror/extensions/rendering/replaceDividers.js

--- a/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderingExtension.ts
@@ -1,4 +1,5 @@
 import addFormattingClasses from './addFormattingClasses';
+import replaceBackslashEscapes from './replaceBackslashEscapes';
 import replaceBulletLists from './replaceBulletLists';
 import replaceCheckboxes from './replaceCheckboxes';
 import replaceDividers from './replaceDividers';
@@ -9,6 +10,7 @@ export default () => {
 		replaceCheckboxes,
 		replaceBulletLists,
 		replaceFormatCharacters,
+		replaceBackslashEscapes,
 		replaceDividers,
 		addFormattingClasses,
 	];

--- a/packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceBackslashEscapes.ts
@@ -1,0 +1,20 @@
+import makeInlineReplaceExtension from './utils/makeInlineReplaceExtension';
+import { Decoration } from '@codemirror/view';
+
+const hideDecoration = Decoration.replace({});
+
+const replaceBackslashEscapes = makeInlineReplaceExtension({
+	createDecoration: (node) => {
+		if (node.name === 'Escape') {
+			return hideDecoration;
+		}
+		return null;
+	},
+	getDecorationRange: (node) => {
+		// The Escape node spans the backslash and the escaped character (e.g., "\*").
+		// We only want to hide the backslash, not the escaped character.
+		return [node.from, node.from + 1];
+	},
+});
+
+export default replaceBackslashEscapes;


### PR DESCRIPTION
## Background

This pr extends the render markup feature to hide backslash escapes on all but the current line (similar to other apps that render markdown in the editor like Obsidian and Typora). 

See: https://discourse.joplinapp.org/t/pr-to-hide-backslash-escapes-when-rendering-markup/47909

## Changes

- Add `replaceBackslashEscapes` extension to hide backslash escape characters when rendering markdown in the editor
- Follows the same pattern as other rendering extensions (e.g., `replaceFormatCharacters`)
- Only the backslash is hidden; the escaped character remains visible
- Backslash escapes are shown on the current line for editing, consistent with other markdown formatting

## Testing

- [x] Open a note with backslash escapes (e.g., `\*`, `\_`, `\#`)
- [x] Verify the backslash is hidden when the cursor is on a different line
- [x] Verify the backslash is visible when the cursor is on the same line
- [x] Verify the escaped character is always visible
- [x] Verify that code blocks/inline code are not effected
- [x] Verify that single backslashes that aren't escaping special characters aren't effected

## Examples (desktop and web app)

https://github.com/user-attachments/assets/5249275c-a883-4e66-9163-532953d97514

https://github.com/user-attachments/assets/e14cb962-636a-4e02-8519-0c4ecf5271c4




