### PR TITLE
Mobile: Refresh note when updated via the API when in edit mode

### DIFF
--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -69,6 +69,7 @@ interface Props {
 	onSelectionChange: OnSelectionChange;
 	onUndoRedoDepthChange: OnUndoRedoDepthChange;
 	onAttach: OnAttach;
+	refreshKey?: number;
 }
 
 function fontFamilyFromSettings() {
@@ -456,6 +457,7 @@ function NoteEditor(props: Props) {
 				minHeight: '30%',
 			}}>
 				<EditorComponent
+					key={props.refreshKey}
 					editorRef={editorRef}
 					webviewRef={webviewRef}
 					themeId={props.themeId}

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -717,6 +717,14 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			if (!editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime) {
 				void shared.reloadNote(this);
 				this.refreshKey = this.props.editorNoteReloadTimeRequest;
+
+				// Clear the undo / redo state, as it will no longer work after the note editor has been refreshed
+				this.setState({
+					undoRedoButtonState: {
+						canUndo: false,
+						canRedo: false,
+					},
+				});
 			}
 		}
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -199,6 +199,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private editorPluginHandler_ = new EditorPluginHandler(PluginService.instance(), saveEvent => {
 		return shared.noteComponent_change(this, 'body', saveEvent.body);
 	});
+	private refreshKey: number;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static navigationOptions(): any {
@@ -715,6 +716,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			const { editorPlugin } = getShownPluginEditorView(this.props.plugins, this.props.windowId);
 			if (!editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime) {
 				void shared.reloadNote(this);
+				this.refreshKey = this.props.editorNoteReloadTimeRequest;
 			}
 		}
 
@@ -1736,6 +1738,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 						onScroll={this.props.editorType === EditorType.RichText ? this.onBodyViewerScroll : this.onMarkdownEditorScroll}
 
 						mode={this.props.editorType}
+						refreshKey={this.refreshKey}
 					/>;
 				}
 			}

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -199,7 +199,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private editorPluginHandler_ = new EditorPluginHandler(PluginService.instance(), saveEvent => {
 		return shared.noteComponent_change(this, 'body', saveEvent.body);
 	});
-	private refreshKey: number;
+	private refreshKey: number | undefined;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static navigationOptions(): any {

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -717,6 +717,18 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			if (!editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime) {
 				void shared.reloadNote(this);
 				this.refreshKey = this.props.editorNoteReloadTimeRequest;
+
+				// Clear the undo / redo state, as undo / redo steps wont be in sync with the current content after the note editor has been refreshed
+				if (!this.useEditorBeta()) {
+					void this.undoRedoService_.reset();
+				}
+
+				this.setState({
+					undoRedoButtonState: {
+						canUndo: false,
+						canRedo: false,
+					},
+				});
 			}
 		}
 

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -717,14 +717,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			if (!editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime) {
 				void shared.reloadNote(this);
 				this.refreshKey = this.props.editorNoteReloadTimeRequest;
-
-				// Clear the undo / redo state, as it will no longer work after the note editor has been refreshed
-				this.setState({
-					undoRedoButtonState: {
-						canUndo: false,
-						canRedo: false,
-					},
-				});
 			}
 		}
 


### PR DESCRIPTION
Following the change in PR https://github.com/laurent22/joplin/pull/13671, when testing the Secure notes plugin alongside changes in https://github.com/laurent22/joplin/pull/14363, I realised that actually the refresh logic introduced in https://github.com/laurent22/joplin/pull/13671 only works when a note is open in view mode or the plain text editor. This is because in the Markdown and Rich text editor, the note contents are not refreshed when the note contents in the state changes.

This PR makes the refresh work for the editors as well, by forcing a component remount in the scenario where the refresh is triggered, after the note contents have been reloaded in the state. This is done by setting a value to the key attribute on the markdown and rich text editor components, which changes when the refresh is required. Note that it wasn't possible to force the NoteEditor component alone to refresh instead, as this breaks the state of the editor toolbar.

### Testing

Testing was done using a modified version of the Secure notes plugin and the code change built on the top the remember editing state PR. I also verified that the undo / redo buttons and steps are correctly cleared for all 3 editors, as note changes made via the API will be out of sync with the undo / redo steps, and therefore should be cleared to avoid issues. Additionally, I verified that when the current note is updated via the API while an editor plugin screen is visible, there is no visible refresh to the screen, and the editor content is updated when switching back to the built in editor. I also tested that a plugin which inserts into the note body directly (eg. the templates plugin) does not cause an unwanted refresh when performing the action which inserts into the built in editor directly.

See video showing the note refresh via an API change, working for the note viewer and all editors.

https://github.com/user-attachments/assets/f56a0a67-21fd-4d70-aaf5-b4ca4b13e78a