### PR TITLE
Desktop: Security: Strengthen Content-Security-Policy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -269,6 +269,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.js
@@ -623,7 +624,8 @@ packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js
 packages/app-desktop/utils/customProtocols/constants.js
-packages/app-desktop/utils/customProtocols/handleCustomProtocols.test.js
+packages/app-desktop/utils/customProtocols/handleCustomProtocols.content.test.js
+packages/app-desktop/utils/customProtocols/handleCustomProtocols.plugins.test.js
 packages/app-desktop/utils/customProtocols/handleCustomProtocols.js
 packages/app-desktop/utils/customProtocols/registerCustomProtocols.js
 packages/app-desktop/utils/getAssetPath.js

--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,7 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/useEditorCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/localisation.js
+packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useKeymap.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useRefocusOnVisiblePaneChange.js
 packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorValue.js
@@ -596,7 +597,8 @@ packages/app-desktop/utils/checkForUpdatesUtils.test.js
 packages/app-desktop/utils/checkForUpdatesUtils.js
 packages/app-desktop/utils/checkForUpdatesUtilsTestData.js
 packages/app-desktop/utils/customProtocols/constants.js
-packages/app-desktop/utils/customProtocols/handleCustomProtocols.test.js
+packages/app-desktop/utils/customProtocols/handleCustomProtocols.content.test.js
+packages/app-desktop/utils/customProtocols/handleCustomProtocols.plugins.test.js
 packages/app-desktop/utils/customProtocols/handleCustomProtocols.js
 packages/app-desktop/utils/customProtocols/registerCustomProtocols.js
 packages/app-desktop/utils/getAssetPath.js

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -16,7 +16,7 @@ const fs = require('fs-extra');
 import { dialog, ipcMain } from 'electron';
 import { _ } from '@joplin/lib/locale';
 import restartInSafeModeFromMain from './utils/restartInSafeModeFromMain';
-import handleCustomProtocols, { CustomProtocolHandler } from './utils/customProtocols/handleCustomProtocols';
+import handleCustomProtocols, { CustomProtocolHandlers } from './utils/customProtocols/handleCustomProtocols';
 import { clearTimeout, setTimeout } from 'timers';
 import { resolve } from 'path';
 import { defaultWindowId } from '@joplin/lib/reducer';
@@ -68,7 +68,7 @@ export default class ElectronAppWrapper {
 
 	private initialCallbackUrl_: string = null;
 	private updaterService_: AutoUpdaterService = null;
-	private customProtocolHandler_: CustomProtocolHandler = null;
+	private customProtocolHandlers_: CustomProtocolHandlers|null = null;
 	private updatePollInterval_: ReturnType<typeof setTimeout>|null = null;
 
 	private profileLocker_: FileLocker|null = null;
@@ -816,8 +816,12 @@ export default class ElectronAppWrapper {
 		}
 	};
 
