### PR TITLE
Mobile: Rich Text Editor: Add shortcuts for inserting code blocks

### DIFF
--- a/packages/editor/ProseMirror/commands/commands.ts
+++ b/packages/editor/ProseMirror/commands/commands.ts
@@ -135,9 +135,12 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 			if (view) {
 				const selectedText = getTextBetween(state.doc, state.selection.from, state.selection.to);
 				const content = selectedText || '...';
-				return showCreateEditablePrompt(
-					block ? `$$\n\t${content}\n$$` : `$${content}$`, !block,
-				)(state, dispatch, view);
+				const blockStart = block ? '$$\n\t' : '$';
+				return showCreateEditablePrompt({
+					source: block ? `${blockStart}${content}\n$$` : `${blockStart}${content}$`,
+					inline: !block,
+					cursor: blockStart.length,
+				})(state, dispatch, view);
 			}
 			return true;
 		}
@@ -180,10 +183,13 @@ const commands: Record<EditorCommandType, ExtendedCommand|null> = {
 		return true;
 	},
 	[EditorCommandType.InsertCodeBlock]: (state, dispatch, view) => {
+		const sourceBlockStart = '```\n';
 		const selectedText = getTextBetween(state.doc, state.selection.from, state.selection.to);
-		return showCreateEditablePrompt(
-			`\`\`\`\n${selectedText}\n\`\`\``, false,
-		)(state, dispatch, view);
+		return showCreateEditablePrompt({
+			source: `${sourceBlockStart}${selectedText}\n\`\`\``,
+			inline: false,
+			cursor: sourceBlockStart.length,
+		})(state, dispatch, view);
 	},
 	[EditorCommandType.ToggleSearch]: (state, dispatch, view) => {
 		const command = setSearchVisible(!getSearchVisible(state));

--- a/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
@@ -163,7 +163,7 @@ const inputRulesExtension = [
 	baseInputRules,
 	inlineInputRules([
 		makeInputRule({
-			contentRegex: /(^|[\n])(```+)(\w+)$/,
+			contentRegex: /(^|[\n])(```+)(\w*)$/,
 			commitCharacter: '',
 			onReplace: (match, view) => {
 				const blockStart = `${match[1]}${match[2]}\n`;
@@ -195,12 +195,6 @@ const inputRulesExtension = [
 			commitCharacter: '_',
 			onReplace: (match) => match[1],
 			marks: [schema.marks.emphasis],
-		}),
-		makeInputRule({
-			contentRegex: `[\`](${inlineContentExp})[\`]`,
-			commitCharacter: '`',
-			onReplace: (match) => match[1],
-			marks: [schema.marks.code],
 		}),
 	], /[ .,?)!;]/),
 ];

--- a/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
@@ -4,19 +4,20 @@ import { MarkType, ResolvedPos } from 'prosemirror-model';
 import { EditorState, Plugin, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { closeHistory } from 'prosemirror-history';
+import showCreateEditablePrompt from './joplinEditablePlugin/showCreateEditablePrompt';
 
 
-interface InlineInputRule {
+interface InputRuleData {
 	match: RegExp;
-	matchEndCharacter: string;
-	handler: (state: EditorState, match: RegExpMatchArray, start: number, end: number, commitCharacter: string)=> Transaction|null;
+	commitCharacter: string|null;
+	handler: (view: EditorView, match: RegExpMatchArray, start: number, end: number, commitCharacter: string)=> Transaction|null;
 }
 
 // A custom input rule extension for inline input replacements.
 //
 // Ref: https://github.com/ProseMirror/prosemirror-inputrules/blob/43ef04ce9c1512ef8f2289578309c40b431ed3c5/src/inputrules.ts#L82
 // See https://discuss.prosemirror.net/t/trigger-inputrule-on-enter/1118 for why this approach is needed.
-const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: RegExp) => {
+const inlineInputRules = (rules: InputRuleData[], commitCharacterExpression: RegExp) => {
 	const getContentBeforeCursor = (cursorInformation: ResolvedPos) => {
 		const parent = cursorInformation.parent;
 		const offsetInParent = cursorInformation.parentOffset;
@@ -25,9 +26,11 @@ const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: R
 	};
 
 	const getApplicableRule = (state: EditorState, cursor: number, justTypedText: string) => {
-		if (!rules.some(rule => justTypedText.endsWith(rule.matchEndCharacter))) {
+		const candidateRules = rules.filter(rule => justTypedText.endsWith(rule.commitCharacter ?? ''));
+		if (!candidateRules.length) {
 			return false;
 		}
+
 		const cursorInformation = state.doc.resolve(cursor);
 		const inCode = cursorInformation.parent.type.spec.code;
 		if (inCode) {
@@ -35,7 +38,7 @@ const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: R
 		}
 		const beforeCursor = getContentBeforeCursor(cursorInformation) + justTypedText;
 
-		for (const rule of rules) {
+		for (const rule of candidateRules) {
 			const match = beforeCursor.match(rule.match);
 			if (!match) continue;
 
@@ -44,7 +47,7 @@ const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: R
 		return null;
 	};
 
-	type PluginState = { pendingRule: InlineInputRule };
+	type PluginState = { pendingRule: InputRuleData };
 	const run = (view: EditorView, cursor: number, commitData: string) => {
 		const commitCharacter = commitCharacterExpression.exec(commitData) ? commitData : '';
 
@@ -57,7 +60,7 @@ const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: R
 		const beforeCursor = getContentBeforeCursor(view.state.doc.resolve(cursor));
 		const match = beforeCursor.match(availableRule.match);
 		if (match) {
-			const transaction = availableRule.handler(view.state, match, cursor - match[0].length, cursor, commitCharacter);
+			const transaction = availableRule.handler(view, match, cursor - match[0].length, cursor, commitCharacter);
 			if (transaction) {
 				// closeHistory: Move the markup completion to a separate history event so that it
 				// can be undone separately.
@@ -109,17 +112,25 @@ const inlineInputRules = (rules: InlineInputRule[], commitCharacterExpression: R
 	return plugin;
 };
 
-const makeMarkInputRule = (
-	regExpString: string, matchEndCharacter: string, replacement: (matches: RegExpMatchArray)=> string, mark: MarkType,
-): InlineInputRule => {
+type OnReplace = (matches: RegExpMatchArray, view: EditorView)=> string;
+interface InputRuleOptions {
+	contentRegex: string|RegExp;
+	commitCharacter: string|null; // null => only "Enter"
+	onReplace: OnReplace;
+	marks: MarkType[];
+}
+
+const makeInputRule = ({
+	contentRegex, commitCharacter, onReplace, marks,
+}: InputRuleOptions): InputRuleData => {
 	const commitCharacterExp = '[.?!,:;¡¿() \\n]';
-	const regex = new RegExp(`(^|${commitCharacterExp})${regExpString}$`);
+	const regex = typeof contentRegex === 'string' ? new RegExp(`(^|${commitCharacterExp})${contentRegex}$`) : contentRegex;
 	return {
 		match: regex,
-		matchEndCharacter,
-		handler: (state, match, start, end, endCommitCharacter) => {
+		commitCharacter,
+		handler: (view, match, start, end, endCommitCharacter) => {
+			const state = view.state;
 			let transaction = state.tr.delete(start, end);
-			const marks = [schema.mark(mark)];
 
 			const startCommitCharacter = match[1];
 
@@ -131,13 +142,12 @@ const makeMarkInputRule = (
 			];
 			matchesWithoutCommitCharacters.groups = match.groups;
 
-			const replacementText = replacement(matchesWithoutCommitCharacters);
-
+			const replacement = onReplace(matchesWithoutCommitCharacters, view);
 			transaction = transaction.insert(
 				transaction.mapping.map(start, -1),
 				[
 					!!startCommitCharacter && schema.text(startCommitCharacter),
-					!!replacementText && schema.text(replacementText, marks),
+					!!replacement && schema.text(replacement, marks.map(type => schema.mark(type))),
 					!!endCommitCharacter && schema.text(endCommitCharacter),
 				].filter(node => !!node),
 			);
@@ -152,30 +162,52 @@ const inlineContentExp = '\\S[^\\n]*\\S|\\S';
 const inputRulesExtension = [
 	baseInputRules,
 	inlineInputRules([
-		makeMarkInputRule(
-			`\\*\\*(${inlineContentExp})\\*\\*`,
-			'*',
-			(match) => match[1],
-			schema.marks.strong,
-		),
-		makeMarkInputRule(
-			`\\*(${inlineContentExp})\\*`,
-			'*',
-			(match) => match[1],
-			schema.marks.emphasis,
-		),
-		makeMarkInputRule(
-			`_(${inlineContentExp})_`,
-			'_',
-			(match) => match[1],
-			schema.marks.emphasis,
-		),
-		makeMarkInputRule(
-			`[\`](${inlineContentExp})[\`]`,
-			'`',
-			(match) => match[1],
-			schema.marks.code,
-		),
+		makeInputRule({
+			contentRegex: /(^|[\n])(```+)(\w+)$/,
+			commitCharacter: '',
+			onReplace: (match, view) => {
+				const blockStart = `${match[1]}${match[2]}\n`;
+				const block = `${blockStart}\n${match[1]}`;
+				showCreateEditablePrompt({
+					source: block,
+					inline: false,
+					cursor: blockStart.length,
+				})(view.state, view.dispatch, view);
+				return '';
+			},
+			marks: [schema.marks.mark],
+		}),
+
+		makeInputRule({
+			contentRegex: `\\*\\*(${inlineContentExp})\\*\\*`,
+			commitCharacter: '*',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.strong],
+		}),
+		makeInputRule({
+			contentRegex: `\\*(${inlineContentExp})\\*`,
+			commitCharacter: '*',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.emphasis],
+		}),
+		makeInputRule({
+			contentRegex: `_(${inlineContentExp})_`,
+			commitCharacter: '_',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.emphasis],
+		}),
+		makeInputRule({
+			contentRegex: `[\`](${inlineContentExp})[\`]`,
+			commitCharacter: '`',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.code],
+		}),
+		makeInputRule({
+			contentRegex: `==(${inlineContentExp})==`,
+			commitCharacter: '=',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.mark],
+		}),
 	], /[ .,?)!;]/),
 ];
 export default inputRulesExtension;

--- a/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
@@ -175,7 +175,7 @@ const inputRulesExtension = [
 				})(view.state, view.dispatch, view);
 				return '';
 			},
-			marks: [schema.marks.mark],
+			marks: [],
 		}),
 
 		makeInputRule({
@@ -201,12 +201,6 @@ const inputRulesExtension = [
 			commitCharacter: '`',
 			onReplace: (match) => match[1],
 			marks: [schema.marks.code],
-		}),
-		makeInputRule({
-			contentRegex: `==(${inlineContentExp})==`,
-			commitCharacter: '=',
-			onReplace: (match) => match[1],
-			marks: [schema.marks.mark],
 		}),
 	], /[ .,?)!;]/),
 ];

--- a/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
@@ -196,6 +196,12 @@ const inputRulesExtension = [
 			onReplace: (match) => match[1],
 			marks: [schema.marks.emphasis],
 		}),
+		makeInputRule({
+			contentRegex: `\`(${inlineContentExp})\``,
+			commitCharacter: '`',
+			onReplace: (match) => match[1],
+			marks: [schema.marks.code],
+		}),
 	], /[ .,?)!;]/),
 ];
 export default inputRulesExtension;

--- a/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/inputRulesPlugin.ts
@@ -159,6 +159,7 @@ const makeInputRule = ({
 
 const baseInputRules = buildInputRules(schema);
 const inlineContentExp = '\\S[^\\n]*\\S|\\S';
+const noMatchRegex = /$^/;
 const inputRulesExtension = [
 	baseInputRules,
 	inlineInputRules([
@@ -177,7 +178,8 @@ const inputRulesExtension = [
 			},
 			marks: [],
 		}),
-
+	], noMatchRegex),
+	inlineInputRules([
 		makeInputRule({
 			contentRegex: `\\*\\*(${inlineContentExp})\\*\\*`,
 			commitCharacter: '*',

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.ts
@@ -23,13 +23,15 @@ const createEditorDialogForNode = (nodePosition: number, view: EditorView, onHid
 		view.state.doc.nodeAt(nodePosition)
 	);
 
+	const openCharacters = getNode().attrs.openCharacters;
 	const { dismiss } = createEditorDialog({
 		editorApi: getEditorApi(view.state),
 		source: [
-			getNode().attrs.openCharacters,
+			openCharacters,
 			getNode().attrs.source,
 			getNode().attrs.closeCharacters,
 		].join(''),
+		cursor: openCharacters.length,
 		onSave: async (source) => {
 			view.dispatch(
 				view.state.tr.setNodeAttribute(

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/joplinEditablePlugin.ts
@@ -23,13 +23,13 @@ const createEditorDialogForNode = (nodePosition: number, view: EditorView, onHid
 		view.state.doc.nodeAt(nodePosition)
 	);
 
-	const openCharacters = getNode().attrs.openCharacters;
+	const openCharacters = getNode().attrs.openCharacters ?? '';
 	const { dismiss } = createEditorDialog({
 		editorApi: getEditorApi(view.state),
 		source: [
 			openCharacters,
 			getNode().attrs.source,
-			getNode().attrs.closeCharacters,
+			getNode().attrs.closeCharacters ?? '',
 		].join(''),
 		cursor: openCharacters.length,
 		onSave: async (source) => {

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.test.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.test.ts
@@ -38,7 +38,11 @@ describe('showCreateEditorPrompt', () => {
 
 	test('should allow creating a new code block', async () => {
 		const editor = createEditor('');
-		showCreateEditablePrompt('```\ntest\n```', false)(editor.state, editor.dispatch, editor);
+		showCreateEditablePrompt({
+			source: '```\ntest\n```',
+			inline: false,
+			cursor: 4,
+		})(editor.state, editor.dispatch, editor);
 
 		const dialog = findEditorDialog();
 		dialog.submitButton.click();

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.test.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.test.ts
@@ -41,7 +41,7 @@ describe('showCreateEditorPrompt', () => {
 		showCreateEditablePrompt({
 			source: '```\ntest\n```',
 			inline: false,
-			cursor: 4,
+			cursor: 8,
 		})(editor.state, editor.dispatch, editor);
 
 		const dialog = findEditorDialog();
@@ -57,5 +57,17 @@ describe('showCreateEditorPrompt', () => {
 				},
 			}],
 		});
+	});
+
+	test('should position the cursor at the provided location', () => {
+		const editor = createEditor('');
+		showCreateEditablePrompt({
+			source: '```\n\n```',
+			inline: false,
+			cursor: 4,
+		})(editor.state, editor.dispatch, editor);
+
+		const dialog = findEditorDialog();
+		expect(dialog.editor.selectionStart).toBe(4);
 	});
 });

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/showCreateEditablePrompt.ts
@@ -5,13 +5,20 @@ import postProcessRenderedHtml from './utils/postProcessRenderedHtml';
 import schema from '../../schema';
 import { JoplinEditableAttributes } from './joplinEditablePlugin';
 
-const showCreateEditablePrompt = (source: string, inline: boolean): Command => (_state, dispatch, view) => {
+interface EditablePromptOptions {
+	source: string;
+	inline: boolean;
+	cursor: number;
+}
+
+const showCreateEditablePrompt = ({ source, inline, cursor }: EditablePromptOptions): Command => (_state, dispatch, view) => {
 	if (!dispatch) return true;
 	if (!view) throw new Error('Missing required argument: view');
 
 	createEditorDialog({
 		editorApi: getEditorApi(view.state),
 		source,
+		cursor,
 		onSave: async (newSource) => {
 			source = newSource;
 		},

--- a/packages/editor/ProseMirror/plugins/joplinEditablePlugin/utils/createEditorDialog.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditablePlugin/utils/createEditorDialog.ts
@@ -1,15 +1,17 @@
 import { EditorApi } from '../../joplinEditorApiPlugin';
 import { EditorLanguageType } from '../../../../types';
 import showModal from '../../../utils/dom/showModal';
+import { focus } from '@joplin/lib/utils/focusHandler';
 
 interface Options {
 	source: string;
+	cursor: number;
 	editorApi: EditorApi;
 	onSave: (newContent: string)=> void;
 	onDismiss: ()=> void;
 }
 
-const createEditorDialog = ({ editorApi, source, onSave, onDismiss }: Options) => {
+const createEditorDialog = ({ editorApi, source, cursor, onSave, onDismiss }: Options) => {
 	const content = document.createElement('div');
 	content.classList.add('editor-dialog-content');
 	document.body.appendChild(content);
@@ -22,9 +24,10 @@ const createEditorDialog = ({ editorApi, source, onSave, onDismiss }: Options) =
 		},
 	);
 	editor.updateBody(source);
+	editor.select(cursor, cursor);
 
 	const _ = editorApi.localize;
-	return showModal({
+	const modal = showModal({
 		content,
 		doneLabel: _('Done'),
 		onDismiss: () => {
@@ -32,6 +35,10 @@ const createEditorDialog = ({ editorApi, source, onSave, onDismiss }: Options) =
 			editor.remove();
 		},
 	});
+
+	focus('createEditorDialog', editor);
+
+	return modal;
 };
 
 export default createEditorDialog;

--- a/packages/editor/ProseMirror/plugins/joplinEditorApiPlugin.ts
+++ b/packages/editor/ProseMirror/plugins/joplinEditorApiPlugin.ts
@@ -48,6 +48,9 @@ const joplinEditorApiPlugin = new Plugin<EditorApi>({
 					updateBody: (newValue) => {
 						editor.textArea.value = newValue;
 					},
+					select: (anchor, head) => {
+						editor.textArea.setSelectionRange(Math.min(anchor, head), Math.max(anchor, head));
+					},
 				};
 			},
 		}),

--- a/packages/editor/ProseMirror/types.ts
+++ b/packages/editor/ProseMirror/types.ts
@@ -14,11 +14,6 @@ export interface RendererControl {
 	renderHtmlToMarkup: HtmlToMarkup;
 }
 
-export interface CodeEditorSelection {
-	anchor: number;
-	head: number;
-}
-
 export interface CodeEditorControl {
 	focus: ()=> void;
 	remove: ()=> void;

--- a/packages/editor/ProseMirror/types.ts
+++ b/packages/editor/ProseMirror/types.ts
@@ -14,10 +14,16 @@ export interface RendererControl {
 	renderHtmlToMarkup: HtmlToMarkup;
 }
 
+export interface CodeEditorSelection {
+	anchor: number;
+	head: number;
+}
+
 export interface CodeEditorControl {
 	focus: ()=> void;
 	remove: ()=> void;
 	updateBody: (newValue: string)=> void;
+	select: (from: number, to: number)=> void;
 }
 export type OnCodeEditorChange = (newValue: string)=> void;
 


### PR DESCRIPTION
# Summary

This pull request makes the following changes:
- **New input rule**: Adds an [input rule](https://prosemirror.net/docs/ref/#inputrules) that creates block code.
   - On an empty line:
      - Typing <code>```language</code>, then pressing <kbd>enter</kbd>, opens the code block editor where the code block has language `language` (`language` can be empty).
   - To support this, `inputRulesPlugin.ts` was refactored. This should simplify creating other input rules in the future.
- **Focus the code dialog**: Auto-focuses the "insert code block" dialog.

# Screen recording

Web:

[Screencast from 2026-01-07 11-44-53.webm](https://github.com/user-attachments/assets/d7557e1a-93cb-461f-b568-4a857ecb3c18)

The above screen recording shows:
- Creating a new code block by typing <code>```</code>, then pressing <kbd>enter</kbd>.
- Creating a new TypeScript code block by typing <code>```typescript</code>, then pressing <kbd>enter</kbd>.
- Creating bold/italic/list/inline code content using the previously-supported input rules.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->