### PR TITLE
Docs : Add video tutorial link for several pages of the documentation

### DIFF
--- a/readme/apps/clipper.md
+++ b/readme/apps/clipper.md
@@ -44,3 +44,8 @@ Copy and paste the content of both the debugging window and the Firefox console,
 ## Using the Web Clipper service
 
 The Web Clipper service can be used to create, modify or delete notes, notebooks, tags, etc. from any other application. It exposes an API with a number of methods to manage Joplin's data. For more information about this API and how to use it, please check the [Joplin API documentation](https://github.com/laurent22/joplin/blob/dev/readme/api/references/rest_api.md).
+
+## Video Tutorial
+
+For a video tutorial on how to install and use the web clipper please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/jeWTF2BILEI/hqdefault.jpg)](https://www.youtube.com/watch?v=jeWTF2BILEI)

--- a/readme/apps/drawing_tool.md
+++ b/readme/apps/drawing_tool.md
@@ -20,6 +20,9 @@ Joplin supports inserting and editing drawings. On mobile, this is built in. On 
 
 Clicking "Draw picture" adds a new drawing to the note. When Joplin's note viewer is open, drawings are added to the end of the note. In editing mode, drawings are added at the cursor.
 
+For a video tutorial on how to add a drawing to a note on mobile app click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/B21GpLXbGWE/hqdefault.jpg)](https://www.youtube.com/watch?v=B21GpLXbGWE)
+
 ### Editing an existing drawing
 
 Existing drawings can be opened and edited from the note viewer.
@@ -49,6 +52,8 @@ Double-click on an existing drawing to edit it:
 
 For more ways to edit existing drawings on desktop, see the [Freehand Drawing plugin's FAQ](https://joplinapp.org/plugins/plugin/io.github.personalizedrefrigerator.js-draw/#faq).
 
+For a video tutorial on how to add a drawing to a note on desktop app click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/TK1RhTlgAlA/hqdefault.jpg)](https://www.youtube.com/watch?v=TK1RhTlgAlA)
 
 ## The editor
 

--- a/readme/apps/email_to_note.md
+++ b/readme/apps/email_to_note.md
@@ -14,6 +14,9 @@ To copy your Joplin Cloud email address you will need to navigate to the [Config
 
 <img src="https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/email_to_note/desktop.png" width="80%"/>
 
+For a video tutorial on how to setup email to note on desktop please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/8r8gS7grFDQ/hqdefault.jpg)](https://www.youtube.com/watch?v=8r8gS7grFDQ)
+
 ### Mobile
 
 To copy your Joplin Cloud email address you will need to navigate to the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md) and find the Joplin Cloud section. You will need to have your [synchronisation set to Joplin Cloud](https://github.com/laurent22/joplin/blob/dev/readme/apps/sync/joplin_cloud.md)

--- a/readme/apps/multiple_instances.md
+++ b/readme/apps/multiple_instances.md
@@ -35,6 +35,10 @@ To start a second instance of Joplin:
 
 This second instance operates independently, allowing you to customise it as needed.
 
+## Video Tutorial
+For a video tutorial on how to open a second instance of Joplin, please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/1PRUj7QBg9g/hqdefault.jpg)](https://www.youtube.com/watch?v=1PRUj7QBg9g)
+
 ## Caveats
 
 ### Launching the primary instance when the secondary instance is active

--- a/readme/apps/ocr.md
+++ b/readme/apps/ocr.md
@@ -24,6 +24,12 @@ The application allows you to view the OCR text associated with an image. To do 
 
 ![](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/ocr/view_ocr_text.png)
 
+## Video Tutorial
+
+For a video tutorial on how to OCR in Joplin please click on the thumbnail:
+
+[![Watch the video](https://img.youtube.com/vi/kmNsWo2KlF8/hqdefault.jpg)](https://www.youtube.com/watch?v=kmNsWo2KlF8)
+
 ## Initial processing
 
 Processing images and PDF may be resource intensive, especially if you have a lot of attachments. So the first time the feature is enabled don't be surprised if Joplin CPU usage is higher than usual. Once the initial scan of all your attachments is done, this will go back to normal. Later, whenever you attach a file it will be scanned quickly in a way that's not noticeable.

--- a/readme/apps/share_notebook.md
+++ b/readme/apps/share_notebook.md
@@ -28,6 +28,10 @@ To make use of this feature, simply select "Can view" or "Can view and edit" fro
 
 ![](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/news/20230825-share-permissions.png)
 
+## Video Tutorial
+For a video tutorial on how to share a notebook and manage share permissions please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/NvQAnea_Lk8/hqdefault.jpg)](https://www.youtube.com/watch?v=NvQAnea_Lk8)
+
 ## FAQ
 
 ### What's the availability of the notebook sharing feature?

--- a/readme/apps/sync/joplin_cloud.md
+++ b/readme/apps/sync/joplin_cloud.md
@@ -3,3 +3,7 @@
 [Joplin Cloud](https://joplinapp.org/plans/) is a web service specifically designed for Joplin. Besides synchronising your data, it also allows you to publish a note to the internet, or share a notebook with your friends, family or colleagues. Joplin Cloud, compared to other services, also features a number of performance improvements allowing for faster synchronisation.
 
 To use it, go to the [Configuration screen](https://github.com/laurent22/joplin/blob/dev/readme/apps/config_screen.md), then to the Synchronisation section. In the list of sync targets, select "Joplin Cloud". Enter your email and password, and you're ready to use Joplin Cloud.
+
+## Video tutorial
+For a video tutorial on how to setup Joplin Cloud synchronisation please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/AxKKxTBO8go/hqdefault.jpg)](https://www.youtube.com/watch?v=AxKKxTBO8go)

--- a/readme/apps/terminal.md
+++ b/readme/apps/terminal.md
@@ -14,6 +14,9 @@ Operating system | Method
 -----------------|----------------
 macOS, Linux, or Windows (via [WSL](https://docs.microsoft.com/en-us/windows/wsl/faq)) | 1. First, [install Node 12+](https://nodejs.org/en/download/package-manager/).<br/><br/>2. Issue the following commands to install Joplin Terminal: <br/>`NPM_CONFIG_PREFIX=~/.joplin-bin npm install --loglevel=error -g joplin`<br/>`sudo ln -s ~/.joplin-bin/bin/joplin /usr/local/bin/joplin`<br><br>3. Enter the following command to start Joplin Terminal:<br>`joplin`<br><br>By default, the application binary will be installed under `~/.joplin-bin`. You may change this directory if needed. Alternatively, if your npm permissions are setup as described [here](https://docs.npmjs.com/getting-started/fixing-npm-permissions#option-2-change-npms-default-directory-to-another-directory) (Option 2) then simply running `npm -g install joplin` would work.
 
+For a video tutorial on how to install Joplin terminal application please click on the thumbnail:
+[![Watch the video](https://img.youtube.com/vi/B6ZT_XENWmw/hqdefault.jpg)](https://www.youtube.com/watch?v=B6ZT_XENWmw)
+
 ### Unsupported methods
 
 There are other ways to install the terminal application. However, they are not supported and problems must be reported to the upstream projects.


### PR DESCRIPTION
Addition of tutorial videos for the following pages:
- Joplin Cloud synchronisation
- OCR
- Email to note
- Multiple instances
- Terminal app
- Share notebook
- Web clipper
- Drawing tool