### PR TITLE
Windows: Fixes #14084: `.onepkg` file import: Fix import failure when notebook titles contain certain Unicode characters

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -338,7 +338,10 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			let newPath;
 
 			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
-			if (fixedFileName !== fileName) {
+			// If the filename includes the Unicode replacement character, file name correction has failed.
+			// Use the original (incorrect) filename in that case:
+			const replacementCharacter = '\uFFFD';
+			if (fixedFileName !== fileName && !fixedFileName.includes(replacementCharacter)) {
 				// In general, the path shouldn't start with "."s or contain path separators.
 				// However, if it does, these characters might cause import errors, so remove them:
 				fixedFileName = fixedFileName.replace(/^\.+/, '');

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -338,7 +338,10 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			let newPath;
 
 			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
-			if (fixedFileName !== fileName) {
+			// If the filename includes the Unicode replacement character, file name correction has failed.
+			// Use the original (incorrect) filename in that case:
+			const replacementCharacter = '\uFFFD';
+			if (fixedFileName !== fileName && !fixedFileName.includes(replacementCharacter)) {
 				const newFullPathSafe = shim.fsDriver().resolveRelativePathWithinDir(
 					basePath,
 					friendlySafeFilename(fixedFileName, 128, true),

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -2,7 +2,7 @@ import { ImportExportResult, ImportModuleOutputFormat, ImportOptions } from './t
 
 import InteropService_Importer_Base from './InteropService_Importer_Base';
 import { NoteEntity } from '../database/types';
-import { rtrimSlashes } from '../../path-utils';
+import { friendlySafeFilename, rtrimSlashes } from '../../path-utils';
 import InteropService_Importer_Md from './InteropService_Importer_Md';
 import { join, resolve, normalize, sep, dirname, extname, basename, relative } from 'path';
 import Logger from '@joplin/utils/Logger';
@@ -338,17 +338,11 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			let newPath;
 
 			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
-			// If the filename includes the Unicode replacement character, file name correction has failed.
-			// Use the original (incorrect) filename in that case:
-			const replacementCharacter = '\uFFFD';
-			if (fixedFileName !== fileName && !fixedFileName.includes(replacementCharacter)) {
-				// In general, the path shouldn't start with "."s or contain path separators.
-				// However, if it does, these characters might cause import errors, so remove them:
-				fixedFileName = fixedFileName.replace(/^\.+/, '');
-				fixedFileName = fixedFileName.replace(/[/\\]/g, ' ');
-
-				// Avoid path traversal: Ensure that the file path is contained within the base directory
-				const newFullPathSafe = shim.fsDriver().resolveRelativePathWithinDir(basePath, fixedFileName);
+			if (fixedFileName !== fileName) {
+				const newFullPathSafe = shim.fsDriver().resolveRelativePathWithinDir(
+					basePath,
+					friendlySafeFilename(fixedFileName, 128, true),
+				);
 				await shim.fsDriver().move(originalPath, newFullPathSafe);
 
 				newPath = newFullPathSafe;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -337,7 +337,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			const originalPath = join(basePath, fileName);
 			let newPath;
 
-			let fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
+			const fixedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
 			// If the filename includes the Unicode replacement character, file name correction has failed.
 			// Use the original (incorrect) filename in that case:
 			const replacementCharacter = '\uFFFD';


### PR DESCRIPTION
# Summary

This pull request adds additional logic to the workaround added in https://github.com/laurent22/joplin/pull/14037. This fixes an import failure when notebook filenames include certain non-Unicode characters.

Fixes #14084.

# Notes

With this change, certain Unicode characters will still be decoded incorrectly. However, they shouldn't break the import.

Joplin currently uses the [EXPAND.EXE](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/expand) utility to extract files from `.onepkg` archives. In the future, it may be worthwhile to switch to a library (e.g. [cab](https://crates.io/crates/cab)) for extracting notebook files from `.onepkg` archives.

# Testing plan

1. Import `testowy.onepkg` (provided in #14084).
2. Verify that the notebook imports without showing an error dialog.
    - **Note**: Currently, the imported notebook has title `GÅ,upoty`, rather than `Głupoty`.
3. Import `tést.onepkg` (from #14037's testing plan).
4. Verify that `tést` and `Tést!` notebooks are imported successfully.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->