### PR TITLE
Desktop: Fixes #14428: E2EE setup dialog theme and cancel validation

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -202,6 +202,8 @@ const EncryptionConfigScreen = (props: Props) => {
 		} else {
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
 			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
+
+			if (newPassword === null) return;
 		}
 
 		if (hasMasterPassword && newEnabled) {

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -326,6 +326,25 @@ a:not([draggable=true]), img:not([draggable=true]) {
 }
 .smalltalk .page {
 	max-width: 30em;
+	background: var(--joplin-background-color);
+	color: inherit;
+}
+.smalltalk .page header { text-shadow: none; }
+.smalltalk input {
+	background-color: inherit;
+	color: inherit;
+	border-color: var(--joplin-divider-color);
+}
+.smalltalk button,
+.smalltalk button:enabled:hover,
+.smalltalk button:enabled:active,
+.smalltalk button:enabled:focus {
+	background-image: none;
+	background-color: var(--joplin-background-color4);
+	color: var(--joplin-color4);
+	border-color: var(--joplin-border-color4);
+	box-shadow: none;
+	text-shadow: none;
 }
 mark {
 	background: #CF3F00;

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -326,6 +326,26 @@ a:not([draggable=true]), img:not([draggable=true]) {
 }
 .smalltalk .page {
 	max-width: 30em;
+	background: var(--joplin-background-color);
+	color: inherit;
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+}
+.smalltalk .page header { text-shadow: none; }
+.smalltalk input {
+	background-color: inherit;
+	color: inherit;
+	border-color: var(--joplin-divider-color);
+}
+.smalltalk button,
+.smalltalk button:enabled:hover,
+.smalltalk button:enabled:active,
+.smalltalk button:enabled:focus {
+	background-image: none;
+	background-color: var(--joplin-background-color4);
+	color: var(--joplin-color4);
+	border-color: var(--joplin-border-color4);
+	box-shadow: none;
+	text-shadow: none;
 }
 mark {
 	background: #CF3F00;

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -327,8 +327,8 @@ a:not([draggable=true]), img:not([draggable=true]) {
 .smalltalk .page {
 	max-width: 30em;
 	background: var(--joplin-background-color);
-	color: inherit;
 	box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+	color: inherit;
 }
 .smalltalk .page header { text-shadow: none; }
 .smalltalk input {


### PR DESCRIPTION
## AI Assistance Disclosure

AI was used only to help with some CSS adjustments so the dialog follows the active app theme.  
I reviewed and tested the code locally and fully understand the changes.

---

## Summary

Fixes two UX issues in the E2EE setup dialog:

1. Dialog did not follow dark theme
2. Cancel/X still triggered “Encryption key is required”

Now the dialog theme matches the app, and validation runs only on OK.

Issue: #14428

---

## Changes

### Theme fix
The E2EE setup dialog now uses the current theme styles instead of default/light styling, so it matches dark mode and other themes.

### Cancel behavior fix
Password validation is now skipped when the dialog is dismissed via **Cancel** or **X**.  
The “Encryption key is required” message appears only when pressing **OK** with an empty password.

---

## Manual testing

### 1. Theme consistency
1. Enable dark theme (or auto)
2. Open **Settings → Synchronisation → Encryption**
3. Click **Enable encryption**

**Screenshot:** 

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/c5fddf1e-6ea9-4e59-b1ca-4bab4bc7140d" />

### 2. Dialog behavior (Cancel vs OK)

1. Open **Enable encryption**
2. Leave password empty
3. Click **Cancel** or **X** → dialog closes with no error
4. Open again
5. Leave password empty
6. Click **OK** → “Encryption key is required” is shown

**Screen recording:**  

https://github.com/user-attachments/assets/eee4e868-9d74-4c0e-83e9-d2316c2efe94
