### PR TITLE
All: Resolves #13216: Move editor settings to dedicated editor section

### DIFF
--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -1,4 +1,4 @@
-import Setting, { AppType, SettingItemType, SettingMetadataSection, SettingSectionSource, SettingStorage } from '../models/Setting';
+import Setting, { SettingItemType, SettingSectionSource, SettingStorage } from '../models/Setting';
 import { setupDatabaseAndSynchronizer, switchClient, expectThrow, expectNotThrow, msleep } from '../testing/test-utils';
 import { readFile, stat, mkdirp, writeFile, pathExists, readdir } from 'fs-extra';
 import Logger from '@joplin/utils/Logger';
@@ -208,68 +208,6 @@ describe('models/Setting', () => {
 		expect(Setting.sectionNameToLabel('mySection')).toBe('My section');
 	}));
 
-	it('should group all editor settings in the editor section', () => {
-		const metadata = Setting.metadata();
-
-		// From 'note' section
-		expect(metadata['editor.autoMatchingBraces'].section).toBe('editor');
-		expect(metadata['editor.autocompleteMarkup'].section).toBe('editor');
-		expect(metadata['editor.enableHtmlToMarkdownBanner'].section).toBe('editor');
-		expect(metadata['editor.pastePreserveColors'].section).toBe('editor');
-		expect(metadata['editor.enableTextPatterns'].section).toBe('editor');
-		expect(metadata['editor.tabMovesFocus'].section).toBe('editor');
-		expect(metadata['editor.highlightActiveLine'].section).toBe('editor');
-		expect(metadata['editor.inlineRendering'].section).toBe('editor');
-		expect(metadata['editor.imageRendering'].section).toBe('editor');
-
-		// From 'appearance' section
-		expect(metadata['style.editor.fontSize'].section).toBe('editor');
-		expect(metadata['style.editor.fontFamily'].section).toBe('editor');
-		expect(metadata['style.editor.monospaceFontFamily'].section).toBe('editor');
-		expect(metadata['style.editor.contentMaxWidth'].section).toBe('editor');
-
-		// From 'general' section
-		expect(metadata['editor.legacyMarkdown'].section).toBe('editor');
-
-		// Previously section-less
-		expect(metadata['editor.keyboardMode'].section).toBe('editor');
-		expect(metadata['editor.spellcheckBeta'].section).toBe('editor');
-		expect(metadata['spellChecker.languages'].section).toBe('editor');
-		expect(metadata['editor.codeView'].section).toBe('editor');
-
-		// Mobile-specific (from 'note')
-		expect(metadata['editor.usePlainText'].section).toBe('editor');
-		expect(metadata['editor.mobile.spellcheckEnabled'].section).toBe('editor');
-		expect(metadata['editor.mobile.toolbarEnabled'].section).toBe('editor');
-	});
-
-	it('should place the editor section after joplinCloud and before plugins in section order', () => {
-		const order = Setting.sectionOrder();
-		const editorIdx = order.indexOf('editor');
-		const joplinCloudIdx = order.indexOf('joplinCloud');
-		const pluginsIdx = order.indexOf('plugins');
-		expect(editorIdx).toBeGreaterThan(-1);
-		expect(editorIdx).toBeGreaterThan(joplinCloudIdx);
-		expect(editorIdx).toBeLessThan(pluginsIdx);
-	});
-
-	it('should configure editor section label, summary, and icons correctly', () => {
-		expect(Setting.sectionNameToLabel('editor')).toBe('Editor');
-
-		const metadata: SettingMetadataSection = { name: 'editor', metadatas: [] };
-		expect(Setting.sectionMetadataToSummary(metadata)).toBe('Typography, spellcheck, layout');
-
-		expect(Setting.sectionNameToIcon('editor', AppType.Desktop)).toBe('fas fa-edit');
-		expect(Setting.sectionNameToIcon('editor', AppType.Mobile)).toBe('fas fa-pen');
-	});
-
-	it('should have updated summaries for appearance and note sections after editor migration', () => {
-		const appearanceMeta: SettingMetadataSection = { name: 'appearance', metadatas: [] };
-		expect(Setting.sectionMetadataToSummary(appearanceMeta)).toBe('Themes');
-
-		const noteMeta: SettingMetadataSection = { name: 'note', metadatas: [] };
-		expect(Setting.sectionMetadataToSummary(noteMeta)).toBe('Geolocation, image resize');
-	});
 
 	it('should save and load settings from file', (async () => {
 		Setting.setValue('sync.target', 9); // Saved to file

--- a/packages/lib/models/Setting.test.ts
+++ b/packages/lib/models/Setting.test.ts
@@ -1,4 +1,4 @@
-import Setting, { SettingItemType, SettingSectionSource, SettingStorage } from '../models/Setting';
+import Setting, { AppType, SettingItemType, SettingMetadataSection, SettingSectionSource, SettingStorage } from '../models/Setting';
 import { setupDatabaseAndSynchronizer, switchClient, expectThrow, expectNotThrow, msleep } from '../testing/test-utils';
 import { readFile, stat, mkdirp, writeFile, pathExists, readdir } from 'fs-extra';
 import Logger from '@joplin/utils/Logger';
@@ -207,6 +207,69 @@ describe('models/Setting', () => {
 
 		expect(Setting.sectionNameToLabel('mySection')).toBe('My section');
 	}));
+
+	it('should group all editor settings in the editor section', () => {
+		const metadata = Setting.metadata();
+
+		// From 'note' section
+		expect(metadata['editor.autoMatchingBraces'].section).toBe('editor');
+		expect(metadata['editor.autocompleteMarkup'].section).toBe('editor');
+		expect(metadata['editor.enableHtmlToMarkdownBanner'].section).toBe('editor');
+		expect(metadata['editor.pastePreserveColors'].section).toBe('editor');
+		expect(metadata['editor.enableTextPatterns'].section).toBe('editor');
+		expect(metadata['editor.tabMovesFocus'].section).toBe('editor');
+		expect(metadata['editor.highlightActiveLine'].section).toBe('editor');
+		expect(metadata['editor.inlineRendering'].section).toBe('editor');
+		expect(metadata['editor.imageRendering'].section).toBe('editor');
+
+		// From 'appearance' section
+		expect(metadata['style.editor.fontSize'].section).toBe('editor');
+		expect(metadata['style.editor.fontFamily'].section).toBe('editor');
+		expect(metadata['style.editor.monospaceFontFamily'].section).toBe('editor');
+		expect(metadata['style.editor.contentMaxWidth'].section).toBe('editor');
+
+		// From 'general' section
+		expect(metadata['editor.legacyMarkdown'].section).toBe('editor');
+
+		// Previously section-less
+		expect(metadata['editor.keyboardMode'].section).toBe('editor');
+		expect(metadata['editor.spellcheckBeta'].section).toBe('editor');
+		expect(metadata['spellChecker.languages'].section).toBe('editor');
+		expect(metadata['editor.codeView'].section).toBe('editor');
+
+		// Mobile-specific (from 'note')
+		expect(metadata['editor.usePlainText'].section).toBe('editor');
+		expect(metadata['editor.mobile.spellcheckEnabled'].section).toBe('editor');
+		expect(metadata['editor.mobile.toolbarEnabled'].section).toBe('editor');
+	});
+
+	it('should place the editor section after joplinCloud and before plugins in section order', () => {
+		const order = Setting.sectionOrder();
+		const editorIdx = order.indexOf('editor');
+		const joplinCloudIdx = order.indexOf('joplinCloud');
+		const pluginsIdx = order.indexOf('plugins');
+		expect(editorIdx).toBeGreaterThan(-1);
+		expect(editorIdx).toBeGreaterThan(joplinCloudIdx);
+		expect(editorIdx).toBeLessThan(pluginsIdx);
+	});
+
+	it('should configure editor section label, summary, and icons correctly', () => {
+		expect(Setting.sectionNameToLabel('editor')).toBe('Editor');
+
+		const metadata: SettingMetadataSection = { name: 'editor', metadatas: [] };
+		expect(Setting.sectionMetadataToSummary(metadata)).toBe('Typography, spellcheck, layout');
+
+		expect(Setting.sectionNameToIcon('editor', AppType.Desktop)).toBe('fas fa-edit');
+		expect(Setting.sectionNameToIcon('editor', AppType.Mobile)).toBe('fas fa-pen');
+	});
+
+	it('should have updated summaries for appearance and note sections after editor migration', () => {
+		const appearanceMeta: SettingMetadataSection = { name: 'appearance', metadatas: [] };
+		expect(Setting.sectionMetadataToSummary(appearanceMeta)).toBe('Themes');
+
+		const noteMeta: SettingMetadataSection = { name: 'note', metadatas: [] };
+		expect(Setting.sectionMetadataToSummary(noteMeta)).toBe('Geolocation, image resize');
+	});
 
 	it('should save and load settings from file', (async () => {
 		Setting.setValue('sync.target', 9); // Saved to file

--- a/packages/lib/models/Setting.ts
+++ b/packages/lib/models/Setting.ts
@@ -1291,6 +1291,7 @@ class Setting extends BaseModel {
 			'sync',
 			'encryption',
 			'joplinCloud',
+			'editor',
 			'plugins',
 			'markdownPlugins',
 			'note',
@@ -1352,6 +1353,7 @@ class Setting extends BaseModel {
 		if (name === 'general') return _('General');
 		if (name === 'sync') return _('Synchronisation');
 		if (name === 'appearance') return _('Appearance');
+		if (name === 'editor') return _('Editor');
 		if (name === 'note') return _('Note');
 		if (name === 'folder') return _('Notebook');
 		if (name === 'markdownPlugins') return _('Markdown');
@@ -1388,11 +1390,12 @@ class Setting extends BaseModel {
 		// TODO: This is currently specific to the mobile app
 		const sectionNameToSummary: Record<string, string> = {
 			'general': _('Language, date format'),
-			'appearance': _('Themes, editor font'),
+			'appearance': _('Themes'),
 			'sync': _('Sync, encryption, proxy'),
 			'joplinCloud': _('Email To Note, login information'),
+			'editor': _('Typography, spellcheck, layout'),
 			'markdownPlugins': _('Media player, math, diagrams, table of contents'),
-			'note': _('Geolocation, spellcheck, editor toolbar, image resize'),
+			'note': _('Geolocation, image resize'),
 			'revisionService': _('Toggle note history, keep notes for'),
 			'tools': _('Logs, profiles, sync status'),
 			'importOrExport': _('Import or export your data'),
@@ -1426,6 +1429,7 @@ class Setting extends BaseModel {
 			'general': 'icon-general',
 			'sync': 'icon-sync',
 			'appearance': 'icon-appearance',
+			'editor': 'fas fa-edit',
 			'note': 'icon-note',
 			'folder': 'icon-notebooks',
 			'plugins': 'icon-plugins',
@@ -1450,6 +1454,7 @@ class Setting extends BaseModel {
 			'general': 'fa fa-sliders-h',
 			'sync': 'fa fa-sync',
 			'appearance': 'fa fa-ruler',
+			'editor': 'fas fa-pen',
 			'note': 'fa fa-sticky-note',
 			'revisionService': 'far fa-history',
 			'plugins': 'fa fa-puzzle-piece',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -95,6 +95,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: true,
 			type: SettingItemType.Bool,
 			public: false,
+			section: 'editor',
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			storage: SettingStorage.File,
 			isGlobal: true,
@@ -738,7 +739,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: true,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Auto-pair braces, parentheses, quotations, etc.'),
 			storage: SettingStorage.File,
@@ -749,7 +750,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			label: () => _('Autocomplete Markdown and HTML'),
 			description: () => _('Enables Markdown list continuation, auto-closing HTML tags, and other markup autocompletions.'),
@@ -761,7 +762,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Enable HTML-to-Markdown conversion banner'),
 			storage: SettingStorage.File,
@@ -771,7 +772,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: false,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Preserve colours when pasting text in Rich Text Editor'),
 			storage: SettingStorage.File,
@@ -781,7 +782,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: true,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Auto-format Markdown in the Rich Text Editor'),
 			description: () => _('Enables Markdown pattern replacement in the Rich Text Editor. For example, when enabled, typing **bold** creates bold text.'),
@@ -801,7 +802,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: false,
 			type: SettingItemType.Bool,
 			public: false,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Tab moves focus'),
 			storage: SettingStorage.File,
@@ -909,7 +910,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'editor.usePlainText': {
 			value: false,
 			type: SettingItemType.Bool,
-			section: 'note',
+			section: 'editor',
 			public: true,
 			appTypes: [AppType.Mobile],
 			label: () => 'Use the plain text editor',
@@ -922,7 +923,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'editor.mobile.spellcheckEnabled': {
 			value: true,
 			type: SettingItemType.Bool,
-			section: 'note',
+			section: 'editor',
 			public: true,
 			appTypes: [AppType.Mobile],
 			label: () => _('Enable spellcheck in the text editor'),
@@ -933,7 +934,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'editor.mobile.toolbarEnabled': {
 			value: true,
 			type: SettingItemType.Bool,
-			section: 'note',
+			section: 'editor',
 			public: true,
 			appTypes: [AppType.Mobile],
 			label: () => _('Enable the Markdown toolbar'),
@@ -1217,7 +1218,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			isGlobal: true,
 			appTypes: [AppType.Desktop, AppType.Mobile],
-			section: 'appearance',
+			section: 'editor',
 			label: () => _('Editor font size'),
 			minimum: 4,
 			maximum: 50,
@@ -1232,7 +1233,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 					public: true,
 					label: () => _('Editor font'),
 					appTypes: [AppType.Mobile],
-					section: 'appearance',
+					section: 'editor',
 					options: () => {
 						// IMPORTANT: The font mapping must match the one in global-styles.js::editorFont()
 						if (mobilePlatform === 'ios') {
@@ -1255,7 +1256,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 					type: SettingItemType.String,
 					public: true,
 					appTypes: [AppType.Desktop],
-					section: 'appearance',
+					section: 'editor',
 					label: () => _('Editor font family'),
 					description: () =>
 						_('Used for most text in the markdown editor. If not found, a generic proportional (variable width) font is used.'),
@@ -1268,7 +1269,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			type: SettingItemType.String,
 			public: true,
 			appTypes: [AppType.Desktop],
-			section: 'appearance',
+			section: 'editor',
 			label: () => _('Editor monospace font family'),
 			description: () =>
 				_('Used where a fixed width font is needed to lay out text legibly (e.g. tables, checkboxes, code). If not found, a generic monospace (fixed width) font is used.'),
@@ -1288,7 +1289,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			subType: SettingItemSubType.FontFamily,
 		},
 
-		'style.editor.contentMaxWidth': { value: 0, type: SettingItemType.Int, public: true, storage: SettingStorage.File, isGlobal: true, appTypes: [AppType.Desktop], section: 'appearance', label: () => _('Editor maximum width'), description: () => _('Set it to 0 to make it take the complete available space. Recommended width is 600.') },
+		'style.editor.contentMaxWidth': { value: 0, type: SettingItemType.Int, public: true, storage: SettingStorage.File, isGlobal: true, appTypes: [AppType.Desktop], section: 'editor', label: () => _('Editor maximum width'), description: () => _('Set it to 0 to make it take the complete available space. Recommended width is 600.') },
 
 		'style.scrollbarSize': {
 			value: ScrollbarSize.Small,
@@ -1476,6 +1477,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: '',
 			type: SettingItemType.String,
 			public: true,
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			isEnum: true,
 			advanced: true,
@@ -1496,6 +1498,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			value: false,
 			type: SettingItemType.Bool,
 			public: true,
+			section: 'editor',
 			appTypes: [AppType.Desktop],
 			label: () => _('Enable spell checking in Markdown editor'),
 			storage: SettingStorage.File,
@@ -1509,7 +1512,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			label: () => _('Markdown editor: Render markup in editor'),
 			description: () => _('Renders markup on all lines that don\'t include the cursor.'),
-			section: 'note',
+			section: 'editor',
 			storage: SettingStorage.File,
 		},
 		'editor.imageRendering': {
@@ -1519,14 +1522,14 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			label: () => _('Markdown editor: Render images'),
 			description: () => _('If an image attachment is on its own line and followed by a blank line, it will be rendered just below its Markdown source.'),
-			section: 'note',
+			section: 'editor',
 			storage: SettingStorage.File,
 		},
 		'editor.highlightActiveLine': {
 			value: false,
 			type: SettingItemType.Bool,
 			public: true,
-			section: 'note',
+			section: 'editor',
 			appTypes: [AppType.Desktop, AppType.Mobile],
 			label: () => _('Markdown editor: Highlight active line'),
 			storage: SettingStorage.File,
@@ -1569,7 +1572,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			advanced: true,
 			value: false,
 			type: SettingItemType.Bool,
-			section: 'general',
+			section: 'editor',
 			public: true,
 			appTypes: [AppType.Desktop],
 			label: () => _('Use the legacy Markdown editor'),
@@ -1725,7 +1728,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 
 		'spellChecker.enabled': { value: true, type: SettingItemType.Bool, isGlobal: true, storage: SettingStorage.File, public: false },
 		'spellChecker.language': { value: '', type: SettingItemType.String, isGlobal: true, storage: SettingStorage.File, public: false }, // Depreciated in favour of spellChecker.languages.
-		'spellChecker.languages': { value: [] as string[], type: SettingItemType.Array, isGlobal: true, storage: SettingStorage.File, public: false },
+		'spellChecker.languages': { value: [] as string[], type: SettingItemType.Array, section: 'editor', isGlobal: true, storage: SettingStorage.File, public: false },
 
 		windowContentZoomFactor: {
 			value: 100,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1559,7 +1559,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'editor.beta': {
 			value: false,
 			type: SettingItemType.Bool,
-			section: 'general',
+			section: 'editor',
 			public: false,
 			appTypes: [AppType.Desktop],
 			label: () => 'Opt-in to the editor beta',
@@ -1726,8 +1726,8 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		'camera.type': { value: CameraDirection.Back, type: SettingItemType.Int, public: false, appTypes: [AppType.Mobile] },
 		'camera.ratio': { value: '4:3', type: SettingItemType.String, public: false, appTypes: [AppType.Mobile] },
 
-		'spellChecker.enabled': { value: true, type: SettingItemType.Bool, isGlobal: true, storage: SettingStorage.File, public: false },
-		'spellChecker.language': { value: '', type: SettingItemType.String, isGlobal: true, storage: SettingStorage.File, public: false }, // Depreciated in favour of spellChecker.languages.
+		'spellChecker.enabled': { value: true, type: SettingItemType.Bool, section: 'editor', isGlobal: true, storage: SettingStorage.File, public: false },
+		'spellChecker.language': { value: '', type: SettingItemType.String, section: 'editor', isGlobal: true, storage: SettingStorage.File, public: false }, // Depreciated in favour of spellChecker.languages.
 		'spellChecker.languages': { value: [] as string[], type: SettingItemType.Array, section: 'editor', isGlobal: true, storage: SettingStorage.File, public: false },
 
 		windowContentZoomFactor: {


### PR DESCRIPTION
Resolves #13216
Created a new Editor section and consolidated all editor-related settings that were previously spread across the Note, Appearance, and General sections. Added unit tests to verify the section grouping, ordering, and metadata. 