### PR TITLE
Desktop: Resolves #14251 : Improved the new version popup window when there is an update

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -463,6 +463,8 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/WhatsNewDialog/ReleaseNotesSection.js
+packages/app-desktop/gui/WhatsNewDialog/WhatsNewDialog.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/.gitignore
+++ b/.gitignore
@@ -436,6 +436,8 @@ packages/app-desktop/gui/ToolbarSpace.js
 packages/app-desktop/gui/TrashNotification/TrashNotification.js
 packages/app-desktop/gui/TrashNotification/TrashNotificationMessage.js
 packages/app-desktop/gui/UpdateNotification/UpdateNotification.js
+packages/app-desktop/gui/WhatsNewDialog/ReleaseNotesSection.js
+packages/app-desktop/gui/WhatsNewDialog/WhatsNewDialog.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/AppDialogs.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/ModalMessageOverlay.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/PluginDialogs.js

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,431 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "bat@latest": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#bat",
+      "source": "devbox-search",
+      "version": "0.26.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/v84wyhzywd3b0q0ahli6aanm9zxfxncm-bat-0.26.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/v84wyhzywd3b0q0ahli6aanm9zxfxncm-bat-0.26.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vqsbq46rv3rm37fj7ri80q8fsy8hd3li-bat-0.26.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vqsbq46rv3rm37fj7ri80q8fsy8hd3li-bat-0.26.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yh82pk7n4blqlr8838f1y7cnj7ka0x08-bat-0.26.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/yh82pk7n4blqlr8838f1y7cnj7ka0x08-bat-0.26.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fz2gayy3kwjyzp66a3cxl826fqbzd5xz-bat-0.26.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fz2gayy3kwjyzp66a3cxl826fqbzd5xz-bat-0.26.1"
+        }
+      }
+    },
+    "cocoapods@latest": {
+      "last_modified": "2026-01-23T17:20:52Z",
+      "resolved": "github:NixOS/nixpkgs/a1bab9e494f5f4939442a57a58d0449a109593fe#cocoapods",
+      "source": "devbox-search",
+      "version": "1.16.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xmpbzlm4h97izn0nwf5r3flxa3hqiawa-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/xmpbzlm4h97izn0nwf5r3flxa3hqiawa-cocoapods-1.16.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kk994ybb09jk38n2k2sp5mifgka5mixg-cocoapods-1.16.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kk994ybb09jk38n2k2sp5mifgka5mixg-cocoapods-1.16.2"
+        }
+      }
+    },
+    "git@2.50.1": {
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#git",
+      "source": "devbox-search",
+      "version": "2.50.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jn9byxgdjndngf0d2by0djg8gcdll7xc-git-2.50.1",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/j8djmq64ckbah7bl6jv1y6arrjr0shmv-git-2.50.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/jn9byxgdjndngf0d2by0djg8gcdll7xc-git-2.50.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h4pvvix6pvnvys9a6y1xj2442r1ajdhl-git-2.50.1",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/q8sicpx16gyzxnp3345a46lj4cz9wd09-git-2.50.1-doc"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/rpxnrnsn4nbx8wm9d2vrgj0fr5xzz5lg-git-2.50.1-debug"
+            }
+          ],
+          "store_path": "/nix/store/h4pvvix6pvnvys9a6y1xj2442r1ajdhl-git-2.50.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8d1n8cvi5x1j0v61459lvhqs26vmcqbl-git-2.50.1",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/yn9cvbs7jz4dfdb17qralgr0ybi5rmjf-git-2.50.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/8d1n8cvi5x1j0v61459lvhqs26vmcqbl-git-2.50.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5i8zvall945kypmwgqd0y47f02pldwp4-git-2.50.1",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/l46kpjpcwwp8l7kzzr1s2dlk646r73z2-git-2.50.1-debug"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/d2lhlzkdziwmijik8nszfwp8srbkskb9-git-2.50.1-doc"
+            }
+          ],
+          "store_path": "/nix/store/5i8zvall945kypmwgqd0y47f02pldwp4-git-2.50.1"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-02-18T13:59:30Z",
+      "resolved": "github:NixOS/nixpkgs/bcc4a9d9533c033d806a46b37dc444f9b0da49dd?lastModified=1771423170"
+    },
+    "nodejs@24.9.0": {
+      "last_modified": "2025-10-07T08:41:47Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/bce5fe2bb998488d8e7e7856315f90496723793c#nodejs_24",
+      "source": "devbox-search",
+      "version": "24.9.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xzvkcyv0l56lcvhfcca7dvfdcgqq329z-nodejs-24.9.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/g4nmkijwfdrbiwf99dcysl95xrrx5f68-nodejs-24.9.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/fcc0nq7bb395chh7z5v0kc2jhzwlxnpp-nodejs-24.9.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/xzvkcyv0l56lcvhfcca7dvfdcgqq329z-nodejs-24.9.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xfb1gljljy07fwd004z4xw8a5w57445b-nodejs-24.9.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/06l4vrrh3jim9dki4vnc0i3a853qbq4g-nodejs-24.9.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/dw4lnpvgi3k5al024dk7wa96nngch1i8-nodejs-24.9.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/xfb1gljljy07fwd004z4xw8a5w57445b-nodejs-24.9.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/513m5y7di1mgb00p0g6smyapsn9bai9c-nodejs-24.9.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/5bnycmgd7j6224ijjqm4a5w32pc5gc4d-nodejs-24.9.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/rifsaq9cwd6lz1qw4ik043p53ppwaypz-nodejs-24.9.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/513m5y7di1mgb00p0g6smyapsn9bai9c-nodejs-24.9.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mdlbr2g2kp104dmkl3cg0d7cbh8hwnng-nodejs-24.9.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/d287r2iqg3ma2af4x9s18xx8wz88pmcp-nodejs-24.9.0-dev"
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/40nhd4s4qm1q8y9d177nh0ga97nnwpv5-nodejs-24.9.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/mdlbr2g2kp104dmkl3cg0d7cbh8hwnng-nodejs-24.9.0"
+        }
+      }
+    },
+    "pkg-config@latest": {
+      "last_modified": "2025-11-23T21:50:36Z",
+      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#pkg-config",
+      "source": "devbox-search",
+      "version": "0.29.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hygaaqwk9ylklp0ybwppqhw75nz8ya41-pkg-config-wrapper-0.29.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/9px0sji43x3r2w4zxl3j3idwsql7lwxx-pkg-config-wrapper-0.29.2-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/hqk44ra6qxw7iixardl6c3hdgb9kq6ns-pkg-config-wrapper-0.29.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/hygaaqwk9ylklp0ybwppqhw75nz8ya41-pkg-config-wrapper-0.29.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lbiigi8qbp7mzf1lpr7p982l1kyf01ql-pkg-config-wrapper-0.29.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/10060k24qggqyzlwdsfmni9y32zxcg0j-pkg-config-wrapper-0.29.2-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/0y4v51ndpyvkj09hwlfqkz0c3h17zfmc-pkg-config-wrapper-0.29.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/lbiigi8qbp7mzf1lpr7p982l1kyf01ql-pkg-config-wrapper-0.29.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vknadizq0q5kffvx6y4379p9gdry9zq3-pkg-config-wrapper-0.29.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/1nyspra675q22gfhf7hn2nmfpi6rgim5-pkg-config-wrapper-0.29.2-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/7lq1axxwrafwljs06n88bzyz9w523rkc-pkg-config-wrapper-0.29.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/vknadizq0q5kffvx6y4379p9gdry9zq3-pkg-config-wrapper-0.29.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8vdiwpbh0g4avsd6x5v4s0di32vcl3dp-pkg-config-wrapper-0.29.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/j9xfpnrygg3v37svc5pfin9q5bm49r94-pkg-config-wrapper-0.29.2-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/x3bypxdxaq20kykybhkf21x4jczsiy8y-pkg-config-wrapper-0.29.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/8vdiwpbh0g4avsd6x5v4s0di32vcl3dp-pkg-config-wrapper-0.29.2"
+        }
+      }
+    },
+    "python@3.13.3": {
+      "last_modified": "2025-05-16T20:19:48Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#python313",
+      "source": "devbox-search",
+      "version": "3.13.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1a8xg8l3m67hxinxzzcsak9736qm9vsf-python3-3.13.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1a8xg8l3m67hxinxzzcsak9736qm9vsf-python3-3.13.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yy0xvc2rydhrs0h1v8d7r3sql347xzz5-python3-3.13.3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/42bxfqfrh8cwspl7szr0cw8739xv8qlq-python3-3.13.3-debug"
+            }
+          ],
+          "store_path": "/nix/store/yy0xvc2rydhrs0h1v8d7r3sql347xzz5-python3-3.13.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gbrigjhghz9v2p0zf9b2fnvs0g0yx7q4-python3-3.13.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/gbrigjhghz9v2p0zf9b2fnvs0g0yx7q4-python3-3.13.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2mab9iiwhcqwk75qwvp3zv0bvbiaq6cs-python3-3.13.3",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/9z6k8ijl2md0y2n95yprbjj4vxbfsi15-python3-3.13.3-debug"
+            }
+          ],
+          "store_path": "/nix/store/2mab9iiwhcqwk75qwvp3zv0bvbiaq6cs-python3-3.13.3"
+        }
+      }
+    },
+    "vips.dev": {
+      "resolved": "github:NixOS/nixpkgs/bcc4a9d9533c033d806a46b37dc444f9b0da49dd#vips.dev",
+      "source": "nixpkg"
+    },
+    "yarn@1.22.19": {
+      "last_modified": "2024-03-08T13:51:52Z",
+      "resolved": "github:NixOS/nixpkgs/a343533bccc62400e8a9560423486a3b6c11a23b#yarn",
+      "source": "devbox-search",
+      "version": "1.22.19",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7r6llb2c10y2vhg7jccynzif8g9zdvbi-yarn-1.22.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7r6llb2c10y2vhg7jccynzif8g9zdvbi-yarn-1.22.19"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6xvv5b8wpxqfl56mssavl7yg29p962ss-yarn-1.22.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6xvv5b8wpxqfl56mssavl7yg29p962ss-yarn-1.22.19"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/467zg6l9icqbjgpqar4i2xzyzzz87a63-yarn-1.22.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/467zg6l9icqbjgpqar4i2xzyzzz87a63-yarn-1.22.19"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/iscnp03q7lm8fsyq0ahajl6dlb8msdb9-yarn-1.22.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/iscnp03q7lm8fsyq0ahajl6dlb8msdb9-yarn-1.22.19"
+        }
+      }
+    }
+  }
+}

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -618,7 +618,7 @@ class Application extends BaseApplication {
 				if (shim.isWindows() || shim.isMac()) {
 					const runAutoUpdateCheck = () => {
 						if (Setting.value('autoUpdateEnabled')) {
-							void checkForUpdates(true, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+							void checkForUpdates(true, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') }, this.store().dispatch);
 						}
 					};
 

--- a/packages/app-desktop/checkForUpdates.ts
+++ b/packages/app-desktop/checkForUpdates.ts
@@ -65,7 +65,7 @@ async function addSkippedVersion(s: string) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-export default async function checkForUpdates(inBackground: boolean, parentWindow: any, options: CheckForUpdateOptions) {
+export default async function checkForUpdates(inBackground: boolean, parentWindow: any, options: CheckForUpdateOptions, dispatch?: (action: any)=> void) {
 	if (isCheckingForUpdate_) {
 		logger.info('Skipping check because it is already running');
 		return;
@@ -94,6 +94,16 @@ export default async function checkForUpdates(inBackground: boolean, parentWindo
 
 			if (shouldSkip) {
 				logger.info('Not displaying notification because version has been skipped');
+			} else if (dispatch) {
+				dispatch({
+					type: 'DIALOG_OPEN',
+					name: 'whatsNew',
+					props: {
+						release: release,
+						isAutoUpdate: false,
+						onSkip: () => { void addSkippedVersion(release.version); },
+					},
+				});
 			} else {
 				const fullReleaseNotes = release.notes.trim() ? `\n\n${release.notes.trim()}` : '';
 				const MAX_RELEASE_NOTES_LENGTH = 1000;

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -543,7 +543,8 @@ function useMenu(props: Props) {
 				if (Setting.value('featureFlag.autoUpdaterServiceEnabled')) {
 					ipcRenderer.send('check-for-updates');
 				} else {
-					void checkForUpdates(false, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') });
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+					void checkForUpdates(false, bridge().mainWindow(), { includePreReleases: Setting.value('autoUpdate.includePreReleases') }, (action: any) => props.dispatch(action));
 				}
 
 			}

--- a/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
+++ b/packages/app-desktop/gui/UpdateNotification/UpdateNotification.tsx
@@ -8,8 +8,11 @@ import shim from '@joplin/lib/shim';
 import { PopupNotificationContext } from '../PopupNotification/PopupNotificationProvider';
 import Button, { ButtonLevel } from '../Button/Button';
 import { NotificationType } from '../PopupNotification/types';
+import { Release } from '../../utils/checkForUpdatesUtils';
 
 interface Props {
+	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
+	dispatch?: Function;
 }
 
 export enum UpdateNotificationEvents {
@@ -28,7 +31,24 @@ const handleApplyUpdate = () => {
 	ipcRenderer.send('apply-update-now');
 };
 
-const UpdateNotification: React.FC<Props> = () => {
+const releaseFromUpdateInfo = (info: UpdateInfo): Release => {
+	let notes = '';
+	if (typeof info.releaseNotes === 'string') {
+		notes = info.releaseNotes;
+	} else if (Array.isArray(info.releaseNotes)) {
+		notes = info.releaseNotes.map(n => n.note).join('\n\n');
+	}
+
+	return {
+		version: info.version,
+		prerelease: false,
+		downloadUrl: '',
+		notes: notes,
+		pageUrl: `https://github.com/laurent22/joplin/releases/tag/v${info.version}`,
+	};
+};
+
+const UpdateNotification: React.FC<Props> = (props) => {
 	const popupManager = useContext(PopupNotificationContext);
 
 	const handleUpdateDownloaded = useCallback((_event: IpcRendererEvent, info: UpdateInfo) => {
@@ -39,6 +59,24 @@ const UpdateNotification: React.FC<Props> = () => {
 					_('See changelog')
 				}</button>
 				<div className='buttons'>
+					{props.dispatch && (
+						<Button
+							level={ButtonLevel.Tertiary}
+							onClick={() => {
+								notification.remove();
+								props.dispatch({
+									type: 'DIALOG_OPEN',
+									name: 'whatsNew',
+									props: {
+										release: releaseFromUpdateInfo(info),
+										isAutoUpdate: true,
+										onDownload: handleApplyUpdate,
+									},
+								});
+							}}
+							title={_('View details')}
+						/>
+					)}
 					<Button
 						level={ButtonLevel.Tertiary}
 						onClick={() => {
@@ -55,7 +93,7 @@ const UpdateNotification: React.FC<Props> = () => {
 				</div>
 			</div>
 		));
-	}, [popupManager]);
+	}, [popupManager, props.dispatch]);
 
 	const handleUpdateNotAvailable = useCallback(() => {
 		const notification = popupManager.createPopup(() => (

--- a/packages/app-desktop/gui/WhatsNewDialog/ReleaseNotesSection.tsx
+++ b/packages/app-desktop/gui/WhatsNewDialog/ReleaseNotesSection.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+interface Props {
+	notes: string;
+}
+
+const NotesContainer = styled.div`
+	max-height: 300px;
+	overflow-y: auto;
+	padding: 1em;
+	background-color: ${props => props.theme.backgroundColor3};
+	border: 1px solid ${props => props.theme.dividerColor};
+	border-radius: 4px;
+	margin-bottom: 1em;
+	font-family: ${props => props.theme.fontFamily};
+	font-size: ${props => props.theme.fontSize}px;
+	color: ${props => props.theme.color};
+	line-height: ${props => props.theme.lineHeight};
+	white-space: pre-wrap;
+	word-wrap: break-word;
+`;
+
+const EmptyNotes = styled.div`
+	padding: 1em;
+	color: ${props => props.theme.colorFaded};
+	font-style: italic;
+`;
+
+const ReleaseNotesSection = (props: Props) => {
+	if (!props.notes || !props.notes.trim()) {
+		return <EmptyNotes>No release notes available.</EmptyNotes>;
+	}
+
+	return (
+		<NotesContainer>
+			{props.notes}
+		</NotesContainer>
+	);
+};
+
+export default ReleaseNotesSection;

--- a/packages/app-desktop/gui/WhatsNewDialog/WhatsNewDialog.tsx
+++ b/packages/app-desktop/gui/WhatsNewDialog/WhatsNewDialog.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import { _ } from '@joplin/lib/locale';
+import DialogButtonRow, { ClickEvent } from '../DialogButtonRow';
+import Dialog from '@joplin/lib/components/Dialog';
+import styled from 'styled-components';
+import DialogTitle from '../DialogTitle';
+import shim from '@joplin/lib/shim';
+import { Release } from '../../utils/checkForUpdatesUtils';
+import ReleaseNotesSection from './ReleaseNotesSection';
+
+interface Props {
+	themeId: number;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Used to match Redux dispatch
+	dispatch: (action: any)=> void;
+	release: Release;
+	isAutoUpdate: boolean;
+	onSkip?: ()=> void;
+	onDownload?: ()=> void;
+}
+
+const StyledRoot = styled.div`
+	min-width: 500px;
+	max-width: 700px;
+`;
+
+const MediaLink = styled.a`
+	display: block;
+	margin-bottom: 1em;
+	color: ${props => props.theme.urlColor};
+	cursor: pointer;
+	font-size: ${props => props.theme.fontSize}px;
+	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
+const ExternalLink = styled.a`
+	display: block;
+	margin-bottom: 1em;
+	color: ${props => props.theme.urlColor};
+	cursor: pointer;
+	font-size: ${props => props.theme.fontSize}px;
+	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+`;
+
+const VersionInfo = styled.div`
+	margin-bottom: 1em;
+	font-size: ${props => props.theme.fontSize}px;
+	color: ${props => props.theme.color};
+	line-height: ${props => props.theme.lineHeight};
+`;
+
+const WhatsNewDialog = (props: Props) => {
+	const closeDialog = useCallback(() => {
+		props.dispatch({
+			type: 'DIALOG_CLOSE',
+			name: 'whatsNew',
+		});
+	}, [props.dispatch]);
+
+	const handleDownload = useCallback(() => {
+		if (props.onDownload) {
+			props.onDownload();
+		} else {
+			shim.openUrl(props.release.downloadUrl || props.release.pageUrl);
+		}
+		closeDialog();
+	}, [props.release, props.onDownload, closeDialog]);
+
+	const handleViewMedia = useCallback(() => {
+		if (props.release.mediaUrl) {
+			shim.openUrl(props.release.mediaUrl);
+		}
+	}, [props.release.mediaUrl]);
+
+	const handleViewFullNotes = useCallback(() => {
+		shim.openUrl(props.release.pageUrl);
+	}, [props.release.pageUrl]);
+
+	const handleButtonClick = useCallback((event: ClickEvent) => {
+		if (event.buttonName === 'ok') {
+			handleDownload();
+		} else if (event.buttonName === 'cancel') {
+			closeDialog();
+		} else if (event.buttonName === 'skip') {
+			if (props.onSkip) props.onSkip();
+			closeDialog();
+		}
+	}, [handleDownload, closeDialog, props.onSkip]);
+
+	const newVersionString = props.release.prerelease
+		? _('%s (pre-release)', props.release.version)
+		: props.release.version;
+
+	return (
+		<Dialog onCancel={closeDialog}>
+			<StyledRoot>
+				<DialogTitle title={_('What\'s New in Joplin %s', newVersionString)} />
+
+				<VersionInfo>
+					{_('A new version of Joplin is available.')}
+				</VersionInfo>
+
+				{props.release.mediaUrl && (
+					<MediaLink href="#" onClick={(e) => { e.preventDefault(); handleViewMedia(); }}>
+						{_('View announcement video/images')}
+					</MediaLink>
+				)}
+
+				<ReleaseNotesSection notes={props.release.notes} />
+
+				<ExternalLink href="#" onClick={(e) => { e.preventDefault(); handleViewFullNotes(); }}>
+					{_('View full release notes')}
+				</ExternalLink>
+
+				<DialogButtonRow
+					themeId={props.themeId}
+					onClick={handleButtonClick}
+					okButtonLabel={props.isAutoUpdate ? _('Restart Now') : _('Download')}
+					cancelButtonLabel={_('Later')}
+					customButtons={[{ name: 'skip', label: _('Skip This Version') }]}
+				/>
+			</StyledRoot>
+		</Dialog>
+	);
+};
+
+export default WhatsNewDialog;

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.tsx
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.tsx
@@ -4,6 +4,7 @@ import SyncWizardDialog from '../../SyncWizard/Dialog';
 import MasterPasswordDialog from '../../MasterPasswordDialog/Dialog';
 import EditFolderDialog from '../../EditFolderDialog/Dialog';
 import PdfViewer from '../../PdfViewer';
+import WhatsNewDialog from '../../WhatsNewDialog/WhatsNewDialog';
 
 interface RegisteredDialogProps {
 	themeId: number;
@@ -42,6 +43,12 @@ const appDialogs: Record<string, RegisteredDialog> = {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		render: (props: RegisteredDialogProps, customProps: any) => {
 			return <PdfViewer key={props.key} dispatch={props.dispatch} themeId={props.themeId} {...customProps}/>;
+		},
+	},
+	whatsNew: {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		render: (props: RegisteredDialogProps, customProps: any) => {
+			return <WhatsNewDialog key={props.key} dispatch={props.dispatch} themeId={props.themeId} {...customProps}/>;
 		},
 	},
 };

--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -1,4 +1,4 @@
-import { extractVersionInfo, Release, Platform, Architecture, GitHubRelease } from './checkForUpdatesUtils';
+import { extractVersionInfo, extractMediaUrl, Release, Platform, Architecture, GitHubRelease } from './checkForUpdatesUtils';
 import { releases1, releases2 } from './checkForUpdatesUtilsTestData';
 
 describe('checkForUpdates', () => {
@@ -146,6 +146,65 @@ describe('checkForUpdates', () => {
 			pageUrl: releaseData.html_url,
 			prerelease: releaseData.prerelease,
 		});
+	});
+
+	it('should extract Twitter media URL from release body', () => {
+		const body = 'Release notes here\n\nSee: https://twitter.com/joplinapp/status/123456';
+		expect(extractMediaUrl(body)).toBe('https://twitter.com/joplinapp/status/123456');
+	});
+
+	it('should extract X.com media URL from release body', () => {
+		const body = 'Check out https://x.com/joplinapp/status/789012 for details';
+		expect(extractMediaUrl(body)).toBe('https://x.com/joplinapp/status/789012');
+	});
+
+	it('should extract YouTube media URL from release body', () => {
+		const body = 'Watch the video: https://www.youtube.com/watch?v=abc-123';
+		expect(extractMediaUrl(body)).toBe('https://www.youtube.com/watch?v=abc-123');
+	});
+
+	it('should extract short YouTube media URL from release body', () => {
+		const body = 'Video: https://youtu.be/abc-123';
+		expect(extractMediaUrl(body)).toBe('https://youtu.be/abc-123');
+	});
+
+	it('should return undefined when no media URL is in release body', () => {
+		const body = 'Release notes without media links\n- Fixed bug\n- Added feature';
+		expect(extractMediaUrl(body)).toBeUndefined();
+	});
+
+	it('should include mediaUrl in extractVersionInfo when present', () => {
+		const releaseData: GitHubRelease = {
+			tag_name: 'v3.0.0',
+			prerelease: false,
+			body: 'Release notes\n\nhttps://twitter.com/joplinapp/status/999',
+			assets: [
+				{
+					name: 'Joplin-3.0.0.dmg',
+					browser_download_url: 'https://github.com/laurent22/joplin/releases/download/v3.0.0/Joplin-3.0.0.dmg',
+				},
+			],
+			html_url: 'https://github.com/laurent22/joplin/releases/tag/v3.0.0',
+		};
+		const result = extractVersionInfo([releaseData], 'darwin', 'x64', false, {});
+		expect(result.mediaUrl).toBe('https://twitter.com/joplinapp/status/999');
+	});
+
+	it('should have undefined mediaUrl when none present in release body', () => {
+		const releaseData: GitHubRelease = {
+			tag_name: 'v3.0.0',
+			prerelease: false,
+			body: 'Simple release notes without media',
+			assets: [
+				{
+					name: 'Joplin-3.0.0.dmg',
+					browser_download_url: 'https://github.com/laurent22/joplin/releases/download/v3.0.0/Joplin-3.0.0.dmg',
+				},
+			],
+			html_url: 'https://github.com/laurent22/joplin/releases/tag/v3.0.0',
+		};
+		const result = extractVersionInfo([releaseData], 'darwin', 'x64', false, {});
+		expect(result.mediaUrl).toBeUndefined();
 	});
 
 });

--- a/packages/app-desktop/utils/checkForUpdatesUtils.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.ts
@@ -25,6 +25,7 @@ export interface Release {
 	downloadUrl: string;
 	notes: string;
 	pageUrl: string;
+	mediaUrl?: string;
 }
 
 export type Platform = typeof process.platform;
@@ -36,6 +37,19 @@ function getMajorMinorTagName(tagName: string) {
 	s.pop();
 	return s.join('.');
 }
+
+export const extractMediaUrl = (body: string): string | undefined => {
+	const patterns = [
+		/https:\/\/(twitter\.com|x\.com)\/\w+\/status\/\d+/,
+		/https:\/\/(www\.)?youtube\.com\/watch\?v=[\w-]+/,
+		/https:\/\/youtu\.be\/[\w-]+/,
+	];
+	for (const pattern of patterns) {
+		const match = body.match(pattern);
+		if (match) return match[0];
+	}
+	return undefined;
+};
 
 export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform, arch: Architecture, portable: boolean, options: CheckForUpdateOptions) => {
 	options = { includePreReleases: false, ...options };
@@ -135,6 +149,7 @@ export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform
 		notes: cleanUpReleaseNotes(fullReleaseNotes),
 		pageUrl: release.html_url,
 		prerelease: release.prerelease,
+		mediaUrl: extractMediaUrl(release.body),
 	};
 
 	return output;


### PR DESCRIPTION
Resolves #14251 

This feature introduces an improved version of the pop up window when there is an update. 

<img width="1512" height="982" alt="Screenshot 2026-02-23 at 13 17 45" src="https://github.com/user-attachments/assets/9787346f-3376-433f-b73c-798dbe116c04" />

## Changes

- **Rich Release Notes Display:** Replaced the native, often-truncated OS message box with a custom, React-based dialog that displays the full, cleanly formatted release notes in a scrollable view.
- **Media Link Extraction:** Updated the version extraction logic in [checkForUpdatesUtils.ts](cci:7://file:///Users/fadex/Downloads/coding-apps/joplin/packages/app-desktop/utils/checkForUpdatesUtils.ts:0:0-0:0) to automatically detect and extract media links (like YouTube or Twitter/X URLs) directly from the GitHub release body.
- **Quick Links:** Added intuitive footer links to the new dialog, allowing users to quickly open the full GitHub changelog or view any associated release announcement media in their browser.

## Manual Testing Plan

To thoroughly test these changes locally, please follow these steps:

### Test 1: Simulating the Popup display (Manual Check)
1. Run the app in development mode (`cd packages/app-desktop && yarn start`).
2. Temporarily open `packages/app-desktop/gui/MainScreen.tsx`.
3. Add the following import to the top of the file:
```typescript
import { extractVersionInfo } from '../utils/checkForUpdatesUtils';
```
4. Add the following `setTimeout` to `componentDidMount` to force the dialog to appear with real release data:
```typescript
		setTimeout(() => {
			void (async () => {
				try {
					const response = await shim.fetch('https://api.github.com/repos/laurent22/joplin/releases');
					if (!response.ok) {
						throw new Error(`Cannot get latest release info: ${await response.text()}`);
					}

					const releases = await response.json();
					const release = extractVersionInfo(releases, process.platform, process.arch, shim.isPortable(), { includePreReleases: true });

					(this.props.dispatch as any)({
						type: 'DIALOG_OPEN',
						name: 'whatsNew',
						props: {
							release,
							isAutoUpdate: false,
						},
					});
				} catch (error) {
					console.error('Failed to fetch test update releases:', error);
				}
			})();
		}, 2000);
```
5. Save the file. The dialog should appear 2 seconds after the app reloads.
4. **Verify:** The "What's New in Joplin 3.2.0" title appears, the notes are visible, and the "View announcement video/images" link is present.

### Test 2: Button Actions
1. While the dialog from Test 1 is open, click **Later**. Verify the dialog closes.
2. Trigger the dialog again. Click **Skip This Version**. Verify the dialog closes (and underneath, it records the skipped version).
3. Trigger the dialog again. Click **Download**. Verify it attempts to trigger the version's download, and the dialog closes.

### Test 3: Media & Changelog Links
*(Note: Because we are testing with live GitHub release data, the latest release might not contain any media links. If it doesn't, the announcement link will be correctly hidden.)*
1. If the **"View announcement video/images"** link is present, click it. Verify it opens the media URL (e.g., Twitter/YouTube) in your external browser.
2. Click the **"View full release notes"** link. Verify it opens the GitHub release page.
3. If you'd like to explicitly test the media link, you can temporarily add `release.mediaUrl = 'https://twitter.com/joplinapp/status/12345';` in your `MainScreen.tsx` test block right before the `dispatch` call. Reload and verify the link appears and works.

### Test 4: Theming
1. You can attempt to change your system settings.
2. Verify the dialog's text, background, and button colors adapt correctly to the active theme.



### AI Assistance Disclosure

- **Parts generated or significantly modified using AI**: The React-based updates to the "What's New" dialog, the `extractVersionInfo` utility refactoring, and the `MainScreen.tsx` test blocks, were drafted using AI assistance. 
- **How AI was used**: I utilized Claude and Gemini to assist with drafting the component code, refactoring the GitHub API parsing logic to support dynamic updates, and improving the wording and clarity of my tests.
- **Review and Understanding**: I can confirm that I have reviewed the generated output carefully, fully understand the generated code and text, and have tested it extensively to ensure the code is correct, runs as it should, and completely aligns with Joplin's existing architectural practices.