### PR TITLE
fixes #13852 avoids searching by username

### DIFF
--- a/packages/tools/tool-utils.ts
+++ b/packages/tools/tool-utils.ts
@@ -323,14 +323,10 @@ export async function githubUsername(email: string, name: string) {
 
 	const oauthToken = await githubOauthToken();
 
+	// Do not fall back to name-based search as it can match the wrong user
+	// https://github.com/laurent22/joplin/issues/13852
 	const urlsToTry = [
 		`https://api.github.com/search/users?q=${encodeURI(email)}+in:email`,
-
-		// Note that this can fail if the email could not be found and the user
-		// shares a name with someone else. It's rare enough that we can leave
-		// it for now.
-		// https://github.com/laurent22/joplin/pull/5390
-		`https://api.github.com/search/users?q=user:${encodeURI(name)}`,
 	];
 
 	for (const url of urlsToTry) {

--- a/readme/about/changelog/server.md
+++ b/readme/about/changelog/server.md
@@ -10,7 +10,7 @@
 ## [server-v3.5.1](https://github.com/laurent22/joplin/releases/tag/server-v3.5.1) - 2025-12-03T11:56:31Z
 
 - New: Add support for DELETE_EXPIRED_SESSIONS_SCHEDULE to prevent auto-logout when using SAML login (ae289be)
-- Improved: Add LOG_LEVEL env var to control logging verbosity (#13503) (#13147 by [@bartolomeo](https://github.com/bartolomeo))
+- Improved: Add LOG_LEVEL env var to control logging verbosity (#13503) (#13147 by Bartolomeo)
 - Improved: Database: Adjust connection pool configuration, make connection pool size configurable (#13681 by [@personalizedrefrigerator](https://github.com/personalizedrefrigerator))
 - Improved: Enable publish and share notebook for SAML login (defe36b)
 - Improved: Improve SAML login error handling and add doc regarding email and displayName attributes (98effef)


### PR DESCRIPTION
fixes #13852 

 Removed the name-based GitHub username search fallback in the changelog generator, which could link to the wrong GitHub profile when the email seaching fails. Also fixed the existing incorrect link in the server changelog.