### PR TITLE
Fix broken internal links in documentation

### DIFF
--- a/readme/apps/sync/s3.md
+++ b/readme/apps/sync/s3.md
@@ -81,6 +81,6 @@ If you provide a configuration and you receive "success!" on the "check config" 
 - Force Path Style: unchecked
 
 ## Tebi
-- URL: `https://s3.tebi.io` ((This is the endpoint URL provided by Tebi)
+- URL: `https://s3.tebi.io` (This is the endpoint URL provided by Tebi)
 - Region: required
 - Force Path Style: unchecked

--- a/readme/dev/gsoc/gsoc2020/index.md
+++ b/readme/dev/gsoc/gsoc2020/index.md
@@ -24,7 +24,7 @@ The GUI's, as listed on the [Joplin's website](https://joplinapp.org/help/#insta
 More details can be found on:
 
 - [How to contribute](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md)
-- [How to build](https://github.com/laurent22/joplin/blob/dev/BUILD.md)
+- [How to build](https://github.com/laurent22/joplin/blob/dev/readme/dev/BUILD.md)
 
 Moreover there are community driven projects such as:
 

--- a/readme/dev/gsoc/gsoc2022/index.md
+++ b/readme/dev/gsoc/gsoc2022/index.md
@@ -17,7 +17,7 @@ All participants will need a Google account in order to join the program. So, sa
 We suggest you read carefully these important documents and bookmark the links as you will need to refer to them throughout GSoC:
 
 - [How to submit a pull request for GSoC](https://joplinapp.org/help/dev/gsoc/gsoc2022/pull_request_guidelines/)
-- [How to build the apps](https://github.com/laurent22/joplin/blob/dev/help/dev/BUILD.md)
+- [How to build the apps](https://github.com/laurent22/joplin/blob/dev/readme/dev/BUILD.md)
 - [How to contribute](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md)
 
 ## Programming Language

--- a/readme/dev/gsoc/gsoc2023/ideas.md
+++ b/readme/dev/gsoc/gsoc2023/ideas.md
@@ -156,5 +156,5 @@ Potential Mentor(s):
 ## More info
 
 - Make sure you read the [Joplin Google Summer of Code Introduction](https://joplinapp.org/help/dev/gsoc/gsoc2023)
-- To build the application, please read [BUILD.md](https://github.com/laurent22/joplin/blob/dev/help/dev/BUILD.md)
+- To build the application, please read [BUILD.md](https://github.com/laurent22/joplin/blob/dev/readme/dev/BUILD.md)
 - And before creating a pull request, please read the [pull request guidelines](https://github.com/laurent22/joplin/blob/dev/readme/dev/gsoc/gsoc2023/pull_request_guidelines.md)

--- a/readme/dev/gsoc/gsoc2023/index.md
+++ b/readme/dev/gsoc/gsoc2023/index.md
@@ -17,7 +17,7 @@ All participants will need a Google account in order to join the program. So, sa
 We suggest you read carefully these important documents and bookmark the links as you will need to refer to them throughout GSoC:
 
 - [How to submit a pull request for GSoC](https://joplinapp.org/help/dev/gsoc/gsoc2023/pull_request_guidelines/)
-- [How to build the apps](https://github.com/laurent22/joplin/blob/dev/help/dev/BUILD.md)
+- [How to build the apps](https://github.com/laurent22/joplin/blob/dev/readme/dev/BUILD.md)
 - [How to contribute](https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md)
 
 ## Programming Language

--- a/readme/dev/gsoc/gsoc2024/ideas.md
+++ b/readme/dev/gsoc/gsoc2024/ideas.md
@@ -1,6 +1,6 @@
 # GSoC 2024 Ideas
 
-This is another round for Joplin at Google Summer of Code. Detailed information on how to get involved and apply are given in the [general Summer of Code introduction](https://joplinapp.org/help/dev/gsoc/gsoc2023/)
+This is another round for Joplin at Google Summer of Code. Detailed information on how to get involved and apply are given in the [general Summer of Code introduction](https://joplinapp.org/help/dev/gsoc/gsoc2024/)
 
 **These are all proposals! We are open to new ideas you might have!!** Do you have an awesome idea you want to work on with Joplin but that is not among the ideas below? That's cool. We love that! But please do us a favour: Get in touch with a mentor early on and make sure your project is realistic and within the scope of Joplin.
 

--- a/readme/dev/spec/architecture.md
+++ b/readme/dev/spec/architecture.md
@@ -2,7 +2,7 @@
 
 Joplin as a project is organised around three main components:
 
-- The user applications: For [desktop](https://github.com/laurent22/joplin/blob/dev/readme/apps/desktop.md), [mobile](https://github.com/laurent22/joplin/blob/dev/readme/apps/mobile.md) and [CLI](https://github.com/laurent22/joplin/blob/dev/readme/apps/terminal.md))
+- The user applications: For [desktop](https://github.com/laurent22/joplin/blob/dev/readme/apps/desktop.md), [mobile](https://github.com/laurent22/joplin/blob/dev/readme/apps/mobile.md) and [CLI](https://github.com/laurent22/joplin/blob/dev/readme/apps/terminal.md)
 - [Joplin Server](https://github.com/laurent22/joplin/blob/dev/packages/server/README.md)
 - [Web Clipper](https://github.com/laurent22/joplin/blob/dev/readme/apps/clipper.md)
 
@@ -67,6 +67,6 @@ It is developed using the [WebExtensions API](https://extensionworkshop.com/docu
 ## More information
 
 - [Plugin Architecture spec](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/plugins.md)
-- [E2EE: Technical spec](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee.md)
+- [E2EE: Technical spec](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee/index.md)
 - [E2EE: Workflow](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee/workflow.md)
 - [All Joplin technical specifications](https://github.com/laurent22/joplin/tree/dev/readme/dev/spec)

--- a/readme/dev/spec/sync.md
+++ b/readme/dev/spec/sync.md
@@ -89,5 +89,5 @@ interface SyncTargetInfo {
 ## See also
 
 - [Synchronisation lock](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/sync_lock.md)
-- [E2EE: Technical spec](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee.md)
+- [E2EE: Technical spec](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee/index.md)
 - [E2EE: Workflow](https://github.com/laurent22/joplin/blob/dev/readme/dev/spec/e2ee/workflow.md)


### PR DESCRIPTION
## Summary

- Fix extra closing parenthesis in CLI link in architecture.md
- Fix E2EE spec links pointing to non-existent `spec/e2ee.md` (should be `spec/e2ee/index.md`) in architecture.md and sync.md
- Fix BUILD.md paths using old `help/dev/` or root path instead of `readme/dev/` in GSoC 2020-2023 docs
- Fix GSoC 2024 introduction link incorrectly pointing to `gsoc2023/` instead of `gsoc2024/`
- Fix extra opening parenthesis in S3 sync docs (s3.md)

## Test plan

- [x] Verify each fixed link resolves to the correct file on GitHub
- [x] Confirm no unintended changes via diff review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple documentation links to point to the correct file locations across developer guides.
  * Fixed a typo in the S3 configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->