### PR TITLE
Desktop: Fixes #14372: Enable Joplin Server OAuth flow on Desktop App

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -130,9 +130,9 @@ class ConfigScreenComponent extends React.Component<any, any> {
 	}
 
 	public screenFromName(screenName: string) {
-		if (screenName === 'encryption') return <EncryptionConfigScreen/>;
-		if (screenName === 'server') return <ClipperConfigScreen themeId={this.props.themeId}/>;
-		if (screenName === 'keymap') return <KeymapConfigScreen themeId={this.props.themeId}/>;
+		if (screenName === 'encryption') return <EncryptionConfigScreen />;
+		if (screenName === 'server') return <ClipperConfigScreen themeId={this.props.themeId} />;
+		if (screenName === 'keymap') return <KeymapConfigScreen themeId={this.props.themeId} />;
 		if (screenName === 'joplinCloud') return <JoplinCloudConfigScreen />;
 
 		throw new Error(`Invalid screen name: ${screenName}`);
@@ -253,6 +253,31 @@ class ConfigScreenComponent extends React.Component<any, any> {
 								title={_('Connect to Joplin Cloud')}
 								level={ButtonLevel.Primary}
 								onClick={goToJoplinCloudLogin}
+							/>
+						</div>,
+					);
+				}
+
+				if (settings['sync.target'] === SyncTargetRegistry.nameToId('joplinServer')) {
+					const server = settings['sync.9.path'] as string;
+
+					const goToJoplinServerLogin = async () => {
+						// Save settings to allow auth with the correct URL.
+						await shared.saveSettings(this);
+
+						this.props.dispatch({
+							type: 'NAV_GO',
+							routeName: 'JoplinServerLogin',
+						});
+					};
+
+					settingComps.push(
+						<div key="connect_to_joplin_server_button" style={this.rowStyle_}>
+							<Button
+								title={_('Login with Joplin Server')}
+								level={ButtonLevel.Primary}
+								onClick={goToJoplinServerLogin}
+								disabled={!server || server?.trim().length === 0}
 							/>
 						</div>,
 					);

--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -272,7 +272,7 @@ class ConfigScreenComponent extends React.Component<any, any> {
 					};
 
 					settingComps.push(
-						<div key="connect_to_joplin_server_button" style={this.rowStyle_}>
+						<div key='connect_to_joplin_server_button' style={this.rowStyle_}>
 							<Button
 								title={_('Login with Joplin Server')}
 								level={ButtonLevel.Primary}

--- a/packages/app-desktop/gui/JoplinServerLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinServerLoginScreen.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
+import ButtonBar from './ConfigScreen/ButtonBar';
+import { _ } from '@joplin/lib/locale';
+import { clipboard } from 'electron';
+import Button, { ButtonLevel } from './Button/Button';
+import { uuidgen } from '@joplin/lib/uuid';
+import { Dispatch } from 'redux';
+import { reducer, defaultState, generateApplicationConfirmUrl } from '@joplin/lib/services/joplinCloudUtils';
+import { AppState } from '../app.reducer';
+import Logger from '@joplin/utils/Logger';
+import { reg } from '@joplin/lib/registry';
+import Setting from '@joplin/lib/models/Setting';
+import eventManager, { EventName } from '@joplin/lib/eventManager';
+import bridge from '../services/bridge';
+
+const logger = Logger.create('JoplinServerLoginScreen');
+const { connect } = require('react-redux');
+
+interface Props {
+	dispatch: Dispatch;
+	joplinServerApi: string;
+}
+
+const JoplinServerScreenComponent = (props: Props) => {
+
+	const confirmUrl = (applicationAuthId: string) => `${props.joplinServerApi}/applications/${applicationAuthId}/confirm`;
+	const applicationAuthUrl = (applicationAuthId: string) => `${props.joplinServerApi}/api/application_auth/${applicationAuthId}`;
+
+	const [intervalIdentifier, setIntervalIdentifier] = useState(undefined);
+	const [state, dispatch] = useReducer(reducer, defaultState);
+
+	const applicationAuthId = useMemo(() => uuidgen(), []);
+
+	const periodicallyCheckForCredentials = () => {
+		if (intervalIdentifier) return;
+
+		let isWaitingResponse = false;
+		const interval = setInterval(async () => {
+			if (isWaitingResponse) return;
+			isWaitingResponse = true;
+
+			try {
+				const apiKey = Setting.value('sync.9.apiKey');
+				const headers: Record<string, string> = {};
+				if (apiKey) headers['X-JOPLIN-CUSTOM-API-KEY'] = apiKey;
+
+				const response = await fetch(applicationAuthUrl(applicationAuthId), { headers });
+				const jsonBody = await response.json();
+
+				if (response.ok && jsonBody.status === 'finished') {
+					Setting.setValue('sync.9.username', jsonBody.id);
+					Setting.setValue('sync.9.password', jsonBody.password);
+
+					const fileApi = await reg.syncTarget().fileApi();
+					await fileApi.driver().api().loadSession();
+					eventManager.emit(EventName.SessionEstablished);
+
+					dispatch({ type: 'COMPLETED' });
+					clearInterval(interval);
+					void reg.scheduleSync(0);
+				}
+			} catch (error) {
+				logger.error(error);
+				dispatch({ type: 'ERROR', payload: error.message });
+				clearInterval(interval);
+			} finally {
+				isWaitingResponse = false;
+			}
+		}, 2 * 1000);
+
+		setIntervalIdentifier(interval);
+	};
+
+	const onButtonUsed = () => {
+		if (state.next === 'LINK_USED') {
+			dispatch({ type: 'LINK_USED' });
+		}
+		periodicallyCheckForCredentials();
+	};
+
+	const onAuthorizeClicked = async () => {
+		const url = await generateApplicationConfirmUrl(confirmUrl(applicationAuthId));
+		void bridge().openExternal(url);
+		onButtonUsed();
+	};
+
+	const onCopyToClipboardClicked = async () => {
+		const url = await generateApplicationConfirmUrl(confirmUrl(applicationAuthId));
+		clipboard.writeText(url);
+		onButtonUsed();
+	};
+
+	useEffect(() => {
+		return () => {
+			clearInterval(intervalIdentifier);
+		};
+	}, [intervalIdentifier]);
+
+	return (
+		<div className="login-page">
+			<div className="page-container">
+				{state.active !== 'COMPLETED' ? (
+					<>
+						<p className="text">{_('To allow Joplin to synchronise with Joplin Server, please login using this URL:')}</p>
+						<div className="buttons-container">
+							<Button
+								onClick={onAuthorizeClicked}
+								title={_('Authorise')}
+								iconName='fa fa-external-link-alt'
+								level={ButtonLevel.Primary}
+							/>
+							<Button
+								onClick={onCopyToClipboardClicked}
+								title={_('Copy link to website')}
+								iconName='fa fa-clone'
+								level={ButtonLevel.Secondary}
+							/>
+
+						</div>
+					</>
+				) : null}
+				<p className={state.className}>{state.message()}
+					{state.active === 'ERROR' ? (
+						<span className={state.className}>{state.errorMessage}</span>
+					) : null}
+				</p>
+				{state.active === 'LINK_USED' ? <div className="loading-animation" /> : null}
+			</div>
+			<ButtonBar onCancelClick={() => props.dispatch({ type: 'NAV_BACK' })} />
+		</div>
+	);
+};
+
+const mapStateToProps = (state: AppState) => {
+	return {
+		joplinServerApi: state.settings['sync.9.path'],
+	};
+};
+
+export default connect(mapStateToProps)(JoplinServerScreenComponent);

--- a/packages/app-desktop/gui/JoplinServerLoginScreen.tsx
+++ b/packages/app-desktop/gui/JoplinServerLoginScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect, useMemo, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 import ButtonBar from './ConfigScreen/ButtonBar';
 import { _ } from '@joplin/lib/locale';
 import { clipboard } from 'electron';
@@ -27,13 +27,13 @@ const JoplinServerScreenComponent = (props: Props) => {
 	const confirmUrl = (applicationAuthId: string) => `${props.joplinServerApi}/applications/${applicationAuthId}/confirm`;
 	const applicationAuthUrl = (applicationAuthId: string) => `${props.joplinServerApi}/api/application_auth/${applicationAuthId}`;
 
-	const [intervalIdentifier, setIntervalIdentifier] = useState(undefined);
+	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [state, dispatch] = useReducer(reducer, defaultState);
 
 	const applicationAuthId = useMemo(() => uuidgen(), []);
 
 	const periodicallyCheckForCredentials = () => {
-		if (intervalIdentifier) return;
+		if (intervalRef.current) return;
 
 		let isWaitingResponse = false;
 		const interval = setInterval(async () => {
@@ -57,19 +57,25 @@ const JoplinServerScreenComponent = (props: Props) => {
 					eventManager.emit(EventName.SessionEstablished);
 
 					dispatch({ type: 'COMPLETED' });
-					clearInterval(interval);
+					if (intervalRef.current) {
+						clearInterval(intervalRef.current);
+						intervalRef.current = null;
+					}
 					void reg.scheduleSync(0);
 				}
 			} catch (error) {
 				logger.error(error);
 				dispatch({ type: 'ERROR', payload: error.message });
-				clearInterval(interval);
+				if (intervalRef.current) {
+					clearInterval(intervalRef.current);
+					intervalRef.current = null;
+				}
 			} finally {
 				isWaitingResponse = false;
 			}
 		}, 2 * 1000);
 
-		setIntervalIdentifier(interval);
+		intervalRef.current = interval;
 	};
 
 	const onButtonUsed = () => {
@@ -93,17 +99,20 @@ const JoplinServerScreenComponent = (props: Props) => {
 
 	useEffect(() => {
 		return () => {
-			clearInterval(intervalIdentifier);
+			if (intervalRef.current) {
+				clearInterval(intervalRef.current);
+				intervalRef.current = null;
+			}
 		};
-	}, [intervalIdentifier]);
+	}, []);
 
 	return (
-		<div className="login-page">
-			<div className="page-container">
+		<div className='login-page'>
+			<div className='page-container'>
 				{state.active !== 'COMPLETED' ? (
 					<>
-						<p className="text">{_('To allow Joplin to synchronise with Joplin Server, please login using this URL:')}</p>
-						<div className="buttons-container">
+						<p className='text'>{_('To allow Joplin to synchronise with Joplin Server, please login using this URL:')}</p>
+						<div className='buttons-container'>
 							<Button
 								onClick={onAuthorizeClicked}
 								title={_('Authorise')}
@@ -125,7 +134,7 @@ const JoplinServerScreenComponent = (props: Props) => {
 						<span className={state.className}>{state.errorMessage}</span>
 					) : null}
 				</p>
-				{state.active === 'LINK_USED' ? <div className="loading-animation" /> : null}
+				{state.active === 'LINK_USED' ? <div className='loading-animation' /> : null}
 			</div>
 			<ButtonBar onCancelClick={() => props.dispatch({ type: 'NAV_BACK' })} />
 		</div>

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -24,6 +24,7 @@ import ProfileEditor from './ProfileEditor';
 import Navigator from './Navigator';
 import WelcomeUtils from '@joplin/lib/WelcomeUtils';
 import JoplinCloudLoginScreen from './JoplinCloudLoginScreen';
+import JoplinServerLoginScreen from './JoplinServerLoginScreen';
 import InteropService from '@joplin/lib/services/interop/InteropService';
 import WindowCommandsAndDialogs from './WindowCommandsAndDialogs/WindowCommandsAndDialogs';
 import { defaultWindowId, stateUtils, WindowState } from '@joplin/lib/reducer';
@@ -102,7 +103,7 @@ class RootComponent extends React.Component<Props, any> {
 		const renderContent = () => {
 			return (
 				<div>
-					<DialogTitle title={_('Confirmation')}/>
+					<DialogTitle title={_('Confirmation')} />
 					<p>{props.message}</p>
 					<DialogButtonRow
 						themeId={props.themeId}
@@ -162,6 +163,7 @@ class RootComponent extends React.Component<Props, any> {
 			OneDriveLogin: { screen: OneDriveLoginScreen, title: () => _('OneDrive Login') },
 			DropboxLogin: { screen: DropboxLoginScreen, title: () => _('Dropbox Login') },
 			JoplinCloudLogin: { screen: JoplinCloudLoginScreen, title: () => _('Joplin Cloud Login') },
+			JoplinServerLogin: { screen: JoplinServerLoginScreen, title: () => _('Joplin Server Login') },
 			JoplinServerSamlLogin: { screen: SsoLoginScreen(new SamlShared()), title: () => _('Joplin Server Login') },
 			Import: { screen: ImportScreen, title: () => _('Import') },
 			Config: { screen: ConfigScreen, title: () => _('Options') },
@@ -174,9 +176,9 @@ class RootComponent extends React.Component<Props, any> {
 			<StyleSheetManager disableVendorPrefixes>
 				<ThemeProvider theme={theme}>
 					<PopupNotificationProvider>
-						<StyleSheetContainer/>
-						<MenuBar/>
-						<GlobalStyle/>
+						<StyleSheetContainer />
+						<MenuBar />
+						<GlobalStyle />
 						<WindowCommandsAndDialogs windowId={defaultWindowId} />
 						<Navigator style={navigatorStyle} screens={screens} className={`profile-${this.props.profileConfigCurrentProfileId}`} />
 						{this.renderSecondaryWindows()}

--- a/packages/lib/SyncTargetJoplinServer.ts
+++ b/packages/lib/SyncTargetJoplinServer.ts
@@ -65,11 +65,25 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 	}
 
 	public async isAuthenticated() {
-		return true;
+		try {
+			const fileApi = await this.fileApi();
+			const api = fileApi.driver().api();
+			const sessionId = await api.sessionId();
+			return !!sessionId;
+		} catch (error) {
+			if (error.code === 403) {
+				return false;
+			}
+			throw error;
+		}
+	}
+
+	public authRouteName() {
+		return 'JoplinServerLogin';
 	}
 
 	public static requiresPassword() {
-		return true;
+		return false;
 	}
 
 	public static override supportsShare(): boolean {
@@ -80,7 +94,7 @@ export default class SyncTargetJoplinServer extends BaseSyncTarget {
 		return super.fileApi();
 	}
 
-	public static async checkConfig(options: FileApiOptions, syncTargetId: number = null, fileApi: FileApi|null = null) {
+	public static async checkConfig(options: FileApiOptions, syncTargetId: number = null, fileApi: FileApi | null = null) {
 		const output = {
 			ok: false,
 			errorMessage: '',


### PR DESCRIPTION
### Description
Fixes #14372: Enable Joplin Server OAuth flow on Desktop App

The Desktop client lacked the OAuth flow implementation for the self-hosted Joplin Server sync target (`sync.target` 9) but correctly used it for the hosted Joplin Cloud. Since Joplin Server and Joplin Cloud share the same backend, this identical OAuth flow has now been configured natively for self-hosted instances without breaking legacy/direct-password entry capabilities.

**Changes:**
- Added a `JoplinServerLoginScreen` component to handle the OAuth flow and polling specifically tailored for the `sync.9` target (Joplin Server).
- Hooked up `JoplinServerLoginScreen` in the [Root.tsx](cci:7://file:///Users/manthannimodiya/Coding/GitHub/GSOC/joplin/packages/app-desktop/gui/Root.tsx:0:0-0:0) navigator.
- Updated [ConfigScreen.tsx](cci:7://file:///Users/manthannimodiya/Coding/GitHub/GSOC/joplin/packages/app-desktop/gui/JoplinCloudConfigScreen.tsx:0:0-0:0) to display a "Login with Joplin Server" button that routes to the new login screen when the sync target is set to Joplin Server.
- Modified [SyncTargetJoplinServer.ts](cci:7://file:///Users/manthannimodiya/Coding/GitHub/GSOC/joplin/packages/lib/SyncTargetJoplinServer.ts:0:0-0:0) to implement [authRouteName()](cci:1://file:///Users/manthannimodiya/Coding/GitHub/GSOC/joplin/packages/lib/SyncTargetJoplinServer.ts:80:1-82:2) pointing to the new login screen, extracting session ID checks inside [isAuthenticated()](cci:1://file:///Users/manthannimodiya/Coding/GitHub/GSOC/joplin/packages/lib/SyncTargetJoplinServer.ts:66:1-78:2), and handling password requirements accurately.

### Demo





https://github.com/user-attachments/assets/ebd2cc70-1c16-4164-9504-f29043d16124





### Testing steps
1. Run a local Joplin Server.
2. In the Config screen, change Synchronization to **Joplin Server**.
3. Input the server URL and click "Login with Joplin Server".
4. Authorize via the browser, and verify session establishes inside the Desktop App without errors.
