### PR TITLE
Android: Fix missing icons where react-native-paper IconButton is used

### DIFF
--- a/packages/app-mobile/android/app/build.gradle
+++ b/packages/app-mobile/android/app/build.gradle
@@ -146,4 +146,13 @@ dependencies {
     }
 }
 
+project.ext.vectoricons = [
+    iconFontNames: [
+        'MaterialCommunityIcons.ttf',
+        'MaterialIcons.ttf',
+        'FontAwesome.ttf',
+        'Ionicons.ttf'
+    ]
+]
+
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"


### PR DESCRIPTION
In the initial release of the Joplin 3.5 mobile app, there is a regression whereby all icons are missing when implemented via the react-native-paper IconButton component. This is only an issue in the release build for Android, hence why it was not noticed until now, where the first 3.5 release was recently made for the mobile app.

Some examples of usages:
DismissibleDialog.tsx
NoteRevisionViewer.tsx
FileSystemPathSelector.tsx
Note.tsx

In the UI, some examples are that the close button is invisible on the plugin details modal, the search button is missing on the search bar of the plugin screen, and the title expand / collapse icon is missing on the note viewer / editor, eg.:

<img width="409" height="897" alt="3 5plugin" src="https://github.com/user-attachments/assets/d5ce915f-e69d-454a-8aa7-7456d73aae1d" />

This PR addresses this issue by ensuring the required vector icons are bundled with the release build of the android app

### Testing

See screenshots from a release build with the code change on this PR

<img width="411" height="899" alt="3 5pluginfix" src="https://github.com/user-attachments/assets/f6d51b26-dae7-4aaf-97ae-290e22310a9e" />
<img width="413" height="898" alt="3 5fix2" src="https://github.com/user-attachments/assets/decb802a-0966-4568-a836-8060bb20cf6b" />
<img width="413" height="898" alt="3 5fix" src="https://github.com/user-attachments/assets/e933e18f-18ec-42d9-8104-3758816d1002" />