### PR TITLE
Desktop: Resolves #14301: Fix Escape key not closing PromptDialog

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -394,6 +394,7 @@ packages/app-desktop/gui/PopupNotification/PopupNotificationList.js
 packages/app-desktop/gui/PopupNotification/PopupNotificationProvider.js
 packages/app-desktop/gui/PopupNotification/types.js
 packages/app-desktop/gui/ProfileEditor.js
+packages/app-desktop/gui/PromptDialog.test.js
 packages/app-desktop/gui/PromptDialog.js
 packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.js
 packages/app-desktop/gui/ResizableLayout/MoveButtons.js

--- a/.gitignore
+++ b/.gitignore
@@ -367,6 +367,7 @@ packages/app-desktop/gui/PopupNotification/PopupNotificationList.js
 packages/app-desktop/gui/PopupNotification/PopupNotificationProvider.js
 packages/app-desktop/gui/PopupNotification/types.js
 packages/app-desktop/gui/ProfileEditor.js
+packages/app-desktop/gui/PromptDialog.test.js
 packages/app-desktop/gui/PromptDialog.js
 packages/app-desktop/gui/ResizableLayout/LayoutItemContainer.js
 packages/app-desktop/gui/ResizableLayout/MoveButtons.js

--- a/packages/app-desktop/gui/PromptDialog.test.ts
+++ b/packages/app-desktop/gui/PromptDialog.test.ts
@@ -1,0 +1,52 @@
+import PromptDialog from './PromptDialog';
+
+describe('PromptDialog Escape key handling', () => {
+
+	const setupKeyHandler = (inputType: string, menuIsOpened: boolean) => {
+		const onCloseMock = jest.fn();
+		const instance = new PromptDialog({
+			themeId: 1,
+			defaultValue: '',
+			visible: true,
+			buttons: ['ok', 'cancel'],
+			onClose: onCloseMock,
+			inputType,
+			description: '',
+			autocomplete: [],
+			label: 'Test',
+			answer: null,
+		});
+		instance.state = { visible: true, answer: 'some-answer' };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Accessing private property for test setup
+		(instance as unknown as any).menuIsOpened_ = menuIsOpened;
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Navigating React element tree for handler extraction
+		const rendered = instance.render() as any;
+		const dialogChildren = rendered.props.children;
+		const inputWrapper = dialogChildren[1];
+		const wrapperChildren = inputWrapper.props.children;
+		const inputComp = Array.isArray(wrapperChildren)
+			? wrapperChildren[0]
+			: wrapperChildren;
+
+		return { onKeyDown: inputComp.props.onKeyDown, onCloseMock };
+	};
+
+	test('closes dialog for text input', () => {
+		const { onKeyDown, onCloseMock } = setupKeyHandler('text', false);
+		onKeyDown({ key: 'Escape' });
+		expect(onCloseMock).toHaveBeenCalledWith(null, 'cancel');
+	});
+
+	test('closes dialog for dropdown when menu is closed', () => {
+		const { onKeyDown, onCloseMock } = setupKeyHandler('dropdown', false);
+		onKeyDown({ key: 'Escape' });
+		expect(onCloseMock).toHaveBeenCalledWith(null, 'cancel');
+	});
+
+	test('does not close dialog when react-select menu is open', () => {
+		const { onKeyDown, onCloseMock } = setupKeyHandler('dropdown', true);
+		onKeyDown({ key: 'Escape' });
+		expect(onCloseMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app-desktop/gui/PromptDialog.tsx
+++ b/packages/app-desktop/gui/PromptDialog.tsx
@@ -251,6 +251,16 @@ export default class PromptDialog extends React.Component<Props, any> {
 				} else {
 					onClose(true);
 				}
+			} else if (event.key === 'Escape') {
+				// react-select calls preventDefault() on the Escape keydown
+				// event, which prevents the native <dialog> cancel event from
+				// firing. We handle Escape explicitly here to ensure the dialog
+				// can be closed with the Escape key.
+				if ((this.props.inputType === 'tags' || this.props.inputType === 'dropdown') && this.menuIsOpened_) {
+					// Let react-select close the dropdown menu
+				} else {
+					onClose(false, 'cancel');
+				}
 			}
 		};
 


### PR DESCRIPTION
## Summary

- Fix Escape key not closing the "Move to Notebook" dialog (and other PromptDialog instances)
- `react-select` calls `preventDefault()` on the Escape `keydown` event, which prevents the native `<dialog>` cancel event from firing
- Added explicit Escape key handling in the `onKeyDown` handler, mirroring the existing Enter key logic
- When a react-select dropdown menu is open, Escape first closes the menu; when the menu is closed, Escape closes the dialog

## Test plan

- [x] Manual testing: Escape closes the "Move to Notebook" dialog
- [x] Manual testing: Escape first closes dropdown menu, then closes dialog on second press

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Escape key behaviour in prompt dialogs: interactive menus close first and Escape closes the dialog only when appropriate, preventing accidental dismissal.

* **Tests**
  * Added tests covering Escape handling across input types and open/closed menu states to prevent regressions.

* **Chores**
  * Updated ignore lists to exclude new test artefacts from linting and version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->