### PR TITLE
Desktop: Fixes #14216: Fix undo/redo menu items in the Rich Text and Markdown editors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -468,6 +468,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalRedo.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalUndo.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
@@ -511,6 +513,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderR
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/togglePerFolderSortOrder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleSideBar.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleVisiblePanes.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/utils/canUseNativeUndo.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/types.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/showFolderPicker.js

--- a/.gitignore
+++ b/.gitignore
@@ -442,6 +442,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/deleteFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/duplicateNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/editAlarm.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/exportPdf.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalRedo.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalUndo.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/gotoAnything.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/hideModalMessage.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.js
@@ -485,6 +487,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderR
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/togglePerFolderSortOrder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleSideBar.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleVisiblePanes.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/utils/canUseNativeUndo.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/types.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/showFolderPicker.js

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -693,17 +693,8 @@ function useMenu(props: Props) {
 						menuItemDic.pasteAsText,
 						menuItemDic.textSelectAll,
 						separator(),
-						// Using the generic "undo"/"redo" roles mean the menu
-						// item will work in every text fields, whether it's the
-						// editor or a regular text field.
-						{
-							role: 'undo',
-							label: _('Undo'),
-						},
-						{
-							role: 'redo',
-							label: _('Redo'),
-						},
+						menuItemDic.globalUndo,
+						menuItemDic.globalRedo,
 						separator(),
 						menuItemDic.textBold,
 						menuItemDic.textItalic,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -294,6 +294,13 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 						window.requestAnimationFrame(() => editor.undoManager.add());
 					},
 					pasteAsText: () => editor.fire(TinyMceEditorEvents.PasteAsText),
+
+					'editor.undo': () => {
+						editor.undoManager.undo();
+					},
+					'editor.redo': () => {
+						editor.undoManager.redo();
+					},
 				};
 
 				if (additionalCommands[cmd.name]) {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalRedo.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalRedo.ts
@@ -1,0 +1,24 @@
+import CommandService, { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import { WindowControl } from '../utils/useWindowControl';
+import bridge from '../../../services/bridge';
+import canUseNativeUndo from './utils/canUseNativeUndo';
+
+export const declaration: CommandDeclaration = {
+	name: 'globalRedo',
+	label: () => _('Redo'),
+};
+
+export const runtime = (control: WindowControl): CommandRuntime => {
+	return {
+		execute: async (_context: CommandContext) => {
+			if (canUseNativeUndo(control)) {
+				bridge().activeWindow().webContents.redo();
+			} else {
+				await CommandService.instance().execute('editor.redo');
+			}
+		},
+
+		enabledCondition: '',
+	};
+};

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalUndo.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/globalUndo.ts
@@ -1,0 +1,27 @@
+import CommandService, { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
+import { _ } from '@joplin/lib/locale';
+import { WindowControl } from '../utils/useWindowControl';
+import bridge from '../../../services/bridge';
+import canUseNativeUndo from './utils/canUseNativeUndo';
+
+export const declaration: CommandDeclaration = {
+	name: 'globalUndo',
+	label: () => _('Undo'),
+};
+
+export const runtime = (control: WindowControl): CommandRuntime => {
+	return {
+		execute: async (_context: CommandContext) => {
+			// As of January 2026, webContents.undo() doesn't work properly in more complex
+			// edit controls (e.g. CodeMirror or TinyMCE). Only use it when a more simple input
+			// has focus:
+			if (canUseNativeUndo(control)) {
+				bridge().activeWindow().webContents.undo();
+			} else {
+				await CommandService.instance().execute('editor.undo');
+			}
+		},
+
+		enabledCondition: '',
+	};
+};

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.ts
@@ -5,6 +5,8 @@ import * as deleteFolder from './deleteFolder';
 import * as duplicateNote from './duplicateNote';
 import * as editAlarm from './editAlarm';
 import * as exportPdf from './exportPdf';
+import * as globalRedo from './globalRedo';
+import * as globalUndo from './globalUndo';
 import * as gotoAnything from './gotoAnything';
 import * as hideModalMessage from './hideModalMessage';
 import * as importFrom from './importFrom';
@@ -54,6 +56,8 @@ const index: any[] = [
 	duplicateNote,
 	editAlarm,
 	exportPdf,
+	globalRedo,
+	globalUndo,
 	gotoAnything,
 	hideModalMessage,
 	importFrom,

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/utils/canUseNativeUndo.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/utils/canUseNativeUndo.ts
@@ -1,0 +1,11 @@
+import { WindowControl } from '../../utils/useWindowControl';
+
+// CodeMirror and TinyMCE both have trouble with native Electron
+// undo/redo.
+// See https://github.com/laurent22/joplin/issues/14216
+const canUseNativeUndo = (control: WindowControl) => {
+	const dom = control.getFocusedDocument();
+	return !dom.activeElement.closest('.CodeMirror, div.joplin-tinymce');
+};
+
+export default canUseNativeUndo;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.ts
@@ -21,7 +21,7 @@ const useWindowCommands = ({ documentRef, customCss, plugins, editorNoteStatuses
 		editorNoteStatuses: editorNoteStatuses,
 		plugins: plugins,
 	});
-	const windowControl = useWindowControl(setDialogState, onPrintCallback);
+	const windowControl = useWindowControl(setDialogState, onPrintCallback, documentRef);
 
 	// This effect needs to run as soon as possible. Certain components may fail to load if window
 	// commands are not registered on their first render.

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo, useRef } from 'react';
+import { RefObject, useMemo, useRef } from 'react';
 import { DialogState } from '../types';
 import { PrintCallback } from './usePrintToCallback';
 import { _ } from '@joplin/lib/locale';
@@ -23,10 +23,11 @@ export interface WindowControl {
 	showPrompt: <T>(options: PromptOptions<T>)=> Promise<T>;
 	printTo: PrintCallback;
 	announcePanelVisibility(panelName: string, visible: boolean): void;
+	getFocusedDocument(): Document;
 }
 
 export type OnSetDialogState = React.Dispatch<React.SetStateAction<DialogState>>;
-const useWindowControl = (setDialogState: OnSetDialogState, onPrint: PrintCallback) => {
+const useWindowControl = (setDialogState: OnSetDialogState, onPrint: PrintCallback, windowDomRef: RefObject<Document>) => {
 	// Use refs to avoid reloading the output where possible -- reloading the window control
 	// may mean reloading all main window commands.
 	const onPrintRef = useRef(onPrint);
@@ -67,9 +68,12 @@ const useWindowControl = (setDialogState: OnSetDialogState, onPrint: PrintCallba
 					});
 				});
 			},
+			getFocusedDocument: () => {
+				return windowDomRef.current;
+			},
 		};
 		return control;
