### PR TITLE
Server: Fixes #14110: Fix new clients on an existing account can download previously unshared items

### DIFF
--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -51,10 +51,11 @@ describe('ChangeModel', () => {
 		expect(allUncompressedChanges.length).toBe(8);
 
 		{
-			// When we get all the changes, we get DELETE 1, CREATE 2, and CREATE 3.
-			// We don't get CREATE 1 since CREATE 1 -> DELETE 1 was compressed.
-			// We don't get any UPDATE event since they've been compressed
-			// down to the CREATE events.
+			// When we get all the changes, we get DELETE 1, CREATE 2, and CREATE 3:
+			// - We don't get CREATE 1 since CREATE 1 -> DELETE 1 was compressed to
+			//   DELETE 1.
+			// - We don't get any UPDATE event since they've been compressed
+			//   down to the CREATE events.
 			const changes = (await changeModel.delta(user.id)).items;
 			expect(changes.length).toBe(3);
 			expect(changes[0].item_id).toBe(item1.id);

--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -51,15 +51,18 @@ describe('ChangeModel', () => {
 		expect(allUncompressedChanges.length).toBe(8);
 
 		{
-			// When we get all the changes, we get CREATE 1, CREATE 2, and CREATE 3.
+			// When we get all the changes, we get DELETE 1, CREATE 2, and CREATE 3.
+			// We don't get CREATE 1 since CREATE 1 -> DELETE 1 was compressed.
 			// We don't get any UPDATE event since they've been compressed
 			// down to the CREATE events.
 			const changes = (await changeModel.delta(user.id)).items;
 			expect(changes.length).toBe(3);
-			expect(changes[0].item_id).toBe(item2.id);
-			expect(changes[0].type).toBe(ChangeType.Create);
-			expect(changes[1].item_id).toBe(item3.id);
+			expect(changes[0].item_id).toBe(item1.id);
+			expect(changes[0].type).toBe(ChangeType.Delete);
+			expect(changes[1].item_id).toBe(item2.id);
 			expect(changes[1].type).toBe(ChangeType.Create);
+			expect(changes[2].item_id).toBe(item3.id);
+			expect(changes[2].type).toBe(ChangeType.Create);
 		}
 
 		{

--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -51,12 +51,11 @@ describe('ChangeModel', () => {
 		expect(allUncompressedChanges.length).toBe(8);
 
 		{
-			// When we get all the changes, we only get CREATE 2 and CREATE 3.
-			// We don't get CREATE 1 because item 1 has been deleted. And we
-			// also don't get any UPDATE event since they've been compressed
+			// When we get all the changes, we get CREATE 1, CREATE 2, and CREATE 3.
+			// We don't get any UPDATE event since they've been compressed
 			// down to the CREATE events.
 			const changes = (await changeModel.delta(user.id)).items;
-			expect(changes.length).toBe(2);
+			expect(changes.length).toBe(3);
 			expect(changes[0].item_id).toBe(item2.id);
 			expect(changes[0].type).toBe(ChangeType.Create);
 			expect(changes[1].item_id).toBe(item3.id);
@@ -355,12 +354,27 @@ describe('ChangeModel', () => {
 			],
 		},
 		{
-			label: 'should remove create -> delete',
+			label: 'should replace create -> delete with delete',
+			// Create -> Delete can't be filtered out without un-deleting items.
+			// This is because compressChanges is often called on an individual **page**
+			// of results. For example, if the first page of results is,
+			// - Create: Item 1
+			// - ... other changes not involving item 1...
+			//
+			// And the second page of results is,
+			// - Create: Item 1
+			// - Delete Item 1
+			//
+			// Then removing the Create -> Delete would result in Item 1 ultimately being
+			// created, rather than deleted, since there's still a "Create: Item 1" in the
+			// first page.
 			changes: [
 				{ type: ChangeType.Create },
 				{ type: ChangeType.Delete },
 			],
-			expected: [],
+			expected: [
+				{ type: ChangeType.Delete },
+			],
 		},
 		{
 			label: 'should replace update -> delete with delete',

--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -384,7 +384,7 @@ export default class ChangeModel extends BaseModel<Change> {
 	// know that the item has changed at least once. The reduction is basically:
 	//
 	//     create - update => create
-	//     create - delete => NOOP
+	//     create - delete => delete
 	//     update - update => update
 	//     update - delete => delete
 	//     delete - create => create
@@ -444,7 +444,7 @@ export default class ChangeModel extends BaseModel<Change> {
 				}
 
 				if (previous.type === ChangeType.Create && change.type === ChangeType.Delete) {
-					itemChanges.delete(itemId);
+					itemChanges.set(itemId, change);
 				}
 
 				if (previous.type === ChangeType.Update && change.type === ChangeType.Update) {


### PR DESCRIPTION
# Summary

This pull request fixes an issue in Joplin Server's [change compression](https://github.com/laurent22/joplin/blob/554e6efaabdf5d9833054a4873a553b1ca8304c3/packages/server/src/models/ChangeModel.ts#L382) logic. As a result of this issue, new clients added to an existing account could download previously-unshared items.

Fixes #14110.

# Notes

#14110 should not affect Joplin Server instances where the [`DELTA_INCLUDES_ITEMS`](https://github.com/laurent22/joplin/blob/554e6efaabdf5d9833054a4873a553b1ca8304c3/packages/server/src/env.ts#L45) environment variable has been set to `false`.


# Testing

- This pull request includes an automated test.
- It has been verified that the initial actions specified in the [sync fuzzer setup from #14110](https://github.com/laurent22/joplin/issues/14110#issuecomment-3761769892) no longer cause the fuzzer to fail.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->