### PR TITLE
Cli: Added keymap command to print existing keybinds in CLI and TUI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -115,7 +115,7 @@ packages/app-cli/app/command-export.js
 packages/app-cli/app/command-geoloc.js
 packages/app-cli/app/command-help.js
 packages/app-cli/app/command-import.js
-packages/app-cli/app/command-keymaps.js
+packages/app-cli/app/command-keymap.js
 packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -115,6 +115,7 @@ packages/app-cli/app/command-export.js
 packages/app-cli/app/command-geoloc.js
 packages/app-cli/app/command-help.js
 packages/app-cli/app/command-import.js
+packages/app-cli/app/command-keymaps.js
 packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,7 @@ packages/app-cli/app/command-export.js
 packages/app-cli/app/command-geoloc.js
 packages/app-cli/app/command-help.js
 packages/app-cli/app/command-import.js
-packages/app-cli/app/command-keymaps.js
+packages/app-cli/app/command-keymap.js
 packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ packages/app-cli/app/command-export.js
 packages/app-cli/app/command-geoloc.js
 packages/app-cli/app/command-help.js
 packages/app-cli/app/command-import.js
+packages/app-cli/app/command-keymaps.js
 packages/app-cli/app/command-ls.js
 packages/app-cli/app/command-mkbook.test.js
 packages/app-cli/app/command-mkbook.js

--- a/packages/app-cli/app/command-keymap.ts
+++ b/packages/app-cli/app/command-keymap.ts
@@ -3,12 +3,8 @@ import app from './app';
 import { _ } from '@joplin/lib/locale';
 const { cliUtils } = require('./cli-utils.js');
 
