### PR TITLE
Server: Fixes #14107: Fix warning when unsharing folder

### DIFF
--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -123,8 +123,9 @@ export default class ItemModel extends BaseModel<Item> {
 			const share = await this.models().share().load(resource.jop_share_id, { fields: ['id', 'owner_id'] });
 
 			if (!share) {
-				// If the share owner has just deleted the share, the share won't exist. In this case, it's still okay to
-				// change the item:
+				// Don't warn in the case where the share doesn't exist. This can happen, for example, when
+				// unsharing a folder.
+				// See https://github.com/laurent22/joplin/issues/14107.
 				if (resource.owner_id !== user.id) {
 					modelLogger.warn('cannot find the share associated with this item. Action:', action, 'User:', user.email, 'Resource:', resource);
 				}

--- a/packages/server/src/models/ItemModel.ts
+++ b/packages/server/src/models/ItemModel.ts
@@ -123,7 +123,11 @@ export default class ItemModel extends BaseModel<Item> {
 			const share = await this.models().share().load(resource.jop_share_id, { fields: ['id', 'owner_id'] });
 
 			if (!share) {
-				modelLogger.warn('cannot find the share associated with this item. Action:', action, 'User:', user, 'Resource:', resource);
+				// If the share owner has just deleted the share, the share won't exist. In this case, it's still okay to
+				// change the item:
+				if (resource.owner_id !== user.id) {
+					modelLogger.warn('cannot find the share associated with this item. Action:', action, 'User:', user.email, 'Resource:', resource);
+				}
 			} else {
 				if (share.owner_id !== user.id) {
 					const shareUser = await this.models().shareUser().byShareAndUserId(share.id, user.id);


### PR DESCRIPTION
# Summary

This pull request updates the `checkIfAllowed` function to:
- Print the "cannot find the share associated with this item" warning in fewer cases.
- Log only the user email (rather than the full user object) when a warning happens.

Fixes #14107.

# Testing

This change was tested by running the sync fuzzer. Previously, the issue was observable after 27 steps (at "unshareFolder").

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->