### PR TITLE
Desktop: Add loading indicator to the sync status screen

### DIFF
--- a/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinCloudLoginScreen.tsx
@@ -106,7 +106,7 @@ const JoplinCloudScreenComponent = (props: Props) => {
 						<span className={state.className}>{state.errorMessage}</span>
 					) : null}
 				</p>
-				{state.active === 'LINK_USED' ? <div id="loading-animation" /> : null}
+				{state.active === 'LINK_USED' ? <div className="loading-animation" /> : null}
 				<JoplinCloudSignUpCallToAction />
 			</div>
 			<ButtonBar onCancelClick={() => props.dispatch({ type: 'NAV_BACK' })} />

--- a/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
+++ b/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
@@ -40,12 +40,15 @@ async function exportDebugReportClick() {
 }
 
 function StatusScreen(props: Props) {
+	const [loading, setLoading] = useState(false);
 	const [report, setReport] = useState<ReportSection[]>([]);
 
 	async function refreshScreen() {
+		setLoading(true);
 		const service = new ReportService();
 		const r = await service.status(Setting.value('sync.target'));
 		setReport(r);
+		setLoading(false);
 	}
 
 	useEffect(() => {
@@ -208,6 +211,7 @@ function StatusScreen(props: Props) {
 		<div style={style}>
 			<div style={containerStyle}>
 				{renderTools()}
+				{loading && <p><span className='loading-animation'/> {_('Loading...')}</p>}
 				{body}
 			</div>
 			<ButtonBar

--- a/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
+++ b/packages/app-desktop/gui/StatusScreen/StatusScreen.tsx
@@ -45,10 +45,13 @@ function StatusScreen(props: Props) {
 
 	async function refreshScreen() {
 		setLoading(true);
-		const service = new ReportService();
-		const r = await service.status(Setting.value('sync.target'));
-		setReport(r);
-		setLoading(false);
+		try {
+			const service = new ReportService();
+			const r = await service.status(Setting.value('sync.target'));
+			setReport(r);
+		} finally {
+			setLoading(false);
+		}
 	}
 
 	useEffect(() => {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.tsx
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.tsx
@@ -14,7 +14,7 @@ const ModalMessageOverlay: React.FC<Props> = ({ message }) => {
 
 	return <Dialog contentFillsScreen={true}>
 		<div className="modal-message">
-			<div id="loading-animation" />
+			<div className="loading-animation" />
 			<div className="text" role="status">
 				{lines}
 			</div>

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -132,10 +132,12 @@ a {
 	margin: 40px 20px;
 }
 
-#loading-animation {
+.loading-animation {
 	margin-right: 20px;
 	width: 20px;
 	height: 20px;
+	display: inline-block;
+	vertical-align: middle;
 	border: 5px solid lightgrey;
 	border-top: 4px solid white;
 	border-radius: 50%;


### PR DESCRIPTION
# Summary

For large item collections, the "sync status" screen can take a long time to load (observed: roughly 30 seconds). This pull request adds a "loading" animation to the sync status screen.


# Screenshot

<img width="972" height="705" alt="screenshot: Loading animation shown below 'advanced tools'" src="https://github.com/user-attachments/assets/840c3367-39f1-47bd-b58a-e44eb3bb3eb3" />

# Testing plan

1. Regression testing: Import a medium/large JEX file. Verify that a "loading" icon is shown.
2. Regression testing: Open the Joplin Cloud login screen. Click "Copy link to website" and verify that the "loading icon is still shown.
3. Open the sync status screen. Verify that a "loading" animation is shown.
   - Note: During testing, `ReportService.status` was made slower using a `msleep`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->