-	public getCustomProtocolHandler() {
-		return this.customProtocolHandler_;
+	public getContentProtocolHandler() {
+		return this.customProtocolHandlers_.appContent;
+	}
+
+	public getPluginProtocolHandler() {
+		return this.customProtocolHandlers_.pluginContent;
 	}
 
 	private async fixLinuxAccessibility_() {
@@ -857,7 +861,7 @@ export default class ElectronAppWrapper {
 
 		await this.fixLinuxAccessibility_();
 
-		this.customProtocolHandler_ = handleCustomProtocols();
+		this.customProtocolHandlers_ = handleCustomProtocols();
 		this.createWindow();
 
 		this.electronApp_.on('before-quit', () => {

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -58,7 +58,7 @@ import OcrDriverTesseract from '@joplin/lib/services/ocr/drivers/OcrDriverTesser
 import OcrDriverTranscribe from '@joplin/lib/services/ocr/drivers/OcrDriverTranscribe';
 import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 import { PackageInfo } from '@joplin/lib/versionInfo';
-import { CustomProtocolHandler } from './utils/customProtocols/handleCustomProtocols';
+import { CustomContentProtocolHandler } from './utils/customProtocols/handleCustomProtocols';
 import { refreshFolders } from '@joplin/lib/folders-screen-utils';
 import initializeCommandService from './utils/initializeCommandService';
 import OcrDriverBase from '@joplin/lib/services/ocr/OcrDriverBase';
@@ -82,7 +82,7 @@ class Application extends BaseApplication {
 	private checkAllPluginStartedIID_: any = null;
 	private initPluginServiceDone_ = false;
 	private ocrService_: OcrService;
-	private protocolHandler_: CustomProtocolHandler;
+	private protocolHandler_: CustomContentProtocolHandler;
 
 	public constructor() {
 		super();
@@ -130,7 +130,7 @@ class Application extends BaseApplication {
 		}
 
 		if (action.type === 'SETTING_UPDATE_ONE' && action.key === 'renderer.fileUrls' || action.type === 'SETTING_UPDATE_ALL') {
-			bridge().electronApp().getCustomProtocolHandler().setMediaAccessEnabled(
+			bridge().electronApp().getContentProtocolHandler().setMediaAccessEnabled(
 				Setting.value('renderer.fileUrls'),
 			);
 		}
@@ -477,7 +477,7 @@ class Application extends BaseApplication {
 		}
 
 		addTask('app/set up custom protocol handler', async () => {
-			this.protocolHandler_ = bridge().electronApp().getCustomProtocolHandler();
+			this.protocolHandler_ = bridge().electronApp().getContentProtocolHandler();
 			this.protocolHandler_.allowReadAccessToDirectory(__dirname); // App bundle directory
 			this.protocolHandler_.allowReadAccessToDirectory(Setting.value('cacheDir'));
 			this.protocolHandler_.allowReadAccessToDirectory(Setting.value('resourceDir'));

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/Editor.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react';
 import { ForwardedRef, RefObject } from 'react';
 import { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react';
-import { EditorProps, LogMessageCallback, OnEventCallback, ContentScriptData } from '@joplin/editor/types';
+import { EditorProps, LogMessageCallback, OnEventCallback } from '@joplin/editor/types';
 import createEditor from '@joplin/editor/CodeMirror/createEditor';
 import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
 import { PluginStates } from '@joplin/lib/services/plugins/reducer';
-import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
-import shim from '@joplin/lib/shim';
-import PluginService from '@joplin/lib/services/plugins/PluginService';
 import setupVim from '@joplin/editor/CodeMirror/utils/setupVim';
-import { dirname } from 'path';
 import useKeymap from './utils/useKeymap';
 import CommandService from '@joplin/lib/services/CommandService';
 import { SearchMarkers } from '../../../utils/useSearchMarkers';
@@ -18,6 +14,7 @@ import Resource from '@joplin/lib/models/Resource';
 import { parseResourceUrl } from '@joplin/lib/urlUtils';
 import { resourceFilename } from '@joplin/lib/models/utils/resourceUtils';
 import getResourceBaseUrl from '../../../utils/getResourceBaseUrl';
+import useContentScriptRegistration from './utils/useContentScriptRegistration';
 
 interface Props extends EditorProps {
 	style: React.CSSProperties;
@@ -64,37 +61,7 @@ const Editor = (props: Props, ref: ForwardedRef<CodeMirrorControl>) => {
 		return editor;
 	}, [editor]);
 
-	useEffect(() => {
-		if (!editor) {
-			return;
-		}
-
-		const contentScripts: ContentScriptData[] = [];
-		for (const pluginId in props.pluginStates) {
-			const pluginState = props.pluginStates[pluginId];
-			const codeMirrorContentScripts = pluginState.contentScripts[ContentScriptType.CodeMirrorPlugin] ?? [];
-
-			for (const contentScript of codeMirrorContentScripts) {
-				contentScripts.push({
-					pluginId,
-					contentScriptId: contentScript.id,
-					contentScriptJs: () => shim.fsDriver().readFile(contentScript.path),
-					loadCssAsset: (name: string) => {
-						const assetPath = dirname(contentScript.path);
-						const path = shim.fsDriver().resolveRelativePathWithinDir(assetPath, name);
-						return shim.fsDriver().readFile(path, 'utf8');
-					},
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-					postMessageHandler: (message: any) => {
-						const plugin = PluginService.instance().pluginById(pluginId);
-						return plugin.emitContentScriptMessage(contentScript.id, message);
-					},
-				});
-			}
-		}
-
-		void editor.setContentScripts(contentScripts);
-	}, [editor, props.pluginStates]);
+	useContentScriptRegistration({ editor, pluginStates: props.pluginStates });
 
 	useEffect(() => {
 		if (!editorContainerRef.current) return () => {};

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.ts
@@ -1,0 +1,98 @@
+import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
+import { ContentScriptData, ContentScriptLoadOptions } from '@joplin/editor/types';
+import { ContentScriptType } from '@joplin/lib/services/plugins/api/types';
+import PluginService from '@joplin/lib/services/plugins/PluginService';
+import { PluginStates } from '@joplin/lib/services/plugins/reducer';
+import shim from '@joplin/lib/shim';
+import { dirname } from 'path';
+import { useEffect, useId, useRef } from 'react';
+import bridge from '../../../../../../services/bridge';
+import type { ContentScriptRegistration } from '../../../../../../utils/customProtocols/handleCustomProtocols';
+
+interface Props {
+	editor: CodeMirrorControl;
+	pluginStates: PluginStates;
+}
+
+const useContentScriptRegistration = ({ editor, pluginStates }: Props) => {
+	const loadedContentScriptRefs = useRef(new Map<string, ContentScriptRegistration>());
+
+	const editorId = useId();
+	useEffect(() => {
+		if (!editor) {
+			return;
+		}
+
+		const contentScripts: ContentScriptData[] = [];
+		for (const pluginId in pluginStates) {
+			const pluginState = pluginStates[pluginId];
+			const codeMirrorContentScripts = pluginState.contentScripts[ContentScriptType.CodeMirrorPlugin] ?? [];
+
+			for (const contentScript of codeMirrorContentScripts) {
+				loadedContentScriptRefs.current.get(contentScript.id)?.revoke();
+
+				contentScripts.push({
+					pluginId,
+					contentScriptId: contentScript.id,
+					contentScriptJs: async (context) => {
+						const handle = await registerContentScriptWithMainProcess({
+							scriptPath: contentScript.path,
+							context,
+
+							// Ensure that the key is unique to the (pluginId, editorId, contentScript) set.
+							// Include the plugin ID to prevent ID collisions if multiple plugins register
+							// content scripts with the same ID:
+							key: `${editorId};${encodeURIComponent(pluginId)};${contentScript.id}`,
+						});
+						loadedContentScriptRefs.current.set(contentScript.id, handle);
+
+						return { uri: handle.uri };
+					},
+					loadCssAsset: (name: string) => {
+						const assetPath = dirname(contentScript.path);
+						const path = shim.fsDriver().resolveRelativePathWithinDir(assetPath, name);
+						return shim.fsDriver().readFile(path, 'utf8');
+					},
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+					postMessageHandler: (message: any) => {
+						const plugin = PluginService.instance().pluginById(pluginId);
+						return plugin.emitContentScriptMessage(contentScript.id, message);
+					},
+				});
+			}
+		}
+
+		void editor.setContentScripts(contentScripts);
+	}, [editor, pluginStates, editorId]);
+
+	useEffect(() => () => {
+		for (const script of loadedContentScriptRefs.current.values()) {
+			script.revoke();
+		}
+		loadedContentScriptRefs.current.clear();
+	}, []);
+};
+
+interface RegisterContentScriptOptions {
+	key: string; // A unique identifier for the content script
+	scriptPath: string;
+	context: ContentScriptLoadOptions;
+}
+
+const registerContentScriptWithMainProcess = async (
+	{ key, scriptPath, context }: RegisterContentScriptOptions,
+) => {
+	const contentScriptJs = [
+		context.contentScriptStartJs,
+		await shim.fsDriver().readFile(scriptPath),
+		context.contentScriptEndJs,
+	].join('\n');
+
+	const content = bridge().electronApp().getPluginProtocolHandler().registerContentScript(
+		encodeURIComponent(key),
+		contentScriptJs,
+	);
+	return content;
+};
+
+export default useContentScriptRegistration;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useContentScriptRegistration.ts
@@ -29,7 +29,11 @@ const useContentScriptRegistration = ({ editor, pluginStates }: Props) => {
 			const codeMirrorContentScripts = pluginState.contentScripts[ContentScriptType.CodeMirrorPlugin] ?? [];
 
 			for (const contentScript of codeMirrorContentScripts) {
-				loadedContentScriptRefs.current.get(contentScript.id)?.revoke();
+				// Ensure that the key is unique to the (pluginId, editorId, contentScript) set.
+				// Include the plugin ID to prevent ID collisions if multiple plugins register
+				// content scripts with the same ID:
+				const scriptId = `${pluginId}::${contentScript.id}`;
+				loadedContentScriptRefs.current.get(scriptId)?.revoke();
 
 				contentScripts.push({
 					pluginId,
@@ -39,12 +43,9 @@ const useContentScriptRegistration = ({ editor, pluginStates }: Props) => {
 							scriptPath: contentScript.path,
 							context,
 
-							// Ensure that the key is unique to the (pluginId, editorId, contentScript) set.
-							// Include the plugin ID to prevent ID collisions if multiple plugins register
-							// content scripts with the same ID:
-							key: `${editorId};${encodeURIComponent(pluginId)};${contentScript.id}`,
+							key: `${editorId}::${scriptId}`,
 						});
-						loadedContentScriptRefs.current.set(contentScript.id, handle);
+						loadedContentScriptRefs.current.set(scriptId, handle);
 
 						return { uri: handle.uri };
 					},

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -86,7 +86,7 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 		const result: NoteViewerControl = {
 			domReady: () => domReadyRef.current,
 			setHtml: (html: string, options: SetHtmlOptions) => {
-				const protocolHandler = bridge().electronApp().getCustomProtocolHandler();
+				const protocolHandler = bridge().electronApp().getContentProtocolHandler();
 
 				// Grant & remove asset access.
 				if (options.pluginAssets) {

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -9,7 +9,7 @@
 				connect-src 'self' * http://* https://* joplin-content://* blob: ;
 				style-src 'unsafe-inline' 'self' blob: joplin-content://* https://* http://* ;
 				child-src 'self' joplin-content://* https://*.youtube.com https://*.youtube-nocookie.com ;
-				script-src 'self' 'unsafe-inline' joplin-content://* ;
+				script-src 'self' joplin-plugin://* joplin-content://* ;
 				media-src 'self' * blob: data: https://* http://* joplin-content://* ;
 				img-src 'self' blob: data: http://* https://* joplin-content://* ;
 				font-src 'self' http://* https://* blob: data: joplin-content://* ;

--- a/packages/app-desktop/services/plugins/UserWebview.tsx
+++ b/packages/app-desktop/services/plugins/UserWebview.tsx
@@ -122,14 +122,16 @@ function UserWebview(props: Props, ref: any) {
 	} as React.CSSProperties), [contentSize.width, contentSize.height]);
 
 	const src = useMemo(() => {
-		const isolate = Setting.value('featureFlag.plugins.isolatePluginWebViews');
+		let isolate = Setting.value('featureFlag.plugins.isolatePluginWebViews');
+		isolate ||= needsIsolation(props.pluginId);
+
 		const path = toForwardSlashes(getAssetPath('services/plugins/UserWebviewIndex.html'));
 		if (isolate) {
 			return `joplin-content://plugin-webview/${path}`;
 		} else {
 			return `file://${path}`;
 		}
-	}, []);
+	}, [props.pluginId]);
 
 	return <iframe
 		id={props.viewId}
@@ -141,3 +143,9 @@ function UserWebview(props: Props, ref: any) {
 }
 
 export default forwardRef(UserWebview);
+
+const needsIsolation = (pluginId: string) => {
+	// Some plugins are broken unless isolated from the main application.
+	// Always enable isolation for these plugins, even if disabled in settings:
+	return ['joplin.plugin.note.tabs', 'joplin.plugin.benji.favorites', 'outline'].includes(pluginId);
+};

--- a/packages/app-desktop/services/plugins/hooks/useScriptLoader.ts
+++ b/packages/app-desktop/services/plugins/hooks/useScriptLoader.ts
@@ -4,7 +4,7 @@ import bridge from '../../bridge';
 // eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
 export default function(postMessage: Function, isReady: boolean, scripts: string[], cssFilePath: string) {
 	const protocolHandler = useMemo(() => {
-		return bridge().electronApp().getCustomProtocolHandler();
+		return bridge().electronApp().getContentProtocolHandler();
 	}, []);
 
 	useEffect(() => {

--- a/packages/app-desktop/utils/customProtocols/constants.ts
+++ b/packages/app-desktop/utils/customProtocols/constants.ts
@@ -2,5 +2,6 @@
 // the note viewer, etc.)
 export const contentProtocolName = 'joplin-content';
 
-// Protocol related to serving plugin content.
+// Protocol related to serving plugin content (e.g. editor content
+// scripts).
 export const pluginProtocolName = 'joplin-plugin';

--- a/packages/app-desktop/utils/customProtocols/constants.ts
+++ b/packages/app-desktop/utils/customProtocols/constants.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const contentProtocolName = 'joplin-content';
+export const pluginProtocolName = 'joplin-plugin';

--- a/packages/app-desktop/utils/customProtocols/constants.ts
+++ b/packages/app-desktop/utils/customProtocols/constants.ts
@@ -1,3 +1,6 @@
-// eslint-disable-next-line import/prefer-default-export
+// Protocol related to note content (e.g. attachments,
+// the note viewer, etc.)
 export const contentProtocolName = 'joplin-content';
+
+// Protocol related to serving plugin content.
 export const pluginProtocolName = 'joplin-plugin';

--- a/packages/app-desktop/utils/customProtocols/handleCustomProtocols.plugins.test.ts
+++ b/packages/app-desktop/utils/customProtocols/handleCustomProtocols.plugins.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+type ProtocolHandler = (request: Request)=> Promise<Response>;
+const customProtocols: Map<string, ProtocolHandler> = new Map();
+
+const handleProtocolMock = jest.fn((scheme: string, handler: ProtocolHandler) => {
+	customProtocols.set(scheme, handler);
+});
+
+jest.doMock('electron', () => {
+	return {
+		protocol: {
+			handle: handleProtocolMock,
+		},
+	};
+});
+
+import handleCustomProtocols from './handleCustomProtocols';
+
+const setUpProtocolHandler = () => {
+	const protocolHandler = handleCustomProtocols();
+
+	expect(handleProtocolMock).toHaveBeenCalled();
+
+	let onRequestListener;
+	for (const call of handleProtocolMock.mock.calls) {
+		if (call[0] === 'joplin-plugin') {
+			onRequestListener = call[1];
+		}
+	}
+
+	// Should have registered the protocol
+	expect(onRequestListener).toBeDefined();
+
+	return {
+		protocolHandler: protocolHandler.pluginContent,
+		onRequestListener,
+	};
+};
+
+
+describe('handleCustomProtocols.plugins', () => {
+	beforeEach(() => {
+		// Reset mocks between tests to ensure a clean testing environment.
+		customProtocols.clear();
+		handleProtocolMock.mockClear();
+	});
+
+	test('should return a 404 error response for unregistered content script paths', async () => {
+		const { onRequestListener } = setUpProtocolHandler();
+
+		const response = await onRequestListener(new Request('joplin-plugin://plugins/testing'));
+		expect(response.status).toBe(404);
+	});
+
+	test('should return a 405 method not supported response for non-get requests', async () => {
+		const { onRequestListener } = setUpProtocolHandler();
+
+		const response = await onRequestListener(new Request('joplin-plugin://plugins/testing', { method: 'POST' }));
+		expect(response.status).toBe(405);
+	});
+
+
+	test('should return a content script', async () => {
+		const { protocolHandler, onRequestListener } = setUpProtocolHandler();
+
+		const handle = protocolHandler.registerContentScript('some-id-here', 'test()');
+		const response = await onRequestListener(new Request(handle.uri));
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe('test()');
+		expect(response.headers.get('Content-Type')).toBe('application/javascript');
+	});
+
+	test('should return a 404 error after a content script has been removed', async () => {
+		const { protocolHandler, onRequestListener } = setUpProtocolHandler();
+
+		const handle = protocolHandler.registerContentScript('some-id-here', 'test()');
+		handle.revoke();
+		const response = await onRequestListener(new Request(handle.uri));
+		expect(response.status).toBe(404);
+	});
+});

--- a/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
@@ -1,7 +1,7 @@
 import { net, protocol } from 'electron';
 import { dirname, resolve, normalize } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { contentProtocolName } from './constants';
+import { contentProtocolName, pluginProtocolName } from './constants';
 import resolvePathWithinDir from '@joplin/lib/utils/resolvePathWithinDir';
 import * as fs from 'fs-extra';
 import { createReadStream } from 'fs';
@@ -12,7 +12,7 @@ export interface AccessController {
 	remove(): void;
 }
 
-export interface CustomProtocolHandler {
+export interface CustomContentProtocolHandler {
 	// note-viewer/ URLs
 	allowReadAccessToDirectory(path: string): void;
 	allowReadAccessToFile(path: string): AccessController;
@@ -21,6 +21,20 @@ export interface CustomProtocolHandler {
 	// file-media/ URLs
 	setMediaAccessEnabled(enabled: boolean): void;
 	getMediaAccessKey(): string;
+}
+
+export interface ContentScriptRegistration {
+	uri: string;
+	revoke: ()=> void;
+}
+
+export interface CustomPluginProtocolHandler {
+	registerContentScript(id: string, js: string): ContentScriptRegistration;
+}
+
+export interface CustomProtocolHandlers {
+	appContent: CustomContentProtocolHandler;
+	pluginContent: CustomPluginProtocolHandler;
 }
 
 
@@ -136,29 +150,20 @@ const makeNotFoundResponse = () => {
 	});
 };
 
-// Creating a custom protocol allows us to isolate iframes by giving them
-// different domain names from the main Joplin app.
-//
-// For example, an iframe with url joplin-content://note-viewer/path/to/iframe.html will run
-// in a different process from a parent frame with url file://path/to/iframe.html.
-//
-// See note_viewer_isolation.md for why this is important.
-//
-// TODO: Use Logger.create (doesn't work for now because Logger is only initialized
-// in the main process.)
-const handleCustomProtocols = (): CustomProtocolHandler => {
-	const logger = {
-		// Disabled for now
-		debug: (..._message: unknown[]) => {},
-	};
+type LoggerSlice = {
+	debug: (...message: unknown[])=> void;
+};
 
+const handleContentProtocol = (logger: LoggerSlice) => {
 	// Allow-listed files/directories for joplin-content://note-viewer/
 	const readableDirectories: string[] = [];
 	const readableFiles = new Map<string, number>();
 	// Access for joplin-content://file-media/
 	let mediaAccessKey: string|false = false;
 
-	// See also the protocol.handle example: https://www.electronjs.org/docs/latest/api/protocol#protocolhandlescheme-handler
+	const appBundleDirectory = dirname(dirname(__dirname));
+
+	// Serves main app content (e.g. the note viewer)
 	protocol.handle(contentProtocolName, async request => {
 		const url = new URL(request.url);
 		const host = url.host;
@@ -251,8 +256,7 @@ const handleCustomProtocols = (): CustomProtocolHandler => {
 		return response;
 	});
 
-	const appBundleDirectory = dirname(dirname(__dirname));
-	const result: CustomProtocolHandler = {
+	const result: CustomContentProtocolHandler = {
 		allowReadAccessToDirectory: (path: string) => {
 			path = resolve(appBundleDirectory, path);
 			logger.debug('protocol handler: Allow read access to directory', path);
@@ -306,6 +310,79 @@ const handleCustomProtocols = (): CustomProtocolHandler => {
 		},
 	};
 	return result;
+};
+
+const handlePluginProtocol = (logger: LoggerSlice) => {
+	const hostedContentScriptJs = new Map<string, string>(); // Maps from content script IDs to content script data
+	protocol.handle(pluginProtocolName, async request => {
+		const url = new URL(request.url);
+		const host = url.host;
+
+		if (host !== 'plugins') {
+			return new Response('Unknown hostname', { status: 400 });
+		}
+
+		if (request.method !== 'GET') {
+			return new Response('Unsupported request method', { status: 405 });
+		}
+
+		const contentScriptPath = '/content-script/';
+		if (url.pathname.startsWith(contentScriptPath)) {
+			const contentScriptId = url.pathname.substring(contentScriptPath.length);
+			logger.debug('Request for content script with ID', contentScriptId);
+
+			const js = hostedContentScriptJs.get(contentScriptId);
+			if (!js) {
+				return new Response('Content script not found', { status: 404 });
+			}
+
+			return new Response(js, {
+				headers: [
+					['Content-Type', 'application/javascript'],
+				],
+			});
+		} else {
+			return new Response('Path not found', { status: 404 });
+		}
+	});
+
+	const handler: CustomPluginProtocolHandler = {
+		registerContentScript: (id: string, js: string) => {
+			id = encodeURIComponent(id);
+			logger.debug('Registering content script with ID', id);
+
+			hostedContentScriptJs.set(id, js);
+
+			return {
+				uri: `${pluginProtocolName}://plugins/content-script/${id}`,
+				revoke: () => {
+					hostedContentScriptJs.delete(id);
+				},
+			};
+		},
+	};
+	return handler;
+};
+
+// Creating a custom protocol allows us to isolate iframes by giving them
+// different domain names from the main Joplin app.
+//
+// For example, an iframe with url joplin-content://note-viewer/path/to/iframe.html will run
+// in a different process from a parent frame with url file://path/to/iframe.html.
+//
+// See note_viewer_isolation.md for why this is important.
+//
+// See also the protocol.handle example: https://www.electronjs.org/docs/latest/api/protocol#protocolhandlescheme-handler
+//
+const handleCustomProtocols = (): CustomProtocolHandlers => {
+	const logger = {
+		// Disabled for now
+		debug: (..._message: unknown[]) => {},
+	};
+
+	const appContent = handleContentProtocol(logger);
+	const pluginContent = handlePluginProtocol(logger);
+	return { appContent, pluginContent };
 };
 
 export default handleCustomProtocols;

--- a/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
@@ -348,6 +348,10 @@ const handlePluginProtocol = (logger: LoggerSlice) => {
 
 	const handler: CustomPluginProtocolHandler = {
 		// Hosts a content script with the given `js` using the plugin protocol.
+		// This can be used to allow loading trusted plugin JavaScript without relying on eval,
+		// inline scripts, or other techniques that would violate the application's
+		// Content-Security-Policy.
+		//
 		// Caution: This assumes that `js` is provided by a trusted source. Be careful
 		// when building/providing `js` to this function.
 		registerContentScript: (id: string, js: string) => {

--- a/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/handleCustomProtocols.ts
@@ -347,6 +347,9 @@ const handlePluginProtocol = (logger: LoggerSlice) => {
 	});
 
 	const handler: CustomPluginProtocolHandler = {
+		// Hosts a content script with the given `js` using the plugin protocol.
+		// Caution: This assumes that `js` is provided by a trusted source. Be careful
+		// when building/providing `js` to this function.
 		registerContentScript: (id: string, js: string) => {
 			id = encodeURIComponent(id);
 			logger.debug('Registering content script with ID', id);

--- a/packages/app-desktop/utils/customProtocols/registerCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/registerCustomProtocols.ts
@@ -1,11 +1,11 @@
 
-import { protocol } from 'electron';
+import { Privileges, protocol } from 'electron';
 import { contentProtocolName, pluginProtocolName } from './constants';
 
 // This must be called before Electron's onReady event.
 // handleCustomProtocols should be called separately, after onReady.
 const registerCustomProtocols = async () => {
-	const contentProtocolPrivileges = {
+	const contentProtocolPrivileges: Privileges = {
 		supportFetchAPI: true,
 
 		// Don't trigger mixed content warnings (see https://stackoverflow.com/a/75988466)
@@ -22,12 +22,9 @@ const registerCustomProtocols = async () => {
 	};
 	// The plugin protocol is currently only used for serving JS and doesn't require as
 	// broad privileges.
-	const pluginProtocolPrivileges = {
+	const pluginProtocolPrivileges: Privileges = {
 		secure: true,
 		standard: true,
-		// Support the fetch API to fix "fetch failed" errors for source map requests.
-		// (Note: Currently all source map requests will return 404)
-		supportFetchApi: true,
 	};
 	protocol.registerSchemesAsPrivileged([
 		{ scheme: contentProtocolName, privileges: contentProtocolPrivileges },

--- a/packages/app-desktop/utils/customProtocols/registerCustomProtocols.ts
+++ b/packages/app-desktop/utils/customProtocols/registerCustomProtocols.ts
@@ -1,11 +1,11 @@
 
 import { protocol } from 'electron';
-import { contentProtocolName } from './constants';
+import { contentProtocolName, pluginProtocolName } from './constants';
 
 // This must be called before Electron's onReady event.
 // handleCustomProtocols should be called separately, after onReady.
 const registerCustomProtocols = async () => {
-	const protocolPrivileges = {
+	const contentProtocolPrivileges = {
 		supportFetchAPI: true,
 
 		// Don't trigger mixed content warnings (see https://stackoverflow.com/a/75988466)
@@ -20,8 +20,18 @@ const registerCustomProtocols = async () => {
 		corsEnabled: true,
 		codeCache: true,
 	};
+	// The plugin protocol is currently only used for serving JS and doesn't require as
+	// broad privileges.
+	const pluginProtocolPrivileges = {
+		secure: true,
+		standard: true,
+		// Support the fetch API to fix "fetch failed" errors for source map requests.
+		// (Note: Currently all source map requests will return 404)
+		supportFetchApi: true,
+	};
 	protocol.registerSchemesAsPrivileged([
-		{ scheme: contentProtocolName, privileges: protocolPrivileges },
+		{ scheme: contentProtocolName, privileges: contentProtocolPrivileges },
+		{ scheme: pluginProtocolName, privileges: pluginProtocolPrivileges },
 	]);
 };
 

--- a/packages/app-mobile/contentScripts/markdownEditorBundle/utils/useCodeMirrorPlugins.ts
+++ b/packages/app-mobile/contentScripts/markdownEditorBundle/utils/useCodeMirrorPlugins.ts
@@ -33,8 +33,14 @@ const useCodeMirrorPlugins = (pluginStates: PluginStates) => {
 				plugins.push({
 					pluginId,
 					contentScriptId,
-					contentScriptJs: async () => {
-						return await shim.fsDriver().readFile(contentScript.path);
+					contentScriptJs: async (context) => {
+						return {
+							sourceJs: [
+								context.contentScriptStartJs,
+								await shim.fsDriver().readFile(contentScript.path),
+								context.contentScriptEndJs,
+							].join('\n'),
+						};
 					},
 					loadCssAsset: (name: string) => {
 						// TODO: This logic is currently shared with app-desktop. Refactor

--- a/packages/editor/CodeMirror/createEditor.test.ts
+++ b/packages/editor/CodeMirror/createEditor.test.ts
@@ -9,7 +9,20 @@ import loadLanguages from './testing/loadLanguages';
 
 import { expect, describe, it } from '@jest/globals';
 import createEditorSettings from '../testing/createEditorSettings';
+import { ContentScriptLoadOptions } from '../types';
 
+const getMockContentScriptSource = (context: ContentScriptLoadOptions) => {
+	return {
+		sourceJs: `
+			${context.contentScriptStartJs}
+			exports.default = context => {
+				context.postMessage(context.pluginId);
+				return {};
+			};
+			${context.contentScriptEndJs}
+		`,
+	};
+};
 
 describe('createEditor', () => {
 	beforeAll(() => {
@@ -76,13 +89,8 @@ describe('createEditor', () => {
 			resolveImageSrc: src=>Promise.resolve(src),
 		});
 
-		const getContentScriptJs = jest.fn(async () => {
-			return `
-				exports.default = context => {
-					context.postMessage(context.pluginId);
-					return {};
-				};
-			`;
+		const getContentScriptJs = jest.fn(async (context) => {
+			return getMockContentScriptSource(context);
 		});
 		const postMessageHandler = jest.fn();
 
@@ -147,13 +155,8 @@ describe('createEditor', () => {
 			resolveImageSrc: src=>Promise.resolve(src),
 		});
 
-		const getContentScriptJs = jest.fn(async () => {
-			return `
-				exports.default = context => {
-					context.postMessage(context.pluginId);
-					return {};
-				};
-			`;
+		const getContentScriptJs = jest.fn(async (context) => {
+			return getMockContentScriptSource(context);
 		});
 		const postMessageHandler = jest.fn();
 

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -85,7 +85,7 @@ export interface ContentScriptLoadOptions {
 	// The startJs/endJs options are responsible for setting up the content script
 	// environment and, among other things, should:
 	// - Set up `joplin.require`.
-	// - Forward `modules.exports` to the editor.
+	// - Forward `module.exports` to the editor.
 	// - Notify the editor when the content script has finished loading.
 	//
 	// The content script should be built similar to the following:

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -81,12 +81,37 @@ export enum EditorCommandType {
 	JumpToHash = 'jumpToHash',
 }
 
+export interface ContentScriptLoadOptions {
+	// The startJs/endJs options are responsible for setting up the content script
+	// environment and, among other things, should:
+	// - Set up `joplin.require`.
+	// - Forward `modules.exports` to the editor.
+	// - Notify the editor when the content script has finished loading.
+	//
+	// The content script should be built similar to the following:
+	//
+	//    const scriptContent = `${contentScriptStartJs}${content}${contentScriptEndJs}`;
+	//
+	contentScriptStartJs: string;
+	contentScriptEndJs: string;
+}
+
+type ContentScriptUriSource = {
+	sourceJs?: undefined;
+	uri: string;
+};
+type ContentScriptInlineSource = {
+	sourceJs: string;
+	uri?: undefined;
+};
+type ContentScriptJs = ContentScriptUriSource|ContentScriptInlineSource;
+
 // Because the editor package can run in a WebView, plugin content scripts
 // need to be provided as text, rather than as file paths.
 export interface ContentScriptData {
 	pluginId: string;
 	contentScriptId: string;
-	contentScriptJs: ()=> Promise<string>;
+	contentScriptJs: (context: ContentScriptLoadOptions)=> Promise<ContentScriptJs>;
 	loadCssAsset: (name: string)=> Promise<string>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	postMessageHandler: (message: any)=> any;


### PR DESCRIPTION
# Summary

This change makes [cross-site-scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks more difficult in the Joplin desktop application by disallowing inline string event handlers and inline `<script>` blocks in the main application window.

> [!IMPORTANT]
>
> **Plugin API breaking change**:
> By default, this change blocks inline scripts and event handlers in plugin WebViews (e.g. the `onclick` on `<button onclick="alert()">test</button>` will be blocked). Plugins can still use inline event handlers and script blocks in the Markdown viewer. (See ["Note viewer isolation"](https://joplinapp.org/help/dev/spec/note_viewer_isolation)).
>
> **Workaround**: If necessary, plugins broken by this change can be added to a list in the `needsIsolation` function. The WebViews for these plugins will be hosted from a different URL with no default Content-Security-Policy. This can also be enabled globally by setting `featureFlag.plugins.isolatePluginWebViews` to `true`.
>
> Please let me know if a specific plugin needs to be added to the legacy plugins list!

# Details

This pull request updates the desktop app's [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) to remove [`unsafe-inline`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#unsafe_inline_script) from list of allowed sources for `scripts`.

This change disallows inline event handlers (e.g. `onclick="alert()"`) and inline script blocks (e.g. `<script>`). This protects against certain types of XSS attacks.

See also: A [similar (merged) pull request](https://github.com/laurent22/joplin/pull/12106) that blocked inline event handlers for the Rich Text Editor.


## Goals

This pull request should:
- Make it safer to load rendered content in plugin panels/webviews.
- Make untrusted HTML rendering bugs less significant.

## See also

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
- https://github.com/laurent22/joplin/pull/12106
- https://github.com/laurent22/joplin/pull/13288

# Testing

## Core functionality

- [x] It's possible to edit notes in the Markdown editor
- [x] It's possible to edit notes in the Rich Text editor
- [x] It's possible to open notes in new windows.
- [x] Links work in the note viewer.
- [x] It's possible to export a note as a PDF from "go to anything", then attach it to a note.

## Plugins

- [x] The YesYouKan plugin loads and can be used to edit a Kanban board.
- [x] The Freehand Drawing plugin loads and can be used to create an image.
- [x] The RevealJS slides plugin loads and it's possible to present a note as a slide deck.
- [x] The Extra Editor Settings plugin loads and displays line numbers in the editor.
- [x] The Rich Markdown plugin:
    - Loads
    - Adds items to the context menu when right-clicking on a note link in the Markdown editor.
    - Adds list item line wrapping styles.
- [x] The debug tool plugin: Adds a panel with information about the current note. The cross-item links in the panel work.
- [x] Quick links: It's possible to create links to notes from the Markdown editor.
- [x] Math mode: Inline math works in the Markdown editor.
- [x] Note tabs, outline, and favorites:
    - **Broken, fixed by applying a workaround**: These were originally broken, but have been added to a list of legacy plugins in `needsIsolation` (see the "Note" section above).
- [ ] Other plugins?

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added support for a separate plugin content protocol alongside app content, and dual protocol handlers.
  - Editor now uses a hook for dynamic content‑script registration and supports inline or external plugin scripts.
  - Webview isolation now applies per‑plugin fallback for specific plugins.

* **Security Improvements**
  - Tightened Content‑Security‑Policy: disallow inline scripts and allow plugin scheme.

* **Tests**
  - Split and expanded tests covering custom protocol behaviour and plugin content scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->