### PR TITLE
Cli: Fix help text for `unpublish` command

### DIFF
--- a/packages/app-cli/app/command-unpublish.ts
+++ b/packages/app-cli/app/command-unpublish.ts
@@ -17,17 +17,11 @@ type Args = {
 
 class Command extends BaseCommand {
 	public usage() {
-		return 'publish [note]';
+		return 'unpublish [note]';
 	}
 
 	public description() {
-		return _('Publishes a note to Joplin Server or Joplin Cloud');
-	}
-
-	public options() {
-		return [
-			['-f, --force', _('Do not ask for user confirmation.')],
-		];
+		return _('Unpublishes a note from Joplin Server or Joplin Cloud');
 	}
 
 	public enabled() {


### PR DESCRIPTION
# Summary

Fixes the name of the `unpublish` command (as reported by the `help` command).

# Details

Previously, the `unpublish` command incorrectly had usage set to `publish [note]` and help text matching the `publish` command. As a result, `unpublish` wasn't listed as an available command by `help` and `help unpublish` confusingly displayed the help text for `publish`.

# Testing plan

1. Start the CLI app.
2. Run `help unpublish`.
3. Verify that the command name is not listed as "publish" and that the help text describes the command.
4. Verify that `unpublish` is listed as a command by `help`.
   - Note: This requires that the synchronization target is set to Joplin Server/Cloud.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->