### PR TITLE
Chore: Sync: Log a warning when a folder is deleted by sync without its content being deleted first

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1138,6 +1138,7 @@ export default class Synchronizer {
 						const item = localFoldersToDelete[i];
 						const noteIds = await Folder.noteIds(item.id);
 						if (noteIds.length) {
+							logger.warn('Conflict: Folder', item.id, 'deleted without deleting its content');
 							// CONFLICT
 							await Folder.markNotesAsConflict(item.id);
 						}


### PR DESCRIPTION
# Summary

Joplin creates conflicts if there are still items in a folder that was deleted by sync. However, nothing was logged in this case, making it difficult to determine why these conflicts were created. This pull request adds additional logging to make it easier to determine the source of such conflicts.
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic logging for conflict detection when deleted folders contain notes during synchronisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->