### PR TITLE
Added video tutorials to documentation pages

### DIFF
--- a/readme/apps/attachments.md
+++ b/readme/apps/attachments.md
@@ -29,3 +29,9 @@ Opening some types of attachments can be dangerous. Some computers try to run so
 If you're certain that a file type is always safe to open, regardless of its source, check the `Always open this file type without asking` box to stop receiving warnings for that file type. It might make sense to do this, for example, if you work with a large number of `.doc` files and know that they're safe to open in the version of Word you have installed.
 
 **What are some examples of unsafe file types?** This depends on your computer. For example, on most Windows systems, `.COM`, `.EXE`, and `.BAT` files are unsafe.
+
+## Video tutorial
+
+Watch this short video to learn how attachments work in Joplin:
+
+[![Watch the video](https://img.youtube.com/vi/lfW3A24f8X4/hqdefault.jpg)](https://www.youtube.com/watch?v=lfW3A24f8X4)

--- a/readme/apps/drawing_tool.md
+++ b/readme/apps/drawing_tool.md
@@ -23,6 +23,7 @@ Clicking "Draw picture" adds a new drawing to the note. When Joplin's note viewe
 ### Video tutorial
 
 Watch this short video to learn how to add a drawing to a note on mobile app:
+
 [![Watch the video](https://img.youtube.com/vi/B21GpLXbGWE/hqdefault.jpg)](https://www.youtube.com/watch?v=B21GpLXbGWE)
 
 ### Editing an existing drawing
@@ -56,7 +57,8 @@ For more ways to edit existing drawings on desktop, see the [Freehand Drawing pl
 
 ### Video tutorial
 
-Watch this short video to learn how to add a drawing to a note on the desktop app. Click on the thumbnail:
+Watch this short video to learn how to add a drawing to a note on the desktop app.
+
 [![Watch the video](https://img.youtube.com/vi/TK1RhTlgAlA/hqdefault.jpg)](https://www.youtube.com/watch?v=TK1RhTlgAlA)
 
 ## The editor

--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -26,7 +26,7 @@ In both cases you can either import a single file or a directory that contains m
 
 ## Video tutorial
 
-Watch this short video to learn how to Migrate from Evernote to Joplin:
+Watch this short video to learn how to export your notebooks from Evernote and import them on Joplin:
 
 [![Watch the video](https://img.youtube.com/vi/_nSrvfUwORM/hqdefault.jpg)](https://www.youtube.com/watch?v=_nSrvfUwORM)  
 
@@ -71,7 +71,7 @@ This requires Joplin >=v3.5.5 and the OneNote Windows desktop app. Be aware that
 
 ## Video tutorial
 
-Watch this short video to learn how to migrate from Onenote to Joplin:
+Watch this short video to learn how to export your notebooks from Onenote and import them on Joplin:
 
 [![Watch the video](https://img.youtube.com/vi/xgYcLZsw0IA/hqdefault.jpg)](https://www.youtube.com/watch?v=xgYcLZsw0IA&t=2s)
 

--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -24,7 +24,9 @@ In both cases you can either import a single file or a directory that contains m
 
 - If you import a directory, Joplin will create a notebook per file and import the notes into them.
 
-For a video tutorial on how to export your notebooks from Evernote and import them on Joplin, please click on the thumbnail:
+## Video tutorial
+
+Watch this short video to learn how to Migrate from Evernote to Joplin:
 
 [![Watch the video](https://img.youtube.com/vi/_nSrvfUwORM/hqdefault.jpg)](https://www.youtube.com/watch?v=_nSrvfUwORM)  
 
@@ -67,7 +69,9 @@ This requires Joplin >=v3.5.5 and the OneNote Windows desktop app. Be aware that
 4. Open the Joplin desktop application.
 5. From the "File" > "Import" menu, select "ZIP - OneNote Notebook". In the file picker, select the just-exported file.
 
-For a video tutorial on how to export your notebooks from Onenote and import them on Joplin, please click on the thumbnail:
+## Video tutorial
+
+Watch this short video to learn how to migrate from Onenote to Joplin:
 
 [![Watch the video](https://img.youtube.com/vi/xgYcLZsw0IA/hqdefault.jpg)](https://www.youtube.com/watch?v=xgYcLZsw0IA&t=2s)
 

--- a/readme/apps/import_export.md
+++ b/readme/apps/import_export.md
@@ -24,8 +24,6 @@ In both cases you can either import a single file or a directory that contains m
 
 - If you import a directory, Joplin will create a notebook per file and import the notes into them.
 
-## Video tutorial
-
 Watch this short video to learn how to export your notebooks from Evernote and import them on Joplin:
 
 [![Watch the video](https://img.youtube.com/vi/_nSrvfUwORM/hqdefault.jpg)](https://www.youtube.com/watch?v=_nSrvfUwORM)  
@@ -68,8 +66,6 @@ This requires Joplin >=v3.5.5 and the OneNote Windows desktop app. Be aware that
 	- Alternatively, select "Notebook", then "OneNote Package (`*.onepkg`)". `*.onepkg` files can only be imported if Joplin is running on Windows.
 4. Open the Joplin desktop application.
 5. From the "File" > "Import" menu, select "ZIP - OneNote Notebook". In the file picker, select the just-exported file.
-
-## Video tutorial
 
 Watch this short video to learn how to export your notebooks from Onenote and import them on Joplin:
 

--- a/readme/apps/markdown.md
+++ b/readme/apps/markdown.md
@@ -216,3 +216,9 @@ The functionality added by these plugins is not part of the CommonMark spec so, 
 | [Emoji](https://github.com/markdown-it/markdown-it-emoji) | `:smile:` | Transforms into 😄. See [this list](https://gist.github.com/rxaviers/7360908) for more emojis | no |[View](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/md_plugins/emoji_plugin.jpg) |
 | [Insert](https://github.com/markdown-it/markdown-it-ins) | `++inserted++` | Transforms into `<ins>inserted</ins>` (<ins>inserted</ins>) | no | [View](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/md_plugins/insert_plugin.jpg) |
 | [Multitable](https://github.com/RedBug312/markdown-it-multimd-table) | See [MultiMarkdown](https://fletcher.github.io/MultiMarkdown-6/syntax/tables.html) page | Adds more power and customization to markdown tables | no | [View](https://raw.githubusercontent.com/laurent22/joplin/dev/Assets/WebsiteAssets/images/md_plugins/multitable_plugin.jpg) |
+
+## Video tutorial
+
+Watch this short video to learn how markdown editor works:
+
+[![Watch the video](https://img.youtube.com/vi/IfK2DgKQ4rw/hqdefault.jpg)](https://www.youtube.com/watch?v=IfK2DgKQ4rw)

--- a/readme/apps/plugins.md
+++ b/readme/apps/plugins.md
@@ -26,6 +26,12 @@ To adhere to AppStore guidelines, the iOS app only allows installing recommended
 
 :::
 
+## Video tutorial
+
+Watch this short video to learn how to find and install plugins:
+
+[![Watch the video](https://img.youtube.com/vi/wutW3IXGTNI/hqdefault.jpg)](https://www.youtube.com/watch?v=wutW3IXGTNI)
+
 ## Managing Plugins
 
 Within the Joplin Plugins page you have the option to turn individual plugins on or off using the toggle control. After changing the state of a plugin Joplin must be restarted, you may need to check Joplin is not minimising to the system tray/notification area rather than fully closing.

--- a/readme/apps/plugins.md
+++ b/readme/apps/plugins.md
@@ -26,12 +26,6 @@ To adhere to AppStore guidelines, the iOS app only allows installing recommended
 
 :::
 
-## Video tutorial
-
-Watch this short video to learn how to find and install plugins:
-
-[![Watch the video](https://img.youtube.com/vi/wutW3IXGTNI/hqdefault.jpg)](https://www.youtube.com/watch?v=wutW3IXGTNI)
-
 ## Managing Plugins
 
 Within the Joplin Plugins page you have the option to turn individual plugins on or off using the toggle control. After changing the state of a plugin Joplin must be restarted, you may need to check Joplin is not minimising to the system tray/notification area rather than fully closing.
@@ -53,3 +47,9 @@ Alternatively you can simply remove *.jpl from the plugin directory (see Install
 There is documentation of the plugin API along with documentation on plugin development. Check the [Joplin API Overview](https://github.com/laurent22/joplin/blob/dev/readme/api/index.md) page for these items.
 For community discussion and assistance on plugin development please also see the [Joplin Discourse `plugins development` category](https://discourse.joplinapp.org/c/development/plugins/19).
 Other resources can be found in the `Joplin API - Get Started` and `Joplin API - Reference` categories on the [Joplin Help page](https://joplinapp.org/help/)
+
+## Video tutorial
+
+Watch this short video to learn how to find and install plugins:
+
+[![Watch the video](https://img.youtube.com/vi/wutW3IXGTNI/hqdefault.jpg)](https://www.youtube.com/watch?v=wutW3IXGTNI)

--- a/readme/apps/publish_note.md
+++ b/readme/apps/publish_note.md
@@ -28,6 +28,6 @@ Using Joplin Cloud Pro or Teams, you have the ability to customise the banner th
 
 ## Video Tutorial
 
-For a video tutorial on how to publish a note and customise the banner please click on the thumbnail:
+Watch this short video to learn how to publish a note and customise the banner:
 
 [![Watch the video](https://img.youtube.com/vi/i1xgInm0PTE/hqdefault.jpg)](https://youtu.be/i1xgInm0PTE)

--- a/readme/apps/rich_text_editor.md
+++ b/readme/apps/rich_text_editor.md
@@ -46,7 +46,7 @@ Most replacements require pressing the <kbd>space</kbd> or <kbd>enter</kbd> key 
 
 These replacements can be disabled in settings &gt; note, using the "Auto-format Markdown" setting.
 
-## Video tutorial
+## Video tutorial - Desktop
 
 Watch this short video to learn how to select and use the Rich Text editor:
 
@@ -56,7 +56,7 @@ Watch this short video to learn how to select and use the Rich Text editor:
 
 The rich text editor is also available on mobile devices. You can select it when editing a note by clicking on the kebab menu and choosing "Edit as Rich Text".
 
-## Video tutorial
+## Video tutorial - Mobile
 
 Watch this short video to learn how to select and use the Rich Text editor on mobile devices:
 

--- a/readme/apps/rich_text_editor.md
+++ b/readme/apps/rich_text_editor.md
@@ -46,10 +46,19 @@ Most replacements require pressing the <kbd>space</kbd> or <kbd>enter</kbd> key 
 
 These replacements can be disabled in settings &gt; note, using the "Auto-format Markdown" setting.
 
+## Video tutorial
+
+Watch this short video to learn how to format your notes with bold, italics, lists, links, and more without needing to write Markdown:
+
+[![Watch the video](https://img.youtube.com/vi/RE_7VVG3qPE/hqdefault.jpg)](https://www.youtube.com/watch?v=RE_7VVG3qPE)
+
+
 ## Rich text editor on mobile
 
 The rich text editor is also available on mobile devices. You can select it when editing a note by clicking on the kebab menu and choosing "Edit as Rich Text".
 
-For a video tutorial on how to select and use the Rich Text editor on mobile devices, please click on the thumbnail:
+## Video tutorial
+
+Watch this short video to learn how to select and use the Rich Text editor on mobile devices:
 
 [![Watch the video](https://img.youtube.com/vi/eXH5Z0b28eM/hqdefault.jpg)](https://www.youtube.com/watch?v=eXH5Z0b28eM)

--- a/readme/apps/rich_text_editor.md
+++ b/readme/apps/rich_text_editor.md
@@ -48,10 +48,9 @@ These replacements can be disabled in settings &gt; note, using the "Auto-format
 
 ## Video tutorial
 
-Watch this short video to learn how to format your notes with bold, italics, lists, links, and more without needing to write Markdown:
+Watch this short video to learn how to select and use the Rich Text editor:
 
 [![Watch the video](https://img.youtube.com/vi/RE_7VVG3qPE/hqdefault.jpg)](https://www.youtube.com/watch?v=RE_7VVG3qPE)
-
 
 ## Rich text editor on mobile
 

--- a/readme/apps/search.md
+++ b/readme/apps/search.md
@@ -57,3 +57,9 @@ Notes are sorted by "relevance". Currently it means the notes that contain the r
 In the desktop application, press <kbd>Ctrl+P</kbd> or <kbd>Cmd+P</kbd> and type a note title or part of its content to jump to it. Or type <kbd>#</kbd> followed by a tag name, or <kbd>@</kbd> followed by a notebook name.
 
 The Goto Anything dialog can also be opened from the "Go" section of the application menubar.
+
+## Video tutorial
+
+Watch this short video to learn how to quickly locate your notes, to-dos, and attachments:
+
+[![Watch the video](https://img.youtube.com/vi/P8-qCi3dcnA/hqdefault.jpg)](https://www.youtube.com/watch?v=P8-qCi3dcnA)

--- a/readme/apps/to-dos.md
+++ b/readme/apps/to-dos.md
@@ -38,3 +38,9 @@ Joplin can be configured to show a notification for incomplete to-dos. This is d
 **On mobile:** Open the note actions menu, then click "set alarm".
 
 Also see [the notifications documentation](https://joplinapp.org/help/apps/notifications) for how notifications are displayed.
+
+## Video tutorial
+
+Watch this short video to learn how to create, manage, and organize tasks effectively:
+
+[![Watch the video](https://img.youtube.com/vi/BtXgBYebR_Y/hqdefault.jpg)](https://www.youtube.com/watch?v=BtXgBYebR_Y)


### PR DESCRIPTION
Solved: #13967

Added YouTube video embeds to several documentation pages that previously had no visual guidance. The pages covered are:

- Attachments
- Drawing tool (mobile + desktop)
- Import/Export (Evernote + OneNote)
- Markdown editor
- Plugins
- Publish note
- Rich text editor (desktop + mobile)
- Search
- To-dos

Also did some minor wording cleanup on a few pages.

## Testing

Opened each modified `.md` file and confirmed the thumbnails render correctly and the links point to the right videos.