### PR TITLE
Windows: Fixes #13430: Experimental auto-updater: Fix application crash on update failure

### DIFF
--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -142,7 +142,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 				autoUpdater.setFeedURL({ provider: 'generic', url: assetUrl });
 				const result = await autoUpdater.checkForUpdates();
 
-				// Wait for the installation to finish. By default, .checkForUpdates runs in the background. 
+				// Wait for the installation to finish. By default, .checkForUpdates runs in the background
 				await result.downloadPromise;
 			} catch (error) {
 				this.logger_.error(`Update download url failed: ${error.message}`);

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -140,7 +140,10 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 				// electron's autoUpdater appends automatically the platform's yml file to the link so we should remove it
 				assetUrl = assetUrl.substring(0, assetUrl.lastIndexOf('/'));
 				autoUpdater.setFeedURL({ provider: 'generic', url: assetUrl });
-				await autoUpdater.checkForUpdates();
+				const result = await autoUpdater.checkForUpdates();
+
+				// Wait for the installation to finish. By default, .checkForUpdates runs in the background. 
+				await result.downloadPromise;
 			} catch (error) {
 				this.logger_.error(`Update download url failed: ${error.message}`);
 				this.isUpdateInProgress = false;


### PR DESCRIPTION
# Summary

Previously, if:
1. The the auto-update setting was enabled (settings > application > advanced > auto-updates, disabled by default).
2. The download or verification failed.

Then the application would crash due to an [unhandled promise rejection.](https://nodejs.org/api/process.html#event-uncaughtexception)

Fixes https://github.com/laurent22/joplin/issues/13430.

# Testing plan

Windows 11:
1. Patch `electron-updater` to always `throw` during signature validation. For example, with the following diff:
    ```diff
    diff --git a/out/NsisUpdater.js b/out/NsisUpdater.js
    index 034bb18ea5dbaaf3f356a940c115e274ef78efcb..a8432cb756f07fd10a8e9d1cf767f7913bdb1dbd 100644
    --- a/out/NsisUpdater.js
    +++ b/out/NsisUpdater.js
    @@ -49,7 +49,7 @@ class NsisUpdater extends BaseUpdater_1.BaseUpdater {
                         (await this.differentialDownloadInstaller(fileInfo, downloadUpdateOptions, destinationFile, provider, builder_util_runtime_1.CURRENT_APP_INSTALLER_FILE_NAME))) {
                         await this.httpExecutor.download(fileInfo.url, destinationFile, downloadOptions);
                     }
    -                const signatureVerificationStatus = await this.verifySignature(destinationFile);
    +                const signatureVerificationStatus = 'test';// await this.verifySignature(destinationFile);
                     if (signatureVerificationStatus != null) {
                         await removeTempDirIfAny();
                         // noinspection ThrowInsideFinallyBlockJS
    ```
2. Decrease the version number for the desktop app.
3. Build a release version of the app with `yarn dist` in `packages/app-desktop`.
4. Install the release build.
5. Start Joplin.
6. Verify that after the update downloads, a "New version 3.5.11 is not signed by the application owner" error is logged to the development tools, but the app doesn't crash.
7. Rebuild and reinstall the application without the patch from step 1.
8. Start Joplin, verifying that the update to v3.5.11 completes successfully.

Testing was done prior to rebasing on release-v3.5.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->