### PR TITLE
Desktop: Fix OCR Norwegian language code mapping

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1545,6 +1545,8 @@ packages/lib/services/ocr/drivers/OcrDriverTranscribe.test.js
 packages/lib/services/ocr/drivers/OcrDriverTranscribe.js
 packages/lib/services/ocr/utils/filterOcrText.test.js
 packages/lib/services/ocr/utils/filterOcrText.js
+packages/lib/services/ocr/utils/ocrLanguageFromLocale.test.js
+packages/lib/services/ocr/utils/ocrLanguageFromLocale.js
 packages/lib/services/ocr/utils/types.js
 packages/lib/services/plugins/BasePlatformImplementation.js
 packages/lib/services/plugins/BasePluginRunner.js

--- a/.gitignore
+++ b/.gitignore
@@ -1518,6 +1518,8 @@ packages/lib/services/ocr/drivers/OcrDriverTranscribe.test.js
 packages/lib/services/ocr/drivers/OcrDriverTranscribe.js
 packages/lib/services/ocr/utils/filterOcrText.test.js
 packages/lib/services/ocr/utils/filterOcrText.js
+packages/lib/services/ocr/utils/ocrLanguageFromLocale.test.js
+packages/lib/services/ocr/utils/ocrLanguageFromLocale.js
 packages/lib/services/ocr/utils/types.js
 packages/lib/services/plugins/BasePlatformImplementation.js
 packages/lib/services/plugins/BasePluginRunner.js

--- a/packages/lib/services/ocr/OcrService.ts
+++ b/packages/lib/services/ocr/OcrService.ts
@@ -1,4 +1,3 @@
-import { toIso639Alpha3 } from '../../locale';
 import Resource from '../../models/Resource';
 import Setting from '../../models/Setting';
 import shim from '../../shim';
@@ -9,6 +8,7 @@ import { Minute } from '@joplin/utils/time';
 import Logger from '@joplin/utils/Logger';
 import TaskQueue from '../../TaskQueue';
 import eventManager, { EventName } from '../../eventManager';
+import ocrLanguageFromLocale from './utils/ocrLanguageFromLocale';
 
 const logger = Logger.create('OcrService');
 
@@ -177,7 +177,7 @@ export default class OcrService {
 		};
 
 		try {
-			const language = toIso639Alpha3(Setting.value('locale'));
+			const language = ocrLanguageFromLocale(Setting.value('locale'));
 			const processedResourceIds: string[] = [];
 
 			// Queue all resources for processing

--- a/packages/lib/services/ocr/utils/ocrLanguageFromLocale.test.ts
+++ b/packages/lib/services/ocr/utils/ocrLanguageFromLocale.test.ts
@@ -1,0 +1,12 @@
+import ocrLanguageFromLocale from './ocrLanguageFromLocale';
+
+describe('ocrLanguageFromLocale', () => {
+	test.each([
+		['nb_NO', 'nor'],
+		['nn_NO', 'nor'],
+		['no', 'nor'],
+		['en_GB', 'eng'],
+	])('maps %s to %s', (input, expected) => {
+		expect(ocrLanguageFromLocale(input)).toBe(expected);
+	});
+});

--- a/packages/lib/services/ocr/utils/ocrLanguageFromLocale.ts
+++ b/packages/lib/services/ocr/utils/ocrLanguageFromLocale.ts
@@ -1,0 +1,13 @@
+import { toIso639Alpha3 } from '../../../locale';
+
+const ocrLanguageOverrides: Record<string, string> = {
+	nob: 'nor',
+	nno: 'nor',
+};
+
+const ocrLanguageFromLocale = (locale: string): string => {
+	const alpha3Code = toIso639Alpha3(locale);
+	return ocrLanguageOverrides[alpha3Code] || alpha3Code;
+};
+
+export default ocrLanguageFromLocale;


### PR DESCRIPTION
## Summary
- fix OCR language resolution for Norwegian locales
- map `nob` and `nno` to `nor` for OCR only
- keep global locale conversion behavior unchanged

## Testing
- yarn workspace @joplin/lib test --runInBand services/ocr/utils/ocrLanguageFromLocale.test.js locale.test.js
- yarn workspace @joplin/lib test --runInBand services/ocr/OcrService.test.js
- yarn workspace @joplin/lib test --runInBand services/ocr/drivers/OcrDriverTranscribe.test.js
- yarn checkIgnoredFiles

Fixes #14345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced OCR language detection mechanism. Improved the mapping system for converting locales to language codes, ensuring more accurate OCR language selection across different regional variants and locale formats.

* **Tests**
  * Added comprehensive test coverage for OCR locale language mapping, validating that language codes are correctly assigned for various locale inputs and regional variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->