### PR TITLE
Chore: Replace deprecated 'request' package with 'node-fetch'

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -37,7 +37,6 @@
     "mustache": "4.2.0",
     "node-fetch": "2.6.7",
     "relative": "3.0.2",
-    "request": "2.88.2",
     "sharp": "0.34.3",
     "source-map-support": "0.5.21",
     "uri-template": "2.0.0",

--- a/packages/tools/update-readme-contributors.ts
+++ b/packages/tools/update-readme-contributors.ts
@@ -1,6 +1,5 @@
 import { rootDir } from './tool-utils';
-
-const request = require('request');
+import fetch from 'node-fetch';
 
 interface Contributor {
 	avatar_url: string;
@@ -12,22 +11,16 @@ const readmePath = `${rootDir}/README.md`;
 const { insertContentIntoFile } = require('./tool-utils.js');
 
 async function gitHubContributors(page: number): Promise<Contributor[]> {
-	return new Promise((resolve, reject) => {
-		request.get({
-			url: `https://api.github.com/repos/laurent22/joplin/contributors${page ? `?page=${page}` : ''}`,
-			json: true,
-			headers: { 'User-Agent': 'Joplin Readme Updater' },
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		}, (error: any, response: any, data: any) => {
-			if (error) {
-				reject(error);
-			} else if (response.statusCode !== 200) {
-				reject(new Error(`Error HTTP ${response.statusCode}`));
-			} else {
-				resolve(data);
-			}
-		});
+	const url = `https://api.github.com/repos/laurent22/joplin/contributors${page ? `?page=${page}` : ''}`;
+	const response = await fetch(url, {
+		headers: { 'User-Agent': 'Joplin Readme Updater' },
 	});
+
+	if (!response.ok) {
+		throw new Error(`Error HTTP ${response.status}`);
+	}
+
+	return await response.json() as Contributor[];
 }
 
 function contributorTable(contributors: Contributor[]) {


### PR DESCRIPTION
## Summary

This PR replaces the deprecated `request` package with `node-fetch` in the `@joplin/tools` package, eliminating several npm deprecation warnings.

## Changes

- Replaced callback-based `request` with async/await `node-fetch` in `update-readme-contributors.ts`
- Removed `request` dependency from `@joplin/tools/package.json`
- Modernized error handling and code structure

## Issues Resolved

This change eliminates the following npm warnings:
- `npm warn deprecated request@2.88.2: request has been deprecated`
- `npm warn deprecated har-validator@5.1.5: this library is no longer supported`
- `npm warn deprecated uuid@3.4.0: Please upgrade to version 7 or higher`

## Testing

- ✅ All existing tests pass (14 test suites, 39 tests)
- ✅ Script tested locally and works correctly
- ✅ TypeScript compilation successful
- ✅ No regressions introduced

## Technical Notes

- `node-fetch` was already a dependency in the package, so no new dependencies were added
- The change modernizes the code from callback-based to async/await pattern
- Compatible with Node.js 18+ (prepares for future native fetch migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)