### PR TITLE
Chore: Desktop: OneNote import: Simplify logic for sanitizing/cleaning up file names

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -313,9 +313,8 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 
 			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
 			if (fixedFileName !== fileName) {
-				// In general, the path shouldn't start with "."s or contain path separators.
-				// However, if it does, these characters might cause import errors, so remove them:
-				fixedFileName = fixedFileName.replace(/^\.+/, '');
+				// In general, the path shouldn't contain path separators.
+				// However, if it does, these characters will cause import errors, so remove them:
 				fixedFileName = fixedFileName.replace(/[/\\]/g, ' ');
 
 				// Avoid path traversal: Ensure that the file path is contained within the base directory

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -2,7 +2,7 @@ import { ImportExportResult, ImportModuleOutputFormat, ImportOptions } from './t
 
 import InteropService_Importer_Base from './InteropService_Importer_Base';
 import { NoteEntity } from '../database/types';
-import { rtrimSlashes } from '../../path-utils';
+import { friendlySafeFilename, rtrimSlashes } from '../../path-utils';
 import InteropService_Importer_Md from './InteropService_Importer_Md';
 import { join, resolve, normalize, sep, dirname, extname, basename, relative } from 'path';
 import Logger from '@joplin/utils/Logger';
@@ -311,14 +311,9 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			const originalPath = join(basePath, fileName);
 			let newPath;
 
-			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
+			const fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
 			if (fixedFileName !== fileName) {
-				// In general, the path shouldn't contain path separators.
-				// However, if it does, these characters will cause import errors, so remove them:
-				fixedFileName = fixedFileName.replace(/[/\\]/g, ' ');
-
-				// Avoid path traversal: Ensure that the file path is contained within the base directory
-				const newFullPathSafe = shim.fsDriver().resolveRelativePathWithinDir(basePath, fixedFileName);
+				const newFullPathSafe = join(basePath, friendlySafeFilename(fixedFileName));
 				await shim.fsDriver().move(originalPath, newFullPathSafe);
 
 				newPath = newFullPathSafe;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -298,8 +298,13 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		};
 	}
 
+	// Works around a decoding issue in which file names are extracted as latin1 strings,
+	// rather than UTF-8 strings. For example, OneNote seems to encode filenames as UTF-8 in .onepkg files.
+	// However, EXPAND.EXE reads the filenames as latin1. As a result, "é.one" becomes
+	// "Ã©.one" when extracted from the archive.
+	// This workaround re-encodes filenames as UTF-8.
 	private async fixIncorrectLatin1Decoding_(parentDir: string) {
-		// Only seems to be necessary on Windows
+		// Only seems to be necessary on Windows.
 		if (!shim.isWindows()) return;
 
 		const fixEncoding = async (basePath: string, fileName: string) => {

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -69,6 +69,8 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 				// other files.
 				fileNamePattern: '*.one',
 			});
+
+			await this.fixIncorrectLatin1Decoding_(extractPath);
 		} else {
 			throw new Error(`Unknown file extension: ${fileExtension}`);
 		}
@@ -294,5 +296,43 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			svgs,
 			changed: true,
 		};
+	}
+
+	private async fixIncorrectLatin1Decoding_(parentDir: string) {
+		// Only seems to be necessary on Windows
+		if (!shim.isWindows()) return;
+
+		const fixEncoding = async (basePath: string, fileName: string) => {
+			const originalPath = join(basePath, fileName);
+			let newPath;
+
+			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
+			if (fixedFileName !== fileName) {
+				// In general, the path shouldn't start with "."s or contain path separators.
+				// However, if it does, these characters might cause import errors, so remove them:
+				fixedFileName = fixedFileName.replace(/^\.+/, '');
+				fixedFileName = fixedFileName.replace(/[/\\]/g, ' ');
+
+				// Avoid path traversal: Ensure that the file path is contained within the base directory
+				const newFullPathSafe = shim.fsDriver().resolveRelativePathWithinDir(basePath, fixedFileName);
+				await shim.fsDriver().move(originalPath, newFullPathSafe);
+
+				newPath = newFullPathSafe;
+			} else {
+				newPath = originalPath;
+			}
+
+			if (await shim.fsDriver().isDirectory(originalPath)) {
+				const children = await shim.fsDriver().readDirStats(newPath, { recursive: false });
+				for (const child of children) {
+					await fixEncoding(originalPath, child.path);
+				}
+			}
+		};
+
+		const stats = await shim.fsDriver().readDirStats(parentDir, { recursive: false });
+		for (const stat of stats) {
+			await fixEncoding(parentDir, stat.path);
+		}
 	}
 }

