### PR TITLE
Chore: Sync fuzzer: Add utilities to allow reproducing a conflict-related share issue

### DIFF
--- a/packages/server/src/tools/debug/populateDatabase.ts
+++ b/packages/server/src/tools/debug/populateDatabase.ts
@@ -7,6 +7,7 @@ import { makeFolderSerializedBody, makeNoteSerializedBody, makeResourceSerialize
 import { randomElement } from '../../utils/array';
 import { CustomErrorCode } from '../../utils/errors';
 import uuid from '@joplin/lib/uuid';
+import { randomWeightedElement } from '@joplin/utils/array';
 
 let logger_: Logger = null;
 
@@ -67,30 +68,6 @@ type Reaction = (context: Context, user: User)=> Promise<boolean>;
 
 const randomInt = (min: number, max: number) => {
 	return Math.floor(Math.random() * (max - min + 1)) + min;
-};
-
-const randomWeightedElement = <T> (items: T[], weights: number[]): T => {
-	if (items.length !== weights.length) {
-		throw new Error('Items and weights must have the same length');
-	}
-	// Normalize the weights so that they add up to one.
-	const weightsSum = weights.reduce((a, b) => a + b, 0);
-	const normalizedWeights = weights.map(w => w / weightsSum);
-
-	// Pair items and weights
-	const weightedItems = items.map((item, index) => ({ item, weight: normalizedWeights[index] }));
-
-	let weightSum = 0;
-	const value = Math.random();
-	// Find the last item with `value` in its range
-	for (const item of weightedItems) {
-		weightSum += item.weight;
-		if (weightSum > value) {
-			return item.item;
-		}
-	}
-
-	return null;
 };
 
 const shuffled = <T> (items: T[]) => {

--- a/packages/tools/fuzzer/ActionRunner.ts
+++ b/packages/tools/fuzzer/ActionRunner.ts
@@ -491,9 +491,9 @@ const getActions = (context: FuzzContext, clientPool: ClientPool, client: Client
 		return true;
 	}, {
 		count: () => context.randInt(1, 512),
-		updateProbability: () => 1,
-		deleteProbability: () => 1,
-		createProbability: () => 1,
+		createProbability: () => 0.3,
+		updateProbability: () => 0.5,
+		deleteProbability: () => 0.2,
 	});
 
 	addAction('publishNote', async ({ id }) => {

--- a/packages/tools/fuzzer/ActionRunner.ts
+++ b/packages/tools/fuzzer/ActionRunner.ts
@@ -482,11 +482,18 @@ const getActions = (context: FuzzContext, clientPool: ClientPool, client: Client
 		return true;
 	}, {});
 
-	addAction('createOrUpdateMany', async ({ count }) => {
-		await client.createOrUpdateMany(count);
+	addAction('createOrUpdateMany', async ({ count, updateProbability, deleteProbability, createProbability }) => {
+		await client.createOrUpdateMany(count, {
+			updateProbability,
+			deleteProbability,
+			createProbability,
+		});
 		return true;
 	}, {
 		count: () => context.randInt(1, 512),
+		updateProbability: () => 1,
+		deleteProbability: () => 1,
+		createProbability: () => 1,
 	});
 
 	addAction('publishNote', async ({ id }) => {

--- a/packages/tools/fuzzer/Fuzzer.ts
+++ b/packages/tools/fuzzer/Fuzzer.ts
@@ -12,6 +12,7 @@ import randomId from './utils/randomId';
 import { ItemId } from './model/types';
 import openDebugSession from './utils/openDebugSession';
 import { readFile } from 'fs/promises';
+import { randomWeightedElement } from '@joplin/utils/array';
 
 const logger = Logger.create('Fuzzer');
 
@@ -148,7 +149,12 @@ const createContext = (config: FuzzerConfig, random: RandomNumberGenerators, ser
 
 		execApi: server.execApi.bind(server),
 		randInt: (a, b) => random.generalRandom.nextInRange(a, b),
-		randomFrom: (data) => data[random.generalRandom.nextInRange(0, data.length)],
+		randomFrom: (data, weights) => {
+			if (!weights) return data[random.generalRandom.nextInRange(0, data.length)];
+
+			const nextFloat = () => random.generalRandom.nextInRange(0, 100_000) / 100_000;
+			return randomWeightedElement(data, weights, nextFloat);
+		},
 		randomString: random.randomStringGenerator,
 		randomId: random.randomIdGenerator,
 		keepAccounts: config.keepAccountsOnClose,

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -134,6 +134,12 @@ interface CreateRandomItemOptions extends CreateOrUpdateOptions {
 	quiet?: boolean;
 }
 
+interface CreateOrUpdateManyOptions {
+	createProbability: number;
+	updateProbability: number;
+	deleteProbability: number;
+}
+
 class ApiResponseError extends Error {
 	public constructor(public readonly code: number, message: string) {
 		super(message);
@@ -708,7 +714,7 @@ class Client implements ActionableClient {
 		}
 	}
 
-	public async createOrUpdateMany(actionCount: number) {
+	public async createOrUpdateMany(actionCount: number, options: CreateOrUpdateManyOptions) {
 		logger.info(`Creating/updating ${actionCount} items...`);
 		const bar = new ProgressBar('Creating/updating');
 
@@ -739,21 +745,21 @@ class Client implements ActionableClient {
 				await this.deleteNote(targetNote.id, { quiet: true });
 			},
 		};
+		const actionKeys: (keyof typeof actions)[] = ['create', 'update', 'delete'];
 
 		for (let i = 0; i < actionCount; i++) {
 			bar.update(i, actionCount);
 
-			const actionId = this.context_.randInt(0, 100);
-
 			const targetNote = await this.randomNote({ includeReadOnly: false });
-			if (!targetNote) {
-				await actions.create();
-			} else if (actionId > 60) {
-				await actions.update(targetNote);
-			} else if (actionId > 50) {
-				await actions.delete(targetNote);
-			} else {
-				await actions.create();
+			const actionWeights = [
+				options.createProbability,
+				targetNote ? options.updateProbability : 0,
+				targetNote ? options.deleteProbability : 0,
+			];
+
+			const actionId = this.context_.randomFrom(actionKeys, actionWeights);
+			if (actionId) {
+				await actions[actionId](targetNote);
 			}
 		}
 		bar.complete();

--- a/packages/tools/fuzzer/ipc/ClientPool.ts
+++ b/packages/tools/fuzzer/ipc/ClientPool.ts
@@ -66,7 +66,7 @@ export default class ClientPool {
 		for (const client of this.clients) {
 			logger.info('Creating items for ', client.email);
 			const actionCount = this.context_.randomFrom([0, 10, 100]);
-			await client.createOrUpdateMany(actionCount);
+			await client.createOrUpdateMany(actionCount, { createProbability: 1, updateProbability: 1, deleteProbability: 1 });
 
 			await client.sync();
 		}

--- a/packages/tools/fuzzer/sample-fuzzer-setup.json
+++ b/packages/tools/fuzzer/sample-fuzzer-setup.json
@@ -15,7 +15,7 @@
 		"// Switch to the first client and do a large number of actions",
 		["switchClient", { "id": 0 }],
 		"syncAndCheckState",
-		["createOrUpdateMany", { "deleteProbability": 0, "count": 200 }],
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 400 }],
 		"syncAndCheckState",
 
 		"// Switch back to the second client. Unshare the folder and do a large number of actions",

--- a/packages/tools/fuzzer/sample-fuzzer-setup.json
+++ b/packages/tools/fuzzer/sample-fuzzer-setup.json
@@ -1,6 +1,6 @@
 {
 	"clientCount": 2,
-	"description": "Sample fuzzer setup: Reproduces the case where (at least historically)",
+	"description": "Sample fuzzer setup: Reproduces the case where (at least historically) a large number of conflicts are created after adding a new client to an account",
 	"actions": [
 		["switchClient", { "id": 0 }],
 		"sync",
@@ -18,16 +18,18 @@
 		["createOrUpdateMany", { "deleteProbability": 0, "count": 200 }],
 		"syncAndCheckState",
 
-		"// Switch back to the second client. Unshare the folder",
+		"// Switch back to the second client. Unshare the folder and do a large number of actions",
 		["switchClient", { "id": 1 }],
 		["unshareFolder", { "folderId": "11111111111111111111111111111112", "clientId": 0 }],
-		["createOrUpdateMany", { "deleteProbability": 0, "count": 200 }],
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 300 }],
+
+		"// ...then share it again...",
 		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
 		"syncAndCheckState",
 
 		"// Switch back to the first client and add a new client to the same account",
 		["switchClient", { "id": 0 }],
-		"newClientOnSameAccount",
+		["newClientOnSameAccount", { "welcomeNoteCount": 10 }],
 		"syncAndCheckState"
 	]
 }

--- a/packages/tools/fuzzer/sample-fuzzer-setup.json
+++ b/packages/tools/fuzzer/sample-fuzzer-setup.json
@@ -1,5 +1,6 @@
 {
 	"clientCount": 2,
+	"description": "Sample fuzzer setup: Reproduces the case where (at least historically)",
 	"actions": [
 		["switchClient", { "id": 0 }],
 		"sync",
@@ -11,16 +12,22 @@
 		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
 		"syncAndCheckState",
 
-		"// Switch to the first client & remove a note from the folder",
+		"// Switch to the first client and do a large number of actions",
 		["switchClient", { "id": 0 }],
-		["newToplevelFolder", { "id": "11111111111111111111111111111111" }],
+		"syncAndCheckState",
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 200 }],
 		"syncAndCheckState",
 
-		["moveNote", { "noteId": "11111111111111111111111111111113", "targetFolderId": "11111111111111111111111111111111" }],
+		"// Switch back to the second client. Unshare the folder",
+		["switchClient", { "id": 1 }],
+		["unshareFolder", { "folderId": "11111111111111111111111111111112", "clientId": 0 }],
+		["createOrUpdateMany", { "deleteProbability": 0, "count": 200 }],
+		["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
 		"syncAndCheckState",
 
-		"// Switch back to the second client and add a new client to the same account",
+		"// Switch back to the first client and add a new client to the same account",
 		["switchClient", { "id": 0 }],
-		"newClientOnSameAccount"
+		"newClientOnSameAccount",
+		"syncAndCheckState"
 	]
 }

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -16,7 +16,7 @@ export interface FuzzContext {
 	randInt: (low: number, high: number)=> number;
 	randomString: (targetLength: number)=> string;
 	randomId: ()=> string;
-	randomFrom: <T> (data: T[])=> T;
+	randomFrom: <T> (data: T[], weights?: number[])=> T;
 
 	execApi(method: HttpMethod, route: string, body: Json|undefined): Promise<Json>;
 }

--- a/packages/utils/array.test.ts
+++ b/packages/utils/array.test.ts
@@ -1,0 +1,15 @@
+import { randomWeightedElement } from './array';
+
+describe('array', () => {
+	it('should select an item from the provided array based on the given weights', () => {
+		expect(randomWeightedElement([1, 2, 3], [1, 0, 0])).toBe(1);
+		expect(randomWeightedElement([1, 2, 3], [0, 1, 0])).toBe(2);
+		expect(randomWeightedElement([1, 2, 3], [0, 0, 1])).toBe(3);
+	});
+
+	it('should use the provided random number generator', () => {
+		expect(randomWeightedElement([1, 2, 3], [0.25, 0.75, 0.25], () => 0.5)).toBe(2);
+		expect(randomWeightedElement([1, 2, 3], [0.25, 0.75, 0.25], () => 0)).toBe(1);
+		expect(randomWeightedElement([1, 2, 3], [0.25, 0.75, 0.25], () => 0.9999)).toBe(3);
+	});
+});

--- a/packages/utils/array.test.ts
+++ b/packages/utils/array.test.ts
@@ -12,4 +12,8 @@ describe('array', () => {
 		expect(randomWeightedElement([1, 2, 3], [0.25, 0.75, 0.25], () => 0)).toBe(1);
 		expect(randomWeightedElement([1, 2, 3], [0.25, 0.75, 0.25], () => 0.9999)).toBe(3);
 	});
+
+	it('should throw if all weights are zero', () => {
+		expect(() => randomWeightedElement([1, 2, 3], [0, 0, 0])).toThrow();
+	});
 });

--- a/packages/utils/array.ts
+++ b/packages/utils/array.ts
@@ -11,7 +11,7 @@ export const randomWeightedElement = <T> (items: T[], weights: number[], random:
 
 	// Normalize the weights so that they add up to one.
 	const weightsSum = weights.reduce((a, b) => a + b, 0);
-	const normalizedWeights = weights.map(w => w / weightsSum);
+	const normalizedWeights = weights.map(w => w / (weightsSum || 1));
 
 	// Pair items and weights
 	const weightedItems = items.map((item, index) => ({ item, weight: normalizedWeights[index] }));

--- a/packages/utils/array.ts
+++ b/packages/utils/array.ts
@@ -1,0 +1,31 @@
+
+
+type RandomFunction = ()=> number; // Should behave like Math.random, with output in [0,1)
+
+// eslint-disable-next-line import/prefer-default-export
+export const randomWeightedElement = <T> (items: T[], weights: number[], random: RandomFunction = Math.random): T|null => {
+	if (items.length !== weights.length) {
+		throw new Error('Items and weights must have the same length');
+	}
+	if (items.length === 0) return null;
+
+	// Normalize the weights so that they add up to one.
+	const weightsSum = weights.reduce((a, b) => a + b, 0);
+	const normalizedWeights = weights.map(w => w / weightsSum);
+
+	// Pair items and weights
+	const weightedItems = items.map((item, index) => ({ item, weight: normalizedWeights[index] }));
+
+	let weightSum = 0;
+	const value = random();
+
+	// Find the last item with `value` in its range
+	for (const item of weightedItems) {
+		weightSum += item.weight;
+		if (weightSum > value) {
+			return item.item;
+		}
+	}
+
+	return null;
+};

--- a/packages/utils/array.ts
+++ b/packages/utils/array.ts
@@ -11,6 +11,11 @@ export const randomWeightedElement = <T> (items: T[], weights: number[], random:
 
 	// Normalize the weights so that they add up to one.
 	const weightsSum = weights.reduce((a, b) => a + b, 0);
+
+	if (!isFinite(weightsSum) || weightsSum === 0) {
+		throw new Error(`Weights must sum to a finite, non-zero value. Provided weights: ${JSON.stringify(weights)}`);
+	}
+
 	const normalizedWeights = weights.map(w => w / (weightsSum || 1));
 
 	// Pair items and weights

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,6 +20,7 @@
     "./ipc": "./dist/ipc.js",
     "./path": "./dist/path.js",
     "./cli": "./dist/cli.js",
+    "./array": "./dist/array.js",
     "./version": "./dist/version.js"
   },
   "publishConfig": {


### PR DESCRIPTION
# Summary

This pull request:
- Adds the ability to specify the probability of different action types in `createOrUpdateMany` actions.
   - For example, `["createOrUpdateMany", { "deleteProbability": 0 }]` disables deletions.
   - The probabilities do not need to sum to 1. 
- Updates `sample-fuzzer-setup.json` to contain the reproduction steps for https://github.com/laurent22/joplin/issues/14383.
   - This uses the ability to specify the probability of different action types to disable deletions in `createOrUpdateMany`.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->