### PR TITLE
All: Fixes #14335: Support include_deleted parameter for GET /folders endpoint

### DIFF
--- a/packages/lib/services/rest/routes/folders.test.ts
+++ b/packages/lib/services/rest/routes/folders.test.ts
@@ -68,4 +68,59 @@ describe('routes/folders', () => {
 		expect((await Note.load(note1.id)).deleted_time).toBeGreaterThanOrEqual(beforeTime);
 		expect(await Note.load(note2.id)).toBeFalsy();
 	});
+
+	test('should return deleted folders when include_deleted is set', async () => {
+		const api = new Api();
+		const folder1 = await Folder.save({});
+		const folder2 = await Folder.save({});
+		await Folder.delete(folder1.id, { toTrash: true });
+
+		{
+			const page = await api.route(RequestMethod.GET, 'folders');
+			expect(page.items.length).toBe(1);
+			expect(page.items[0].id).toBe(folder2.id);
+		}
+
+		{
+			const page = await api.route(RequestMethod.GET, 'folders', { include_deleted: '1' });
+			expect(page.items.length).toBe(2);
+		}
+	});
+
+	test('should return deleted folders in tree view when include_deleted is set', async () => {
+		const api = new Api();
+		const folder1 = await Folder.save({});
+		const folder2 = await Folder.save({});
+		await Folder.delete(folder1.id, { toTrash: true });
+
+		{
+			const tree = await api.route(RequestMethod.GET, 'folders', { as_tree: 1 });
+			expect(tree.length).toBe(1);
+			expect(tree[0].id).toBe(folder2.id);
+		}
+
+		{
+			const tree = await api.route(RequestMethod.GET, 'folders', { as_tree: 1, include_deleted: '1' });
+			expect(tree.length).toBe(2);
+		}
+	});
+
+	test('should return deleted notes in folder when include_deleted is set', async () => {
+		const api = new Api();
+		const folder = await Folder.save({});
+		const note1 = await Note.save({ parent_id: folder.id });
+		const note2 = await Note.save({ parent_id: folder.id });
+		await Note.delete(note1.id, { toTrash: true });
+
+		{
+			const notes = await api.route(RequestMethod.GET, `folders/${folder.id}/notes`);
+			expect(notes.items.length).toBe(1);
+			expect(notes.items[0].id).toBe(note2.id);
+		}
+
+		{
+			const notes = await api.route(RequestMethod.GET, `folders/${folder.id}/notes`, { include_deleted: '1' });
+			expect(notes.items.length).toBe(2);
+		}
+	});
 });

