### PR TITLE
Android: Fixes #13854: Fix missing icons where react-native-paper IconButton is used

### DIFF
--- a/packages/app-mobile/metro.config.js
+++ b/packages/app-mobile/metro.config.js
@@ -102,4 +102,11 @@ const config = {
 	watchFolders: watchedFolders,
 };
 
-module.exports = mergeConfig(defaultConfig, getExpoDefaultConfig(__dirname), config);
+// For release builds of the Android app, do not use the expo default config, as this causes an issue with missing icons
+// See https://github.com/laurent22/joplin/issues/13854
+const isAndroid = process.argv.includes('--platform') && process.argv.includes('android');
+const isRelease = process.argv.includes('--dev') && process.argv.includes('false');
+
+module.exports = isAndroid && isRelease
+	? mergeConfig(defaultConfig, config)
+	: mergeConfig(defaultConfig, getExpoDefaultConfig(__dirname), config);


### PR DESCRIPTION
In the initial release of the Joplin 3.5 mobile app, there is a regression whereby all icons are missing when implemented via the react-native-paper IconButton component. This is only an issue in the release build for Android, hence why it was not noticed until now, where the first 3.5 release was recently made for the mobile app.

The issue relates to the inclusion of getExpoDefaultConfig(__dirname) in the metro configuration (originally added in React Native 0.77 upgrade in PR https://github.com/laurent22/joplin/issues/12179). I made various attempts suggested by AI and [suggestions online](https://stackoverflow.com/questions/72469850/expo-react-native-metro-config-file), to override potentially problematic sections of the default expo config, however none of the suggested solutions were able to resolve the issue. However, what is clear from my testing is that the release build of Android works fine without any obvious issues when completely excluding getExpoDefaultConfig(__dirname), but it is required for the dev build to work. Therefore this PR resolves the issue by excluding this config, but only when building a release build and for the Android app specifically.

The issue is very likely related to issues various users have reported on this GitHub issue https://github.com/expo/expo/issues/21568. On that report, some users have reported the missing icons issue only happening on Android, although a couple of users mentioned it happening on iOS as well. I have not tested whether or not this issue occurs on iOS release builds as well, but if it is also an issue on iOS, this change could potentially be extended to cover iOS as well in a followup PR.

This fixes https://github.com/laurent22/joplin/issues/13854

### Testing

1. Using a modified version of the build-android pipeline which publishes the built apk as a release, I have verified that the built apk installs and loads without any obvious issues, and that the missing icons problem is fixed. See https://github.com/mrjo118/joplin/releases/tag/1765068956
2. At some point since the Joplin 3.4 release, I stopped being able to build Android release apks without modifying the code locally to get it to work on Windows. I had to remove getExpoDefaultConfig(__dirname) in metro.config.js to bypass the build issues. Now I am able to build a release using 'gradlew.bat assembleRelease', with the only modification being supplying valid certificate details, and the resulting apk does not have the missing icon issue
3. I have verified that building and installing a dev build of Joplin still works without issues
4. I verified the web app is unaffected

**Screenshots:**

Before:

<img width="300" height="897" alt="3 5plugin" src="https://github.com/user-attachments/assets/403f108d-0377-4dd7-bb73-e696f148f619" />

After:

<img width="300" height="899" alt="3 5pluginfix" src="https://github.com/user-attachments/assets/ea2fdc2e-6e0f-4356-a9be-019d01510fe3" />