### PR TITLE
Desktop: OneNote importer: Handle the case where an entity GUID is missing

### DIFF
--- a/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
+++ b/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
@@ -7,7 +7,7 @@ use crate::fsshttpb_onestore::revision_role::RevisionRole;
 use crate::onestore;
 use crate::shared::cell_id::CellId;
 use crate::shared::exguid::ExGuid;
-use parser_utils::errors::{ErrorKind, Result};
+use parser_utils::errors::Result;
 use std::collections::HashMap;
 
 pub(crate) type GroupData<'a> = HashMap<(ExGuid, u64), &'a ObjectGroupData>;
@@ -59,12 +59,10 @@ impl<'b> ObjectSpace {
         let object_space_id = cell_id.1;
 
         let cell_manifest_id = ObjectSpace::find_cell_manifest_id(mapping.id, packaging)
-            .ok_or_else(|| ErrorKind::MalformedOneStoreData("cell manifest id not found".into()))?;
+            .ok_or_else(|| parser_error!(MalformedOneStoreData, "cell manifest id not found"))?;
         let revision_manifest_id = storage_index
             .find_revision_mapping_id(cell_manifest_id)
-            .ok_or_else(|| {
-                ErrorKind::MalformedOneStoreData("no revision manifest id found".into())
-            })?;
+            .ok_or_else(|| parser_error!(MalformedOneStoreData, "No revision manifest id found. (Unable to find revision)."))?;
 
         let mut objects = HashMap::new();
         let mut roots = HashMap::new();

--- a/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
+++ b/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
@@ -62,7 +62,12 @@ impl<'b> ObjectSpace {
             .ok_or_else(|| parser_error!(MalformedOneStoreData, "cell manifest id not found"))?;
         let revision_manifest_id = storage_index
             .find_revision_mapping_id(cell_manifest_id)
-            .ok_or_else(|| parser_error!(MalformedOneStoreData, "No revision manifest id found. (Unable to find revision)."))?;
+            .ok_or_else(|| {
+                parser_error!(
+                    MalformedOneStoreData,
+                    "No revision manifest id found. (Unable to find revision)."
+                )
+            })?;
 
         let mut objects = HashMap::new();
         let mut roots = HashMap::new();

--- a/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
+++ b/packages/onenote-converter/parser/src/fsshttpb_onestore/object_space.rs
@@ -65,7 +65,7 @@ impl<'b> ObjectSpace {
             .ok_or_else(|| {
                 parser_error!(
                     MalformedOneStoreData,
-                    "No revision manifest id found. (Unable to find revision)."
+                    "No revision manifest id found. (Unable to find revision?)."
                 )
             })?;
 

--- a/packages/onenote-converter/parser/src/one/property_set/section_node.rs
+++ b/packages/onenote-converter/parser/src/one/property_set/section_node.rs
@@ -7,7 +7,7 @@ use crate::one::property_set::PropertySetId;
 use crate::onestore::object::Object;
 use crate::shared::exguid::ExGuid;
 use crate::shared::guid::Guid;
-use parser_utils::errors::{Result};
+use parser_utils::errors::Result;
 use parser_utils::log_warn;
 
 /// A section.
@@ -19,7 +19,6 @@ use parser_utils::log_warn;
 #[allow(dead_code)]
 pub(crate) struct Data {
     //pub(crate) context_id: ExGuid, // Removed -- but may be necessary
-
     /// Used for creating links to sections. If not present, defaults to `Guid::nil`.
     pub(crate) entity_guid: Guid,
     pub(crate) page_series: Vec<ExGuid>,


### PR DESCRIPTION
# Summary

This pull request:
- Slightly improves the error message when a revision's full ID can't be resolved (in a notebook downloaded from OneNote online).
    - Using `parser_error!` to log the error message adds file information.
- Logs a warning rather than failing when a section is missing a [`NotebookManagementEntityGuid`](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-one/34ea5601-f060-4a69-b5f9-5843a1f14098).

Partially resolves https://github.com/laurent22/joplin/issues/13785.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->