### PR TITLE
Mobile: Rich Text Editor: Set the default math/code block content to the selection

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1155,6 +1155,7 @@ packages/editor/ProseMirror/utils/dom/showModal.js
 packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.js
 packages/editor/ProseMirror/utils/extractSelectedLinesTo.js
 packages/editor/ProseMirror/utils/forEachHeading.js
+packages/editor/ProseMirror/utils/getTextBetween.js
 packages/editor/ProseMirror/utils/insertRenderedMarkdown.js
 packages/editor/ProseMirror/utils/jumpToHash.js
 packages/editor/ProseMirror/utils/makeLinksClickableInElement.js

--- a/.gitignore
+++ b/.gitignore
@@ -1127,6 +1127,7 @@ packages/editor/ProseMirror/utils/dom/showModal.js
 packages/editor/ProseMirror/utils/extractSelectedLinesTo.test.js
 packages/editor/ProseMirror/utils/extractSelectedLinesTo.js
 packages/editor/ProseMirror/utils/forEachHeading.js
+packages/editor/ProseMirror/utils/getTextBetween.js
 packages/editor/ProseMirror/utils/insertRenderedMarkdown.js
 packages/editor/ProseMirror/utils/jumpToHash.js
 packages/editor/ProseMirror/utils/makeLinksClickableInElement.js

--- a/packages/editor/ProseMirror/commands/commands.ts
+++ b/packages/editor/ProseMirror/commands/commands.ts
@@ -92,7 +92,10 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 
 		if (canReplaceSelectionWith(state.selection, nodeType)) {
 			if (view) {
-				return showCreateEditablePrompt(block ? '$$\n\t...\n$$' : '$...$', !block)(state, dispatch, view);
+				const content = selectedText || '...';
+				return showCreateEditablePrompt(
+					block ? `$$\n\t${content}\n$$` : `$${content}$`, !block,
+				)(state, dispatch, view);
 			}
 			return true;
 		}
@@ -135,7 +138,10 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 		return true;
 	},
 	[EditorCommandType.InsertCodeBlock]: (state, dispatch, view) => {
-		return showCreateEditablePrompt('```\n\n```', false)(state, dispatch, view);
+		const selectedText = state.doc.textBetween(state.selection.from, state.selection.to);
+		return showCreateEditablePrompt(
+			`\`\`\`\n${selectedText}\n\`\`\``, false,
+		)(state, dispatch, view);
 	},
 	[EditorCommandType.ToggleSearch]: (state, dispatch, view) => {
 		const command = setSearchVisible(!getSearchVisible(state));

--- a/packages/editor/ProseMirror/commands/commands.ts
+++ b/packages/editor/ProseMirror/commands/commands.ts
@@ -15,6 +15,7 @@ import jumpToHash from '../utils/jumpToHash';
 import focusEditor from './focusEditor';
 import canReplaceSelectionWith from '../utils/canReplaceSelectionWith';
 import showCreateEditablePrompt from '../plugins/joplinEditablePlugin/showCreateEditablePrompt';
+import getTextBetween from '../utils/getTextBetween';
 
 type Dispatch = (tr: Transaction)=> void;
 type ExtendedCommand = (state: EditorState, dispatch: Dispatch, view?: EditorView, options?: string[])=> boolean;
@@ -86,7 +87,7 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 	[EditorCommandType.ToggleItalicized]: toggleMark(schema.marks.emphasis),
 	[EditorCommandType.ToggleCode]: toggleCode,
 	[EditorCommandType.ToggleMath]: (state, dispatch, view) => {
-		const selectedText = state.doc.textBetween(state.selection.from, state.selection.to);
+		const selectedText = getTextBetween(state.doc, state.selection.from, state.selection.to);
 		const block = selectedText.includes('\n');
 		const nodeType = block ? schema.nodes.joplinEditableBlock : schema.nodes.joplinEditableInline;
 
@@ -138,7 +139,7 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 		return true;
 	},
 	[EditorCommandType.InsertCodeBlock]: (state, dispatch, view) => {
-		const selectedText = state.doc.textBetween(state.selection.from, state.selection.to);
+		const selectedText = getTextBetween(state.doc, state.selection.from, state.selection.to);
 		return showCreateEditablePrompt(
 			`\`\`\`\n${selectedText}\n\`\`\``, false,
 		)(state, dispatch, view);

--- a/packages/editor/ProseMirror/schema.ts
+++ b/packages/editor/ProseMirror/schema.ts
@@ -161,6 +161,7 @@ const nodes = addDefaultToplevelAttributes({
 		inline: true,
 		group: 'inlineBreak',
 		selectable: false,
+		leafText: () => '\n',
 		parseDOM: [{ tag: 'br' }],
 		toDOM: () => domOutputSpecs.br,
 	},

--- a/packages/editor/ProseMirror/utils/getTextBetween.ts
+++ b/packages/editor/ProseMirror/utils/getTextBetween.ts
@@ -1,0 +1,8 @@
+import { Node } from 'prosemirror-model';
+
+const getTextBetween = (doc: Node, from: number, to: number) => {
+	const blockSeparator = '\n\n';
+	return doc.textBetween(from, to, blockSeparator);
+};
+
+export default getTextBetween;


### PR DESCRIPTION
# Summary

This pull request sets the default content of the mobile Rich Text Editor's code/math editor to the content of the selection. This makes it easier to convert existing text to a code or math block.

Prior to https://github.com/laurent22/joplin/pull/13776, selecting text and clicking the "math" button would create a math block from the selected text. After #13776, the same action opens an editor window with the content `$...$`.

# Screen recording

[Screencast from 2025-12-18 10-56-48.webm](https://github.com/user-attachments/assets/d835ec47-7f93-41fd-a324-c1a9cfc41345)

The above screen recording shows:
- Creating a math block by selecting content and clicking the "Σ" button.
- Creating a code block by selecting content and clicking the "<>" button.
- Creating inline math by selecting content and clicking the "Σ" button.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->