### PR TITLE
Fix: Only embed YouTube videos when URL is on its own line 

### DIFF
--- a/packages/app-cli/tests/md_to_html/external_embed_edges.html
+++ b/packages/app-cli/tests/md_to_html/external_embed_edges.html
@@ -1,0 +1,16 @@
+<h1>Additional Edge Cases for External Embed</h1>
+<p>URL at start of paragraph with text after:</p>
+<p><a href="https://www.youtube.com/watch?v=start123">https://www.youtube.com/watch?v=start123</a> is a great video.</p>
+<p>URL at end of paragraph with text before:</p>
+<p>This is a video <a href="https://www.youtube.com/watch?v=end456">https://www.youtube.com/watch?v=end456</a></p>
+<p>Properly standalone URL in between:</p>
+
+				<div class="joplin-editable">
+					<span class="joplin-source" data-joplin-source-open="" data-joplin-source-close="">https://www.youtube.com/watch?v=proper789</span>
+					<div class="joplin-youtube-player-rendered">
+						<iframe src="https://www.youtube-nocookie.com/embed/proper789" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+					</div>
+				</div>
+			
+<p>Multiple URLs inline:</p>
+<p>Check <a href="https://youtu.be/first111">https://youtu.be/first111</a> and <a href="https://youtu.be/second222">https://youtu.be/second222</a> out.</p>

--- a/packages/app-cli/tests/md_to_html/external_embed_edges.md
+++ b/packages/app-cli/tests/md_to_html/external_embed_edges.md
@@ -2,16 +2,16 @@
 
 URL at start of paragraph with text after:
 
-https://www.youtube.com/watch?v=start123 is a great video.
+https://www.youtube.com/watch?v=start123abc is a great video.
 
 URL at end of paragraph with text before:
 
-This is a video https://www.youtube.com/watch?v=end456
+This is a video https://www.youtube.com/watch?v=end456defgh
 
 Properly standalone URL in between:
 
-https://www.youtube.com/watch?v=proper78901
+https://www.youtube.com/watch?v=proper789jk
 
 Multiple URLs inline:
 
-Check https://youtu.be/first111 and https://youtu.be/second222 out.
+Check https://youtu.be/first111xyz and https://youtu.be/second222pq out.

--- a/packages/app-cli/tests/md_to_html/external_embed_edges.md
+++ b/packages/app-cli/tests/md_to_html/external_embed_edges.md
@@ -1,0 +1,17 @@
+# Additional Edge Cases for External Embed
+
+URL at start of paragraph with text after:
+
+https://www.youtube.com/watch?v=start123 is a great video.
+
+URL at end of paragraph with text before:
+
+This is a video https://www.youtube.com/watch?v=end456
+
+Properly standalone URL in between:
+
+https://www.youtube.com/watch?v=proper789
+
+Multiple URLs inline:
+
+Check https://youtu.be/first111 and https://youtu.be/second222 out.

--- a/packages/app-cli/tests/md_to_html/external_embed_edges.md
+++ b/packages/app-cli/tests/md_to_html/external_embed_edges.md
@@ -10,7 +10,7 @@ This is a video https://www.youtube.com/watch?v=end456
 
 Properly standalone URL in between:
 
-https://www.youtube.com/watch?v=proper789
+https://www.youtube.com/watch?v=proper78901
 
 Multiple URLs inline:
 

--- a/packages/app-cli/tests/md_to_html/external_embed_inline.html
+++ b/packages/app-cli/tests/md_to_html/external_embed_inline.html
@@ -1,0 +1,11 @@
+<p>This paragraph has an inline YouTube URL: <a href="https://www.youtube.com/watch?v=test123">https://www.youtube.com/watch?v=test123</a> which should NOT be embedded.</p>
+<p>Here's another inline case: Check out <a href="https://youtu.be/inline789">https://youtu.be/inline789</a> for more info.</p>
+<p>But this URL on its own line should be embedded:</p>
+
+				<div class="joplin-editable">
+					<span class="joplin-source" data-joplin-source-open="" data-joplin-source-close="">https://www.youtube.com/watch?v=standalone456</span>
+					<div class="joplin-youtube-player-rendered">
+						<iframe src="https://www.youtube-nocookie.com/embed/standalone456" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
+					</div>
+				</div>
+			

--- a/packages/app-cli/tests/md_to_html/external_embed_inline.md
+++ b/packages/app-cli/tests/md_to_html/external_embed_inline.md
@@ -1,0 +1,7 @@
+This paragraph has an inline YouTube URL: https://www.youtube.com/watch?v=test123 which should NOT be embedded.
+
+Here's another inline case: Check out https://youtu.be/inline789 for more info.
+
+But this URL on its own line should be embedded:
+
+https://www.youtube.com/watch?v=standalone456

--- a/packages/app-cli/tests/md_to_html/external_embed_inline.md
+++ b/packages/app-cli/tests/md_to_html/external_embed_inline.md
@@ -1,7 +1,7 @@
-This paragraph has an inline YouTube URL: https://www.youtube.com/watch?v=test123 which should NOT be embedded.
+This paragraph has an inline YouTube URL: https://www.youtube.com/watch?v=abcde123456 which should NOT be embedded.
 
-Here's another inline case: Check out https://youtu.be/inline789 for more info.
+Here's another inline case: Check out https://youtu.be/fghij789012 for more info.
 
 But this URL on its own line should be embedded:
 
-https://www.youtube.com/watch?v=standalone456
+https://www.youtube.com/watch?v=klmno345678

