### PR TITLE
Server: Fixes #14355: Admin emails sorting fails due to invalid user_id column

### DIFF
--- a/packages/server/src/routes/admin/emails.ts
+++ b/packages/server/src/routes/admin/emails.ts
@@ -40,7 +40,7 @@ router.get('admin/emails', async (_path: SubPath, ctx: AppContext) => {
 				label: 'To',
 			},
 			{
-				name: 'user_id',
+				name: 'recipient_id',
 				label: 'User',
 			},
 			{


### PR DESCRIPTION
## Description  
Fixes #14355

Sorting by the **User** column in **Admin → Emails** caused a SQL error because the table was configured to use user_id, while the emails table actually uses recipient_id.


This updates the sort field to recipient_id, aligning it with the database schema and resolving the error.


### Changes


- Replaced `user_id` with `recipient_id` in the admin emails table sorting configuration  


### Testing


- Rebuilt the server
- Confirmed the SQL error no longer occurs  