### PR TITLE
Desktop,Mobile: Resolves #9745: Markdown: Allow specifying the start/end of audio, videos, and PDFs

### DIFF
--- a/packages/app-cli/tests/MdToHtml.ts
+++ b/packages/app-cli/tests/MdToHtml.ts
@@ -12,6 +12,7 @@ function newTestMdToHtml(options: any = null) {
 		ResourceModel: {
 			isResourceUrl: isResourceUrl,
 			urlToId: resourceUrlToId,
+			fullPath: () => '/some/path/here',
 		},
 		fsDriver: shim.fsDriver(),
 		...options,
@@ -56,6 +57,21 @@ describe('MdToHtml', () => {
 				mdToHtmlOptions.mapsToLine = true;
 			} else if (mdFilename.startsWith('resource_')) {
 				mdToHtmlOptions.resources = {};
+			} else if (mdFilename.startsWith('pdf_')) {
+				mdToHtmlOptions.resources = {
+					'00000000000000000000000000000001': {
+						item: { mime: 'application/pdf' },
+						localState: { },
+					},
+				};
+				mdToHtmlOptions.pdfViewerEnabled = true;
+			} else if (mdFilename.startsWith('video_')) {
+				mdToHtmlOptions.resources = {
+					'00000000000000000000000000000001': {
+						item: { mime: 'video/mp4' },
+						localState: { },
+					},
+				};
 			}
 
 			const markdown = await shim.fsDriver().readFile(mdFilePath);
@@ -86,7 +102,7 @@ describe('MdToHtml', () => {
 				// eslint-disable-next-line no-console
 				console.info(msg.join('\n'));
 
-				expect(false).toBe(true);
+				expect(actualHtml).toBe(expectedHtml);
 				// return;
 			} else {
 				expect(true).toBe(true);

--- a/packages/app-cli/tests/md_to_html/pdf_embed.html
+++ b/packages/app-cli/tests/md_to_html/pdf_embed.html
@@ -1,0 +1,4 @@
+<p>Embed without starting page:</p>
+<p><a data-from-md data-resource-id='00000000000000000000000000000001' type='application/pdf' href='#' onclick='postMessage(&quot;joplin://00000000000000000000000000000001&quot;, { resourceId: &quot;00000000000000000000000000000001&quot; }); return false;'><span class="resource-icon fa-file-pdf"></span>pdf</a><object data="file:///some/path/here" class="media-player media-pdf" type="application/pdf"></object></p>
+<p>Embed with starting page:</p>
+<p><a data-from-md data-resource-id='00000000000000000000000000000001' type='application/pdf' href='#' onclick='postMessage(&quot;joplin://00000000000000000000000000000001#page=1&quot;, { resourceId: &quot;00000000000000000000000000000001&quot; }); return false;'><span class="resource-icon fa-file-pdf"></span>pdf</a><object data="file:///some/path/here#page=1" class="media-player media-pdf" type="application/pdf"></object></p>

--- a/packages/app-cli/tests/md_to_html/pdf_embed.md
+++ b/packages/app-cli/tests/md_to_html/pdf_embed.md
@@ -1,0 +1,8 @@
+
+Embed without starting page:
+
+[pdf](:/00000000000000000000000000000001)
+
+Embed with starting page:
+
+[pdf](:/00000000000000000000000000000001#page=1)

--- a/packages/app-cli/tests/md_to_html/video_embed.html
+++ b/packages/app-cli/tests/md_to_html/video_embed.html
@@ -1,0 +1,10 @@
+<p><a data-from-md data-resource-id='00000000000000000000000000000001' type='video/mp4' href='#' onclick='postMessage(&quot;joplin://00000000000000000000000000000001#t=1,2&quot;, { resourceId: &quot;00000000000000000000000000000001&quot; }); return false;'><span class="resource-icon fa-file-video"></span>video, with start/end time</a>
+			<video class="media-player media-video" controls>
+				<source src="file:///some/path/here#t=1,2" type="video/mp4">
+			</video>
+		</p>
+<p><a data-from-md data-resource-id='00000000000000000000000000000001' type='video/mp4' href='#' onclick='postMessage(&quot;joplin://00000000000000000000000000000001&quot;, { resourceId: &quot;00000000000000000000000000000001&quot; }); return false;'><span class="resource-icon fa-file-video"></span>video, without start/end time</a>
+			<video class="media-player media-video" controls>
+				<source src="file:///some/path/here" type="video/mp4">
+			</video>
+		</p>

--- a/packages/app-cli/tests/md_to_html/video_embed.md
+++ b/packages/app-cli/tests/md_to_html/video_embed.md
@@ -1,0 +1,4 @@
+
+[video, with start/end time](:/00000000000000000000000000000001#t=1,2)
+
+[video, without start/end time](:/00000000000000000000000000000001)

--- a/packages/renderer/MdToHtml/renderMedia.ts
+++ b/packages/renderer/MdToHtml/renderMedia.ts
@@ -27,12 +27,35 @@ function resourceUrl(resourceFullPath: string): string {
 	return `file://${toForwardSlashes(resourceFullPath)}`;
 }
 
+const resourceHash = (link: string) => {
+	// Preserve certain #hash strings when rendering resources.
+	// These patterns can be used to customize the starting/ending points for
+	// audio/video/PDF embeds:
+	const patterns = [
+		// Starting PDF page
+		/#page=\d+$/,
+		// Staring/ending playback time
+		/#t=[0-9:,]+$/,
+	];
+
+	for (const pattern of patterns) {
+		const match = link.match(pattern);
+		if (match) {
+			return match[0];
+		}
+	}
+
+	return '';
+};
+
 export default function(link: Link, options: Options, linkIndexes: LinkIndexes) {
 	const resource = link.resource;
 
 	if (!link.resourceReady || !resource || !resource.mime) return '';
 
-	const escapedResourcePath = htmlentities(resourceUrl(link.resourceFullPath));
+	const escapedResourcePath = htmlentities(
+		resourceUrl(link.resourceFullPath) + resourceHash(link.href),
+	);
 	const escapedMime = htmlentities(resource.mime);
 
 	if (options.videoPlayerEnabled && resource.mime.indexOf('video/') === 0) {


### PR DESCRIPTION
# Summary

This pull request allows specifying:
- The start/end timestamps for videos. For example,
  ```markdown
  [This video starts at 1s and plays until 2s](:/12345678901234567890123456789012#t=1,2)
  ```
- The focused PDF page. For example,
  ```markdown
  [A PDF that is initially on page 5](:/23456789012345678901234567890123#page=5)
  ```

This is done by preserving [#t=](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Audio_and_video_delivery#specifying_playback_range) and `#page=` URL suffixes when rendering embedded audio/video/PDF.

Resolves #9745.

# Screen recording

[Screencast: Changing `#t=` and `#page=` on PDFs and videos](https://github.com/user-attachments/assets/fca45277-0dab-4a99-add1-38b3327b96b3)




<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->