### PR TITLE
Desktop, Mobile: Accessibility: In-editor rendering: Fix rendered checkboxes are very small on mobile

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -104,7 +104,7 @@ const replaceCheckboxes = [
 			},
 		},
 		[`& .${checkboxClassName}`]: {
-			verticalAlign: 'baseline',
+			verticalAlign: 'middle',
 
 			// Ensure that the checkbox grows as the font size increases:
 			width: '100%',
@@ -112,7 +112,7 @@ const replaceCheckboxes = [
 
 			// Shift the checkbox slightly so that it's aligned with the list item bullet point
 			margin: '0',
-			marginTop: '3px',
+			marginBottom: '3px',
 		},
 		[`& .${completedTaskClassName}`]: {
 			opacity: 0.69,

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -96,15 +96,16 @@ const replaceCheckboxes = [
 				top: '0',
 				bottom: '0',
 
+				// Ensure that the checkbox is at least as tall as the default
+				// checkbox height in Chromium (13px), even for very small font
+				// sizes.
+				height: 'max(13px, 70%)',
+
 				// Center it:
 				marginLeft: 'auto',
 				marginRight: 'auto',
-
-				// A small margin seems to be necessary to align the checkbox
-				// with the list item marker. Use percents so that the relative
-				// size adjusts with the font size/line height.
-				marginTop: '15%',
-				marginBottom: '10%',
+				marginTop: 'auto',
+				marginBottom: 'auto',
 			},
 		},
 		[`& .${completedTaskClassName}`]: {

--- a/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceCheckboxes.ts
@@ -3,7 +3,8 @@ import { SyntaxNodeRef } from '@lezer/common';
 import makeReplaceExtension from './utils/makeInlineReplaceExtension';
 import toggleCheckboxAt from '../../utils/markdown/toggleCheckboxAt';
 
-const checkboxClassName = 'cm-ext-checkbox-toggle';
+const checkboxContainerClassName = 'cm-ext-checkbox-toggle';
+const checkboxClassName = 'cm-ext-checkbox';
 
 
 class CheckboxWidget extends WidgetType {
@@ -24,7 +25,7 @@ class CheckboxWidget extends WidgetType {
 	}
 
 	private applyContainerClasses(container: HTMLElement) {
-		container.classList.add(checkboxClassName);
+		container.classList.add(checkboxContainerClassName);
 		// For sizing: Should have the same font/styles as non-rendered checkboxes:
 		container.classList.add('cm-taskMarker');
 
@@ -45,13 +46,17 @@ class CheckboxWidget extends WidgetType {
 		sizingNode.textContent = this.markup;
 		container.appendChild(sizingNode);
 
+		const checkboxWrapper = document.createElement('span');
+		checkboxWrapper.classList.add('content');
+		container.appendChild(checkboxWrapper);
+
 		const checkbox = document.createElement('input');
 		checkbox.type = 'checkbox';
 		checkbox.checked = this.checked;
 		checkbox.ariaLabel = this.label;
 		checkbox.title = this.label;
-		checkbox.classList.add('content');
-		container.appendChild(checkbox);
+		checkbox.classList.add(checkboxClassName);
+		checkboxWrapper.appendChild(checkbox);
 
 		checkbox.oninput = () => {
 			toggleCheckboxAt(view.posAtDOM(container))(view);
@@ -82,7 +87,7 @@ const completedListItemDecoration = Decoration.line({ class: completedTaskClassN
 
 const replaceCheckboxes = [
 	EditorView.theme({
-		[`& .${checkboxClassName}`]: {
+		[`& .${checkboxContainerClassName}`]: {
 			position: 'relative',
 
 			'& > .sizing': {
@@ -95,18 +100,19 @@ const replaceCheckboxes = [
 				right: '0',
 				top: '0',
 				bottom: '0',
-
-				// Ensure that the checkbox is at least as tall as the default
-				// checkbox height in Chromium (13px), even for very small font
-				// sizes.
-				height: 'max(13px, 70%)',
-
-				// Center it:
-				marginLeft: 'auto',
-				marginRight: 'auto',
-				marginTop: 'auto',
-				marginBottom: 'auto',
+				textAlign: 'center',
 			},
+		},
+		[`& .${checkboxClassName}`]: {
+			verticalAlign: 'baseline',
+
+			// Ensure that the checkbox grows as the font size increases:
+			width: '100%',
+			minHeight: '70%',
+
+			// Shift the checkbox slightly so that it's aligned with the list item bullet point
+			margin: '0',
+			marginTop: '3px',
 		},
 		[`& .${completedTaskClassName}`]: {
 			opacity: 0.69,
@@ -115,7 +121,7 @@ const replaceCheckboxes = [
 	EditorView.domEventHandlers({
 		mousedown: (event) => {
 			const target = event.target as Element;
-			if (target.nodeName === 'INPUT' && target.parentElement?.classList?.contains(checkboxClassName)) {
+			if (target.nodeName === 'INPUT' && target.classList?.contains(checkboxClassName)) {
 				// Let the checkbox handle the event
 				return true;
 			}


### PR DESCRIPTION
# Summary

When "render markup in editor" is enabled, in-editor checkboxes are currently very small on mobile with the default font size. This is a regression from https://github.com/laurent22/joplin/pull/14044. For example, on my test Android device, checkboxes currently have a height of 12px. In the note viewer, checkboxes have a height of 16px.

This pull request adjusts the in-editor checkbox HTML/CSS so that the **minimum checkbox height** matches the default WebView/browser styles. On my test Android device, this minimum height is 16px. On desktop, this height seems to be 13px.

Related: [WCAG 2.2 SC 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum). 

# Screenshots

| Label | Before | After |
|-------|--------|-------|
| **Android: Note editor with checklist, default font size** | <img width="1200" height="2000" alt="screenshot: checkboxes are small" src="https://github.com/user-attachments/assets/82f2bcd3-952f-4f92-b523-3a6e4972d5c1" /> | <img width="1200" height="2000" alt="screenshot: checkboxes are larger" src="https://github.com/user-attachments/assets/e1bd300e-c205-4ad7-a32b-b14d6f4efe9e" /> |
| Android: Note editor with checklist, large font size | <img width="1200" height="2000" alt="before: nested checklist, large text and checkboxes" src="https://github.com/user-attachments/assets/8a9ec4a9-4b02-4bf0-b73f-162714fbecba" /> | <img width="1200" height="2000" alt="image: looks roughly the same as the before case, checkboxes are perhaps slightly larger" src="https://github.com/user-attachments/assets/13af9641-34b2-4d1c-ac0b-53f0747f9c7e" /> |
| Desktop: Note editor+viewer with checklist | <img width="810" height="473" alt="before: Joplin editor and viewer are both visible" src="https://github.com/user-attachments/assets/72734ea9-da27-4fe9-a60a-cea7a1c512ee" /> | <img width="810" height="473" alt="after: checkboxes are roughly the same size" src="https://github.com/user-attachments/assets/0797be88-75a3-486c-811c-4e43a64e2e6a" /> |
| Desktop: Editor with large font size | <img width="812" height="685" alt="before: nested checklist, both text and checkboxes are large" src="https://github.com/user-attachments/assets/ea4d0d8a-5d26-4af9-8230-1deb67185dd8" /> | <img width="812" height="685" alt="after: nested checklist, checkboxes/text have roughly the same size as before" src="https://github.com/user-attachments/assets/5fa600a0-a020-4508-ad4e-2572d4613af0" /> |
| Desktop: Editor with small font size | <img width="800" height="296" alt="before: nested checklist with small text and checkboxes" src="https://github.com/user-attachments/assets/aff58807-1db3-4616-9a73-00ad52c45e91" /> | <img width="800" height="296" alt="after: checkboxes have roughly the same height as the line" src="https://github.com/user-attachments/assets/b0c94c99-636e-49c1-8074-ded209c43d75" /> |




<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->