### PR TITLE
Bug/14271 invalid plugin manifest error

### DIFF
--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,7 +34,7 @@ export interface Plugins {
 }
 
 export interface SettingAndValue {
-	[settingName: string]: string|number|boolean;
+	[settingName: string]: string | number | boolean;
 }
 
 export interface DefaultPluginSettings {
@@ -81,7 +81,7 @@ function makePluginId(source: string): string {
 	return uslug(source).substr(0, 32);
 }
 
-type LoadedPluginsChangeListener = ()=> void;
+type LoadedPluginsChangeListener = () => void;
 
 export default class PluginService extends BaseService {
 
@@ -143,7 +143,7 @@ export default class PluginService extends BaseService {
 		this.isSafeMode_ = v;
 	}
 
-	public addLoadedPluginsChangeListener(listener: ()=> void) {
+	public addLoadedPluginsChangeListener(listener: () => void) {
 		this.pluginsChangeListeners_.push(listener);
 
 		return {
@@ -211,7 +211,7 @@ export default class PluginService extends BaseService {
 		return this.pluginById(id).manifest?.name ?? 'Unknown';
 	}
 
-	public viewControllerByViewId(id: string): ViewController|null {
+	public viewControllerByViewId(id: string): ViewController | null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);
 		}
@@ -370,15 +370,6 @@ export default class PluginService extends BaseService {
 		}
 
 		const deprecationNotices: DeprecationNotice[] = [];
-
-		if (!manifestObj.app_min_version) {
-			manifestObj.app_min_version = '1.4';
-			deprecationNotices.push({
-				message: 'The manifest must contain an "app_min_version" key, which should be the minimum version of the app you support.',
-				goneInVersion: '1.4',
-				isError: true,
-			});
-		}
 
 		if (!manifestObj.id) {
 			manifestObj.id = pluginIdIfNotSpecified;

--- a/packages/lib/services/plugins/utils/manifestFromObject.ts
+++ b/packages/lib/services/plugins/utils/manifestFromObject.ts
@@ -6,7 +6,12 @@ import validatePluginPlatforms from './validatePluginPlatforms';
 export default function manifestFromObject(o: any): PluginManifest {
 
 	const getString = (name: string, required = true, defaultValue = ''): string => {
-		if (required && !o[name]) throw new Error(`Missing required field: ${name}`);
+		if (required && !o[name]) {
+			if (name === 'app_min_version') {
+				throw new Error('Invalid plugin manifest: missing required field "app_min_version"');
+			}
+			throw new Error(`Missing required field: ${name}`);
+		}	
 		if (!o[name]) return defaultValue;
 		if (typeof o[name] !== 'string') throw new Error(`Field must be a string: ${name}`);
 		return o[name];
@@ -58,7 +63,7 @@ export default function manifestFromObject(o: any): PluginManifest {
 		name: getString('name', true),
 		version: getString('version', true),
 		app_min_version: getString('app_min_version', true),
-		app_min_version_mobile: getString('app_min_version', false),
+		app_min_version_mobile: getString('app_min_version_mobile', false),
 		platforms: getStrings('platforms', false),
 
 		author: getString('author', false),

--- a/packages/lib/services/plugins/utils/manifestFromObject.ts
+++ b/packages/lib/services/plugins/utils/manifestFromObject.ts
@@ -4,26 +4,23 @@ import validatePluginPlatforms from './validatePluginPlatforms';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export default function manifestFromObject(o: any): PluginManifest {
-
 	const getString = (name: string, required = true, defaultValue = ''): string => {
 		if (required && !o[name]) {
 			if (name === 'app_min_version') {
 				throw new Error('Invalid plugin manifest: missing required field "app_min_version"');
 			}
 			throw new Error(`Missing required field: ${name}`);
-		}	
+		}
 		if (!o[name]) return defaultValue;
 		if (typeof o[name] !== 'string') throw new Error(`Field must be a string: ${name}`);
 		return o[name];
 	};
-
 	const getNumber = (name: string, required = true): number => {
 		if (required && !o[name]) throw new Error(`Missing required field: ${name}`);
 		if (!o[name]) return 0;
 		if (typeof o[name] !== 'number') throw new Error(`Field must be a number: ${name}`);
 		return o[name];
-	};
-
+	}
 	const getStrings = (name: string, required = true, defaultValue: string[] = []): string[] => {
 		if (required && !o[name]) throw new Error(`Missing required field: ${name}`);
 		if (!o[name]) return defaultValue;


### PR DESCRIPTION
I added a validation for missing app_min_version in manifestFromObject and I removed the default fallback in PluginService which was preventing the validation from triggering.
Now this ensures that the invalid plugin manifests fail with a clear error.