### PR TITLE
iOS: Fixes #14063: Fix icon rendering

### DIFF
--- a/packages/app-mobile/ios/Joplin/Info.plist
+++ b/packages/app-mobile/ios/Joplin/Info.plist
@@ -77,21 +77,14 @@
 	<key>UIAppFonts</key>
 	<array>
 		<string>AntDesign.ttf</string>
-		<string>Entypo.ttf</string>
-		<string>EvilIcons.ttf</string>
-		<string>Feather.ttf</string>
 		<string>FontAwesome.ttf</string>
 		<string>FontAwesome5_Brands.ttf</string>
 		<string>FontAwesome5_Regular.ttf</string>
 		<string>FontAwesome5_Solid.ttf</string>
-		<string>Foundation.ttf</string>
 		<string>Ionicons.ttf</string>
 		<string>MaterialIcons.ttf</string>
+		<string>MaterialDesignIcons.ttf</string>
 		<string>MaterialCommunityIcons.ttf</string>
-		<string>SimpleLineIcons.ttf</string>
-		<string>Octicons.ttf</string>
-		<string>Zocial.ttf</string>
-		<string>Fontisto.ttf</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
# Summary

Updates the font list in `Info.plist` to match the names of icon fonts used by the mobile app. Previously, icons from the material icon pack failed to display in release mode on iOS.

Fixes #14063, which seems to be a regression from https://github.com/laurent22/joplin/pull/13905.


# Testing plan

iOS 26.2 simulator:
1. Run the iOS app in release mode.
2. Open a note.
3. Verify that the Markdown toolbar icons load.
4. Open settings.
5. Verify that the icons for the settings tabs load.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->