### PR TITLE
Desktop: Fixes #13872: Fix importing HTML links with multi-line `title`s as Markdown

### DIFF
--- a/packages/app-cli/tests/html_to_md/anchor_multiline_title.html
+++ b/packages/app-cli/tests/html_to_md/anchor_multiline_title.html
@@ -1,0 +1,11 @@
+<ul>
+	<li><a href="https://example.com/" title="This
+
+is a test title
+testing!
+
+Test...">Test!</a></li>
+	<li><a href="http://example.com" title="
+Test
+">Another test...</a></li>
+</ul>

--- a/packages/app-cli/tests/html_to_md/anchor_multiline_title.md
+++ b/packages/app-cli/tests/html_to_md/anchor_multiline_title.md
@@ -1,0 +1,5 @@
+- [Test!](https://example.com/ "This
+    is a test title
+    testing!
+    Test...")
+- [Another test...](http://example.com "Test")

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -385,12 +385,13 @@ function filterLinkHref (href) {
   return href
 }
 
-function filterImageTitle(title) {
+function filterTitleAttribute(title) {
   if (!title) return ''
   title = title.trim()
   title = title.replace(/\"/g, '&quot;');
   title = title.replace(/\(/g, '&#40;');
   title = title.replace(/\)/g, '&#41;');
+  title = title.replace(/\n{2,}/g, '\n');
   return title
 }
 
@@ -431,7 +432,7 @@ rules.inlineLink = {
     if (!href) {
       return getNamedAnchorFromLink(node, options) + filterLinkContent(content)
     } else {
-      var title = node.title && node.title !== href ? ' "' + node.title + '"' : ''
+      var title = node.title && node.title !== href ? ' "' + filterTitleAttribute(node.title) + '"' : ''
       if (!href) title = ''
       let output = getNamedAnchorFromLink(node, options) + '[' + filterLinkContent(content) + '](' + href + title + ')'
 
@@ -579,7 +580,7 @@ function imageMarkdownFromAttributes(attributes) {
   var alt = attributes.alt || ''
   var src = filterLinkHref(attributes.src || '')
   var title = attributes.title || ''
-  var titlePart = title ? ' "' + filterImageTitle(title) + '"' : ''
+  var titlePart = title ? ' "' + filterTitleAttribute(title) + '"' : ''
   return src ? '![' + alt.replace(/([[\]])/g, '\\$1') + ']' + '(' + src + titlePart + ')' : ''
 }
 


### PR DESCRIPTION
# Summary

This pull request replaces two or more subsequent newline characters with a single newline character in HTML `title="..."` attributes when converting to Markdown. This fixes an issue in which multiple subsequent newline characters in an HTML `title="..."` attribute could cause part of the `title` content to move to a new paragraph.

Fixes #13872.

# Testing

This pull request includes an automated test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->