### PR TITLE
Desktop: OneNote import: Fix onepkg import stops after the first section fails to import

### DIFF
--- a/packages/onenote-converter/renderer/src/errors.rs
+++ b/packages/onenote-converter/renderer/src/errors.rs
@@ -50,6 +50,9 @@ pub enum ErrorKind {
     #[error("IO failure: {0}")]
     IoError(std::io::Error),
 
+    #[error("onepkg import failure: {0}")]
+    OnePkgImportFailure(String),
+
     #[error("Failure: {0}")]
     OtherError(ColorError),
 }


### PR DESCRIPTION
# Summary

Fixes a regression from https://github.com/laurent22/joplin/pull/14094 that caused import to stop early if a section failed to render. 

#14094 is in Joplin >= 3.6.2, so this issue does not affect the v3.5.x stable release.

Thank you @h-jangra for opening the original version of this pull request in #14243!

# Details

`.onepkg` files are [CAB archives](https://en.wikipedia.org/wiki/Cabinet_(file_format)) and can contain one or more `.one` section files. Prior to #14037, each of these `.one` files was parsed and rendered within a JavaScript `try`/`catch` block:
https://github.com/laurent22/joplin/blob/c278b45c7876953d39328b78db303b6845421d91/packages/lib/services/interop/InteropService_Importer_OneNote.ts#L93-L97
As a result, if a particular `.one` file resulted in an import error, the other `.one` files were still processed by the importer.

With #14094, the `.onepkg` extraction is handled in Rust. Rather than extracting the `.onepkg` file with `EXPAND.EXE` and processing each of the `.one` files individually, the full `.onepkg` file is processed. If a single `.one` file within the `.onepkg` failed to render, the in-Rust [import loop](https://github.com/laurent22/joplin/blob/c278b45c7876953d39328b78db303b6845421d91/packages/onenote-converter/renderer/src/lib.rs#L131) exits early, leaving any remaining `.one` files unimported.

This change adjusts the in-Rust error handling to:
1. Attempt to render **all** sections, regardless of whether previous sections failed to parse/render.
3. Create an error report with the list of sections that failed to import (and why). 
4. Send the error report back to JS.
   - This causes the "Some files failed to import" dialog to be shown.

# Differences from #14243

- Sends error reports to JS (continues to return `Err` on import failure).
  - As a result, the "Some files failed to import" dialog is still shown.
- Doesn't create an `IMPORT_ERROR.md` file specifically for `.onepkg` import errors.
  - Most import errors are included in an `⚠️ Errors ⚠️` note (see https://github.com/laurent22/joplin/pull/13736).
  - Other errors (e.g. `.one` file read failures) are sent to JS.

# Testing plan

Screen recording:

[Screencast from 2026-02-02 09-04-35.webm](https://github.com/user-attachments/assets/a4a00736-b724-4d77-8115-aaf2d5ba41c0)

Steps:

1. Modify `section.rs` to always return an `Err` (simulate an import error).
2. Import a `.onepkg` file.
3. Verify that a "Some files failed to import" dialog box is shown.
4. Verify that all sections **did** import (since `section.rs` still renders the files).
5. Verify that an error report is logged.
6. Revert the changes to `section.rs`.
7. Verify that the `.onepkg` file can still be imported successfully (without showing an error dialog).

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->