### PR TITLE
Android: Fixes #14267: Fix titlebar underline missing on some Android devices

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -546,7 +546,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			marginTop: 0,
 			paddingLeft: 0,
 			color: theme.color,
-			backgroundColor: theme.backgroundColor,
 			fontWeight: 'bold',
 			fontSize: theme.fontSize,
 			paddingTop: 10, // Added for iOS (Not needed for Android??)


### PR DESCRIPTION
# Summary

Fixes #14267 by removing the `backgroundColor:` style on the title input.

# Testing plan 

Testing (Android 15):
1. Create a new note.
2. Verify that the note titlebar has a bottom border.
2. Edit the note title.
3. Verify that the note titlebar has a bottom border.
4. Switch to dark mode in Joplin's settings.
5. Open a note.
6. Verify that the title input's content is visible and that the bottom border is visible.
7. Edit the note.
8. Verify that the title input's content is visible and that the bottom border is visible.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->