### PR TITLE
Desktop,Mobile: Resolves #14158: Markdown Editor: Make code block highlighting closer to the viewer

### DIFF
--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -139,25 +139,7 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		},
 
 		'& .cm-codeBlock': {
-			'&.cm-regionFirstLine, &.cm-regionLastLine': {
-				borderRadius: '3px',
-			},
-			'&:not(.cm-regionFirstLine)': {
-				borderTop: 'none',
-				borderTopLeftRadius: 0,
-				borderTopRightRadius: 0,
-			},
-			'&:not(.cm-regionLastLine)': {
-				borderBottom: 'none',
-				borderBottomLeftRadius: 0,
-				borderBottomRightRadius: 0,
-			},
-
-			borderWidth: '1px',
-			borderStyle: 'solid',
-			borderColor: theme.colorFaded,
-			backgroundColor: 'rgba(155, 155, 155, 0.1)',
-
+			backgroundColor: 'rgba(155, 155, 155, 0.07)',
 			...monospaceStyle,
 		},
 
@@ -269,8 +251,8 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		},
 		{
 			tag: tags.comment,
-			opacity: 0.9,
 			fontStyle: 'italic',
+			color: isDarkTheme ? '#b18eb1' : '#707187',
 		},
 		{
 			tag: tags.link,
@@ -281,26 +263,23 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 			fontStyle: 'italic',
 		},
 
-		// Content of code blocks
+		// Content of code blocks. This should roughly match the colors used by the default
+		// highlight.js theme in the note viewer, while also preserving at least 4.5:1 contrast.
 		{
 			tag: tags.keyword,
-			color: isDarkTheme ? '#ff7' : '#740',
-		},
-		{
-			tag: tags.operator,
-			color: isDarkTheme ? '#f7f' : '#805',
+			color: isDarkTheme ? '#F92672' : '#a626a4',
 		},
 		{
 			tag: tags.literal,
 			color: isDarkTheme ? '#aaf' : '#037',
 		},
 		{
-			tag: tags.operator,
-			color: isDarkTheme ? '#fa9' : '#490',
+			tag: tags.number,
+			color: isDarkTheme ? '#d19a66' : '#986801',
 		},
 		{
 			tag: tags.typeName,
-			color: isDarkTheme ? '#7ff' : '#a00',
+			color: isDarkTheme ? '#d19a66' : '#986801',
 		},
 		{
 			tag: tags.inserted,
@@ -312,12 +291,20 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		},
 		{
 			tag: tags.propertyName,
-			color: isDarkTheme ? '#d96' : '#940',
+			color: isDarkTheme ? '#61aeee' : '#406be5',
+		},
+		{
+			tag: tags.string,
+			color: isDarkTheme ? '#98c379' : '#50a14f',
 		},
 		{
 			// CSS class names (and class names in other languages)
 			tag: tags.className,
 			color: isDarkTheme ? '#d8a' : '#904',
+		},
+		{
+			tag: tags.macroName,
+			color: isDarkTheme ? '#e6c07b' : '#986801',
 		},
 	]);
 

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -252,7 +252,7 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		{
 			tag: tags.comment,
 			fontStyle: 'italic',
-			color: isDarkTheme ? '#b18eb1' : '#707187',
+			color: isDarkTheme ? '#b18eb1' : '#6d7086',
 		},
 		{
 			tag: tags.link,


### PR DESCRIPTION
# Summary

This pull request adjusts code blocks in the Markdown editor by:
- Removing the border/rounded corners from code blocks.
- Adjusting the code block background color.
- Adjusting the syntax highlighting theme to more closely match the viewer.

Resolves #14158.

# Notes

- Some of the remaining differences are related to different syntax tags exposed by `highlight.js` and CodeMirror.
- To avoid accessibility regressions, some of the syntax highlighting colors have been adjusted.
    - [WCAG 2.2 SC 1.4.3](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html) specifies that "text and images of text" should have a contrast ratio of at least 4.5:1 (with exceptions for large text and logos).
    - The viewer's code block highlighting has low contrast for a few syntax tokens (e.g. 3.06:1 contrast for class names, 3.87:1 for function names).
    - According to Electron's developer tools, the Markdown editor's syntax highlighting seems to have previously had contrast ratios of >= 6:1 (testing in light mode), with the exception of syntax highlighting for `tags.operator`.
    - With this change, contrast should still be at least 4.5:1 in the Markdown editor.

# Screenshots

## Dark mode

<img width="989" height="1234" alt="screenshot: dark mode syntax highlighting shown in the viewer and editor side-by-side" src="https://github.com/user-attachments/assets/1ea64a82-a079-42dd-94ff-bbd29c61a07f" />

## Light mode

<img width="989" height="1234" alt="image" src="https://github.com/user-attachments/assets/62034305-aab6-40ee-bd64-4402279642f0" />


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->