### PR TITLE
Chore: Sync fuzzer: Fix fuzzer failure caused by incorrect expected state

### DIFF
--- a/packages/tools/fuzzer/model/FolderRecord.ts
+++ b/packages/tools/fuzzer/model/FolderRecord.ts
@@ -118,10 +118,10 @@ export default class FolderRecord implements FolderData {
 		);
 	}
 
-	private withShareState_(shareState: readonly ShareRecord[]) {
+	private withShareState_(isShared: boolean, shareState: readonly ShareRecord[]) {
 		return new FolderRecord({
 			...this.metadata_,
-			isShared: shareState.length > 0,
+			isShared,
 			sharedWith: [...shareState],
 		});
 	}
@@ -147,7 +147,7 @@ export default class FolderRecord implements FolderData {
 			throw new Error('Cannot share non-top-level folder');
 		}
 
-		return this.withShareState_([
+		return this.withShareState_(true, [
 			...this.sharedWith_.filter(record => record.email !== recipientEmail),
 			{ email: recipientEmail, readOnly },
 		]);
@@ -159,6 +159,8 @@ export default class FolderRecord implements FolderData {
 		}
 
 		return this.withShareState_(
+			// Even if no users are present in the share, Joplin still considers the folder to be shared
+			this.isShared_,
 			this.sharedWith_.filter(record => record.email !== recipientEmail),
 		);
 	}
@@ -168,6 +170,6 @@ export default class FolderRecord implements FolderData {
 			return this;
 		}
 
-		return this.withShareState_([]);
+		return this.withShareState_(false, []);
 	}
 }

--- a/packages/tools/fuzzer/model/FolderRecord.ts
+++ b/packages/tools/fuzzer/model/FolderRecord.ts
@@ -7,8 +7,8 @@ export type ShareRecord = {
 };
 
 interface InitializationOptions extends FolderData {
-	childIds: ItemId[];
-	sharedWith: ShareRecord[];
+	childIds: readonly ItemId[];
+	sharedWith: readonly ShareRecord[];
 	isShared: boolean;
 	// Email of the Joplin Server account that controls the item
 	ownedByEmail: string;
@@ -23,12 +23,10 @@ export default class FolderRecord implements FolderData {
 	public readonly id: ItemId;
 	public readonly title: string;
 	public readonly ownedByEmail: string;
-	public readonly childIds: ItemId[];
+	public readonly childIds: readonly ItemId[];
 
-	// Only valid for root folders. Note that a separate isShared_ is needed
-	// because Joplin folders can be 'shared' even if there are no share recipients.
 	private readonly isShared_: boolean;
-	private readonly sharedWith_: ShareRecord[];
+	private readonly sharedWith_: readonly ShareRecord[];
 
 	public constructor(options: InitializationOptions) {
 		this.parentId = options.parentId;
@@ -65,7 +63,7 @@ export default class FolderRecord implements FolderData {
 	}
 
 	public get isRootSharedItem() {
-		return this.isShared_;
+		return this.isShared_ && this.parentId === '';
 	}
 
 	public isSharedWith(email: string) {
@@ -99,7 +97,7 @@ export default class FolderRecord implements FolderData {
 		});
 	}
 
-	public withChildren(childIds: ItemId[]) {
+	public withChildren(childIds: readonly ItemId[]) {
 		return new FolderRecord({
 			...this.metadata_,
 			childIds: [...childIds],
@@ -120,6 +118,26 @@ export default class FolderRecord implements FolderData {
 		);
 	}
 
+	private withShareState_(shareState: readonly ShareRecord[]) {
+		return new FolderRecord({
+			...this.metadata_,
+			isShared: shareState.length > 0,
+			sharedWith: [...shareState],
+		});
+	}
+
+	public withShareOwner(email: string) {
+		if (email === this.ownedByEmail) return this;
+
+		const sharedWith = this.metadata_.sharedWith.filter(recipient => recipient.email !== email);
+		return new FolderRecord({
+			...this.metadata_,
+			sharedWith: sharedWith,
+			isShared: sharedWith.length > 0,
+			ownedByEmail: email,
+		});
+	}
+
 	public withShared(recipientEmail: string, readOnly: boolean) {
 		if (this.isSharedWith(recipientEmail) && this.isReadOnlySharedWith(recipientEmail) === readOnly) {
 			return this;
@@ -129,14 +147,10 @@ export default class FolderRecord implements FolderData {
 			throw new Error('Cannot share non-top-level folder');
 		}
 
-		return new FolderRecord({
-			...this.metadata_,
-			isShared: true,
-			sharedWith: [
-				...this.sharedWith_.filter(record => record.email !== recipientEmail),
-				{ email: recipientEmail, readOnly },
-			],
-		});
+		return this.withShareState_([
+			...this.sharedWith_.filter(record => record.email !== recipientEmail),
+			{ email: recipientEmail, readOnly },
+		]);
 	}
 
 	public withRemovedFromShare(recipientEmail: string) {
@@ -144,10 +158,9 @@ export default class FolderRecord implements FolderData {
 			return this;
 		}
 
-		return new FolderRecord({
-			...this.metadata_,
-			sharedWith: this.sharedWith_.filter(record => record.email !== recipientEmail),
-		});
+		return this.withShareState_(
+			this.sharedWith_.filter(record => record.email !== recipientEmail),
+		);
 	}
 
 	public withUnshared() {
@@ -155,10 +168,6 @@ export default class FolderRecord implements FolderData {
 			return this;
 		}
 
-		return new FolderRecord({
-			...this.metadata_,
-			sharedWith: [],
-			isShared: false,
-		});
+		return this.withShareState_([]);
 	}
 }


### PR DESCRIPTION
# Summary

This pull request:
- **Fixes a sync fuzzer failure:** caused by incorrect expected state when moving a folder to toplevel.
   - Previously, folders incorrectly retained their original share owner information after being moved to toplevel, causing the fuzzer to incorrectly identify them as accessible 
- **Improves the state validation logic:** Adds additional validation logic to the function responsible for checking the consistency of the expected state.

# Testing

The fuzzer failure was originally observed roughly 35 steps after running the `actions` in this initial config:
<details><summary>Fuzzer setup</summary>

```json
{
	"clientCount": 2,
	"actions": [
		["switchClient", { "id": 1 }],
		"sync",

		["switchClient", { "id": 0 }],
		["newToplevelFolder", { "id": "11111111111111111111111111111112" }],
		["newNote", { "id": "11111111111111111111111111111113", "parentId": "11111111111111111111111111111112" }],
		"sync",
		["shareFolder", { "folderId": "11111111111111111111111111111112" }],
		"syncAndCheckState",

		["switchClient", { "id": 1 }],
		["newSubfolder", { "id": "11111111111111111111111111111114", "parentId": "11111111111111111111111111111112" }],
		"syncAndCheckState",

		["switchClient", {"id": 0}],
		"syncAndCheckState",

		["deleteFolder", { "folderId": "11111111111111111111111111111114" }],
		"syncAndCheckState"

	]
}
```

</details>

With this change and the above initial config, the sync fuzzer runs successfully for 54 steps, before failing with unexpected conflicts.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->