### PR TITLE
Chore: Remove usage of watchman when running Jest tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,6 @@
+// This is the base Jest configuration - all
+// jest.config.js files should inherit from it.
+
+module.exports = {
+	watchman: false,
+};

--- a/packages/app-cli/jest.config.js
+++ b/packages/app-cli/jest.config.js
@@ -24,7 +24,10 @@
 // 4. Remove tests one by one to narrow it down to the one with the async
 //    call that's causing problem.
 
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
 	testMatch: [
 		'**/tests/HtmlToHtml.js',
 		'**/tests/HtmlToMd.js',

--- a/packages/app-desktop/jest.config.js
+++ b/packages/app-desktop/jest.config.js
@@ -1,7 +1,10 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
 	// All imported modules in your tests should be mocked automatically
 	// automock: false,
 

--- a/packages/app-mobile/jest.config.js
+++ b/packages/app-mobile/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	preset: 'react-native',
 
 	'moduleFileExtensions': [

--- a/packages/editor/jest.config.js
+++ b/packages/editor/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	'moduleFileExtensions': [
 		'ts',
 		'tsx',

--- a/packages/fork-uslug/jest.config.js
+++ b/packages/fork-uslug/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/generator-joplin/jest.config.js
+++ b/packages/generator-joplin/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/htmlpack/jest.config.js
+++ b/packages/htmlpack/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: ['**/*.test.js'],
 	testPathIgnorePatterns: ['<rootDir>/node_modules/'],
 };

--- a/packages/lib/jest.config.js
+++ b/packages/lib/jest.config.js
@@ -1,3 +1,4 @@
+const baseConfig = require('../../jest.config.base.js');
 
 const testPathIgnorePatterns = [
 	'<rootDir>/node_modules/',
@@ -11,6 +12,7 @@ if (!process.env.IS_CONTINUOUS_INTEGRATION) {
 }
 
 module.exports = {
+	...baseConfig,
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/pdf-viewer/jest.config.js
+++ b/packages/pdf-viewer/jest.config.js
@@ -1,7 +1,10 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
 	// All imported modules in your tests should be mocked automatically
 	// automock: false,
 

--- a/packages/plugin-repo-cli/jest.config.js
+++ b/packages/plugin-repo-cli/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/renderer/jest.config.js
+++ b/packages/renderer/jest.config.js
@@ -1,7 +1,10 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
 	// All imported modules in your tests should be mocked automatically
 	// automock: false,
 

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/tools/jest.config.js
+++ b/packages/tools/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/transcribe/jest.config.js
+++ b/packages/transcribe/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	testMatch: [
 		'**/*.test.js',
 	],

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,4 +1,8 @@
+const baseConfig = require('../../jest.config.base.js');
+
 module.exports = {
+	...baseConfig,
+
 	'moduleFileExtensions': [
 		'ts',
 		'tsx',


### PR DESCRIPTION
We don't actually use Watchman but it's making running the tests much slower. At least on my laptop it's freezing for 60 seconds before it starts running them because it's waiting for something from Watchman (which is not running).