### PR TITLE
Desktop: Markdown Editor: Collapse selection to a single cursor when pressing "escape"

### DIFF
--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -8,7 +8,7 @@ import {
 	EditorView, drawSelection, highlightSpecialChars, ViewUpdate, Command, rectangularSelection,
 	dropCursor,
 } from '@codemirror/view';
-import { history, undoDepth, redoDepth, standardKeymap, insertTab } from '@codemirror/commands';
+import { history, undoDepth, redoDepth, standardKeymap, insertTab, simplifySelection } from '@codemirror/commands';
 
 import { keymap, KeyBinding } from '@codemirror/view';
 import { searchKeymap } from '@codemirror/search';
@@ -235,6 +235,11 @@ const createEditor = (
 		}, true),
 
 		...standardKeymap, ...historyKeymap, ...searchKeymap,
+
+		// The escape -> simplifySelection mapping is present in "defaultKeymap",
+		// which is disabled on desktop but enabled on mobile. Enable this mapping
+		// globally for consistency:
+		keyCommand('Escape', simplifySelection, true),
 	]));
 
 	const editor = new EditorView({


### PR DESCRIPTION
# Summary

This pull request collapses multiple selections in the Markdown editor to a single selection when pressing <kbd>escape</kbd>. This matches the behavior of the legacy Markdown editor and the Markdown editor in the web/mobile apps.

See [the relevant forum post](https://discourse.joplinapp.org/t/escaping-multiple-cursors-in-the-new-editor/48029).

# Testing plan

Desktop:
1. Create multiple selections in the editor (e.g. by ctrl-clicking).
2. Press <kbd>escape</kbd>.
3. Verify that only a single selection is present.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->