### PR TITLE
Desktop: Fixes #14224: Update app id to fix generic Wayland icon for AppImage on KDE

### DIFF
--- a/packages/app-desktop/package.json
+++ b/packages/app-desktop/package.json
@@ -32,6 +32,9 @@
     "appId": "net.cozic.joplin-desktop",
     "compression": "normal",
     "productName": "Joplin",
+    "extraMetadata": {
+      "name": "joplin"
+    },
     "npmRebuild": false,
     "afterSign": "./tools/notarizeMacApp.js",
     "extraResources": [


### PR DESCRIPTION
Fixing my own issue: https://github.com/laurent22/joplin/issues/14224

This solution keeps the same packageName, but uses extraMetadata to overwrite it while building. This way Yarn Workspaces can work the same, while the bug is fixed.

### Before
<img width="840" height="923" alt="before" src="https://github.com/user-attachments/assets/ce195cf4-0a15-4308-bc03-e6ac0ec012e3" />

### After
<img width="838" height="914" alt="after" src="https://github.com/user-attachments/assets/ef9656b0-40c6-4346-8025-7b0c9a3426ab" />

## StartupWMClass

Also, StartupWMClass doesn't seem to do anything for Wayland, only for X11. So in a future PR maybe we could replace the logic in `package.json` and `Joplin_install_and_update.sh` to be just "Joplin".

<img width="1396" height="340" alt="image" src="https://github.com/user-attachments/assets/0da7a642-f8e6-4a41-8a2a-cc292eee556c" />

