### PR TITLE
Desktop: Fixes #12569: extend auto-pair feature to support fenced code blocks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1025,6 +1025,7 @@ packages/editor/CodeMirror/editorCommands/markdownCommands.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.test.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
+packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.js
 packages/editor/CodeMirror/extensions/biDirectionalTextExtension.js
 packages/editor/CodeMirror/extensions/ctrlClickActionExtension.js
 packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.js

--- a/.gitignore
+++ b/.gitignore
@@ -997,6 +997,7 @@ packages/editor/CodeMirror/editorCommands/markdownCommands.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.test.js
 packages/editor/CodeMirror/editorCommands/sortSelectedLines.js
 packages/editor/CodeMirror/editorCommands/supportsCommand.js
+packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.js
 packages/editor/CodeMirror/extensions/biDirectionalTextExtension.js
 packages/editor/CodeMirror/extensions/ctrlClickActionExtension.js
 packages/editor/CodeMirror/extensions/ctrlClickCheckboxExtension.js

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -18,6 +18,7 @@ import renderingExtension from './extensions/rendering/renderingExtension';
 import { RenderedContentContext } from './extensions/rendering/types';
 import highlightActiveLineExtension from './extensions/highlightActiveLineExtension';
 import renderBlockImages from './extensions/rendering/renderBlockImages';
+import autoCloseFencedCodeBlockExtension from './extensions/autoCloseFencedCodeBlockExtension';
 
 const configFromSettings = (settings: EditorSettings, context: RenderedContentContext) => {
 	const languageExtension = (() => {
@@ -76,6 +77,7 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 	if (settings.automatchBraces) {
 		extensions.push(closeBrackets());
 		extensions.push(keymap.of(closeBracketsKeymap));
+		extensions.push(autoCloseFencedCodeBlockExtension());
 	}
 
 	if (settings.keymap === EditorKeymap.Vim) {

--- a/packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.ts
+++ b/packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.ts
@@ -23,14 +23,14 @@ const autoCloseFencedCodeBlockExtension = () => {
 
 		// Check if we just typed the third backtick in a sequence
 		// Pattern: line starts with exactly two backticks (possibly with leading whitespace)
-		const tripleBacktickMatch = /^(\s*)``$/.test(textBeforeCursor);
+		const match = /^(\s*)``$/.exec(textBeforeCursor);
 
-		if (!tripleBacktickMatch) {
+		if (!match) {
 			return false;
 		}
 
 		// Insert: backtick + newline + three backticks
-		const indent = textBeforeCursor.match(/^(\s*)/)?.[1] || '';
+		const indent = match[1];
 		const insert = `\`\n${indent}\`\`\``;
 
 		const changes = state.changes({

--- a/packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.ts
+++ b/packages/editor/CodeMirror/extensions/autoCloseFencedCodeBlockExtension.ts
@@ -1,0 +1,55 @@
+import { EditorView } from '@codemirror/view';
+import intersectsSyntaxNode from '../utils/isInSyntaxNode';
+
+// Auto-completes fenced code blocks by adding closing backticks after typing three opening backticks
+const autoCloseFencedCodeBlockExtension = () => {
+	return EditorView.inputHandler.of((view: EditorView, from: number, to: number, text: string): boolean => {
+		// Only handle single backtick input
+		if (text !== '`') {
+			return false;
+		}
+
+		const state = view.state;
+		const doc = state.doc;
+
+		// Don't trigger inside lists
+		if (intersectsSyntaxNode(state, { from, to: from }, 'ListItem')) {
+			return false;
+		}
+
+		// Get text before cursor
+		const lineStart = doc.lineAt(from).from;
+		const textBeforeCursor = doc.sliceString(lineStart, from);
+
+		// Check if we just typed the third backtick in a sequence
+		// Pattern: line starts with exactly two backticks (possibly with leading whitespace)
+		const tripleBacktickMatch = /^(\s*)``$/.test(textBeforeCursor);
+
+		if (!tripleBacktickMatch) {
+			return false;
+		}
+
+		// Insert: backtick + newline + three backticks
+		const indent = textBeforeCursor.match(/^(\s*)/)?.[1] || '';
+		const insert = `\`\n${indent}\`\`\``;
+
+		const changes = state.changes({
+			from: from,
+			to: to,
+			insert: insert,
+		});
+
+		// Position cursor right after the third backtick so user can type language identifier
+		const cursorPos = from + 1;
+
+		view.dispatch({
+			changes,
+			selection: { anchor: cursorPos },
+			userEvent: 'input.type',
+		});
+
+		return true;
+	});
+};
+
+export default autoCloseFencedCodeBlockExtension;


### PR DESCRIPTION
## Overview

Addresses #12569 by extending the auto-pair feature to support fenced code blocks. When typing three backticks at the start of a line, the editor automatically inserts closing backticks and positions the cursor for quick language specification

## Implementation notes

This is a very basic implementation:

- Only triggers the auto-completion when typing 3 backticks on line with no preceding (non whitespace) text
- No list handling (there are many edge cases with code blocks in lists, uses intersectsSyntaxNode to completely avoid triggering auto complete fenced code inside lists)
- No change in behavior for selected text (uses the standard closeBrackets behavior, no attempt to wrap multi-line selected text in code blocks for now)

## Testing

- [x] Verify that auto complete of code fence only triggers on line with no preceding text
- [x] Verify that auto complete of code fence doesn't trigger inside lists
- [x] Test normal auto-pair behavior with inline code, quotes, parentheses
- [x] Verify that behavior with selected text is unchanged
- [x] Test with auto-pair disabled and verify behavior is not triggered after typing 3 backticks

## Example

https://github.com/user-attachments/assets/a7c945a7-814a-4a0a-aa48-cc41979349fc

