### PR TITLE
Mobile: Plugins: Allow adding new actions to the "new note" menu

### DIFF
--- a/packages/app-cli/tests/support/plugins/register_command/api/types.ts
+++ b/packages/app-cli/tests/support/plugins/register_command/api/types.ts
@@ -285,6 +285,13 @@ export enum MenuItemLocation {
 	 * - `tagId:string`: ID of the tag that was right-clicked on
 	 */
 	TagContextMenu = 'tagContextMenu',
+
+	/**
+	 * **Mobile only**: Adds the action to the new note popup menu.
+	 *
+	 * <span class="platform-mobile">mobile</span>
+	 */
+	NewNoteMenu = 'newNoteMenu',
 }
 
 export function isContextMenuItemLocation(location: MenuItemLocation): boolean {
@@ -372,6 +379,19 @@ export interface DialogResult {
 	formData?: any;
 }
 
+export enum ToastType {
+	Info = 'info',
+	Success = 'success',
+	Error = 'error',
+}
+
+export interface Toast {
+	message: string;
+	type?: ToastType;
+	duration?: number;
+	timestamp?: number;
+}
+
 export interface Size {
 	width?: number;
 	height?: number;
@@ -384,17 +404,71 @@ export interface Rectangle {
 	height?: number;
 }
 
-export type ActivationCheckCallback = ()=> Promise<boolean>;
+export interface EditorUpdateEvent {
+	newBody: string;
+	noteId: string;
+}
+export type UpdateCallback = (event: EditorUpdateEvent)=> Promise<void>;
 
-export type UpdateCallback = ()=> Promise<void>;
+
+export interface ActivationCheckEvent {
+	handle: ViewHandle;
+	noteId: string;
+}
+export type ActivationCheckCallback = (event: ActivationCheckEvent)=> Promise<boolean>;
+
+/**
+ * Required callbacks for creating an editor plugin.
+ */
+export interface EditorPluginCallbacks {
+	/**
+	 * Emitted when the editor can potentially be activated - this is for example when the current
+	 * note is changed, or when the application is opened. At that point you should check the
+	 * current note and decide whether your editor should be activated or not. If it should, return
+	 * `true`, otherwise return `false`.
+	 */
+	onActivationCheck: ActivationCheckCallback;
+
+	/**
+	 * Emitted when an editor view is created. This happens, for example, when a new window containing
+	 * a new editor is created.
+	 *
+	 * This callback should set the editor plugin's HTML using `editors.setHtml`, add scripts to the editor
+	 * with `editors.addScript`, and optionally listen for external changes using `editors.onUpdate`.
+	 */
+	onSetup: (handle: ViewHandle)=> Promise<void>;
+}
 
 export type VisibleHandler = ()=> Promise<void>;
 
+/**
+ * Identifies the type of element that was right-clicked in the editor context menu.
+ */
+export enum ContextMenuItemType {
+	None = '',
+	Image = 'image',
+	Resource = 'resource',
+	Text = 'text',
+	Link = 'link',
+}
+
 export interface EditContextMenuFilterObject {
 	items: MenuItem[];
+	/**
+	 * Context about what was right-clicked. Plugins should use this instead of
+	 * checking the editor cursor position, as the cursor may not reflect the
+	 * actual click location.
+	 */
+	context?: {
+		resourceId?: string;
+		itemType?: ContextMenuItemType;
+		textToCopy?: string;
+	};
 }
 
 export interface EditorActivationCheckFilterObject {
+	effectiveNoteId: string;
+	windowId: string;
 	activatedEditors: {
 		pluginId: string;
 		viewId: string;
@@ -403,6 +477,20 @@ export interface EditorActivationCheckFilterObject {
 }
 
 export type FilterHandler<T> = (object: T)=> Promise<T>;
+
+export type CommandArgument = string|number|object|boolean|null;
+
+export interface MenuTemplateItem {
+	label?: string;
+	command?: string;
+	commandArgs?: CommandArgument[];
+}
+
+export interface WebviewApi {
+	postMessage: (message: object)=> unknown;
+	onMessage: (message: object)=> void;
+	menuPopupFromTemplate: (template: MenuTemplateItem[])=> void;
+}
 
 // =================================================================
 // Settings types
@@ -529,6 +617,30 @@ export interface SettingSection {
 export type Path = string[];
 
 // =================================================================
+// Clipboard API types
+// =================================================================
+
+/**
+ * Represents content that can be written to the clipboard in multiple formats.
+ */
+export interface ClipboardContent {
+	/**
+	 * Plain text representation of the content
+	 */
+	text?: string;
+
+	/**
+	 * HTML representation of the content
+	 */
+	html?: string;
+
+	/**
+	 * Image in [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) format
+	 */
+	image?: string;
+}
+
+// =================================================================
 // Content Script types
 // =================================================================
 
@@ -609,6 +721,27 @@ export interface CodeMirrorControl {
 		 */
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		enableLanguageDataAutocomplete: { of: (enabled: boolean)=> any };
+
+		/**
+		 * A CodeMirror [facet](https://codemirror.net/docs/ref/#state.EditorState.facet) that contains
+		 * the ID of the note currently open in the editor.
+		 *
+		 * Access the value of this facet using
+		 * ```ts
+		 * const noteIdFacet = editorControl.joplinExtensions.noteIdFacet;
+		 * const editorState = editorControl.editor.state;
+		 * const noteId = editorState.facet(noteIdFacet);
+		 * ```
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- No better type available
+		noteIdFacet: any;
+		/**
+		 * A CodeMirror [StateEffect](https://codemirror.net/docs/ref/#state.StateEffect) that is
+		 * included in a [Transaction](https://codemirror.net/docs/ref/#state.Transaction) when the
+		 * note ID changes.
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- No better type available
+		setNoteIdEffect: any;
 	};
 }
 

--- a/packages/app-cli/tests/support/plugins/register_command/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/register_command/src/index.ts
@@ -51,6 +51,15 @@ joplin.plugins.register({
 			},
 		});
 
+		await joplin.commands.register({
+			name: 'noteMenuExample',
+			label: 'Plugin note',
+			iconName: 'fas fa-plus',
+			execute: async () => {
+				joplin.commands.execute('newNote', 'A new note from a plugin!');
+			},
+		});
+
 		// Commands that return a result and take argument can only be used
 		// programmatically, so it's not necessary to set a label and icon.
 		await joplin.commands.register({
@@ -74,6 +83,9 @@ joplin.plugins.register({
 
 		await joplin.views.menuItems.create('folderMenuItem1', 'folderContextMenuExample', MenuItemLocation.FolderContextMenu);
 		await joplin.views.menuItems.create('tagMenuItem1', 'tagContextMenuExample', MenuItemLocation.TagContextMenu);
+
+		// Only takes effect on mobile:
+		await joplin.views.menuItems.create('newNoteMenuItem', 'noteMenuExample', MenuItemLocation.NewNoteMenu);
 
 		console.info('Running command with arguments...');
 		const result = await joplin.commands.execute('commandWithResult', 'abcd', 123);

--- a/packages/app-cli/tests/support/plugins/register_command/src/index.ts
+++ b/packages/app-cli/tests/support/plugins/register_command/src/index.ts
@@ -56,7 +56,7 @@ joplin.plugins.register({
 			label: 'Plugin note',
 			iconName: 'fas fa-plus',
 			execute: async () => {
-				joplin.commands.execute('newNote', 'A new note from a plugin!');
+				await joplin.commands.execute('newNote', 'A new note from a plugin!');
 			},
 		});
 

--- a/packages/app-cli/tests/support/plugins/register_command/src/manifest.json
+++ b/packages/app-cli/tests/support/plugins/register_command/src/manifest.json
@@ -1,6 +1,7 @@
 {
 	"id": "org.joplinapp.plugins.RegisterCommandDemo",
 	"manifest_version": 1,
+	"platforms": ["desktop", "mobile"],
 	"app_min_version": "1.4",
 	"name": "Register Command Test",
 	"description": "To test registering commands",

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -85,7 +85,7 @@ const NewNoteButton: React.FC<Props> = props => {
 	};
 
 	const pluginShortcutButtons = props.pluginActions.map(action => {
-		return renderShortcutButton(action.name, action.onClick, action.iconName, action.title);
+		return renderShortcutButton(`plugin-${action.name}`, action.onClick, action.iconName, action.title);
 	});
 
 	const menuContent = <View style={styles.menuContent}>

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -16,6 +16,7 @@ import { AppState } from '../../../utils/types';
 import { utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import ToolbarButtonUtils, { ToolbarItem } from '@joplin/lib/services/commands/ToolbarButtonUtils';
 import stateToWhenClauseContext from '../../../services/commands/stateToWhenClauseContext';
+import { MenuItemLocation } from '@joplin/lib/services/plugins/api/types';
 
 const logger = Logger.create('NewNoteButton');
 
@@ -62,8 +63,12 @@ const styles = StyleSheet.create({
 });
 
 const toolbarButtonUtils = new ToolbarButtonUtils(CommandService.instance());
-const toolbarButtonsFromState = (state: AppState) => {
-	const pluginCommandNames = pluginUtils.commandNamesFromViews(state.pluginService.plugins, 'newNoteMenu');
+const menuButtonsFromState = (state: AppState) => {
+	const views = pluginUtils.viewsByType(state.pluginService.plugins, 'menuItem');
+	const pluginCommandNames = views
+		.filter(view => view.location === MenuItemLocation.NewNoteMenu)
+		.map(view => view.commandName);
+
 	return toolbarButtonUtils.commandsToToolbarButtons(pluginCommandNames, stateToWhenClauseContext(state));
 };
 
@@ -72,20 +77,24 @@ const NewNoteButton: React.FC<Props> = props => {
 
 	type ActionType = AttachFileAction|(()=> void);
 	const renderShortcutButton = (key: string, action: ActionType, icon: string, title: string) => {
-		const actionSource = typeof action === 'function' ? null : action;
-		action = typeof action === 'function' ? action : () => makeNewNote(false, actionSource);
+		const noteAttachmentAction = typeof action === 'function' ? null : action;
+		action = typeof action === 'function' ? action : () => makeNewNote(false, noteAttachmentAction);
+		const hint = noteAttachmentAction ? _('Creates a new note with an attachment of type %s', title) : undefined;
+
 		return <LabelledIconButton
 			key={key}
 			onPress={action}
 			style={styles.shortcutButton}
 			title={title}
-			accessibilityHint={_('Creates a new note with an attachment of type %s', title)}
+			accessibilityHint={hint}
 			icon={icon}
 		/>;
 	};
 
 	const pluginShortcutButtons = props.pluginActions.map(action => {
-		return renderShortcutButton(`plugin-${action.name}`, action.onClick, action.iconName, action.title);
+		return renderShortcutButton(
+			`plugin-${action.name}`, action.onClick, action.iconName, action.title || action.tooltip,
+		);
 	});
 
 	const menuContent = <View style={styles.menuContent}>
@@ -160,5 +169,5 @@ const NewNoteButton: React.FC<Props> = props => {
 };
 
 export default connect((state: AppState) => ({
-	pluginActions: toolbarButtonsFromState(state),
+	pluginActions: menuButtonsFromState(state),
 }))(NewNoteButton);

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -11,11 +11,16 @@ import { useCallback, useMemo, useRef } from 'react';
 import Logger from '@joplin/utils/Logger';
 import focusView from '../../../utils/focusView';
 import NavService from '@joplin/lib/services/NavService';
+import { connect } from 'react-redux';
+import { AppState } from '../../../utils/types';
+import { utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
+import ToolbarButtonUtils, { ToolbarItem } from '@joplin/lib/services/commands/ToolbarButtonUtils';
+import stateToWhenClauseContext from '../../../services/commands/stateToWhenClauseContext';
 
 const logger = Logger.create('NewNoteButton');
 
 interface Props {
-
+	pluginActions: ToolbarItem[];
 }
 
 const makeNewNote = (isTodo: boolean, action?: AttachFileAction) => {
@@ -56,14 +61,21 @@ const styles = StyleSheet.create({
 	},
 });
 
-const NewNoteButton: React.FC<Props> = _props => {
+const toolbarButtonUtils = new ToolbarButtonUtils(CommandService.instance());
+const toolbarButtonsFromState = (state: AppState) => {
+	const pluginCommandNames = pluginUtils.commandNamesFromViews(state.pluginService.plugins, 'newNoteMenu');
+	return toolbarButtonUtils.commandsToToolbarButtons(pluginCommandNames, stateToWhenClauseContext(state));
+};
+
+const NewNoteButton: React.FC<Props> = props => {
 	const newNoteRef = useRef<View|null>(null);
 
 	type ActionType = AttachFileAction|(()=> void);
-	const renderShortcutButton = (action: ActionType, icon: string, title: string) => {
+	const renderShortcutButton = (key: string, action: ActionType, icon: string, title: string) => {
 		const actionSource = typeof action === 'function' ? null : action;
 		action = typeof action === 'function' ? action : () => makeNewNote(false, actionSource);
 		return <LabelledIconButton
+			key={key}
 			onPress={action}
 			style={styles.shortcutButton}
 			title={title}
@@ -72,13 +84,18 @@ const NewNoteButton: React.FC<Props> = _props => {
 		/>;
 	};
 
+	const pluginShortcutButtons = props.pluginActions.map(action => {
+		return renderShortcutButton(action.name, action.onClick, action.iconName, action.title);
+	});
+
 	const menuContent = <View style={styles.menuContent}>
 		<View style={styles.buttonRow}>
-			{renderShortcutButton(AttachFileAction.AttachFile, 'material attachment', _('Attachment'))}
-			{renderShortcutButton(AttachFileAction.RecordAudio, 'material microphone', _('Recording'))}
-			{renderShortcutButton(AttachFileAction.TakePhoto, 'material camera', _('Camera'))}
-			{renderShortcutButton(AttachFileAction.AttachDrawing, 'material draw', _('Drawing'))}
-			{renderShortcutButton(() => NavService.go('DocumentScanner'), 'material data-matrix-scan', _('Scan notebook'))}
+			{renderShortcutButton('attach', AttachFileAction.AttachFile, 'material attachment', _('Attachment'))}
+			{renderShortcutButton('record', AttachFileAction.RecordAudio, 'material microphone', _('Recording'))}
+			{renderShortcutButton('photo', AttachFileAction.TakePhoto, 'material camera', _('Camera'))}
+			{renderShortcutButton('drawing', AttachFileAction.AttachDrawing, 'material draw', _('Drawing'))}
+			{renderShortcutButton('scan', () => NavService.go('DocumentScanner'), 'material data-matrix-scan', _('Scan notebook'))}
+			{pluginShortcutButtons}
 		</View>
 		<Divider/>
 		<View style={[styles.buttonRow, styles.mainButtonRow]}>
@@ -142,4 +159,6 @@ const NewNoteButton: React.FC<Props> = _props => {
 	/>;
 };
 
-export default NewNoteButton;
+export default connect((state: AppState) => ({
+	pluginActions: toolbarButtonsFromState(state),
+}))(NewNoteButton);

--- a/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
+++ b/packages/app-mobile/components/screens/Notes/NewNoteButton.tsx
@@ -92,8 +92,13 @@ const NewNoteButton: React.FC<Props> = props => {
 	};
 
 	const pluginShortcutButtons = props.pluginActions.map(action => {
+		if (action.type === 'separator') return null;
+
 		return renderShortcutButton(
-			`plugin-${action.name}`, action.onClick, action.iconName, action.title || action.tooltip,
+			`plugin-${action.name}`,
+			action.onClick,
+			action.iconName,
+			action.title || action.tooltip,
 		);
 	});
 

--- a/packages/generator-joplin/generators/app/templates/api/noteListType.d.ts
+++ b/packages/generator-joplin/generators/app/templates/api/noteListType.d.ts
@@ -30,9 +30,9 @@ export type OnClickHandler = (event: OnClickEvent) => Promise<void>;
  * The `item.*` properties are specific to the rendered item. The most important being
  * `item.selected`, which you can use to display the selected note in a different way.
  */
-export type ListRendererDependency = ListRendererDatabaseDependency | 'item.index' | 'item.selected' | 'item.size.height' | 'item.size.width' | 'note.folder.title' | 'note.isWatched' | 'note.tags' | 'note.todoStatusText' | 'note.titleHtml';
+export type ListRendererDependency = ListRendererDatabaseDependency | 'item.index' | 'item.selected' | 'item.size.height' | 'item.size.width' | 'note.checkboxes' | 'note.folder.title' | 'note.isWatched' | 'note.tags' | 'note.todoStatusText' | 'note.titleHtml';
 export type ListRendererItemValueTemplates = Record<string, string>;
-export declare const columnNames: readonly ["note.folder.title", "note.is_todo", "note.latitude", "note.longitude", "note.source_url", "note.tags", "note.title", "note.todo_completed", "note.todo_due", "note.user_created_time", "note.user_updated_time"];
+export declare const columnNames: readonly ["note.checkboxes", "note.folder.title", "note.is_todo", "note.latitude", "note.longitude", "note.source_url", "note.tags", "note.title", "note.todo_completed", "note.todo_due", "note.user_created_time", "note.user_updated_time"];
 export type ColumnName = typeof columnNames[number];
 export interface ListRenderer {
     /**

--- a/packages/generator-joplin/generators/app/templates/api/noteListType.ts
+++ b/packages/generator-joplin/generators/app/templates/api/noteListType.ts
@@ -50,6 +50,7 @@ export type ListRendererDependency =
 	'item.selected' |
 	'item.size.height' |
 	'item.size.width' |
+	'note.checkboxes' |
 	'note.folder.title' |
 	'note.isWatched' |
 	'note.tags' |
@@ -59,6 +60,7 @@ export type ListRendererDependency =
 export type ListRendererItemValueTemplates = Record<string, string>;
 
 export const columnNames = [
+	'note.checkboxes',
 	'note.folder.title',
 	'note.is_todo',
 	'note.latitude',

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -285,6 +285,13 @@ export enum MenuItemLocation {
 	 * - `tagId:string`: ID of the tag that was right-clicked on
 	 */
 	TagContextMenu = 'tagContextMenu',
+
+	/**
+	 * **Mobile only**: Adds the action to the new note popup menu.
+	 *
+	 * <span class="platform-mobile">mobile</span>
+	 */
+	NewNoteMenu = 'newNoteMenu',
 }
 
 export function isContextMenuItemLocation(location: MenuItemLocation): boolean {
@@ -356,13 +363,6 @@ export enum ToolbarButtonLocation {
 	 * This toolbar is right above the text editor. It applies to the note body only.
 	 */
 	EditorToolbar = 'editorToolbar',
-
-	/**
-	 * **Mobile only**: Adds the action to the "new note" menu.
-	 *
-	 * <span class="platform-mobile">mobile</span>
-	 */
-	NewNoteMenu = 'newNoteMenu',
 }
 
 export type ViewHandle = string;

--- a/packages/generator-joplin/generators/app/templates/api/types.ts
+++ b/packages/generator-joplin/generators/app/templates/api/types.ts
@@ -356,6 +356,13 @@ export enum ToolbarButtonLocation {
 	 * This toolbar is right above the text editor. It applies to the note body only.
 	 */
 	EditorToolbar = 'editorToolbar',
+
+	/**
+	 * **Mobile only**: Adds the action to the "new note" menu.
+	 *
+	 * <span class="platform-mobile">mobile</span>
+	 */
+	NewNoteMenu = 'newNoteMenu',
 }
 
 export type ViewHandle = string;
@@ -434,8 +441,29 @@ export interface EditorPluginCallbacks {
 
 export type VisibleHandler = ()=> Promise<void>;
 
+/**
+ * Identifies the type of element that was right-clicked in the editor context menu.
+ */
+export enum ContextMenuItemType {
+	None = '',
+	Image = 'image',
+	Resource = 'resource',
+	Text = 'text',
+	Link = 'link',
+}
+
 export interface EditContextMenuFilterObject {
 	items: MenuItem[];
+	/**
+	 * Context about what was right-clicked. Plugins should use this instead of
+	 * checking the editor cursor position, as the cursor may not reflect the
+	 * actual click location.
+	 */
+	context?: {
+		resourceId?: string;
+		itemType?: ContextMenuItemType;
+		textToCopy?: string;
+	};
 }
 
 export interface EditorActivationCheckFilterObject {

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -356,6 +356,13 @@ export enum ToolbarButtonLocation {
 	 * This toolbar is right above the text editor. It applies to the note body only.
 	 */
 	EditorToolbar = 'editorToolbar',
+
+	/**
+	 * **Mobile only**: Adds the action to the "new note" menu.
+	 *
+	 * <span class="platform-mobile">mobile</span>
+	 */
+	NewNoteMenu = 'newNoteMenu',
 }
 
 export type ViewHandle = string;

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -285,6 +285,13 @@ export enum MenuItemLocation {
 	 * - `tagId:string`: ID of the tag that was right-clicked on
 	 */
 	TagContextMenu = 'tagContextMenu',
+
+	/**
+	 * **Mobile only**: Adds the action to the new note popup menu.
+	 *
+	 * <span class="platform-mobile">mobile</span>
+	 */
+	NewNoteMenu = 'newNoteMenu',
 }
 
 export function isContextMenuItemLocation(location: MenuItemLocation): boolean {
@@ -356,13 +363,6 @@ export enum ToolbarButtonLocation {
 	 * This toolbar is right above the text editor. It applies to the note body only.
 	 */
 	EditorToolbar = 'editorToolbar',
-
-	/**
-	 * **Mobile only**: Adds the action to the "new note" menu.
-	 *
-	 * <span class="platform-mobile">mobile</span>
-	 */
-	NewNoteMenu = 'newNoteMenu',
 }
 
 export type ViewHandle = string;

--- a/packages/lib/services/plugins/reducer.ts
+++ b/packages/lib/services/plugins/reducer.ts
@@ -108,9 +108,10 @@ export const utils = {
 		return output;
 	},
 
-	viewsByType: function(plugins: PluginStates, type: string) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+	viewsByType: function(plugins: PluginStates, type: string): any[] {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const output: PluginViewState[] = [];
+		const output: any[] = [];
 
 		for (const pluginId in plugins) {
 			const plugin = plugins[pluginId];

--- a/packages/lib/services/plugins/reducer.ts
+++ b/packages/lib/services/plugins/reducer.ts
@@ -108,10 +108,9 @@ export const utils = {
 		return output;
 	},
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	viewsByType: function(plugins: PluginStates, type: string): any[] {
+	viewsByType: function(plugins: PluginStates, type: string) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const output: any[] = [];
+		const output: PluginViewState[] = [];
 
 		for (const pluginId in plugins) {
 			const plugin = plugins[pluginId];


### PR DESCRIPTION
# Summary

This pull request makes it possible for plugins to add buttons to the new note menu on mobile:
<img height="200" alt="screenshot: new note menu includes a 'plugin note' button" src="https://github.com/user-attachments/assets/7e76017c-606f-40d3-8ae7-b279ada49e4c" />

This may be useful for [YesYouKan](https://joplinapp.org/plugins/plugin/org.joplinapp.plugins.YesYouKan/?from-tab=home) and similar plugins that operate on notes in a specific format.

**Note**: Some changes in this pull request (e.g. the addition of `'note.checkboxes'` to `columnNames`) were made automatically by `yarn updatePluginTypes`.

# API

New buttons can be added to the new note menu using the existing `joplin.views.menuItems.create` API:
```ts
	await joplin.commands.register({
		name: 'noteMenuExample',
		label: 'Plugin note',
		iconName: 'fas fa-plus',
		execute: async () => {
			const body = 'A new note from a plugin!';
			joplin.commands.execute('newNote', body);
		},
	});
	await joplin.views.menuItems.create('newNoteMenuItem', 'noteMenuExample', MenuItemLocation.NewNoteMenu);
```

Items with the `MenuItemLocation.NewNoteMenu` API are currently shown on mobile, but not on desktop. `NewNoteMenu` is marked as mobile-only in its documentation string.

# Testing

This pull request has been tested on web by:
1. Building and installing the updated `register_command` plugin.
2. Opening the new note menu.
3. Clicking the new "plugin note" button.
4. Verifying that this creates a new (provisional) note.
5. Pressing the back button.
6. Repeating.

Screen recording:

[Screencast from 2026-02-24 15-30-02.webm](https://github.com/user-attachments/assets/e7a846c1-e58e-4278-8894-dd565d8d0c20)



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->