### PR TITLE
Doc: Add uninstall instructions for linux

### DIFF
--- a/readme/install.md
+++ b/readme/install.md
@@ -57,6 +57,8 @@ A community maintained list of these distributions can be found here: [Unofficia
 **On Linux**
 
 To uninstall on Linux, delete the following folders & files:
-`~/.joplin` // Contains the executable
-`~/.config/joplin-desktop` // Contains configuration and notes
-`~/.local/share/applications/appimagekit-joplin.desktop` // is the desktop file
+```
+~/.joplin // Contains the executable
+~/.config/joplin-desktop // Contains configuration and notes
+~/.local/share/applications/appimagekit-joplin.desktop // is the desktop file
+```

--- a/readme/install.md
+++ b/readme/install.md
@@ -56,4 +56,7 @@ A community maintained list of these distributions can be found here: [Unofficia
 
 **On Linux**
 
-If you installed via the application script, you can remove Joplin with the command: `rm -rf ~/.joplin`
+To uninstall on Linux, delete the following folders & files:
+`~/.joplin` // Contains the executable
+`~/.config/joplin-desktop` // Contains configuration and notes
+`~/.local/share/applications/appimagekit-joplin.desktop` // is the desktop file

--- a/readme/install.md
+++ b/readme/install.md
@@ -51,3 +51,9 @@ There are a number of unofficial alternative Joplin distributions. If you do not
 However these come with a caveat in that they are not officially supported so certain issues may not be supportable by the main project. Rather support requests, bug reports and general advice would need to go to the maintainers of these distributions.
 
 A community maintained list of these distributions can be found here: [Unofficial Joplin distributions](https://discourse.joplinapp.org/t/unofficial-alternative-joplin-distributions/23703)
+
+# Uninstall
+
+**On Linux**
+
+If you installed via the application script, you can remove Joplin with the command: `rm -rf ~/.joplin`


### PR DESCRIPTION
Documentation update to add missing instructions for how to remove Joplin on linux.
For novice linux users it is not clear how to remove the app after installing.