### PR TITLE
Desktop: Add tooltip and aria-label to All notes item

### DIFF
--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -60,14 +60,16 @@ const AllNotesItem: React.FC<Props> = props => {
 			itemIndex={props.index}
 			itemCount={props.itemCount}
 		>
-			<EmptyExpandLink/>
-			<StyledAllNotesIcon aria-hidden='true' role='img' className='icon-notes'/>
+			<EmptyExpandLink />
+			<StyledAllNotesIcon aria-hidden='true' role='img' className='icon-notes' />
 			<StyledListItemAnchor
 				className="list-item"
 				isSpecialItem={true}
 				selected={props.selectionState.selected}
 				onClick={onAllNotesClick_}
 				onContextMenu={toggleAllNotesContextMenu}
+				title="Show all notes"
+				aria-label="Show all notes"
 			>
 				{props.item.label}
 			</StyledListItemAnchor>


### PR DESCRIPTION
## Summary
Adds a tooltip and aria-label to the "All notes" sidebar item.

## Motivation
- Improves discoverability via tooltip
- Improves accessibility for screen reader users
- No functional or behavioral changes

## Testing
- Desktop app (Windows)
- Hovered over "All notes" to confirm tooltip
- Verified click and context menu still work
