### PR TITLE
Fixes #14141: Left selection border cut off in Rich Text Editor

### DIFF
--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -76,7 +76,7 @@ export const whiteBackgroundNoteStyle = () => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export default function(theme: any, options: Options = null) {
+export default function (theme: any, options: Options = null) {
 	options = {
 		contentMaxWidth: 0,
 		...options,
@@ -406,10 +406,22 @@ export default function(theme: any, options: Options = null) {
 		/* For TinyMCE */
 		/* =============================================== */
 
-		.mce-content-body {
-			/* Note: we give a bit more padding at the bottom, to allow scrolling past the end of the document */
-			padding: 5px 10px 10em 0;
-		}
+		// body.mce-content-body {
+		// 	/* Note: we give a bit more padding at the bottom, to allow scrolling past the end of the document */
+		// 	padding: 5px 10px 10em 3px !important;
+		// }
+		// .mce-content-body .joplin-editable[data-mce-selected] pre.hljs {
+	    //     overflow-x: visible;
+        // }
+		// .mce-content-body [contentEditable=false][data-mce-selected] {
+	    //     outline-offset: -3px;
+        // }
+		body.mce-content-body .joplin-editable[contenteditable="false"][data-mce-selected] {
+	        outline: 3px solid #b4d7ff;
+	        outline-offset: -3px;
+	        padding-left: 3px;
+	        box-sizing: border-box;
+        }
 
 		/*
 		.mce-content-body code {

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -406,16 +406,6 @@ export default function (theme: any, options: Options = null) {
 		/* For TinyMCE */
 		/* =============================================== */
 
-		// body.mce-content-body {
-		// 	/* Note: we give a bit more padding at the bottom, to allow scrolling past the end of the document */
-		// 	padding: 5px 10px 10em 3px !important;
-		// }
-		// .mce-content-body .joplin-editable[data-mce-selected] pre.hljs {
-	    //     overflow-x: visible;
-        // }
-		// .mce-content-body [contentEditable=false][data-mce-selected] {
-	    //     outline-offset: -3px;
-        // }
 		body.mce-content-body .joplin-editable[contenteditable="false"][data-mce-selected] {
 	        outline: 3px solid #b4d7ff;
 	        outline-offset: -3px;

--- a/packages/renderer/noteStyle.ts
+++ b/packages/renderer/noteStyle.ts
@@ -76,7 +76,7 @@ export const whiteBackgroundNoteStyle = () => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export default function (theme: any, options: Options = null) {
+export default function(theme: any, options: Options = null) {
 	options = {
 		contentMaxWidth: 0,
 		...options,


### PR DESCRIPTION
This PR fixes an issue where the left selection border was cut off in the Rich Text Editor when selecting non-editable blocks such as code blocks.

The selection outline was clipped on the left side. This change adjusts the selection styling so the border is fully visible without overlapping the text.

Fixes #14141
