### PR TITLE
Desktop: E2EE setup dialog inconsistent with dark theme and shows “key required” after Cancel

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -202,6 +202,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		} else {
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
 			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
+			if (newPassword === null) return;
 		}
 
 		if (hasMasterPassword && newEnabled) {

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -323,9 +323,34 @@ a:not([draggable=true]), img:not([draggable=true]) {
 }
 .smalltalk input {
 	margin-top: 1em;
+	background-color: var(--joplin-background-color);
+	color: var(--joplin-color);
+	border: 1px solid var(--joplin-divider-color);
 }
 .smalltalk .page {
 	max-width: 30em;
+	background-color: var(--joplin-background-color);
+	color: var(--joplin-color);
+}
+.smalltalk .page header {
+	color: var(--joplin-color);
+}
+.smalltalk button {
+	background-image: none;
+	box-shadow: none;
+	text-shadow: none;
+	background-color: var(--joplin-background-color);
+	color: var(--joplin-color) ;
+	border: 1px solid var(--joplin-divider-color) ;
+}
+.smalltalk button:enabled:hover, .smalltalk button:enabled:active {
+	background-color: var(--joplin-background-color-hover3);
+	background-image: none;
+	box-shadow: none;
+	text-shadow: none;
+}
+.smalltalk button:enabled:focus, .smalltalk input:enabled:focus {
+	border-color: var(--joplin-focus-outline-color);
 }
 mark {
 	background: #CF3F00;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->
# Summary
- Fixed issue #14428 
- Now the E2EE setup dialogue shows consistent dark color scheme when it is turned on