--- a/packages/renderer/MdToHtml/rules/externalEmbed.ts
+++ b/packages/renderer/MdToHtml/rules/externalEmbed.ts
@@ -39,19 +39,25 @@ const plugin = (markdownIt: MarkdownIt) => {
 				let hasTextBefore = false;
 				for (let i = idx - 1; i >= 0; i--) {
 					const prevToken = tokens[i];
-					if (prevToken.type === 'text' && prevToken.content.trim() !== '') {
-						hasTextBefore = true;
-						break;
-					}
+					// Ignore pure whitespace text
+					if (prevToken.type === 'text' && prevToken.content.trim() === '') continue;
+					// Ignore soft/hard line breaks (treated as whitespace)
+					if (prevToken.type === 'softbreak' || prevToken.type === 'hardbreak') continue;
+					// Any other token before the link counts as surrounding content
+					hasTextBefore = true;
+					break;
 				}
 				
 				let hasTextAfter = false;
 				for (let i = idx + 3; i < tokens.length; i++) {
 					const nextToken = tokens[i];
-					if (nextToken.type === 'text' && nextToken.content.trim() !== '') {
-						hasTextAfter = true;
-						break;
-					}
+					// Ignore pure whitespace text
+					if (nextToken.type === 'text' && nextToken.content.trim() === '') continue;
+					// Ignore soft/hard line breaks (treated as whitespace)
+					if (nextToken.type === 'softbreak' || nextToken.type === 'hardbreak') continue;
+					// Any other token after the link counts as surrounding content
+					hasTextAfter = true;
+					break;
 				}
 				
 				if (!hasTextBefore && !hasTextAfter) {

--- a/packages/renderer/MdToHtml/rules/externalEmbed.ts
+++ b/packages/renderer/MdToHtml/rules/externalEmbed.ts
@@ -21,14 +21,12 @@ const plugin = (markdownIt: MarkdownIt) => {
 		return (self.renderToken as any)(tokens, idx, options, env, self);
 	};
 
-	// Track active embed state
 	let activeEmbedVideo: { videoId: string; originalUrl: string } | null = null;
 
 	markdownIt.renderer.rules.link_open = function(tokens, idx, options, env, self) {
 		const token = tokens[idx];
 		const href = token.attrGet('href');
 
-		// Check if this is a standalone YouTube link (next token is text matching href, then link_close)
 		if (href &&
 			idx + 2 < tokens.length &&
 			tokens[idx + 1].type === 'text' &&
@@ -38,8 +36,28 @@ const plugin = (markdownIt: MarkdownIt) => {
 			const videoId = extractVideoId(href);
 
 			if (videoId) {
-				activeEmbedVideo = { videoId, originalUrl: href };
-				return '';
+				let hasTextBefore = false;
+				for (let i = idx - 1; i >= 0; i--) {
+					const prevToken = tokens[i];
+					if (prevToken.type === 'text' && prevToken.content.trim() !== '') {
+						hasTextBefore = true;
+						break;
+					}
+				}
+				
+				let hasTextAfter = false;
+				for (let i = idx + 3; i < tokens.length; i++) {
+					const nextToken = tokens[i];
+					if (nextToken.type === 'text' && nextToken.content.trim() !== '') {
+						hasTextAfter = true;
+						break;
+					}
+				}
+				
+				if (!hasTextBefore && !hasTextAfter) {
+					activeEmbedVideo = { videoId, originalUrl: href };
+					return '';
+				}
 			}
 		}
 
@@ -47,7 +65,6 @@ const plugin = (markdownIt: MarkdownIt) => {
 	};
 
 	markdownIt.renderer.rules.text = function(tokens, idx, options, env, self) {
-		// Skip text content if we're in an active embed
 		if (activeEmbedVideo) {
 			return '';
 		}
@@ -55,11 +72,10 @@ const plugin = (markdownIt: MarkdownIt) => {
 	};
 
 	markdownIt.renderer.rules.link_close = function(tokens, idx, options, env, self) {
-		// Check if we have an active embed to close
 		if (activeEmbedVideo) {
 			const videoId = activeEmbedVideo.videoId;
 			const originalUrl = activeEmbedVideo.originalUrl;
-			activeEmbedVideo = null; // Clear state
+			activeEmbedVideo = null;
 
 			const embedUrl = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}`;
 			const escapedUrl = markdownIt.utils.escapeHtml(originalUrl);


### PR DESCRIPTION
Fixes #14352

## Problem
When `markdown.plugin.externalEmbed` is enabled, YouTube videos were being embedded even when the URL appeared inline with other text, not just when standalone on its own line.

## Solution
Modified the `externalEmbed` plugin to check for surrounding text content before/after YouTube links:
- Checks for any text tokens before the link in the same paragraph
- Checks for any text tokens after the link in the same paragraph
- Only embeds the video if no surrounding text is found (URL is standalone)
- Inline URLs are now rendered as regular links

## Test Cases
Added comprehensive test cases:
- `external_embed_inline.md/html` - Tests inline and standalone scenarios
- `external_embed_edges.md/html` - Edge cases (URL at start/end of paragraph, multiple URLs)

## Examples
 **Before:** Inline URL would embed → `Text https://youtube.com/watch?v=xyz more text` ❌  
 **After:** Inline URL shows as link → `Text https://youtube.com/watch?v=xyz more text` ✓  
 **Standalone still embeds:** Empty line with just URL → Embeds video ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Markdown and HTML test cases covering various external embed edge cases (URLs at start/end of paragraphs, standalone URLs, multiple inline URLs, YouTube embed behaviour).

* **Improvements**
  * YouTube/video embedding now triggers only for truly standalone links; links surrounded by other text render as regular anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->