### PR TITLE
Add optional GPU support to Transcribe server

### DIFF
--- a/.env-transcribe-sample
+++ b/.env-transcribe-sample
@@ -16,6 +16,9 @@ HTR_CLI_DOCKER_IMAGE=joplin/htr-cli:latest
 #HTR_CLI_IMAGES_FOLDER=/home/user/joplin/packages/transcribe/images
 HTR_CLI_IMAGES_FOLDER=
 
+# GPU layers to offload (0 = CPU only; 999 = all layers). Use with a GPU-capable binary (e.g. CUDA/Metal or llamafile).
+# HTR_CLI_NGL=999
+
 QUEUE_DRIVER=pg
 # QUEUE_DRIVER=sqlite
 

--- a/Dockerfile.transcribe
+++ b/Dockerfile.transcribe
@@ -10,7 +10,8 @@ ENV NODE_ENV=production
 
 RUN corepack enable
 
-# Download llama.cpp binary
+# Download llama.cpp binary (CPU-only by default). For GPU, use a CUDA/Metal build
+# and set HTR_CLI_BINARY_PATH + HTR_CLI_NGL at runtime, or build a custom image.
 WORKDIR /opt/llama
 RUN wget -q https://github.com/ggml-org/llama.cpp/releases/download/b5449/llama-b5449-bin-ubuntu-x64.zip \
     && unzip llama-b5449-bin-ubuntu-x64.zip \

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -115,4 +115,5 @@ services:
             - API_KEY=${TRANSCRIBE_API_KEY}
             - HTR_CLI_IMAGES_FOLDER=/app/packages/transcribe/images
             - HTR_CLI_MODELS_FOLDER=/opt/models
+            - HTR_CLI_NGL=${HTR_CLI_NGL:-0}
 

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -1,3 +1,5 @@
+CUDA
+llamafile
 zblesk
 zxcvbn
 zžżź

