### PR TITLE
Server: Ensure that shared items are processed in the correct order

### DIFF
--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -83,7 +83,7 @@ export default class ChangeModel extends BaseModel<Change> {
 		const startChange: Change = id ? await this.load(id) : null;
 		const query = this.db(this.tableName).select(...this.defaultFields);
 		if (startChange) void query.where('counter', '>', startChange.counter);
-		void query.limit(limit);
+		void query.limit(limit).orderBy('counter', 'asc');
 		let results: Change[] = await query;
 		const hasMore = !!results.length;
 		const cursor = results.length ? results[results.length - 1].id : id;


### PR DESCRIPTION
# Summary

This pull request adds an `ORDER BY counter` to a query. Previously, the order in which changes were processed in some situations was undefined (though on my system, PostgreSQL seems to have returned the changes in the correct order).

As per the PostgreSQL documentation, when no order is specified,
> If ORDER BY is not given, the rows are returned in whatever order the system finds fastest to produce. (See [ORDER BY Clause](https://www.postgresql.org/docs/18/sql-select.html#SQL-ORDERBY) below.)
>
> — https://www.postgresql.org/docs/18/sql-select.html#:~:text=If%20the%20ORDER,below%2E%29

# Testing plan

With PostgreSQL,
1. Run `DELETE FROM key_values WHERE key='ShareService::latestProcessedChange';` to force the share service to re-process all changes.
2. Apply the following patch to `ChangeModel.ts`:
  ```diff
  diff --git a/packages/server/src/models/ChangeModel.ts b/packages/server/src/models/ChangeModel.ts
  index d19f70636..dab9a034d 100644
  --- a/packages/server/src/models/ChangeModel.ts
  +++ b/packages/server/src/models/ChangeModel.ts
  @@ -87,6 +87,15 @@ export default class ChangeModel extends BaseModel<Change> {
 		  let results: Change[] = await query;
 		  const hasMore = !!results.length;
 		  const cursor = results.length ? results[results.length - 1].id : id;
  +
  +		let last = results[0];
  +		for (const item of results) {
  +			if (last.counter > item.counter) {
  +				throw new Error('Results are in the wrong order.');
  +			}
  +			last = item;
  +		}
  +
 		  results = await this.removeDeletedItems(results);
 		  results = await this.compressChanges_(results);
 		  return {
  
  ```
3. Start Joplin Server and verify that there are no "Results are in the wrong order" errors.
   - **Note:** Since the share service is re-processing items, there may be errors similar to "ShareModel: Could not remove a user item because it has already been removed". To show only output containing "wrong order", run `DB_CLIENT=pg yarn start --env dev 2>&1 | grep -i 'wrong order'`.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->