### PR TITLE
fix: show correct error when plugin manifest is missing app_min_version

### DIFF
--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -525,7 +525,7 @@ export default class PluginService extends BaseService {
 		const minVersion = minVersionForPlatform(this.appType_, manifest);
 		if (minVersion) {
 			return _('Please upgrade Joplin to version %s or later to use this plugin.', minVersion);
-		} else {
+		} else if (minVersion === false) {
 			let platformDescription = 'Unknown';
 			if (this.appType_ === AppType.Mobile) {
 				platformDescription = _('Joplin Mobile');
@@ -533,6 +533,10 @@ export default class PluginService extends BaseService {
 				platformDescription = _('Joplin Desktop');
 			}
 			return _('This plugin doesn\'t support %s.', platformDescription);
+		} else {
+			// minVersion is undefined -- the platform is supported but
+			// app_min_version is missing from the manifest.
+			return _('The plugin manifest is missing a required "app_min_version" field.');
 		}
 	}
 

--- a/packages/lib/services/plugins/utils/isCompatible/index.test.ts
+++ b/packages/lib/services/plugins/utils/isCompatible/index.test.ts
@@ -1,8 +1,17 @@
 import { AppType } from '../../../../models/Setting';
 import isCompatible from '../isCompatible';
+import minVersionForPlatform from './minVersionForPlatform';
 
 describe('isCompatible', () => {
 	test.each([
+		// Should treat missing app_min_version as incompatible
+		{
+			manifest: {},
+			appVersion: '2.1.0',
+			shouldSupportDesktop: false,
+			shouldSupportMobile: false,
+		},
+
 		// Should support the case where no platform is provided
 		{
 			manifest: { app_min_version: '2.0' },
@@ -91,5 +100,28 @@ describe('isCompatible', () => {
 		expect(mobileCompatible).toBe(shouldSupportMobile);
 		const desktopCompatible = isCompatible(appVersion, AppType.Desktop, fullManifest);
 		expect(desktopCompatible).toBe(shouldSupportDesktop);
+	});
+
+	describe('minVersionForPlatform', () => {
+		test('should return undefined (not false) when app_min_version is missing but platform is supported', () => {
+			// When app_min_version is missing, minVersionForPlatform returns undefined
+			// (the platform is supported, but the version field is absent).
+			// This is distinct from returning false (platform not supported).
+			const manifest = { id: 'com.example.id' };
+			const result = minVersionForPlatform(AppType.Desktop, manifest);
+			expect(result).toBeUndefined();
+		});
+
+		test('should return false when the platform is not supported', () => {
+			const manifest = { id: 'com.example.id', app_min_version: '2.0', platforms: ['mobile'] };
+			const result = minVersionForPlatform(AppType.Desktop, manifest);
+			expect(result).toBe(false);
+		});
+
+		test('should return the version string when app_min_version is present and platform is supported', () => {
+			const manifest = { id: 'com.example.id', app_min_version: '2.0' };
+			const result = minVersionForPlatform(AppType.Desktop, manifest);
+			expect(result).toBe('2.0');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #14271

When a plugin manifest is missing the `app_min_version` field, Joplin currently shows an incorrect error message: **"This plugin doesn't support Joplin Desktop"**. The actual problem is that the required `app_min_version` field is absent from the manifest.

## Root Cause

In `PluginService.describeIncompatibility()`, the code calls `minVersionForPlatform()` which can return:
- A version string (platform supported, version found)
- `false` (platform not supported)
- `undefined` (platform supported, but `app_min_version` is missing)

The old code only checked for truthy vs falsy, so both `false` (unsupported platform) and `undefined` (missing field) fell into the same `else` branch, producing the misleading "doesn't support Joplin Desktop" message.

## Fix

Distinguish between `false` (platform not supported) and `undefined` (missing `app_min_version`):
- `minVersion === false` → "This plugin doesn't support Joplin Desktop/Mobile"
- `minVersion === undefined` → "The plugin manifest is missing a required app_min_version field"

## Tests Added

- Test that `isCompatible` returns `false` when `app_min_version` is missing
- Tests for `minVersionForPlatform` to verify it correctly returns `undefined` (not `false`) when `app_min_version` is missing but the platform is supported
