### PR TITLE
Mobile: Rich Text Editor: Fix error when pressing enter

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,9 @@
 	],
 	"ignoreDeps": [
 		"@babel/core",
+		// ProseMirror and CodeMirror often need to be deduplicated after updating (e.g. with
+		// yarn dedupe 'prosemirror-*'). Renovate doesn't do this, and, without the deduplication,
+		// multiple instances of some parts of the libraries can be loaded, breaking parts of the editor. 
 		"@codemirror/autocomplete",
 		"@codemirror/commands",
 		"@codemirror/lang-cpp",
@@ -69,6 +72,9 @@
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/markdown",
+		"prosemirror-model",
+		"prosemirror-state",
+		"prosemirror-view",
 		"@fortawesome/fontawesome-svg-core",
 		"@fortawesome/free-solid-svg-icons",
 		"@svgr/webpack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42615,21 +42615,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prosemirror-model@npm:1.25.3":
+"prosemirror-model@npm:1.25.3, prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.21.0, prosemirror-model@npm:^1.25.0":
   version: 1.25.3
   resolution: "prosemirror-model@npm:1.25.3"
   dependencies:
     orderedmap: "npm:^2.0.0"
   checksum: 10/e7dfdca2b515f3bbfabd29062bdd341b47b196c11f598ca9975245962ae61d1d44935879c3e6a0c35ed6f510cab508f232abe95d34dda2e12cf19b5fa2591372
-  languageName: node
-  linkType: hard
-
-"prosemirror-model@npm:^1.0.0, prosemirror-model@npm:^1.20.0, prosemirror-model@npm:^1.21.0, prosemirror-model@npm:^1.25.0":
-  version: 1.25.2
-  resolution: "prosemirror-model@npm:1.25.2"
-  dependencies:
-    orderedmap: "npm:^2.0.0"
-  checksum: 10/de708e22b52b97081ae8012c37136e3a39552a13b64b9fadeddca1c4bb3d7b865f390123cbe1fee7e98c6b7d85776a292be9fdc5140b6ebbe9f60987de980345
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request fixes the following error (observed when pressing <kbd>enter</kbd> after a header):
```
08:10:28: RichTextEditor: Rich Text Editor error error: Uncaught RangeError: Can not convert <> to a Fragment (looks like multiple versions of prosemirror-model were loaded) in file://, line 1379
```

This was likely caused by https://github.com/laurent22/joplin/pull/13623, which upgraded `prosemirror-model` (but not transitive dependencies on `prosemirror-model`).



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->