### PR TITLE
Mobile: Fixes #14387: Reset undo/redo button state when toggling an editor plugin

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -708,12 +708,17 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			});
 		}
 
-		if (this.props.visibleEditorPluginIds !== prevProps.visibleEditorPluginIds || this.props.editorNoteReloadTimeRequest !== prevProps.editorNoteReloadTimeRequest) {
+		const editorPluginIdsChanged = this.props.visibleEditorPluginIds !== prevProps.visibleEditorPluginIds;
+		if (editorPluginIdsChanged || this.props.editorNoteReloadTimeRequest !== prevProps.editorNoteReloadTimeRequest) {
 			const { editorPlugin } = getShownPluginEditorView(this.props.plugins, this.props.windowId);
-			if (!editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime) {
+			const explicitReloadRequired = !editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime;
+
+			if (explicitReloadRequired) {
 				void shared.reloadNote(this);
 				this.refreshKey = this.props.editorNoteReloadTimeRequest;
+			}
 
+			if (explicitReloadRequired || (editorPlugin && editorPluginIdsChanged)) {
 				// Clear the undo / redo state, as undo / redo steps wont be in sync with the current content after the note editor has been refreshed
 				if (!this.useEditorBeta()) {
 					void this.undoRedoService_.reset();


### PR DESCRIPTION
Currently after toggling an editor plugin, pressing the undo button when available, causes the app to crash. This PR addresses the issue by ensuring the undo / redo buttons states are reset, and therefore are hidden, when toggling editor plugins with the eye button. This is addressed by expanding the scope of the existing logic which resets the undo/redo button state when an EDITOR_NOTE_NEEDS_RELOAD event is broadcast, which involves similar conditions to be applied.

This change is mostly refactoring of the conditions to remove repetition, but the actual change to the logic is splitting the undo / redo state resetting into a separate condition and adding this this condition:
` || (editorPlugin && editorPluginIdsChanged)`
Note that the editorPlugin (=== true) condition is required to ensure that when a plugin opens a modal over the note editor, it will not reset the undo / redo state, which would be the case for the encrypt / decrypt note dialog of the secure notes plugin, without this condition

This fixes https://github.com/laurent22/joplin/issues/14387

### Testing

I tested this by following the reproduction steps detailed on the issue, and also verified the undo / redo state is reset when toggling between view and edit mode on the note and when navigating through and backwards from note links, all these scenarios work as per existing behaviour.

**See video:**

https://github.com/user-attachments/assets/e2c8b0d4-7cfa-4d0a-bcd5-8f463400f0be

