### PR TITLE
Fix admin email sorting to use recipient_id instead of non-existent u…

### DIFF
--- a/packages/server/src/routes/admin/emails.ts
+++ b/packages/server/src/routes/admin/emails.ts
@@ -40,7 +40,7 @@ router.get('admin/emails', async (_path: SubPath, ctx: AppContext) => {
 				label: 'To',
 			},
 			{
-				name: 'user_id',
+				name: 'recipient_id',
 				label: 'User',
 			},
 			{


### PR DESCRIPTION
## Summary

Fixes an error when sorting the "User" column in Admin → Emails.

The column was configured to sort by user_id, but the emails table
does not contain this column. It contains recipient_id and sender_id.

This change updates the sort field to use recipient_id, which exists
in the database.

## Result

Sorting by the "User" column now works without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the admin emails table column header naming to properly align with the underlying data field, ensuring accurate representation of recipient information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->