### PR TITLE
Chore: Desktop: Fix warning logged when opening the note viewer

### DIFF
--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -239,8 +239,7 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 			className="noteTextViewer"
 			ref={setWebview}
 			style={viewerStyle}
-			allow='clipboard-write=(self) fullscreen=(self) autoplay=(self) local-fonts=(self) encrypted-media=(self)'
-			allowFullScreen={true}
+			allow="clipboard-write 'self' joplin-content://note-viewer/; fullscreen 'self' joplin-content://note-viewer/; autoplay 'self' joplin-content://note-viewer/; local-fonts 'self' joplin-content://note-viewer/; encrypted-media 'self' joplin-content://note-viewer/"
 			aria-label={_('Note viewer')}
 			src={`joplin-content://note-viewer/${toForwardSlashes(getAssetPath('gui/note-viewer/index.html'))}`}
 		></iframe>

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -58,6 +58,17 @@ const usePluginMessageResponder = (webviewRef: RefObject<HTMLIFrameElement>) => 
 	}, [webviewRef, windowId]);
 };
 
+const useAllowAttribute = () => {
+	// Specifies what content in the note viewer can do. See
+	// https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allow
+	// allow=fullscreen: Required to allow the user to fullscreen videos.
+	return [
+		'clipboard-write', 'fullscreen', 'autoplay', 'local-fonts', 'encrypted-media',
+	].map(
+		attr => `${attr} joplin-content://note-viewer/`,
+	).join('; ');
+};
+
 const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerControl>) => {
 	const [webview, setWebview] = useState<HTMLIFrameElement|null>(null);
 	const webviewRef = useRef<HTMLIFrameElement|null>(null);
@@ -233,13 +244,13 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 		return { border: 'none', ...props.viewerStyle };
 	}, [props.viewerStyle]);
 
-	// allow=fullscreen: Required to allow the user to fullscreen videos.
+	const allow = useAllowAttribute();
 	return (
 		<iframe
 			className="noteTextViewer"
 			ref={setWebview}
 			style={viewerStyle}
-			allow="clipboard-write 'self' joplin-content://note-viewer/; fullscreen 'self' joplin-content://note-viewer/; autoplay 'self' joplin-content://note-viewer/; local-fonts 'self' joplin-content://note-viewer/; encrypted-media 'self' joplin-content://note-viewer/"
+			allow={allow}
 			aria-label={_('Note viewer')}
 			src={`joplin-content://note-viewer/${toForwardSlashes(getAssetPath('gui/note-viewer/index.html'))}`}
 		></iframe>


### PR DESCRIPTION
# Summary

Prior to this pull request, opening the note viewer caused warnings similar to the following:
```
Unrecognized feature: 'clipboard-write=(self)'
```

This was caused by an incorrectly-specified `allow=` attribute on the note viewer `<iframe>`.

Previously, the `allow` attribute used the syntax expected for the [Permission-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy#basic_usage) header, rather than that of the [`allow`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/allow) attribute.


# Testing

1. Attach a video to a note. Verify that the video can still be fullscreened.
2. Verify that YouTube video embeds can still be fullscreened:
   - Add `https://www.youtube.com/embed/iJqe9pC-z-Y` to the note on a new line. Verify that the fullcreen button works in the note viewer.
3. Check "Enable file:// URLs for images and videos" in settings > markdown. Attach an image to a note using an external `file://` URL. Verify that the image renders in the note viewer.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->