### PR TITLE
Desktop: Editor plugins: Fix error logged when pressing enter and a plugin-created input is focused

### DIFF
--- a/packages/app-desktop/services/plugins/UserWebview.tsx
+++ b/packages/app-desktop/services/plugins/UserWebview.tsx
@@ -29,12 +29,9 @@ export interface Props {
 	borderBottom?: boolean;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	theme?: any;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onSubmit?: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onDismiss?: Function;
-	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
-	onReady?: Function;
+	onSubmit?: ()=> void;
+	onDismiss?: ()=> void;
+	onReady?: ()=> void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/app-desktop/services/plugins/hooks/useSubmitHandler.ts
+++ b/packages/app-desktop/services/plugins/hooks/useSubmitHandler.ts
@@ -1,13 +1,14 @@
 import { RefObject } from 'react';
 import useMessageHandler from './useMessageHandler';
 
-// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-export default function(viewRef: RefObject<HTMLIFrameElement>, onSubmit: Function, onDismiss: Function) {
+type OnEvent = ()=> void;
+
+export default function(viewRef: RefObject<HTMLIFrameElement>, onSubmit: OnEvent, onDismiss: OnEvent) {
 	useMessageHandler(viewRef, event => {
 		const message = event.data?.message;
-		if (message === 'form-submit') {
+		if (message === 'form-submit' && onSubmit) {
 			onSubmit();
-		} else if (message === 'dismiss') {
+		} else if (message === 'dismiss' && onDismiss) {
 			onDismiss();
 		}
 	});


### PR DESCRIPTION
# Summary

Currently, pressing <kbd>enter</kbd> within an `<input>` within a plugin webview sends a `form-submit` event to the main process. This is handled here:

https://github.com/laurent22/joplin/blob/e626db3b8c3a0bf2a4ee44b4d1a8a4a68ffde9fb/packages/app-desktop/services/plugins/hooks/useSubmitHandler.ts#L8-L9

If there is no `onSubmit` handler registered for the WebView (as is the case for editor UI webviews), this throws an "is not a function" exception.

> [!NOTE]
>
> This probably won't fix<span><!----></span> #13669. The error is thrown in an event handler in the main process, which shouldn't prevent YesYouKan's save logic from running.

# Testing plan

1. Start Joplin.
3. Create a Kanban board.
4. Double-click on the title of a column.
5. Change the title.
6. Press <kbd>enter</kbd>.
7. Verify that no "is not a function" error is included in the log.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->