### PR TITLE
Desktop: OneNote import: Import invalid attachments as empty attachments

### DIFF
--- a/packages/onenote-converter/parser/src/local_onestore/file_node/file_node.rs
+++ b/packages/onenote-converter/parser/src/local_onestore/file_node/file_node.rs
@@ -767,14 +767,9 @@ impl AttachmentInfo {
             .into())
         } else if self.data_ref.starts_with("<invfdo>") {
             // "invalid"
-            log_warn!("Attempted to load an invalid {} file", self.extension);
-            Err(parser_error!(
-                ResolutionFailed,
-                "Unable to load invalid file reference: {} (ext: {})",
-                self.data_ref,
-                self.extension
-            )
-            .into())
+            log_warn!("Attempted to load an invalid {} file. Importing an empty file.", self.extension);
+            // Return empty data
+            Ok(FileBlob::default())
         } else {
             Err(parser_error!(
                 ResolutionFailed,


### PR DESCRIPTION
# Summary

Previously, invalid attachments caused full pages to fail to import (see, for example, [this forum post](https://discourse.joplinapp.org/t/error-importing-notes-from-format-one/48424)).

With this change, [attachments marked as invalid](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-onestore/da2bbc7d-0529-4bf4-a843-6f3f55c87e8f#:~:text=.guidReference%20fields.-,%3Cinvfdo%3E,-Invalid) should be imported as empty file attachments.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->