-type Args = {
-	note: string;
-	options: {
-		force?: boolean;
-	};
-};
+// eslint-disable-next-line @typescript-eslint/ban-types -- no args expected
+type Args = {};
 
 class Command extends BaseCommand {
 	public override usage() {

--- a/packages/app-cli/app/command-keymap.ts
+++ b/packages/app-cli/app/command-keymap.ts
@@ -3,8 +3,7 @@ import app from './app';
 import { _ } from '@joplin/lib/locale';
 const { cliUtils } = require('./cli-utils.js');
 
-// eslint-disable-next-line @typescript-eslint/ban-types -- no args expected
-type Args = {};
+interface Args { }
 
 class Command extends BaseCommand {
 	public override usage() {

--- a/packages/app-cli/app/command-keymap.ts
+++ b/packages/app-cli/app/command-keymap.ts
@@ -3,9 +3,16 @@ import app from './app';
 import { _ } from '@joplin/lib/locale';
 const { cliUtils } = require('./cli-utils.js');
 
+type Args = {
+	note: string;
+	options: {
+		force?: boolean;
+	};
+};
+
 class Command extends BaseCommand {
 	public override usage() {
-		return 'keymaps';
+		return 'keymap';
 	}
 
 	public override description() {
@@ -16,8 +23,7 @@ class Command extends BaseCommand {
 		return ['cli', 'gui'];
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public override async action(_args: any) {
+	public override async action(_args: Args) {
 		const keymaps = await app().loadKeymaps();
 
 		this.stdout(_('Configured keyboard shortcuts:\n'));
@@ -25,12 +31,12 @@ class Command extends BaseCommand {
 		const rows = [];
 		const padding = '  ';
 
-		rows.push([`${padding}KEYS`, 'TYPE', 'COMMAND']);
+		rows.push([`${padding}${_('KEYS')}`, _('TYPE'), _('COMMAND')]);
 		rows.push([`${padding}----`, '----', '-------']);
 
 		for (const item of keymaps) {
 			const formattedKeys = item.keys
-				.map((k: string) => (k === ' ' ? '(SPACE)' : k))
+				.map((k: string) => (k === ' ' ? `(${'SPACE'})` : k))
 				.join(', ');
 			rows.push([padding + formattedKeys, item.type, item.command]);
 		}

--- a/packages/app-cli/app/command-keymaps.ts
+++ b/packages/app-cli/app/command-keymaps.ts
@@ -12,10 +12,6 @@ class Command extends BaseCommand {
 		return _('Displays the configured keyboard shortcuts.');
 	}
 
-	public override options(): string[][] {
-		return [];
-	}
-
 	public override compatibleUis() {
 		return ['cli', 'gui'];
 	}
@@ -24,29 +20,22 @@ class Command extends BaseCommand {
 	public override async action(_args: any) {
 		const keymaps = await app().loadKeymaps();
 
-		this.stdout(_('Configured keyboard shortcuts:'));
-		this.stdout('');
+		this.stdout(_('Configured keyboard shortcuts:\n'));
 
 		const rows = [];
+		const padding = '  ';
 
-		// Add header row
-		rows.push(['KEYS', 'TYPE', 'COMMAND']);
+		rows.push([`${padding}KEYS`, 'TYPE', 'COMMAND']);
+		rows.push([`${padding}----`, '----', '-------']);
 
-		// Add separator row
-		rows.push(['----', '----', '-------']);
-
-		// Add keymap rows
 		for (const item of keymaps) {
 			const formattedKeys = item.keys
 				.map((k: string) => (k === ' ' ? '(SPACE)' : k))
 				.join(', ');
-			rows.push([formattedKeys, item.type, item.command]);
+			rows.push([padding + formattedKeys, item.type, item.command]);
 		}
 
-		// Print with left padding
-		const padding = '  ';
-		const originalStdout = this.stdout.bind(this);
-		cliUtils.printArray((line: string) => originalStdout(padding + line), rows);
+		cliUtils.printArray(this.stdout.bind(this), rows, rows);
 
 		if (app().gui() && !app().gui().isDummy()) {
 			app().gui().showConsole();

--- a/packages/app-cli/app/command-keymaps.ts
+++ b/packages/app-cli/app/command-keymaps.ts
@@ -1,0 +1,58 @@
+import BaseCommand from './base-command';
+import app from './app';
+import { _ } from '@joplin/lib/locale';
+const { cliUtils } = require('./cli-utils.js');
+
+class Command extends BaseCommand {
+	public override usage() {
+		return 'keymaps';
+	}
+
+	public override description() {
+		return _('Displays the configured keyboard shortcuts.');
+	}
+
+	public override options(): string[][] {
+		return [];
+	}
+
+	public override compatibleUis() {
+		return ['cli', 'gui'];
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+	public override async action(_args: any) {
+		const keymaps = await app().loadKeymaps();
+
+		this.stdout(_('Configured keyboard shortcuts:'));
+		this.stdout('');
+
+		const rows = [];
+
+		// Add header row
+		rows.push(['KEYS', 'TYPE', 'COMMAND']);
+
+		// Add separator row
+		rows.push(['----', '----', '-------']);
+
+		// Add keymap rows
+		for (const item of keymaps) {
+			const formattedKeys = item.keys
+				.map((k: string) => (k === ' ' ? '(SPACE)' : k))
+				.join(', ');
+			rows.push([formattedKeys, item.type, item.command]);
+		}
+
+		// Print with left padding
+		const padding = '  ';
+		const originalStdout = this.stdout.bind(this);
+		cliUtils.printArray((line: string) => originalStdout(padding + line), rows);
+
+		if (app().gui() && !app().gui().isDummy()) {
+			app().gui().showConsole();
+			app().gui().maximizeConsole();
+		}
+	}
+}
+
+module.exports = Command;

--- a/packages/app-cli/app/command-keymaps.ts
+++ b/packages/app-cli/app/command-keymaps.ts
@@ -35,7 +35,7 @@ class Command extends BaseCommand {
 			rows.push([padding + formattedKeys, item.type, item.command]);
 		}
 
-		cliUtils.printArray(this.stdout.bind(this), rows, rows);
+		cliUtils.printArray(this.stdout.bind(this), rows);
 
 		if (app().gui() && !app().gui().isDummy()) {
 			app().gui().showConsole();


### PR DESCRIPTION
# feat: added keymap command to print existing keybinds in CLI and TUI

As a terminal UI power user, I often forget some of the keymaps / keybindings configured.

This PR adds a simple command that configures a new command to print the keybindings.

This pretty-prints the configured keybinds; it's main use is in the TUI but it's also made available in the CLI (this can be removed if relevant).

Currently I didn't add a test as the functionality would be mostly duplicated, however happy to add an extra test as required.

**All tests pass locally**.

## Functionality - CLI

Run the command directly (from `packages/app-cli`) as:

```
> node build/main.js keybind
```

Output expected:

```
Configured keyboard shortcuts:

  KEYS                  TYPE     COMMAND
  ----                  ----     -------
  :                     function enter_command_line_mode
  TAB, l                function focus_next
  SHIFT_TAB, h          function focus_previous
  UP, k                 function move_up
  DOWN, j               function move_down
  PAGE_UP, K, gg        function page_up
  PAGE_DOWN, J, G       function page_down
  ENTER                 function activate
  DELETE, BACKSPACE, dd function delete
  n                     function next_link
  b                     function previous_link
  o                     function open_link
  tt                             todo toggle $n
  tc                    function toggle_console
  tm                    function toggle_metadata
  ti                    function toggle_ids
  r                     prompt   restore $n
  /                     prompt   search ""
  mn                    prompt   mknote ""
  mt                    prompt   mktodo ""
  mb                    prompt   mkbook ""
  yy                    prompt   cp $n ""
  cc                    prompt   mv $n ""
  z                     function toggle_folder_collapse
  q                     prompt   exit
  w                              sync
  mg                    prompt   tag add "" $n
  oR                             config notes.sortOrder.reverse "true"
  or                             config notes.sortOrder.reverse "false"
  ot                             config notes.sortOrder.field "title"
  oc                             config notes.sortOrder.field "user_created_time"
  ou                             config notes.sortOrder.field "user_updated_time"
  nt                             tag notetags $n
  ns                    prompt   status
  tu                             todo clear $n
  mm                    prompt   ren $n ""
```

## Functionality - TUI

Run command from command prompt.

```
:keybinds
```

Same output expected.

# Proposed Alternative

As part of the implementation I was able to implement it using a modal popup which seems could be the preferred option as it allows for simple scrolling, the required changes are outlined below. 

I haven't added it as it would require extra changes in app-gui.ts, which seem quite minimal but do seem to add new expected behaviour, so I will await for feedback as always simpler is better (+ can always iterate from baseline)

```diff
diff --git a/packages/app-cli/app/command-keymaps.ts b/packages/app-cli/app/command-keymaps.ts
index c172cd7ef..668d23f6c 100644
--- a/packages/app-cli/app/command-keymaps.ts
+++ b/packages/app-cli/app/command-keymaps.ts
@@ -19,9 +19,6 @@ class Command extends BaseCommand {
        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
        public override async action(_args: any) {
                const keymaps = await app().loadKeymaps();
-
-               this.stdout(_('Configured keyboard shortcuts:\n'));
-
                const rows = [];
                const padding = '  ';

@@ -35,11 +32,17 @@ class Command extends BaseCommand {
                        rows.push([padding + formattedKeys, item.type, item.command]);
                }

-               cliUtils.printArray(this.stdout.bind(this), rows, rows);
+        const lines = [_('Configured keyboard shortcuts:\n\n')];
+        cliUtils.printArray((line: string) => lines.concat(line), rows);
+        const text = lines.join('\n');

                if (app().gui() && !app().gui().isDummy()) {
-                       app().gui().showConsole();
-                       app().gui().maximizeConsole();
+                       // Show in scrollable modal in TUI mode
+                       app().gui().showModalOverlay(text);
+                       await app().gui().forceRender();
+               } else {
+                       // Show as table in console in CLI mode
+                       this.stdout(text);
                }
        }
 }
```

```diff
diff --git a/packages/app-cli/app/app-gui.js b/packages/app-cli/app/app-gui.js
index 444b2b027..7bd3b0096 100644
--- a/packages/app-cli/app/app-gui.js
+++ b/packages/app-cli/app/app-gui.js
@@ -748,6 +748,14 @@ class AppGui {
                                // Handle special shortcuts
                                // -------------------------------------------------------------------------

+                               // Close modal overlay on ESC
+                               if (name === 'ESCAPE') {
+                                       if (this.widget('overlayWindow') && this.widget('overlayWindow').visible) {
+                                               this.hideModalOverlay();
+                                               return;
+                                       }
+                               }
+
                                if (name === 'CTRL_D') {
                                        const cmd = this.app().currentCommand();

```