--- a/packages/lib/services/rest/routes/folders.ts
+++ b/packages/lib/services/rest/routes/folders.ts
@@ -27,7 +27,8 @@ export default async function(request: Request, id: string = null, link: string 
 	if (request.method === RequestMethod.GET && id) {
 		if (link && link === 'notes') {
 			const folder = await Folder.load(id);
-
+			if (!folder) throw new ErrorNotFound();
+			
 			let sql = 'parent_id = ?';
 			if (!includeDeleted) {
 				sql += ' AND deleted_time = 0';

--- a/packages/lib/services/rest/routes/folders.ts
+++ b/packages/lib/services/rest/routes/folders.ts
@@ -9,23 +9,30 @@ import { allForDisplay } from '../../../folders-screen-utils';
 const { ErrorNotFound } = require('../utils/errors');
 
 export default async function(request: Request, id: string = null, link: string = null) {
+	const includeDeleted = request.query.include_deleted === '1';
 	if (request.method === RequestMethod.GET && !id) {
+
 		if (request.query.as_tree) {
 			const folders = await allForDisplay({
 				fields: requestFields(request, BaseModel.TYPE_FOLDER),
-				includeDeleted: false,
+				includeDeleted: includeDeleted,
 			});
 			const output = await Folder.allAsTree(folders);
 			return output;
 		} else {
-			return defaultAction(BaseModel.TYPE_FOLDER, request, id, link, null, { sql: 'deleted_time = 0' });
+			return defaultAction(BaseModel.TYPE_FOLDER, request, id, link, null, includeDeleted ? null : { sql: 'deleted_time = 0' });
 		}
 	}
 
 	if (request.method === RequestMethod.GET && id) {
 		if (link && link === 'notes') {
 			const folder = await Folder.load(id);
-			return paginatedResults(BaseModel.TYPE_NOTE, request, { sql: 'parent_id = ? AND deleted_time = 0', params: [folder.id] });
+
+			let sql = 'parent_id = ?';
+			if (!includeDeleted) {
+				sql += ' AND deleted_time = 0';
+			}
+			return paginatedResults(BaseModel.TYPE_NOTE, request, { sql, params: [folder.id] });
 		} else if (link) {
 			throw new ErrorNotFound();
 		}

--- a/packages/lib/services/rest/routes/folders.ts
+++ b/packages/lib/services/rest/routes/folders.ts
@@ -28,7 +28,6 @@ export default async function(request: Request, id: string = null, link: string 
 		if (link && link === 'notes') {
 			const folder = await Folder.load(id);
 			if (!folder) throw new ErrorNotFound();
-			
 			const sql = includeDeleted ? 'parent_id = ?' : 'parent_id = ? AND deleted_time = 0';
 			return paginatedResults(BaseModel.TYPE_NOTE, request, { sql, params: [folder.id] });
 		} else if (link) {

--- a/packages/lib/services/rest/routes/folders.ts
+++ b/packages/lib/services/rest/routes/folders.ts
@@ -15,7 +15,7 @@ export default async function(request: Request, id: string = null, link: string 
 		if (request.query.as_tree) {
 			const folders = await allForDisplay({
 				fields: requestFields(request, BaseModel.TYPE_FOLDER),
-				includeDeleted: includeDeleted,
+				includeDeleted,
 			});
 			const output = await Folder.allAsTree(folders);
 			return output;
@@ -29,10 +29,7 @@ export default async function(request: Request, id: string = null, link: string 
 			const folder = await Folder.load(id);
 			if (!folder) throw new ErrorNotFound();
 			
-			let sql = 'parent_id = ?';
-			if (!includeDeleted) {
-				sql += ' AND deleted_time = 0';
-			}
+			const sql = includeDeleted ? 'parent_id = ?' : 'parent_id = ? AND deleted_time = 0';
 			return paginatedResults(BaseModel.TYPE_NOTE, request, { sql, params: [folder.id] });
 		} else if (link) {
 			throw new ErrorNotFound();


### PR DESCRIPTION
fixes #14335 
### AI Assistant Disclosure
AI tools were used to assist with:
- Understanding Problem Deeply
- Improving wording and clarity in the PR description
### Problem

When using the plugin API to list folders with `include_deleted: 1`, deleted folders (those in the trash) are never returned:

```javascript
const folders = await joplin.data.get(['folders'], {
    fields: ['id', 'deleted_time'],
    include_deleted: 1,
});
// folders.items never contains trashed folders — include_deleted is silently ignored
```

This is inconsistent with the `GET /notes` endpoint, which already supports `include_deleted=1` correctly. Since the plugin API documentation states that `joplin.data` uses the same REST API, plugins reasonably expect the same parameter to work for folders too.

### Root Cause

In `packages/lib/services/rest/routes/folders.ts`, the SQL filter `deleted_time = 0` was hardcoded in three places without checking the `include_deleted` query parameter. By contrast, `notes.ts` already conditionally applies this filter.

### Changes

**`packages/lib/services/rest/routes/folders.ts`**

- `GET /folders` (paginated list): Now conditionally applies `deleted_time = 0` based on `include_deleted`
- `GET /folders?as_tree=1` (tree view): Now passes `include_deleted` through to `allForDisplay()` instead of hardcoding `false`
- `GET /folders/:id/notes` (notes within a folder): Now conditionally applies `deleted_time = 0`

The implementation mirrors the existing pattern from `notes.ts`.

**`packages/lib/services/rest/routes/folders.test.ts`**

Added three new tests:
- `should return deleted folders when include_deleted is set`
- `should return deleted folders in tree view when include_deleted is set`
- `should return deleted notes in folder when include_deleted is set`

### Testing

All existing tests pass with no regressions:

- `folders.test.ts` — 6/6 passed (3 existing + 3 new)
- `notes.test.ts` — 19/19 passed
- `Api.test.ts` — 45/45 passed

## Manual Verification – Web Clipper API Testing

### 1️⃣ Default Request (Deleted Folders Excluded)

`GET /folders`
<img width="1287" height="485" alt="Screenshot 2026-02-22 at 1 17 52 PM" src="https://github.com/user-attachments/assets/6eeb3cf6-f3bc-49fe-b704-42d499aff0c2" />
---
### 2️⃣ include_deleted=1 (Deleted Folders Included)

`GET /folders?as_tree=1&include_deleted=1`
<img width="1482" height="370" alt="Screenshot 2026-02-22 at 1 24 51 PM" src="https://github.com/user-attachments/assets/9eb5b25f-7745-4302-8268-50751533112d" />
---
### 🎥 Demo Video

`GET /folders?include_deleted=1`

https://github.com/user-attachments/assets/7c052dd7-4940-453b-8eeb-b8b122ef94c8

