### PR TITLE
Mobile: Feature flags: Fix "voice typing" feature flag

### DIFF
--- a/packages/app-mobile/services/voiceTyping/whisper.ts
+++ b/packages/app-mobile/services/voiceTyping/whisper.ts
@@ -213,7 +213,7 @@ const modelLocalFilepath = () => {
 };
 
 const whisper: VoiceTypingProvider = {
-	supported: () => !!SpeechToTextModule && Setting.value('featureFlag.voiceTypingEnabled'),
+	supported: () => !!SpeechToTextModule && Setting.value('buildFlag.voiceTypingEnabled'),
 	modelLocalFilepath: modelLocalFilepath,
 	getDownloadUrl: (locale) => {
 		const lang = languageCodeOnly(locale).toLowerCase();

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -16,9 +16,10 @@ const customCssFilePath = (Setting: typeof SettingType, filename: string): strin
 	return `${Setting.value('rootProfileDir')}/${filename}`;
 };
 
-const showVoiceTypingSettings = () => (
+type VoiceTypingSettingSlice = Record<'buildFlag.voiceTypingEnabled', boolean>;
+const showVoiceTypingSettings = (settings: VoiceTypingSettingSlice) => (
 	// For now, iOS and web don't support voice typing.
-	shim.mobilePlatform() === 'android'
+	shim.mobilePlatform() === 'android' && !!settings['buildFlag.voiceTypingEnabled']
 );
 
 export enum CameraDirection {
@@ -1910,14 +1911,12 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		// As of December 2025, the voice typing feature doesn't work well on low-resource devices.
 		// There have been requests to allow disabling the voice typing feature at build time. This
 		// feature flag allows doing so, by changing the default `value` from `true` to `false`:
-		'featureFlag.voiceTypingEnabled': {
+		'buildFlag.voiceTypingEnabled': {
 			value: true,
 			type: SettingItemType.Bool,
 			public: false,
 			appTypes: [AppType.Mobile],
 			label: () => 'Voice typing: Enable the voice typing feature',
-			section: 'note',
-			advanced: true,
 		},
 
 		'survey.webClientEval2025.progress': {
@@ -1984,7 +1983,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Mobile],
 			label: () => _('Voice typing: Glossary'),
 			description: () => _('A comma-separated list of words. May be used for uncommon words, to help voice typing spell them correctly.'),
-			show: () => showVoiceTypingSettings(),
+			show: showVoiceTypingSettings,
 			section: 'note',
 		},
 


### PR DESCRIPTION
# Summary

This change fixes a regression from https://github.com/laurent22/joplin/pull/13977: the internal `voiceTypingEnabled` feature flag was incorrectly shown in "Settings" > "More information". Additionally, this pull request hides voice typing settings when `voiceTypingEnabled` is set to `false`.

See #13977 for further details.

# Testing plan

Android 13:
1. Verify that it's possible to open the voice typing dialog from the note screen.
2. Open configuration > note. Verify that the "Voice typing language files (URL)" and "Voice typing: Glossary" settings are visible.
3. Set `buildFlag.voiceTypingEnabled` to `false` (patch `builtInMetadata.ts`) and restart.
4. Verify that the voice typing menu item is not visible in the note actions menu.
5. Open configuration > note. Verify that the voice typing-related settings are not visible.
6. Open configuration > more information. Verify that the voice typing feature flag is not visible.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->