### PR TITLE
Clipper: Support importing math from Wikipedia and other websites

### DIFF
--- a/packages/app-cli/tests/html_to_md/wikipedia_math_inline.html
+++ b/packages/app-cli/tests/html_to_md/wikipedia_math_inline.html
@@ -71,4 +71,4 @@
     </mrow>
     <annotation encoding="application/x-tex">{\displaystyle f(n)={\begin{cases}n/2&amp;{\text{if }}n\equiv 0{\pmod {2}},\\3n+1&amp;{\text{if }}n\equiv 1{\pmod {2}}.\end{cases}}}</annotation>
   </semantics>
-</math></span>
+</math></span><img src="/some/src/here" class="mwe-math-fallback-image-display mw-invert skin-invert" aria-hidden="true" style="vertical-align: -3.171ex; width:45.735ex; height:7.509ex;"/>

--- a/packages/app-cli/tests/html_to_md/wikipedia_math_inline.html
+++ b/packages/app-cli/tests/html_to_md/wikipedia_math_inline.html
@@ -1,0 +1,74 @@
+<!-- From https://en.wikipedia.org/wiki/Collatz_conjecture -->
+<math display="block" xmlns="http://www.w3.org/1998/Math/MathML" alttext="{\displaystyle f(n)={\begin{cases}n/2&amp;{\text{if }}n\equiv 0{\pmod {2}},\\3n+1&amp;{\text{if }}n\equiv 1{\pmod {2}}.\end{cases}}}">
+  <semantics>
+    <mrow class="MJX-TeXAtom-ORD">
+      <mstyle displaystyle="true" scriptlevel="0">
+        <mi>f</mi>
+        <mo stretchy="false">(</mo>
+        <mi>n</mi>
+        <mo stretchy="false">)</mo>
+        <mo>=</mo>
+        <mrow class="MJX-TeXAtom-ORD">
+          <mrow>
+            <mo>{</mo>
+            <mtable columnalign="left left" rowspacing=".2em" columnspacing="1em" displaystyle="false">
+              <mtr>
+                <mtd>
+                  <mi>n</mi>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mo>/</mo>
+                  </mrow>
+                  <mn>2</mn>
+                </mtd>
+                <mtd>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mtext>if&nbsp;</mtext>
+                  </mrow>
+                  <mi>n</mi>
+                  <mo>\u2261</mo>
+                  <mn>0</mn>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0.444em"></mspace>
+                    <mo stretchy="false">(</mo>
+                    <mi>mod</mi>
+                    <mspace width="0.333em"></mspace>
+                    <mn>2</mn>
+                    <mo stretchy="false">)</mo>
+                  </mrow>
+                  <mo>,</mo>
+                </mtd>
+              </mtr>
+              <mtr>
+                <mtd>
+                  <mn>3</mn>
+                  <mi>n</mi>
+                  <mo>+</mo>
+                  <mn>1</mn>
+                </mtd>
+                <mtd>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mtext>if&nbsp;</mtext>
+                  </mrow>
+                  <mi>n</mi>
+                  <mo>\u2261</mo>
+                  <mn>1</mn>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0.444em"></mspace>
+                    <mo stretchy="false">(</mo>
+                    <mi>mod</mi>
+                    <mspace width="0.333em"></mspace>
+                    <mn>2</mn>
+                    <mo stretchy="false">)</mo>
+                  </mrow>
+                  <mo>.</mo>
+                </mtd>
+              </mtr>
+            </mtable>
+            <mo fence="true" stretchy="true" symmetric="true"></mo>
+          </mrow>
+        </mrow>
+      </mstyle>
+    </mrow>
+    <annotation encoding="application/x-tex">{\displaystyle f(n)={\begin{cases}n/2&amp;{\text{if }}n\equiv 0{\pmod {2}},\\3n+1&amp;{\text{if }}n\equiv 1{\pmod {2}}.\end{cases}}}</annotation>
+  </semantics>
+</math></span>

--- a/packages/app-cli/tests/html_to_md/wikipedia_math_inline.md
+++ b/packages/app-cli/tests/html_to_md/wikipedia_math_inline.md
@@ -1,0 +1,1 @@
+${\displaystyle f(n)={\begin{cases}n/2&{\text{if }}n\equiv 0{\pmod {2}},\\3n+1&{\text{if }}n\equiv 1{\pmod {2}}.\end{cases}}}$

--- a/packages/app-clipper/content_scripts/index.js
+++ b/packages/app-clipper/content_scripts/index.js
@@ -165,6 +165,10 @@
 				if (a && a.toLowerCase().indexOf('math/tex') >= 0) isVisible = true;
 			}
 
