### PR TITLE
Desktop: Fixes #14350: Make notebook search accent-insensitive in GotoAnything

### DIFF
--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -356,13 +356,18 @@ class DialogComponent extends React.PureComponent<Props, State> {
 				results = await Tag.searchAllWithNotes({ titlePattern: searchQuery });
 			} else if (this.state.query.indexOf('@') === 0) { // FOLDERS
 				listType = BaseModel.TYPE_FOLDER;
-				searchQuery = `*${this.state.query.split(' ')[0].substr(1).trim()}*`;
-				results = await Folder.search({ titlePattern: searchQuery });
+				searchQuery = this.state.query.substr(1).trim();
+				const normalizedSearchQuery = removeDiacritics(searchQuery.toLowerCase());
 
-				for (let i = 0; i < results.length; i++) {
-					const row = results[i];
-					const path = Folder.folderPathString(this.props.folders, row.parent_id);
-					results[i] = { ...row, path: path ? path : '/' };
+				results = [];
+				for (const folder of this.props.folders) {
+					if (folder.deleted_time) continue;
+
+					const normalizedTitle = removeDiacritics(folder.title.toLowerCase());
+					if (normalizedSearchQuery && normalizedTitle.indexOf(normalizedSearchQuery) < 0) continue;
+
+					const path = Folder.folderPathString(this.props.folders, folder.parent_id);
+					results.push({ ...folder, path: path ? path : '/' });
 				}
 			} else { // Note TITLE or BODY
 				listType = BaseModel.TYPE_NOTE;

--- a/packages/app-desktop/plugins/GotoAnything.tsx
+++ b/packages/app-desktop/plugins/GotoAnything.tsx
@@ -357,13 +357,13 @@ class DialogComponent extends React.PureComponent<Props, State> {
 			} else if (this.state.query.indexOf('@') === 0) { // FOLDERS
 				listType = BaseModel.TYPE_FOLDER;
 				searchQuery = this.state.query.substr(1).trim();
-				const normalizedSearchQuery = removeDiacritics(searchQuery.toLowerCase());
+				const normalizedSearchQuery = removeDiacritics(searchQuery).toLowerCase();
 
 				results = [];
 				for (const folder of this.props.folders) {
 					if (folder.deleted_time) continue;
 
-					const normalizedTitle = removeDiacritics(folder.title.toLowerCase());
+					const normalizedTitle = removeDiacritics(folder.title).toLowerCase();
 					if (normalizedSearchQuery && normalizedTitle.indexOf(normalizedSearchQuery) < 0) continue;
 
 					const path = Folder.folderPathString(this.props.folders, folder.parent_id);


### PR DESCRIPTION
## Summary

This PR fixes accent-sensitive notebook search in GotoAnything when using the `@` prefix followed by a notebook name.

Issue: #14350

---

## Problem

Notebook search with the `@` prefix is accent-sensitive.

Example:

- `@vetement` → does NOT return `Vêtement`
- `@vêtement` → returns only the accented notebook

---

## Root Cause

Notebook search uses: `Folder.search({ titlePattern })`


This relies on a SQLite `LIKE` query, which can be accent-sensitive depending on configuration.

Normal search goes through `SearchEngine`, which performs diacritic normalization.

This creates inconsistent behavior.

---

## Solution

Replaced database-based folder search with client-side filtering using `this.props.folders`, which are already available in Redux state.

Implementation details:

- Remove leading `@`
- Normalize query using `removeDiacritics()`
- Normalize folder titles using `removeDiacritics()`
- Perform lowercase accent-insensitive `indexOf()` comparison
- Skip deleted folders
- Preserve path calculation via `Folder.folderPathString()`

---

## Manual Testing Plan

### 1. Basic Accent Matching
- Create notebook: `Vêtement`
- Search `@vetement`
- Notebook appears

### 2. Accent Query
- Search `@vêtement`
- Notebook appears

### 3. Mixed Notebooks
- Create notebook: `vetement_plain`
- Search `@vetement`
- Both relevant notebooks appear

### 4. Nested Notebooks
- Create nested notebook under `Vêtement`
- Search `@vetement`
- Correct path is displayed

### 5. Empty Query
- Type `@`
- All notebooks appear as before

---

## Screenshots

### Case Setup

Two notebooks exist:
- `Vêtement`
- `vetement_plain`

### Search: `@vetement`

Both notebooks are returned:
- `Vêtement`
- `vetement_plain`

<img width="772" height="189" alt="image" src="https://github.com/user-attachments/assets/58743e1b-6a44-4ca0-ae69-744720b60f4f" />

### Search: `@vêtement`

Both notebooks are also returned:

- `Vêtement`
- `vetement_plain`

<img width="772" height="189" alt="image" src="https://github.com/user-attachments/assets/e72c7a15-8167-4059-808a-7c9779b9e7d2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder search now ignores deleted folders and matches queries regardless of accents or case, improving accuracy in Go to Anything.

* **New Features**
  * Search results now include each folder's path (defaults to '/'), making it easier to locate items at a glance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->