### PR TITLE
Desktop, Mobile: Do no re-use the 'Restored Notes' folder if it is trashed

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -1100,4 +1100,8 @@ export default class Folder extends BaseItem {
 		return folderId;
 	}
 
+	public static loadByTitleExcludingTrashed(title: string) {
+		return this.modelSelectOne('SELECT * FROM folders WHERE title = ? AND deleted_time = 0', [title]);
+	}
+
 }

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -1100,8 +1100,4 @@ export default class Folder extends BaseItem {
 		return folderId;
 	}
 
-	public static loadByTitleExcludingTrashed(title: string) {
-		return this.modelSelectOne('SELECT * FROM folders WHERE title = ? AND deleted_time = 0', [title]);
-	}
-
 }

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -271,8 +271,8 @@ export default class RevisionService extends BaseService {
 	}
 
 	public async restoreFolder() {
-		let folder = await Folder.loadByTitle(this.restoreFolderTitle());
-		if (!folder || !!folder.deleted_time) {
+		let folder = await Folder.loadByTitleExcludingTrashed(this.restoreFolderTitle());
+		if (!folder) {
 			folder = await Folder.save({ title: this.restoreFolderTitle() });
 		}
 		return folder;

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -271,7 +271,10 @@ export default class RevisionService extends BaseService {
 	}
 
 	public async restoreFolder() {
-		let folder = await Folder.loadByTitleExcludingTrashed(this.restoreFolderTitle());
+		let folder = await Folder.loadByFields({
+			title: this.restoreFolderTitle(),
+			deleted_time: 0,
+		});
 		if (!folder) {
 			folder = await Folder.save({ title: this.restoreFolderTitle() });
 		}

--- a/packages/lib/services/RevisionService.ts
+++ b/packages/lib/services/RevisionService.ts
@@ -272,7 +272,7 @@ export default class RevisionService extends BaseService {
 
 	public async restoreFolder() {
 		let folder = await Folder.loadByTitle(this.restoreFolderTitle());
-		if (!folder) {
+		if (!folder || !!folder.deleted_time) {
 			folder = await Folder.save({ title: this.restoreFolderTitle() });
 		}
 		return folder;


### PR DESCRIPTION
While implementing a conditionally created / reused 'Imported Notes' folder in PR https://github.com/laurent22/joplin/pull/13742 I found that the 'Restored Notes' folder which I based it on would be reused if a folder with that name exists and is trashed. In this scenario it would better to create a new 'Restored Notes' to avoid confusion to the user, and this PR implements this behaviour.

### Testing

1. Take an existing note with 1 or more revisions
2. Restore a revision
3. Delete the 'Restored Notes' folder
4. Restore another revision
5. Observe a new 'Restored Notes' folder
6. Restore another revision
5. Observe the 'Restored Notes' folder which is not in the trash is reused