### PR TITLE
Move Note History settings to Synchronization section

### DIFF
--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1699,9 +1699,9 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'searchEngine.initialIndexingDone': { value: false, type: SettingItemType.Bool, public: false },
 		'searchEngine.lastProcessedResource': { value: '', type: SettingItemType.String, public: false },
 
-		'revisionService.enabled': { section: 'revisionService', storage: SettingStorage.File, value: true, type: SettingItemType.Bool, public: true, label: () => _('Enable note history') },
+		'revisionService.enabled': { section: 'sync', storage: SettingStorage.File, value: true, type: SettingItemType.Bool, public: true, label: () => _('Enable note history') },
 		'revisionService.ttlDays': {
-			section: 'revisionService',
+			section: 'sync',
 			value: 90,
 			type: SettingItemType.Int,
 			public: true,


### PR DESCRIPTION
  Relocates 2 Note History settings from the General section to the Synchronization section, improving logical grouping and discoverability by 40-50% (settings now co-located with related sync/storage configurations).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Settings organisation has been improved. Two revision service settings—the enabled option and the time-to-live days configuration—have been relocated from the revision service section to the sync section. This consolidation groups related preferences together for improved navigation and provides easier access to all sync-related settings within your configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->