### PR TITLE
Chore: Editor CI: Retry flaky test on failure

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceInlineHtml.test.ts
@@ -14,6 +14,8 @@ const createEditor = async (initialMarkdown: string, expectedTags: string[] = ['
 };
 
 describe('replaceInlineHtml', () => {
+	jest.retryTimes(2);
+
 	test.each([
 		{ markdown: '<sup>Test</sup>', expectedDomTags: 'sup' },
 		{ markdown: '<strike>Test</strike>', expectedDomTags: 'strike' },


### PR DESCRIPTION
# Summary

This pull request adds logic to retry the tests in `replaceInlineHtml.test.ts`, which frequently fail in CI.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by implementing retry logic for the inline HTML rendering test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->