### PR TITLE
Desktop: Improve new note title placeholder text

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -120,7 +120,7 @@ export default function NoteTitleBar(props: Props) {
 				className="title-input"
 				type="text"
 				ref={props.titleInputRef}
-				placeholder={props.isProvisional ? (props.noteIsTodo ? _('Creating new to-do...') : _('Creating new note...')) : ''}
+				placeholder={props.isProvisional ? _('Enter title here...') : ''}
 				aria-label={props.isProvisional ? undefined : _('Note title')}
 				style={styles.titleInput}
 				readOnly={props.disabled}


### PR DESCRIPTION
This PR updates the title placeholder shown for newly created notes.

The previous text (“Creating new note…”) reads like a status message and can be confusing for first-time users. Replacing it with “Enter title here…” makes it clearer that the field is editable, while preserving existing behavior.

Desktop-only change.