### PR TITLE
Desktop: Fixes #13540: Improve context menu handling in secondary windows

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -115,12 +115,7 @@ export default class ElectronAppWrapper {
 	}
 
 	public activeWindow() {
-		for (const window of this.allAppWindows()) {
-			if (window.isFocused()) {
-				return window;
-			}
-		}
-		return this.win_;
+		return BrowserWindow.getFocusedWindow() ?? this.win_;
 	}
 
 	public ipcServerStarted() {

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -115,7 +115,12 @@ export default class ElectronAppWrapper {
 	}
 
 	public activeWindow() {
-		return BrowserWindow.getFocusedWindow() ?? this.win_;
+		for (const window of this.allAppWindows()) {
+			if (window.isFocused()) {
+				return window;
+			}
+		}
+		return this.win_;
 	}
 
 	public ipcServerStarted() {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -1,6 +1,6 @@
 
 import { ContextMenuParams, Event } from 'electron';
-import { useEffect, RefObject } from 'react';
+import { useEffect, RefObject, useContext } from 'react';
 import { _ } from '@joplin/lib/locale';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import { EditContextMenuFilterObject, MenuItemLocation } from '@joplin/lib/services/plugins/api/types';
@@ -11,6 +11,7 @@ import type CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl'
 import eventManager from '@joplin/lib/eventManager';
 import bridge from '../../../../../services/bridge';
 import Setting from '@joplin/lib/models/Setting';
+import { WindowIdContext } from '../../../../NewWindowOrIFrame';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -29,6 +30,7 @@ interface ContextMenuProps {
 
 const useContextMenu = (props: ContextMenuProps) => {
 	const editorRef = props.editorRef;
+	const windowId = useContext(WindowIdContext);
 
 	// The below code adds support for spellchecking when it is enabled
 	// It might be buggy, refer to the below issue
@@ -156,7 +158,7 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 		// Prepend the event listener so that it gets called before
 		// the listener that shows the default menu.
-		const targetWindow = bridge().activeWindow();
+		const targetWindow = bridge().windowById(windowId);
 		targetWindow.webContents.prependListener('context-menu', onContextMenu);
 
 		return () => {
@@ -167,6 +169,7 @@ const useContextMenu = (props: ContextMenuProps) => {
 	}, [
 		props.plugins, props.editorClassName, editorRef, props.containerRef,
 		props.editorCutText, props.editorCopyText, props.editorPaste,
+		windowId,
 	]);
 };
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -1,7 +1,7 @@
 import { MenuItemLocation } from '@joplin/lib/services/plugins/api/types';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
 import SpellCheckerService from '@joplin/lib/services/spellChecker/SpellCheckerService';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import bridge from '../../../../../services/bridge';
 import { ContextMenuOptions, ContextMenuItemType } from '../../../utils/contextMenuUtils';
 import { menuItems } from '../../../utils/contextMenu';
@@ -18,6 +18,7 @@ import { Dispatch } from 'redux';
 import { _ } from '@joplin/lib/locale';
 import type { MenuItem as MenuItemType } from 'electron';
 import isItemId from '@joplin/lib/models/utils/isItemId';
+import { WindowIdContext } from '../../../../NewWindowOrIFrame';
 
 const Menu = bridge().Menu;
 const MenuItem = bridge().MenuItem;
@@ -30,11 +31,12 @@ interface ContextMenuActionOptions {
 const contextMenuActionOptions: ContextMenuActionOptions = { current: null };
 
 export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatch, htmlToMd: HtmlToMarkdownHandler, mdToHtml: MarkupToHtmlHandler, editDialog: EditDialogControl) {
+	const windowId = useContext(WindowIdContext);
 	useEffect(() => {
 		if (!editor) return () => {};
 
 		const contextMenuItems = menuItems(dispatch);
-		const targetWindow = bridge().activeWindow();
+		const targetWindow = bridge().windowById(windowId);
 
 		const makeMainMenuItems = (element: Element) => {
 			let itemType: ContextMenuItemType = ContextMenuItemType.None;
@@ -175,5 +177,5 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 				targetWindow.webContents.off('context-menu', onElectronContextMenu);
 			}
 		};
-	}, [editor, plugins, dispatch, htmlToMd, mdToHtml, editDialog]);
+	}, [editor, plugins, dispatch, htmlToMd, mdToHtml, editDialog, windowId]);
 }


### PR DESCRIPTION
# Summary

Prior to this pull request, editor context menus were always registered on the active window, rather than the window containing the editor. This could cause problems if, for example, the active window did not contain an editor (as in https://github.com/laurent22/joplin/pull/14248) or if the active window contained a different editor instance.

With this pull request, context menu listeners are registered on the window that contains the editor component.

Fixes #13540.
Based on changes in https://github.com/laurent22/joplin/pull/14248 by @laurent22.

# Screen recording

[Screencast from 2026-02-03 16-44-07.webm](https://github.com/user-attachments/assets/79f0e3c3-49ee-4bf3-bf36-67bda3dac666)



The above screen recording shows:
1. Opening a note that includes an attachment.
2. Right-clicking on a resource link within the note.
   - The context menu items added by Rich Markdown are shown.
3. Opening a new window.
4. Right-clicking on a resource link within the note.
   - The context menu items added by Rich Markdown are shown.
5. Opening a dialog in the new window.
6. Closing the window from step 3.
7. Right-clicking on a resource link within the main window.
   - The context menu items added by Rich Markdown are shown.
   - Prior to this pull request, they were not.
8. Opening a new window and switching both windows to the Rich Text Editor.
8. Switching the note shown in the main window.
10. Right-clicking on a resource link in both the main and secondary windows.
   - The additional resource-link context menu items added by Joplin are shown for both windows.
<!-- This second part might not always be true. It was observed in one Joplin instance, but not another:   - Prior to this pull request, the resource context menu only worked in one window, if the secondary and main windows were viewing separate notes.-->

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->