### PR TITLE
Desktop: Add context menu to non-image resources in Markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.test.ts
@@ -4,62 +4,38 @@ describe('useContextMenu', () => {
 	const resourceId = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
 	const resourceId2 = 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5';
 
-	it('should return resource ID when cursor is inside markdown image', () => {
+	it('should return type=image when cursor is inside markdown image', () => {
 		const line = `![alt text](:/${resourceId})`;
-		expect(getResourceIdFromMarkup(line, 0)).toBe(resourceId);
-		expect(getResourceIdFromMarkup(line, 15)).toBe(resourceId);
-		expect(getResourceIdFromMarkup(line, line.length - 1)).toBe(resourceId);
+		expect(getResourceIdFromMarkup(line, 15)).toEqual({ resourceId, type: 'image' });
 	});
 
-	it('should return null when cursor is outside markdown image', () => {
+	it('should return type=file when cursor is inside markdown link', () => {
+		const line = `[document.pdf](:/${resourceId})`;
+		expect(getResourceIdFromMarkup(line, 15)).toEqual({ resourceId, type: 'file' });
+	});
+
+	it('should return null when cursor is outside markup', () => {
 		const line = `Some text ![alt](:/${resourceId}) more text`;
 		expect(getResourceIdFromMarkup(line, 5)).toBeNull();
 		expect(getResourceIdFromMarkup(line, line.length - 5)).toBeNull();
 	});
 
-	it('should handle markdown image without alt text', () => {
-		const line = `![](:/${resourceId})`;
-		expect(getResourceIdFromMarkup(line, 5)).toBe(resourceId);
-	});
-
-	it('should return resource ID when cursor is inside HTML img tag', () => {
-		const line = `<img src=":/${resourceId}" />`;
-		expect(getResourceIdFromMarkup(line, 10)).toBe(resourceId);
-	});
-
-	it('should handle HTML img tag with additional attributes', () => {
-		const line = `<img alt="test" src=":/${resourceId}" width="100" />`;
-		expect(getResourceIdFromMarkup(line, 25)).toBe(resourceId);
-	});
-
-	it('should return null when cursor is outside HTML img tag', () => {
-		const line = `text <img src=":/${resourceId}" /> more`;
-		expect(getResourceIdFromMarkup(line, 2)).toBeNull();
-		expect(getResourceIdFromMarkup(line, line.length - 2)).toBeNull();
-	});
-
-	it('should return correct resource ID when multiple images on same line', () => {
-		const line = `![first](:/${resourceId}) ![second](:/${resourceId2})`;
-		expect(getResourceIdFromMarkup(line, 10)).toBe(resourceId);
-		expect(getResourceIdFromMarkup(line, 50)).toBe(resourceId2);
+	it('should correctly distinguish between image and file on same line', () => {
+		const line = `![image](:/${resourceId}) [file](:/${resourceId2})`;
+		expect(getResourceIdFromMarkup(line, 10)).toEqual({ resourceId, type: 'image' });
+		expect(getResourceIdFromMarkup(line, 48)).toEqual({ resourceId: resourceId2, type: 'file' });
 	});
 
 	it('should return null for empty line', () => {
 		expect(getResourceIdFromMarkup('', 0)).toBeNull();
 	});
 
-	it('should return null for line without images', () => {
+	it('should return null for line without resources', () => {
 		expect(getResourceIdFromMarkup('Just some regular text', 10)).toBeNull();
 	});
 
-	it('should return null for non-resource links', () => {
-		const line = '![alt](https://example.com/image.png)';
-		expect(getResourceIdFromMarkup(line, 10)).toBeNull();
-	});
-
-	it('should handle cursor at exact boundaries of image markup', () => {
-		const line = `![a](:/${resourceId})`;
-		expect(getResourceIdFromMarkup(line, 0)).toBe(resourceId);
-		expect(getResourceIdFromMarkup(line, line.length)).toBe(resourceId);
+	it('should return null for non-resource URLs', () => {
+		expect(getResourceIdFromMarkup('![alt](https://example.com/image.png)', 10)).toBeNull();
+		expect(getResourceIdFromMarkup('[link](https://example.com)', 10)).toBeNull();
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -17,9 +17,16 @@ import isItemId from '@joplin/lib/models/utils/isItemId';
 import { extractResourceUrls } from '@joplin/lib/urlUtils';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
 
-// Extract resource ID from image markup at a given cursor position within a line.
-// Returns the resource ID if the cursor is within an image markup, null otherwise.
-export const getResourceIdFromMarkup = (lineContent: string, cursorPosInLine: number): string | null => {
+export type ResourceMarkupType = 'image' | 'file';
+
+export interface ResourceMarkupInfo {
+	resourceId: string;
+	type: ResourceMarkupType;
+}
+
+// Extract resource ID from resource markup (images or file attachments) at a given cursor position within a line.
+// Returns the resource ID and its type if the cursor is within a resource markup, null otherwise.
+export const getResourceIdFromMarkup = (lineContent: string, cursorPosInLine: number): ResourceMarkupInfo | null => {
 	const resourceUrls = extractResourceUrls(lineContent);
 	if (!resourceUrls.length) return null;
 
@@ -27,16 +34,38 @@ export const getResourceIdFromMarkup = (lineContent: string, cursorPosInLine: nu
 		const resourcePattern = new RegExp(`[:](/?${resourceInfo.itemId})`, 'g');
 		let match;
 		while ((match = resourcePattern.exec(lineContent)) !== null) {
-			// Look backwards for ![ or <img
-			let markupStart = lineContent.lastIndexOf('![', match.index);
+			// Look backwards for ![, [, <img, or <a
+			const imageMarkupStart = lineContent.lastIndexOf('![', match.index);
+			const linkMarkupStart = lineContent.lastIndexOf('[', match.index);
 			const imgTagStart = lineContent.lastIndexOf('<img', match.index);
-			if (imgTagStart > markupStart) markupStart = imgTagStart;
+			const aTagStart = lineContent.lastIndexOf('<a', match.index);
+
+			// Find the closest markup start and determine type
+			let markupStart = -1;
+			let markupType: ResourceMarkupType = 'file';
+
+			if (imageMarkupStart !== -1 && imageMarkupStart > markupStart) {
+				markupStart = imageMarkupStart;
+				markupType = 'image';
+			}
+			if (linkMarkupStart !== -1 && linkMarkupStart > markupStart && lineContent[linkMarkupStart - 1] !== '!') {
+				markupStart = linkMarkupStart;
+				markupType = 'file';
+			}
+			if (imgTagStart !== -1 && imgTagStart > markupStart) {
+				markupStart = imgTagStart;
+				markupType = 'image';
+			}
+			if (aTagStart !== -1 && aTagStart > markupStart) {
+				markupStart = aTagStart;
+				markupType = 'file';
+			}
 
 			if (markupStart === -1) continue;
 
 			// Find the end of the markup
 			let markupEnd: number;
-			if (lineContent[markupStart] === '!') {
+			if (lineContent[markupStart] === '!' || lineContent[markupStart] === '[') {
 				markupEnd = lineContent.indexOf(')', match.index);
 				if (markupEnd !== -1) markupEnd += 1;
 			} else {
@@ -45,7 +74,7 @@ export const getResourceIdFromMarkup = (lineContent: string, cursorPosInLine: nu
 			}
 
 			if (markupEnd !== -1 && cursorPosInLine >= markupStart && cursorPosInLine <= markupEnd) {
-				return resourceInfo.itemId;
+				return { resourceId: resourceInfo.itemId, type: markupType };
 			}
 		}
 	}
@@ -132,8 +161,8 @@ const useContextMenu = (props: ContextMenuProps) => {
 			return clickedElement?.closest(`.${imageClassName}`) as HTMLElement | null;
 		};
 
-		// Get resource ID from image markup at click position (not cursor position)
-		const getResourceIdAtClickPos = (params: ContextMenuParams): string | null => {
+		// Get resource info from markup at click position (not cursor position)
+		const getResourceInfoAtClickPos = (params: ContextMenuParams): ResourceMarkupInfo | null => {
 			if (!editorRef.current) return null;
 
 			const editor = editorRef.current.editor;
@@ -152,10 +181,10 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 		const targetWindow = bridge().windowById(windowId);
 
-		const showImageContextMenu = async (resourceId: string) => {
+		const showResourceContextMenu = async (resourceId: string, type: ResourceMarkupType) => {
 			const menu = new Menu();
 			const contextMenuOptions: ContextMenuOptions = {
-				itemType: ContextMenuItemType.Image,
+				itemType: type === 'image' ? ContextMenuItemType.Image : ContextMenuItemType.Resource,
 				resourceId,
 				filename: null,
 				mime: null,
@@ -170,8 +199,8 @@ const useContextMenu = (props: ContextMenuProps) => {
 				mdToHtml: null,
 			};
 
-			const imageMenuItems = await buildMenuItems(menuItems(props.dispatch), contextMenuOptions);
-			for (const item of imageMenuItems) {
+			const resourceMenuItems = await buildMenuItems(menuItems(props.dispatch), contextMenuOptions);
+			for (const item of resourceMenuItems) {
 				menu.append(item);
 			}
 
@@ -206,17 +235,17 @@ const useContextMenu = (props: ContextMenuProps) => {
 					if (resourceId) {
 						event.preventDefault();
 						moveCursorToImageLine(imageContainer);
-						await showImageContextMenu(resourceId);
+						await showResourceContextMenu(resourceId, 'image');
 						return;
 					}
 				}
 			}
 
-			// Check if right-clicking on image markup text
-			const markupResourceId = getResourceIdAtClickPos(params);
-			if (markupResourceId && pointerInsideEditor(params)) {
+			// Check if right-clicking on resource markup text (images or file attachments)
+			const markupResourceInfo = getResourceInfoAtClickPos(params);
+			if (markupResourceInfo && pointerInsideEditor(params)) {
 				event.preventDefault();
-				await showImageContextMenu(markupResourceId);
+				await showResourceContextMenu(markupResourceInfo.resourceId, markupResourceInfo.type);
 				return;
 			}
 


### PR DESCRIPTION
*Done with the assistance of AI*

Previously, the context menu in the Markdown editor would displayed only for images. This change add support for non-images too.