### PR TITLE
Mobile: Prevent opening the edit / delete dialog when long pressing the conflicts notebook

### DIFF
--- a/packages/app-mobile/components/side-menu-content.tsx
+++ b/packages/app-mobile/components/side-menu-content.tsx
@@ -26,6 +26,7 @@ import { StateDecryptionWorker, StateResourceFetcher } from '@joplin/lib/reducer
 import useOnLongPressProps from '../utils/hooks/useOnLongPressProps';
 import { TouchableRipple } from 'react-native-paper';
 import shim from '@joplin/lib/shim';
+import getConflictFolderId from '@joplin/lib/models/utils/getConflictFolderId';
 const { substrWithEllipsis } = require('@joplin/lib/string-utils');
 
 interface Props {
@@ -337,6 +338,8 @@ const SideMenuContentComponent = (props: Props) => {
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const menuItems: any[] = [];
+
+		if (folder && folder.id === getConflictFolderId()) return;
 
 		if (folder && folder.id === getTrashFolderId()) {
 			menuItems.push({


### PR DESCRIPTION
Currently on the mobile app, when the conflicts notebook is present, it is possible to access a delete button on the notebook when long pressing the notebook. Pressing the delete button will do nothing, without prompting any kind of error. You can also access the option to rename the notebook, but you will get an error if you attempt to change it.

https://github.com/user-attachments/assets/25536931-ce75-4572-9686-6135de404a28

This PR prevents opening the edit / delete dialog when long pressing the conflicts notebook, to avoid giving the user options to do actions which don't actually work.

### Testing

See video:

https://github.com/user-attachments/assets/a6814677-2bfe-452e-99d4-244c6fbe62ab
