### PR TITLE
Desktop, Mobile: Fixes #13660: Defer starting revision service maintenance until the initial sync has completed

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -638,6 +638,7 @@ class Application extends BaseApplication {
 
 			if (Setting.value('env') === 'dev') {
 				void AlarmService.updateAllNotifications();
+				RevisionService.instance().runInBackground();
 			} else {
 				// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
 				void reg.scheduleSync(1000).then(() => {
@@ -646,10 +647,11 @@ class Application extends BaseApplication {
 					void AlarmService.updateAllNotifications();
 
 					void DecryptionWorker.instance().scheduleStart();
+
+					RevisionService.instance().runInBackground();
 				});
 			}
 
-			RevisionService.instance().runInBackground();
 			this.startRotatingLogMaintenance(Setting.value('profileDir'));
 		});
 

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -417,10 +417,6 @@ const buildStartupTasks = (
 		ResourceFetcher.instance().on('downloadComplete', resourceFetcher_downloadComplete);
 		void ResourceFetcher.instance().start();
 
-		// Collect revisions more frequently on mobile because it doesn't auto-save
-		// and it cannot collect anything when the app is not active.
-		RevisionService.instance().runInBackground(1000 * 30);
-
 		reg.setupRecurrentSync();
 
 		// When the app starts we want the full sync to
@@ -434,6 +430,10 @@ const buildStartupTasks = (
 			void AlarmService.updateAllNotifications();
 
 			void DecryptionWorker.instance().scheduleStart();
+
+			// Collect revisions more frequently on mobile because it doesn't auto-save
+			// and it cannot collect anything when the app is not active.
+			RevisionService.instance().runInBackground(1000 * 30);
 		});
 	});
 	addTask('buildStartupTasks/set up welcome utils', async () => {


### PR DESCRIPTION
It is possible for revisions which have already been deleted by the revision cleaner on one device to be deleted again and pushed up to the server again unnecessarily when switching to another Joplin client. This is because revision cleaning is distributed and happens on all clients, and begins upon startup of the app. Because the deletion step is the first step in the sync, it will delete items (without checking if they exist or not) before downloading any changes or deletions. This can add additional duration to the time it takes to sync, whenever switching to a Joplin client which has not been synced for a few days. This will get worse the longer since a client was last synced, where Joplin is used on a regular basis, and is moreso an issue for slow sync targets.

This PR mitigates the issue in most cases (i.e. where the first sync triggered at startup is successful), by deferring the startup of the revision service maintenance, so that it will only start after the intitial sync when starting up the app has completed (including cancellation or failure), or when the app is initialised in the case that the sync does not run (such as when sync is disabled). This change covers both the desktop and mobile app, however the cli is not impacted, because it does not perform an automatic sync upon startup, so therefore the revision service cannot be deferred.

This partially fixes https://github.com/laurent22/joplin/issues/13660

### Testing

I have tested the following scenarios on both desktop (release build) and mobile, and verified when the revision service starts by monitoring the logs during app startup:

1. When sync is disabled, the revision service starts immediately upon initialisation of the app
2. When sync is enabled, the revision service starts only after the automatically triggered sync has completed or being cancelled, regardless of whether or not there is a sync error
3. When sync is enabled, if I manually trigger a sync before the automatic triggering of the sync when the app starts up, the revision service starts after logging an entry that the sync is already in progress
4. When the desktop app is in dev mode, the revision service starts immediately upon initialisation of the app