### PR TITLE
Desktop, Mobile, Cli: Resolves #14336: Store note history settings in sync info

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -531,6 +531,13 @@ export default class Synchronizer {
 
 					// console.info('NEW', newInfo);
 
+					if (newInfo.revisionServiceEnabled !== localInfo.revisionServiceEnabled) {
+						Setting.setValue('revisionService.enabled', newInfo.revisionServiceEnabled);
+					}
+					if (newInfo.revisionServiceTtlDays !== localInfo.revisionServiceTtlDays) {
+						Setting.setValue('revisionService.ttlDays', newInfo.revisionServiceTtlDays);
+					}
+
 					if (newInfo.e2ee !== previousE2EE) {
 						if (newInfo.e2ee) {
 							const mk = getActiveMasterKey(newInfo);

--- a/packages/lib/components/shared/reduxSharedMiddleware.ts
+++ b/packages/lib/components/shared/reduxSharedMiddleware.ts
@@ -10,6 +10,7 @@ import BaseItem from '../../models/BaseItem';
 import shim from '../../shim';
 import { Dispatch } from 'redux';
 import { State } from '../../reducer';
+import { onRevisionServiceSettingsChanged } from '../../services/synchronizer/syncInfoUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 let sortNoteListTimeout: any = null;
@@ -29,6 +30,10 @@ export default async (store: any, _next: any, action: any, dispatch: Dispatch) =
 
 	if (action.type === 'SETTING_UPDATE_ONE' && !!action.key.match(/^sync\.\d+\.path$/)) {
 		reg.resetSyncTarget();
+	}
+
+	if (action.type === 'SETTING_UPDATE_ONE') {
+		onRevisionServiceSettingsChanged(action.key, action.value);
 	}
 
 	let mustAutoAddResources = false;

--- a/packages/lib/services/SettingUtils.ts
+++ b/packages/lib/services/SettingUtils.ts
@@ -3,7 +3,7 @@
 import KeychainService from './keychain/KeychainService';
 import Setting from '../models/Setting';
 import uuid from '../uuid';
-import { migrateLocalSyncInfo, setupRevisionServiceSettingsSync } from './synchronizer/syncInfoUtils';
+import { migrateLocalSyncInfo } from './synchronizer/syncInfoUtils';
 import KeychainServiceDriverBase from './keychain/KeychainServiceDriverBase';
 import shim from '../shim';
 
@@ -46,7 +46,6 @@ export async function loadKeychainServiceAndSettings(keychainServiceDrivers: Key
 	// contains the master keys, etc. Once it has been set, it becomes a noop
 	// on future calls.
 	await migrateLocalSyncInfo(Setting.db());
-	setupRevisionServiceSettingsSync();
 
 	if (!clientIdSetting) Setting.setValue('clientId', clientId);
 	await KeychainService.instance().detectIfKeychainSupported();

--- a/packages/lib/services/SettingUtils.ts
+++ b/packages/lib/services/SettingUtils.ts
@@ -3,7 +3,7 @@
 import KeychainService from './keychain/KeychainService';
 import Setting from '../models/Setting';
 import uuid from '../uuid';
-import { migrateLocalSyncInfo } from './synchronizer/syncInfoUtils';
+import { migrateLocalSyncInfo, setupRevisionServiceSettingsSync } from './synchronizer/syncInfoUtils';
 import KeychainServiceDriverBase from './keychain/KeychainServiceDriverBase';
 import shim from '../shim';
 
@@ -46,6 +46,7 @@ export async function loadKeychainServiceAndSettings(keychainServiceDrivers: Key
 	// contains the master keys, etc. Once it has been set, it becomes a noop
 	// on future calls.
 	await migrateLocalSyncInfo(Setting.db());
+	setupRevisionServiceSettingsSync();
 
 	if (!clientIdSetting) Setting.setValue('clientId', clientId);
 	await KeychainService.instance().detectIfKeychainSupported();

--- a/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.revisions.test.ts
@@ -4,6 +4,7 @@ import { synchronizerStart, revisionService, setupDatabaseAndSynchronizer, synch
 import Note from '../../models/Note';
 import Revision from '../../models/Revision';
 import { loadMasterKeysFromSettings, setupAndEnableEncryption } from '../e2ee/utils';
+import { onRevisionServiceSettingsChanged } from './syncInfoUtils';
 
 describe('Synchronizer.revisions', () => {
 
@@ -301,4 +302,27 @@ describe('Synchronizer.revisions', () => {
 
 		jest.useRealTimers();
 	});
+
+	it('should sync revision service settings across clients', (async () => {
+		const changeSetting = (key: string, value: unknown) => {
+			Setting.setValue(key, value);
+			onRevisionServiceSettingsChanged(key, value);
+		};
+
+		changeSetting('revisionService.enabled', false);
+		await synchronizerStart();
+		await switchClient(2);
+
+		expect(Setting.value('revisionService.enabled')).toBe(true);
+		await synchronizerStart();
+		expect(Setting.value('revisionService.enabled')).toBe(false);
+
+		changeSetting('revisionService.enabled', true);
+		await synchronizerStart();
+		await switchClient(1);
+
+		expect(Setting.value('revisionService.enabled')).toBe(false);
+		await synchronizerStart();
+		expect(Setting.value('revisionService.enabled')).toBe(true);
+	}));
 });

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -283,6 +283,14 @@ describe('syncInfoUtils', () => {
 					'publicKey': '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCA...',
 				},
 			},
+			'revisionServiceEnabled': {
+				'updatedTime': 0,
+				'value': true,
+			},
+			'revisionServiceTtlDays': {
+				'updatedTime': 0,
+				'value': 90,
+			},
 			'version': 3,
 		});
 	});
@@ -392,4 +400,29 @@ describe('syncInfoUtils', () => {
 		Setting.setValue('sync.wipeOutFailSafe', true);
 		expect(fetchSyncInfo(fileApi())).resolves.not.toThrow();
 	}));
+
+	it('should merge revision service settings based on timestamps', () => {
+		const s1 = new SyncInfo();
+		s1.revisionServiceEnabled = false;
+		s1.revisionServiceTtlDays = 30;
+
+		const s2 = new SyncInfo();
+		s2.revisionServiceEnabled = true;
+		s2.revisionServiceTtlDays = 90;
+
+		s1.setKeyTimestamp('revisionServiceEnabled', 200);
+		s1.setKeyTimestamp('revisionServiceTtlDays', 100);
+		s2.setKeyTimestamp('revisionServiceEnabled', 100);
+		s2.setKeyTimestamp('revisionServiceTtlDays', 200);
+
+		const merged = mergeSyncInfos(s1, s2);
+		expect(merged.revisionServiceEnabled).toBe(false);
+		expect(merged.revisionServiceTtlDays).toBe(90);
+	});
+
+	it('should use default revision service settings when not present in sync info', () => {
+		const s = new SyncInfo(JSON.stringify({ version: 3 }));
+		expect(s.revisionServiceEnabled).toBe(true);
+		expect(s.revisionServiceTtlDays).toBe(90);
+	});
 });

