### PR TITLE
Desktop: Use the "--no-sandbox" flag for Tuxedo OS

### DIFF
--- a/Joplin_install_and_update.sh
+++ b/Joplin_install_and_update.sh
@@ -275,7 +275,7 @@ if command -v lsb_release &> /dev/null; then
   # without writing the AppImage to a non-user-writable location (without invalidating other security
   # controls). See https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/.
   HAS_USERNS_RESTRICTIONS=false
-  if [[ "$DISTVER" =~ ^Ubuntu && $DISTMAJOR -ge 23 ]]; then
+  if [[ "$DISTVER" =~ ^(Ubuntu|Tuxedo) && $DISTMAJOR -ge 23 ]]; then
     HAS_USERNS_RESTRICTIONS=true
   fi
 


### PR DESCRIPTION
The PR is related to [this forum thread](https://discourse.joplinapp.org/t/2025-11-20-joplin-3-3-12-prod-linux-questions/47893/13).

Tuxedo OS is based on Ubuntu. It suffers from the same issue as Ubuntu, explained in the [forum](https://discourse.joplinapp.org/t/possible-future-requirement-for-no-sandbox-flag-for-ubuntu-23-10/32160/5) and in the [code](https://github.com/laurent22/joplin/blob/e2a32c599374905a75c9c423d505cbd953efbba2/Joplin_install_and_update.sh#L273-L276) already.

The versioning scheme is based on Ubuntu. For example Tuxedo OS 24.04 is based on Ubuntu 24.04. That's why I simply extended the regex to check for `Ubuntu` or `Tuxedo`. The complete `DISTVER` string is `Tuxedo24.04` in this case.