### PR TITLE
All: Fixes #12545: Handle missing script assets in HTML export

### DIFF
--- a/packages/htmlpack/index.test.ts
+++ b/packages/htmlpack/index.test.ts
@@ -48,7 +48,7 @@ describe('htmlpack/index', () => {
 </html>`;
 
 		await writeFile(inputFile, inputHtml, 'utf8');
-		await expect(htmlpack(inputFile, outputFile)).resolves.not.toThrow();
+		await htmlpack(inputFile, outputFile);
 
 		const outputContent = await readFile(outputFile, 'utf8');
 		expect(outputContent).toContain('<p>Test</p>');

--- a/packages/htmlpack/index.test.ts
+++ b/packages/htmlpack/index.test.ts
@@ -1,4 +1,4 @@
-import { exists, mkdir, readFile, remove } from 'fs-extra';
+import { exists, mkdir, readFile, remove, writeFile } from 'fs-extra';
 import { join } from 'path';
 import htmlpack from '.';
 
@@ -34,6 +34,9 @@ describe('htmlpack/index', () => {
 	});
 
 	test('should not throw when a script asset is missing', async () => {
+		const inputFile = join(outputDirectory, 'input.html');
+		const outputFile = join(outputDirectory, 'output.html');
+
 		const inputHtml = `
 <html>
     <head>
@@ -44,15 +47,10 @@ describe('htmlpack/index', () => {
     </body>
 </html>`;
 
-		const packToString = (await import('./packToString')).default;
-		const result = await packToString(outputDirectory, inputHtml, {
-			exists: (path: string) => exists(path),
-			readFileText: (path: string) => readFile(path, 'utf8'),
-			readFileDataUri: async (_path: string) => '',
-		});
+		await writeFile(inputFile, inputHtml, 'utf8');
+		await expect(htmlpack(inputFile, outputFile)).resolves.not.toThrow();
 
-		// The missing script tag should be kept as-is (not inlined)
-		expect(result).toContain('<script type="application/javascript" src="missing-script.js">');
-		expect(result).toContain('<p>Test</p>');
+		const outputContent = await readFile(outputFile, 'utf8');
+		expect(outputContent).toContain('<p>Test</p>');
 	});
 });

--- a/packages/htmlpack/index.test.ts
+++ b/packages/htmlpack/index.test.ts
@@ -32,4 +32,27 @@ describe('htmlpack/index', () => {
     </body>
 </html>`);
 	});
+
+	test('should not throw when a script asset is missing', async () => {
+		const inputHtml = `
+<html>
+    <head>
+        <script type="application/javascript" src="missing-script.js"></script>
+    </head>
+    <body>
+        <p>Test</p>
+    </body>
+</html>`;
+
+		const packToString = (await import('./packToString')).default;
+		const result = await packToString(outputDirectory, inputHtml, {
+			exists: (path: string) => exists(path),
+			readFileText: (path: string) => readFile(path, 'utf8'),
+			readFileDataUri: async (_path: string) => '',
+		});
+
+		// The missing script tag should be kept as-is (not inlined)
+		expect(result).toContain('<script type="application/javascript" src="missing-script.js">');
+		expect(result).toContain('<p>Test</p>');
+	});
 });

--- a/packages/htmlpack/packToString.ts
+++ b/packages/htmlpack/packToString.ts
@@ -132,6 +132,7 @@ const packToString = async (baseDir: string, inputFileText: string, fs: FileApi)
 		if (!src) return null;
 
 		const scriptFilePath = `${baseDir}/${src}`;
+		if (!await fs.exists(scriptFilePath)) return null;
 		let content = await fs.readFileText(scriptFilePath);
 
 		// There's no simple way to insert arbitrary content in <script> tags.


### PR DESCRIPTION
Fixes #12545 
## Problem

Exporting a note to PDF (or HTML) fails with an ENOENT ("no such file or directory") error when a JavaScript plugin asset is missing at export time. This can happen after a plugin update, file corruption, or if the asset source path becomes invalid during the session.


## Reproduction steps

1. Start Joplin desktop
2. Enable Mermaid diagram support in Settings → Markdown
3. While the app is running, delete a JS plugin asset (e.g. `pluginAssets/mermaid/mermaid_render.js`)
4. Create a note with mermaid content and export as HTML or PDF
5. Before fix: ENOENT error. After fix: export succeeds gracefully.
## Cause

In `packages/htmlpack/packToString.ts`, the `processScriptTag` function reads script files without first checking if they exist on disk. When a referenced `<script src="...">` file is missing, `readFileText` throws an ENOENT error, crashing the export.

The other tag handlers (`processLinkTag` for CSS and `processImgTag` for images) already guard against this with an `fs.exists()` check before reading.



## Fix

Added the same `fs.exists()` guard to `processScriptTag`, consistent with how `processLinkTag` and `processImgTag` handle missing files:

```diff
 const scriptFilePath = `${baseDir}/${src}`;
+if (!await fs.exists(scriptFilePath)) return null;
 let content = await fs.readFileText(scriptFilePath);
```

When a script file is missing, the original `<script>` tag is kept as-is instead of crashing.

## Testing

- Added a regression test (`should not throw when a script asset is missing`) that verifies `packToString` handles a missing `<script src>` gracefully.