--- a/packages/onenote-converter/renderer/src/lib.rs
+++ b/packages/onenote-converter/renderer/src/lib.rs
@@ -49,8 +49,10 @@ pub fn convert(path: &str, output_dir: &str, base_path: &str) -> Result<()> {
 
             let section = parser.parse_section(path.to_owned())?;
 
-            let section_output_dir = fs_driver().get_output_path(base_path, output_dir, path);
-            section::Renderer::new().render(&section, section_output_dir.to_owned())?;
+            // Workaround: Section .one file names sometimes don't include properly-encoded UTF-8 characters.
+            let output_dir_name = sanitize_filename::sanitize(section.display_name());
+            let section_output_dir = fs_driver().join(output_dir, &output_dir_name);
+            section::Renderer::new().render(&section, section_output_dir)?;
         }
         ".onetoc2" => {
             let _name: String = fs_driver().get_file_name(path).expect("Missing file name");

--- a/packages/onenote-converter/renderer/src/lib.rs
+++ b/packages/onenote-converter/renderer/src/lib.rs
@@ -40,8 +40,8 @@ pub fn convert(path: &str, output_dir: &str, base_path: &str) -> Result<()> {
 
     match extension.as_str() {
         ".one" => {
-            let file_name: String = fs_driver().get_file_name(path).expect("Missing file name");
-            log!("Parsing .one file: {}", file_name);
+            let _name: String = fs_driver().get_file_name(path).expect("Missing file name");
+            log!("Parsing .one file: {}", _name);
 
             if path.contains("OneNote_RecycleBin") {
                 return Ok(());
@@ -49,24 +49,8 @@ pub fn convert(path: &str, output_dir: &str, base_path: &str) -> Result<()> {
 
             let section = parser.parse_section(path.to_owned())?;
 
-            let section_output_path = fs_driver().get_output_path(base_path, output_dir, path);
-
-            let display_name = section.display_name();
-            let section_display_name_safe = sanitize_filename::sanitize(if display_name.len() > 0 {
-                display_name
-            } else {
-                &file_name
-            });
-            // Workaround: Change the name of the output directory to avoid encoding issues.
-            // Joplin's extraction logic (which uses EXPAND.EXE) seems to result in UTF-8-encoded
-            // filenames being decoded as latin1.
-            // Joplin uses the name of the output folder name as the imported folder title. As
-            // such, it's important that the folder name be correctly encoded.
-            let section_output_dir = fs_driver().join(
-                &fs_driver().get_dir_name(&section_output_path),
-                &section_display_name_safe
-            );
-            section::Renderer::new().render(&section, section_output_dir)?;
+            let section_output_dir = fs_driver().get_output_path(base_path, output_dir, path);
+            section::Renderer::new().render(&section, section_output_dir.to_owned())?;
         }
         ".onetoc2" => {
             let _name: String = fs_driver().get_file_name(path).expect("Missing file name");


### PR DESCRIPTION
# Summary

This pull request replaces a call to `resolveRelativePathWithinDir` (which ensures that a relative path is actually within a directory) and calls to `.replace` with `friendlySafeFilename`. `friendlySafeFilename` is used in other places related to import/export (e.g. the [ENEX importer](https://github.com/laurent22/joplin/blob/5951a66fef642eea4d514b203ed8f21dd3323bef/packages/lib/import-enex.ts#L205) and [Markdown exporter](https://github.com/laurent22/joplin/blob/5951a66fef642eea4d514b203ed8f21dd3323bef/packages/lib/services/interop/InteropService_Exporter_Md.ts#L34)) to sanitize filenames.

Follow-up to https://github.com/laurent22/joplin/pull/14037. 

# Testing

Windows 11:
1. Locate the `.onepkg` export created in the testing plan for https://github.com/laurent22/joplin/pull/14037.
2. Import the `.onepkg` file from Joplin.
3. Verify that notebook "tést" and sub-notebook "Tést" have been imported successfully.
4. Import `Carnet de test migration   Joplin - 2025-10-21.onepkg` from the `Archive.zip` file provided in #13549.
6. Verify that the "Procédures" subnotebook is imported as "Procédures" (and not "ProcÃ©dures").
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->