### PR TITLE
Docs: Add information about the sync fuzzer to the "Debugging the server project" page

### DIFF
--- a/readme/dev/spec/server_debug.md
+++ b/readme/dev/spec/server_debug.md
@@ -56,11 +56,11 @@ When running in development mode, several debug commands can be run by sending r
 
 ## Fuzzing
 
-The sync fuzzer looks for sync bugs by performing pseudorandomly-selected actions. It works by:
+The sync fuzzer looks for sync bugs. It works by:
 
 - Starting an instance of Joplin Server in development mode.
 - Starting instances of the CLI app and connecting them to the server.
-- Performing random actions (e.g. "create note", "delete note").
+- Performing pseudorandom actions (e.g. "create note", "delete note", "sync").
 
 The fuzzer maintains a model of the expected state of the CLI apps. When the actual state of the CLI apps no longer matches this model, the fuzzer stops.
 
@@ -75,4 +75,4 @@ To pause the fuzzer at breakpoints in the client/server logic, use a "JavaScript
 1. Open a debug terminal in VS Code (command palette > "Debug: JavaScript Debug Terminal").
 2. Start the sync fuzzer (`yarn syncFuzzer start`).
 
-When debugging, the `--snapshot-after=<steps>` and `--restore-from-snapshot` options can be particularly helpful.
+When debugging, the `--setup=<path to setup file>`, `--snapshot-after=<steps>` and `--restore-from-snapshot` options can be particularly helpful (see `yarn syncFuzzer start --help`).

--- a/readme/dev/spec/server_debug.md
+++ b/readme/dev/spec/server_debug.md
@@ -53,3 +53,42 @@ When running in development mode, several debug commands can be run by sending r
 - The `benchmarkDeltaPerformance` command tests the performance of `models.change().delta` by calling `delta` multiple times for each user account. Data is saved in `packages/server/delta-perf.csv`.
 	- `ChangeModel.delta` is called during sync and has historically been a performance bottleneck.
 	- Example: `curl --data '{"action":"benchmarkDeltaPerformance"}' -H 'Content-Type: application/json' http://localhost:22300/api/debug`.
+
+## Fuzzing
+
+The sync fuzzer looks for server bugs by performing pseudorandomly-selected actions. It works by:
+
+- Starting a Joplin Server instance.
+- Starting instances of the CLI app and connecting them to the server.
+- Performing random actions (e.g. "create note", "delete note").
+
+The fuzzer stops when one or more of the CLI apps has incorrect or unexpected content in its notebook/note/resource collection.
+
+To start the fuzzer the server, run `yarn syncFuzzer start` from the main Joplin workspace directory. See `yarn syncFuzzer start --help` for the available configuration options.
+
+**Note**: If you encounter an "unauthorized" error, it may be necessary to set the `FUZZER_SERVER_ADMIN_PASSWORD` environment variable prior to running the fuzzer.
+
+### Useful options
+
+When debugging using the sync fuzzer, these options are particularly helpful:
+
+- Simplifying the environment:
+	- `--random-strings=false`: Don't use random binary data for note content
+	- `--enable-e2ee=false`: Disable E2EE
+- Snapshots:
+	- `--snapshot-after=<steps>`: Create a snapshot of the fuzzer state after a certain number of steps
+	- `--restore-from-snapshot`: Restore the fuzzer state to the previous snapshot
+- Custom initial setup:
+	- `--setup=<path>`: A path to an initial setup/configuration file. For example, to use the `sample-fuzzer-setup.json` file,
+	  ```
+	  yarn syncFuzzer start --setup=./packages/tools/fuzzer/sample-fuzzer-setup.json
+	  ```
+
+
+### Fuzzing with breakpoints
+
+To pause the fuzzer at breakpoints in the client/server logic, use a "JavaScript Debug Terminal" in VS Code:
+
+1. Open a debug terminal in VS Code (command palette > "Debug: JavaScript Debug Terminal").
+2. Start the sync fuzzer (`yarn syncFuzzer start`).
+

--- a/readme/dev/spec/server_debug.md
+++ b/readme/dev/spec/server_debug.md
@@ -66,7 +66,7 @@ The fuzzer maintains a model of the expected state of the CLI apps. When the act
 
 To start the fuzzer, run `yarn syncFuzzer start` from the main Joplin workspace directory. See `yarn syncFuzzer start --help` for more information.
 
-**Note**: If you encounter an "unauthorized" error, it may be necessary to set the `FUZZER_SERVER_ADMIN_PASSWORD` environment variable prior to running the fuzzer.
+**Note**: If you encounter an "unauthorized" error, it may be necessary to set the `FUZZER_SERVER_ADMIN_PASSWORD` environment variable before running the fuzzer.
 
 ### Fuzzing with breakpoints
 

--- a/readme/dev/spec/server_debug.md
+++ b/readme/dev/spec/server_debug.md
@@ -56,34 +56,17 @@ When running in development mode, several debug commands can be run by sending r
 
 ## Fuzzing
 
-The sync fuzzer looks for server bugs by performing pseudorandomly-selected actions. It works by:
+The sync fuzzer looks for sync bugs by performing pseudorandomly-selected actions. It works by:
 
-- Starting a Joplin Server instance.
+- Starting an instance of Joplin Server in development mode.
 - Starting instances of the CLI app and connecting them to the server.
 - Performing random actions (e.g. "create note", "delete note").
 
-The fuzzer stops when one or more of the CLI apps has incorrect or unexpected content in its notebook/note/resource collection.
+The fuzzer maintains a model of the expected state of the CLI apps. When the actual state of the CLI apps no longer matches this model, the fuzzer stops.
 
-To start the fuzzer the server, run `yarn syncFuzzer start` from the main Joplin workspace directory. See `yarn syncFuzzer start --help` for the available configuration options.
+To start the fuzzer, run `yarn syncFuzzer start` from the main Joplin workspace directory. See `yarn syncFuzzer start --help` for more information.
 
 **Note**: If you encounter an "unauthorized" error, it may be necessary to set the `FUZZER_SERVER_ADMIN_PASSWORD` environment variable prior to running the fuzzer.
-
-### Useful options
-
-When debugging using the sync fuzzer, these options are particularly helpful:
-
-- Simplifying the environment:
-	- `--random-strings=false`: Don't use random binary data for note content
-	- `--enable-e2ee=false`: Disable E2EE
-- Snapshots:
-	- `--snapshot-after=<steps>`: Create a snapshot of the fuzzer state after a certain number of steps
-	- `--restore-from-snapshot`: Restore the fuzzer state to the previous snapshot
-- Custom initial setup:
-	- `--setup=<path>`: A path to an initial setup/configuration file. For example, to use the `sample-fuzzer-setup.json` file,
-	  ```
-	  yarn syncFuzzer start --setup=./packages/tools/fuzzer/sample-fuzzer-setup.json
-	  ```
-
 
 ### Fuzzing with breakpoints
 
@@ -92,3 +75,4 @@ To pause the fuzzer at breakpoints in the client/server logic, use a "JavaScript
 1. Open a debug terminal in VS Code (command palette > "Debug: JavaScript Debug Terminal").
 2. Start the sync fuzzer (`yarn syncFuzzer start`).
 
+When debugging, the `--snapshot-after=<steps>` and `--restore-from-snapshot` options can be particularly helpful.


### PR DESCRIPTION
# Summary

This pull request adds a section explaining how to use the sync fuzzer to the "Debugging the server project" development documentation. The sync fuzzer was previously not mentioned in the `readme/dev` development documentation.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->