### PR TITLE
Desktop: Fixes #14210: OneNote importer: Skip importing ink when ID lookup fails

### DIFF
--- a/packages/onenote-converter/parser/src/onenote/ink.rs
+++ b/packages/onenote-converter/parser/src/onenote/ink.rs
@@ -4,6 +4,7 @@ use crate::one::property_set::{
 use crate::onestore::object_space::ObjectSpaceRef;
 use crate::shared::exguid::ExGuid;
 use parser_utils::errors::{ErrorKind, Result};
+use parser_utils::log_warn;
 
 /// An ink object.
 #[derive(Clone, Debug)]
@@ -203,9 +204,11 @@ pub(crate) fn parse_ink_data(
     scale_x: Option<f32>,
     scale_y: Option<f32>,
 ) -> Result<(Vec<InkStroke>, Option<InkBoundingBox>)> {
-    let ink_data_object = space
-        .get_object(ink_data_id)
-        .ok_or_else(|| ErrorKind::MalformedOneNoteData("ink data node is missing".into()))?;
+    let Some(ink_data_object) = space.get_object(ink_data_id) else {
+        log_warn!("Ink data object {ink_data_id:?} not found! Not importing the ink.");
+        return Ok((vec![], None));
+    };
+
     let ink_data = ink_data_node::parse(&ink_data_object)?;
 
     let strokes = ink_data


### PR DESCRIPTION
# Summary

This pull request updates the OneNote importer to skip importing ink objects when an ID lookup fails.

May fix #14210.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->