### PR TITLE
Mobile: Fixes #12839: Scale code block font size with base font setting in Rich Text Editor

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { useMemo, useCallback, useRef } from 'react';
 import { NativeSyntheticEvent } from 'react-native';
 
-import { EditorProps } from './types';
+import { EditorProps, EditorSettings } from './types';
 import { _ } from '@joplin/lib/locale';
 import { WebViewErrorEvent } from 'react-native-webview/lib/RNCWebViewNativeComponent';
 import Logger from '@joplin/utils/Logger';
@@ -17,10 +17,12 @@ import shim from '@joplin/lib/shim';
 
 const logger = Logger.create('RichTextEditor');
 
-function useCss(themeId: number, editorCss: string): string {
+function useCss(themeId: number, editorCss: string, editorSettings: EditorSettings): string {
 	return useMemo(() => {
 		const theme = themeStyle(themeId);
 		const themeVariableCss = themeToCss(theme);
+		const themeData = editorSettings.themeData;
+		const fontSize = `${themeData.fontSize}${themeData.fontSizeUnits ?? 'px'}`;
 		return `
 			${themeVariableCss}
 			${editorCss}
@@ -41,7 +43,7 @@ function useCss(themeId: number, editorCss: string): string {
 				padding-bottom: 1px;
 				padding-top: 10px;
 
-				font-size: 13pt;
+				font-size: ${fontSize};
 				font-family: ${JSON.stringify(theme.fontFamily)}, sans-serif;
 			}
 
@@ -52,7 +54,7 @@ function useCss(themeId: number, editorCss: string): string {
 				position: relative;
 			}
 		`;
-	}, [themeId, editorCss]);
+	}, [themeId, editorCss, editorSettings]);
 }
 
 function useHtml(initialCss: string): string {
@@ -127,7 +129,7 @@ const RichTextEditor: React.FC<EditorProps> = props => {
 		true;
 	`;
 
-	const css = useCss(props.themeId, editorWebViewSetup.pageSetup.css);
+	const css = useCss(props.themeId, editorWebViewSetup.pageSetup.css, props.editorSettings);
 	const html = useHtml(css);
 
 	const onMessage = useCallback((event: OnMessageEvent) => {


### PR DESCRIPTION
## Summary

This PR fixes an issue where code blocks in the Rich Text Editor on mobile did not scale with the base font size setting.

**Fixes:** #12839

## Problem

The Rich Text Editor on mobile used a hardcoded font size (`13pt`) for the body element. Since code blocks use relative `em` units for their font size (inherited from the body), changing the base font size setting had no effect on code block text - only regular text would resize.

## Solution

Updated `RichTextEditor.tsx` to use the font size from `editorSettings.themeData` instead of the hardcoded value. This ensures that:
- The body font size matches the user's font size setting
- Code blocks (which use `em` units) properly scale along with the body font
- Inline code and code blocks now respond to font size changes consistently with regular text

## Changes

- Added `EditorSettings` import to `RichTextEditor.tsx`
- Updated `useCss` function to accept `editorSettings` parameter
- Replaced hardcoded `font-size: 13pt;` with the theme's configured font size
- Updated the call site to pass `props.editorSettings`

## Testing

1. Open the mobile app and create a note with code blocks
2. Go to Settings > Note Viewer Font Size and change the value
3. Verify that both regular text and code blocks scale accordingly

---

[Gittensor contribution - GlobalStar117]