### PR TITLE
Chore: Mobile: Fix test warnings

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -166,19 +166,21 @@ describe('screens/Note', () => {
 
 	it('should show the currently selected note', async () => {
 		await openNewNote({ title: 'Test note (title)', body: '# Testing...' });
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		const titleInput = await screen.findByDisplayValue('Test note (title)');
 		expect(titleInput).toBeVisible();
 
 		const renderedNote = await getNoteViewerDom();
 		expect(renderedNote.querySelector('h1')).toMatchObject({ textContent: 'Testing...' });
+
+		unmount();
 	});
 
 	it('changing the note title input should update the note\'s title', async () => {
 		const noteId = await openNewNote({ title: 'Change me!', body: 'Unchanged body' });
 
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		const titleInput = await screen.findByDisplayValue('Change me!');
 
@@ -205,6 +207,8 @@ describe('screens/Note', () => {
 				await waitForNoteToMatch(noteId, { title: expectedTitle });
 			}
 		});
+
+		unmount();
 	});
 
 	it('changing the note body in the editor should update the note\'s body', async () => {
@@ -237,7 +241,7 @@ describe('screens/Note', () => {
 
 	it('pressing "delete" should move the note to the trash', async () => {
 		const noteId = await openNewNote({ title: 'To be deleted', body: '...' });
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		await openNoteActionsMenu();
 		const deleteButton = await screen.findByText('Delete');
@@ -246,11 +250,13 @@ describe('screens/Note', () => {
 		await waitFor(async () => {
 			expect((await Note.load(noteId)).deleted_time).toBeGreaterThan(0);
 		});
+
+		unmount();
 	});
 
 	it('pressing "delete permanently" should permanently delete a note', async () => {
 		const noteId = await openNewNote({ title: 'To be deleted', body: '...', deleted_time: Date.now() });
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		// Permanently delete note shows a confirmation dialog -- mock it.
 		const deleteId = 0;
@@ -264,6 +270,8 @@ describe('screens/Note', () => {
 			expect(await Note.load(noteId)).toBeUndefined();
 		});
 		expect(shim.showMessageBox).toHaveBeenCalled();
+
+		unmount();
 	});
 
 	it('delete should be disabled in a read-only note', async () => {
@@ -284,7 +292,7 @@ describe('screens/Note', () => {
 			),
 		).toBe(true);
 
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		const titleInput = await screen.findByDisplayValue('Title: Read-only note');
 		expect(titleInput).toBeVisible();
@@ -295,6 +303,7 @@ describe('screens/Note', () => {
 		expect(deleteButton).toHaveProp('disabled', true);
 
 		act(() => cleanup());
+		unmount();
 	});
 
 	it.each([
@@ -317,7 +326,7 @@ describe('screens/Note', () => {
 
 		await openExistingNote(note.id);
 
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		// Note should render
 		const titleInput = await screen.findByDisplayValue('Note 1');
@@ -339,16 +348,20 @@ describe('screens/Note', () => {
 				throw new Error(`Should not be testing downloadMode: ${downloadMode}.`);
 			}
 		});
+
+		unmount();
 	});
 
 	it('the toggleVisiblePanes command should start and stop editing', async () => {
 		await openNewNote({ title: 'To be edited', body: '...' });
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 
 		await expectToBeEditing(false);
 		await runEditorCommand('toggleVisiblePanes');
 		await expectToBeEditing(true);
 		await runEditorCommand('toggleVisiblePanes');
 		await expectToBeEditing(false);
+
+		unmount();
 	});
 });


### PR DESCRIPTION
# Summary

This pull request explicitly unmounts the `Note` screen before each test completes. This should fix warnings emitted by `Note.test.tsx` after tests finish (e.g. "An update to AccessibleView inside a test was not wrapped in act(...)"). 
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->