### PR TITLE
Web: Note viewer: Fix assets from development plugins don't load

### DIFF
--- a/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
@@ -217,21 +217,19 @@ const useWebViewSetup = (props: Props): Result => {
 					if (assetPath.startsWith('pluginAssets/')) { // Built-in plugin asset
 						assetPath = assetPath.replace(/^pluginAssets\//, '');
 
-						// Ensures that the assetPath actually points to a file within the assets
-						// directory:
 						const fullPath = shim.fsDriver().resolveRelativePathWithinDir(
 							Setting.value('pluginAssetDir'), assetPath,
 						);
 						return shim.fsDriver().fileAtPath(fullPath);
-					} else { // Asset from an installed plugin
-						// User-installed plugins
-						const possibleBasePaths = [Setting.value('cacheDir')];
-						// Development plugins
+					} else { // Asset from an installed/development plugin
+						// User-installed plugins are stored in cacheDir
+						const allowedBasePaths = [Setting.value('cacheDir')];
+						// Development plugins are stored in other locations. Add them separately:
 						if (Setting.value('plugins.devPluginPaths')) {
-							possibleBasePaths.push(...Setting.value('plugins.devPluginPaths').split(','));
+							allowedBasePaths.push(...Setting.value('plugins.devPluginPaths').split(','));
 						}
 
-						for (const basePath of possibleBasePaths) {
+						for (const basePath of allowedBasePaths) {
 							const resolved = resolvePathWithinDir(basePath, assetPath);
 							if (resolved) {
 								return shim.fsDriver().fileAtPath(resolved);


### PR DESCRIPTION
# Summary

This pull request refactors `readAssetBlob`. This fixes two issues:
- Assets from renderer [development plugins](https://joplinapp.org/help/api/references/mobile_plugin_debugging#web-automatic-reloading) failed to load.
- In secondary profiles, the web app sometimes failed to load KaTeX, Mermaid, and similar resources.
   - This was observed locally with a dev-mode instance of Joplin, but I was unable to reproduce the issue with a release build.

# Details

`readAssetBlob` is responsible for loading plugin assets for both built-in (e.g. the Mermaid.js renderer) and 3rd-party plugins on web. It previously only allowed reading files in `Setting.value('resourceDir')` (for plugin assets) or `Setting.value('cacheDir')` (for installed plugins).

However, installed development plugins are not located in `cacheDir`. As a result, development plugin assets failed to load. This pull request adds development plugin paths to the list of possible base directories.

# Testing plan

1. Add the "Extra Viewer Settings" plugin as a development plugin.
2. Verify that the plugin UI loads when opening a note.
3. Install the "Function Plot" plugin (not as a development plugin).
4. Verify that it's possible to plot one of the [examples from the plugin's README](https://joplinapp.org/plugins/plugin/com.hieuthi.joplin.function-plot/).
5. Add a Mermaid diagram. Verify that the diagram renders.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->