### PR TITLE
Desktop: Fixes #14092:  Built-in plugins: Upgrade Freehand Drawing to v4.3.0

### DIFF
--- a/packages/default-plugins/package.json
+++ b/packages/default-plugins/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/yargs": "17.0.33",
-    "joplin-plugin-freehand-drawing": "4.2.0",
+    "joplin-plugin-freehand-drawing": "4.3.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10643,7 +10643,7 @@ __metadata:
     "@joplin/utils": "npm:~3.5"
     "@types/yargs": "npm:17.0.33"
     fs-extra: "npm:11.3.2"
-    joplin-plugin-freehand-drawing: "npm:4.2.0"
+    joplin-plugin-freehand-drawing: "npm:4.3.0"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.8.3"
     yargs: "npm:17.7.2"
@@ -35004,13 +35004,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joplin-plugin-freehand-drawing@npm:4.2.0":
-  version: 4.2.0
-  resolution: "joplin-plugin-freehand-drawing@npm:4.2.0"
+"joplin-plugin-freehand-drawing@npm:4.3.0":
+  version: 4.3.0
+  resolution: "joplin-plugin-freehand-drawing@npm:4.3.0"
   dependencies:
     "@js-draw/material-icons": "npm:1.33.0"
     js-draw: "npm:1.33.0"
-  checksum: 10/457c23b7fbd6f1e3a48568395c1e456d570a3c68e25b40fba97973fd848de1b513be2f1ece6eb9babae862e19ba140aca871eee0e3a8a9cb5a033e0c0fd78934
+  checksum: 10/b9ee96e149637f4bd52e894f75ba72e5c64b2512002df3a95ecf23c0b6593fdb260d61c0a30cab5450da142520b1aec63c709b11bf3a2491caa3049db0174fdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Upgrades the built-in Freehand Drawing plugin to [v4.3.0](https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/releases/tag/v4.3.0).

# Details

Key changes:

- Adds a French translation for non-editor strings (in https://github.com/personalizedrefrigerator/joplin-plugin-freehand-drawing/pull/33 by [Pritam-Sing-2025](https://github.com/Pritam-Sing-2025)).
- Fixes a locale detection issue, in which the OS locale overrode the Joplin locale for strings within the editor WebView.
- Adjusts the Freehand Drawing plugin's development environment setup logic. Should fix #14092.
   - The Freehand Drawing plugin has logic for registering pre-commit hooks for linting and formatting. When installed as an NPM dependency, this logic overrode Joplin's own pre-commit hooks.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->