### PR TITLE
Chore: Mobile plugin IPC: Fix possible error format issue

### DIFF
--- a/packages/lib/utils/ipc/RemoteMessenger.ts
+++ b/packages/lib/utils/ipc/RemoteMessenger.ts
@@ -353,7 +353,7 @@ export default abstract class RemoteMessenger<LocalInterface, RemoteInterface> {
 				channelId: this.channelId,
 			});
 		} catch (error) {
-			console.error(`Error (in RemoteMessenger, calling ${message?.methodPath}): `, error, error.stack, JSON.stringify(message));
+			console.error('Error:', `(in RemoteMessenger, calling ${message?.methodPath}): `, error, error.stack, JSON.stringify(message));
 
 			this.postMessage({
 				kind: MessageType.ErrorResponse,


### PR DESCRIPTION
# Summary

Prevents `message?.methodPath` from being [interpreted as a format string](https://developer.mozilla.org/en-US/docs/Web/API/console#using_string_substitutions), when passed to `console.error`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->