### PR TITLE
Android: Fixes #14265: Opt out of Android 16 predictive back behavior

### DIFF
--- a/packages/app-mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/app-mobile/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,11 @@
 
 		android:resizeableActivity: allows user to resize Joplin window
 		https://github.com/laurent22/joplin/issues/3547
+
+		android:enableOnBackInvokedCallback: Workaround: Joplin currently does not support predictive back gestures.
+		- https://stackoverflow.com/a/79861863
+		- https://github.com/laurent22/joplin/issues/14265
+		- https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture
 	-->
 	<application
 		android:name=".MainApplication"
@@ -44,6 +49,7 @@
 		android:requestLegacyExternalStorage="true"
 		android:resizeableActivity="true"
 		android:theme="@style/AppTheme"
+		android:enableOnBackInvokedCallback="false"
 		android:usesCleartextTraffic="${usesCleartextTraffic}"
 		android:supportsRtl="true">
 


### PR DESCRIPTION
# Summary

Fixes #14265 by [opting out of Android 16's predictive back behavior](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#opt-out).

See also:
- [Android 16: Predictive back gestures](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture)
- Similar [Expo issue](https://github.com/expo/expo/issues/39092) (related to Expo Router, which we don't use)
- Related [StackOverflow post](https://stackoverflow.com/a/79861863)

# Testing plan


https://github.com/user-attachments/assets/f6908b7a-66c5-41d0-93a6-115ff932d34f



Android 16 emulator:
1. Create a release Android APK and install it on an Android 16 emulator.
2. Open Joplin.
3. Open a note.
4. Press the back button. Verify that this opens the note list.
5. Press the back button. Verify that this minimizes Joplin.
6. Re-open Joplin.
7. Open a note.
8. Press the back button. Verify that this opens the note list.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->