### PR TITLE
Mobile: Accessibility: Dark mode: Improve contrast of conflicts notebook title, error messages in "Logs"

### DIFF
--- a/packages/lib/themes/dark.ts
+++ b/packages/lib/themes/dark.ts
@@ -13,7 +13,7 @@ const theme: Theme = {
 	backgroundColorTransparent: 'rgba(255,255,255,0.9)',
 	oddBackgroundColor: '#141517',
 	color: '#dddddd',
-	colorError: 'red',
+	colorError: '#ff4444',
 	colorCorrect: '#72b972',
 	colorWarn: '#9A5B00',
 	colorWarnUrl: '#ffff82',


### PR DESCRIPTION
# Summary

In dark mode, this pull request brings the mobile conflicts folder title and error message text to 4.79:1 contrast **when unselected**.
 - Previously, these components had [4.08:1](https://webaim.org/resources/contrastchecker/?fcolor=FF0000&bcolor=1D2024) contrast in dark mode, which is less than the [4.5:1 contrast ratio required by the WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/#contrast-minimum).

# Screenshots

## Conflicts folder

**Before** (4.08:1): 
<img width="335" height="65" alt="text: conflicts" src="https://github.com/user-attachments/assets/aaf82974-10ef-4901-9a12-753ef7f3cca1" />
**After** (4.79:1): 
<img width="335" height="65" alt="text: conflicts" src="https://github.com/user-attachments/assets/d3e842f3-0353-41a9-9bcc-7e454654d819" />

## Log screen

**Before** (4.08:1): 
<img width="636" height="186" alt="screenshot: Log screen, including a 'Synchronizer: TypeError: Failed to fetch' error. The error is in red" src="https://github.com/user-attachments/assets/e8ee91d0-52a7-4d90-86e3-86ebb205cd06" />

**After** (4.79:1): 
<img width="636" height="186" alt="screenshot: Log screen, including a 'Synchronizer: TypeError: Failed to fetch' error. The error is in slightly-brighter red" src="https://github.com/user-attachments/assets/f52673ef-2341-4272-a939-5e46253e5522" />


# Notes

- **This does not resolve #13437**: The conflicts notebook still has low ([1.81:1](https://webaim.org/resources/contrastchecker/?fcolor=FF4444&bcolor=616161)) contrast when selected:
  <img width="483" height="415" alt="image" src="https://github.com/user-attachments/assets/a68f9190-1acd-4f6d-bd73-d349b7044c47" />
- One way to resolve #13437 would be to adjust the background color of the selection. However, doing so makes it difficult to see which items are selected on desktop. For example, setting the `selectedColor` to `#484848` results in [1.42:1](https://webaim.org/resources/contrastchecker/?fcolor=484848&bcolor=2E3138) contrast:
  <img width="483" height="415" alt="screenshot: Low contrast between selection and note list" src="https://github.com/user-attachments/assets/09daf12e-8a85-4784-a33f-52f5a9fbce36" />
   - [The WCAG requires non-text content](https://webaim.org/articles/contrast/#sc1411) in many cases to have at least 3:1 contrast.
   - Refactoring may be necessary to allow fixing conflicts folder contrast issues, without also causing contrast issues on desktop.
- Further adjustments may be necessary to improve contrast in light mode.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->