### PR TITLE
Server: Fixes #14131: Allow changing the password for the admin account when SAML is enabled

### DIFF
--- a/packages/server/src/routes/index/users.test.ts
+++ b/packages/server/src/routes/index/users.test.ts
@@ -6,6 +6,7 @@ import { ErrorForbidden } from '../../utils/errors';
 import { execRequest, execRequestC } from '../../utils/testing/apiUtils';
 import { beforeAllDb, afterAllTests, beforeEachDb, koaAppContext, createUserAndSession, models, parseHtml, checkContextError, expectHttpError, expectThrow } from '../../utils/testing/testUtils';
 import { uuidgen } from '@joplin/lib/uuid';
+import config from '../../config';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 async function postUser(sessionId: string, email: string, password: string = null, props: any = null): Promise<User> {
@@ -349,4 +350,29 @@ describe('index/users', () => {
 		expect(await models().application().count()).toBe(0);
 	});
 
+	test.each([
+		{ isExternal: true, expectedDisabled: true },
+		{ isExternal: false, expectedDisabled: false },
+	])('should disable password fields for external users, enable for internal users (case: %j)', async ({
+		isExternal, expectedDisabled,
+	}) => {
+		const { user, session } = await createUserAndSession();
+
+		config().SAML_ENABLED = true;
+		try {
+			await models().user().save({
+				id: user.id,
+				is_external: isExternal ? 1 : 0,
+			}, { skipValidation: true });
+
+			const userHtml = await getUserHtml(session.id, user.id);
+			const doc = parseHtml(userHtml);
+
+			expect(
+				doc.querySelector<HTMLInputElement>('input[name=password]').disabled,
+			).toBe(expectedDisabled);
+		} finally {
+			config().SAML_ENABLED = false;
+		}
+	});
 });

--- a/packages/server/src/routes/index/users.ts
+++ b/packages/server/src/routes/index/users.ts
@@ -119,7 +119,9 @@ router.get('users/:id', async (path: SubPath, ctx: AppContext, formUser: User = 
 	view.content.hasFlags = !!userFlagViews.length;
 	view.content.userFlagViews = userFlagViews;
 	view.content.stripePortalUrl = stripePortalUrl();
-	view.content.disabledIfExternalAuth = isUsingExternalAuth(config()) ? 'disabled' : '';
+
+	const isExternalAuth = isUsingExternalAuth(config());
+	view.content.disabledIfExternalAuth = isExternalAuth && user.is_external ? 'disabled' : '';
 
 	view.jsFiles.push('zxcvbn');
 	view.cssFiles.push('index/user');


### PR DESCRIPTION
# Summary

This pull request enables the full name, email, and password fields in the "Your profile page" for accounts with `is_external = 0` (e.g. the admin account).

Fixes #14131.

# Testing plan

1. Start Joplin Server with `SAML_ENABLED=1`:
   ```
   SAML_ENABLED=1 yarn start-dev
   ```
2. Sign in as `admin@localhost`.
3. Open the "your profile" screen.
4. Verify that the password fields are enabled.
5. Change the password.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->