### PR TITLE
Mobile: Fixes #13825: Fix incompatible plugins cannot be uninstalled

### DIFF
--- a/packages/app-mobile/components/buttons/CardButton.tsx
+++ b/packages/app-mobile/components/buttons/CardButton.tsx
@@ -11,7 +11,7 @@ export enum InstallState {
 
 interface Props {
 	onPress: ()=> void;
-	disabled: boolean;
+	disabled?: boolean;
 	children: React.ReactNode;
 	style?: ViewStyle;
 	testID?: string;

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -70,7 +70,7 @@ const PluginBox: React.FC<Props> = props => {
 			style={styles.cardContainer}
 			onPress={props.onShowPluginInfo ? onPress : null}
 			testID='plugin-card'
-			disabled={!props.isCompatible}
+			disabled={false}
 		>
 			<Card.Content style={styles.content}>
 				<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginBox/index.tsx
@@ -70,7 +70,6 @@ const PluginBox: React.FC<Props> = props => {
 			style={styles.cardContainer}
 			onPress={props.onShowPluginInfo ? onPress : null}
 			testID='plugin-card'
-			disabled={false}
 		>
 			<Card.Content style={styles.content}>
 				<View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>


### PR DESCRIPTION
Using the install from file option on the plugins screen of both the native app and web app, install a plugin which is not compatible with mobile, eg. https://joplinapp.org/plugins/plugin/joplin-plugin-conflict-resolution/

It is then not possible to uninstall the plugin, because clicking the plugin tile or the 'incompatible' label on the tile does not do anything, due to being in a disabled state.

This is due to a regression introduced by https://github.com/laurent22/joplin/pull/13234, which incorrectly disables the state of the CardButton when the plugin is incompatible. This PR fixes the issue by ensuring the CardButton is always enabled.

This fixes https://github.com/laurent22/joplin/issues/13825

### Testing

See video:

https://github.com/user-attachments/assets/d1407335-5c28-4d3b-8c35-e49dadefbd35

Clicking the 'incompatible' label now also works correctly