### PR TITLE
Desktop: Resolves: #13804: Change search Resources feature to case insensitive

### DIFF
--- a/packages/app-desktop/gui/ResourceScreen.tsx
+++ b/packages/app-desktop/gui/ResourceScreen.tsx
@@ -87,7 +87,7 @@ const ResourceTableComp = (props: ResourceTable) => {
 		(resource: InnerResource) => {
 			if (props.filter) {
 				const filterLowerCase = props.filter.toLowerCase();
-				return resource.title?.toLocaleLowerCase().includes(filterLowerCase) || resource.id.toLowerCase().includes(filterLowerCase);
+				return resource.title?.toLowerCase().includes(filterLowerCase) || resource.id.toLowerCase().includes(filterLowerCase);
 			}
 			return true;
 		},

--- a/packages/app-desktop/gui/ResourceScreen.tsx
+++ b/packages/app-desktop/gui/ResourceScreen.tsx
@@ -85,7 +85,7 @@ const ResourceTableComp = (props: ResourceTable) => {
 
 	const filteredResources = props.resources.filter(
 		(resource: InnerResource) => {
-			if (!props.filter) {
+			if (props.filter) {
 				const filterLowerCase = props.filter.toLowerCase();
 				return resource.title?.toLocaleLowerCase().includes(filterLowerCase) || resource.id.toLowerCase().includes(filterLowerCase);
 			}

--- a/packages/app-desktop/gui/ResourceScreen.tsx
+++ b/packages/app-desktop/gui/ResourceScreen.tsx
@@ -84,7 +84,13 @@ const ResourceTableComp = (props: ResourceTable) => {
 	};
 
 	const filteredResources = props.resources.filter(
-		(resource: InnerResource) => !props.filter || resource.title?.includes(props.filter) || resource.id.includes(props.filter),
+		(resource: InnerResource) => {
+			if (!props.filter) {
+				const filterLowerCase = props.filter.toLowerCase();
+				return resource.title?.toLocaleLowerCase().includes(filterLowerCase) || resource.id.toLowerCase().includes(filterLowerCase);
+			}
+			return true;
+		},
 	);
 
 	const renderSortableHeader = (title: string, order: SortingOrder) => {
@@ -297,7 +303,7 @@ class ResourceScreenComponent extends React.Component<Props, State> {
 					<div style={{ ...theme.notificationBox, marginBottom: 10 }}>{
 						_('This is an advanced tool to show the attachments that are linked to your notes. Please be careful when deleting one of them as they cannot be restored afterwards.')
 					}</div>
-					<div style={{ float: 'right' }}>
+					<p style={{ float: 'left', paddingRight: 10 }}>
 						<input
 							style={theme.inputStyle}
 							type="search"
@@ -305,7 +311,7 @@ class ResourceScreenComponent extends React.Component<Props, State> {
 							onChange={this.onFilterUpdate}
 							placeholder={_('Search...')}
 						/>
-					</div>
+					</p>
 					{this.state.isLoading && <div>{_('Please wait...')}</div>}
 					{!this.state.isLoading && <div>
 						{!this.state.resources && <div>


### PR DESCRIPTION
Fixes #13804

## Summary

This PR changes search functionality in Resources screen to case insensitive, adds a margin below the search field and align the search field to the left with CSS fixes for loading indicator.

## Testing

1. Add attachments to your notes.
2. Go to Tools -> Note attachments...
3. Use search field to filter the attachments list


https://github.com/user-attachments/assets/462a5b65-f27e-407c-bc3f-241e1ab6eab2

