### PR TITLE
Desktop: Resolves #14292: Display percentage completion of checkbox lists in note list

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1525,6 +1525,7 @@ packages/lib/services/keychain/KeychainServiceDriver.dummy.js
 packages/lib/services/keychain/KeychainServiceDriver.electron.js
 packages/lib/services/keychain/KeychainServiceDriver.node.js
 packages/lib/services/keychain/KeychainServiceDriverBase.js
+packages/lib/services/noteList/checkboxPieCss.js
 packages/lib/services/noteList/defaultLeftToRightListRenderer.js
 packages/lib/services/noteList/defaultListRenderer.js
 packages/lib/services/noteList/defaultMultiColumnsRenderer.js

--- a/.gitignore
+++ b/.gitignore
@@ -1498,6 +1498,7 @@ packages/lib/services/keychain/KeychainServiceDriver.dummy.js
 packages/lib/services/keychain/KeychainServiceDriver.electron.js
 packages/lib/services/keychain/KeychainServiceDriver.node.js
 packages/lib/services/keychain/KeychainServiceDriverBase.js
+packages/lib/services/noteList/checkboxPieCss.js
 packages/lib/services/noteList/defaultLeftToRightListRenderer.js
 packages/lib/services/noteList/defaultListRenderer.js
 packages/lib/services/noteList/defaultMultiColumnsRenderer.js

