### PR TITLE
Mobile: Fixes #14309: Title field border changes thickness when switching between view and edit and when in focus

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -526,10 +526,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 		styles.noteBodyViewerPreview = {
 			...styles.noteBodyViewer,
-			borderTopColor: theme.dividerColor,
-			borderTopWidth: 1,
-			borderBottomColor: theme.dividerColor,
-			borderBottomWidth: 1,
 		};
 
 		styles.titleContainer = {
@@ -537,9 +533,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			flexDirection: 'row',
 			flexBasis: 'auto',
 			paddingLeft: theme.marginLeft,
-			borderBottomColor: theme.dividerColor,
-			borderBottomWidth: 1,
 			maxHeight: '40%',
+		};
+
+		styles.separator = {
+			height: StyleSheet.hairlineWidth,
+			backgroundColor: theme.dividerColor,
 		};
 
 		styles.titleContainerTodo = { ...styles.titleContainer };
@@ -1782,42 +1781,45 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			/>;
 
 		const titleComp = (
-			<View
-				style={titleContainerStyle}
-				onLayout={(e) => {
-					const width = e.nativeEvent.layout.width;
-					if (width !== this.state.titleContainerWidth) {
-						this.setState({ titleContainerWidth: width });
-					}
-				}}
-			>
-				<TextWrapCalculator
-					textCompStyle={this.styles().titleTextInput}
-					textCompContainerWidth={this.state.titleContainerWidth}
-					showMultilineToggle={this.state.showMultilineToggle}
-					multiline={this.state.multiline}
-					text={note.title}
-					updateState={textWrapCalculator_updateState}
-				/>
-				{isTodo && <Checkbox style={this.styles().checkbox} checked={!!Number(note.todo_completed)} onChange={this.todoCheckbox_change} />}
-				<TextInput
-					key={this.state.multiline ? 'multiLine' : 'singleLine'}
-					ref={this.titleTextFieldRef}
-					underlineColorAndroid="#ffffff00"
-					autoCapitalize="sentences"
-					style={this.styles().titleTextInput}
-					value={note.title}
-					onChangeText={this.title_changeText}
-					selectionColor={theme.textSelectionColor}
-					keyboardAppearance={theme.keyboardAppearance}
-					placeholder={_('Add title')}
-					placeholderTextColor={theme.colorFaded}
-					editable={!this.state.readOnly}
-					multiline={this.state.multiline}
-					submitBehavior = "blurAndSubmit"
-				/>
-				{ titleToggleButton }
-			</View>
+			<>
+				<View
+					style={titleContainerStyle}
+					onLayout={(e) => {
+						const width = e.nativeEvent.layout.width;
+						if (width !== this.state.titleContainerWidth) {
+							this.setState({ titleContainerWidth: width });
+						}
+					}}
+				>
+					<TextWrapCalculator
+						textCompStyle={this.styles().titleTextInput}
+						textCompContainerWidth={this.state.titleContainerWidth}
+						showMultilineToggle={this.state.showMultilineToggle}
+						multiline={this.state.multiline}
+						text={note.title}
+						updateState={textWrapCalculator_updateState}
+					/>
+					{isTodo && <Checkbox style={this.styles().checkbox} checked={!!Number(note.todo_completed)} onChange={this.todoCheckbox_change} />}
+					<TextInput
+						key={this.state.multiline ? 'multiLine' : 'singleLine'}
+						ref={this.titleTextFieldRef}
+						underlineColorAndroid="#ffffff00"
+						autoCapitalize="sentences"
+						style={this.styles().titleTextInput}
+						value={note.title}
+						onChangeText={this.title_changeText}
+						selectionColor={theme.textSelectionColor}
+						keyboardAppearance={theme.keyboardAppearance}
+						placeholder={_('Add title')}
+						placeholderTextColor={theme.colorFaded}
+						editable={!this.state.readOnly}
+						multiline={this.state.multiline}
+						submitBehavior = "blurAndSubmit"
+					/>
+					{ titleToggleButton }
+				</View>
+				<View style={this.styles().separator} />
+			</>
 		);
 
 		const noteTagDialog = !this.state.noteTagDialogShown ? null : <NoteTagsDialog onCloseRequested={this.noteTagDialog_closeRequested} />;


### PR DESCRIPTION
### Summary
Fixes #14309  an anti-aliasing rendering issue on Android where the bottom border of the note title field would appear to change in thickness (±1 pixel) when switching between view/edit mode or focusing on the title input.

### Root Cause
The borderBottomWidth: 1 CSS border on the title container gets rendered as a fractional number of physical pixels on high-DPI Android devices. When the component repositions (e.g., during mode switches or focus changes), the sub-pixel rounding shifts, causing the border to appear thicker or thinner — a classic anti-aliasing artifact.

### Fix

Replaced the CSS border on the title container with a dedicated separator <View> using StyleSheet.hairlineWidth for its height, which maps to exactly 1 physical pixel and avoids fractional pixel rounding. A solid backgroundColor on a dedicated <View> renders more consistently than a CSS border across layout changes.

### Changes:

Removed borderBottomWidth / borderBottomColor from titleContainer style
Added a new separator style using StyleSheet.hairlineWidth and theme.dividerColor
Added a <View style={separator} /> after the title container
Removed unused border properties from noteBodyViewerPreview style