### PR TITLE
All: Fixes #14271: Correct error message for missing app_min_version in plugin manifest

### DIFF
--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,7 +34,7 @@ export interface Plugins {
 }
 
 export interface SettingAndValue {
-	[settingName: string]: string|number|boolean;
+	[settingName: string]: string | number | boolean;
 }
 
 export interface DefaultPluginSettings {
@@ -211,7 +211,7 @@ export default class PluginService extends BaseService {
 		return this.pluginById(id).manifest?.name ?? 'Unknown';
 	}
 
-	public viewControllerByViewId(id: string): ViewController|null {
+	public viewControllerByViewId(id: string): ViewController | null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);
 		}
@@ -370,15 +370,6 @@ export default class PluginService extends BaseService {
 		}
 
 		const deprecationNotices: DeprecationNotice[] = [];
-
-		if (!manifestObj.app_min_version) {
-			manifestObj.app_min_version = '1.4';
-			deprecationNotices.push({
-				message: 'The manifest must contain an "app_min_version" key, which should be the minimum version of the app you support.',
-				goneInVersion: '1.4',
-				isError: true,
-			});
-		}
 
 		if (!manifestObj.id) {
 			manifestObj.id = pluginIdIfNotSpecified;


### PR DESCRIPTION
### Proposed Changes

This PR fixes the issue by removing the default assignment of `app_min_version` in "PluginService". This allows the schema validator "manifestFromObject" to correctly identify the missing field and throw the specific error: **"Missing required field: app_min_version"**.

### Test plan

**Automated Check:**
Verified locally using a standalone script that instantiates "PluginService" with mocked dependencies.
1.  **Before:** Loading a manifest without `app_min_version` would default it to `1.4` and fail later with a generic compatibility error.
2.  **After:** Loading the same manifest immediately throws `Error: Missing required field: app_min_version`.
3.  **Regression Check:** Verified that valid manifests (with `app_min_version` present) are still processed correctly.

**Manual UI Verification:**
Verified in the Joplin Desktop application by loading a test plugin with an invalid manifest. The console correctly displayed the error.

**Screenshots**
<img width="1527" height="823" alt="Screenshot 2026-02-12 065726" src="https://github.com/user-attachments/assets/babe3f97-362f-42f5-a068-770d5e6aa2ae" />

**Related issues**
Fixes #14271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic default minimum application version injection for plugins; explicit version requirements must now be specified in plugin manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->