### PR TITLE
Chore: Android: Allow disabling the voice typing feature at build time

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -77,6 +77,7 @@ import { IconButton } from 'react-native-paper';
 import { writeTextToCacheFile } from '../../../utils/ShareUtils';
 import shareFile from '../../../utils/shareFile';
 import NotePositionService from '@joplin/lib/services/NotePositionService';
+import VoiceTyping from '../../../services/voiceTyping/VoiceTyping';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 const emptyArray: any[] = [];
@@ -1305,8 +1306,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			});
 		}
 
-		const voiceTypingSupported = Platform.OS === 'android';
-		if (voiceTypingSupported) {
+		if (VoiceTyping.supported()) {
 			output.push({
 				title: _('Voice typing...'),
 				onPress: () => {

--- a/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
+++ b/packages/app-mobile/components/voiceTyping/SpeechToTextBanner.tsx
@@ -4,7 +4,6 @@ import { Text, Button } from 'react-native-paper';
 import { _, languageName } from '@joplin/lib/locale';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import VoiceTyping, { OnTextCallback, VoiceTypingSession } from '../../services/voiceTyping/VoiceTyping';
-import whisper from '../../services/voiceTyping/whisper';
 import { RecorderState } from './types';
 import RecordingControls from './RecordingControls';
 import { PrimaryButton } from '../buttons';
@@ -38,7 +37,7 @@ const useVoiceTyping = ({ locale, onSetPreview, onText }: UseVoiceTypingProps) =
 	voiceTypingRef.current = voiceTyping;
 
 	const builder = useMemo(() => {
-		return new VoiceTyping(locale, [whisper]);
+		return new VoiceTyping(locale);
 	}, [locale]);
 
 	const [redownloadCounter, setRedownloadCounter] = useState(0);

--- a/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
+++ b/packages/app-mobile/services/voiceTyping/VoiceTyping.ts
@@ -39,15 +39,17 @@ export interface VoiceTypingProvider {
 
 export default class VoiceTyping {
 	private provider: VoiceTypingProvider|null = null;
-	public constructor(
-		private locale: string,
-		allProviders: VoiceTypingProvider[],
-	) {
-		this.provider = allProviders.find(p => p.supported()) ?? null;
+	public constructor(private locale: string) {
+		this.provider = VoiceTyping.providers_.find(p => p.supported()) ?? null;
 	}
 
-	public supported() {
-		return this.provider !== null;
+	private static providers_: VoiceTypingProvider[] = [];
+	public static initialize(providers: VoiceTypingProvider[]) {
+		this.providers_ = providers;
+	}
+
+	public static supported() {
+		return this.providers_.some(p => p.supported());
 	}
 
 	private getModelPath() {

--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -213,7 +213,7 @@ const modelLocalFilepath = () => {
 };
 
 const whisper: VoiceTypingProvider = {
-	supported: () => !!SpeechToTextModule,
+	supported: () => !!SpeechToTextModule && Setting.value('featureFlag.voiceTypingEnabled'),
 	modelLocalFilepath: modelLocalFilepath,
 	getDownloadUrl: (locale) => {
 		const lang = languageCodeOnly(locale).toLowerCase();

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -90,6 +90,8 @@ import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import { Profile } from '@joplin/lib/services/profileConfig/types';
 import shim from '@joplin/lib/shim';
 import { Platform } from 'react-native';
+import VoiceTyping from '../services/voiceTyping/VoiceTyping';
+import whisper from '../services/voiceTyping/whisper';
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -361,6 +363,9 @@ const buildStartupTasks = (
 	});
 	addTask('buildStartupTasks/migrate PPK', async () => {
 		await migratePpk();
+	});
+	addTask('buildStartupTasks/set up voice typing', async () => {
+		VoiceTyping.initialize([whisper]);
 	});
 	addTask('buildStartupTasks/load folders', async () => {
 		await refreshFolders(dispatch, '');

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1907,6 +1907,19 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		// As of December 2025, the voice typing feature doesn't work well on low-resource devices.
+		// There have been requests to allow disabling the voice typing feature at build time. This
+		// feature flag allows doing so, by changing the default `value` from `true` to `false`:
+		'featureFlag.voiceTypingEnabled': {
+			value: true,
+			type: SettingItemType.Bool,
+			public: false,
+			appTypes: [AppType.Mobile],
+			label: () => 'Voice typing: Enable the voice typing feature',
+			section: 'note',
+			advanced: true,
+		},
+
 		'survey.webClientEval2025.progress': {
 			value: SurveyProgress.NotStarted,
 			type: SettingItemType.Int,


### PR DESCRIPTION
# Summary

There have been requests to allow disabling the voice typing feature for custom Android builds due to https://github.com/laurent22/joplin/issues/13912 (switching to a smaller model on low-resource devices isn't sufficient). This pull request adds a `featureFlag.voiceTypingEnabled` feature flag that can be set (with a patch) to disable voice typing at build time.

# Testing plan

Android 13 (dev mode, change similar to https://github.com/laurent22/joplin/pull/13975 applied):
1. Open a note.
2. Open the voice typing dialog from "note actions" > "voice typing...".
3. Verify that the voice typing dialog can still be opened.
4. Verify that the voice typing feature still works.
5. Set `featureFlag.voiceTypingEnabled` to `false` in `builtInMetadata.ts`.
6. Verify that the voice typing menu option isn't included in the note actions menu.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->