### PR TITLE
Desktop: OneNote import: Fix video embeds aren't imported: Import video embeds as links

### DIFF
--- a/packages/onenote-converter/renderer/src/page/embedded_file.rs
+++ b/packages/onenote-converter/renderer/src/page/embedded_file.rs
@@ -25,9 +25,11 @@ impl<'a> Renderer<'a> {
 
         let file_type = Self::guess_type(file);
         match file_type {
-            // TODO: we still don't have support for the audio tag on html notes https://github.com/laurent22/joplin/issues/11939.
-            // TODO: Joplin currently can't import <video> resources in HTML notes, render as links
-            //       instead.
+            // TODO: As of 01-06-2026, Joplin has limited or no support for <video> and <audio> elements in HTML notes.
+            // For example, <video> elements can only reference web URLs and <audio> elements aren't
+            // supported at all.
+            //
+            // See also: https://github.com/laurent22/joplin/issues/11939.
             // FileType::Audio => content = format!("<audio class=\"media-player media-audio\"controls><source src=\"{}\" type=\"audio/x-wav\"></source></audio>", filename),
             // FileType::Video => content = format!("<video controls src=\"{}\" {}></video>", filename, styles.to_html_attr()),
             FileType::Unknown | FileType::Audio | FileType::Video => {

--- a/packages/onenote-converter/renderer/src/page/embedded_file.rs
+++ b/packages/onenote-converter/renderer/src/page/embedded_file.rs
@@ -25,10 +25,12 @@ impl<'a> Renderer<'a> {
 
         let file_type = Self::guess_type(file);
         match file_type {
-            // TODO: we still don't have support for the audio tag on html notes https://github.com/laurent22/joplin/issues/11939
+            // TODO: we still don't have support for the audio tag on html notes https://github.com/laurent22/joplin/issues/11939.
+            // TODO: Joplin currently can't import <video> resources in HTML notes, render as links
+            //       instead.
             // FileType::Audio => content = format!("<audio class=\"media-player media-audio\"controls><source src=\"{}\" type=\"audio/x-wav\"></source></audio>", filename),
-            FileType::Video => content = format!("<video controls src=\"{}\" {}></video>", filename, styles.to_html_attr()),
-            FileType::Unknown | FileType::Audio => {
+            // FileType::Video => content = format!("<video controls src=\"{}\" {}></video>", filename, styles.to_html_attr()),
+            FileType::Unknown | FileType::Audio | FileType::Video => {
                 styles.set("font-size", "11pt".into());
                 styles.set("line-height", "17px".into());
                 let style_attr = styles.to_html_attr();


### PR DESCRIPTION
# Summary

This pull request works around an import issue by importing `<video>` embeds in OneNote notebooks as `<a>` links. Previously, `<video>` embeds were imported as unplayable videos with a missing resource.

Partially resolves #13549.

# Notes

A better fix might be to add support for `<video>` resources in HTML notes. Currently, the HTML importer doesn't import `<video>` markup as resources (see https://github.com/laurent22/joplin/pull/13899) and the HTML->HTML renderer doesn't support rendering `<video>`s that reference HTML resources.

# Testing plan

1. Import "Tuto vidéo - partage Carnet de notes Joplin.one" (from #13549).
2. Verify that a link to an MP4 video has been created.
3. Verify that clicking the link opens the video.
4. Convert the note to Markdown.
5. Verify that the video renders in the note viewer.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->