### PR TITLE
Chore: Mobile: Allow disabling features known to be incompatible with small screens at build time

### DIFF
--- a/packages/app-mobile/contentScripts/imageEditorBundle/useWebViewSetup.tsx
+++ b/packages/app-mobile/contentScripts/imageEditorBundle/useWebViewSetup.tsx
@@ -80,6 +80,21 @@ const useCss = (editorTheme: Theme) => {
 			.toolbar-edge-toolbar:not(.one-row) .toolwidget-tag--exit .toolbar-icon {
 				display: none;
 			}
+
+			${Setting.value('featureFlag.ui.disableSmallScreenIncompatibleFeatures') ? `
+				/* As of December 2025, the help overlay is difficult to use on small screens
+				   (slow to load, help text overlapping content in some cases). */
+				.js-draw .toolbar-help-overlay-button {
+					display: none;
+				}
+
+				/* As of December 2025, the pipette button is difficult to use on small screens:
+				   It may not be clear that it's necessary to dismiss the tool menu in order to
+				   pick a color from the screen. */
+				.js-draw .color-input-container > button.pipetteButton.pipetteButton {
+					display: none;
+				}
+			` : ''}
 		`;
 	}, [editorTheme]);
 };

--- a/packages/app-mobile/contentScripts/imageEditorBundle/useWebViewSetup.tsx
+++ b/packages/app-mobile/contentScripts/imageEditorBundle/useWebViewSetup.tsx
@@ -81,7 +81,7 @@ const useCss = (editorTheme: Theme) => {
 				display: none;
 			}
 
-			${Setting.value('featureFlag.ui.disableSmallScreenIncompatibleFeatures') ? `
+			${Setting.value('buildFlag.ui.disableSmallScreenIncompatibleFeatures') ? `
 				/* As of December 2025, the help overlay is difficult to use on small screens
 				   (slow to load, help text overlapping content in some cases). */
 				.js-draw .toolbar-help-overlay-button {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1920,7 +1920,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 		},
 
-		'featureFlag.ui.disableSmallScreenIncompatibleFeatures': {
+		'buildFlag.ui.disableSmallScreenIncompatibleFeatures': {
 			value: false,
 			type: SettingItemType.Bool,
 			public: false,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1926,8 +1926,6 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			public: false,
 			appTypes: [AppType.Mobile],
 			label: () => 'UI: Disable features known to be incompatible with small screens',
-			section: 'note',
-			advanced: true,
 		},
 
 		'survey.webClientEval2025.progress': {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1920,6 +1920,16 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 		},
 
+		'featureFlag.ui.disableSmallScreenIncompatibleFeatures': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			appTypes: [AppType.Mobile],
+			label: () => 'UI: Disable features known to be incompatible with small screens',
+			section: 'note',
+			advanced: true,
+		},
+
 		'survey.webClientEval2025.progress': {
 			value: SurveyProgress.NotStarted,
 			type: SettingItemType.Int,


### PR DESCRIPTION
# Summary

Some of the features in the drawing tool don't work well on small screens. It was requested that it be made possible to disable these features at build time.

This pull request adds a feature flag that allows disabling the "pick color from screen" tool and the help overlay in the drawing tool. This feature flag can be changed by patching `builtInMetadata.ts`.

Related: https://github.com/laurent22/joplin/pull/13977, https://github.com/laurent22/joplin/pull/13981.

# Testing

1. Open the drawing tool. Verify that the "pick color from screen" button and the "help" button are both still present.
2. Set the feature flag to `true` and re-run.
3. Verify that the "pick color from screen" and the "help" button are both absent.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->