### PR TITLE
Desktop: Resolves #14121: Improve new note title placeholder text

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteTitle/NoteTitleBar.tsx
@@ -120,7 +120,7 @@ export default function NoteTitleBar(props: Props) {
 				className="title-input"
 				type="text"
 				ref={props.titleInputRef}
-				placeholder={props.isProvisional ? (props.noteIsTodo ? _('Creating new to-do...') : _('Creating new note...')) : ''}
+				placeholder={props.isProvisional ? _('Enter title here...') : ''}
 				aria-label={props.isProvisional ? undefined : _('Note title')}
 				style={styles.titleInput}
 				readOnly={props.disabled}


### PR DESCRIPTION
When a new note is created, the placeholder text in the title input area says “Creating new note…”. This makes it seem like the note is still being created, and is misleading to users (first-time users in particular). If the placeholder text was something more simpler like “Enter title here…”, it will make it clearer that the field is editable, while preserving existing behavior. I know this is just a really tiny feature, but it would make a good deal of difference. Desktop-only change.

<img width="818" height="261" alt="Image" src="https://github.com/user-attachments/assets/48e3f8d5-31ee-4b4a-aba6-68bad18c6431" />

I have discussed this in the forum: https://discourse.joplinapp.org/t/change-new-note-title-input-area-placeholder-text/48359?u=siddhu