### PR TITLE
Chore: Sync fuzzer: Don't attempt to publish read-only notes

### DIFF
--- a/packages/tools/fuzzer/ActionRunner.ts
+++ b/packages/tools/fuzzer/ActionRunner.ts
@@ -487,16 +487,12 @@ const getActions = (context: FuzzContext, clientPool: ClientPool, client: Client
 	});
 
 	addAction('publishNote', async ({ id }) => {
-		const note = id ? noteById(id) : await client.randomNote({
-			includeReadOnly: true,
-		});
+		const note = noteById(id);
 		if (!note || note.published) return false;
 
 		await client.publishNote(note.id);
 		return true;
-	}, {
-		id: undefinedId,
-	});
+	}, { id: selectOrCreateWriteableNote });
 
 	addAction('unpublishNote', async ({ id }) => {
 		const note = id ? noteById(id) : await client.randomNote({ includeReadOnly: true });


### PR DESCRIPTION
# Summary

Previously, the sync fuzzer could attempt to publish read-only notes. This would fail, since read-only notes cannot be modified.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->