### PR TITLE
Desktop: Fixes #13793: Make conflicts caused by resource duplication less likely

### DIFF
--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -639,12 +639,21 @@ export default class Folder extends BaseItem {
 			// one note. If it is not, we create duplicate resources so that
 			// each note has its own separate resource.
 
+			// Order unshared items first: This makes conflicts less likely, since shared
+			// items are more likely to be duplicated by multiple users.
+			const orderingSql = 'ORDER BY is_shared ASC';
+
 			const noteResourceAssociations = await this.db().selectAll(`
-				SELECT resource_id, note_id, notes.share_id
+				SELECT
+					resource_id,
+					note_id,
+					notes.share_id,
+					(notes.share_id != '') AS is_shared
 				FROM note_resources
 				LEFT JOIN notes ON notes.id = note_resources.note_id
 				WHERE resource_id IN (${this.escapeIdsForSql(resourceIds)})
 				AND is_associated = 1
+				${orderingSql}
 			`) as NoteResourceRow[];
 
 			const resourceIdToNotes: Record<string, NoteResourceRow[]> = {};


### PR DESCRIPTION
# Summary

This pull makes share-related broken attachments and conflicts less likely.

**Partially** resolves #13793.

> [!NOTE]
>
> This pull request should make attachment conflicts less likely, but it doesn't entirely fix #13793. For example, it's still possible to get attachment conflicts with the following sync fuzzer config:
> <details>
>
> ```json
>{
>	"clientCount": 2,
>	"description": "Fuzzer setup for https://github.com/laurent22/joplin/issues/13793, v2",
>	"actions": [
>		"// Setup: Create one folder in each client",
>		["switchClient", { "id": 0 }],
>		"sync",
>		["switchClient", { "id": 1 }],
>		"sync",
>
>		"// Setup: Switch to client 1 and share a folder",
> 		["switchClient", { "id": 1 }],
> 		["newToplevelFolder", { "id": "01111111111111111111111111111112" }],
> 		["shareFolder", { "folderId": "01111111111111111111111111111112", "otherClientId": 0}],
> 		["newToplevelFolder", { "id": "01111111111111111111111111111122" }],
> 		["shareFolder", { "folderId": "01111111111111111111111111111122", "otherClientId": 0}],
> 
> 		"// Setup: Create a note in the shared folder and attach a resource",
> 		["newNote", { "id": "11111111111111111111111111111113", "parentId": "01111111111111111111111111111112" }],
> 		["attachResourceTo", { "noteId": "11111111111111111111111111111113" }],
> 
> 		"// Setup: Verify that all clients have the expected state",
> 		"syncAndCheckState",
> 
> 		"// Duplicate the resource in client 1",
> 		["duplicateNote", { "id": "11111111111111111111111111111113", "newNoteId": "11111111111111111111111111111117" }],
> 		["moveNote", { "noteId": "11111111111111111111111111111117", "targetFolderId": "01111111111111111111111111111122" }],
> 		"// Don't sync yet...",
> 
> 		"// Duplicate the note from client 0",
> 		["switchClient", { "id": 0 }],
> 		"sync",
> 		["duplicateNote", { "id": "11111111111111111111111111111113", "newNoteId": "11111111111111111111111111111115" }],
> 		["moveNote", { "noteId": "11111111111111111111111111111115", "targetFolderId": "01111111111111111111111111111122" }],
> 
> 		"// Final state check",
> 		"// If https://github.com/laurent22/joplin/issues/13793 is still an issue, one of the clients will have conflicts",
> 		"syncAndCheckState"
> 	]
> }
> ```
> </details>

# Details

`Folder.updateResourceShareIds` is responsible for preventing resources from being present in multiple shares at once. This is done by duplicating resources that are attached to notes with different `share_id`s and updating notes to point to different copies of the resource.

This is problematic if multiple Joplin clients attempt to update the same resources simultaneously. For example, suppose that:
1. Account A has the following notebooks:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 1
  📁 not shared (1)
  | 📄 Note 2
  ```
2. Account B has the following notebooks:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 1
  📁 not shared (2)
  | 📄 Note 3
  ```
3. A Joplin client on Account A copies `🖼️ resource 1` to `📄 Note 2`, without syncing:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 1
  📁 not shared (1)
  | 📄 Note 2
  |  | Links to: 🖼️ resource 1
  ```
3. A Joplin client on Account B copies `🖼️ resource 1` to `📄 Note 3`, also without syncing:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 1
  📁 not shared (2)
  | 📄 Note 3
  |  | Links to: 🖼️ resource 1
  ```
4. The client on Account B runs `Folder.updateResourceShareIds`. This updates the link in `📄 Note 1` and creates a new `🖼️ resource 2`:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 2
  📁 not shared (2)
  | 📄 Note 3
  |  | Links to: 🖼️ resource 1
  ```
  - This removes `🖼️ resource 1` from the share.
5. The client on Account B syncs, removing `🖼️ resource 1` from the share on the server.
6. The client on Account A runs `Folder.updateResourceShareIds`. This updates the link in **its copy of** `📄 Note 1` and creates a new `🖼️ resource 3`:
  ```
  📁 shared 🔄
  | 📄 Note 1
  |  | Links to: 🖼️ resource 3
  📁 not shared (2)
  | 📄 Note 3
  |  | Links to: 🖼️ resource 1
  ```
7. The client on Account A syncs.
   - Since Account B removed `🖼️ resource 1` from the share in steps 4-5, `🖼️ resource 1` is deleted locally and `📄 Note 3` now contains a broken link.
   - A conflict is created for `📄 Note 1`, since it was modified by Account B in step 4.

By making `Folder.updateResourceShareIds` prefer to modify unshared notes, `Folder.updateResourceShareIds` is less likely to remove attachments from shares (as it did in step 4).

# Testing

## Automated testing

This pull request includes an automated test.

## Sync fuzzer testing

1. Apply the sync fuzzer changes from https://github.com/laurent22/joplin/issues/13793.
2. Apply the changes from this pull request to `models/Folder.ts`.
3. Set the content of `sample-fuzzer-setup.json` to the test plan specified in https://github.com/laurent22/joplin/issues/13793#issuecomment-3793091411.
4. Run the sync fuzzer:
   ```console
   bash$ yarn syncFuzzer start --setup ./packages/tools/fuzzer/sample-fuzzer-setup.json --steps 1
   ```
   - The "--steps 1" stops the fuzzer 1 step after running all actions from `./packages/tools/fuzzer/sample-fuzzer-setup.json`.
5. Verify that the fuzzer runs `sample-fuzzer-setup.json` successfully.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->