### PR TITLE
fix: prevent file sync when path is not configured (#14322)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1256,6 +1256,7 @@ packages/lib/PerformanceLogger.js
 packages/lib/PoorManIntervals.js
 packages/lib/RotatingLogs.test.js
 packages/lib/RotatingLogs.js
+packages/lib/SyncTargetFilesystem.test.js
 packages/lib/SyncTargetFilesystem.js
 packages/lib/SyncTargetJoplinCloud.js
 packages/lib/SyncTargetJoplinServer.js

--- a/.gitignore
+++ b/.gitignore
@@ -1229,6 +1229,7 @@ packages/lib/PerformanceLogger.js
 packages/lib/PoorManIntervals.js
 packages/lib/RotatingLogs.test.js
 packages/lib/RotatingLogs.js
+packages/lib/SyncTargetFilesystem.test.js
 packages/lib/SyncTargetFilesystem.js
 packages/lib/SyncTargetJoplinCloud.js
 packages/lib/SyncTargetJoplinServer.js

--- a/packages/lib/SyncTargetFilesystem.test.ts
+++ b/packages/lib/SyncTargetFilesystem.test.ts
@@ -1,0 +1,64 @@
+import Setting from './models/Setting';
+import SyncTargetFilesystem from './SyncTargetFilesystem';
+
+// Mock FileApiDriverLocal to avoid actual filesystem operations
+jest.mock('./file-api-driver-local', () => {
+	return {
+		__esModule: true,
+		default: jest.fn().mockImplementation(() => ({
+			mkdir: jest.fn(),
+		})),
+	};
+});
+
+// Mock file-api
+jest.mock('./file-api', () => {
+	return {
+		FileApi: jest.fn().mockImplementation(() => ({
+			setLogger: jest.fn(),
+			setSyncTargetId: jest.fn(),
+		})),
+	};
+});
+
+describe('SyncTargetFilesystem', () => {
+	let syncTarget: SyncTargetFilesystem;
+
+	beforeEach(() => {
+		syncTarget = new SyncTargetFilesystem(null);
+		syncTarget.setLogger({
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock logger for testing
+		} as any);
+	});
+
+	it('should return false when sync path is empty', async () => {
+		Setting.setValue('sync.2.path', '');
+		expect(await syncTarget.isAuthenticated()).toBe(false);
+	});
+
+	it('should return false when sync path is whitespace only', async () => {
+		Setting.setValue('sync.2.path', '   ');
+		expect(await syncTarget.isAuthenticated()).toBe(false);
+	});
+
+	it('should return true when sync path is set', async () => {
+		Setting.setValue('sync.2.path', '/tmp/joplin-sync-test');
+		expect(await syncTarget.isAuthenticated()).toBe(true);
+	});
+
+	it('should throw an error when sync path is not set', async () => {
+		Setting.setValue('sync.2.path', '');
+		await expect(syncTarget.initFileApi()).rejects.toThrow(
+			'File system sync path is not set',
+		);
+	});
+
+	it('should not throw when sync path is set', async () => {
+		Setting.setValue('sync.2.path', '/tmp/joplin-sync-test');
+		await expect(syncTarget.initFileApi()).resolves.toBeDefined();
+	});
+});

--- a/packages/lib/SyncTargetFilesystem.ts
+++ b/packages/lib/SyncTargetFilesystem.ts
@@ -23,7 +23,7 @@ export default class SyncTargetFilesystem extends BaseSyncTarget {
 	}
 
 	public async isAuthenticated() {
-		return true;
+		return !!this.syncPath_()?.trim();
 	}
 
 	private syncPath_() {
@@ -31,6 +31,11 @@ export default class SyncTargetFilesystem extends BaseSyncTarget {
 	}
 
 	public async initFileApi() {
+		const syncPath = this.syncPath_()?.trim();
+		if (!syncPath) {
+			throw new Error('File system sync path is not set. Please configure the sync path in the settings.');
+		}
+
 		const driver = new FileApiDriverLocal();
 
 		const fileApi = new FileApi(() => {
@@ -41,7 +46,6 @@ export default class SyncTargetFilesystem extends BaseSyncTarget {
 		fileApi.setLogger(this.logger());
 		fileApi.setSyncTargetId(SyncTargetFilesystem.id());
 
-		const syncPath = this.syncPath_();
 		await driver.mkdir(syncPath);
 		return fileApi;
 	}


### PR DESCRIPTION
### AI Assistant Disclosure 
AI tools were used to assist with:
- Generating some unit test cases for verification
## Summary

When a user switches the sync target dropdown to "File system" on mobile and
leaves without configuring a path, Joplin would repeatedly attempt to sync every
5 minutes and fail with `Error: Directory could not be created. Path: (probably blank)`.

This happened because `SyncTargetFilesystem.isAuthenticated()` always returned
`true`, so the sync scheduler in [registry.ts](cci:7://file:///Users/sriramvarunkumar/Desktop/joplin/packages/lib/registry.ts:0:0-0:0) never skipped the sync attempt.

## Changes

- `SyncTargetFilesystem.isAuthenticated()` now returns `false` when the sync
  path (`sync.2.path`) is empty or whitespace-only
- Added an early guard in [initFileApi()](cci:1://file:///Users/sriramvarunkumar/Desktop/joplin/packages/lib/BaseSyncTarget.ts:109:1-112:2) that throws a descriptive error if the
  sync path is not set (defense-in-depth)
- Added unit tests covering empty, whitespace-only, and valid path scenarios

## How it works

The sync scheduler in [registry.ts](cci:7://file:///Users/sriramvarunkumar/Desktop/joplin/packages/lib/registry.ts:0:0-0:0) already checks [isAuthenticated()](cci:1://file:///Users/sriramvarunkumar/Desktop/joplin/packages/lib/SyncTargetFilesystem.ts:24:1-26:2) before
starting a sync. With this fix, that existing guard correctly prevents sync
attempts when no file system path has been configured. The scheduler logs:
`Synchroniser is missing credentials - manual sync required to authenticate.`

## Testing

- 5 unit tests added and passing ([SyncTargetFilesystem.test.ts](cci:7://file:///Users/sriramvarunkumar/Desktop/joplin/packages/lib/SyncTargetFilesystem.test.ts:0:0-0:0))
- Existing registry tests pass with no regressions
