### PR TITLE
Chore: Fixes #13983: Remove conflicting macos dependency for devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -11,11 +11,6 @@
     },
     "nodejs":     "24.5.0",
     "pkg-config": "latest",
-    "darwin.apple_sdk.frameworks.Foundation": { // satisfies missing CoreText/CoreText.h
-      // https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/darwin/apple-sdk/default.nix
-      "version":   "",
-      "platforms": ["aarch64-darwin", "x86_64-darwin"],
-    },
     "python": "3.13.3",
     "bat":    "latest",
     "electron": {


### PR DESCRIPTION
Fixes #13983

# bug: removed conflicting macos dependency for devbox

When setting up devbox (i.e. `devbox shell`) in MacOS it results in the following error below.

It seems that the devbox is out of date, however this at least seems to be a robust patch to unblock development. 

Confirmed all tests pass in MacOS as of today in dev branch

### Previous error message (before workaround)

```
Warning: Your devbox.json at <...Path> contains packages in legacy format. Please run devbox update to update your devbox.json.
Info: Ensuring packages are installed.

Error: error installing package darwin.apple_sdk.frameworks.Foundation
source: nix: command error: nix --extra-experimental-features ca-derivations --option experimental-features 'nix-command flakes fetch-closure' path-info 'github:NixOS/nixpkgs/cfc52a405c6e85462364651a8f11e28ae8065c91#darwin.apple_sdk.frameworks.Foundation' --json --impure: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions: exit code 1

Error: There was an internal error. Run with DEVBOX_DEBUG=1 for a detailed error message, and consider reporting it at https://github.com/jetify-com/devbox/issues```

