### PR TITLE
Desktop: Fix search markers vanish when moving focus to a secondary window

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -50,7 +50,7 @@ import WarningBanner from './WarningBanner/WarningBanner';
 import UserWebview from '../../services/plugins/UserWebview';
 import Logger from '@joplin/utils/Logger';
 import usePluginEditorView from './utils/usePluginEditorView';
-import { stateUtils } from '@joplin/lib/reducer';
+import { defaultWindowId, stateUtils } from '@joplin/lib/reducer';
 import { WindowIdContext } from '../NewWindowOrIFrame';
 import useResourceUnwatcher from './utils/useResourceUnwatcher';
 import StatusBar from './StatusBar';
@@ -722,6 +722,8 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		bodyEditor = 'CodeMirror5';
 	}
 
+	const mainWindowState = stateUtils.windowStateById(state, defaultWindowId);
+
 	return {
 		noteId,
 		bodyEditor,
@@ -740,7 +742,9 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		customCss: state.customViewerCss,
 		noteVisiblePanes: windowState.noteVisiblePanes,
 		watchedResources: windowState.watchedResources,
-		highlightedWords: state.highlightedWords,
+		// For now, only the main window has search UI. Show the same search markers in all
+		// windows:
+		highlightedWords: mainWindowState.highlightedWords,
 		plugins: state.pluginService.plugins,
 		pluginHtmlContents: state.pluginService.pluginHtmlContents,
 		toolbarButtonInfos: toolbarButtonUtils.commandsToToolbarButtons([

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -3,7 +3,7 @@ import Logger, { TargetType, LoggerWrapper } from '@joplin/utils/Logger';
 import shim from './shim';
 const { setupProxySettings } = require('./shim-init-node');
 import BaseService from './services/BaseService';
-import reducer, { defaultWindowId, getNotesParent, serializeNotesParent, setStore, State } from './reducer';
+import reducer, { getNotesParent, serializeNotesParent, setStore, State } from './reducer';
 import KeychainServiceDriverNode from './services/keychain/KeychainServiceDriver.node';
 import KeychainServiceDriverElectron from './services/keychain/KeychainServiceDriver.electron';
 import { setLocale } from './locale';
@@ -263,16 +263,10 @@ export default class BaseApplication {
 			}
 		}
 
-		// Currently, the parent type is per-window, while the set of highlighted search terms
-		// is global. To avoid clearing the global set of highlighted terms when switching to a
-		// secondary window (where parentType != search), only update which terms are highlighted
-		// when the main window has focus.
-		if (state.windowId === defaultWindowId) {
-			this.store().dispatch({
-				type: 'SET_HIGHLIGHTED',
-				words: highlightedWords,
-			});
-		}
+		this.store().dispatch({
+			type: 'SET_HIGHLIGHTED',
+			words: highlightedWords,
+		});
 
 		this.store().dispatch({
 			type: 'SEARCH_RESULTS_SET',

--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -3,7 +3,7 @@ import Logger, { TargetType, LoggerWrapper } from '@joplin/utils/Logger';
 import shim from './shim';
 const { setupProxySettings } = require('./shim-init-node');
 import BaseService from './services/BaseService';
-import reducer, { getNotesParent, serializeNotesParent, setStore, State } from './reducer';
+import reducer, { defaultWindowId, getNotesParent, serializeNotesParent, setStore, State } from './reducer';
 import KeychainServiceDriverNode from './services/keychain/KeychainServiceDriver.node';
 import KeychainServiceDriverElectron from './services/keychain/KeychainServiceDriver.electron';
 import { setLocale } from './locale';
@@ -263,10 +263,16 @@ export default class BaseApplication {
 			}
 		}
 
-		this.store().dispatch({
-			type: 'SET_HIGHLIGHTED',
-			words: highlightedWords,
-		});
+		// Currently, the parent type is per-window, while the set of highlighted search terms
+		// is global. To avoid clearing the global set of highlighted terms when switching to a
+		// secondary window (where parentType != search), only update which terms are highlighted
+		// when the main window has focus.
+		if (state.windowId === defaultWindowId) {
+			this.store().dispatch({
+				type: 'SET_HIGHLIGHTED',
+				words: highlightedWords,
+			});
+		}
 
 		this.store().dispatch({
 			type: 'SEARCH_RESULTS_SET',

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -91,6 +91,8 @@ export interface WindowState {
 	selectedItemType: string;
 	selectedSmartFilterId: string;
 
+	highlightedWords: string[];
+
 	backwardHistoryNotes: NoteEntity[];
 	forwardHistoryNotes: NoteEntity[];
 	lastSelectedNotesIds: StateLastSelectedNotesIds;
@@ -113,6 +115,7 @@ export const defaultWindowState: WindowState = {
 	selectedSmartFilterId: null,
 	selectedItemType: 'note',
 	selectedNoteTags: [],
+	highlightedWords: [],
 	backwardHistoryNotes: [],
 	forwardHistoryNotes: [],
 	lastSelectedNotesIds: {
@@ -138,7 +141,6 @@ export interface State extends WindowState {
 	notLoadedMasterKeys: string[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	searches: any[];
-	highlightedWords: string[];
 	showSideMenu: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	screens: any;


### PR DESCRIPTION
# Summary

Previously, highlighted search terms would vanish when moving focus from the primary to a secondary window. With this change, secondary windows continue to highlight the search terms from the primary window, when selected.

Follow-up to a [change](https://github.com/laurent22/joplin/issues/13399#issuecomment-3509397881) that mostly resolved #13399.

# Screen recording

[Screencast from 2025-12-16 16-21-06.webm](https://github.com/user-attachments/assets/9a979c44-e3f0-4340-baa0-5fbcfffb5494)


The above screen recording shows:
- Moving focus between multiple windows.
    - The highlighted search terms remain the same.
- Changing the search query from the main window.
    - The highlighted search terms update in the secondary windows and the main window.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->