### PR TITLE
Mobile: Fixes #13544: Ensure the latest state is retained when a note is saved

### DIFF
--- a/packages/lib/components/shared/note-screen-shared.ts
+++ b/packages/lib/components/shared/note-screen-shared.ts
@@ -151,7 +151,7 @@ shared.saveNoteButton_press = async function(comp: BaseNoteScreenComponent, stat
 
 	const savedNote = 'fields' in saveOptions && !saveOptions.fields.length ? { ...note } : await Note.save(note, saveOptions);
 
-	const stateNote = state.note;
+	const stateNote = comp.state.note;
 
 	// Note was reloaded while being saved.
 	if (!recreatedNote && (!stateNote || stateNote.id !== savedNote.id)) return releaseMutex();


### PR DESCRIPTION
There have been a couple of issues raised regarding the title field of notes having severe input flicker / loss of text, which looked to be related to the component state of the title field, which is a controlled component. This likely started manifesting since various restructuring of the code was done for the React Native 0.79 upgrade. While this changes may have contributed to the problem, the root cause of the issue has been in the code for a long time, and it would seem the more recent changes have just increased the chances of a race condition occurring.

There is some logic in the saveNoteButton_press function which conditionally replaces the title and body fields of a note with the latest values in the component state, when populating the new state object to update the component with. However, this uses the 'state' parameter of the function to populate the value. The problem is that this parameter contains the state of the component at the point when the change to save is enqueued (which would be at least 500 ms before the save is actioned), rather than the latest state for the component. This PR fixes the issue by ensuring the latest state of the component is used as the basis for populating the new state.

This fixes https://github.com/laurent22/joplin/issues/13544. It will likely also fix https://github.com/laurent22/joplin/issues/14057, but I cannot verify this as I am unable to reproduce the issue on the Android app

### Testing

Using the web app, I have verified issue https://github.com/laurent22/joplin/issues/13544 is fixed (tested in Firefox and Chrome on Windows). See video:
https://github.com/user-attachments/assets/4509fe34-4454-4906-86b2-1264517bad8f

I also verified auto title still works correctly and the title input works as expected on the Android app