### PR TITLE
Server: Remove support for DELTA_INCLUDES_ITEMS

### DIFF
--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -42,8 +42,6 @@ const defaultEnvValues: EnvVariables = {
 	MAX_TIME_DRIFT: 2000,
 	NTP_SERVER: 'pool.ntp.org:123',
 
-	DELTA_INCLUDES_ITEMS: true,
-
 	// Whether or not to allow users logging in with a username/password combo.
 	// If this is disabled, a SAML-based login flow must be configured.
 	LOCAL_AUTH_ENABLED: true,
@@ -206,7 +204,6 @@ export interface EnvVariables {
 
 	MAX_TIME_DRIFT: number;
 	NTP_SERVER: string;
-	DELTA_INCLUDES_ITEMS: boolean;
 	IS_ADMIN_INSTANCE: boolean;
 	INSTANCE_NAME: string;
 

--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -1,4 +1,4 @@
-import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, expectThrow, createFolder, createItemTree3, expectNotThrow, createNote, updateNote, deleteNote } from '../utils/testing/testUtils';
+import { createUserAndSession, beforeAllDb, afterAllTests, beforeEachDb, models, expectThrow, createFolder, createItemTree3, expectNotThrow, createNote, updateNote } from '../utils/testing/testUtils';
 import { ChangeType } from '../services/database/types';
 import { Day, msleep } from '../utils/time';
 import { ChangePagination } from './ChangeModel';
@@ -275,65 +275,10 @@ describe('ChangeModel', () => {
 		jest.useRealTimers();
 	});
 
-	test('should return whole item when doing a delta call', async () => {
-		const { user, session } = await createUserAndSession(1, true);
-
-		await createItemTree3(user.id, '', '', [
-			{
-				id: '000000000000000000000000000000F1',
-				title: 'Folder 1',
-				children: [
-					{
-						id: '00000000000000000000000000000001',
-						title: 'Note 1',
-					},
-					{
-						id: '00000000000000000000000000000002',
-						title: 'Note 2',
-					},
-				],
-			},
-		]);
-
-		let cursor = '';
-
-		{
-			const result = await models().change().delta(user.id);
-			cursor = result.cursor;
-			const titles = result.items.map(it => it.jopItem.title).sort();
-			expect(titles).toEqual(['Folder 1', 'Note 1', 'Note 2']);
-		}
-
-		await msleep(1);
-
-		await updateNote(session.id, {
-			id: '00000000000000000000000000000001',
-			title: 'new title',
-		});
-
-		{
-			const result = await models().change().delta(user.id, { cursor });
-			cursor = result.cursor;
-			expect(result.items.length).toBe(1);
-			expect(result.items[0].jopItem.title).toBe('new title');
-		}
-
-		await msleep(1);
-
-		await deleteNote(user.id, '00000000000000000000000000000002');
-
-		{
-			const result = await models().change().delta(user.id, { cursor });
-			expect(result.items.length).toBe(1);
-			expect(result.items[0].jopItem).toBe(null);
-		}
-	});
-
-	test('should not return the whole item if the option is disabled', async () => {
+	test('should not return the whole item', async () => {
 		const { user } = await createUserAndSession(1, true);
 
 		const changeModel = await models().change();
-		changeModel.deltaIncludesItems_ = false;
 
 		await createItemTree3(user.id, '', '', [
 			{

--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -51,11 +51,8 @@ export function requestDeltaPagination(query: any): ChangePagination {
 
 export default class ChangeModel extends BaseModel<Change> {
 
-	public deltaIncludesItems_: boolean;
-
 	public constructor(db: DbConnection, dbSlave: DbConnection, modelFactory: NewModelFactoryHandler, config: Config) {
 		super(db, dbSlave, modelFactory, config);
-		this.deltaIncludesItems_ = config.DELTA_INCLUDES_ITEMS;
 	}
 
 	public get tableName(): string {
@@ -307,36 +304,18 @@ export default class ChangeModel extends BaseModel<Change> {
 			false,
 		);
 
-		let items: Item[] = await this.db('items').select('id', 'jop_updated_time').whereIn('items.id', changes.map(c => c.item_id));
+		const items: Item[] = await this.db('items').select('id', 'jop_updated_time').whereIn('items.id', changes.map(c => c.item_id));
 
 		let processedChanges = this.compressChanges_(changes);
 		processedChanges = await this.removeDeletedItems(processedChanges, items);
 
-		if (this.deltaIncludesItems_) {
-			items = await this.models().item().loadWithContentMulti(processedChanges.map(c => c.item_id), {
-				fields: [
-					'content',
-					'id',
-					'jop_encryption_applied',
-					'jop_id',
-					'jop_parent_id',
-					'jop_share_id',
-					'jop_type',
-					'jop_updated_time',
-				],
-			});
-		}
-
 		const finalChanges = processedChanges.map(change => {
 			const item = items.find(item => item.id === change.item_id);
-			if (!item) return this.deltaIncludesItems_ ? { ...change, jopItem: null } : { ...change };
+			if (!item) return { ...change };
 			const deltaChange: DeltaChange = {
 				...change,
 				jop_updated_time: item.jop_updated_time,
 			};
-			if (this.deltaIncludesItems_) {
-				deltaChange.jopItem = item.jop_type ? this.models().item().itemToJoplinItem(item) : null;
-			}
 			return deltaChange;
 		});
 


### PR DESCRIPTION
# Summary

Removes support for the `DELTA_INCLUDES_ITEMS` server configuration option. When `DELTA_INCLUDES_ITEMS` was enabled (the previous default), delta queries could produce incorrect results in some cases.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->