### PR TITLE
Added a sync verification

### DIFF
--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -15,6 +15,7 @@ import ResourceService from '../ResourceService';
 import { addMasterKey, getEncryptionEnabled, localSyncInfo } from '../synchronizer/syncInfoUtils';
 import { ShareInvitation, SharePermissions, State, stateRootKey, StateShare } from './reducer';
 import PerformanceLogger from '../../PerformanceLogger';
+import SyncTargetRegistry from '../../SyncTargetRegistry';
 
 const logger = Logger.create('ShareService');
 const perfLogger = PerformanceLogger.create();
@@ -86,7 +87,11 @@ export default class ShareService {
 			userContentBaseUrl: () => Setting.value(`sync.${syncTargetId}.userContentPath`),
 			username: () => Setting.value(`sync.${syncTargetId}.username`),
 			password: () => Setting.value(`sync.${syncTargetId}.password`),
-			apiKey: () => Setting.value(`sync.${syncTargetId}.apiKey`),
+			apiKey: () => {
+				if (!Setting.value(`sync.${syncTargetId}.apiKey`)) { return null; } else {
+					return Setting.value(`sync.${syncTargetId}.apiKey`);
+				}
+			},
 			session: () => {
 				if (syncTargetId === 11) {
 					return {
@@ -390,8 +395,12 @@ export default class ShareService {
 	public async deleteShare(shareId: string) {
 		await this.api().exec('DELETE', `api/shares/${shareId}`);
 	}
-
+	private isServerSyncTarget(): boolean {
+		const syncTargetId = Setting.value('sync.target');
+		return SyncTargetRegistry.infoById(syncTargetId).supportsShare;
+	}
 	private async loadShares() {
+		if (!this.isServerSyncTarget()) return [];
 		return this.api().exec('GET', 'api/shares');
 	}
 
@@ -527,6 +536,13 @@ export default class ShareService {
 	}
 
 	public async refreshShares(): Promise<StateShare[]> {
+		if (!this.isServerSyncTarget()) {
+			this.store.dispatch({
+				type: 'SHARE_SET',
+				shares: [],
+			});
+			return [];
+		}
 		const result = await this.loadShares();
 
 		logger.info('Refreshed shares:', result);


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

Added guards in ShareService.refreshShares() and ShareService.loadShares() using SyncTargetRegistry.infoById(syncTargetId).supportsShare to ensure sharing logic only runs when the active sync target supports sharing (Joplin Server / Joplin Cloud). This prevents invalid API calls and runtime errors when using sync targets such as WebDAV that do not implement the sharing API.