### PR TITLE
Desktop: Fixes #14078: Fixed HTML blocks being escaped on Markdown<->RTE editor switch

### DIFF
--- a/packages/app-cli/tests/html_to_md/html_block_no_escape.html
+++ b/packages/app-cli/tests/html_to_md/html_block_no_escape.html
@@ -1,0 +1,1 @@
+<div class="jop-noMdConv" style="color:red">**Test** This is a test!</div>

--- a/packages/app-cli/tests/html_to_md/html_block_no_escape.md
+++ b/packages/app-cli/tests/html_to_md/html_block_no_escape.md
@@ -1,0 +1,1 @@
+<div style="color:red">**Test** This is a test!</div>

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -837,17 +837,30 @@ rules.joplinHtmlInMarkdown = {
   filter: function (node) {
     // Tables are special because they may be entirely kept as HTML depending on
     // the logic in table.js, for example if they contain code.
-    return node && node.classList && node.classList.contains('jop-noMdConv') && node.nodeName !== 'TABLE';
+    return (
+      node &&
+      node.classList &&
+      node.classList.contains("jop-noMdConv") &&
+      node.nodeName !== "TABLE"
+    );
+  },
+
+  escapeContent: function () {
+    // Do not escape content inside HTML block the content is raw HTML/Markdown
+    // that must be preserved as it is . Without this, switching between the Markdown
+    // and Rich Text editors adds extra backslashes on every switch.
+    // Fixes: https://github.com/laurent22/joplin/issues/14078
+    return false;
   },
 
   replacement: function (content, node) {
-    node.classList.remove('jop-noMdConv');
+    node.classList.remove("jop-noMdConv");
     const nodeName = node.nodeName.toLowerCase();
     let attrString = attributesHtml(node.attributes, { skipEmptyClass: true });
-    if (attrString) attrString = ' ' + attrString;
-    return '<' + nodeName + attrString + '>' + content + '</' + nodeName + '>';
-  }
-}
+    if (attrString) attrString = " " + attrString;
+    return "<" + nodeName + attrString + ">" + content + "</" + nodeName + ">";
+  },
+};
 
 // ===============================================================================
 // Joplin Source block support


### PR DESCRIPTION
When a note contains raw HTML blocks (e.g. `<div style="color:red">**bold**</div>`), 
switching between the Markdown editor and Rich Text editor repeatedly corrupts the content
by adding extra backslashes before Markdown special characters (`*`, `_`, `

Then click **Create pull request**.
