### PR TITLE
All: Resolves #14106: Improve Fountain notes exported as PDF

### DIFF
--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -1,6 +1,7 @@
 const fountain = require('../../vendor/fountain.min.js');
 
-const pluginAssets = function() {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Theme is defined in @joplin/lib and we don't import it here
+const pluginAssets = function(theme: any) {
 	return [
 		{
 			inline: true,
@@ -21,7 +22,7 @@ const pluginAssets = function() {
 				}
 
 				.fountain .title-page {
-					border-bottom: 1px solid #d2d2d2;
+					border-bottom: 1px solid ${theme.dividerColor};
 				}
 
 				@media print {
@@ -37,7 +38,7 @@ const pluginAssets = function() {
 
 				.fountain hr {
 					border: none;
-					border-top: 1px solid #d2d2d2;
+					border-top: 1px solid ${theme.dividerColor};
 					margin: 2em 0;
 				}
 

--- a/packages/renderer/MdToHtml/rules/fountain.ts
+++ b/packages/renderer/MdToHtml/rules/fountain.ts
@@ -15,11 +15,30 @@ const pluginAssets = function() {
 				}
 
 				.fountain .title-page,
-				.fountain .page { 
-					box-shadow: 0 0 5px rgba(0,0,0,0.1);
-					border: 1px solid #d2d2d2;
-					padding: 10%;
+				.fountain .page {
+					padding: 1em 2em;
 					margin-bottom: 2em;
+				}
+
+				.fountain .title-page {
+					border-bottom: 1px solid #d2d2d2;
+				}
+
+				@media print {
+					.fountain .title-page,
+					.fountain .page {
+						page-break-after: always;
+					}
+
+					.fountain .title-page {
+						border-bottom: none;
+					}
+				}
+
+				.fountain hr {
+					border: none;
+					border-top: 1px solid #d2d2d2;
+					margin: 2em 0;
 				}
 
 				.fountain h1,
@@ -121,6 +140,7 @@ function renderFountainScript(markdownIt: any, content: string) {
 	}
 
 	return `
+		<!-- joplin-metadata-print-title = false -->
 		<div class="fountain joplin-editable">
 			<pre class="joplin-source" data-joplin-language="fountain" data-joplin-source-open="\`\`\`fountain&#10;" data-joplin-source-close="&#10;\`\`\`&#10;">${markdownIt.utils.escapeHtml(content)}</pre>
 			${titlePageHtml}


### PR DESCRIPTION
- Remove note title from exported PDF when the note contains a Fountain block
- Removed border and shadow around page (not really needed and is a problem when exporting to PDF)
- Reduced left and right margins
- Handle page breaks properly