--- a/packages/lib/services/synchronizer/syncInfoUtils.test.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.test.ts
@@ -1,6 +1,6 @@
 import { afterAllCleanUp, setupDatabaseAndSynchronizer, logger, switchClient, encryptionService, msleep, fileApi } from '../../testing/test-utils';
 import MasterKey from '../../models/MasterKey';
-import { checkIfCanSync, localSyncInfo, masterKeyEnabled, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyEnabled, SyncInfo, syncInfoEquals, checkSyncTargetIsValid, fetchSyncInfo } from './syncInfoUtils';
+import { checkIfCanSync, localSyncInfo, masterKeyEnabled, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyEnabled, SyncInfo, syncInfoEquals, checkSyncTargetIsValid, fetchSyncInfo, onRevisionServiceSettingsChanged } from './syncInfoUtils';
 import Setting from '../../models/Setting';
 import BaseItem from '../../models/BaseItem';
 import BaseModel from '../../models/BaseItem';
@@ -424,5 +424,42 @@ describe('syncInfoUtils', () => {
 		const s = new SyncInfo(JSON.stringify({ version: 3 }));
 		expect(s.revisionServiceEnabled).toBe(true);
 		expect(s.revisionServiceTtlDays).toBe(90);
+	});
+
+	it('should update syncInfo when revision service setting changes', async () => {
+		const s = new SyncInfo();
+		s.revisionServiceTtlDays = 90;
+		s.setKeyTimestamp('revisionServiceTtlDays', 0);
+		saveLocalSyncInfo(s);
+
+		onRevisionServiceSettingsChanged('revisionService.ttlDays', 30);
+
+		const updated = localSyncInfo();
+		expect(updated.revisionServiceTtlDays).toBe(30);
+		expect(updated.keyTimestamp('revisionServiceTtlDays')).toBeGreaterThan(0);
+	});
+
+	it('should not update syncInfo when revision service setting value is unchanged', async () => {
+		const s = new SyncInfo();
+		s.revisionServiceTtlDays = 90;
+		s.setKeyTimestamp('revisionServiceTtlDays', 0);
+		saveLocalSyncInfo(s);
+
+		onRevisionServiceSettingsChanged('revisionService.ttlDays', 90);
+
+		const updated = localSyncInfo();
+		expect(updated.keyTimestamp('revisionServiceTtlDays')).toBe(0);
+	});
+
+	it('should ignore unrelated keys in onRevisionServiceSettingsChanged', async () => {
+		const s = new SyncInfo();
+		s.revisionServiceTtlDays = 90;
+		s.setKeyTimestamp('revisionServiceTtlDays', 0);
+		saveLocalSyncInfo(s);
+
+		onRevisionServiceSettingsChanged('sync.target', 1);
+
+		const updated = localSyncInfo();
+		expect(updated.keyTimestamp('revisionServiceTtlDays')).toBe(0);
 	});
 });

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -51,13 +51,20 @@ export const setAppMinVersion = (v: string) => {
 };
 
 export function setupRevisionServiceSettingsSync() {
-	const revisionServiceKeys = ['revisionService.enabled', 'revisionService.ttlDays'];
 	eventManager.on(EventName.SettingsChange, (event) => {
-		if (!event.keys.some(k => revisionServiceKeys.includes(k))) return;
+		const relevant = event.keys.filter(k => k === 'revisionService.enabled' || k === 'revisionService.ttlDays');
+		if (!relevant.length) return;
 		const s = localSyncInfo();
-		if (event.keys.includes('revisionService.enabled')) s.revisionServiceEnabled = Setting.value('revisionService.enabled');
-		if (event.keys.includes('revisionService.ttlDays')) s.revisionServiceTtlDays = Setting.value('revisionService.ttlDays');
-		saveLocalSyncInfo(s);
+		let changed = false;
+		if (relevant.includes('revisionService.enabled')) {
+			const next = Setting.value('revisionService.enabled');
+			if (s.revisionServiceEnabled !== next) { s.revisionServiceEnabled = next; changed = true; }
+		}
+		if (relevant.includes('revisionService.ttlDays')) {
+			const next = Setting.value('revisionService.ttlDays');
+			if (s.revisionServiceTtlDays !== next) { s.revisionServiceTtlDays = next; changed = true; }
+		}
+		if (changed) saveLocalSyncInfo(s);
 	});
 }
 

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -10,6 +10,7 @@ import { compareVersions } from 'compare-versions';
 import { _ } from '../../locale';
 import JoplinError from '../../JoplinError';
 import { ErrorCode } from '../../errors';
