### PR TITLE
Fix typos and grammar in developer documentation

### DIFF
--- a/readme/api/get_started/plugins.md
+++ b/readme/api/get_started/plugins.md
@@ -4,7 +4,7 @@ In this article you will learn the basic steps to build and test a plugin in Jop
 
 ## Setting up your environment
 
-First you need to setup your environment:
+First you need to set up your environment:
 
 - Make sure you have [Node.js](https://nodejs.org/) and [git](https://git-scm.com) installed.
 - Install [Joplin](https://joplinapp.org/)

--- a/readme/api/references/plugin_theming.md
+++ b/readme/api/references/plugin_theming.md
@@ -2,7 +2,7 @@
 
 ## CSS
 
-Plugins add custom content to the UI using [webview panels](https://joplinapp.org/api/references/plugin_api/classes/joplinviewspanels.html). The HTML content of a a panel is styled with CSS.
+Plugins add custom content to the UI using [webview panels](https://joplinapp.org/api/references/plugin_api/classes/joplinviewspanels.html). The HTML content of a panel is styled with CSS.
 
 To keep the look and feel of a plugin consistent with the rest of the Joplin UI, you are automatically provided with variables derived from the current theme.
 
@@ -60,4 +60,4 @@ const App = () => {
 export default App;
 ```
 
-If you are not using React, just ask ChatGPT on how to do the above using you preferred JS framework.
+If you are not using React, just ask ChatGPT on how to do the above using your preferred JS framework.

--- a/readme/api/references/rest_api.md
+++ b/readme/api/references/rest_api.md
@@ -35,7 +35,7 @@ If needed you may also [request the token programmatically](https://github.com/l
 
 ## Using the API
 
-All the calls, unless noted otherwise, receives and send **JSON data**. For example to create a new note:
+All the calls, unless noted otherwise, receive and send **JSON data**. For example to create a new note:
 
 ```shell
 curl --data '{ "title": "My note", "body": "Some note in **Markdown**"}' http://localhost:41184/notes
@@ -101,7 +101,7 @@ Then you will resume fetching the results using this query:
 curl http://localhost:41184/notes?order_by=updated_time&order_dir=ASC&limit=10&page=2
 ```
 
-Eventually you will get some results that do not contain an "has_more" parameter, at which point you will have retrieved all the results
+Eventually you will get some results that do not contain a "has_more" parameter, at which point you will have retrieved all the results
 
 As an example the pseudo-code below could be used to fetch all the notes:
 
@@ -136,7 +136,7 @@ Call **GET /ping** to check if the service is available. It should return "Jopli
 
 ## Searching
 
-Call **GET /search?query=YOUR_QUERY** to search for notes. This end-point supports the `field` parameter which is recommended to use so that you only get the data that you need. The query syntax is as described in the main documentation: https://joplinapp.org/help/apps/search
+Call **GET /search?query=YOUR_QUERY** to search for notes. This end-point supports the `fields` parameter which is recommended to use so that you only get the data that you need. The query syntax is as described in the main documentation: https://joplinapp.org/help/apps/search
 
 To retrieve non-notes items, such as notebooks or tags, add a `type` parameter and set it to the required [item type name](#item-type-ids). In that case, full text search will not be used - instead it will be a simple case-insensitive search. You can also use `*` as a wildcard. This is convenient for example to retrieve notebooks or tags by title.
 
@@ -212,7 +212,7 @@ command | 16
 
 Gets all notes
 
-By default, this call will return the all notes **except** the notes in the trash folder and any conflict note. To include these too, you can specify `include_deleted=1` and `include_conflicts=1` as query parameters.
+By default, this call will return all notes **except** the notes in the trash folder and any conflict note. To include these too, you can specify `include_deleted=1` and `include_conflicts=1` as query parameters.
 
 ### GET /notes/:id
 

--- a/readme/api/tutorials/cm6_plugin.md
+++ b/readme/api/tutorials/cm6_plugin.md
@@ -57,7 +57,7 @@ To do this, replace the contents of `webpack.config.js` with [the unreleased ver
 
 Now that the plugin has been created, we can create and register a CodeMirror content script.
 
-Start by opening `plugin.config.json`.It should look similar to this:
+Start by opening `plugin.config.json`. It should look similar to this:
 ```json
 {
 	"extraScripts": []

--- a/readme/api/tutorials/toc_plugin.md
+++ b/readme/api/tutorials/toc_plugin.md
@@ -3,9 +3,9 @@ sidebar_position: 1
 ---
 # Creating a table of contents plugin
 
-This tutorial will guide you through the steps to create a table of contents plugin for Joplin. It will display a view next to the current note that will contain links to the sections of a note. It will be possible to click on one of the header to jump to the relevant section.
+This tutorial will guide you through the steps to create a table of contents plugin for Joplin. It will display a view next to the current note that will contain links to the sections of a note. It will be possible to click on one of the headers to jump to the relevant section.
 
-Through this tutorial you will learn about several aspect of the Joplin API, including:
+Through this tutorial you will learn about several aspects of the Joplin API, including:
 
 - The plugin API
 - How to create a webview
@@ -260,7 +260,7 @@ Try the plugin and the styling should be improved. You may also try to switch to
 
 ## Making the webview interactive
 
-The next step is to make the TOC interactive so that when the user clicks on a link, the note is scrolled to right header. This can be done using an external JavaScript file that will handle the click events. As for the CSS file, create a `webview.js` file next to `index.ts`, then add the script to the webview:
+The next step is to make the TOC interactive so that when the user clicks on a link, the note is scrolled to the right header. This can be done using an external JavaScript file that will handle the click events. As for the CSS file, create a `webview.js` file next to `index.ts`, then add the script to the webview:
 
 ```typescript
 // In index.ts

--- a/readme/dev/BUILD.md
+++ b/readme/dev/BUILD.md
@@ -118,4 +118,4 @@ The application was originally written in JavaScript, however it has slowly been
 
 ## Troubleshooting
 
-Please read for the [Build Troubleshooting Document](https://github.com/laurent22/joplin/blob/dev/readme/dev/build_troubleshooting.md) for various tips on how to get the build working.
+Please read the [Build Troubleshooting Document](https://github.com/laurent22/joplin/blob/dev/readme/dev/build_troubleshooting.md) for various tips on how to get the build working.

--- a/readme/dev/DEPLOY.md
+++ b/readme/dev/DEPLOY.md
@@ -18,7 +18,7 @@ The desktop application is built for Windows, macOS and Linux via continuous int
 
 ## Android application
 
-The app is built and upload to GitHub using:
+The app is built and uploaded to GitHub using:
 
 	yarn releaseAndroid --type=prerelease
 

--- a/readme/dev/coding_style.md
+++ b/readme/dev/coding_style.md
@@ -263,7 +263,7 @@ Use the provided escape functions in `lib/markdownUtils`:
 
 - `escapeTableCell()` for tables
 - `escapeInlineCode()` for inline code
-- `escapeTitleText()`and `escapeLinkUrl()` for links:
+- `escapeTitleText()` and `escapeLinkUrl()` for links:
 
 ```ts
 const markdown = `[${markdownUtils.escapeTitleText(linkTitle)}](${markdownUtils.escapeLinkUrl(linkUrl)})`;
@@ -384,7 +384,7 @@ We use `snake_case` for table names and column names.
 
 ### Everything is NOT NULL
 
-All columns should be defined as `NOT NULL`, possibly with a default value (but see below). This helps keeping queries more simple as we don't have to do check for both `NULL` and `0` or empty string.
+All columns should be defined as `NOT NULL`, possibly with a default value (but see below). This helps keeping queries more simple as we don't have to check for both `NULL` and `0` or empty string.
 
 ### Use defaults sparingly
 
@@ -392,7 +392,7 @@ Don't automatically give a default value to a column - in many cases it's better
 
 ### Use an integer for enum-like values
 
-If a column can be set to a fixed number of values, please set the type to integer. In code, you would then have a TypeScript enum that defines what each values is for. For example:
+If a column can be set to a fixed number of values, please set the type to integer. In code, you would then have a TypeScript enum that defines what each value is for. For example:
 
 ```typescript
 export enum Action {
@@ -447,11 +447,11 @@ const data = await service.readConfig('/path/to/file.json');
 expect(data.version).toBe(1);
 ```
 
-### Avoid spying on method
+### Avoid spying on methods
 
 In unit testing, spying means creating a mock function (a spy) for a specific method of an object.
 
-Like mock objects, spies should be avoided whenever possible because they usually test implementation details that may change in the future. And having many spies makes refactoring difficult since we need to update tests that should not have been broken to being with, since the input and output of the algorithm hasn't changed.
+Like mock objects, spies should be avoided whenever possible because they usually test implementation details that may change in the future. And having many spies makes refactoring difficult since we need to update tests that should not have been broken to begin with, since the input and output of the algorithm hasn't changed.
 
 This is not a hard rule as spies are sometimes useful, but it should only be used when there's no other option.
 
@@ -490,7 +490,7 @@ We aren't using these guides, but they may still be helpful!
 * [TypeScript Deep Dive — Style Guide](https://basarat.gitbook.io/typescript/styleguide)
 * [Google TypeScript style guide](https://google.github.io/styleguide/tsguide.html)
 	* See also [`ts.dev`'s style guide](https://ts.dev/style/#function-expressions), which is based on the Google style guide.
-* [Javascript standardstyle](https://standardjs.com/rules.html)
+* [JavaScript Standard Style](https://standardjs.com/rules.html)
 
 ### Posts/resources related to Joplin's style
 

--- a/readme/dev/index.md
+++ b/readme/dev/index.md
@@ -111,7 +111,7 @@ To add a test, simply create a new file with an extension `.test.ts` in the same
 
 #### Setting the testing environment
 
-Many utility functions are available under the package `@joplin/lib/testing/test-utils`. Have a look for example at [Note.test.ts](https://github.com/laurent22/joplin/blob/dev/packages/lib/models/Note.test.ts) to see how to setup test units with database support and synchroniser support. Note that this is not needed for all tests - if you just have a simple functions to test you won't need that extra setup.
+Many utility functions are available under the package `@joplin/lib/testing/test-utils`. Have a look for example at [Note.test.ts](https://github.com/laurent22/joplin/blob/dev/packages/lib/models/Note.test.ts) to see how to set up unit tests with database support and synchroniser support. Note that this is not needed for all tests - if you just have simple functions to test you won't need that extra setup.
 
 #### Testing React Hooks
 

--- a/readme/dev/localisation.md
+++ b/readme/dev/localisation.md
@@ -16,7 +16,7 @@ To **update a translation**, follow the same steps as above but instead of getti
 
 ## Translating the documentation
 
-The Joplin documentation translations are managed from [our project on Crowdin](https://crowdin.com/project/joplin-website). To participate simple create a Crowdin account and start translating.
+The Joplin documentation translations are managed from [our project on Crowdin](https://crowdin.com/project/joplin-website). To participate, simply create a Crowdin account and start translating.
 
 If you would like to add a new language or for any other issue, please contact us [on the forum](https://discourse.joplinapp.org/) or GitHub.
 

--- a/readme/dev/spec/architecture.md
+++ b/readme/dev/spec/architecture.md
@@ -12,7 +12,7 @@ The desktop, mobile and CLI applications have the same architecture and mostly t
 
 The overall architecture for each application is as such:
 
-- Front end: The user facing part of the app. This is different for each applications (see below for the difference between applications)
+- Front end: The user facing part of the app. This is different for each application (see below for the difference between applications)
 
 - Back end: This is shared by all applications. It is made of:
 

--- a/readme/dev/spec/background_windows.md
+++ b/readme/dev/spec/background_windows.md
@@ -72,7 +72,7 @@ For example, if a user switches from `window1` to `window2`, the state change lo
 		// </shared state>
 	}
 	```
-2. The reducer receives the `WINDOW_FOCUS` action and swaps which window state is in `backgroundWindows`. notice that only the window state is moved (the shared state is unmodified):
+2. The reducer receives the `WINDOW_FOCUS` action and swaps which window state is in `backgroundWindows`. Notice that only the window state is moved (the shared state is unmodified):
    ```js
 	state = {
 		backgroundWindows: {
@@ -160,4 +160,4 @@ Suppose `<MyComponent>` could be displayed in any window of the app and we want 
 
 - **All windows have the same menubar:** Currently, Joplin sets the application menubar with `Menu.setApplicationMenu`. This allows the menu to be updated later with `Menu.getApplicationMenu`, but means that all windows have the same menu.
 	- An alternative might be to set menus on individual windows with [`BrowserWindow.setMenu`](https://www.electronjs.org/docs/latest/api/browser-window#winsetmenumenu-linux-windows), but this doesn't allow accessing the menu later (e.g. from Playwright) with `Menu.getApplicationMenu` and does not work on MacOS.
-- **Certain UI only available on the main window:** At present, certain parts of the UI (e.g. sidebars, warning banners, etc.) are only visible on the main window.While this simplifies multi-window support by limiting which components need to work in secondary windows, it makes secondary windows more limited than primary windows.
+- **Certain UI only available on the main window:** At present, certain parts of the UI (e.g. sidebars, warning banners, etc.) are only visible on the main window. While this simplifies multi-window support by limiting which components need to work in secondary windows, it makes secondary windows more limited than primary windows.

--- a/readme/dev/spec/e2ee/index.md
+++ b/readme/dev/spec/e2ee/index.md
@@ -88,7 +88,7 @@ Public-private key pairs (PPK) are used to transfer secrets between users. Speci
 
 - Alice shares a notebook with Bob
 - Since the notebook is encrypted, Alice also sends the key to Bob, but it needs to be encrypted too.
-- To do so, she downloads Bob's public key and encrypt the key with it
+- To do so, she downloads Bob's public key and encrypts the key with it
 - When accepting the share, Bob receives this key
 - Bob decrypts it with his private key
 - Once decrypted, he reencrypts it with his master password

--- a/readme/dev/spec/e2ee/native_encryption.md
+++ b/readme/dev/spec/e2ee/native_encryption.md
@@ -286,12 +286,11 @@ The Initialization Vector (IV) length is set to 96 bits because extending it doe
 
 ### 3.6. Extended Equivalent Nonce
 Although AES-GCM has been used in TLS for years and has not shown significant vulnerabilities, there are still some security considerations:</br>
-- The Galois Counter Mode (GCM) is vulnerable when the IV and key is reused.
+- The Galois Counter Mode (GCM) is vulnerable when the IV and key are reused.
 - While a simple counter could serve as the IV, it's not easy to maintain a reliable monotonic counter across all clients.
-- The AES-GCM cipher has a maximum IV length of 96 bits (as discussed in [Section 3.5](#35-cipherdecipher-parameters)
-), which is relatively short.
+- The AES-GCM cipher has a maximum IV length of 96 bits (as discussed in [Section 3.5](#35-cipherdecipher-parameters)), which is relatively short.
 
-Although unlikely, a Joplin user could run into two pieces of ciphertext encrypted with the same IV even if the IV is randomly generated. This cause security vulnerabilities if the notes and resources is encrypted with the same Master Key directly. To resolve this, a 256-bit generated salt is used for each encryption to derive a new encryption key from the Master Key, so the key passed to the cipher changes every time. In theory, this approach provides a equivalent nonce with a length of (256+96) bits.
+Although unlikely, a Joplin user could run into two pieces of ciphertext encrypted with the same IV even if the IV is randomly generated. This causes security vulnerabilities if the notes and resources are encrypted with the same Master Key directly. To resolve this, a 256-bit generated salt is used for each encryption to derive a new encryption key from the Master Key, so the key passed to the cipher changes every time. In theory, this approach provides an equivalent nonce with a length of (256+96) bits.
 
 The salt is generated using the following formula:
 

--- a/readme/dev/spec/history.md
+++ b/readme/dev/spec/history.md
@@ -18,7 +18,7 @@ Every time an object is changed in Joplin, some metadata is added to the changed
 
 2. The note was recently modified, but before that it hadn't had a revision for more than 7 days
 
-Condition 1 saves the current state of the note (i.e. **after** the edit). Condition 2 saves the state has it was **before** the edit.
+Condition 1 saves the current state of the note (i.e. **after** the edit). Condition 2 saves the state as it was **before** the edit.
 
 The reason for that is that we save revisions every 10 minutes, but if you make many changes within a few minutes and then stop modifying the note, the final revision will not contain the current content of the note. Basically at one point (let's say at t1) the service will see there's a revision from less than 10 minutes, and will not save a new one.
 

--- a/readme/dev/spec/plugins.md
+++ b/readme/dev/spec/plugins.md
@@ -203,7 +203,7 @@ flowchart
 
 ##### Second: Send all queued messages
 
-After both messengers are ready, we wend all queued messages. In this case, that's the `setCss` message:
+After both messengers are ready, we send all queued messages. In this case, that's the `setCss` message:
 ```typescript
 {
 	kind: MessageType.InvokeMethod,

--- a/readme/dev/spec/server_delta_sync.md
+++ b/readme/dev/spec/server_delta_sync.md
@@ -6,7 +6,7 @@ Delta sync provides an API end point that gives a list of the latest change even
 
 - User calls `/api/files/delta` and get a list of the latest changes on the sync target. They also get a `cursor` object that can be used to check for the latest changes at a later time. A `cursor` essentially represents a point in time.
 
-- Later on, they call `/api/file/delta?cursor=CURSOR`, with the cursor they previously got, and they will get the latest events since that cursor. They will also get a new cursor, which they would use again to get the following events, and so on.
+- Later on, they call `/api/files/delta?cursor=CURSOR`, with the cursor they previously got, and they will get the latest events since that cursor. They will also get a new cursor, which they would use again to get the following events, and so on.
 
 The events are tied to a particular parent ID - in other words it's only possible to list the changes associated with a particular directory (non-recursive). For now, this is sufficient for the purpose of Joplin synchronisation, but later on it might be possible to get the changes in a recursive way.
 

--- a/readme/dev/spec/server_items.md
+++ b/readme/dev/spec/server_items.md
@@ -16,4 +16,4 @@ To upload an item to Joplin Server:
 
 - `items.jop_id` is the ID as it was generated on the client. `items.id` is the server-side ID. We need two different IDs because we have no way to guarantee that `items.jop_id` is globally unique since it's generated client-side.
 
-- In `ItemModel` there are various utility functions to deal with the content. This is because it may be saved in different places depending on configuration. It can be saved to the `items.content` field in the database, or it can be saved to S3, or to the filesystem. This is why any code that deals with item content must used these utility functions.
+- In `ItemModel` there are various utility functions to deal with the content. This is because it may be saved in different places depending on configuration. It can be saved to the `items.content` field in the database, or it can be saved to S3, or to the filesystem. This is why any code that deals with item content must use these utility functions.

--- a/readme/dev/spec/server_sharing.md
+++ b/readme/dev/spec/server_sharing.md
@@ -23,7 +23,7 @@ On the server, a service is running at regular interval to check the `share_id` 
 
 Technically, the server would only need to know the root shared folder, and from that can be find out its children. This approach was tried but it makes the system much more complex because some information is lost after sync - in particular when notes or notebooks are moved out of folders, when resources are attached or removed, etc. Keeping track of all this is possible but complex and inefficient.
 
-On the other hand, all that information is present on the client. Whenever a notes is moved out a shared folder, or whenever a resources is attached, the changes are tracked, and that can be used to easily assign a `share_id` property. Once this is set, it makes the whole system more simple and reliable.
+On the other hand, all that information is present on the client. Whenever a note is moved out of a shared folder, or whenever a resource is attached, the changes are tracked, and that can be used to easily assign a `share_id` property. Once this is set, it makes the whole system more simple and reliable.
 
 ### When are changes to `share_id` synced?
 
@@ -55,6 +55,6 @@ Any linked note will **not** be shared, due to the following reasons:
 
 ### Multiple share links for a given note
 
-It should be possible to have multiple share links for a given note. For example: I share a note with one person, then the same note with a different person. I revoke the share for one person, but I sill want the other person to access the note.
+It should be possible to have multiple share links for a given note. For example: I share a note with one person, then the same note with a different person. I revoke the share for one person, but I still want the other person to access the note.
 
 So when a share link is created for a note, the API always returns a new link.

--- a/readme/dev/spec/server_user_status.md
+++ b/readme/dev/spec/server_user_status.md
@@ -2,7 +2,7 @@
 
 ## User flags
 
-User flags are used to indicate problem conditions with a particular account. They are usually automatically set by various services, for example when an account go over the limit, or when a payment fails. Likewise they are removed automatically when the condition changes.
+User flags are used to indicate problem conditions with a particular account. They are usually automatically set by various services, for example when an account goes over the limit, or when a payment fails. Likewise they are removed automatically when the condition changes.
 
 The list of flags is defined in `UserFlagType`.
 

--- a/readme/dev/spec/sync.md
+++ b/readme/dev/spec/sync.md
@@ -24,7 +24,7 @@ Additionally, every few minutes, the client is going to poll the server and down
 
 ## Code architecture
 
-- `packages/lib/Synchronizer.ts`: This file is responsible for the main synchronisation process. It download changes, upload them, and apply any deletion. The class is relatively generic and receive a `SyncTarget` object that handles sync target-specific operations. The synchroniser is also going encrypt and decrypt items if E2EE is enabled.
+- `packages/lib/Synchronizer.ts`: This file is responsible for the main synchronisation process. It downloads changes, uploads them, and applies any deletion. The class is relatively generic and receives a `SyncTarget` object that handles sync target-specific operations. The synchroniser is also going to encrypt and decrypt items if E2EE is enabled.
 
 - `packages/lib/SyncTarget*.ts`: These files are the entry points for the various sync targets. They expose some metadata such as name, description, what options they support, etc. Some may also implement a function to test whether the configuration is working (used from the configuration screen). Finally, the main role of this class is to initialise an instance of a `FileApi`.
 
@@ -32,7 +32,7 @@ Additionally, every few minutes, the client is going to poll the server and down
 
 - `packages/lib/*Api.ts`: The `file-api-driver` will call some low-level API to perform its operations. For example `file-api-driver-local` will use the `fs` package to read/write files, `file-api-driver-amazon-s3` will use the AWS API to work with S3. In some cases however such a low-level API is not available - in that case, we usually create an `*Api.ts` file, which is used by the file API driver to perform its operations. For example, there is a `JoplinServerApi.ts`, which is used to connect to Joplin Server.
 
-- In general, each object in the database is represented by a `BaseModel` class. Then each object than can be synced is represented by a `BaseItem` class that inherits from `BaseModel`. This class is where many sync-related utilities can be found such as `itemsThatNeedSync()` or methods that encrypt items so that they can be uploaded when E2EE is enabled.
+- In general, each object in the database is represented by a `BaseModel` class. Then each object that can be synced is represented by a `BaseItem` class that inherits from `BaseModel`. This class is where many sync-related utilities can be found such as `itemsThatNeedSync()` or methods that encrypt items so that they can be uploaded when E2EE is enabled.
 
 - The state of each item is saved to the `sync_items` table. There is saved in particular the `sync_time` property which tells when the item was last synced. It is then used to decide what needs to be synced or not. Additional sync-related properties include `sync_disabled`, which is used in the rare case an item cannot be synced at all - for example if blocked by Dropbox for being "restricted content" (copyrighted), or is over the limit on Joplin Cloud. Each entry in `sync_items` is scoped to a sync target (`sync_target` property), so theoretically it's possible to sync the same items to multiple sync targets.
 

--- a/readme/dev/spec/sync_scroll.md
+++ b/readme/dev/spec/sync_scroll.md
@@ -67,7 +67,7 @@ For correct operation, the map should be discarded, when it becomes outdated, su
 
 ### Implementation Details
 
-The implementation details are out of the scope this document and described in the following pull requests.
+The implementation details are out of the scope of this document and described in the following pull requests.
 
 - [Desktop: Fix #5708: Scroll positions are remembered/preserved (Line-Percent-based Sync Scroll) by ken1kob - Pull Request #5826 - laurent22/joplin](https://github.com/laurent22/joplin/pull/5826)
 - [Desktop: Fix #2242: Sync-Scroll for Markdown Editor and Viewer by ken1kob - Pull Request #5512 - laurent22/joplin](https://github.com/laurent22/joplin/pull/5512)

--- a/readme/dev/spec/web_app.md
+++ b/readme/dev/spec/web_app.md
@@ -47,7 +47,7 @@ External files are mounted as subdirectories of the virtual `/external/` directo
 
 The web app uses [`@sqlite.org/sqlite-wasm`](https://github.com/sqlite/sqlite-wasm) for database access.
 
-To function properly (likely due to use of `SharedArrayBuffer`), `@sqlite.org/sqlite-wasm` requires [cross origin isolation to be enabled](https://web.dev/articles/coop-coep). This is done adding certain HTTP headers to responses from the server.
+To function properly (likely due to use of `SharedArrayBuffer`), `@sqlite.org/sqlite-wasm` requires [cross origin isolation to be enabled](https://web.dev/articles/coop-coep). This is done by adding certain HTTP headers to responses from the server.
 
 As of July 2024, the official deployment of the Web App is hosted on GitHub pages, [which doesn't support serving with these headers](https://github.com/orgs/community/discussions/13309). The Web App works around this by providing these headers in a `ServiceWorker`.
 

--- a/readme/dev/technical_spec.md
+++ b/readme/dev/technical_spec.md
@@ -44,7 +44,7 @@ Again, **always start from the user's perspective**:
 - How will you label the buttons or tooltip
 - If you're adding a keyboard shortcut, what keys should the user press, etc.
 
-All these details are very important because they give a clear picture of what you are going to do, and it helps reviewer assess the implementation.
+All these details are very important because they give a clear picture of what you are going to do, and it helps reviewers assess the implementation.
 
 It's also an easy way for everybody, even non-technical people, to get involved and help you refine your spec.
 
@@ -52,7 +52,7 @@ Also, if you can, provide a UI mockup.
 
 #### Technical solution
 
-Explain in general terms how you are going to a solve the issue at a technical level.
+Explain in general terms how you are going to solve the issue at a technical level.
 
 Please describe what will be the impact and risks associated with your change. For example if it's just adding a button to change text formatting, it's probably low impact. If it's modifying the sync algorithm it's high impact, because there's a potential for data loss.
 
@@ -64,7 +64,7 @@ In this section you may mention code and filenames, but try not to go into too m
 
 How do you plan to test your changes?
 
-Please provide test units if possible.
+Please provide unit tests if possible.
 
 If it's for GSoC, test units are compulsory. We don't accept pull requests without.
 


### PR DESCRIPTION
## Summary

Fixes ~40 typos and grammar errors across developer documentation including:

- Dev root docs (index, BUILD, coding_style, DEPLOY, localisation, technical_spec)
- Dev spec docs (architecture, background_windows, e2ee/index, e2ee/native_encryption, history, plugins, server_delta_sync, server_items, server_sharing, server_user_status, sync, sync_scroll, web_app)
- API docs (get_started/plugins, references/plugin_theming, references/rest_api, tutorials/cm6_plugin, tutorials/toc_plugin)

Common fixes include subject-verb agreement, missing articles/prepositions, spelling corrections, and punctuation fixes.

## Test plan

- [ ] Verify each fix is a clear improvement (no meaning changes)
- [ ] Confirm spellcheck passes (verified via lint-staged)
- [ ] Spot-check rendered markdown for formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and consistency across API and developer guides with numerous grammatical and spelling corrections.
  * Updated API parameter naming for consistency (search endpoint parameters).
  * Enhanced documentation examples and explanatory text for better readability and accuracy.
  * Refined technical specifications with clearer phrasing and corrected terminology throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->