### PR TITLE
Add support for FrontMatter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1045,6 +1045,8 @@ packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.js
 packages/editor/CodeMirror/extensions/links/utils/openLink.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.js
+packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.js
+packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.js
 packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.js
 packages/editor/CodeMirror/extensions/markdownHighlightExtension.js
 packages/editor/CodeMirror/extensions/markdownMathExtension.test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1813,6 +1813,8 @@ packages/renderer/MdToHtml/rules/code_inline.js
 packages/renderer/MdToHtml/rules/externalEmbed.js
 packages/renderer/MdToHtml/rules/fence.js
 packages/renderer/MdToHtml/rules/fountain.js
+packages/renderer/MdToHtml/rules/frontmatter.test.js
+packages/renderer/MdToHtml/rules/frontmatter.js
 packages/renderer/MdToHtml/rules/highlight_keywords.js
 packages/renderer/MdToHtml/rules/html_image.js
 packages/renderer/MdToHtml/rules/image.js

--- a/.gitignore
+++ b/.gitignore
@@ -1019,6 +1019,8 @@ packages/editor/CodeMirror/extensions/links/utils/getUrlAtPosition.js
 packages/editor/CodeMirror/extensions/links/utils/openLink.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.js
 packages/editor/CodeMirror/extensions/markdownDecorationExtension.js
+packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.js
+packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.js
 packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.js
 packages/editor/CodeMirror/extensions/markdownHighlightExtension.js
 packages/editor/CodeMirror/extensions/markdownMathExtension.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1787,6 +1787,8 @@ packages/renderer/MdToHtml/rules/code_inline.js
 packages/renderer/MdToHtml/rules/externalEmbed.js
 packages/renderer/MdToHtml/rules/fence.js
 packages/renderer/MdToHtml/rules/fountain.js
+packages/renderer/MdToHtml/rules/frontmatter.test.js
+packages/renderer/MdToHtml/rules/frontmatter.js
 packages/renderer/MdToHtml/rules/highlight_keywords.js
 packages/renderer/MdToHtml/rules/html_image.js
 packages/renderer/MdToHtml/rules/image.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEditDialog.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useEditDialog.ts
@@ -51,6 +51,15 @@ function newBlockSource(language = '', content = '', previousSource: SourceInfo 
 		} else {
 			fence = '$$';
 		}
+	} else if (language === 'frontmatter') {
+		// Frontmatter uses --- delimiters instead of code fences
+		return {
+			openCharacters: '---\n',
+			closeCharacters: '\n---\n',
+			content: content,
+			node: null,
+			language: language,
+		};
 	}
 
 	const fenceLanguage = language === 'katex' ? '' : language;

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -7,6 +7,7 @@ import { deleteMarkupBackward, markdown, markdownLanguage } from '@codemirror/la
 import { GFM as GitHubFlavoredMarkdownExtension } from '@lezer/markdown';
 import markdownMathExtension from './extensions/markdownMathExtension';
 import markdownHighlightExtension from './extensions/markdownHighlightExtension';
+import markdownFrontMatterExtension from './extensions/markdownFrontMatterExtension';
 import lookUpLanguage from './utils/markdown/codeBlockLanguages/lookUpLanguage';
 import { html } from '@codemirror/lang-html';
 import { defaultKeymap, emacsStyleKeymap } from '@codemirror/commands';
