### PR TITLE
Server: Fixes #14384: Error logged on first startup

### DIFF
--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -86,7 +86,7 @@ export interface Migration {
 
 export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 	const connection: DbConfigConnection = {};
-	let pool: KnexPoolConfig | undefined = undefined;
+	let pool: KnexPoolConfig|undefined = undefined;
 
 	if (dbConfig.client === 'sqlite3') {
 		connection.filename = dbConfig.name;

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -86,7 +86,7 @@ export interface Migration {
 
 export function makeKnexConfig(dbConfig: DatabaseConfig): KnexDatabaseConfig {
 	const connection: DbConfigConnection = {};
-	let pool: KnexPoolConfig|undefined = undefined;
+	let pool: KnexPoolConfig | undefined = undefined;
 
 	if (dbConfig.client === 'sqlite3') {
 		connection.filename = dbConfig.name;
@@ -312,7 +312,9 @@ export const sqliteSyncSlave = async (master: DbConnection, slave: DbConnection)
 // Incorrectly named migrations may end up being applied in the wrong order.
 const fixMigrationNames = async (db: DbConnection) => {
 	try {
+		const context: QueryContext = { noSuchTableErrorLoggingDisabled: true };
 		await db('knex_migrations')
+			.queryContext(context)
 			.update({ name: '20250404091200_user_auth_code.js' })
 			.where('name', '=', '202504040912000_user_auth_code.js');
 	} catch (error) {

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -312,6 +312,8 @@ export const sqliteSyncSlave = async (master: DbConnection, slave: DbConnection)
 // Incorrectly named migrations may end up being applied in the wrong order.
 const fixMigrationNames = async (db: DbConnection) => {
 	try {
+		// By default, Knex logs 'no such table' errors, even if caught by the try/catch block.
+		// See https://github.com/laurent22/joplin/pull/14401 for details.
 		const context: QueryContext = { noSuchTableErrorLoggingDisabled: true };
 		await db('knex_migrations')
 			.queryContext(context)


### PR DESCRIPTION
Fixes #14384
The fixMigrationNames function tries to update the knex_migrations table before migrations run. The knex error event handler logged the error before the catch block could handle it silently.
Added a QueryContext with noSuchTableErrorLoggingDisabled: true to the query, preventing the error from being logged while still allowing the catch block to handle it.