### PR TITLE
Chore: Sync fuzzer: Include the step at which an action happened in the action log

### DIFF
--- a/packages/tools/fuzzer/Fuzzer.ts
+++ b/packages/tools/fuzzer/Fuzzer.ts
@@ -138,13 +138,23 @@ const createRandomNumberGenerators = (config: RandomConfig): RandomNumberGenerat
 	};
 };
 
+interface ExtendedFuzzContext extends FuzzContext {
+	setCurrentStep(step: number): void;
+}
+
 
 const createContext = (config: FuzzerConfig, random: RandomNumberGenerators, server: Server, profilesDirectory: string) => {
-	const fuzzContext: FuzzContext = {
+	let currentStep = 0;
+	const fuzzContext: ExtendedFuzzContext = {
 		serverUrl: server.url,
 		isJoplinCloud: config.isJoplinCloud,
 		enableE2ee: config.enableE2ee,
 		baseDir: profilesDirectory,
+
+		currentStep: () => currentStep,
+		setCurrentStep: (step: number) => {
+			currentStep = step;
+		},
 
 		execApi: server.execApi.bind(server),
 		randInt: (a, b) => random.generalRandom.nextInRange(a, b),
@@ -166,7 +176,7 @@ export default class Fuzzer {
 		private clients_: ClientPool,
 		private server_: Server,
 		private actionRunner_: ActionRunner,
-		private context_: FuzzContext,
+		private context_: ExtendedFuzzContext,
 	) {
 	}
 
@@ -332,6 +342,9 @@ export default class Fuzzer {
 			this.server_.assertCanUseSnapshots();
 		}
 
+		// Set the step to 0 during setup:
+		this.context_.setCurrentStep(0);
+
 		if (this.state_.currentStep <= 0) {
 			logger.info('Starting setup:');
 			await this.actionRunner_.doActions(this.config_.setupActions);
@@ -347,6 +360,7 @@ export default class Fuzzer {
 			stepIndex++
 		) {
 			this.state_.currentStep = stepIndex;
+			this.context_.setCurrentStep(stepIndex);
 
 			const client = this.clients_.randomClient();
 			this.actionRunner_.switchClient(client);

--- a/packages/tools/fuzzer/ipc/Client.ts
+++ b/packages/tools/fuzzer/ipc/Client.ts
@@ -1144,11 +1144,7 @@ class Client implements ActionableClient {
 
 				output.push(`id: ${id} (${itemTitle(id)})`);
 				if (log.length > 0) {
-					output.push(
-						log
-							.map(item => `\t${item.source}: ${item.action}`)
-							.join('\n'),
-					);
+					output.push(`\t${hangingIndent(log, '\t')}`);
 				} else {
 					output.push('\tNo history found');
 				}

--- a/packages/tools/fuzzer/model/ActionTracker.ts
+++ b/packages/tools/fuzzer/model/ActionTracker.ts
@@ -19,13 +19,14 @@ interface ClientInfo {
 interface ActionLogEntry {
 	action: string;
 	source: string;
+	step: number;
 }
 
 const schema = {
 	idToActionLog: [
 		[
 			'string',
-			[{ action: 'string', source: 'string' }, '...'],
+			[{ action: 'string', source: 'string', step: 'number' }, '...'],
 		],
 		'...',
 	],
@@ -97,19 +98,22 @@ class ActionTracker extends Serializable<typeof schema> {
 	}
 
 	public getActionLog(id: ItemId) {
-		return [...(this.idToActionLog_.get(id) ?? [])];
+		const logData = this.idToActionLog_.get(id) ?? [];
+		return logData
+			.map(item => {
+				const formattedStep = String(item.step).padStart(2, '0');
+				return `(${formattedStep}) ${item.source}: ${item.action}`;
+			})
+			.join('\n');
 	}
 
 	public printActionLog(id: ItemId) {
-		const logEntries = this.getActionLog(id);
-		if (logEntries.length === 0) {
+		const log = this.getActionLog(id);
+		if (log.length === 0) {
 			process.stdout.write('N/A\n');
 			return;
 		}
 
-		const log = logEntries
-			.map(item => `in:${item.source}: ${item.action}`)
-			.join('\n');
 		process.stdout.write(`${log}\n`);
 	}
 
@@ -123,7 +127,7 @@ class ActionTracker extends Serializable<typeof schema> {
 		const log = this.idToActionLog_.get(itemId) ?? [];
 		this.idToActionLog_.set(itemId, log);
 
-		log.push({ action, source });
+		log.push({ action, source, step: this.context_.currentStep() });
 	}
 
 	private getToplevelParent_(item: ItemId|TreeItem) {

--- a/packages/tools/fuzzer/model/ActionTracker.ts
+++ b/packages/tools/fuzzer/model/ActionTracker.ts
@@ -19,14 +19,13 @@ interface ClientInfo {
 interface ActionLogEntry {
 	action: string;
 	source: string;
-	step: number;
 }
 
 const schema = {
 	idToActionLog: [
 		[
 			'string',
-			[{ action: 'string', source: 'string', step: 'number' }, '...'],
+			[{ action: 'string', source: 'string' }, '...'],
 		],
 		'...',
 	],
@@ -100,10 +99,7 @@ class ActionTracker extends Serializable<typeof schema> {
 	public getActionLog(id: ItemId) {
 		const logData = this.idToActionLog_.get(id) ?? [];
 		return logData
-			.map(item => {
-				const formattedStep = String(item.step).padStart(2, '0');
-				return `(${formattedStep}) ${item.source}: ${item.action}`;
-			})
+			.map(item => `${item.source}: ${item.action}`)
 			.join('\n');
 	}
 
@@ -127,7 +123,13 @@ class ActionTracker extends Serializable<typeof schema> {
 		const log = this.idToActionLog_.get(itemId) ?? [];
 		this.idToActionLog_.set(itemId, log);
 
-		log.push({ action, source, step: this.context_.currentStep() });
+		// Prepend the step at which the action took place. This allows comparing action logs
+		// for two different items:
+		const step = this.context_.currentStep();
+		const stepString = String(step);
+		source = `(${stepString.padStart(2)}) ${source}`;
+
+		log.push({ action, source });
 	}
 
 	private getToplevelParent_(item: ItemId|TreeItem) {

--- a/packages/tools/fuzzer/model/ActionTracker.ts
+++ b/packages/tools/fuzzer/model/ActionTracker.ts
@@ -127,7 +127,7 @@ class ActionTracker extends Serializable<typeof schema> {
 		// for two different items:
 		const step = this.context_.currentStep();
 		const stepString = String(step);
-		source = `(${stepString.padStart(2)}) ${source}`;
+		source = `(step ${stepString.padStart(2, '0')}) ${source}`;
 
 		log.push({ action, source });
 	}

--- a/packages/tools/fuzzer/types.ts
+++ b/packages/tools/fuzzer/types.ts
@@ -13,6 +13,8 @@ export interface FuzzContext {
 	enableE2ee: boolean;
 	baseDir: string;
 
+	currentStep(): number;
+
 	randInt: (low: number, high: number)=> number;
 	randomString: (targetLength: number)=> string;
 	randomId: ()=> string;


### PR DESCRIPTION
# Summary

This pull request updates the sync fuzzer's item history log to include the step at which each change happened.

When debugging a fuzzer failure, this makes it easier to determine whether a change to one item happened before or after a change to another item.

# Sample output

Before:
```
fuzzer-user-z6bycoexu31qk5pujegexe@localhost: created (toplevel)
fuzzer-user-z6bycoexu31qk5pujegexe@localhost: shared with fuzzer-user-kq2ekykngjyiuic7taegxe@localhost
```

After:
```
(step 00) fuzzer-user-z6bycoexu31qk5pujegexe@localhost: created (toplevel)
(step 06) fuzzer-user-z6bycoexu31qk5pujegexe@localhost: shared with fuzzer-user-kq2ekykngjyiuic7taegxe@localhost
```

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->