### PR TITLE
fixes #14300

### DIFF
--- a/packages/lib/markdownUtils.ts
+++ b/packages/lib/markdownUtils.ts
@@ -43,6 +43,7 @@ const markdownUtils = {
 		url = url.replace(/\(/g, '%28');
 		url = url.replace(/\)/g, '%29');
 		url = url.replace(/ /g, '%20');
+		url = url.replace(/#/g, '%23');
 		return url;
 	},
 
@@ -68,6 +69,7 @@ const markdownUtils = {
 		url = url.replace(/%28/g, '(');
 		url = url.replace(/%29/g, ')');
 		url = url.replace(/%20/g, ' ');
+		url = url.replace(/%23/g, '#');
 		return url;
 	},
 

--- a/packages/lib/markdownUtils2.test.ts
+++ b/packages/lib/markdownUtils2.test.ts
@@ -82,6 +82,7 @@ describe('markdownUtils', () => {
 			['file:///Users/who put spaces in their username??/.config/joplin', 'file:///Users/who%20put%20spaces%20in%20their%20username??/.config/joplin'],
 			['file:///Users/(and brackets???)/.config/joplin', 'file:///Users/%28and%20brackets???%29/.config/joplin'],
 			['file:///Users/thisisfine/.config/joplin', 'file:///Users/thisisfine/.config/joplin'],
+			['../C#/note.md', '../C%23/note.md'],
 		];
 
 		for (let i = 0; i < testCases.length; i++) {

--- a/packages/lib/path-utils.ts
+++ b/packages/lib/path-utils.ts
@@ -4,7 +4,7 @@ import { _ } from './locale';
 import { fileExtension, filename, safeFileExtension } from '@joplin/utils/path';
 export * from '@joplin/utils/path';
 
-let friendlySafeFilename_blackListChars = '/\n\r<>:\'"\\|?*#';
+let friendlySafeFilename_blackListChars = '/\n\r<>:\'"\\|?*';
 for (let i = 0; i < 32; i++) {
 	friendlySafeFilename_blackListChars += String.fromCharCode(i);
 }

--- a/packages/lib/pathUtils.test.js
+++ b/packages/lib/pathUtils.test.js
@@ -13,6 +13,7 @@ describe('pathUtils', () => {
 			['  no space before either', 'no space before either'],
 			['no\nnewline\n\rplease', 'no_newline__please'],
 			['thatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylongthatsreallylong', 'thatsreallylongthatsreallylongthatsreallylongthats'],
+			['C#', 'C#'],
 		];
 
 		for (let i = 0; i < testCases.length; i++) {


### PR DESCRIPTION
Fixes #14300  

## Summary
  - Removed `#` from the blacklisted characters in `friendlySafeFilename` so that filenames containing `#` (e.g. "C#") are preserved during notebook export
  - Added a test case to verify `#` is no longer stripped from filenames

  ## Test plan
  - [X] Export a notebook containing a note with `#` in the title (e.g. "C# Notes")
  - [X] Verify the exported filename preserves the `#` character
  - [X] Run `yarn jest packages/lib/pathUtils.test.js` and confirm tests pass