### PR TITLE
Android: Fix `react-native-vector-icons` error when opening a note

### DIFF
--- a/packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.ts
@@ -1,42 +1,17 @@
 import { _ } from '@joplin/lib/locale';
-import Setting from '@joplin/lib/models/Setting';
 import { themeStyle } from '@joplin/lib/theme';
 import { Theme } from '@joplin/lib/themes/type';
 import { useMemo } from 'react';
-import { extname } from 'path';
-import shim from '@joplin/lib/shim';
-import { Platform } from 'react-native';
-import { Ionicons as Icon } from '@react-native-vector-icons/ionicons';
 
 export const editPopupClass = 'joplin-editPopup';
 
 const getEditIconSrc = (theme: Theme) => {
-	// Use an inline edit icon on web -- getImageSourceSync isn't supported there.
-	if (Platform.OS === 'web') {
-		const svgData = `
-			<svg viewBox="-103 60 180 180" width="30" height="30" version="1.1" baseProfile="full" xmlns="http://www.w3.org/2000/svg">
-				<path d="m 100,19 c -11.7,0 -21.1,9.5 -21.2,21.2 0,0 42.3,0 42.3,0 0,-11.7 -9.5,-21.2 -21.2,-21.2 z M 79,43 v 143 l 21.3,26.4 21,-26.5 V 42.8 Z" style="transform: rotate(45deg)" fill=${JSON.stringify(theme.color2)}/>
-			</svg>
-		`.replace(/[ \t\n]+/, ' ');
-		return `data:image/svg+xml;utf8,${encodeURIComponent(svgData)}`;
-	}
-
-	const iconUri = Icon.getImageSourceSync('pencil', 20, theme.color2).uri;
-
-	// Copy to a location that can be read within a WebView
-	// (necessary on iOS)
-	const destPath = `${Setting.value('resourceDir')}/edit-icon${extname(iconUri)}`;
-
-	// Copy in the background -- the edit icon popover script doesn't need the
-	// icon immediately.
-	void (async () => {
-		// Can be '' in a testing environment.
-		if (iconUri) {
-			await shim.fsDriver().copy(iconUri, destPath);
-		}
-	})();
-
-	return destPath;
+	const svgData = `
+		<svg viewBox="-103 60 180 180" width="30" height="30" version="1.1" baseProfile="full" xmlns="http://www.w3.org/2000/svg">
+			<path d="m 100,19 c -11.7,0 -21.1,9.5 -21.2,21.2 0,0 42.3,0 42.3,0 0,-11.7 -9.5,-21.2 -21.2,-21.2 z M 79,43 v 143 l 21.3,26.4 21,-26.5 V 42.8 Z" style="transform: rotate(45deg)" fill=${JSON.stringify(theme.color2)}/>
+		</svg>
+	`.replace(/[ \t\n]+/, ' ');
+	return `data:image/svg+xml;utf8,${encodeURIComponent(svgData)}`;
 };
 
 // Creates JavaScript/CSS that can be used to create an "Edit" button.

--- a/packages/app-mobile/jest.setup.js
+++ b/packages/app-mobile/jest.setup.js
@@ -114,10 +114,7 @@ jest.doMock('@expo/vector-icons/MaterialCommunityIcons', () => {
 
 const mockIconLibrary = (libraryName, exportName) => {
 	jest.doMock(libraryName, () => {
-		const MockIconComponent = class extends require('react-native').View {
-			// Used by the renderer
-			static getImageSourceSync = () => ({ uri: '' });
-		};
+		const MockIconComponent = require('react-native').View;
 		return {
 			default: MockIconComponent,
 			[exportName]: MockIconComponent,


### PR DESCRIPTION
# Summary

This pull request resolves an error when running Joplin (observed in development mode):
```
You attemted to call `getImageForFontSync`: Expo dev client with `@react-native-vector-icons/get-image` installed is required for this. Alternatively, call `getImageForFont` or generate the image yourself and bundle it with the app.
```
This error is related to the call to [`getImageSourceSync('pencil', ...)`](https://github.com/laurent22/joplin/blob/bcb3f69d1598ab2e50350f2fb01ab8164d9d67c3/packages/app-mobile/contentScripts/rendererBundle/utils/useEditPopup.ts#L24) in `useEditPopup.ts`.

This pull request replaces the call to `getImageSourceSync` (<img width="34" height="34" alt="pencil" src="https://github.com/user-attachments/assets/fb7b7941-fdcb-47b1-a787-e3c359bdfa30" />) with the fallback icon (<img width="34" height="33" alt="pencil" src="https://github.com/user-attachments/assets/806d427a-f63c-42fb-a0c9-44f079d5594e" />) previously used only on web. The fallback icon was previously used as a workaround for lack of support for `getImageSourceSync` on web.

# Notes

This issue wasn't observed while testing https://github.com/laurent22/joplin/pull/13905. One possibility is that this is due to different development setups (#13905 was tested with Android emulators running on MacOS). To-do: Investigate this further.


# Testing plan

Physical Android 13 device (Joplin in dev mode):
1. Start Joplin in development mode.
2. Open a note.
3. Verify that the note opens successfully.
4. Attach a new drawing.
5. Open the note viewer.
6. Verify that it's possible to edit the drawing by pressing the "edit" button.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->