### PR TITLE
Desktop: Resolves #13794: Add Close Window shortcut and menu item on Windows/Linux

### DIFF
--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -615,6 +615,18 @@ function useMenu(props: Props) {
 
 				...(shim.isMac() ? [] : profilesAndAppInstancesItems),
 
+				shim.isMac() ? noItem : {
+					type: 'separator',
+				},
+
+				shim.isMac() ? noItem : {
+					label: _('Close Window'),
+					accelerator: keymapService.getAccelerator('closeWindow'),
+					click: () => {
+						bridge().activeWindow()?.close();
+					},
+				},
+
 				shim.isMac() ? {
 					label: _('Hide %s', 'Joplin'),
 					platforms: ['darwin'],

--- a/packages/lib/services/KeymapService.test.js
+++ b/packages/lib/services/KeymapService.test.js
@@ -115,14 +115,17 @@ describe('services_KeymapService', () => {
 			expect(keymapService.getAccelerator('synchronize')).toEqual('Cmd+S');
 			expect(keymapService.getAccelerator('textSelectAll')).toEqual('Cmd+A');
 			expect(keymapService.getAccelerator('textBold')).toEqual('Cmd+B');
+			expect(keymapService.getAccelerator('closeWindow')).toEqual('Cmd+W');
 
 			keymapService.initialize([], 'linux');
 			expect(keymapService.getAccelerator('newNote')).toEqual('Ctrl+N');
 			expect(keymapService.getAccelerator('synchronize')).toEqual('Ctrl+S');
+			expect(keymapService.getAccelerator('closeWindow')).toEqual('Ctrl+W');
 
 			keymapService.initialize([], 'win32');
 			expect(keymapService.getAccelerator('textSelectAll')).toEqual('Ctrl+A');
 			expect(keymapService.getAccelerator('textBold')).toEqual('Ctrl+B');
+			expect(keymapService.getAccelerator('closeWindow')).toEqual('Ctrl+W');
 		});
 
 		it('should throw when an invalid command is requested', () => {

--- a/packages/lib/services/KeymapService.ts
+++ b/packages/lib/services/KeymapService.ts
@@ -73,6 +73,7 @@ const defaultKeymapItems = {
 		{ accelerator: 'Ctrl+T', command: 'newTodo' },
 		{ accelerator: 'Ctrl+S', command: 'synchronize' },
 		{ accelerator: 'Ctrl+Q', command: 'quit' },
+		{ accelerator: 'Ctrl+W', command: 'closeWindow' },
 		{ accelerator: 'Ctrl+C', command: 'textCopy' },
 		{ accelerator: 'Ctrl+X', command: 'textCut' },
 		{ accelerator: 'Ctrl+V', command: 'textPaste' },


### PR DESCRIPTION
## Summary

On macOS, secondary windows (opened via "Open note in new window") can be closed with `Cmd+W` using the existing "Close Window" menu item. On Windows and Linux, there is no equivalent keyboard shortcut or menu item, making it impossible to close secondary windows without window decorations (common on tiling window managers).

This PR adds:
- A **`Ctrl+W` keyboard shortcut** mapped to `closeWindow` in the Windows/Linux default keymap
- A **"Close Window" menu item** in the File menu on Windows/Linux

The shortcut and menu item close whichever window is currently focused. For secondary windows, this closes the window. For the main window, this follows the existing platform behavior (hide to tray if tray icon is shown or secondary windows exist, otherwise quit).

## How it works

The implementation leverages the existing `closeWindow` infrastructure that was already in place for macOS:

1. **KeymapService default keymaps** (`packages/lib/services/KeymapService.ts`): Added `{ accelerator: 'Ctrl+W', command: 'closeWindow' }` to the `default` (Windows/Linux) keymap array. The macOS keymap already has `Cmd+W` mapped to `closeWindow`.

2. **File menu** (`packages/app-desktop/gui/MenuBar.tsx`): Added a "Close Window" menu item to the Windows/Linux File menu, placed between the profiles section and the quit section. The click handler calls `bridge().activeWindow()?.close()`, which returns `BrowserWindow.getFocusedWindow()` and triggers the existing close event handlers:
   - **Secondary windows**: The `window.once('close')` handler in `ElectronAppWrapper.ts` removes the window from tracking, and the React Portal cleanup dispatches the `WINDOW_CLOSE` Redux action to clean up state.
   - **Main window**: The `win_.on('close')` handler in `ElectronAppWrapper.ts` applies the existing platform-specific behavior (hide if tray or secondary windows exist, otherwise initiate quit).

3. **Automated tests** (`packages/lib/services/KeymapService.test.js`): Added assertions verifying `closeWindow` returns `Ctrl+W` on Linux and Win32, and `Cmd+W` on macOS.

No new files were created. No new commands were added to the CommandService — `closeWindow` follows the same pattern as `quit`, `hideApp`, and `minimizeWindow`, which are keymap-only entries handled directly as menu items.

## Manual testing plan

Since the MenuBar component has no existing test infrastructure, the following manual tests should be performed on Windows or Linux:

### Feature tests

1. **Secondary window — keyboard shortcut**: Open a note in a new window (`Ctrl+Alt+N`). Focus the secondary window. Press `Ctrl+W`. **Expected**: The secondary window closes. The main window remains open with its original note.

2. **Secondary window — menu item**: Open a note in a new window. Focus the secondary window. Click File > Close Window. **Expected**: The secondary window closes.

3. **Multiple secondary windows**: Open two notes in separate new windows. Close one with `Ctrl+W`. **Expected**: Only the focused secondary window closes. The other secondary window and the main window remain.

4. **Main window with tray icon**: Enable the tray icon (Options > Appearance > Show tray icon). Focus the main window. Press `Ctrl+W`. **Expected**: The main window hides to the tray. The app continues running.

5. **Main window with secondary windows open**: Open a secondary window. Focus the main window. Press `Ctrl+W`. **Expected**: The main window hides. The secondary window remains visible.

6. **Main window alone**: Ensure no tray icon and no secondary windows. Press `Ctrl+W`. **Expected**: The application quits.

7. **Shortcut customization**: Go to Options > Keyboard Shortcuts. Verify `closeWindow` appears with `Ctrl+W` as default. Change it. **Expected**: The new shortcut works; `Ctrl+W` no longer does.

### Regression tests

8. **macOS unchanged**: `Cmd+W` still works. The new menu item is not visible on macOS.
9. **Quit shortcut**: `Ctrl+Q` still quits the application.
10. **Open in new window**: `Ctrl+Alt+N` still opens notes in a new window.
11. **Editor shortcuts**: `Ctrl+C`, `Ctrl+V`, `Ctrl+Z`, `Ctrl+B`, etc. still work. No conflict with `Ctrl+W`.

## Notes

- The test file `KeymapService.test.js` is JavaScript. Per the coding style guide, JS files should ideally be converted to TypeScript before modification. Since this PR adds only 3 assertions to an existing 345-line test file, converting the entire file would be out of scope for this PR.
- KosmKero volunteered to work on this issue on Jan 1, but no PR has been submitted in over 5 weeks and the issue remains unassigned.

Resolves #13794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Close Window menu option in the File menu for Windows and Linux users.
  * Implemented keyboard shortcuts for closing windows: Ctrl+W on Windows/Linux and Cmd+W on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->