### PR TITLE
Fix: Prevent redundant image loading requests in Markdown editor

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -8,6 +8,7 @@ const imageClassName = 'cm-md-image';
 
 class ImageWidget extends WidgetType {
 	private resolvedSrc_: string;
+	private loading_ = false;
 
 	public constructor(
 		private readonly context_: RenderedContentContext,
@@ -48,10 +49,14 @@ class ImageWidget extends WidgetType {
 		};
 
 		if (!this.resolvedSrc_) {
-			void (async () => {
-				this.resolvedSrc_ = await this.context_.resolveImageSrc(this.src_, this.reloadCounter_);
-				updateImageUrl();
-			})();
+			if (!this.loading_) {
+				this.loading_ = true;
+				void (async () => {
+					this.resolvedSrc_ = await this.context_.resolveImageSrc(this.src_, this.reloadCounter_);
+					this.loading_ = false;
+					updateImageUrl();
+				})();
+			}
 		} else {
 			updateImageUrl();
 		}


### PR DESCRIPTION
Hi there! I've been looking into this issue.

It seems like the problem is caused by a race condition in the ImageWidget where multiple asynchronous image resolution requests can be triggered simultaneously (e.g., during fast scrolling), leading to inconsistent updates.

I've implemented a fix that adds a loading flag to ensure only one request is active at a time per widget.

I've raised a PR with the fix here.

Let me know if you have any feedback!