### PR TITLE
Chore: Sync fuzzer: Do not attempt to unpublish read-only notes

### DIFF
--- a/packages/tools/fuzzer/ActionRunner.ts
+++ b/packages/tools/fuzzer/ActionRunner.ts
@@ -495,12 +495,22 @@ const getActions = (context: FuzzContext, clientPool: ClientPool, client: Client
 	}, { id: selectOrCreateWriteableNote });
 
 	addAction('unpublishNote', async ({ id }) => {
-		const note = id ? noteById(id) : await client.randomNote({ includeReadOnly: true });
-		if (!note || !note.published) return false;
+		if (!id) return false;
+
+		const note = noteById(id);
+		assert.ok(note.published, 'can only unpublish published notes');
 
 		await client.unpublishNote(note.id);
 		return true;
-	}, { id: undefinedId });
+	}, {
+		id: async () => {
+			const note = await client.randomNote({
+				includeReadOnly: false,
+				filter: (note) => note.published,
+			});
+			return note?.id;
+		},
+	});
 
 	addAction('sync', async () => {
 		await client.sync();

--- a/packages/tools/fuzzer/ActionTracker.ts
+++ b/packages/tools/fuzzer/ActionTracker.ts
@@ -718,9 +718,13 @@ class ActionTracker {
 			},
 			randomNote: async (options) => {
 				let notes = await tracker.listNotes();
+				if (options.filter) {
+					notes = notes.filter(options.filter);
+				}
 				if (!options.includeReadOnly) {
 					notes = notes.filter(note => !isReadOnly(note.id));
 				}
+
 				const noteIndex = this.context_.randInt(0, notes.length);
 				return notes.length ? notes[noteIndex] : null;
 			},

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -83,6 +83,7 @@ export interface RandomFolderOptions {
 
 export interface RandomNoteOptions {
 	includeReadOnly: boolean;
+	filter?: (note: NoteData)=> boolean;
 }
 
 export interface ShareOptions {


### PR DESCRIPTION
# Summary

Previously, the sync fuzzer could attempt to unpublish a note from a client that has read-only access to that note. This would fail, since read-only items cannot be modified. Fixes a sync fuzzer failure.

See also: https://github.com/laurent22/joplin/pull/14205.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->