### PR TITLE
Mobile: Align tag search-input-clear behavior across input methods (#13243)

### DIFF
--- a/packages/app-mobile/components/ComboBox.tsx
+++ b/packages/app-mobile/components/ComboBox.tsx
@@ -438,9 +438,8 @@ const useInputEventHandlers = ({
 	const onSubmit = useCallback(() => {
 		if (selectedResult) {
 			onItemSelected(selectedResult, selectedIndex);
-			setSearch('');
 		}
-	}, [onItemSelected, selectedResult, selectedIndex, setSearch]);
+	}, [onItemSelected, selectedResult, selectedIndex]);
 
 	// For now, onKeyPress only works on web.
 	// See https://github.com/react-native-community/discussions-and-proposals/issues/249


### PR DESCRIPTION
This PR fixes the inconsistent tag search input clear behavior in the mobile tag association screen. Now, creating new tags always clears the input and selecting previous tags always retains the input.

## Problem

Currently, the tag search combobox has inconsistent behavior when adding tags:
- **Adding an existing tag** (via keyboard or touchscreen) → retains search input 
- **Adding a new tag via keyboard Enter** → clears search input
- **Adding a new tag via "+ Add new" button** → clears search input

This inconsistency was confusing for users as reported in #13243.

## Solution

After reviewing the [[ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) and discussion on the issue #13243, the solution was finalized:

https://github.com/laurent22/joplin/issues/13243#issuecomment-3707268498

> ...It would be better to retain the search term if enter is pressed when an existing tag is selected, and clear the input if the add new tag option is selected when pressing enter. Then it would be consistent with the behaviour of the touch interactions.

## Changes Made

- Removed `setSearch` from the `useInputEventHandlers` hook's `onSubmit` method (line 438) and from its dependency array in `ComboBox.tsx`

## Testing

### Manual Testing Steps

1. **Open the tag association screen** on a note
2. **Test adding existing tags via keyboard**:
   - Type a search term that matches existing tags
   - Press Enter or tap a result
   - ✅ Verify: Search input is retained
3. **Test adding new tags via keyboard**:
   - Type a new tag name
   - Press Enter
   - ✅ Verify: Search input is cleared
4. **Test adding new tags via button**:
   - Type a new tag name
   - Tap the "+ Add new" button
   - ✅ Verify: Search input is cleared
5. **Test adding existing tags via touch**:
   - Type a search term
   - Tap on a search result
   - ✅ Verify: Search input is retained
6. **Test rapid multi-tag addition**:
   - Add 5+ tags in quick succession using different methods
   - ✅ Verify: Behavior is consistent across all methods

### Related Functionality Verification

- Note editing still works as expected
- Tag list updates correctly after additions
- Search results filter properly as you type
- Tag removal functionality unchanged

## Benefits

- ✅ Consistent behavior across all input methods for note tags input box

## Screenshots/Videos

[View demo video](https://github.com/user-attachments/assets/94b6a4da-512a-4291-bcb1-16746fdfc9de)
## Related Issue

Fixes #13243