+import eventManager, { EventName } from '../../eventManager';
 const fastDeepEqual = require('fast-deep-equal');
 
 const logger = Logger.create('syncInfoUtils');
@@ -21,6 +22,11 @@ export interface SyncInfoValueBoolean {
 
 export interface SyncInfoValueString {
 	value: string;
+	updatedTime: number;
+}
+
+export interface SyncInfoValueInt {
+	value: number;
 	updatedTime: number;
 }
 
@@ -43,6 +49,17 @@ let appMinVersion_ = '3.0.0';
 export const setAppMinVersion = (v: string) => {
 	appMinVersion_ = v;
 };
+
+export function setupRevisionServiceSettingsSync() {
+	const revisionServiceKeys = ['revisionService.enabled', 'revisionService.ttlDays'];
+	eventManager.on(EventName.SettingsChange, (event) => {
+		if (!event.keys.some(k => revisionServiceKeys.includes(k))) return;
+		const s = localSyncInfo();
+		if (event.keys.includes('revisionService.enabled')) s.revisionServiceEnabled = Setting.value('revisionService.enabled');
+		if (event.keys.includes('revisionService.ttlDays')) s.revisionServiceTtlDays = Setting.value('revisionService.ttlDays');
+		saveLocalSyncInfo(s);
+	});
+}
 
 export async function migrateLocalSyncInfo(db: JoplinDatabase) {
 	if (Setting.value('syncInfoCache')) return; // Already initialized
@@ -75,6 +92,10 @@ export async function migrateLocalSyncInfo(db: JoplinDatabase) {
 	//   most likely not what the user wants.
 	syncInfo.setKeyTimestamp('e2ee', 0);
 	syncInfo.setKeyTimestamp('activeMasterKeyId', 0);
+	syncInfo.revisionServiceEnabled = Setting.valueNoThrow('revisionService.enabled', true);
+	syncInfo.revisionServiceTtlDays = Setting.valueNoThrow('revisionService.ttlDays', 90);
+	syncInfo.setKeyTimestamp('revisionServiceEnabled', 0);
+	syncInfo.setKeyTimestamp('revisionServiceTtlDays', 0);
 
 	await saveLocalSyncInfo(syncInfo);
 }
@@ -219,6 +240,8 @@ export function mergeSyncInfos(s1: SyncInfo, s2: SyncInfo): SyncInfo {
 
 	output.setWithTimestamp(s1.keyTimestamp('e2ee') > s2.keyTimestamp('e2ee') ? s1 : s2, 'e2ee');
 	output.setWithTimestamp(s1.keyTimestamp('ppk') > s2.keyTimestamp('ppk') ? s1 : s2, 'ppk');
+	output.setWithTimestamp(s1.keyTimestamp('revisionServiceEnabled') > s2.keyTimestamp('revisionServiceEnabled') ? s1 : s2, 'revisionServiceEnabled');
+	output.setWithTimestamp(s1.keyTimestamp('revisionServiceTtlDays') > s2.keyTimestamp('revisionServiceTtlDays') ? s1 : s2, 'revisionServiceTtlDays');
 	output.version = s1.version > s2.version ? s1.version : s2.version;
 
 	mergeActiveMasterKeys(s1, s2, output);
@@ -255,11 +278,15 @@ export class SyncInfo {
 	private masterKeys_: MasterKeyEntity[] = [];
 	private ppk_: SyncInfoValuePublicPrivateKeyPair;
 	private appMinVersion_: string = appMinVersion_;
+	private revisionServiceEnabled_: SyncInfoValueBoolean;
+	private revisionServiceTtlDays_: SyncInfoValueInt;
 
 	public constructor(serialized: string = null) {
 		this.e2ee_ = { value: false, updatedTime: 0 };
 		this.activeMasterKeyId_ = { value: '', updatedTime: 0 };
 		this.ppk_ = { value: null, updatedTime: 0 };
+		this.revisionServiceEnabled_ = { value: true, updatedTime: 0 };
+		this.revisionServiceTtlDays_ = { value: 90, updatedTime: 0 };
 
 		if (serialized) this.load(serialized);
 	}
@@ -273,6 +300,8 @@ export class SyncInfo {
 			masterKeys: this.masterKeys,
 			ppk: this.ppk_,
 			appMinVersion: this.appMinVersion,
+			revisionServiceEnabled: this.revisionServiceEnabled_,
+			revisionServiceTtlDays: this.revisionServiceTtlDays_,
 		};
 	}
 
@@ -315,6 +344,8 @@ export class SyncInfo {
 		this.masterKeys_ = 'masterKeys' in s ? s.masterKeys : [];
 		this.ppk_ = 'ppk' in s ? s.ppk : { value: null, updatedTime: 0 };
 		this.appMinVersion_ = s.appMinVersion ? s.appMinVersion : '0.0.0';
+		this.revisionServiceEnabled_ = 'revisionServiceEnabled' in s ? s.revisionServiceEnabled : { value: true, updatedTime: 0 };
+		this.revisionServiceTtlDays_ = 'revisionServiceTtlDays' in s ? s.revisionServiceTtlDays : { value: 90, updatedTime: 0 };
 
 		// Migration for master keys that didn't have "hasBeenUsed" property -
 		// in that case we assume they've been used at least once.
@@ -380,6 +411,26 @@ export class SyncInfo {
 		if (v === this.activeMasterKeyId) return;
 
 		this.activeMasterKeyId_ = { value: v, updatedTime: Date.now() };
+	}
+
+	public get revisionServiceEnabled(): boolean {
+		return this.revisionServiceEnabled_.value;
+	}
+
+	public set revisionServiceEnabled(v: boolean) {
+		if (v === this.revisionServiceEnabled) return;
+
+		this.revisionServiceEnabled_ = { value: v, updatedTime: Date.now() };
+	}
+
+	public get revisionServiceTtlDays(): number {
+		return this.revisionServiceTtlDays_.value;
+	}
+
+	public set revisionServiceTtlDays(v: number) {
+		if (v === this.revisionServiceTtlDays) return;
+
+		this.revisionServiceTtlDays_ = { value: v, updatedTime: Date.now() };
 	}
 
 	public get masterKeys(): MasterKeyEntity[] {

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -10,7 +10,6 @@ import { compareVersions } from 'compare-versions';
 import { _ } from '../../locale';
 import JoplinError from '../../JoplinError';
 import { ErrorCode } from '../../errors';
-import eventManager, { EventName } from '../../eventManager';
 const fastDeepEqual = require('fast-deep-equal');
 
 const logger = Logger.create('syncInfoUtils');
@@ -50,22 +49,19 @@ export const setAppMinVersion = (v: string) => {
 	appMinVersion_ = v;
 };
 
-export function setupRevisionServiceSettingsSync() {
-	eventManager.on(EventName.SettingsChange, (event) => {
-		const relevant = event.keys.filter(k => k === 'revisionService.enabled' || k === 'revisionService.ttlDays');
-		if (!relevant.length) return;
-		const s = localSyncInfo();
-		let changed = false;
-		if (relevant.includes('revisionService.enabled')) {
-			const next = Setting.value('revisionService.enabled');
-			if (s.revisionServiceEnabled !== next) { s.revisionServiceEnabled = next; changed = true; }
-		}
-		if (relevant.includes('revisionService.ttlDays')) {
-			const next = Setting.value('revisionService.ttlDays');
-			if (s.revisionServiceTtlDays !== next) { s.revisionServiceTtlDays = next; changed = true; }
-		}
-		if (changed) saveLocalSyncInfo(s);
-	});
+export function onRevisionServiceSettingsChanged(key: string, value: unknown) {
+	if (key !== 'revisionService.enabled' && key !== 'revisionService.ttlDays') return;
+	const s = localSyncInfo();
+	let changed = false;
+	if (key === 'revisionService.enabled' && s.revisionServiceEnabled !== value) {
+		s.revisionServiceEnabled = value as boolean;
+		changed = true;
+	}
+	if (key === 'revisionService.ttlDays' && s.revisionServiceTtlDays !== value) {
+		s.revisionServiceTtlDays = value as number;
+		changed = true;
+	}
+	if (changed) saveLocalSyncInfo(s);
 }
 
 export async function migrateLocalSyncInfo(db: JoplinDatabase) {
@@ -99,8 +95,8 @@ export async function migrateLocalSyncInfo(db: JoplinDatabase) {
 	//   most likely not what the user wants.
 	syncInfo.setKeyTimestamp('e2ee', 0);
 	syncInfo.setKeyTimestamp('activeMasterKeyId', 0);
-	syncInfo.revisionServiceEnabled = Setting.valueNoThrow('revisionService.enabled', true);
-	syncInfo.revisionServiceTtlDays = Setting.valueNoThrow('revisionService.ttlDays', 90);
+	syncInfo.revisionServiceEnabled = Setting.value('revisionService.enabled');
+	syncInfo.revisionServiceTtlDays = Setting.value('revisionService.ttlDays');
 	syncInfo.setKeyTimestamp('revisionServiceEnabled', 0);
 	syncInfo.setKeyTimestamp('revisionServiceTtlDays', 0);
 

--- a/packages/lib/services/synchronizer/syncInfoUtils.ts
+++ b/packages/lib/services/synchronizer/syncInfoUtils.ts
@@ -54,11 +54,13 @@ export function onRevisionServiceSettingsChanged(key: string, value: unknown) {
 	const s = localSyncInfo();
 	let changed = false;
 	if (key === 'revisionService.enabled' && s.revisionServiceEnabled !== value) {
-		s.revisionServiceEnabled = value as boolean;
+		if (typeof value !== 'boolean') return;
+		s.revisionServiceEnabled = value;
 		changed = true;
 	}
 	if (key === 'revisionService.ttlDays' && s.revisionServiceTtlDays !== value) {
-		s.revisionServiceTtlDays = value as number;
+		if (typeof value !== 'number') return;
+		s.revisionServiceTtlDays = value;
 		changed = true;
 	}
 	if (changed) saveLocalSyncInfo(s);


### PR DESCRIPTION
Resolves #14336
Currently, revisionService.enabled and revisionService.ttlDays behave like local-only settings, which means each device needs to be configured separately. This change moves these values into syncInfo so that when Note History settings are updated on one device, the change automatically propagates to all synced clients. There are no UI changes in this PR, the options remain under Note History. This only affects how the settings are stored and shared between devices behind the scenes.

### Changes:
In syncInfoUtils.ts, a new SyncInfoValueInt interface was added to represent numeric values using the same { value, updatedTime } structure already used by other sync-level properties. Two new fields, revisionServiceEnabled and revisionServiceTtlDays, were introduced following that existing pattern. During migration, migrateLocalSyncInfo seeds these values from the current local settings with updatedTime = 0, ensuring that any future user change on any client takes precedence. The merge logic in mergeSyncInfos remains timestamp-based, selecting whichever value was updated most recently. A helper, setupRevisionServiceSettingsSync, listens for SettingsChange events so that when a user updates Note History in the UI, the change is immediately written into syncInfoCache.

In SettingUtils.ts, the sync setup runs once at startup after migration. In Synchronizer.ts, after merging info.json, the resolved values are written back to local Setting when they differ from what is stored locally, ensuring consistency across devices.

### AI disclosure
AI assistance was used to help review possible implementation approaches, validate edge cases, and select an optimal minimal solution aligned with the existing sync architecture. AI was also used to help update and extend the related test cases to ensure correct merge behaviour and backward compatibility.


https://github.com/user-attachments/assets/552a9791-c306-4a17-b885-cb2adec643bc

