### PR TITLE
Desktop: Fixes #14080: Added argument in emoji picker to change theme based on system preferences

### DIFF
--- a/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/Dialog.tsx
@@ -145,6 +145,7 @@ export default function(props: Props) {
 								title={_('Select emoji...')}
 								icon={folderIcon}
 								onChange={onFolderIconChange}
+								themeId={props.themeId}
 							/>
 							<Button ml={1} title={_('Select file...')} onClick={onBrowseClick}/>
 							{ folderIcon && <Button ml={1} title={_('Clear')} onClick={onClearClick}/> }

--- a/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
@@ -62,6 +62,7 @@ export const IconSelector = (props: Props) => {
 		const p: EmojiButton = new (window as any).EmojiButton({
 			zIndex: 10000,
 			rootElement: buttonRef.current?.parentElement,
+			theme: 'auto',
 		});
 
 		const onEmoji = (selection: FolderIcon) => {

--- a/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
+++ b/packages/app-desktop/gui/EditFolderDialog/IconSelector.tsx
@@ -1,10 +1,11 @@
 import { EmojiButton } from '@joeattardi/emoji-button';
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import { loadScript } from '../utils/loadScript';
 import Button from '../Button/Button';
 import { FolderIcon, FolderIconType } from '@joplin/lib/services/database/types';
 import bridge from '../../services/bridge';
+import { themeStyle } from '@joplin/lib/theme';
 
 export interface ChangeEvent {
 	value: FolderIcon;
@@ -16,12 +17,16 @@ interface Props {
 	onChange: ChangeHandler;
 	icon: FolderIcon | null;
 	title: string;
+	themeId: number;
 }
 
 export const IconSelector = (props: Props) => {
 	const [emojiButtonClassReady, setEmojiButtonClassReady] = useState<boolean>(false);
 	const [picker, setPicker] = useState<EmojiButton>();
 	const buttonRef = useRef<HTMLButtonElement>(null);
+	const pickerTheme = useMemo(() => {
+		return themeStyle(props.themeId).appearance;
+	}, [props.themeId]);
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		const loadScripts = async () => {
@@ -62,7 +67,7 @@ export const IconSelector = (props: Props) => {
 		const p: EmojiButton = new (window as any).EmojiButton({
 			zIndex: 10000,
 			rootElement: buttonRef.current?.parentElement,
-			theme: 'auto',
+			theme: pickerTheme,
 		});
 
 		const onEmoji = (selection: FolderIcon) => {
@@ -77,7 +82,7 @@ export const IconSelector = (props: Props) => {
 			p.off('emoji', onEmoji);
 			p.destroyPicker();
 		};
-	}, [emojiButtonClassReady, props.onChange]);
+	}, [emojiButtonClassReady, props.onChange, pickerTheme]);
 
 	const onClick = useCallback(() => {
 		picker.togglePicker(buttonRef.current);


### PR DESCRIPTION
Fixes #14080 

Added argument for the emoji picker to automatically change theme based on system preferences

The emoji picker before was rendering in light theme regardless if the system preferences are set to be dark. Adding this argument ensures the emoji picker changes based on system preferences.

Emoji picker now if my system preferences are set to dark -> 

<img width="2480" height="2130" alt="image" src="https://github.com/user-attachments/assets/96b86f9a-c3cc-4523-a2f6-e84c9175cb48" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The emoji picker in folder settings now adapts to your application theme, ensuring consistent styling across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->