### PR TITLE
Desktop: Fixes #11870: DevTools ignores light/dark mode setting at startup

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -257,6 +257,12 @@ export default class ElectronAppWrapper {
 		if (shim.isLinux()) windowOptions.icon = path.join(__dirname, '..', 'build/icons/128x128.png');
 
 		this.win_ = new BrowserWindow(windowOptions);
+		this.win_.webContents.once('did-finish-load', () => {
+			void this.win_?.webContents.openDevTools({
+				mode: 'detach',
+				activate: false,
+			});
+		});
 
 		require('@electron/remote/main').enable(this.win_.webContents);
 


### PR DESCRIPTION
### Root cause

When **DevTools** is opened during startup, it does not respect the current **nativeTheme** setting. As a result, **DevTools** defaults to the light theme even if Joplin is running in dark mode.

This happens because **DevTools** is opened before the renderer has fully finished loading, so the theme state is not properly applied.

### Fix#11870

**DevTools** is now opened after the did-finish-load event of the main window.

This ensures that:

1. The renderer is fully initialized

2. The correct nativeTheme state is available

3. DevTools uses the correct light/dark theme at startup

4. The change is limited to the Desktop (Electron) application and does not affect Mobile or CLI.

**Testing**

Tested manually on Linux:

- Set Joplin to dark mode.

- Restart the application.
 
- Open DevTools.

- DevTools now opens with the correct theme instead of defaulting to light mode.