### PR TITLE
Desktop,Mobile: Markdown editor: Fix error logged in "hide markdown" mode for certain markup

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
@@ -14,13 +14,18 @@ const createEditor = async (initialMarkdown: string, expectedTags: string[] = ['
 
 describe('replaceInlineHtml', () => {
 	test.each([
-		{ markdown: '<sup>Test</sup>', expectedTagsQuery: 'sup' },
-		{ markdown: '<strike>Test</strike>', expectedTagsQuery: 'strike' },
-		{ markdown: 'Test: <span style="color: red;">Test</span>', expectedTagsQuery: 'span[style]' },
-		{ markdown: 'Test: <span style="color: rgb(123, 0, 0);">Test</span>', expectedTagsQuery: 'span[style]' },
-	])('should render inline HTML (case %#)', async ({ markdown, expectedTagsQuery }) => {
+		{ markdown: '<sup>Test</sup>', expectedDomTags: 'sup' },
+		{ markdown: '<strike>Test</strike>', expectedDomTags: 'strike' },
+		{ markdown: 'Test: <span style="color: red;">Test</span>', expectedDomTags: 'span[style]' },
+		{ markdown: 'Test: <span style="color: rgb(123, 0, 0);">Test</span>', expectedDomTags: 'span[style]' },
+		{
+			markdown: '<sup>Test *test*...</sup>',
+			expectedDomTags: 'sup',
+			initialSyntaxTags: ['HTMLTag', 'Emphasis'],
+		},
+	])('should render inline HTML (case %#)', async ({ markdown, expectedDomTags: expectedTagsQuery, initialSyntaxTags }) => {
 		// Add additional newlines: Ensure that the cursor isn't initially on the same line as the content to be rendered:
-		const editor = await createEditor(`\n\n${markdown}\n\n`);
+		const editor = await createEditor(`\n\n${markdown}\n\n`, initialSyntaxTags);
 
 		expect(editor.contentDOM.querySelector(expectedTagsQuery)).toBeTruthy();
 	});

--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.ts
@@ -31,9 +31,9 @@ const createHtmlReplacementExtension = (tagName: string, onRenderContent: OnRend
 		// Find the matching closing tag
 		for (; !!cursor && nestedTagCounter > 0; cursor = cursor.nextSibling) {
 			const info = htmlNodeInfo(cursor, state);
-			if (isMatchingOpeningTag(info)) {
+			if (info && isMatchingOpeningTag(info)) {
 				nestedTagCounter ++;
-			} else if (isMatchingClosingTag(info)) {
+			} else if (info && isMatchingClosingTag(info)) {
 				nestedTagCounter --;
 			}
 


### PR DESCRIPTION
# Summary

Prior to this pull request, with "Markdown editor: Render markup in editor" enabled, opening a note with markup similar to the following would result in an error logged to the console:
```markdown
Test: <span style="color: red;">test **test** test</span>
```
For example,
>      TypeError: Cannot read properties of null (reading 'tagName')

This error is a regression from https://github.com/laurent22/joplin/pull/14133.

# Testing plan

This pull request includes an automated regression test.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->