### PR TITLE
Server: Improve name generation for uploaded files

### DIFF
--- a/packages/server/src/utils/requestUtils.ts
+++ b/packages/server/src/utils/requestUtils.ts
@@ -4,6 +4,7 @@ import { AppContext } from './types';
 import * as formidable from 'formidable';
 import { Fields, Files } from 'formidable';
 import { IncomingMessage } from 'http';
+import { uuidgen } from './uuid';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export type BodyFields = Record<string, any>;
@@ -80,6 +81,16 @@ export async function formParse(request: IncomingMessage): Promise<FormParseResu
 		const form = formidable({
 			allowEmptyFiles: true,
 			minFileSize: 0,
+			filename: (_name) => {
+				// Joplin uses a version of Formidable in which the default filename generation
+				// logic is insecure. See:
+				// 1. https://github.com/node-formidable/formidable/commit/022c2c5577dfe14d2947f10909d81b03b6070bf5
+				// 2. https://github.com/node-formidable/formidable/commit/720cdfdfb9d8c8ae99817f2b70ac76153d50ad13
+				//
+				// Issue 2 should only impact Joplin if returning untrusted values from `filename`. Issue 1
+				// is related to possible collisions in how formidable generates random filenames.
+				return `upload-${uuidgen()}`;
+			},
 		});
 
 		try {


### PR DESCRIPTION
# Summary

Replaces `formidable`'s default filename generation logic with a function based on Joplin Server's existing `uuid` function.

# Testing

Manual testing: A PDF attached to a note from one Joplin client can be downloaded from another.
Sync fuzzer: With this change, the sync fuzzer runs successfully for >= 40 steps.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->