### PR TITLE
Android: Fixes #14268: Fix additional space included above keyboard

### DIFF
--- a/packages/app-mobile/components/app-nav.tsx
+++ b/packages/app-mobile/components/app-nav.tsx
@@ -63,17 +63,17 @@ const AppNavComponent: React.FC<Props> = (props) => {
 
 	const theme = themeStyle(props.themeId);
 	const styles = useStyles(theme);
-	const autocompletionBarPadding = keyboardState.keyboardVisible ? safeAreaPadding.top : 0;
+	// Workaround: On Android 15 and 16, the main app content seems to auto-resize when the keyboard is shown.
+	// On earlier Android versions (and in modals), this does not seem to be the case.
+	const keyboardAvoidingViewEnabled =
+		(Platform.OS === 'android' && Platform.Version < 35)
+		|| Platform.OS === 'ios';
+	const autocompletionBarPadding = keyboardState.keyboardVisible && keyboardAvoidingViewEnabled ? safeAreaPadding.top : 0;
 
 	return (
 		<KeyboardAvoidingView
 			style={styles.keyboardAvoidingView}
-			enabled={
-				// Workaround: On Android 15 and 16, the main app content seems to auto-resize when the keyboard is shown.
-				// On earlier Android versions (and in modals), this does not seem to be the case.
-				(Platform.OS === 'android' && Platform.Version < 35)
-				|| Platform.OS === 'ios'
-			}
+			enabled={keyboardAvoidingViewEnabled}
 		>
 			<NotesScreen visible={notesScreenVisible} />
 			{searchScreenLoaded && <SearchScreen visible={searchScreenVisible} />}


### PR DESCRIPTION
## Summary

Fixes a regression from #14232 in which Android >= API 35 devices had additional space between the top of the keyboard and the Markdown toolbar.

Fixes #14268.

## Testing

Manual testing (Android 16/dev mode, Android 12/dev mode):
- Initial configuration:
  - Android 16: The software keyboard should be preconfigured to be docked to the bottom of the screen (disable the floating keyboard).
- Testing plan
  1. Start Joplin.
  2. Open the note editor and the software keyboard.
  3. Verify that the autocompletion bar is above the keyboard with no space between the completion bar and the top of the keyboard.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->