### PR TITLE
Desktop, Mobile: Fixes #14030: Fix "Check synchronization configuration" button

### DIFF
--- a/packages/lib/components/shared/config/config-shared.ts
+++ b/packages/lib/components/shared/config/config-shared.ts
@@ -1,6 +1,5 @@
 import Setting, { AppType, SettingMetadataSection, SettingSectionSource } from '../../../models/Setting';
 import SyncTargetRegistry from '../../../SyncTargetRegistry';
-const ObjectUtils = require('../../../ObjectUtils');
 const { _ } = require('../../../locale');
 import { createSelector } from 'reselect';
 import Logger from '@joplin/utils/Logger';
@@ -8,6 +7,7 @@ import Logger from '@joplin/utils/Logger';
 import { type ReactNode } from 'react';
 import { type Registry } from '../../../registry';
 import settingValidations from '../../../models/settings/settingValidations';
+import { convertValuesToFunctions } from '../../../ObjectUtils';
 
 const logger = Logger.create('config-shared');
 
@@ -75,11 +75,11 @@ export const checkSyncConfig = async (comp: ConfigScreenComponent, settings: any
 	const SyncTargetClass = SyncTargetRegistry.classById(syncTargetId);
 
 	const options = {
-		...Setting.subValues(`sync.${syncTargetId}`, settings),
-		...Setting.subValues('net', settings) };
+		...Setting.subValues(`sync.${syncTargetId}`, settings, { includeConstants: true }),
+		...Setting.subValues('net', settings, { includeConstants: true }) };
 
 	comp.setState({ checkSyncConfigResult: 'checking' });
-	const result = await SyncTargetClass.checkConfig(ObjectUtils.convertValuesToFunctions(options));
+	const result = await SyncTargetClass.checkConfig(convertValuesToFunctions(options));
 	comp.setState({ checkSyncConfigResult: result });
 
 	if (result.ok) {


### PR DESCRIPTION
# Summary

https://github.com/laurent22/joplin/commit/418a660a66cc6c9821577d5f294d70eb6b88c608 added a new required option to the `JoplinServerApi` sync target. This option was not specified when calling `SyncTargetClass.checkConfig`, which auto-generates the sync target config options based on the sync target settings.

Fixes #14030.

# Testing

1. Start the desktop app (with sync set up with Joplin Server).
2. Open settings > sync.
3. Click "Check synchronisation configuration".
4. Verify that "Success! Synchronisation configuration appears to be correct." is shown.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->