### PR TITLE
Desktop: Accessibility: Make sidebar "jump to next match" case insensitive

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnSidebarKeyDownHandler.ts
@@ -51,9 +51,11 @@ const getParentOffset = (childIndex: number, listItems: ListItem[]): number|null
 };
 
 const findNextTypeAheadMatch = (selectedIndex: number, query: string, listItems: ListItem[]) => {
+	const normalize = (text: string) => text.trim().toLowerCase();
 	const matches = (item: ListItem) => {
-		return item.label.startsWith(query);
+		return normalize(item.label).startsWith(normalize(query));
 	};
+
 	const indexBefore = listItems.slice(0, selectedIndex).findIndex(matches);
 	// Search in all results **after** the current. This prevents the current item from
 	// always being identified as the next match, if the user repeatedly presses the

--- a/packages/app-desktop/integration-tests/sidebar.spec.ts
+++ b/packages/app-desktop/integration-tests/sidebar.spec.ts
@@ -64,6 +64,10 @@ test.describe('sidebar', () => {
 		await expect(mainWindow.locator(':focus')).toHaveText('Folder b');
 		await mainWindow.keyboard.type('A');
 		await expect(mainWindow.locator(':focus')).toHaveText('All notes');
+
+		// Should be case-insensitive
+		await mainWindow.keyboard.type('f');
+		await expect(mainWindow.locator(':focus')).toHaveText('Folder b');
 	});
 
 	test('left/right arrow keys should expand/collapse notebooks', async ({ electronApp, mainWindow }) => {


### PR DESCRIPTION
# Summary

This pull request makes the sidebar "jump to next match" logic case insensitive. Previously, it was necessary to press <kbd>shift</kbd>-<kbd>a</kbd>, for example, to jump to "All notes". This was problematic, since <kbd>shift</kbd> is also used for notebook multiselect.

# Testing

In addition to the new automated test, the following manual testing has been done (Linux/Fedora 43):
1. Start Joplin. Create several notebooks starting with "T".
2. Press <kbd>t</kbd> repeatedly. Verify that this cycles through the just-created notebooks, "Trash", "TAGS", and any other notebooks that previously started with T.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->