### PR TITLE
Chore: Allow specifying a custom API key at build time

### DIFF
--- a/packages/app-cli/app/command-testing.ts
+++ b/packages/app-cli/app/command-testing.ts
@@ -107,6 +107,7 @@ class Command extends BaseCommand {
 				userContentBaseUrl: () => joplinServerAuth.userContentBaseUrl,
 				username: () => joplinServerAuth.email,
 				password: () => joplinServerAuth.password,
+				apiKey: () => '',
 				session: (): Session => null,
 			});
 

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -178,6 +178,9 @@ const buildStartupTasks = (
 		Setting.setConstant('pluginAssetDir', `${Setting.value('resourceDir')}/pluginAssets`);
 		Setting.setConstant('pluginDir', `${getProfilesRootDir()}/plugins`);
 		Setting.setConstant('pluginDataDir', getPluginDataDir(currentProfile, isSubProfile));
+		Setting.setConstant('sync.9.apiKey', '');
+		Setting.setConstant('sync.10.apiKey', '');
+		Setting.setConstant('sync.11.apiKey', '');
 	});
 	addTask('buildStartupTasks/make resource directory', async () => {
 		await shim.fsDriver().mkdir(Setting.value('resourceDir'));

--- a/packages/lib/JoplinServerApi.ts
+++ b/packages/lib/JoplinServerApi.ts
@@ -16,6 +16,7 @@ interface Options {
 	userContentBaseUrl(): string;
 	username(): string;
 	password(): string;
+	apiKey(): string;
 	session(): Session | null;
 	env?: Env;
 }
@@ -43,7 +44,6 @@ export interface Session {
 }
 
 export default class JoplinServerApi {
-
 	private options_: Options;
 	private session_: Session;
 	private debugRequests_ = false;
@@ -96,6 +96,7 @@ export default class JoplinServerApi {
 			this.session_ = await this.exec_('POST', 'api/sessions', null, {
 				email: this.options_.username(),
 				password: this.options_.password(),
+				apiKey: this.options_.apiKey(),
 				...clientInfo,
 			});
 

--- a/packages/lib/SyncTargetJoplinCloud.ts
+++ b/packages/lib/SyncTargetJoplinCloud.ts
@@ -10,6 +10,7 @@ interface FileApiOptions {
 	userContentPath(): string;
 	username(): string;
 	password(): string;
+	apiKey(): string;
 }
 
 export default class SyncTargetJoplinCloud extends BaseSyncTarget {
@@ -89,6 +90,7 @@ export default class SyncTargetJoplinCloud extends BaseSyncTarget {
 			userContentPath: () => Setting.value('sync.10.userContentPath'),
 			username: () => Setting.value('sync.10.username'),
 			password: () => Setting.value('sync.10.password'),
+			apiKey: () => Setting.value('sync.10.apiKey'),
 		});
 	}
 

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -14,6 +14,7 @@ export interface FileApiOptions {
 	userContentPath(): string;
 	username(): string;
 	password(): string;
+	apiKey(): string;
 }
 
 export async function newFileApi(id: number, options: FileApiOptions) {
@@ -22,6 +23,7 @@ export async function newFileApi(id: number, options: FileApiOptions) {
 		userContentBaseUrl: () => options.userContentPath(),
 		username: () => options.username(),
 		password: () => options.password(),
+		apiKey: () => options.apiKey(),
 		session: (): Session => null,
 		env: Setting.value('env'),
 	};
@@ -148,6 +150,7 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 			userContentPath: () => Setting.value('sync.9.userContentPath'),
 			username: () => Setting.value('sync.9.username'),
 			password: () => Setting.value('sync.9.password'),
+			apiKey: () => Setting.value('sync.9.apiKey'),
 		});
 	}
 

--- a/packages/lib/SyncTargetJoplinServerSAML.ts
+++ b/packages/lib/SyncTargetJoplinServerSAML.ts
@@ -12,6 +12,7 @@ export async function newFileApi(id: number, options: FileApiOptions) {
 		userContentBaseUrl: () => options.userContentPath(),
 		username: () => '',
 		password: () => '',
+		apiKey: () => Setting.value('sync.11.apiKey'),
 		session: () => ({ id: Setting.value('sync.11.id'), user_id: Setting.value('sync.11.userId') }),
 		env: Setting.value('env'),
 	};
@@ -128,6 +129,7 @@ export default class SyncTargetJoplinServerSAML extends SyncTargetJoplinServer {
 			userContentPath: () => Setting.value('sync.11.userContentPath'),
 			username: () => '',
 			password: () => '',
+			apiKey: () => Setting.value('sync.11.apiKey'),
 		};
 		return initFileApi(SyncTargetJoplinServerSAML.id(), this.logger(), this.lastFileApiOptions_);
 	}

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -61,6 +61,10 @@ export interface Constants {
 	syncVersion: number;
 	startupDevPlugins: string[];
 	isSubProfile: boolean;
+
+	'sync.9.apiKey': string;
+	'sync.10.apiKey': string;
+	'sync.11.apiKey': string;
 }
 
 interface SettingSections {
@@ -296,6 +300,10 @@ class Setting extends BaseModel {
 		syncVersion: 3,
 		startupDevPlugins: [],
 		isSubProfile: false,
+
+		'sync.9.apiKey': '',
+		'sync.10.apiKey': '',
+		'sync.11.apiKey': '',
 	};
 
 	public static autoSaveEnabled = true;

--- a/packages/lib/services/joplinCloudUtils.ts
+++ b/packages/lib/services/joplinCloudUtils.ts
@@ -103,7 +103,7 @@ export const checkIfLoginWasSuccessful = async (applicationsUrl: string) => {
 
 		const response = await fetch(applicationsUrl, {
 			headers: {
-				'X-JOPLIN-CUSTOM-API-KEY': '',
+				'X-JOPLIN-CUSTOM-API-KEY': Setting.value('sync.10.apiKey'),
 			},
 		});
 		const jsonBody = await response.json();

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -86,6 +86,7 @@ export default class ShareService {
 			userContentBaseUrl: () => Setting.value(`sync.${syncTargetId}.userContentPath`),
 			username: () => Setting.value(`sync.${syncTargetId}.username`),
 			password: () => Setting.value(`sync.${syncTargetId}.password`),
+			apiKey: () => Setting.value(`sync.${syncTargetId}.apiKey`),
 			session: () => {
 				if (syncTargetId === 11) {
 					return {

--- a/packages/lib/testing/test-utils.ts
+++ b/packages/lib/testing/test-utils.ts
@@ -706,6 +706,7 @@ async function initFileApi() {
 			userContentBaseUrl: () => joplinServerAuth.userContentBaseUrl,
 			username: () => joplinServerAuth.email,
 			password: () => joplinServerAuth.password,
+			apiKey: () => '',
 			session: (): Session => null,
 		});
 

--- a/packages/tools/fuzzer/Server.ts
+++ b/packages/tools/fuzzer/Server.ts
@@ -15,6 +15,7 @@ const createApi = async (serverUrl: string, adminAuth: UserData) => {
 		password: () => adminAuth.password,
 		username: () => adminAuth.email,
 		session: ()=>null,
+		apiKey: ()=>'',
 		env: Env.Dev,
 	});
 	await api.loadSession();


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/laurent22/joplin/commit/364bdd9bb0e84e25e72a8e99cc2a8d0784d79e97. This change adds support for sending an `apiKey` to Joplin Cloud/Server when creating a session (in addition to when creating an account).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->