-	}, [setDialogState]);
+	}, [setDialogState, windowDomRef]);
 };
 
 export default useWindowControl;

--- a/packages/app-desktop/gui/menuCommandNames.ts
+++ b/packages/app-desktop/gui/menuCommandNames.ts
@@ -50,13 +50,16 @@ export default function() {
 		'editor.duplicateLine',
 		'openSecondaryAppInstance',
 		'openPrimaryAppInstance',
-		// We cannot put the undo/redo commands in the menu because they are
-		// editor-specific commands. If we put them there it will break the
-		// undo/redo in regular text fields.
-		// https://github.com/laurent22/joplin/issues/6214
 
-		// 'editor.undo',
-		// 'editor.redo',
+		// We cannot put the editor.undo/editor.redo commands in the menu because they are
+		// editor-specific commands. If we put them there it will break the  undo/redo in
+		// regular text fields (https://github.com/laurent22/joplin/issues/6214).
+		// However, the native Electron undo/redo doesn't work well in TinyMCE/CodeMirror.
+		// As a workaround, use these commands that switch between editor.undo and native Electron
+		// undo/redo depending on the type of selected editor:
+		'globalUndo',
+		'globalRedo',
+
 		'editor.indentLess',
 		'editor.indentMore',
 		'editor.toggleComment',

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -381,5 +381,24 @@ test.describe('markdownEditor', () => {
 		await goToAnything.runCommand(electronApp, 'textPaste');
 		await noteEditor.expectToHaveText(/^Test \(new content!\)[\n]+/);
 	});
+
+	test('the undo and redo menu items should work', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.waitFor();
+
+		await mainScreen.createNewNote('Test undo/redo');
+
+		const noteEditor = mainScreen.noteEditor;
+		await noteEditor.focusCodeMirrorEditor();
+
+		await mainWindow.keyboard.type('A');
+		await noteEditor.expectToHaveText('A');
+
+		await activateMainMenuItem(electronApp, 'Undo');
+		await noteEditor.expectToHaveText('\n');
+
+		await activateMainMenuItem(electronApp, 'Redo');
+		await noteEditor.expectToHaveText('A');
+	});
 });
 


### PR DESCRIPTION
# Summary

This pull request works around what seems to be an Electron/Chromium bug related to the undo/redo menu items (see [comment](https://github.com/laurent22/joplin/issues/14216#issuecomment-3808301196)).

When the CodeMirror or TinyMCE editor has focus, the "Undo" and "Redo" menu items now use the `editor.undo` and `editor.redo` commands. Otherwise, the native Electron undo/redo is used. Previously, the "undo" and "redo" menu items always used the default Electron undo/redo.

Fixes #14216.

# Testing plan

[Screencast from 2026-01-27 17-23-20.webm](https://github.com/user-attachments/assets/62aa6e00-1f1a-4ae7-b663-c5f186e896e5)

On Fedora 43 Linux:

1. Focus the note title.
2. Clear the note title.
3. Use the edit > undo menu item to undo.
4. Use the edit > redo menu item to redo.
5. Use the edit > undo menu item to undo.
6. Repeat steps 1-5 for the note body (Markdown editor).
7. Repeat steps 1-5 for the note body (Rich Text editor).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->