### PR TITLE
Chore: Refactoring: Improve ObjectUtils types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1227,6 +1227,7 @@ packages/lib/InMemoryCache.js
 packages/lib/JoplinDatabase.js
 packages/lib/JoplinError.js
 packages/lib/JoplinServerApi.js
+packages/lib/ObjectUtils.test.js
 packages/lib/ObjectUtils.js
 packages/lib/PerformanceLogger.test.js
 packages/lib/PerformanceLogger.js

--- a/.gitignore
+++ b/.gitignore
@@ -1200,6 +1200,7 @@ packages/lib/InMemoryCache.js
 packages/lib/JoplinDatabase.js
 packages/lib/JoplinError.js
 packages/lib/JoplinServerApi.js
+packages/lib/ObjectUtils.test.js
 packages/lib/ObjectUtils.js
 packages/lib/PerformanceLogger.test.js
 packages/lib/PerformanceLogger.js

--- a/packages/lib/ObjectUtils.test.ts
+++ b/packages/lib/ObjectUtils.test.ts
@@ -1,0 +1,24 @@
+import { convertValuesToFunctions, sortByValue } from './ObjectUtils';
+
+describe('ObjectUtils', () => {
+	test('should convert object values to functions', () => {
+		const v = convertValuesToFunctions({ a: 6, b: ()=>7, c: 'test' });
+		expect(v.a()).toBe(6);
+		expect(v.b()).toBe(7);
+		expect(v.c()).toBe('test');
+	});
+
+	test('should sort an object\'s entries by value', () => {
+		expect(sortByValue({
+			a: 1,
+			b: 'test1',
+			c: 'test3',
+			d: 'test2',
+		})).toEqual({
+			b: 'test1',
+			d: 'test2',
+			c: 'test3',
+			a: 1,
+		});
+	});
+});

--- a/packages/lib/ObjectUtils.ts
+++ b/packages/lib/ObjectUtils.ts
@@ -1,5 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function sortByValue(object: any) {
+type AnyObject = Record<string|symbol, unknown>;
+
+type SortableValue = string|number;
+type SortableObject = Record<string, SortableValue>;
+
+export function sortByValue<T extends SortableObject>(object: T): T {
 	const temp = [];
 	for (const k in object) {
 		if (!object.hasOwnProperty(k)) continue;
@@ -10,8 +14,8 @@ export function sortByValue(object: any) {
 	}
 
 	temp.sort((a, b) => {
-		let v1 = a.value;
-		let v2 = b.value;
+		let v1: SortableValue = a.value;
+		let v2: SortableValue = b.value;
 		if (typeof v1 === 'string') v1 = v1.toLowerCase();
 		if (typeof v2 === 'string') v2 = v2.toLowerCase();
 		if (v1 === v2) return 0;
@@ -28,8 +32,7 @@ export function sortByValue(object: any) {
 	return output;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function fieldsEqual(o1: any, o2: any) {
+export function fieldsEqual(o1: AnyObject, o2: AnyObject) {
 	if ((!o1 || !o2) && o1 !== o2) return false;
 
 	for (const k in o1) {
@@ -45,8 +48,11 @@ export function fieldsEqual(o1: any, o2: any) {
 	return true;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function convertValuesToFunctions(o: any) {
+type ValuesToFunctions<T extends AnyObject> = {
+	[k in keyof T]: T[k] extends ()=> unknown ? T[k] : ()=> T[k]
+};
+
+export function convertValuesToFunctions<T extends AnyObject>(o: T): ValuesToFunctions<T> {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const output: any = {};
 	for (const n in o) {
@@ -58,8 +64,7 @@ export function convertValuesToFunctions(o: any) {
 	return output;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export function isEmpty(o: any) {
+export function isEmpty(o: AnyObject|null) {
 	if (!o) return true;
 	return Object.keys(o).length === 0 && o.constructor === Object;
 }


### PR DESCRIPTION
# Summary

This pull request:
1. Refactors `ObjectUtils` to use fewer `any` types, and
2. adds automated tests for `sortByValue` and `convertValuesToFunctions`.

Related to https://github.com/laurent22/joplin/pull/14031.

# Notes

The `fieldsEqual` and `isEmpty` functions in `ObjectUtils.ts` seem to be unused. It may make sense to remove them in a follow-up pull request.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->