### PR TITLE
Desktop: Fix "Copy dev mode command" producing an unquotable path on Windows

### DIFF
--- a/packages/app-desktop/commands/copyDevCommand.ts
+++ b/packages/app-desktop/commands/copyDevCommand.ts
@@ -13,7 +13,8 @@ export const runtime = (): CommandRuntime => {
 	return {
 		execute: async () => {
 			const appPath = app.getPath('exe');
-			const cmd = `${appPath} --env dev`;
+			// Quote the path so it works when it contains spaces (e.g. "C:\Program Files\Joplin\Joplin.exe" on Windows)
+			const cmd = `"${appPath}" --env dev`;
 			clipboard.writeText(cmd);
 			await shim.showMessageBox(`The dev mode command has been copied to clipboard:\n\n${cmd}`, { type: MessageBoxType.Info });
 		},


### PR DESCRIPTION
fixes #14328.

### Problem
On Windows, `app.getPath('exe')` returns the long path like `C:\Program Files\Joplin\Joplin.exe.` When that gets pasted into a terminal without quotes, the shell interprets the spaces as argument separators and the command fails.

### Fix
The fix wraps the executable path in double quotes, producing` "C:\Program Files\Joplin\Joplin.exe" --env dev` which pastes and runs correctly in both cmd.exe and PowerShell. Quoting is also harmless on macOS and Linux, so no platform check is needed.

