### PR TITLE
Desktop, Mobile: Fixes #13229: Insert time command not respecting locale settings

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useWindowCommandHandler.ts
@@ -2,7 +2,7 @@ import { RefObject, Dispatch, SetStateAction, useEffect } from 'react';
 import { WindowCommandDependencies, NoteBodyEditorRef, OnChangeEvent, ScrollOptionTypes } from './types';
 import editorCommandDeclarations, { enabledCondition } from '../editorCommandDeclarations';
 import CommandService, { CommandDeclaration, CommandRuntime, CommandContext, RegisteredRuntime } from '@joplin/lib/services/CommandService';
-import time from '@joplin/lib/time';
+import { formatMsToLocal } from '@joplin/utils/time';
 import { reg } from '@joplin/lib/registry';
 import getWindowCommandPriority from './getWindowCommandPriority';
 
@@ -50,7 +50,7 @@ function editorCommandRuntime(
 			if (declaration.name === 'insertDateTime') {
 				return editorRef.current.execCommand({
 					name: 'insertText',
-					value: time.formatMsToLocal(new Date().getTime()),
+					value: formatMsToLocal(Date.now()),
 				});
 			} else if (declaration.name === 'scrollToHash') {
 				return editorRef.current.scrollTo({

--- a/packages/app-mobile/components/screens/Note/commands/insertDateTime.ts
+++ b/packages/app-mobile/components/screens/Note/commands/insertDateTime.ts
@@ -1,7 +1,7 @@
 import { CommandRuntime, CommandDeclaration, CommandContext } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
 import { CommandRuntimeProps } from '../types';
-import time from '@joplin/lib/time';
+import { formatMsToLocal } from '@joplin/utils/time';
 
 export const declaration: CommandDeclaration = {
 	name: 'insertDateTime',
@@ -12,7 +12,7 @@ export const declaration: CommandDeclaration = {
 export const runtime = (props: CommandRuntimeProps): CommandRuntime => {
 	return {
 		execute: async (_context: CommandContext) => {
-			props.insertText(time.formatDateToLocal(new Date()));
+			props.insertText(formatMsToLocal(Date.now()));
 		},
 
 		enabledCondition: '!noteIsReadOnly',


### PR DESCRIPTION
The "Insert time" command (Ctrl+Shift+T) was not respecting the user's locale settings. When a user set their locale to Spanish (es_ES) and used a date format like "dddd YYYY-MM-DD", the day name was displayed in English (e.g., "Tuesday") instead of the configured locale (e.g., "Martes").

Root cause:
- The command was using `time.formatMsToLocal()` from `@joplin/lib/time` which uses moment.js but does not load locale data
- moment.js requires explicit locale imports to display localized strings

Fix:
- Switch to using `formatMsToLocal()` from `@joplin/utils/time` which uses dayjs with properly loaded locale data for all supported languages

This fix applies to both desktop and mobile apps.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->