@@ -29,6 +30,9 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 				markdown({
 					extensions: [
 						GitHubFlavoredMarkdownExtension,
+
+						// FrontMatter support (YAML blocks at start of document)
+						markdownFrontMatterExtension,
 
 						settings.markdownMarkEnabled ? markdownHighlightExtension : [],
 

--- a/packages/editor/CodeMirror/extensions/markdownDecorationExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownDecorationExtension.ts
@@ -32,6 +32,10 @@ const mathBlockDecoration = Decoration.line({
 	attributes: { class: 'cm-mathBlock', ...noSpellCheckAttrs },
 });
 
+const frontMatterDecoration = Decoration.line({
+	attributes: { class: 'cm-frontMatter', ...noSpellCheckAttrs },
+});
+
 const inlineMathDecoration = Decoration.mark({
 	attributes: { class: 'cm-inlineMath', ...noSpellCheckAttrs },
 });
@@ -116,6 +120,7 @@ const nodeNameToLineDecoration: Record<string, Decoration> = {
 	'FencedCode': codeBlockDecoration,
 	'CodeBlock': codeBlockDecoration,
 	'BlockMath': mathBlockDecoration,
+	'FrontMatter': frontMatterDecoration,
 	'Blockquote': blockQuoteDecoration,
 	'OrderedList': orderedListDecoration,
 	'BulletList': unorderedListDecoration,
@@ -152,6 +157,7 @@ const multilineNodes = {
 	'FencedCode': true,
 	'CodeBlock': true,
 	'BlockMath': true,
+	'FrontMatter': true,
 	'Blockquote': true,
 	'OrderedList': true,
 	'BulletList': true,

--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
@@ -1,0 +1,105 @@
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { frontMatterTagName, frontMatterContentTagName, frontMatterMarkerTagName } from './markdownFrontMatterExtension';
+
+import createTestEditor from '../testing/createTestEditor';
+import findNodesWithName from '../testing/findNodesWithName';
+
+// Creates an EditorState with FrontMatter and markdown extensions
+const createEditorState = async (initialText: string, expectedTags: string[]): Promise<EditorState> => {
+	return (await createTestEditor(initialText, EditorSelection.cursor(0), expectedTags)).state;
+};
+
+describe('MarkdownFrontMatterExtension', () => {
+
+	jest.retryTimes(2);
+
+	it('should parse a basic FrontMatter block at the start of the document', async () => {
+		const documentText = '---\ntitle: Test\n---\n\n# Heading';
+		const editor = await createEditorState(documentText, [frontMatterTagName, 'ATXHeading1']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+
+		expect(frontMatterNodes.length).toBe(1);
+		expect(frontMatterNodes[0].from).toBe(0);
+		expect(frontMatterNodes[0].to).toBe('---\ntitle: Test\n---'.length);
+	});
+
+	it('should parse FrontMatter with multiple properties', async () => {
+		const frontMatter = '---\ntitle: Test\ndate: 2024-01-01\ntags: [one, two]\n---';
+		const documentText = `${frontMatter}\n\nContent here.`;
+		const editor = await createEditorState(documentText, [frontMatterTagName]);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+
+		expect(frontMatterNodes.length).toBe(1);
+		expect(frontMatterNodes[0].from).toBe(0);
+		expect(frontMatterNodes[0].to).toBe(frontMatter.length);
+	});
+
+	it('should not parse FrontMatter if not at document start', async () => {
+		const documentText = 'Some text\n\n---\ntitle: Test\n---';
+		const editor = await createEditorState(documentText, ['Paragraph']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+
+		// Should not be recognized as FrontMatter since it's not at the start
+		expect(frontMatterNodes.length).toBe(0);
+	});
+
+	it('should not parse FrontMatter without closing delimiter', async () => {
+		// Test document with --- at start but no closing delimiter
+		// This should be parsed as a horizontal rule followed by content
+		const documentText = '# Heading\n\n---\ntitle: Test';
+		const editor = await createEditorState(documentText, ['ATXHeading1', 'HorizontalRule']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+
+		// FrontMatter only works at the very start of the document, so this should not be recognized
+		expect(frontMatterNodes.length).toBe(0);
+	});
+
+	it('should handle empty FrontMatter block', async () => {
+		const documentText = '---\n---\n\n# Heading';
+		const editor = await createEditorState(documentText, [frontMatterTagName, 'ATXHeading1']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+
+		expect(frontMatterNodes.length).toBe(1);
+		expect(frontMatterNodes[0].from).toBe(0);
+		expect(frontMatterNodes[0].to).toBe('---\n---'.length);
+	});
+
+	it('should have FrontMatterContent as child node', async () => {
+		const documentText = '---\nkey: value\n---';
+		const editor = await createEditorState(documentText, [frontMatterTagName]);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+		const contentNodes = findNodesWithName(editor, frontMatterContentTagName);
+
+		expect(frontMatterNodes.length).toBe(1);
+		// Content node may be replaced by YAML parser, but if not, it should exist
+		// The presence depends on whether YAML language was loaded
+		expect(contentNodes.length).toBeGreaterThanOrEqual(0);
+	});
+
+	it('should not confuse horizontal rules with FrontMatter', async () => {
+		const documentText = '# Title\n\n---\n\nSome text';
+		const editor = await createEditorState(documentText, ['ATXHeading1', 'HorizontalRule']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+		const hrNodes = findNodesWithName(editor, 'HorizontalRule');
+
+		expect(frontMatterNodes.length).toBe(0);
+		expect(hrNodes.length).toBe(1);
+	});
+
+	it('should create FrontMatterMarker nodes for the delimiters', async () => {
+		const documentText = '---\ntitle: Test\n---\n\n# Heading';
+		const editor = await createEditorState(documentText, [frontMatterTagName, frontMatterMarkerTagName]);
+		const markerNodes = findNodesWithName(editor, frontMatterMarkerTagName);
+
+		// Should have two markers: opening and closing ---
+		expect(markerNodes.length).toBe(2);
+
+		// Opening marker
+		expect(markerNodes[0].from).toBe(0);
+		expect(markerNodes[0].to).toBe(3); // '---'.length
+
+		// Closing marker
+		expect(markerNodes[1].from).toBe('---\ntitle: Test\n'.length);
+		expect(markerNodes[1].to).toBe('---\ntitle: Test\n---'.length);
+	});
+});

--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
@@ -1,0 +1,128 @@
+// Extension for parsing and highlighting YAML FrontMatter blocks at the start of a document.
+//
+// A FrontMatter block is delimited by --- at the very start of the document:
+// ---
+// title: My Document
+// date: 2024-01-01
+// ---
+
+import { Tag } from '@lezer/highlight';
+import { parseMixed, SyntaxNodeRef, Input, NestedParse, ParseWrapper } from '@lezer/common';
+import { MarkdownConfig, BlockContext, Line, LeafBlock, MarkdownExtension } from '@lezer/markdown';
+import { StreamLanguage } from '@codemirror/language';
+import { yaml } from '@codemirror/legacy-modes/mode/yaml';
+
+export const frontMatterTagName = 'FrontMatter';
+export const frontMatterContentTagName = 'FrontMatterContent';
+export const frontMatterMarkerTagName = 'FrontMatterMarker';
+
+export const frontMatterTag = Tag.define();
+
+// Create the YAML language parser using the legacy mode
+const yamlLanguage = StreamLanguage.define(yaml);
+
+// Wraps a YAML parser for the FrontMatter content.
+// This replaces [nodeTag] from the syntax tree with a region handled by the YAML parser.
+const wrappedYamlParser = (nodeTag: string): ParseWrapper => {
+	return parseMixed((node: SyntaxNodeRef, _input: Input): NestedParse => {
+		if (node.name !== nodeTag) {
+			return null;
+		}
+
+		return {
+			parser: yamlLanguage.parser,
+		};
+	});
+};
+
+// Regex to match the FrontMatter delimiter (--- at start of line)
+const frontMatterDelimiterRegex = /^---\s*$/;
+
+const frontMatterConfig: MarkdownConfig = {
+	defineNodes: [
+		{
+			name: frontMatterTagName,
+			style: frontMatterTag,
+		},
+		{
+			name: frontMatterContentTagName,
+		},
+		{
+			name: frontMatterMarkerTagName,
+			style: frontMatterTag,
+		},
+	],
+	parseBlock: [{
+		name: frontMatterTagName,
+		before: 'HorizontalRule',
+		parse(cx: BlockContext, line: Line): boolean {
+			// FrontMatter must be at the very start of the document
+			if (cx.lineStart !== 0) {
+				return false;
+			}
+
+			// Check if the first line is ---
+			if (!frontMatterDelimiterRegex.test(line.text)) {
+				return false;
+			}
+
+			// Store the opening delimiter position
+			const openingMarkerStart = cx.lineStart;
+			const openingMarkerEnd = cx.lineStart + line.text.length;
+
+			const contentStart = openingMarkerEnd + 1; // Start after the opening --- and newline
+			let foundEnd = false;
+
+			// Consume lines until we find the closing ---
+			while (cx.nextLine()) {
+				if (frontMatterDelimiterRegex.test(line.text)) {
+					foundEnd = true;
+					break;
+				}
+			}
+
+			if (!foundEnd) {
+				// No closing delimiter found - not a valid FrontMatter block
+				return false;
+			}
+
+			// The content is between the two --- delimiters
+			const contentEnd = cx.lineStart; // Start of the closing --- line
+
+			// Closing delimiter positions
+			const closingMarkerStart = cx.lineStart;
+			const closingMarkerEnd = cx.lineStart + line.text.length;
+
+			// Create marker elements for the --- delimiters
+			const openingMarkerElem = cx.elt(frontMatterMarkerTagName, openingMarkerStart, openingMarkerEnd);
+			const closingMarkerElem = cx.elt(frontMatterMarkerTagName, closingMarkerStart, closingMarkerEnd);
+
+			// Create the content element (the YAML content between delimiters)
+			const contentElem = cx.elt(frontMatterContentTagName, contentStart, contentEnd);
+
+			// Create the container element spanning from start of first --- to end of last ---
+			const containerElement = cx.elt(
+				frontMatterTagName,
+				0, // Start at document beginning
+				closingMarkerEnd, // End after closing ---
+				[openingMarkerElem, contentElem, closingMarkerElem],
+			);
+
+			cx.addElement(containerElement);
+
+			// Move past the closing delimiter
+			cx.nextLine();
+
+			return true;
+		},
+		// FrontMatter blocks can end leaf blocks like paragraphs
+		endLeaf(_cx: BlockContext, line: Line, _leaf: LeafBlock): boolean {
+			return frontMatterDelimiterRegex.test(line.text);
+		},
+	}],
+	wrap: wrappedYamlParser(frontMatterContentTagName),
+};
+
+const markdownFrontMatterExtension: MarkdownExtension = [frontMatterConfig];
+
+export default markdownFrontMatterExtension;

--- a/packages/editor/CodeMirror/extensions/rendering/replaceDividers.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceDividers.ts
@@ -26,6 +26,9 @@ class DividerWidget extends WidgetType {
 
 const dividerLineMark = Decoration.line({ class: dividerLineClassName });
 
+// Node names that should be rendered as dividers
+const dividerNodeNames = ['HorizontalRule', 'FrontMatterMarker'];
+
 const replaceDividers = [
 	EditorView.theme({
 		[`& .cm-line.${dividerLineClassName}`]: {
@@ -47,7 +50,7 @@ const replaceDividers = [
 	}),
 	makeInlineReplaceExtension({
 		createDecoration: (node) => {
-			if (node.name === 'HorizontalRule') {
+			if (dividerNodeNames.includes(node.name)) {
 				return new DividerWidget();
 			}
 			return null;
@@ -55,7 +58,7 @@ const replaceDividers = [
 	}),
 	makeInlineReplaceExtension({
 		createDecoration: (node) => {
-			if (node.name === 'HorizontalRule') {
+			if (dividerNodeNames.includes(node.name)) {
 				return dividerLineMark;
 			}
 			return null;

--- a/packages/editor/CodeMirror/testing/createTestEditor.ts
+++ b/packages/editor/CodeMirror/testing/createTestEditor.ts
@@ -7,6 +7,7 @@ import forceFullParse from './forceFullParse';
 import loadLanguages from './loadLanguages';
 import markdownMathExtension from '../extensions/markdownMathExtension';
 import markdownHighlightExtension from '../extensions/markdownHighlightExtension';
+import markdownFrontMatterExtension from '../extensions/markdownFrontMatterExtension';
 
 // Creates and returns a minimal editor with markdown extensions. Waits to return the editor
 // until all syntax tree tags in `expectedSyntaxTreeTags` exist.
@@ -26,7 +27,7 @@ const createTestEditor = async (
 		selection: EditorSelection.create(initialSelection),
 		extensions: [
 			markdown({
-				extensions: [markdownMathExtension, markdownHighlightExtension, GithubFlavoredMarkdownExt],
+				extensions: [markdownMathExtension, markdownHighlightExtension, markdownFrontMatterExtension, GithubFlavoredMarkdownExt],
 				addKeymap: addMarkdownKeymap,
 			}),
 			indentUnit.of('\t'),

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -42,6 +42,7 @@ interface RendererPlugins {
 
 // /!\/!\ Note: the order of rules is important!! /!\/!\
 const rules: RendererRules = {
+	frontmatter: require('./MdToHtml/rules/frontmatter').default,
 	fence: require('./MdToHtml/rules/fence').default,
 	sanitize_html: require('./MdToHtml/rules/sanitize_html').default,
 	image: require('./MdToHtml/rules/image').default,

--- a/packages/renderer/MdToHtml/rules/frontmatter.test.ts
+++ b/packages/renderer/MdToHtml/rules/frontmatter.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from '@jest/globals';
+import MarkdownIt = require('markdown-it');
+import frontmatter from './frontmatter';
+
+const createMarkdownIt = () => {
+	const markdownIt = new MarkdownIt();
+	markdownIt.use(frontmatter.plugin, {});
+	return markdownIt;
+};
+
+describe('frontmatter', () => {
+
+	test('should render a basic frontmatter block', () => {
+		const md = createMarkdownIt();
+		const input = '---\ntitle: Test\n---\n\n# Heading';
+		const output = md.render(input);
+
+		expect(output).toContain('joplin-editable');
+		expect(output).toContain('joplin-frontmatter');
+		expect(output).toContain('joplin-source');
+		expect(output).toContain('data-joplin-language="frontmatter"');
+		expect(output).toContain('title: Test');
+		expect(output).toContain('<h1>Heading</h1>');
+	});
+
+	test('should render frontmatter with multiple properties', () => {
+		const md = createMarkdownIt();
+		const input = '---\ntitle: My Document\ndate: 2024-01-01\ntags: [one, two]\n---\n\nContent here.';
+		const output = md.render(input);
+
+		expect(output).toContain('joplin-frontmatter');
+		expect(output).toContain('title: My Document');
+		expect(output).toContain('date: 2024-01-01');
+		expect(output).toContain('tags: [one, two]');
+		expect(output).toContain('<p>Content here.</p>');
+	});
+
+	test('should not parse frontmatter if not at document start', () => {
+		const md = createMarkdownIt();
+		const input = 'Some text\n\n---\ntitle: Test\n---';
+		const output = md.render(input);
+
+		// Should not contain frontmatter class
+		expect(output).not.toContain('joplin-frontmatter');
+		// The --- should be treated as a horizontal rule
+		expect(output).toContain('<hr');
+	});
+
+	test('should not parse frontmatter without closing delimiter', () => {
+		const md = createMarkdownIt();
+		const input = '---\ntitle: Test\n\n# Heading';
+		const output = md.render(input);
+
+		// Should not contain frontmatter class since there's no closing ---
+		expect(output).not.toContain('joplin-frontmatter');
+		// The --- at the start becomes a horizontal rule
+		expect(output).toContain('<hr');
+	});
+
+	test('should handle empty frontmatter block', () => {
+		const md = createMarkdownIt();
+		const input = '---\n---\n\n# Heading';
+		const output = md.render(input);
+
+		expect(output).toContain('joplin-frontmatter');
+		expect(output).toContain('<h1>Heading</h1>');
+	});
+
+	test('should include horizontal rule markers in rendered output', () => {
+		const md = createMarkdownIt();
+		const input = '---\ntitle: Test\n---\n\nContent';
+		const output = md.render(input);
+
+		// Should have the frontmatter markers (rendered as <hr>)
+		expect(output).toContain('joplin-frontmatter-marker');
+	});
+
+	test('should have correct source-open and source-close attributes for round-trip editing', () => {
+		const md = createMarkdownIt();
+		const input = '---\nkey: value\n---\n\nText';
+		const output = md.render(input);
+
+		// The joplin-source should contain just the YAML content
+		expect(output).toContain('key: value');
+		// The data-joplin-source-open should have the opening delimiter with newline
+		expect(output).toContain('data-joplin-source-open="---&#10;"');
+		// The data-joplin-source-close should have newline + closing delimiter + newline
+		expect(output).toContain('data-joplin-source-close="&#10;---&#10;"');
+	});
+});

--- a/packages/renderer/MdToHtml/rules/frontmatter.ts
+++ b/packages/renderer/MdToHtml/rules/frontmatter.ts
@@ -1,0 +1,142 @@
+import type * as MarkdownIt from 'markdown-it';
+import type * as StateBlock from 'markdown-it/lib/rules_block/state_block';
+import hljs from '../../highlight';
+
+// Regex to match the FrontMatter delimiter (--- at start of line, optionally with trailing whitespace)
+const frontMatterDelimiterRegex = /^---\s*$/;
+
+const plugin = (markdownIt: MarkdownIt, _ruleOptions: unknown) => {
+	// Add a block rule to parse frontmatter at the beginning of the document
+	markdownIt.block.ruler.before('fence', 'frontmatter', (state: StateBlock, startLine: number, endLine: number, silent: boolean): boolean => {
+		// FrontMatter must be at the very start of the document
+		if (startLine !== 0) {
+			return false;
+		}
+
+		const startPos = state.bMarks[startLine] + state.tShift[startLine];
+		const startMax = state.eMarks[startLine];
+		const startLineText = state.src.slice(startPos, startMax);
+
+		// Check if the first line is ---
+		if (!frontMatterDelimiterRegex.test(startLineText)) {
+			return false;
+		}
+
+		// Find the closing ---
+		let nextLine = startLine + 1;
+		let foundEnd = false;
+
+		while (nextLine < endLine) {
+			const pos = state.bMarks[nextLine] + state.tShift[nextLine];
+			const max = state.eMarks[nextLine];
+			const lineText = state.src.slice(pos, max);
+
+			if (frontMatterDelimiterRegex.test(lineText)) {
+				foundEnd = true;
+				break;
+			}
+			nextLine++;
+		}
+
+		if (!foundEnd) {
+			// No closing delimiter - not a valid FrontMatter block
+			return false;
+		}
+
+		// If we're just checking if the rule matches (silent mode), return true
+		if (silent) {
+			return true;
+		}
+
+		// Extract the content between the delimiters
+		const contentStartLine = startLine + 1;
+		const contentEndLine = nextLine;
+
+		let content = '';
+		for (let line = contentStartLine; line < contentEndLine; line++) {
+			const pos = state.bMarks[line];
+			const max = state.eMarks[line];
+			content += `${state.src.slice(pos, max)}\n`;
+		}
+		// Remove trailing newline
+		content = content.slice(0, -1);
+
+		// Create the token
+		const token = state.push('frontmatter', 'div', 0);
+		token.content = content;
+		token.map = [startLine, nextLine + 1];
+		token.markup = '---';
+
+		// Move past the closing delimiter
+		state.line = nextLine + 1;
+
+		return true;
+	});
+
+	// Add a renderer for the frontmatter token
+	markdownIt.renderer.rules.frontmatter = (tokens, idx) => {
+		const token = tokens[idx];
+		const content = token.content;
+		const escapeHtml = markdownIt.utils.escapeHtml;
+
+		// Escape the content for HTML
+		const contentHtml = escapeHtml(content);
+
+		// Apply YAML syntax highlighting
+		let highlightedContent: string;
+		try {
+			if (hljs.getLanguage('yaml')) {
+				highlightedContent = hljs.highlight(content, { language: 'yaml', ignoreIllegals: true }).value;
+			} else {
+				highlightedContent = contentHtml;
+			}
+		} catch (_error) {
+			highlightedContent = contentHtml;
+		}
+
+		// Return the joplin-editable block structure
+		// The source block contains just the YAML content (without delimiters)
+		// The data-joplin-source-open and data-joplin-source-close attributes define
+		// what gets prepended/appended when converting back to markdown
+		// &#10; is the HTML entity for newline
+		// Note: We use <pre class="hljs"> without a <code> child to avoid the
+		// isCodeBlock() detection in turndown which would convert it to a fenced code block
+		// IMPORTANT: No whitespace between joplin-editable and joplin-source elements!
+		// The turndown joplinEditableBlockInfo function iterates childNodes and crashes
+		// on text nodes (whitespace) because they don't have classList.
+		return `<div class="joplin-editable joplin-frontmatter"><pre class="joplin-source" data-joplin-language="frontmatter" data-joplin-source-open="---&#10;" data-joplin-source-close="&#10;---&#10;">${contentHtml}</pre><div class="joplin-rendered joplin-frontmatter-rendered"><hr class="joplin-frontmatter-marker"/><pre class="hljs">${highlightedContent}</pre><hr class="joplin-frontmatter-marker"/></div></div>`;
+	};
+};
+
+const assets = () => {
+	return [
+		{
+			inline: true,
+			mime: 'text/css',
+			text: `
+				.joplin-frontmatter-rendered {
+					margin-bottom: 1em;
+				}
+				.joplin-frontmatter-rendered pre.hljs {
+					margin: 0;
+					border-radius: 0;
+				}
+				.joplin-frontmatter-marker {
+					margin: 0;
+					border: none;
+					border-top: 2px solid var(--joplin-divider-color, #ccc);
+				}
+			`,
+		},
+	].map(e => {
+		return {
+			source: 'frontmatter',
+			...e,
+		};
+	});
+};
+
+export default {
+	plugin,
+	assets,
+};


### PR DESCRIPTION
*Implemented with the assistance of AI*

FrontMatter is used for templates and can be useful to add custom metadata to notes.

This pull request add proper support for it.

<img width="546" height="280" alt="image" src="https://github.com/user-attachments/assets/5c3c791c-bd77-478a-955c-f79501cd3f4e" />


* * *

- [x] Add support for Markdown editor
- [x] Add support for Preview
- [x] Add support for RichText editor