### PR TITLE
Desktop: Add CJK characters counter in statistics panel

### DIFF
--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -31,7 +31,7 @@ function markupToHtml() {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-function countElements(text: string, wordSetter: Function, characterSetter: Function, characterNoSpaceSetter: Function, cjkCharacterSetter: Function, lineSetter: Function) {
+function countElements(text: string, wordSetter: Function, characterSetter: Function, characterNoSpaceSetter: Function, cjkCharacterSetter: React.Dispatch<React.SetStateAction<number>>, lineSetter: Function) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	Countable.count(text, (counter: any) => {
 		wordSetter(counter.words);

--- a/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NoteContentPropertiesDialog.tsx
@@ -31,13 +31,15 @@ function markupToHtml() {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-function countElements(text: string, wordSetter: Function, characterSetter: Function, characterNoSpaceSetter: Function, lineSetter: Function) {
+function countElements(text: string, wordSetter: Function, characterSetter: Function, characterNoSpaceSetter: Function, cjkCharacterSetter: Function, lineSetter: Function) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	Countable.count(text, (counter: any) => {
 		wordSetter(counter.words);
 		characterSetter(counter.all);
 		characterNoSpaceSetter(counter.characters);
 	});
+	const cjkMatches = text.match(/[\p{Script=Han}\p{Script=Bopomofo}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu);
+	cjkCharacterSetter(cjkMatches ? cjkMatches.length : 0);
 	lineSetter(text === '' ? 0 : text.split('\n').length);
 }
 
@@ -58,23 +60,25 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	const [words, setWords] = useState<number>(0);
 	const [characters, setCharacters] = useState<number>(0);
 	const [charactersNoSpace, setCharactersNoSpace] = useState<number>(0);
+	const [cjkCharacters, setCjkCharacters] = useState<number>(0);
 	// For source with Markdown syntax stripped out
 	const [strippedLines, setStrippedLines] = useState<number>(0);
 	const [strippedWords, setStrippedWords] = useState<number>(0);
 	const [strippedCharacters, setStrippedCharacters] = useState<number>(0);
 	const [strippedCharactersNoSpace, setStrippedCharactersNoSpace] = useState<number>(0);
+	const [strippedCjkCharacters, setStrippedCjkCharacters] = useState<number>(0);
 	const [strippedReadTime, setStrippedReadTime] = useState<number>(0);
 	// This amount based on the following paper:
 	// https://www.researchgate.net/publication/332380784_How_many_words_do_we_read_per_minute_A_review_and_meta-analysis_of_reading_rate
 	const wordsPerMinute = 250;
 
 	useEffect(() => {
-		countElements(props.text, setWords, setCharacters, setCharactersNoSpace, setLines);
+		countElements(props.text, setWords, setCharacters, setCharactersNoSpace, setCjkCharacters, setLines);
 	}, [props.text]);
 
 	useEffect(() => {
 		const strippedText: string = markupToHtml().stripMarkup(props.markupLanguage, props.text);
-		countElements(strippedText, setStrippedWords, setStrippedCharacters, setStrippedCharactersNoSpace, setStrippedLines);
+		countElements(strippedText, setStrippedWords, setStrippedCharacters, setStrippedCharactersNoSpace, setStrippedCjkCharacters, setStrippedLines);
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [props.text]);
 
@@ -88,6 +92,7 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 		words: words,
 		characters: characters,
 		charactersNoSpace: charactersNoSpace,
+		cjkCharacters: cjkCharacters,
 	};
 
 	const strippedTextProperties: TextPropertiesMap = {
@@ -99,12 +104,14 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 		words: strippedWords,
 		characters: strippedCharacters,
 		charactersNoSpace: strippedCharactersNoSpace,
+		cjkCharacters: strippedCjkCharacters,
 	};
 
 	const keyToLabel: KeyToLabelMap = {
 		words: _('Words'),
 		characters: _('Characters'),
 		charactersNoSpace: _('Characters excluding spaces'),
+		cjkCharacters: _('Chinese/Japanese/Korean characters'),
 		lines: _('Lines'),
 	};
 
@@ -147,6 +154,7 @@ export default function NoteContentPropertiesDialog(props: NoteContentProperties
 	);
 
 	for (const key in textProperties) {
+		if (key === 'cjkCharacters' && textProperties[key] === 0 && strippedTextProperties[key] === 0) continue;
 		const comp = createTableBodyRow(key, textProperties[key], strippedTextProperties[key]);
 		tableBodyComps.push(comp);
 	}

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -219,4 +219,5 @@ tablatures
 tablature
 REVO
 REVOGB
+Bopomofo
 Linkosed


### PR DESCRIPTION
This PR adds a CJK characters counter to the statistics panel, which is a common feature in MS Office and LibreOffice.
<img width="50%" height="50%" alt="img" src="https://github.com/user-attachments/assets/551752cd-acae-4efa-997b-126d0e7400a6" />

The counter won't appear if the note doesn't contain CJK characters, just like how LibreOffice shows.
<img width="50%" height="50%" alt="img" src="https://github.com/user-attachments/assets/d370510a-a6f1-490f-9727-d557cefe9b67" />
<img width="50%" height="50%" alt="img" src="https://github.com/user-attachments/assets/07e3a08a-137f-433e-9392-85ec6545dc4f" />
<img width="50%" height="50%" alt="img" src="https://github.com/user-attachments/assets/4224e049-5f65-42ad-863e-793012a1e3db" />

