### PR TITLE
Mobile: Fixes #13081: Rich Text Editor: Fix checklists saved with extra space

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.test.tsx
@@ -215,8 +215,7 @@ describe('RichTextEditor', () => {
 		firstCheckbox.click();
 
 		await waitFor(async () => {
-			// At present, lists are saved as non-tight lists:
-			expect(body.trim()).toBe('- [x] Test\n    \n- [x] Another test');
+			expect(body.trim()).toBe('- [x] Test\n- [x] Another test');
 		});
 	});
 
@@ -433,8 +432,14 @@ describe('RichTextEditor', () => {
 		expect(editor.textContent).toContain('3^2 + 4^2 = 5^2');
 	});
 
-	it('should save lists as single-spaced', async () => {
-		let body = 'Test:\n\n- this\n- is\n- a\n- test.';
+	it.each(['-', '- [ ]'])('should save lists as single-spaced (list markers: %j)', async (marker) => {
+		let body = [
+			'Test:\n',
+			'this',
+			'is',
+			'a',
+			'test.',
+		].join(`\n${marker} `);
 
 		render(<WrappedEditor
 			noteBody={body}
@@ -445,7 +450,13 @@ describe('RichTextEditor', () => {
 		mockTyping(window, ' Testing');
 
 		await waitFor(async () => {
-			expect(body.trim()).toBe('Test:\n\n- this\n- is\n- a\n- test. Testing');
+			expect(body.trim()).toBe([
+				'Test:\n',
+				'this',
+				'is',
+				'a',
+				'test. Testing',
+			].join(`\n${marker} `));
 		});
 	});
 

--- a/packages/editor/ProseMirror/utils/postprocessEditorOutput.test.ts
+++ b/packages/editor/ProseMirror/utils/postprocessEditorOutput.test.ts
@@ -31,4 +31,30 @@ describe('postprocessEditorOutput', () => {
 			`),
 		);
 	});
+
+	// Removing extra space around checklist item content prevents extra space from being
+	// added when converting from HTML to Markdown
+	test('should remove wrapper paragraphs from around checklist items', () => {
+		const doc = new DOMParser().parseFromString(`
+			<body>
+				<ul>
+					<li><input><div><p>Should remove single wrapper paragraphs to avoid extra newlines when saving as Markdown.</p></div></li>
+					<li><input><div><p>Should not remove paragraphs...</p><p>...when there are multiple.</p></div></li>
+				</ul>
+			</body>
+		`, 'text/html');
+
+		const output = postprocessEditorOutput(doc.body);
+
+		expect(
+			normalizeHtmlString(output.querySelector('ul').outerHTML),
+		).toBe(
+			normalizeHtmlString(`
+				<ul>
+					<li><input><span>Should remove single wrapper paragraphs to avoid extra newlines when saving as Markdown.</span></li>
+					<li><input><div><p>Should not remove paragraphs...</p><p>...when there are multiple.</p></div></li>
+				</ul>
+			`),
+		);
+	});
 });


### PR DESCRIPTION
# Summary

Fixes #13081. Previously, the mobile Rich Text Editor added extra newlines when saving checklists.

# Testing

## Automated testing

This pull request adds two automated tests:
- An integration test verifies that editing a checklist does not add extra newlines to the end of each item.
- A unit test verifies that the editor content postprocessor correctly converts `<li><input><div><p>Should remove single wrapper paragraphs to avoid extra newlines when saving as Markdown.</p></div></li>` (which Turndown saves with extra newlines) to `<li><input><span>Should remove single wrapper paragraphs to avoid extra newlines when saving as Markdown.</span></li>` (which Turndown saves correctly).

## Manual testing

[Screencast from 2025-12-18 10-21-09.webm](https://github.com/user-attachments/assets/69ddfadd-8929-4191-b1a3-5785e27da440)

The above screen recording shows:
1. Creating a checklist with nested list items in the Rich Text Editor.
2. Switching to the Markdown editor.
   - The saved list contains extra blank lines, but only when changing the indentation level.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->