### PR TITLE
Desktop,Mobile: implement cache for rendered images, partially addresses #13933

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -71,10 +71,7 @@ class ImageWidget extends WidgetType {
 				image.src = this.resolvedSrc_;
 				// When the image loads, measure and cache the height
 				image.onload = () => {
-					// We measure the container because that's what CodeMirror cares about
-					// assuming the container wraps the image tightly or as intended.
-					// In this case renderBlockImages sets max-width: 100% etc on .image
-					// and the container is a div wrapper.
+					// Measure container height (what CodeMirror uses for scroll calculations).
 					if (dom.isConnected) {
 						imageHeightCache.set(this.cacheKey, dom.offsetHeight);
 					}

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -113,7 +113,7 @@ class ImageWidget extends WidgetType {
 	}
 
 	private get cacheKey() {
-		return `${this.src_}_${this.width_ ?? ''}`;
+		return `${this.src_}_${this.width_ ?? ''}_${this.reloadCounter_}`;
 	}
 
 	public get estimatedHeight() {

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -6,6 +6,33 @@ import makeBlockReplaceExtension from './utils/makeBlockReplaceExtension';
 
 const imageClassName = 'cm-md-image';
 
+class ImageHeightCache {
+	private readonly cache = new Map<string, number>();
+	private readonly maxEntries = 500;
+
+	public get(key: string): number | undefined {
+		const value = this.cache.get(key);
+		if (value !== undefined) {
+			// Refresh recency
+			this.cache.delete(key);
+			this.cache.set(key, value);
+		}
+		return value;
+	}
+
+	public set(key: string, height: number): void {
+		if (this.cache.has(key)) {
+			this.cache.delete(key);
+		} else if (this.cache.size >= this.maxEntries) {
+			const firstKey = this.cache.keys().next().value;
+			if (firstKey) this.cache.delete(firstKey);
+		}
+		this.cache.set(key, height);
+	}
+}
+
+const imageHeightCache = new ImageHeightCache();
+
 class ImageWidget extends WidgetType {
 	private resolvedSrc_: string;
 
@@ -41,9 +68,19 @@ class ImageWidget extends WidgetType {
 
 		const updateImageUrl = () => {
 			if (this.resolvedSrc_) {
-				// Use a background-image style property rather than img[src=]. This
-				// simplifies setting the image to the correct size/position.
 				image.src = this.resolvedSrc_;
+				// When the image loads, measure and cache the height
+				image.onload = () => {
+					// We measure the container because that's what CodeMirror cares about
+					// assuming the container wraps the image tightly or as intended.
+					// In this case renderBlockImages sets max-width: 100% etc on .image
+					// and the container is a div wrapper.
+					if (dom.isConnected) {
+						imageHeightCache.set(this.cacheKey, dom.offsetHeight);
+					}
+
+					dom.style.minHeight = '';
+				};
 			}
 		};
 
@@ -56,10 +93,16 @@ class ImageWidget extends WidgetType {
 			updateImageUrl();
 		}
 
+		// Apply cached height as min-height to prevent collapse during load.
+		const cached = imageHeightCache.get(this.cacheKey);
+		if (cached) {
+			dom.style.minHeight = `${cached}px`;
+		}
+
 		return true;
 	}
 
-	public toDOM() {
+	public toDOM(_view: EditorView) {
 		const container = document.createElement('div');
 		container.classList.add(imageClassName);
 
@@ -72,8 +115,12 @@ class ImageWidget extends WidgetType {
 		return container;
 	}
 
+	private get cacheKey() {
+		return `${this.src_}_${this.width_ ?? ''}`;
+	}
+
 	public get estimatedHeight() {
-		return -1;
+		return imageHeightCache.get(this.cacheKey) ?? -1;
 	}
 }
 


### PR DESCRIPTION
This PR adds an LRU cache to store rendered image heights in the markdown editor. Once an image has been viewed, subsequent renders use the cached height for accurate scroll position calculations. 

> [!note]
> This change was made with LLM assistance, but the code was manually reviewed and QA tested

### Changes:

- Add ImageHeightCache class with LRU eviction
- Measure and cache image container height on load
- Apply cached height as minHeight during image loading to prevent layout collapse
- Return cached height via estimatedHeight for CodeMirror's scroll calculations

### Notes

This does not change behavior when scrolling downwards in a note with many large images for the 1st time on a cold start (the image heights aren't cached yet, so you can see some jumping on the initial scroll down). 

However, once images are cached, scrolling is smooth (up and down) with no jumps.

- This PR still uses -1 (unknown) for uncached images. I tested setting a "reasonable" guess (100-400px) for uncached images, but it exacerbates the scroll jumping in notes containing images with highly variable sizes.

### Testing performed

- Scrolling notes with mixed markdown/html images on desktop and mobile (web app)
- Regression tests for image rendering (pasting new images into a note, adjusting width attribute on html images, copy/pasting image embeds to different notes, manipulating attributes on html images).

### Example

Current behavior:

https://github.com/user-attachments/assets/7f944722-8dd0-4318-a8fe-02ccea173d10

With the changes in this PR:

https://github.com/user-attachments/assets/dc8ccf7c-b1fb-4394-bd07-2b923302fea0