### PR TITLE
fixes #14299 Add missing major, minor, and latest multi-arch manifest tags for Docker image

### DIFF
--- a/.github/scripts/publish_docker_manifest.sh
+++ b/.github/scripts/publish_docker_manifest.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 VERSION=$(echo "$GIT_TAG_NAME" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f1-2)
 
 echo "GIT_TAG_NAME=$GIT_TAG_NAME"
 echo "VERSION=$VERSION"
+echo "MAJOR=$MAJOR"
+echo "MINOR=$MINOR"
 echo "SERVER_TAG_PREFIX=$SERVER_TAG_PREFIX"
 echo "SERVER_REPOSITORY=$SERVER_REPOSITORY"
 
@@ -24,11 +28,16 @@ if [ $? -ne 0 ]; then
 	exit 0
 fi
 
-docker manifest create $SERVER_REPOSITORY:$VERSION \
-	$SERVER_REPOSITORY:arm64-$VERSION \
-	$SERVER_REPOSITORY:amd64-$VERSION
+# Create and push multi-arch manifests for all tag variants
+for TAG in "$VERSION" "$MINOR" "$MAJOR" "latest"; do
+	echo "Creating manifest for tag: $TAG"
 
-docker manifest annotate $SERVER_REPOSITORY:$VERSION $SERVER_REPOSITORY:arm64-$VERSION --arch arm64
-docker manifest annotate $SERVER_REPOSITORY:$VERSION $SERVER_REPOSITORY:amd64-$VERSION --arch amd64
+	docker manifest create $SERVER_REPOSITORY:$TAG \
+		$SERVER_REPOSITORY:arm64-$TAG \
+		$SERVER_REPOSITORY:amd64-$TAG
 
-docker manifest push $SERVER_REPOSITORY:$VERSION
+	docker manifest annotate $SERVER_REPOSITORY:$TAG $SERVER_REPOSITORY:arm64-$TAG --arch arm64
+	docker manifest annotate $SERVER_REPOSITORY:$TAG $SERVER_REPOSITORY:amd64-$TAG --arch amd64
+
+	docker manifest push $SERVER_REPOSITORY:$TAG
+done


### PR DESCRIPTION
fixes #14299 


 Summary

  - The build script (buildServerDocker.ts) already pushes architecture-prefixed images for all tag variants (amd64-3, arm64-3, amd64-3.5, arm64-3.5, amd64-latest,
  arm64-latest)
  - However, publish_docker_manifest.sh only created a multi-arch manifest for the full version tag (e.g., 3.5.2)
  - This meant tags like 3, 3.5, and latest had no multi-arch manifest, so docker pull joplin/server:3 wouldn't work
  - Fixed by looping over all tag variants (VERSION, MINOR, MAJOR, latest) when creating and pushing manifests