### PR TITLE
Chore: Testing: Give the plugin panel test more time to pass

### DIFF
--- a/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/panels.js
@@ -23,7 +23,7 @@ const waitFor = async (condition) => {
 			setTimeout(() => resolve(), 100);
 		});
 	};
-	for (let i = 0; i < 100; i++) {
+	for (let i = 0; i < 500; i++) {
 		if (await condition()) {
 			return;
 		}


### PR DESCRIPTION
# Summary

This pull request increases the maximum timeout for `waitFor` in `panels.js`. This may resolve CI failures similar [to this one](https://github.com/laurent22/joplin/actions/runs/21362006807/job/61483514515?pr=14198).
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->