### PR TITLE
Android: Fixes #14266: Fix import/export buttons have wrong background after task completes

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/SettingsButton.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/SettingsButton.tsx
@@ -29,7 +29,14 @@ const SettingsButton: FunctionComponent<Props> = props => {
 		<View style={styles.settingContainer}>
 			<View style={{ flex: 1, flexDirection: 'column' }}>
 				<View style={{ flex: 1 }}>
-					<Button title={props.title} onPress={props.clickHandler} disabled={!!props.disabled} />
+					<Button
+						title={props.title}
+						onPress={props.clickHandler}
+						disabled={!!props.disabled}
+						// Workaround for https://github.com/facebook/react-native/issues/54293:
+						// Force the button to reload when the enabled state changes.
+						key={`button-${!!props.disabled}`}
+					/>
 				</View>
 				{props.statusComponent}
 				{descriptionComp}


### PR DESCRIPTION
# Summary

Fixes #14266 by forcing the import/export buttons to reload when the button enabled state changes.

> [!NOTE]
>
> An alternate fix would be to replace the `react-native` `<Button` with a `react-native-paper` button (for example, as is done [on this branch](https://github.com/personalizedrefrigerator/joplin/tree/pr/android/fix-button-appearance-2)).

# Testing plan

Android 16 emulator (release mode):
1. Open configuration > Import/export.
2. Import a JEX file.
3. Verify that the "Import" button is disabled during the import.
4. Verify that the "Import" button no longer appears disabled after import completes.
5. Export all notes as JEX.
6. Verify that the "Export" button no longer appears disabled after export completes.

Screen recording:

https://github.com/user-attachments/assets/5d3ceec5-c387-4835-8ffc-5f81827e5b79



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->