--- a/packages/transcribe/README.md
+++ b/packages/transcribe/README.md
@@ -32,6 +32,29 @@ docker run --env-file .env-transcribe -p 4567:4567 \
 	transcribe
 ```
 
+### GPU support
+
+The default Docker image uses a **CPU-only** binary. To use the GPU:
+
+1. **Use a GPU-capable binary.** Either build llama.cpp with CUDA (NVIDIA) or Metal (Apple), or use a [llama.cpp release](https://github.com/ggml-org/llama.cpp/releases) that includes GPU support. Point `HTR_CLI_BINARY_PATH` at that binary (e.g. by building a custom image or mounting the binary).
+2. **Set GPU layer offload.** Set the environment variable `HTR_CLI_NGL` to the number of model layers to run on the GPU (e.g. `999` for all layers):
+   ```shell
+   -e HTR_CLI_NGL=999
+   ```
+   Leave unset or set to `0` for CPU-only.
+
+In Docker Compose, add `HTR_CLI_NGL=999` to the `transcribe` service environment when using a GPU-capable image or host-mounted binary.
+
+### Using llamafile (optional)
+
+[llamafile](https://github.com/mozilla-ai/llamafile) provides single-file executables (llama.cpp + Cosmopolitan) that run on many OSes and support GPU (CUDA, Metal) via the same `-ngl` flag. You can use a llamafile-built multimodal CLI as a drop-in for `llama-mtmd-cli`:
+
+- Set `HTR_CLI_BINARY_PATH` to the path of the llamafile executable.
+- Set `HTR_CLI_NGL=999` (or another value) for GPU offload when the binary supports it.
+- Keep the same model and mmproj paths; the server passes `-m`, `--mmproj`, and `--image` as with the standard binary.
+
+This can simplify deployment (one fat binary per platform) when the llamafile CLI is compatible with the flags used by the transcribe server.
+
 ## Using Docker Compose
 
 The minimal configuration is provided in `.env-sample` and `docker-compose.server.yml`.
@@ -87,9 +110,10 @@ yarn start
 
 ### Environment variables
 
-- `HTR_CLI_BINARY_PATH`: Path to the llama-mtmd-cli binary
+- `HTR_CLI_BINARY_PATH`: Path to the llama-mtmd-cli (or compatible) binary
 - `HTR_CLI_MODELS_FOLDER`: Path to the models directory
 - `HTR_CLI_IMAGES_FOLDER`: Path where uploaded images are stored
+- `HTR_CLI_NGL`: Number of model layers to offload to GPU (0 = CPU only; 999 = all layers). Only used when the binary supports GPU (e.g. CUDA/Metal build or llamafile)
 
 ---
 

--- a/packages/transcribe/src/api/app.ts
+++ b/packages/transcribe/src/api/app.ts
@@ -38,6 +38,7 @@ const init = async (logger: LoggerWrapper) => {
 		htrCliImagesFolder: envVariables.HTR_CLI_IMAGES_FOLDER,
 		binaryPath: envVariables.HTR_CLI_BINARY_PATH,
 		modelsFolder: envVariables.HTR_CLI_MODELS_FOLDER,
+		gpuLayers: envVariables.HTR_CLI_NGL > 0 ? envVariables.HTR_CLI_NGL : undefined,
 	});
 
 	const jobProcessor = new JobProcessor(queue, htrCli, fileStorage);

--- a/packages/transcribe/src/core/HtrCli.test.ts
+++ b/packages/transcribe/src/core/HtrCli.test.ts
@@ -53,6 +53,7 @@ describe('HtrCli', () => {
 	};
 
 	beforeEach(() => {
+		(execCommand as jest.Mock).mockClear();
 		(execCommand as jest.Mock).mockResolvedValue(fakeExecOutput);
 	});
 

--- a/packages/transcribe/src/core/HtrCli.test.ts
+++ b/packages/transcribe/src/core/HtrCli.test.ts
@@ -46,39 +46,37 @@ describe('HtrCli', () => {
 		expect(result).toMatchSnapshot();
 	});
 
-	describe('gPU CLI flag', () => {
-		const baseOpts = {
-			htrCliImagesFolder: '/img',
-			binaryPath: '/bin/llama-mtmd-cli',
-			modelsFolder: '/models',
-		};
+	const baseOpts = {
+		htrCliImagesFolder: '/img',
+		binaryPath: '/bin/llama-mtmd-cli',
+		modelsFolder: '/models',
+	};
 
-		beforeEach(() => {
-			(execCommand as jest.Mock).mockResolvedValue(fakeExecOutput);
-		});
+	beforeEach(() => {
+		(execCommand as jest.Mock).mockResolvedValue(fakeExecOutput);
+	});
 
-		it('should NOT add -ngl when gpuLayers is 0 or undefined', async () => {
-			// undefined (omit gpuLayers)
-			const cliUndefined = new HtrCli({ ...baseOpts });
-			await cliUndefined.run('test.png');
-			let command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
-			expect(command).not.toContain('-ngl');
+	it('gPU CLI flag - should NOT add -ngl when gpuLayers is 0 or undefined', async () => {
+		// undefined (omit gpuLayers)
+		const cliUndefined = new HtrCli({ ...baseOpts });
+		await cliUndefined.run('test.png');
+		let command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+		expect(command).not.toContain('-ngl');
 
-			// explicit 0
-			(execCommand as jest.Mock).mockClear();
-			const cliZero = new HtrCli({ ...baseOpts, gpuLayers: 0 });
-			await cliZero.run('test.png');
-			command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
-			expect(command).not.toContain('-ngl');
-		});
+		// explicit 0
+		(execCommand as jest.Mock).mockClear();
+		const cliZero = new HtrCli({ ...baseOpts, gpuLayers: 0 });
+		await cliZero.run('test.png');
+		command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+		expect(command).not.toContain('-ngl');
+	});
 
-		it('should add -ngl <value> when gpuLayers is greater than 0', async () => {
-			const cliGpu = new HtrCli({ ...baseOpts, gpuLayers: 999 });
-			await cliGpu.run('test.png');
-			const command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
-			const nglIndex = command.indexOf('-ngl');
-			expect(nglIndex).toBeGreaterThanOrEqual(0);
-			expect(command[nglIndex + 1]).toBe('999');
-		});
+	it('gPU CLI flag - should add -ngl <value> when gpuLayers is greater than 0', async () => {
+		const cliGpu = new HtrCli({ ...baseOpts, gpuLayers: 999 });
+		await cliGpu.run('test.png');
+		const command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+		const nglIndex = command.indexOf('-ngl');
+		expect(nglIndex).toBeGreaterThanOrEqual(0);
+		expect(command[nglIndex + 1]).toBe('999');
 	});
 });

--- a/packages/transcribe/src/core/HtrCli.test.ts
+++ b/packages/transcribe/src/core/HtrCli.test.ts
@@ -1,6 +1,18 @@
 import { readFile } from 'fs-extra';
 import HtrCli from './HtrCli';
 
+jest.mock('@joplin/utils', () => {
+	const actual = jest.requireActual('@joplin/utils') as object;
+	return {
+		...actual,
+		execCommand: jest.fn(),
+	};
+});
+
+const { execCommand } = require('@joplin/utils');
+
+const fakeExecOutput = 'image decoded\n\nllama_perf_context_print:';
+
 describe('HtrCli', () => {
 	const dt = new HtrCli({ htrCliImagesFolder: '', binaryPath: '', modelsFolder: '' });
 	it('should parse multiline result', async () => {
@@ -32,5 +44,41 @@ describe('HtrCli', () => {
 		const testCase = await readFile('./test-cases/6.txt');
 		const result = dt.cleanUpResult(testCase.toString());
 		expect(result).toMatchSnapshot();
+	});
+
+	describe('gPU CLI flag', () => {
+		const baseOpts = {
+			htrCliImagesFolder: '/img',
+			binaryPath: '/bin/llama-mtmd-cli',
+			modelsFolder: '/models',
+		};
+
+		beforeEach(() => {
+			(execCommand as jest.Mock).mockResolvedValue(fakeExecOutput);
+		});
+
+		it('should NOT add -ngl when gpuLayers is 0 or undefined', async () => {
+			// undefined (omit gpuLayers)
+			const cliUndefined = new HtrCli({ ...baseOpts });
+			await cliUndefined.run('test.png');
+			let command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+			expect(command).not.toContain('-ngl');
+
+			// explicit 0
+			(execCommand as jest.Mock).mockClear();
+			const cliZero = new HtrCli({ ...baseOpts, gpuLayers: 0 });
+			await cliZero.run('test.png');
+			command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+			expect(command).not.toContain('-ngl');
+		});
+
+		it('should add -ngl <value> when gpuLayers is greater than 0', async () => {
+			const cliGpu = new HtrCli({ ...baseOpts, gpuLayers: 999 });
+			await cliGpu.run('test.png');
+			const command = (execCommand as jest.Mock).mock.calls[0][0] as string[];
+			const nglIndex = command.indexOf('-ngl');
+			expect(nglIndex).toBeGreaterThanOrEqual(0);
+			expect(command[nglIndex + 1]).toBe('999');
+		});
 	});
 });

--- a/packages/transcribe/src/core/HtrCli.ts
+++ b/packages/transcribe/src/core/HtrCli.ts
@@ -11,6 +11,7 @@ export interface HtrCliOptions {
 	htrCliImagesFolder: string;
 	binaryPath: string;
 	modelsFolder: string;
+	gpuLayers?: number; // -ngl: number of layers to offload to GPU (0 = CPU only)
 }
 
 export default class HtrCli implements WorkHandler {
@@ -22,7 +23,8 @@ export default class HtrCli implements WorkHandler {
 	}
 
 	public async init() {
-		logger.info('Using embedded llama.cpp binary');
+		const gpu = (this.options.gpuLayers ?? 0) > 0;
+		logger.info(gpu ? `Using binary with GPU offload (${this.options.gpuLayers} layers)` : 'Using binary (CPU only)');
 	}
 
 	public async run(imageName: string) {
@@ -44,8 +46,8 @@ export default class HtrCli implements WorkHandler {
 	}
 
 	private buildCommand(imageName: string): string[] {
-		const { binaryPath, modelsFolder, htrCliImagesFolder } = this.options;
-		return [
+		const { binaryPath, modelsFolder, htrCliImagesFolder, gpuLayers } = this.options;
+		const args: string[] = [
 			binaryPath,
 			'-m', `${modelsFolder}/Model-7.6B-Q4_K_M.gguf`,
 			'--mmproj', `${modelsFolder}/mmproj-model-f16.gguf`,
@@ -57,6 +59,11 @@ export default class HtrCli implements WorkHandler {
 			'--image', `${htrCliImagesFolder}/${imageName}`,
 			'-p', systemPrompt,
 		];
+		const ngl = gpuLayers ?? 0;
+		if (ngl > 0) {
+			args.push('-ngl', String(ngl));
+		}
+		return args;
 	}
 
 	public cleanUpResult(transcriptionAndLogs: string) {

--- a/packages/transcribe/src/env.ts
+++ b/packages/transcribe/src/env.ts
@@ -9,6 +9,7 @@ export const defaultEnvValues: EnvVariables = {
 	HTR_CLI_IMAGES_FOLDER: '',
 	HTR_CLI_BINARY_PATH: '',
 	HTR_CLI_MODELS_FOLDER: '',
+	HTR_CLI_NGL: 0, // GPU layers to offload (0 = CPU only; 999 = all layers when using a GPU build)
 	QUEUE_DRIVER: 'pg', // 'sqlite'
 	QUEUE_DATABASE_PASSWORD: '',
 	QUEUE_DATABASE_NAME: '',
@@ -29,6 +30,7 @@ export interface EnvVariables {
 	HTR_CLI_IMAGES_FOLDER: string;
 	HTR_CLI_BINARY_PATH: string;
 	HTR_CLI_MODELS_FOLDER: string;
+	HTR_CLI_NGL: number;
 	QUEUE_DRIVER: string;
 	QUEUE_DATABASE_PASSWORD: string;
 	QUEUE_DATABASE_NAME: string;


### PR DESCRIPTION
## Summary
This pull request addresses #14253 by adding optional GPU support to the Transcribe server.

The change allows model layers to be offloaded to the GPU using the `-ngl` flag, while keeping the default CPU-only behavior unchanged. GPU usage is fully opt-in and enabled only when explicitly configured.

## Implementation details
- Adds a new environment variable, `HTR_CLI_NGL`, to control GPU layer offloading
  - Default value is `0` (CPU-only)
  - When set to a value greater than `0` (for example `999`), the server passes `-ngl <value>` to the underlying transcription CLI
- Extends `HtrCli` to conditionally append the `-ngl` flag based on configuration
- Updates Docker configuration, environment samples, and documentation
- Documents optional use of a **llamafile-based CLI** as a drop-in replacement to simplify deployment without changing existing workflows

## Behavior
- Existing CPU-only behavior remains the default
- GPU support is enabled only when:
  - `HTR_CLI_NGL` is explicitly set to a value greater than `0`, and
  - a GPU-capable CLI binary is used
- No breaking changes are introduced

## Tests
- Added unit tests in `packages/transcribe/src/core/HtrCli.test.ts` to verify CLI argument handling:
  - Ensures `-ngl` is not added when GPU support is disabled
  - Ensures `-ngl <value>` is added when GPU support is enabled
- All tests pass:
<img width="617" height="211" alt="Tests Image" src="https://github.com/user-attachments/assets/bc00a09f-f952-4348-949a-d5725a70c2ae" />