--- a/packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts
+++ b/packages/app-desktop/gui/NoteListHeader/utils/getColumnTitle.ts
@@ -2,6 +2,7 @@ import { _ } from '@joplin/lib/locale';
 import { ColumnName } from '@joplin/lib/services/plugins/api/noteListType';
 
 const titles: Record<ColumnName, ()=> string> = {
+	'note.checkboxes': () => _('Checkbox completion'),
 	'note.folder.title': () => _('Notebook: %s', _('Title')),
 	'note.is_todo': () => _('To-do'),
 	'note.latitude': () => _('Latitude'),
@@ -16,6 +17,7 @@ const titles: Record<ColumnName, ()=> string> = {
 };
 
 const titlesForHeader: Partial<Record<ColumnName, ()=> string>> = {
+	'note.checkboxes': () => '◐',
 	'note.is_todo': () => '✓',
 };
 

--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
@@ -4,6 +4,34 @@ import { Size } from '@joplin/utils/types';
 import Note from '@joplin/lib/models/Note';
 import { _ } from '@joplin/lib/locale';
 
+interface CheckboxStats {
+	total: number;
+	checked: number;
+	percent: number;
+	isComplete: boolean;
+}
+
+const countCheckboxes = (body: string): CheckboxStats | null => {
+	if (!body) return null;
+
+	// Match unchecked: - [ ] and checked: - [x] or - [X]
+	const uncheckedMatches = body.match(/- \[ \]/g);
+	const checkedMatches = body.match(/- \[[xX]\]/g);
+
+	const unchecked = uncheckedMatches ? uncheckedMatches.length : 0;
+	const checked = checkedMatches ? checkedMatches.length : 0;
+	const total = unchecked + checked;
+
+	if (total === 0) return null;
+
+	return {
+		total,
+		checked,
+		percent: Math.round((checked / total) * 100),
+		isComplete: checked === total,
+	};
+};
+
 const prepareViewProps = async (
 	dependencies: ListRendererDependency[],
 	note: NoteEntity,
@@ -40,6 +68,10 @@ const prepareViewProps = async (
 					taskStatus = note.todo_completed ? _('Complete to-do') : _('Incomplete to-do');
 				}
 				output.note[propName] = taskStatus;
+			} else if (dep === 'note.checkboxes') {
+				// Load the note body if not already loaded
+				if (!('body' in note)) note = await Note.load(note.id);
+				output.note[propName] = countCheckboxes(note.body);
 			} else {
 				// The notes in the state only contain the properties defined in
 				// Note.previewFields(). It means that if a view request a

--- a/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/prepareViewProps.ts
@@ -2,6 +2,7 @@ import { ListRendererDependency } from '@joplin/lib/services/plugins/api/noteLis
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
 import { Size } from '@joplin/utils/types';
 import Note from '@joplin/lib/models/Note';
+import Setting from '@joplin/lib/models/Setting';
 import { _ } from '@joplin/lib/locale';
 
 interface CheckboxStats {
@@ -69,9 +70,13 @@ const prepareViewProps = async (
 				}
 				output.note[propName] = taskStatus;
 			} else if (dep === 'note.checkboxes') {
-				// Load the note body if not already loaded
-				if (!('body' in note)) note = await Note.load(note.id);
-				output.note[propName] = countCheckboxes(note.body);
+				// Only load the note body and compute checkbox stats if the setting is enabled
+				if (Setting.value('notes.showCheckboxCompletionChart')) {
+					if (!('body' in note)) note = await Note.load(note.id);
+					output.note[propName] = countCheckboxes(note.body);
+				} else {
+					output.note[propName] = null;
+				}
 			} else {
 				// The notes in the state only contain the properties defined in
 				// Note.previewFields(). It means that if a view request a

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1004,6 +1004,17 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: false,
 		},
 
+		'notes.showCheckboxCompletionChart': {
+			value: true,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+			section: 'appearance',
+			public: true,
+			appTypes: [AppType.Desktop],
+			label: () => _('Show checkbox completion chart in note list'),
+			isGlobal: true,
+		},
+
 		'plugins.states': {
 			value: {} as PluginSettings,
 			type: SettingItemType.Object,

--- a/packages/lib/services/noteList/checkboxPieCss.ts
+++ b/packages/lib/services/noteList/checkboxPieCss.ts
@@ -1,0 +1,27 @@
+// Shared CSS for checkbox completion pie chart used in note list renderers
+
+const checkboxPieCss = // css
+`
+	.checkbox-pie > .pie {
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background: conic-gradient(
+			var(--joplin-color4) calc(var(--percent) * 1%),
+			var(--joplin-background-color) calc(var(--percent) * 1%)
+		);
+		border: 1px solid var(--joplin-color-faded);
+		box-sizing: border-box;
+	}
+
+	.checkbox-pie > .pie.-complete {
+		background: var(--joplin-background-color);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 10px;
+		color: var(--joplin-color4);
+	}
+`;
+
+export default checkboxPieCss;

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -1,5 +1,6 @@
 import { _ } from '../../locale';
 import CommandService from '../CommandService';
+import Setting from '../../models/Setting';
 import { ItemFlow, ListRenderer, OnClickEvent } from '../plugins/api/noteListType';
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 		title: string;
 		is_todo: number;
 		todo_completed: number;
+		body: string;
 	};
 	item: {
 		// index: number;
@@ -17,6 +19,34 @@ interface Props {
 		selected: boolean;
 	};
 }
+
+interface CheckboxStats {
+	total: number;
+	checked: number;
+	percent: number;
+	isComplete: boolean;
+}
+
+const countCheckboxes = (body: string): CheckboxStats | null => {
+	if (!body) return null;
+
+	// Match unchecked: - [ ] and checked: - [x] or - [X]
+	const uncheckedMatches = body.match(/- \[ \]/g);
+	const checkedMatches = body.match(/- \[[xX]\]/g);
+
+	const unchecked = uncheckedMatches ? uncheckedMatches.length : 0;
+	const checked = checkedMatches ? checkedMatches.length : 0;
+	const total = unchecked + checked;
+
+	if (total === 0) return null;
+
+	return {
+		total,
+		checked,
+		percent: Math.round((checked / total) * 100),
+		isComplete: checked === total,
+	};
+};
 
 const renderer: ListRenderer = {
 	id: 'compact',
@@ -34,6 +64,7 @@ const renderer: ListRenderer = {
 		// 'item.index',
 		'item.selected',
 		'item.size.height',
+		'note.body',
 		'note.id',
 		'note.is_shared',
 		'note.is_todo',
@@ -96,6 +127,34 @@ const renderer: ListRenderer = {
 					color: var(--joplin-color);
 				}
 			}
+
+			> .checkbox-pie {
+				display: flex;
+				align-items: center;
+				padding-right: 12px;
+				padding-left: 8px;
+
+				> .pie {
+					width: 16px;
+					height: 16px;
+					border-radius: 50%;
+					background: conic-gradient(
+						var(--joplin-color4) calc(var(--percent) * 1%),
+						var(--joplin-background-color) calc(var(--percent) * 1%)
+					);
+					border: 1px solid var(--joplin-color-faded);
+					box-sizing: border-box;
+				}
+
+				> .pie.-complete {
+					background: var(--joplin-background-color);
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					font-size: 10px;
+					color: var(--joplin-color4);
+				}
+			}
 		}
 
 		> .content.-shared {
@@ -147,11 +206,25 @@ const renderer: ListRenderer = {
 				<i class="watchedicon fa fa-share-square"></i>
 				<span>{{note.title}}</span>
 			</div>
+			{{#checkboxStats}}
+				<div class="checkbox-pie" title="{{checked}}/{{total}} completed">
+					{{#isComplete}}
+						<div class="pie -complete">✓</div>
+					{{/isComplete}}
+					{{^isComplete}}
+						<div class="pie" style="--percent: {{percent}};"></div>
+					{{/isComplete}}
+				</div>
+			{{/checkboxStats}}
 		</div>
 	`,
 
 	onRenderNote: async (props: Props) => {
-		return props;
+		const showChart = Setting.value('notes.showCheckboxCompletionChart');
+		return {
+			...props,
+			checkboxStats: showChart ? countCheckboxes(props.note.body) : null,
+		};
 	},
 };
 

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -1,7 +1,13 @@
 import { _ } from '../../locale';
 import CommandService from '../CommandService';
-import Setting from '../../models/Setting';
 import { ItemFlow, ListRenderer, OnClickEvent } from '../plugins/api/noteListType';
+
+interface CheckboxStats {
+	total: number;
+	checked: number;
+	percent: number;
+	isComplete: boolean;
+}
 
 interface Props {
 	note: {
@@ -9,7 +15,7 @@ interface Props {
 		title: string;
 		is_todo: number;
 		todo_completed: number;
-		body: string;
+		checkboxes: CheckboxStats | null;
 	};
 	item: {
 		// index: number;
@@ -19,34 +25,6 @@ interface Props {
 		selected: boolean;
 	};
 }
-
-interface CheckboxStats {
-	total: number;
-	checked: number;
-	percent: number;
-	isComplete: boolean;
-}
-
-const countCheckboxes = (body: string): CheckboxStats | null => {
-	if (!body) return null;
-
-	// Match unchecked: - [ ] and checked: - [x] or - [X]
-	const uncheckedMatches = body.match(/- \[ \]/g);
-	const checkedMatches = body.match(/- \[[xX]\]/g);
-
-	const unchecked = uncheckedMatches ? uncheckedMatches.length : 0;
-	const checked = checkedMatches ? checkedMatches.length : 0;
-	const total = unchecked + checked;
-
-	if (total === 0) return null;
-
-	return {
-		total,
-		checked,
-		percent: Math.round((checked / total) * 100),
-		isComplete: checked === total,
-	};
-};
 
 const renderer: ListRenderer = {
 	id: 'compact',
@@ -64,7 +42,7 @@ const renderer: ListRenderer = {
 		// 'item.index',
 		'item.selected',
 		'item.size.height',
-		'note.body',
+		'note.checkboxes',
 		'note.id',
 		'note.is_shared',
 		'note.is_todo',
@@ -220,10 +198,9 @@ const renderer: ListRenderer = {
 	`,
 
 	onRenderNote: async (props: Props) => {
-		const showChart = Setting.value('notes.showCheckboxCompletionChart');
 		return {
 			...props,
-			checkboxStats: showChart ? countCheckboxes(props.note.body) : null,
+			checkboxStats: props.note.checkboxes,
 		};
 	},
 };

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -1,6 +1,7 @@
 import { _ } from '../../locale';
 import CommandService from '../CommandService';
 import { ItemFlow, ListRenderer, OnClickEvent } from '../plugins/api/noteListType';
+import checkboxPieCss from './checkboxPieCss';
 
 interface CheckboxStats {
 	total: number;
@@ -111,29 +112,10 @@ const renderer: ListRenderer = {
 				align-items: center;
 				padding-right: 12px;
 				padding-left: 8px;
-
-				> .pie {
-					width: 16px;
-					height: 16px;
-					border-radius: 50%;
-					background: conic-gradient(
-						var(--joplin-color4) calc(var(--percent) * 1%),
-						var(--joplin-background-color) calc(var(--percent) * 1%)
-					);
-					border: 1px solid var(--joplin-color-faded);
-					box-sizing: border-box;
-				}
-
-				> .pie.-complete {
-					background: var(--joplin-background-color);
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					font-size: 10px;
-					color: var(--joplin-color4);
-				}
 			}
 		}
+
+		${checkboxPieCss}
 
 		> .content.-shared {
 			> .title {

--- a/packages/lib/services/noteList/defaultListRenderer.ts
+++ b/packages/lib/services/noteList/defaultListRenderer.ts
@@ -185,7 +185,7 @@ const renderer: ListRenderer = {
 				<span>{{note.title}}</span>
 			</div>
 			{{#checkboxStats}}
-				<div class="checkbox-pie" title="{{checked}}/{{total}} completed">
+				<div class="checkbox-pie" title="{{checked}}/{{total}}">
 					{{#isComplete}}
 						<div class="pie -complete">✓</div>
 					{{/isComplete}}

--- a/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
+++ b/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
@@ -1,6 +1,7 @@
 import { _ } from '../../locale';
 import CommandService from '../CommandService';
 import { ItemFlow, ListRenderer, OnClickEvent } from '../plugins/api/noteListType';
+import checkboxPieCss from './checkboxPieCss';
 
 const renderer: ListRenderer = {
 	id: 'detailed',
@@ -59,27 +60,6 @@ const renderer: ListRenderer = {
 				opacity: 1;
 			}
 
-			> .item[data-name="note.checkboxes"] > .content > .checkbox-pie > .pie {
-				width: 16px;
-				height: 16px;
-				border-radius: 50%;
-				background: conic-gradient(
-					var(--joplin-color4) calc(var(--percent) * 1%),
-					var(--joplin-background-color) calc(var(--percent) * 1%)
-				);
-				border: 1px solid var(--joplin-color-faded);
-				box-sizing: border-box;
-			}
-
-			> .item[data-name="note.checkboxes"] > .content > .checkbox-pie > .pie.-complete {
-				background: var(--joplin-background-color);
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				font-size: 10px;
-				color: var(--joplin-color4);
-			}
-
 			> .item > .content > .watchedicon {
 				display: none;
 				margin-right: 8px;
@@ -105,6 +85,8 @@ const renderer: ListRenderer = {
 		> .row:hover, &.-focus-visible > .row {
 			background-color: var(--joplin-background-color-hover3);
 		}
+
+		${checkboxPieCss}
 	`,
 
 	onHeaderClick: async (event: OnClickEvent) => {

--- a/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
+++ b/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
@@ -54,8 +54,30 @@ const renderer: ListRenderer = {
 			}
 
 			> .item[data-name="note.is_todo"],
-			> .item[data-name="note.title"] {
+			> .item[data-name="note.title"],
+			> .item[data-name="note.checkboxes"] {
 				opacity: 1;
+			}
+
+			> .item[data-name="note.checkboxes"] > .content > .checkbox-pie > .pie {
+				width: 16px;
+				height: 16px;
+				border-radius: 50%;
+				background: conic-gradient(
+					var(--joplin-color4) calc(var(--percent) * 1%),
+					var(--joplin-background-color) calc(var(--percent) * 1%)
+				);
+				border: 1px solid var(--joplin-color-faded);
+				box-sizing: border-box;
+			}
+
+			> .item[data-name="note.checkboxes"] > .content > .checkbox-pie > .pie.-complete {
+				background: var(--joplin-background-color);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				font-size: 10px;
+				color: var(--joplin-color4);
 			}
 
 			> .item > .content > .watchedicon {
@@ -116,6 +138,19 @@ const renderer: ListRenderer = {
 						{{#note.todo_completed}}checked="checked"{{/note.todo_completed}}>
 				</div>
 			{{/note.is_todo}}
+		`,
+		'note.checkboxes': // html
+			`
+			{{#note.checkboxes}}
+				<div class="checkbox-pie" title="{{note.checkboxes.checked}}/{{note.checkboxes.total}} completed">
+					{{#note.checkboxes.isComplete}}
+						<div class="pie -complete">✓</div>
+					{{/note.checkboxes.isComplete}}
+					{{^note.checkboxes.isComplete}}
+						<div class="pie" style="--percent: {{note.checkboxes.percent}};"></div>
+					{{/note.checkboxes.isComplete}}
+				</div>
+			{{/note.checkboxes}}
 		`,
 	},
 

--- a/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
+++ b/packages/lib/services/noteList/defaultMultiColumnsRenderer.ts
@@ -142,7 +142,7 @@ const renderer: ListRenderer = {
 		'note.checkboxes': // html
 			`
 			{{#note.checkboxes}}
-				<div class="checkbox-pie" title="{{note.checkboxes.checked}}/{{note.checkboxes.total}} completed">
+				<div class="checkbox-pie" title="{{note.checkboxes.checked}}/{{note.checkboxes.total}}">
 					{{#note.checkboxes.isComplete}}
 						<div class="pie -complete">✓</div>
 					{{/note.checkboxes.isComplete}}

--- a/packages/lib/services/plugins/api/noteListType.ts
+++ b/packages/lib/services/plugins/api/noteListType.ts
@@ -50,6 +50,7 @@ export type ListRendererDependency =
 	'item.selected' |
 	'item.size.height' |
 	'item.size.width' |
+	'note.checkboxes' |
 	'note.folder.title' |
 	'note.isWatched' |
 	'note.tags' |
@@ -59,6 +60,7 @@ export type ListRendererDependency =
 export type ListRendererItemValueTemplates = Record<string, string>;
 
 export const columnNames = [
+	'note.checkboxes',
 	'note.folder.title',
 	'note.is_todo',
 	'note.latitude',


### PR DESCRIPTION
*Done with the assistance of AI*

Notebook support would be a different feature, if it gets implemented.

This change means that the renderer pulls `note.body` which is a bit inefficient, but still manageable since it only does this for the visible notes in the list. An alternative would be to pre-process the notes and save the checkbox list count to the database but that's probably not necessary. On the other hand, it only does this when the setting is active.

## TODO

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checkbox completion progress indicator to the note list, displayed as a small pie visual showing completion percentage and complete state.

* **Configuration**
  * New setting to enable or disable the checkbox completion chart in the note list view.

* **Tests**
  * Added unit tests covering checkbox-statistics computation and behaviour when the setting is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->