### PR TITLE
Desktop,Mobile,Cli: Fixes #14383: Fix unexpected conflicts sometimes created after a full sync

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -871,7 +871,7 @@ export default class Synchronizer {
 
 				let context = null;
 				let newDeltaContext = null;
-				const localFoldersToDelete = [];
+				const localFoldersToDelete = new Set<string>();
 				let hasCancelled = false;
 				if (lastContext.delta) context = lastContext.delta;
 
@@ -973,6 +973,8 @@ export default class Synchronizer {
 									reason = 'remote exists but local does not';
 									content = await loadContent();
 									ItemClass = content ? BaseItem.itemClass(content) : null;
+								} else {
+									reason = 'skipping: the item was deleted';
 								}
 							} else {
 								ItemClass = BaseItem.itemClass(local);
@@ -981,8 +983,14 @@ export default class Synchronizer {
 									action = SyncAction.DeleteLocal;
 									reason = 'remote has been deleted';
 								} else {
+									if (localFoldersToDelete.has(remoteId)) {
+										logger.debug('Removing a scheduled folder deletion (', remoteId, '). It was recreated by sync.');
+										localFoldersToDelete.delete(remoteId);
+									}
+
 									if (this.api().supportsAccurateTimestamp && remote.jop_updated_time === local.updated_time) {
 										// Nothing to do, and no need to fetch the content
+										reason = 'nothing to do and no need to fetch the content. The item is up-to-date';
 									} else {
 										content = await loadContent();
 										if (content && content.updated_time > local.updated_time) {
@@ -993,6 +1001,7 @@ export default class Synchronizer {
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync
 											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
+											reason = 'rescan for enhanced basic delta algorithm';
 										}
 									}
 								}
@@ -1067,7 +1076,12 @@ export default class Synchronizer {
 									await MasterKey.save(content);
 								}
 							} else {
-								await ItemClass.save(content, options);
+								const saved = await ItemClass.save(content, options);
+
+								// Ensure that the item can be found if another create/update event is received for the same item:
+								if (!local) {
+									locals.push(saved);
+								}
 							}
 
 							if (creatingOrUpdatingResource) this.dispatch({ type: 'SYNC_CREATED_OR_UPDATED_RESOURCE', id: content.id });
@@ -1084,7 +1098,7 @@ export default class Synchronizer {
 							if (content.encryption_applied) this.dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' });
 						} else if (action === SyncAction.DeleteLocal) {
 							if (local.type_ === BaseModel.TYPE_FOLDER) {
-								localFoldersToDelete.push(local);
+								localFoldersToDelete.add(local.id);
 								continue;
 							}
 
@@ -1134,12 +1148,12 @@ export default class Synchronizer {
 				// ------------------------------------------------------------------------
 
 				if (!this.cancelling()) {
-					for (let i = 0; i < localFoldersToDelete.length; i++) {
-						const item = localFoldersToDelete[i];
-						const noteIds = await Folder.noteIds(item.id);
+					for (const folderId of localFoldersToDelete) {
+						const noteIds = await Folder.noteIds(folderId);
 						if (noteIds.length) {
+							logger.warn('Conflict: Folder to be deleted', folderId, 'still contains notes', noteIds);
 							// CONFLICT
-							await Folder.markNotesAsConflict(item.id);
+							await Folder.markNotesAsConflict(folderId);
 						}
 
 						const deletionOptions: DeleteOptions = {
@@ -1148,7 +1162,7 @@ export default class Synchronizer {
 							changeSource: ItemChange.SOURCE_SYNC,
 							sourceDescription: 'Sync',
 						};
-						await Folder.delete(item.id, deletionOptions);
+						await Folder.delete(folderId, deletionOptions);
 					}
 				}
 

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -990,7 +990,6 @@ export default class Synchronizer {
 
 									if (this.api().supportsAccurateTimestamp && remote.jop_updated_time === local.updated_time) {
 										// Nothing to do, and no need to fetch the content
-										reason = 'nothing to do and no need to fetch the content. The item is up-to-date';
 									} else {
 										content = await loadContent();
 										if (content && content.updated_time > local.updated_time) {
@@ -1001,7 +1000,6 @@ export default class Synchronizer {
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync
 											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
-											reason = 'rescan for enhanced basic delta algorithm';
 										}
 									}
 								}


### PR DESCRIPTION
# Summary

As a part of Joplin's sync process, sync targets create or fetch a list of changes to be applied to the local state. Previously, if this change list included:
1. A folder deletion.
2. A recreation of the folder.

Then the recreation change would be ignored and the folder would be deleted. This created conflicts if the folder still contained notes.

This issue was observed when syncing with Joplin Server after removing and re-adding an account to a share, then adding a new Joplin client to the account.

Fixes #14383.

# Testing plan

1. Merge the sync fuzzer related changes from [this pull request](https://github.com/laurent22/joplin/pull/14382).
2. Update the fuzzer config to match (if it isn't already):
   <details><summary>Config</summary>

   `tools/fuzzer/sample-fuzzer-setup.json`:
   ```json
    {
	    "clientCount": 2,
	    "description": "Sample fuzzer setup: Reproduces the case where a large number of conflicts are created after adding a new client to an account",
	    "actions": [
		    ["switchClient", { "id": 0 }],
		    "sync",
    
		    "// Switch to the second client & share a folder",
		    ["switchClient", { "id": 1 }],
		    ["newToplevelFolder", { "id": "11111111111111111111111111111112" }],
		    ["newNote", { "id": "11111111111111111111111111111113", "parentId": "11111111111111111111111111111112" }],
		    ["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
		    "syncAndCheckState",
    
		    "// Switch to the first client and do a large number of actions",
		    ["switchClient", { "id": 0 }],
		    "syncAndCheckState",
		    ["createOrUpdateMany", { "deleteProbability": 0, "count": 400 }],
		    "syncAndCheckState",
    
		    "// Switch back to the second client. Unshare the folder and do a large number of actions",
		    ["switchClient", { "id": 1 }],
		    ["unshareFolder", { "folderId": "11111111111111111111111111111112", "clientId": 0 }],
		    ["createOrUpdateMany", { "deleteProbability": 0, "count": 300 }],
    
		    "// ...then share it again...",
		    ["shareFolder", { "folderId": "11111111111111111111111111111112", "otherClientId": 0, "readOnly": false }],
		    "syncAndCheckState",
    
		    "// Switch back to the first client and add a new client to the same account",
		    ["switchClient", { "id": 0 }],
		    ["newClientOnSameAccount", { "welcomeNoteCount": 10 }],
		    "syncAndCheckState"
	    ]
    }
   ```
   </details>
3. Clear the server's database.
4. Re-run the sync fuzzer with
   ```
   yarn syncFuzzer start --setup ./packages/tools/fuzzer/sample-fuzzer-setup.json --enable-e2ee=false --random-strings=false
   ```
5. Verify that the sync fuzzer setup steps run successfully.


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->