### PR TITLE
Desktop, Mobile: Resolves #13159: Markdown editor: Prevent layout shift when hiding/showing rendered checkboxes

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -7,12 +7,20 @@ const checkboxClassName = 'cm-ext-checkbox-toggle';
 
 
 class CheckboxWidget extends WidgetType {
-	public constructor(private checked: boolean, private depth: number, private label: string) {
+	public constructor(
+		private checked: boolean,
+		private depth: number,
+		private label: string,
+		private markup: string,
+	) {
 		super();
 	}
 
 	public eq(other: CheckboxWidget) {
-		return other.checked === this.checked && other.depth === this.depth && other.label === this.label;
+		return other.checked === this.checked
+			&& other.depth === this.depth
+			&& other.label === this.label
+			&& other.markup === this.markup;
 	}
 
 	private applyContainerClasses(container: HTMLElement) {
@@ -34,7 +42,7 @@ class CheckboxWidget extends WidgetType {
 
 		const sizingNode = document.createElement('span');
 		sizingNode.classList.add('sizing');
-		sizingNode.textContent = `[${this.checked ? 'x' : ' '}]`;
+		sizingNode.textContent = this.markup;
 		container.appendChild(sizingNode);
 
 		const checkbox = document.createElement('input');
@@ -83,13 +91,14 @@ const replaceCheckboxes = [
 				marginTop: '4px',
 				marginBottom: '4px',
 
+				// Center it:
 				marginLeft: 'auto',
 				marginRight: 'auto',
 				verticalAlign: 'middle',
 			},
 
 			'& > .sizing': {
-				color: 'transparent',
+				visibility: 'hidden',
 			},
 
 			'& > .content': {
@@ -122,8 +131,14 @@ const replaceCheckboxes = [
 			if (node.name === 'TaskMarker') {
 				const containerLine = state.doc.lineAt(node.from);
 				const labelText = state.doc.sliceString(node.to, containerLine.to);
+				const markerText = state.doc.sliceString(node.from, node.to);
 
-				return new CheckboxWidget(markerIsChecked(node), parentTags.get('ListItem') ?? 0, labelText);
+				return new CheckboxWidget(
+					markerIsChecked(node),
+					parentTags.get('ListItem') ?? 0,
+					labelText,
+					markerText,
+				);
 			} else if (node.name === 'Task') {
 				const marker = node.node.getChild('TaskMarker');
 				if (marker && markerIsChecked(marker)) {

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -85,18 +85,6 @@ const replaceCheckboxes = [
 		[`& .${checkboxClassName}`]: {
 			position: 'relative',
 
-			'& > input': {
-				width: '1.1em',
-				height: '1.1em',
-				marginTop: '4px',
-				marginBottom: '4px',
-
-				// Center it:
-				marginLeft: 'auto',
-				marginRight: 'auto',
-				verticalAlign: 'middle',
-			},
-
 			'& > .sizing': {
 				visibility: 'hidden',
 			},
@@ -105,6 +93,18 @@ const replaceCheckboxes = [
 				position: 'absolute',
 				left: '0',
 				right: '0',
+				top: '0',
+				bottom: '0',
+
+				// Center it:
+				marginLeft: 'auto',
+				marginRight: 'auto',
+
+				// A small margin seems to be necessary to align the checkbox
+				// with the list item marker. Use percents so that the relative
+				// size adjusts with the font size/line height.
+				marginTop: '15%',
+				marginBottom: '10%',
 			},
 		},
 		[`& .${completedTaskClassName}`]: {

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -119,7 +119,7 @@ const replaceCheckboxes = [
 					return null;
 				}
 
-				return [listMarker.from, node.to];
+				return [node.from, node.to];
 			} else if (node.name === 'Task') {
 				const taskLine = state.doc.lineAt(node.from);
 				return [taskLine.from];

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -17,6 +17,8 @@ class CheckboxWidget extends WidgetType {
 
 	private applyContainerClasses(container: HTMLElement) {
 		container.classList.add(checkboxClassName);
+		// For sizing: Should have the same font/styles as non-rendered checkboxes:
+		container.classList.add('cm-taskMarker');
 
 		for (const className of [...container.classList]) {
 			if (className.startsWith('-depth-')) {
@@ -30,11 +32,17 @@ class CheckboxWidget extends WidgetType {
 	public toDOM(view: EditorView) {
 		const container = document.createElement('span');
 
+		const sizingNode = document.createElement('span');
+		sizingNode.classList.add('sizing');
+		sizingNode.textContent = `[${this.checked ? 'x' : ' '}]`;
+		container.appendChild(sizingNode);
+
 		const checkbox = document.createElement('input');
 		checkbox.type = 'checkbox';
 		checkbox.checked = this.checked;
 		checkbox.ariaLabel = this.label;
 		checkbox.title = this.label;
+		checkbox.classList.add('content');
 		container.appendChild(checkbox);
 
 		checkbox.oninput = () => {
@@ -67,14 +75,27 @@ const completedListItemDecoration = Decoration.line({ class: completedTaskClassN
 const replaceCheckboxes = [
 	EditorView.theme({
 		[`& .${checkboxClassName}`]: {
+			position: 'relative',
+
 			'& > input': {
 				width: '1.1em',
 				height: '1.1em',
-				margin: '4px',
+				marginTop: '4px',
+				marginBottom: '4px',
+
+				marginLeft: 'auto',
+				marginRight: 'auto',
 				verticalAlign: 'middle',
 			},
-			'&:not(.-depth-1) > input': {
-				marginInlineStart: 0,
+
+			'& > .sizing': {
+				color: 'transparent',
+			},
+
+			'& > .content': {
+				position: 'absolute',
+				left: '0',
+				right: '0',
 			},
 		},
 		[`& .${completedTaskClassName}`]: {


### PR DESCRIPTION
# Summary

Previously, when "Markdown editor: Render markup in editor" was enabled, the rendered version of a checkbox list item was smaller than the non-rendered version. As a result, content after the checkbox shifted when a line switched from the text representation to the rendered representation.

With this change, rendered checkboxes have the same width as their Markdown source.

Resolves #13159.

# Screenshot comparison

|| Before | After |
|----|--------|-------|
| **Default font size** | <img width="933" height="357" alt="screenshot: bullet points not visible in rendered mode" src="https://github.com/user-attachments/assets/c42209b7-17f4-489a-bf2a-585050a85447" /> | <img width="933" height="357" alt="screenshot: bullet points visible even in rendered mode in addition to checkboxes" src="https://github.com/user-attachments/assets/680b8585-75c8-49a4-9828-fad0d49fef1a" /> |
| **Large font size** | <img width="947" height="744" alt="image" src="https://github.com/user-attachments/assets/f7281d42-3b38-441b-a987-ead119336d87" /> | <img width="931" height="733" alt="image" src="https://github.com/user-attachments/assets/4363c624-b886-4c78-9972-5fc4c2801e2b" /> |

# Screen recording

**Desktop**:

[Screencast from 2026-01-06 10-35-19.webm](https://github.com/user-attachments/assets/cd699daa-e6c8-4a7a-9ae7-c4fd27707c1e)


The above screen recording shows moving the cursor between lines containing checkboxes in a checklist. The text after each checkbox stays in the same position when a line is in rendered vs non-rendered mode.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->