### PR TITLE
Desktop, Mobile: Fixes #13963, listen for syntax tree updates in makeBlockReplaceExtension

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/utils/makeBlockReplaceExtension.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/utils/makeBlockReplaceExtension.ts
@@ -77,7 +77,9 @@ const makeBlockReplaceExtension = (extensionSpec: ReplacementExtension) => {
 				return extensionSpec.shouldFullReRender(transaction);
 			};
 
-			if (transaction.docChanged || selectionChanged || wasRerenderRequested()) {
+			const treeChanged = syntaxTree(transaction.state) !== syntaxTree(transaction.startState);
+
+			if (transaction.docChanged || selectionChanged || wasRerenderRequested() || treeChanged) {
 				decorations = updateDecorations(transaction.state, extensionSpec);
 			}
 


### PR DESCRIPTION
## Overview

> [!note]
> This change was made with LLM assistance, but the code was manually reviewed and QA tested

When opening a note, the initial syntax tree may be incomplete. this can sometimes result in images not being rendered until the user interacts with the note (e.g. clicking somewhere in the note)

This PR addresses issue #13963 by checking if the syntax tree has changed between transactions. If it has, it now triggers a decoration update

Note: This issue is very intermittent/difficult to re-create on desktop, but very easy to re-create in the mobile/web app (I can re-create it 100% of the time in a note with many images).

> [!note] 
Checking for tree changes in this manner is covered in the Codemirror documentation here: https://codemirror.net/examples/decoration/

```
  update(update: ViewUpdate) {
    if (update.docChanged || update.viewportChanged ||
        syntaxTree(update.startState) != syntaxTree(update.state))
      this.decorations = checkboxes(update.view)
  }
 ```

Previous behavior:

https://github.com/user-attachments/assets/d6298060-db68-4510-95ab-fcf3012f5be1

With the change from this PR:

https://github.com/user-attachments/assets/e8e3dbdd-116a-4f89-b430-512916aa9210

## Testing

- Ran renderBlockImages.test.ts tests
- Tested accessing notes with images (html and markdown format) in both desktop and web app
- Tested adjusting images in the editor (cut/paste image embeds, adjust attributes for html images, etc...)
- Tested drag/drop to add new images

