### PR TITLE
Android: Attempt to fix application hang when opening the camera

### DIFF
--- a/packages/app-mobile/components/CameraView/Camera/index.tsx
+++ b/packages/app-mobile/components/CameraView/Camera/index.tsx
@@ -5,7 +5,6 @@ import { ForwardedRef, forwardRef, useCallback, useEffect, useImperativeHandle, 
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import { CameraRef, Props } from './types';
 import { _ } from '@joplin/lib/locale';
-import { Platform } from 'react-native';
 import Logger from '@joplin/utils/Logger';
 
 const logger = Logger.create('Camera/expo');
@@ -66,7 +65,9 @@ const Camera = (props: Props, ref: ForwardedRef<CameraRef>) => {
 		// iOS issue workaround: Since upgrading to Expo SDK 52, closing and reopening the camera on iOS
 		// never emits onCameraReady. As a workaround, call .resumePreview and wait for it to resolve,
 		// rather than relying on the CameraView's onCameraReady prop.
-		if (Platform.OS === 'ios' && camera) {
+		//
+		// Update 12/23/2025: This also happens on certain Android devices.
+		if (camera) {
 			// Work around an issue on iOS where the onCameraReady callback is never called.
 			// Instead, wait for the preview to start using resumePreview:
 			await camera.resumePreview();

--- a/packages/app-mobile/components/CameraView/CameraView.tsx
+++ b/packages/app-mobile/components/CameraView/CameraView.tsx
@@ -85,7 +85,7 @@ const useStyles = ({ themeId, style, cameraRatio }: UseStyleProps) => {
 	}, [themeId, style, outputPositioning]);
 };
 
-const androidRatios = ['1:1', '4:3', '16:9'];
+const androidRatios = ['4:3', '16:9'];
 const iOSRatios: string[] = [];
 const useAvailableRatios = (): string[] => {
 	return Platform.OS === 'android' ? androidRatios : iOSRatios;


### PR DESCRIPTION
# Summary

This pull request *may* fix/work around two fix camera-related issues observed on some Android devices:
- Switching to the 1:1 camera aspect ratio caused the app to hang.
    - **Workaround:** Disable the 1:1 camera aspect ratio.
- The camera sometimes failed to start.
    - **Workaround:** Previously, a workaround for a similar issue was enabled on iOS. This pull request enables that workaround on Android.

**Important**: So far, I have been unable to reproduce the issues related to this pull request locally. As a result, this pull request includes changes that _may_ fix the issues, but also may not. Neither solution is ideal.


# Regression testing

On Android 13, running Joplin in development mode (with some of the changes from https://github.com/laurent22/joplin/pull/13975 applied):
1. Open a note. Verify that it's possible to attach a photo to a note using Attach > Take photo. Verify that it's possible to cycle between the 4:3 and 16:9 aspect ratios.
2. Open the note list. Verify that it's possible to create a new note with a single photo attachment using the "scan notebook" feature.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->