### PR TITLE
  All: Fixes #14300: Preserve # character in folder/note names during export

### DIFF
--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -4,7 +4,7 @@ import { _ } from './locale';
 import { fileExtension, filename, safeFileExtension } from '@joplin/utils/path';
 export * from '@joplin/utils/path';
 
-let friendlySafeFilename_blackListChars = '/\n\r<>:\'"\\|?*#';
+let friendlySafeFilename_blackListChars = '/\n\r<>:\'"\\|?*';
 for (let i = 0; i < 32; i++) {
 	friendlySafeFilename_blackListChars += String.fromCharCode(i);
 }

--- a/packages/lib/pathUtils.test.js
+++ b/packages/lib/pathUtils.test.js
@@ -12,6 +12,9 @@ describe('pathUtils', () => {
 			['nor dots...', 'nor dots'],
 			['  no space before either', 'no space before either'],
 			['no\nnewline\n\rplease', 'no_newline__please'],
+			['C#', 'C#'],
+			['F# programming', 'F# programming'],
+			['Note with # hash', 'Note with # hash'],
 			['thatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylong', 'thatsreallylongthatsreallylongthatsreallylongthats'],
 		];
 


### PR DESCRIPTION
Fixes #14300

This PR allows the use of the `#` (hash) character in filenames exported by Joplin. 

Previously, the `#` symbol was included in the `friendlySafeFilename_blackListChars` string, which meant any notes or documents containing `#` in their titles (e.g., "C# programming", "F# notes") would have the character stripped when exporting. 

## Why this is safe
This modification is completely safe to implement for the following reasons:
1. **File System Compatibility**: The `#` character is entirely valid and supported on Windows, macOS, and Linux filesystems. It does not conflict with OS paths.
2. **Server and URL Handling**: For URL-facing contexts (such as the Joplin Server), the codebase already utilizes `encodeURIComponent()` sequentially *after* `friendlySafeFilename()` is called. This guarantees that any `#` characters are properly encoded as `%23` in URIs, preventing any routing or fragment identifier conflicts.

## Changes
- **Filename Sanitization:** Removed the `#` character from the `friendlySafeFilename_blackListChars` string in [packages/lib/path-utils.ts](cci:7://file:///Users/fadex/Downloads/coding-apps/joplin/packages/lib/path-utils.ts:0:0-0:0).
- **Unit Tests:** Added new test cases in [packages/lib/pathUtils.test.js](cci:7://file:///Users/fadex/Downloads/coding-apps/joplin/packages/lib/pathUtils.test.js:0:0-0:0) validating that titles containing `#` (e.g., `C#`, `F# programming`, `Note with # hash`) retain the character when passed through the `friendlySafeFilename()` function.
## Manual Testing Plan
To thoroughly test these changes locally, please follow these steps:
### Test 1: Unit Tests
1. Run the test suite for the path utilities:
   ```bash
   yarn test pathUtils

**AI Assistance Disclosure**
- Unit Tests were generated using AI