### PR TITLE
Mobile: Fix heading links

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -364,4 +364,17 @@ describe('screens/Note', () => {
 
 		unmount();
 	});
+
+	it('should set the initial editor cursor location to the specified hash', async () => {
+		await openNewNote({ title: 'To be edited', body: 'a test\n\n# Test\n\n# Test 2\n\n# Test 3' });
+		store.dispatch({ type: 'NAV_GO', noteHash: 'test-2' });
+		const { unmount } = render(<WrappedNoteScreen />);
+
+		await openEditor();
+		const editor = await getMarkdownEditorControl();
+
+		expect(editor.getCursor().line).toBe(4);
+
+		unmount();
+	});
 });

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -236,12 +236,16 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			multiline: false,
 		};
 
-		const initialCursorLocation = NotePositionService.instance().getCursorPosition(props.noteId, defaultWindowId).markdown;
-		if (initialCursorLocation) {
-			this.selection = { start: initialCursorLocation, end: initialCursorLocation };
-		}
 		const initialScroll = NotePositionService.instance().getScrollPercent(props.noteId, defaultWindowId);
-		this.lastBodyScroll = initialScroll;
+		const initialCursorLocation = NotePositionService.instance().getCursorPosition(props.noteId, defaultWindowId).markdown;
+		// Ignore the initial scroll and cursor location when there's a note hash. The editor/viewer should jump to
+		// the hash, rather than the last position.
+		if (!props.noteHash) {
+			if (initialCursorLocation) {
+				this.selection = { start: initialCursorLocation, end: initialCursorLocation };
+			}
+			this.lastBodyScroll = initialScroll;
+		}
 
 		this.titleTextFieldRef = React.createRef();
 


### PR DESCRIPTION
# Summary

On mobile, cross-note heading links (e.g. `[link](:/024bb2a7642f4711a97520c6e9df64f0#test`) were broken. Rather than jumping to the linked header, the last scroll position within the note was restored. This change updates `Note.tsx` to ignore the last cursor/scroll position when `noteHash` is specified.

This pull request fixes a regression from https://github.com/laurent22/joplin/pull/13962.

# Testing plan

Screen recording:

[Screencast from 2026-01-26 13-34-55.webm](https://github.com/user-attachments/assets/32d9c81c-ddba-4b2a-ba9f-fef27cce58de)


Web:
1. Open the Markdown editor and create a link to a heading in another note.
2. Switch to the viewer and open the link.
3. Verify that the associated heading is scrolled into view.
4. Switch to the Markdown editor.
5. Verify that the cursor has been moved to the heading.
6. Press the back button.
7. Verify that the note viewer's scroll position from step 1 has been restored.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->