### PR TITLE
Desktop: Fixes #14396: Fixed Google Docs paste producing stray ** and literal <br/> in Markdown

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -104,6 +104,67 @@ describe('resourceHandling', () => {
 		expect(result).toContain('<br>');
 	});
 
+	it('should split <p> containing <br> into multiple <p> blocks', () => {
+		const html = '<b id="docs-internal-guid-abc123" style="font-weight:normal">' +
+			'<p><span>Line one</span><br><span>Line two</span><br><span>Line three</span></p></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line one');
+		expect(result).toContain('Line two');
+		expect(result).toContain('Line three');
+		expect((result.match(/<p>/g) || []).length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('should handle trailing <br> inside <p>', () => {
+		const html = '<b id="docs-internal-guid-abc123" style="font-weight:normal">' +
+			'<p><span>Line 1</span><br><span>Line 2</span><br><span>Line 3</span><br></p></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line 1');
+		expect(result).toContain('Line 2');
+		expect(result).toContain('Line 3');
+	});
+
+	it('should unwrap <br> from <span> wrappers (real Google Docs format)', () => {
+		const html = '<b id="docs-internal-guid-abc123" style="font-weight:normal">' +
+			'<p>' +
+			'<span style="font-size:11pt">Line 1</span>' +
+			'<span style="font-size:11pt"><br></span>' +
+			'<span style="font-size:11pt">Line 2</span>' +
+			'<span style="font-size:11pt"><br></span>' +
+			'<span style="font-size:11pt">Line 3</span>' +
+			'<span style="font-size:11pt"><br><br></span>' +
+			'</p></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line 1');
+		expect(result).toContain('Line 2');
+		expect(result).toContain('Line 3');
+		expect((result.match(/<p>/g) || []).length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('should handle <br> between and after <p> blocks', () => {
+		// <br> after <p> at body level
+		const html = '<b id="docs-internal-guid-abc123" style="font-weight:normal">' +
+			'<p><span>Line 1</span></p><br><p><span>Line 2</span></p><br></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line 1');
+		expect(result).toContain('Line 2');
+	});
+
+	it('should handle Google Docs structure with empty paragraph breaks', () => {
+		const html = '<b id="docs-internal-guid-xyz" style="font-weight:normal">' +
+			'<p><span>Line one</span><br><span>Line 2</span><br><span>Line 3</span></p>' +
+			'<p><br></p>' +
+			'<p><span>Hello</span>&nbsp;&nbsp;<span>World</span></p></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line one');
+		expect(result).toContain('Hello');
+		expect(result).toContain('World');
+	});
+
 	it('should NOT touch content when <p> blocks already exist', () => {
 		const html = '<b id="docs-internal-guid-xyz" style="font-weight:normal">' +
 			'<p>Para 1</p><br><p>Para 2</p></b>';
@@ -111,11 +172,47 @@ describe('resourceHandling', () => {
 		// Existing <p> blocks should be preserved as-is.
 		expect(result).toContain('<p>Para 1</p>');
 		expect(result).toContain('<p>Para 2</p>');
+		// The <br> between <p> blocks should be removed.
+		expect(result).not.toMatch(/<br\s*\/?>/i);
 	});
 
 	it('should return non-Google Docs HTML unchanged', () => {
 		const html = '<b></b><span>Hello</span><br><span>World</span>';
 		const result = sanitizeGoogleDocsHtml(html);
 		expect(result).toBe(html);
+	});
+
+	it('end-to-end: Google Docs paste produces clean Markdown with all content preserved', async () => {
+		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
+
+		const googleDocsInput =
+			'<b id="docs-internal-guid-abc123" style="font-weight:normal">' +
+			'<p><span style="font-size:11pt">Hello World</span></p>' +
+			'<p><span style="font-size:11pt">Line one</span><br>' +
+			'<span style="font-size:11pt">Line two</span><br>' +
+			'<span style="font-size:11pt">Line three</span></p>' +
+			'</b>' +
+			'<b style="font-weight:normal"></b>';
+
+		const result = await processPastedHtml(googleDocsInput, htmlToMd, markupToHtml);
+
+		// Req 1: Text content is preserved exactly
+		expect(result).toContain('Hello World');
+		expect(result).toContain('Line one');
+		expect(result).toContain('Line two');
+		expect(result).toContain('Line three');
+
+		// Req 2: Paragraph breaks are preserved
+		expect((result.match(/<p>/g) || []).length).toBeGreaterThanOrEqual(4);
+
+		// Req 3: No stray ** lines appear
+		expect(result).not.toMatch(/^\*\*$/m);
+		expect(result).not.toContain('****');
+
+		// Req 4: No injected formatting markup
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+
+		// Req 5: No &nbsp; entities from Google Docs
+		expect(result).not.toContain('&nbsp;');
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -1,5 +1,5 @@
 import Setting from '@joplin/lib/models/Setting';
-import { processPastedHtml } from './resourceHandling';
+import { processPastedHtml, sanitizeGoogleDocsHtml } from './resourceHandling';
 import markupLanguageUtils from '@joplin/lib/markupLanguageUtils';
 import HtmlToMd from '@joplin/lib/HtmlToMd';
 import { HtmlToMarkdownHandler, MarkupToHtmlHandler } from './types';
@@ -62,5 +62,62 @@ describe('resourceHandling', () => {
 		// All images in the resource directory should be preserved.
 		const html = `<img src="file://${encodeURI(Setting.value('resourceDir'))}/resource.png" alt="test"/>`;
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
+	});
+
+	describe('sanitizeGoogleDocsHtml', () => {
+		const googleDocsWrap = (inner: string) =>
+			`<b id="docs-internal-guid-abc123" style="font-weight:normal">${inner}</b>`;
+
+		it('should remove empty inline formatting tags', () => {
+			const html = `${googleDocsWrap('<span>Hello</span>')}<b style="font-weight:normal"></b>`;
+			const result = sanitizeGoogleDocsHtml(html);
+			expect(result).not.toContain('<b style="font-weight:normal"></b>');
+			expect(result).toContain('Hello');
+		});
+
+		it('should remove empty <b> tags containing only empty spans', () => {
+			const html = `${googleDocsWrap('<span>Hi</span>')}<b><span></span></b>`;
+			const result = sanitizeGoogleDocsHtml(html);
+			expect(result).not.toContain('<b><span></span></b>');
+		});
+
+		it('should unwrap fake-bold <b style="font-weight:normal"> with content', () => {
+			const html = googleDocsWrap('<span style="font-size:11pt">Some text</span>');
+			const result = sanitizeGoogleDocsHtml(html);
+			// The <b> wrapper should be removed, but the span content preserved.
+			expect(result).not.toMatch(/<b[^>]*>/);
+			expect(result).toContain('Some text');
+		});
+
+		it('should normalize top-level <br> into <p> blocks', () => {
+			const html = `${googleDocsWrap('<span>Line A</span>')}<br><span>Line B</span>`;
+			const result = sanitizeGoogleDocsHtml(html);
+			expect(result).toContain('<p>');
+			expect(result).not.toMatch(/<br\s*\/?>/i);
+			expect(result).toContain('Line A');
+			expect(result).toContain('Line B');
+		});
+
+		it('should NOT normalize <br> inside <li>', () => {
+			const html = googleDocsWrap('<ul><li>Line1<br>Line2</li></ul>');
+			const result = sanitizeGoogleDocsHtml(html);
+			// <br> inside <li> should be preserved.
+			expect(result).toContain('<br>');
+		});
+
+		it('should NOT touch content when <p> blocks already exist', () => {
+			const html = '<b id="docs-internal-guid-xyz" style="font-weight:normal">' +
+				'<p>Para 1</p><br><p>Para 2</p></b>';
+			const result = sanitizeGoogleDocsHtml(html);
+			// Existing <p> blocks should be preserved as-is.
+			expect(result).toContain('<p>Para 1</p>');
+			expect(result).toContain('<p>Para 2</p>');
+		});
+
+		it('should return non-Google Docs HTML unchanged', () => {
+			const html = '<b></b><span>Hello</span><br><span>World</span>';
+			const result = sanitizeGoogleDocsHtml(html);
+			expect(result).toBe(html);
+		});
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -64,60 +64,58 @@ describe('resourceHandling', () => {
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
 	});
 
-	describe('sanitizeGoogleDocsHtml', () => {
-		const googleDocsWrap = (inner: string) =>
-			`<b id="docs-internal-guid-abc123" style="font-weight:normal">${inner}</b>`;
+	const googleDocsWrap = (inner: string) =>
+		`<b id="docs-internal-guid-abc123" style="font-weight:normal">${inner}</b>`;
 
-		it('should remove empty inline formatting tags', () => {
-			const html = `${googleDocsWrap('<span>Hello</span>')}<b style="font-weight:normal"></b>`;
-			const result = sanitizeGoogleDocsHtml(html);
-			expect(result).not.toContain('<b style="font-weight:normal"></b>');
-			expect(result).toContain('Hello');
-		});
+	it('should remove empty inline formatting tags', () => {
+		const html = `${googleDocsWrap('<span>Hello</span>')}<b style="font-weight:normal"></b>`;
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toContain('<b style="font-weight:normal"></b>');
+		expect(result).toContain('Hello');
+	});
 
-		it('should remove empty <b> tags containing only empty spans', () => {
-			const html = `${googleDocsWrap('<span>Hi</span>')}<b><span></span></b>`;
-			const result = sanitizeGoogleDocsHtml(html);
-			expect(result).not.toContain('<b><span></span></b>');
-		});
+	it('should remove empty <b> tags containing only empty spans', () => {
+		const html = `${googleDocsWrap('<span>Hi</span>')}<b><span></span></b>`;
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).not.toContain('<b><span></span></b>');
+	});
 
-		it('should unwrap fake-bold <b style="font-weight:normal"> with content', () => {
-			const html = googleDocsWrap('<span style="font-size:11pt">Some text</span>');
-			const result = sanitizeGoogleDocsHtml(html);
-			// The <b> wrapper should be removed, but the span content preserved.
-			expect(result).not.toMatch(/<b[^>]*>/);
-			expect(result).toContain('Some text');
-		});
+	it('should unwrap fake-bold <b style="font-weight:normal"> with content', () => {
+		const html = googleDocsWrap('<span style="font-size:11pt">Some text</span>');
+		const result = sanitizeGoogleDocsHtml(html);
+		// The <b> wrapper should be removed, but the span content preserved.
+		expect(result).not.toMatch(/<b[^>]*>/);
+		expect(result).toContain('Some text');
+	});
 
-		it('should normalize top-level <br> into <p> blocks', () => {
-			const html = `${googleDocsWrap('<span>Line A</span>')}<br><span>Line B</span>`;
-			const result = sanitizeGoogleDocsHtml(html);
-			expect(result).toContain('<p>');
-			expect(result).not.toMatch(/<br\s*\/?>/i);
-			expect(result).toContain('Line A');
-			expect(result).toContain('Line B');
-		});
+	it('should normalize top-level <br> into <p> blocks', () => {
+		const html = `${googleDocsWrap('<span>Line A</span>')}<br><span>Line B</span>`;
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).toContain('<p>');
+		expect(result).not.toMatch(/<br\s*\/?>/i);
+		expect(result).toContain('Line A');
+		expect(result).toContain('Line B');
+	});
 
-		it('should NOT normalize <br> inside <li>', () => {
-			const html = googleDocsWrap('<ul><li>Line1<br>Line2</li></ul>');
-			const result = sanitizeGoogleDocsHtml(html);
-			// <br> inside <li> should be preserved.
-			expect(result).toContain('<br>');
-		});
+	it('should NOT normalize <br> inside <li>', () => {
+		const html = googleDocsWrap('<ul><li>Line1<br>Line2</li></ul>');
+		const result = sanitizeGoogleDocsHtml(html);
+		// <br> inside <li> should be preserved.
+		expect(result).toContain('<br>');
+	});
 
-		it('should NOT touch content when <p> blocks already exist', () => {
-			const html = '<b id="docs-internal-guid-xyz" style="font-weight:normal">' +
-				'<p>Para 1</p><br><p>Para 2</p></b>';
-			const result = sanitizeGoogleDocsHtml(html);
-			// Existing <p> blocks should be preserved as-is.
-			expect(result).toContain('<p>Para 1</p>');
-			expect(result).toContain('<p>Para 2</p>');
-		});
+	it('should NOT touch content when <p> blocks already exist', () => {
+		const html = '<b id="docs-internal-guid-xyz" style="font-weight:normal">' +
+			'<p>Para 1</p><br><p>Para 2</p></b>';
+		const result = sanitizeGoogleDocsHtml(html);
+		// Existing <p> blocks should be preserved as-is.
+		expect(result).toContain('<p>Para 1</p>');
+		expect(result).toContain('<p>Para 2</p>');
+	});
 
-		it('should return non-Google Docs HTML unchanged', () => {
-			const html = '<b></b><span>Hello</span><br><span>World</span>';
-			const result = sanitizeGoogleDocsHtml(html);
-			expect(result).toBe(html);
-		});
+	it('should return non-Google Docs HTML unchanged', () => {
+		const html = '<b></b><span>Hello</span><br><span>World</span>';
+		const result = sanitizeGoogleDocsHtml(html);
+		expect(result).toBe(html);
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -178,6 +178,147 @@ const processImagesInPastedHtml = async (html: string) => {
 	return htmlUtils.replaceImageUrls(html, (src: string) => mappedResources[src]);
 };
 
+// Inline formatting tag names that, when empty, produce stray Markdown
+// markers (e.g. ** from empty <b>).
+const removableInlineTags = new Set(['b', 'strong', 'i', 'em', 'u', 's']);
+
+// Block-level tags whose children should NOT be paragraph-normalized.
+const blockTags = new Set([
+	'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+	'ul', 'ol', 'li', 'table', 'thead', 'tbody', 'tr', 'td', 'th',
+	'blockquote', 'pre', 'hr', 'figure', 'figcaption', 'section',
+]);
+
+function hasVisibleText(node: Node): boolean {
+	if (node.nodeType === Node.TEXT_NODE) return node.textContent.trim().length > 0;
+	if (node.nodeType === Node.ELEMENT_NODE) {
+		for (const child of Array.from(node.childNodes)) {
+			if (hasVisibleText(child)) return true;
+		}
+	}
+	return false;
+}
+
+// Sanitize HTML produced by Google Docs before the HTML→Markdown round-trip.
+//
+// Only runs when the HTML contains the `docs-internal-guid-` marker that
+// Google Docs injects. For all other sources the HTML is returned as-is.
+//
+// Fixes:
+// - Empty `<b>`, `<strong>`, etc. that Turndown converts to stray `**` / `*`
+// - `<b style="font-weight:normal">` wrappers that are not actually bold
+// - `<br>` between top-level inline elements that should be paragraph breaks
+export function sanitizeGoogleDocsHtml(html: string): string {
+	if (!html.includes('docs-internal-guid-')) return html;
+
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+
+	// --- Step 1: Clean inline formatting nodes ---
+	const walkAndClean = (root: Node) => {
+		// Iterate in reverse so removals don't shift indices.
+		const children = Array.from(root.childNodes);
+		for (const node of children) {
+			if (node.nodeType !== Node.ELEMENT_NODE) continue;
+			const el = node as HTMLElement;
+			const tag = el.tagName.toLowerCase();
+
+			if (removableInlineTags.has(tag)) {
+				if (!hasVisibleText(el)) {
+					// Empty formatting tag — remove entirely.
+					el.remove();
+					continue;
+				}
+				// <b style="font-weight:normal"> is a Google Docs container, not bold.
+				if (tag === 'b' && el.style.fontWeight === 'normal') {
+					if (!el.parentNode) continue;
+					// Unwrap: replace the <b> with its children.
+					while (el.firstChild) {
+						el.parentNode.insertBefore(el.firstChild, el);
+					}
+					el.remove();
+					continue;
+				}
+			}
+
+			// Skip block elements that manage their own structure.
+			if (!blockTags.has(tag)) {
+				walkAndClean(el);
+			}
+		}
+	};
+
+	walkAndClean(doc.body);
+
+	// --- Step 2: Normalize top-level <br>-separated inlines into <p> blocks ---
+	const normalizeBrs = (container: Element) => {
+		const children = Array.from(container.childNodes);
+		// Only normalize if there are <br> elements at this level.
+		const hasBr = children.some(
+			n => n.nodeType === Node.ELEMENT_NODE && (n as Element).tagName.toLowerCase() === 'br',
+		);
+		if (!hasBr) return;
+
+		// Check if container already uses <p> blocks — if so, don't touch.
+		const hasExistingParagraphs = children.some(
+			n => n.nodeType === Node.ELEMENT_NODE && (n as Element).tagName.toLowerCase() === 'p',
+		);
+		if (hasExistingParagraphs) return;
+
+		const groups: Node[][] = [[]];
+		for (const node of children) {
+			if (node.nodeType === Node.ELEMENT_NODE) {
+				const el = node as Element;
+				const tag = el.tagName.toLowerCase();
+
+				if (el.tagName.toLowerCase() === 'br') {
+					// End current group, start a new one.
+					groups.push([]);
+					continue;
+				}
+
+				if (blockTags.has(tag)) {
+					// Flush current group, pass block through as its own group.
+					groups.push([node]);
+					groups.push([]);
+					continue;
+				}
+			}
+
+			// Inline node or text node — add to current group.
+			groups[groups.length - 1].push(node);
+		}
+
+		// Clear the container and rebuild with <p> wrappers.
+		while (container.firstChild) container.firstChild.remove();
+
+		for (const group of groups) {
+			if (group.length === 0) continue;
+
+			// If the group is a single block element, append it directly.
+			if (group.length === 1 && group[0].nodeType === Node.ELEMENT_NODE) {
+				const tag = (group[0] as Element).tagName.toLowerCase();
+				if (blockTags.has(tag)) {
+					container.appendChild(group[0]);
+					continue;
+				}
+			}
+
+			// Skip groups that are only whitespace.
+			const groupText = group.map(n => n.textContent).join('').trim();
+			if (!groupText) continue;
+
+			const p = doc.createElement('p');
+			for (const node of group) p.appendChild(node);
+			container.appendChild(p);
+		}
+	};
+
+	// Only normalize at the top-level container (body or Google's root wrapper).
+	normalizeBrs(doc.body);
+
+	return doc.body.innerHTML;
+}
+
 export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHandler | null, mdToHtml: MarkupToHtmlHandler | null) {
 	// When copying text from eg. GitHub, the HTML might contain non-breaking
 	// spaces instead of regular spaces. If these non-breaking spaces are
@@ -185,6 +326,9 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	// dropped. So here we convert them to regular spaces.
 	// https://stackoverflow.com/a/31790544/561309
 	html = html.replace(/[\u202F\u00A0]/g, ' ');
+
+	// Sanitize Google Docs-specific HTML quirks before the round-trip.
+	html = sanitizeGoogleDocsHtml(html);
 
 	html = await processImagesInPastedHtml(html);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -249,7 +249,61 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 
 	walkAndClean(doc.body);
 
-	// --- Step 2: Normalize top-level <br>-separated inlines into <p> blocks ---
+	// --- Step 2: Split <p> elements containing <br> into multiple <p> blocks ---
+	// Google Docs wraps <br> inside styled <span> elements
+	// (e.g. <span style="..."><br/></span>). We first unwrap those, then split
+	// the <p> at <br> boundaries into separate <p> blocks.
+	// Only targets <p> elements — leaves <li>, <td>, <blockquote> etc. alone.
+	const paragraphs = Array.from(doc.querySelectorAll('p'));
+	for (const p of paragraphs) {
+		if (!p.querySelector('br')) continue;
+		if (!p.parentNode) continue;
+
+		// Unwrap <br> from inline wrappers like <span><br></span>.
+		for (const child of Array.from(p.childNodes)) {
+			if (child.nodeType !== Node.ELEMENT_NODE) continue;
+			const el = child as Element;
+			const tag = el.tagName.toLowerCase();
+			if (tag === 'br') continue;
+			if (blockTags.has(tag)) continue;
+
+			// If this inline element contains ONLY <br> tags (no visible text),
+			// replace the wrapper with its <br> children directly.
+			if (!hasVisibleText(el) && el.querySelector('br')) {
+				const brs = el.querySelectorAll('br');
+				for (const br of Array.from(brs)) {
+					p.insertBefore(br, el);
+				}
+				el.remove();
+			}
+		}
+
+		// Now split the <p> at <br> boundaries.
+		const nodes = Array.from(p.childNodes);
+		const groups: Node[][] = [[]];
+
+		for (const node of nodes) {
+			if (node.nodeType === Node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'br') {
+				groups.push([]);
+				continue;
+			}
+			groups[groups.length - 1].push(node);
+		}
+
+		const parent = p.parentNode;
+		for (const group of groups) {
+			if (!group.length) continue;
+			const text = group.map(n => n.textContent).join('').trim();
+			if (!text) continue;
+
+			const newP = doc.createElement('p');
+			for (const node of group) newP.appendChild(node);
+			parent.insertBefore(newP, p);
+		}
+		parent.removeChild(p);
+	}
+
+	// --- Step 3: Normalize top-level <br>-separated inlines into <p> blocks ---
 	const normalizeBrs = (container: Element) => {
 		const children = Array.from(container.childNodes);
 		// Only normalize if there are <br> elements at this level.
@@ -316,6 +370,15 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 	// Only normalize at the top-level container (body or Google's root wrapper).
 	normalizeBrs(doc.body);
 
+	// --- Step 4: Remove any remaining top-level <br> elements ---
+	// After Steps 2-3, any <br> still at the body level is between <p> blocks
+	// and redundant. Remove them to prevent literal <br> in Markdown output.
+	for (const node of Array.from(doc.body.childNodes)) {
+		if (node.nodeType === Node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'br') {
+			node.remove();
+		}
+	}
+
 	return doc.body.innerHTML;
 }
 
@@ -329,6 +392,10 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 
 	// Sanitize Google Docs-specific HTML quirks before the round-trip.
 	html = sanitizeGoogleDocsHtml(html);
+
+	// The sanitizer's DOMParser→innerHTML round-trip may reintroduce &nbsp;
+	// entities from the original HTML. Replace them with regular spaces.
+	html = html.replace(/&nbsp;/g, ' ').replace(/[\u00A0]/g, ' ');
 
 	html = await processImagesInPastedHtml(html);
 

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -189,14 +189,29 @@ const blockTags = new Set([
 	'blockquote', 'pre', 'hr', 'figure', 'figcaption', 'section',
 ]);
 
-function hasVisibleText(node: Node): boolean {
+// Void elements that represent meaningful content even without text.
+const meaningfulVoidTags = new Set(['img', 'video', 'svg', 'canvas', 'audio']);
+
+function hasVisibleContent(node: Node): boolean {
 	if (node.nodeType === Node.TEXT_NODE) return node.textContent.trim().length > 0;
 	if (node.nodeType === Node.ELEMENT_NODE) {
+		const tag = (node as Element).tagName?.toLowerCase();
+		if (meaningfulVoidTags.has(tag)) return true;
 		for (const child of Array.from(node.childNodes)) {
-			if (hasVisibleText(child)) return true;
+			if (hasVisibleContent(child)) return true;
 		}
 	}
 	return false;
+}
+
+function groupHasContent(group: Node[]): boolean {
+	const text = group.map(n => n.textContent).join('').trim();
+	if (text) return true;
+	return group.some(n =>
+		n.nodeType === Node.ELEMENT_NODE &&
+		(meaningfulVoidTags.has((n as Element).tagName?.toLowerCase()) ||
+			!!(n as Element).querySelector?.(Array.from(meaningfulVoidTags).join(','))),
+	);
 }
 
 // Sanitize HTML produced by Google Docs before the HTML→Markdown round-trip.
@@ -223,7 +238,7 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 			const tag = el.tagName.toLowerCase();
 
 			if (removableInlineTags.has(tag)) {
-				if (!hasVisibleText(el)) {
+				if (!hasVisibleContent(el)) {
 					// Empty formatting tag — remove entirely.
 					el.remove();
 					continue;
@@ -269,7 +284,7 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 
 			// If this inline element contains ONLY <br> tags (no visible text),
 			// replace the wrapper with its <br> children directly.
-			if (!hasVisibleText(el) && el.querySelector('br')) {
+			if (!hasVisibleContent(el) && el.querySelector('br')) {
 				const brs = el.querySelectorAll('br');
 				for (const br of Array.from(brs)) {
 					p.insertBefore(br, el);
@@ -293,8 +308,7 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 		const parent = p.parentNode;
 		for (const group of groups) {
 			if (!group.length) continue;
-			const text = group.map(n => n.textContent).join('').trim();
-			if (!text) continue;
+			if (!groupHasContent(group)) continue;
 
 			const newP = doc.createElement('p');
 			for (const node of group) newP.appendChild(node);
@@ -357,9 +371,8 @@ export function sanitizeGoogleDocsHtml(html: string): string {
 				}
 			}
 
-			// Skip groups that are only whitespace.
-			const groupText = group.map(n => n.textContent).join('').trim();
-			if (!groupText) continue;
+			// Skip groups that have no visible content.
+			if (!groupHasContent(group)) continue;
 
 			const p = doc.createElement('p');
 			for (const node of group) p.appendChild(node);


### PR DESCRIPTION
fixes #14396

### AI Assistance Disclosure
AI tools were used to assist with:
- Translating my designed logic into implementation code
- Generating additional test case ideas for verification
- Improving wording and clarity in the PR description

The core logic, architectural decisions, and debugging process were done by me. All AI-generated output was carefully reviewed, validated, and modified where necessary. I fully understand the submitted code.

### Problem:
When you paste content from Google Docs into the Rich Text editor, the resulting Markdown ends up with stray `** `markers, literal `<br/>` tags, and `&nbsp`; characters scattered throughout the note.

This happens because Google Docs puts some unusual HTML on the clipboard:

- It wraps text in `<b style="font-weight:normal">` tags — bold tags that aren't actually bold
- It leaves behind empty `<b></b>` tags with no content
- It wraps `<br>` inside styled `<span>` tags (e.g.` <span style="..."><br/></span>`) instead of using bare`<br>`
- It uses `<br>` for line breaks instead of proper `<p>` paragraphs
- It injects `&nbsp;` entities for spacing

When our HTML-to-Markdown converter (Turndown) processes this, an empty `<b></b>` becomes `**,` and the `<br> `tags cause broken paragraph spacing,  and `&nbsp;` entities leak into the Markdown.

### Fix
This PR adds a `sanitizeGoogleDocsHtml() `function in `resourceHandling.ts` that cleans up Google Docs HTML before it goes through the HTML→Markdown→HTML conversion. It only runs when the clipboard contains Google Docs content (detected by the` docs-internal-guid-` marker), so paste from other sources is completely unaffected.

The cleanup does four things:

1. **Strips empty formatting tags**  : removes `<b></b>,` `<strong></strong>`, `<i></i>`, etc. that have no visible text
2. **Unwraps fake-bold wrappers** : replaces `<b style="font-weight:normal">content</b> `with just content 
3. **Splits `<p>` containing `<br`> into separate `<p>` blocks**: first unwraps `<br>` from `<span>` wrappers (Google Docs' actual format), then splits at `<br>` boundaries. Only targets` <p>`  leaves `<li>`, `<td>`, `<blockquote>` alone
4.  **Normalises top-level` <br>` into proper `<p>` blocks** : only at the top level; `<br>` inside lists, tables, and blockquotes is preserved, and existing` <p>` blocks are left alone
Additionally, `&nbsp;` entities reintroduced by the `sanitizer's DOMParser`→`innerHTML` round-trip are cleaned to regular spaces.
### Architecture Safety

- `sanitizeGoogleDocsHtml` is only called inside `processPastedHtml`, which is only used by TinyMCE (Rich Text editor) paste
- CodeMirror (Markdown editor) does not call this function
- No files in `packages/lib/`, `packages/app-mobile/`, `packages/app-cli/`, or `packages/server/` were modified
- `HtmlToMd` and `MdToHtml` are untouched
- The function is idempotent  after sanitization, the `docs-internal-guid-` marker is removed, so a second pass returns immediately
- Non-text content (`<img>`, `<video>`, `<svg>`) is preserved during both the empty-tag removal and `<br>` splitting steps

### Test results
```
PASS gui/NoteEditor/utils/resourceHandling.test.ts
  resourceHandling
    ✓ should sanitize pasted HTML
    ✓ should clean up pasted HTML
    ✓ should preserve images pasted from the resource directory
    ✓ should remove empty inline formatting tags
    ✓ should remove empty <b> tags containing only empty spans
    ✓ should unwrap fake-bold <b style="font-weight:normal"> with content
    ✓ should normalize top-level <br> into <p> blocks
    ✓ should NOT normalize <br> inside <li>
    ✓ should split <p> containing <br> into multiple <p> blocks
    ✓ should handle trailing <br> inside <p>
    ✓ should unwrap <br> from <span> wrappers (real Google Docs format)
    ✓ should handle <br> between and after <p> blocks
    ✓ should handle Google Docs structure with empty paragraph breaks
    ✓ should NOT touch content when <p> blocks already exist
    ✓ should return non-Google Docs HTML unchanged
    ✓ end-to-end: Google Docs paste produces clean Markdown with all content preserved
Tests: 16 passed, 16 total

```
### Demo



https://github.com/user-attachments/assets/6e208f14-b5a0-4792-82d0-053cae30e3f0

