### PR TITLE
All: Sync: Make resource processing in read-only shares more reliable

### DIFF
--- a/packages/lib/models/Folder.sharing.test.ts
+++ b/packages/lib/models/Folder.sharing.test.ts
@@ -564,6 +564,55 @@ describe('models/Folder.sharing', () => {
 		expect(await Note.load(note2.id)).not.toMatchObject({ body: note2.body, share_id: '' });
 	});
 
+
+	it('should not duplicate a resource if both instances are in different read-only shares', async () => {
+		const resourceService = new ResourceService();
+
+		const folder1 = await createFolderTree('', [
+			{
+				title: 'folder 1', // Share 1
+				children: [
+					{
+						title: 'note 1',
+					},
+				],
+			},
+			{
+				title: 'folder 2', // Share 2
+				children: [
+					{
+						title: 'note 2',
+					},
+				],
+			},
+		]);
+
+		const folder2 = await Folder.loadByTitle('folder 2');
+
+		let note1: NoteEntity = await Note.loadByTitle('note 1');
+		const note2: NoteEntity = await Note.loadByTitle('note 2');
+		note1 = await shim.attachFileToNote(note1, testImagePath);
+		await Note.save({ id: note2.id, body: note1.body });
+
+		const shareId1 = 'testing1';
+		const shareId2 = 'testing2';
+		await Folder.save({ id: folder1.id, share_id: shareId1 });
+		await Folder.save({ id: folder2.id, share_id: shareId2 });
+
+		await msleep(1);
+
+		const reset = simulateReadOnlyShareEnv([shareId1, shareId2]);
+		try {
+			await resourceService.indexNoteResources(); // Populate note_resources
+			await Folder.updateAllShareIds(resourceService, []);
+
+			// After: Should not have duplicated the resource
+			expect(await Resource.all()).toHaveLength(1);
+		} finally {
+			reset();
+		}
+	});
+
 	it('should clear share_ids for items that are no longer part of an existing share', async () => {
 		await createFolderTree('', [
 			{

--- a/packages/lib/models/Folder.sharing.test.ts
+++ b/packages/lib/models/Folder.sharing.test.ts
@@ -181,7 +181,29 @@ describe('models/Folder.sharing', () => {
 		}
 	}));
 
-	it('should not fail to update share IDs when an outdated share ID is contained in a read-only folder', async () => {
+	it('updating share IDs should not fail when a read-only resource is linked to a writeable note', async () => {
+		const root = await Folder.save({ title: 'read-only' });
+		let note = await Note.save({ title: 'Test', parent_id: root.id });
+		note = await shim.attachFileToNote(note, testImagePath);
+		const resourceId = Note.linkedItemIds(note.body)[0];
+
+		// Associate the resource with the share
+		const shareId = 'abcd1234';
+		await Resource.save({
+			id: resourceId,
+			share_id: shareId,
+			is_shared: 1,
+		});
+
+		const reset = simulateReadOnlyShareEnv([shareId]);
+		try {
+			await Folder.updateAllShareIds(resourceService(), []);
+		} finally {
+			reset();
+		}
+	});
+
+	it('should not fail to update note share IDs when an outdated share ID is contained in a read-only folder', async () => {
 		const shareId = 'abcd1234';
 		const root = await Folder.save({ title: 'read-only', share_id: shareId });
 		// Save a child with a different share ID

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -1,5 +1,5 @@
 import { BaseItemEntity, defaultFolderIcon, FolderEntity, FolderIcon, NoteEntity, ResourceEntity } from '../services/database/types';
-import BaseModel, { DeleteOptions } from '../BaseModel';
+import BaseModel, { DeleteOptions, ModelType } from '../BaseModel';
 import { FolderLoadOptions } from './utils/types';
 import time from '../time';
 import { _ } from '../locale';
@@ -19,6 +19,8 @@ import getConflictFolderId from './utils/getConflictFolderId';
 import getTrashFolderId from '../services/trash/getTrashFolderId';
 import { getCollator } from './utils/getCollator';
 import Setting from './Setting';
+import { itemIsReadOnlySync, ItemSlice } from './utils/readOnly';
+import ItemChange from './ItemChange';
 const { substrWithEllipsis } = require('../string-utils.js');
 
 const logger = Logger.create('models/Folder');
@@ -593,6 +595,16 @@ export default class Folder extends BaseItem {
 		// resume the process from the start (thus the loop) so that we deal
 		// with the right note/resource associations.
 
+		const isReadOnly = (type: ModelType, item: NoteEntity|ResourceEntity) => {
+			return itemIsReadOnlySync(
+				type,
+				ItemChange.SOURCE_UNSPECIFIED,
+				item as ItemSlice,
+				Setting.value('sync.userId'),
+				BaseItem.syncShareCache,
+			);
+		};
+
 		interface Row {
 			id: string;
 			share_id: string;
@@ -672,7 +684,19 @@ export default class Folder extends BaseItem {
 					const row = rows[i];
 					const note: NoteEntity = await Note.load(row.note_id);
 					if (!note) continue; // probably got deleted in the meantime?
+					// Don't update read-only notes:
+					if (isReadOnly(ModelType.Note, note)) continue;
+
 					const newResource = await Resource.duplicateResource(resourceId);
+					// Ensure that the resource starts with the correct share_id and is_shared.
+					// This reduces the number of resources to be processed in the next loop iteration
+					// and seems to fix an issue related to resources not syncing with read-only shares.
+					await Resource.save({
+						id: newResource.id,
+						is_shared: note.is_shared,
+						share_id: note.share_id,
+					});
+
 					logger.info(`updateResourceShareIds: Automatically created resource "${newResource.id}" to replace resource "${resourceId}" because it is shared and duplicate across notes:`, row);
 					const regex = new RegExp(resourceId, 'gi');
 					const newBody = note.body.replace(regex, newResource.id);
@@ -721,7 +745,9 @@ export default class Folder extends BaseItem {
 						resource.blob_updated_time = now;
 					}
 
-					await Resource.save(resource, { autoTimestamp: false });
+					if (!isReadOnly(ModelType.Resource, resource)) {
+						await Resource.save(resource, { autoTimestamp: false });
+					}
 				}
 				return;
 			}

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -691,6 +691,9 @@ export default class Folder extends BaseItem {
 						// Ensure that the resource starts with the correct share_id and is_shared.
 						// This reduces the number of resources to be processed in the next loop iteration
 						// and seems to fix an issue related to resources not syncing with read-only shares.
+						//
+						// These properties are set directly in the "duplicateResource" call to prevent
+						// race conditions.
 						is_shared: note.is_shared,
 						share_id: note.share_id,
 					});

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -687,12 +687,10 @@ export default class Folder extends BaseItem {
 					// Don't update read-only notes:
 					if (isReadOnly(ModelType.Note, note)) continue;
 
-					const newResource = await Resource.duplicateResource(resourceId);
-					// Ensure that the resource starts with the correct share_id and is_shared.
-					// This reduces the number of resources to be processed in the next loop iteration
-					// and seems to fix an issue related to resources not syncing with read-only shares.
-					await Resource.save({
-						id: newResource.id,
+					const newResource = await Resource.duplicateResource(resourceId, {
+						// Ensure that the resource starts with the correct share_id and is_shared.
+						// This reduces the number of resources to be processed in the next loop iteration
+						// and seems to fix an issue related to resources not syncing with read-only shares.
 						is_shared: note.is_shared,
 						share_id: note.share_id,
 					});

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -446,7 +446,7 @@ export default class Resource extends BaseItem {
 
 	public static async duplicateResource(
 		resourceId: string,
-		// When set, changes some of the properties in the duplicate:
+		// Overrides property values in the duplicate resource.
 		propertyOverrides: ResourceEntity = {},
 	): Promise<ResourceEntity> {
 		const resource = await Resource.load(resourceId);

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -444,7 +444,11 @@ export default class Resource extends BaseItem {
 		return await this.fsDriver().readFile(Resource.fullPath(resource), encoding);
 	}
 
-	public static async duplicateResource(resourceId: string): Promise<ResourceEntity> {
+	public static async duplicateResource(
+		resourceId: string,
+		// When set, changes some of the properties in the duplicate:
+		propertyOverrides: ResourceEntity = {},
+	): Promise<ResourceEntity> {
 		const resource = await Resource.load(resourceId);
 		const localState = await Resource.localState(resource);
 
@@ -452,7 +456,10 @@ export default class Resource extends BaseItem {
 		delete newResource.id;
 		delete newResource.is_shared;
 		delete newResource.share_id;
-		newResource = await Resource.save(newResource);
+		newResource = await Resource.save({
+			...newResource,
+			...propertyOverrides,
+		});
 
 		const newLocalState = { ...localState };
 		newLocalState.resource_id = newResource.id;


### PR DESCRIPTION
# Summary

This change:
- Fixes an issue in which `Folder.updateResourceShareIds` could fail in some cases involving read-only shares.
- Makes `Folder.updateResourceShareIds` less likely to create conflicts related to read-only shares.
- Seems to fix an issue in which `Folder.updateResourceShareIds` created resources that failed to download for read-only share recipients.

# Details

This pull request modifies `Folder.updateResourceShareIds` by:
- Adding additional checks to prevent `Folder.updateResourceShareIds` from attempting to modify read-only resources and notes.
   - Modifying a read-only note creates a conflict.
   - Attempting to modify a read-only resource threw an `Error`.
- Initializing new resources created by `Folder.updateResourceShareIds` with the correct `share_id` and `is_shared`:
   - Previously, the duplicated resources were initialized with an empty share_id/is_shared and didn't sync to read-only share recipients. This seems to fix the issue.
   - This also reduces the number of resources that will need to be processed by the next iteration of the `Folder.updateResourceShareIds` loop.

# Testing

This pull request adds an automated test to check that `Folder.updateResourceShareIds` doesn't try to update notes in read-only shares.

<details><summary>Sync fuzzer testing</summary>

The `actions` in the following sync fuzzer config failed to run/validate prior to this pull request. At least one of the clients had broken resource links and unexpected attachment conflicts:
```json
{
	"clientCount": 2,
	"note": "Requires a Joplin Server instance with read-only share support.",
	"actions": [
		"// Setup: Create one folder in each client",
		["switchClient", { "id": 0 }],
		["newToplevelFolder", { "id": "01111111111111111111111111111111" }],
		"sync",
		["switchClient", { "id": 1 }],
		"sync",

		["switchClient", { "id": 0}],
		["shareFolder", { "folderId": "01111111111111111111111111111111", "otherClientId": 1, "readOnly": true}],


		"// Setup: Switch to client 1 and share a folder",
		["switchClient", { "id": 1 }],
		["newToplevelFolder", { "id": "01111111111111111111111111111112" }],
		["newToplevelFolder", { "id": "01111111111111111111111111111113" }],
		["shareFolder", { "folderId": "01111111111111111111111111111112", "otherClientId": 0, "readOnly": true}],

		"// Setup: Create a note in the shared folder and attach a resource",
		["newNote", { "id": "11111111111111111111111111111113", "parentId": "01111111111111111111111111111112" }],
		["attachResourceTo", { "noteId": "11111111111111111111111111111113", "resourceId": "21111111111111111111111111111113" }],

		"// Setup: Verify that all clients have the expected state",
		"syncAndCheckState",

		"// Re-attach the resource from client 0",
		["switchClient", { "id": 0 }],
		"sync",
		["newNote", { "id": "11111111111111111111111111111115", "parentId": "01111111111111111111111111111111" }],
		["attachResourceTo", { "noteId": "11111111111111111111111111111115", "resourceId": "21111111111111111111111111111113" }],
		["newNote", { "id": "11111111111111111111111111111116", "parentId": "01111111111111111111111111111111" }],
		["attachResourceTo", { "noteId": "11111111111111111111111111111116", "resourceId": "21111111111111111111111111111113" }],
		["newNote", { "id": "11111111111111111111111111111117", "parentId": "01111111111111111111111111111111" }],
		["attachResourceTo", { "noteId": "11111111111111111111111111111117", "resourceId": "21111111111111111111111111111113" }],

		"// Final state check: If the issue still occurs, 1) some resources will be missing from one of the clients, 2) there will be attachment conflicts.",
		"syncAndCheckState",
		["switchClient", { "id": 1 }],
		"syncAndCheckState"
	]
}
```

</details>


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->