### PR TITLE
Chore: Fix incorrect test for `versionInfo`

### DIFF
--- a/packages/lib/versionInfo.test.ts
+++ b/packages/lib/versionInfo.test.ts
@@ -31,7 +31,7 @@ const packageInfo = {
 	},
 };
 
-describe('getPluginLists', () => {
+describe('versionInfo', () => {
 
 	beforeAll(() => {
 		(reg.db as jest.Mock).mockReturnValue(mockedDb);
@@ -114,17 +114,18 @@ describe('getPluginLists', () => {
 
 		const v = versionInfo(packageInfo, plugins);
 
-		const body = '\n';
+		const pluginMessage = [];
 		for (let i = 1; i <= 21; i++) {
-			body.concat(`\nPlugin${i}: 1`);
+			pluginMessage.push(`Plugin${i}: 1`);
 		}
-		expect(v.body).toMatch(new RegExp(body));
+		// Plugin order should be determined by locale:
+		pluginMessage.sort(Intl.Collator().compare);
 
-		const message = '\n';
-		for (let i = 1; i <= 20; i++) {
-			message.concat(`\nPlugin${i}: 1`);
-		}
-		message.concat('\n...');
-		expect(v.message).toMatch(new RegExp(message));
+		// The body should contain the full plugin list
+		expect(v.body).toContain(pluginMessage.join('\n'));
+
+		// The message should only include the first 20.
+		const nonEllipsizedEntries = pluginMessage.slice(0, 20);
+		expect(v.message).toContain(`${nonEllipsizedEntries.join('\n')}\n...`);
 	});
 });


### PR DESCRIPTION
# Summary

Fixes two issues in `versionInfo.test.ts`:
- The title of the `describe` block was incorrect.
- Logic for building the expected body in `should show an abridged list of plugins in message and the full list in body` was incorrect.

(Thank you @Ashutoshx7 for raising this issue!)


<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->