+			if (nodeName === 'annotation') {
+				if (node.getAttribute('encoding') === 'application/x-tex') isVisible = true;
+			}
+
 			if (nodeName === 'source' && nodeParentName === 'picture') {
 				isVisible = false;
 			}

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -775,6 +775,55 @@ rules.mathjaxScriptBlock = {
 // ===============================================================================
 
 // ===============================================================================
+// MathML support (Wikipedia & KaTeX math)
+// ===============================================================================
+
+// Returns the contents of a <semantics><annotation>...</annotation></semantics> within
+// a math block.
+const getSourceText = (mathNode) => {
+  const semantics = findFirstDescendant(mathNode, 'nodeName', 'semantics');
+  if (!semantics) return '';
+
+  const annotation = findFirstDescendant(semantics, 'nodeName', 'annotation');
+  if (!annotation) return '';
+  return annotation.textContent;
+};
+
+rules.mathMlScriptBlock = {
+  filter: function (node) {
+    return node.nodeName === 'math' && !!getSourceText(node);
+  },
+
+  escapeContent: function() {
+    return false;
+  },
+
+  replacement: function (_content, node, _options) {
+    return '$' + getSourceText(node) + '$';
+  }
+};
+
+// Math renderers often include:
+// - MathML
+// - Stylized display HTML for browsers that don't suppport MathML.
+//
+// Joplin usually can't properly import the display HTML (and the MathML can usually
+// be imported separately). Skip it:
+rules.ignoreMathDisplay = {
+  filter: function (node) {
+    const hidden = node.getAttribute('aria-hidden') === 'true';
+    const hasClass = (className) => node.classList.contains(className);
+
+    const isWikipediaMathFallback = node.nodeName === 'IMG' && hasClass('mwe-math-fallback-image-display') && hidden;
+    const isKatexDisplay = node.nodeName === 'SPAN' && hasClass('katex-html') && hidden;
+    return isWikipediaMathFallback || isKatexDisplay;
+  },
+
+  replacement: () => '',
+};
+
+
+// ===============================================================================
 // Joplin "noMdConv" support
 // 
 // Tags that have the class "jop-noMdConv" are not converted to Markdown

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -177,6 +177,27 @@ rules.resourcePlaceholder = {
   }
 }
 
+// Math renderers often include:
+// - MathML
+// - Stylized display HTML for browsers that don't suppport MathML.
+//
+// Joplin usually can't properly import the display HTML (and the MathML can usually
+// be imported separately). Skip it:
+rules.ignoreMathDisplay = {
+  filter: function (node) {
+    const hidden = node.getAttribute('aria-hidden') === 'true';
+    const hasClass = (className) => node.classList.contains(className);
+
+    const isWikipediaMathFallback = node.nodeName === 'IMG' && (
+      hasClass('mwe-math-fallback-image-display') || hasClass('mwe-math-fallback-image-inline')
+    ) && hidden;
+    const isKatexDisplay = node.nodeName === 'SPAN' && hasClass('katex-html') && hidden;
+    return isWikipediaMathFallback || isKatexDisplay;
+  },
+
+  replacement: () => '',
+};
+
 // ==============================
 // END Joplin format support
 // ==============================
@@ -802,26 +823,6 @@ rules.mathMlScriptBlock = {
     return '$' + getSourceText(node) + '$';
   }
 };
-
-// Math renderers often include:
-// - MathML
-// - Stylized display HTML for browsers that don't suppport MathML.
-//
-// Joplin usually can't properly import the display HTML (and the MathML can usually
-// be imported separately). Skip it:
-rules.ignoreMathDisplay = {
-  filter: function (node) {
-    const hidden = node.getAttribute('aria-hidden') === 'true';
-    const hasClass = (className) => node.classList.contains(className);
-
-    const isWikipediaMathFallback = node.nodeName === 'IMG' && hasClass('mwe-math-fallback-image-display') && hidden;
-    const isKatexDisplay = node.nodeName === 'SPAN' && hasClass('katex-html') && hidden;
-    return isWikipediaMathFallback || isKatexDisplay;
-  },
-
-  replacement: () => '',
-};
-
 
 // ===============================================================================
 // Joplin "noMdConv" support


### PR DESCRIPTION
# Summary

Wikipedia and KaTeX both embed the original KaTeX source for math expressions within `<semantics><annotation encoding="application/x-tex">...</annotation></semantics>` blocks. This pull request adds support for importing math expressions that follow this format.

> [!NOTE]
>
> To prevent `<annotation encoding="application/x-tex">`s from being removed from the HTML during pre-processing, this pull request modifies the web clipper content script. Previously, the web clipper content script marked these annotations for removal.

# Testing

Import https://en.wikipedia.org/wiki/Collatz_conjecture as Markdown (full page). Verify that the math formulas are imported successfully and that the (broken) image links aren't.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->