### PR TITLE
All: Fix unexpected conflicts created during sync in some cases

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -870,7 +870,7 @@ export default class Synchronizer {
 
 				let context = null;
 				let newDeltaContext = null;
-				const localFoldersToDelete = [];
+				const localFoldersToDelete = new Set<string>();
 				let hasCancelled = false;
 				if (lastContext.delta) context = lastContext.delta;
 
@@ -972,6 +972,8 @@ export default class Synchronizer {
 									reason = 'remote exists but local does not';
 									content = await loadContent();
 									ItemClass = content ? BaseItem.itemClass(content) : null;
+								} else {
+									reason = 'skipping: the item was deleted';
 								}
 							} else {
 								ItemClass = BaseItem.itemClass(local);
@@ -980,6 +982,11 @@ export default class Synchronizer {
 									action = SyncAction.DeleteLocal;
 									reason = 'remote has been deleted';
 								} else {
+									if (localFoldersToDelete.has(remoteId)) {
+										logger.debug('Removing a scheduled folder deletion (', remoteId, '). It was recreated by sync.');
+										localFoldersToDelete.delete(remoteId);
+									}
+
 									if (this.api().supportsAccurateTimestamp && remote.jop_updated_time === local.updated_time) {
 										// Nothing to do, and no need to fetch the content
 									} else {
@@ -1066,7 +1073,12 @@ export default class Synchronizer {
 									await MasterKey.save(content);
 								}
 							} else {
-								await ItemClass.save(content, options);
+								const saved = await ItemClass.save(content, options);
+
+								// Ensure that the item can be found if another create/update event is received for the same item:
+								if (!local) {
+									locals.push(saved);
+								}
 							}
 
 							if (creatingOrUpdatingResource) this.dispatch({ type: 'SYNC_CREATED_OR_UPDATED_RESOURCE', id: content.id });
@@ -1083,7 +1095,7 @@ export default class Synchronizer {
 							if (content.encryption_applied) this.dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' });
 						} else if (action === SyncAction.DeleteLocal) {
 							if (local.type_ === BaseModel.TYPE_FOLDER) {
-								localFoldersToDelete.push(local);
+								localFoldersToDelete.add(local.id);
 								continue;
 							}
 
@@ -1133,12 +1145,12 @@ export default class Synchronizer {
 				// ------------------------------------------------------------------------
 
 				if (!this.cancelling()) {
-					for (let i = 0; i < localFoldersToDelete.length; i++) {
-						const item = localFoldersToDelete[i];
-						const noteIds = await Folder.noteIds(item.id);
+					for (const folderId of localFoldersToDelete) {
+						const noteIds = await Folder.noteIds(folderId);
 						if (noteIds.length) {
+							logger.warn('Conflict: Folder to be deleted', folderId, 'still contains notes', noteIds);
 							// CONFLICT
-							await Folder.markNotesAsConflict(item.id);
+							await Folder.markNotesAsConflict(folderId);
 						}
 
 						const deletionOptions: DeleteOptions = {
@@ -1147,7 +1159,7 @@ export default class Synchronizer {
 							changeSource: ItemChange.SOURCE_SYNC,
 							sourceDescription: 'Sync',
 						};
-						await Folder.delete(item.id, deletionOptions);
+						await Folder.delete(folderId, deletionOptions);
 					}
 				}
 


### PR DESCRIPTION
# Summary

This pull request backports https://github.com/laurent22/joplin/pull/14388 to `release-3.5`.

https://github.com/laurent22/joplin/pull/14388 fixes [an issue](https://github.com/laurent22/joplin/issues/14383) that could cause items in a shared notebook to be moved to the conflicts folder when completing a full sync. See https://github.com/laurent22/joplin/pull/14388 for details.

> [!IMPORTANT]
> 
> Targets `release-3.5`.
> 

> [!NOTE]
>
> https://github.com/laurent22/joplin/pull/14388 is in `dev`, but has not yet been included in a pre-release.

<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->