### PR TITLE
Mobile: Rich Text Editor: Fix table delete row/delete column buttons can't remove the last row/column from a table

### DIFF
--- a/packages/editor/ProseMirror/plugins/tablePlugin.ts
+++ b/packages/editor/ProseMirror/plugins/tablePlugin.ts
@@ -1,4 +1,4 @@
-import { addColumnAfter, addRowAfter, deleteColumn, deleteRow, tableEditing } from 'prosemirror-tables';
+import { addColumnAfter, addRowAfter, deleteColumn, deleteRow, deleteTable, tableEditing } from 'prosemirror-tables';
 import createFloatingButtonPlugin, { ToolbarType } from './utils/createFloatingButtonPlugin';
 import addColumnRightIcon from '../vendor/icons/addColumnRight';
 import addRowBelowIcon from '../vendor/icons/addRowBelow';
@@ -9,6 +9,13 @@ import { Command } from 'prosemirror-state';
 
 const tableCommand = (command: Command): Command => (state, dispatch, view) => {
 	return command(state, dispatch, view) && focusEditor(state, dispatch, view);
+};
+
+// By default, commands like deleteRow or deleteColumn don't delete the last
+// row/column in the table. This command removes the table when there are no more
+// rows/columns to delete:
+const runCommandOrDeleteTable = (command: Command): Command => (state, dispatch, view) => {
+	return command(state, dispatch, view) || deleteTable(state, dispatch);
 };
 
 const tablePlugin = [
@@ -27,12 +34,12 @@ const tablePlugin = [
 		{
 			icon: removeRowIcon,
 			label: (_) => _('Delete row'),
-			command: () => tableCommand(deleteRow),
+			command: () => tableCommand(runCommandOrDeleteTable(deleteRow)),
 		},
 		{
 			icon: removeColumnIcon,
 			label: (_) => _('Delete column'),
-			command: () => tableCommand(deleteColumn),
+			command: () => tableCommand(runCommandOrDeleteTable(deleteColumn)),
 		},
 	], ToolbarType.FloatAboveBelow),
 ];


### PR DESCRIPTION
# Summary

This pull request fixes an issue where the delete row/delete column buttons could not delete the last row/column of a table.

# Testing plan

Web:
1. Switch to the Rich Text Editor and create a table.
2. Click the "delete row" button until the table has been removed.
3. Repeat steps 1-2 for the "delete column" button.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->