### PR TITLE
Mobile: Fixes #14452: Make the view / edit note button hidden when an editor plugin is visible

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1843,6 +1843,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		};
 
 		const { editorPlugin: activeEditorPlugin } = getActivePluginEditorView(this.props.plugins, this.props.windowId);
+		const voiceTypingDialogShown = this.state.showSpeechToTextDialog || this.state.showAudioRecorder;
 
 		const header = <ScreenHeader
 			folderPickerOptions={this.folderPickerOptions()}
@@ -1858,7 +1859,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			undoButtonDisabled={!this.state.undoRedoButtonState.canUndo && this.state.undoRedoButtonState.canRedo}
 			onUndoButtonPress={this.screenHeader_undoButtonPress}
 			onRedoButtonPress={this.screenHeader_redoButtonPress}
-			showViewToggleButton={!!this.state.note && !this.state.note.deleted_time}
+			showViewToggleButton={!!this.state.note && !this.state.note.deleted_time && !voiceTypingDialogShown && !editorView}
 			viewToggleIconName={this.state.mode === 'edit' ? 'ionicon book' : 'ionicon pencil'}
 			onViewTogglePress={this.toggleVisiblePanes}
 			title={getDisplayParentTitle(this.state.note, this.state.folder)}

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -1843,7 +1843,6 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		};
 
 		const { editorPlugin: activeEditorPlugin } = getActivePluginEditorView(this.props.plugins, this.props.windowId);
-		const voiceTypingDialogShown = this.state.showSpeechToTextDialog || this.state.showAudioRecorder;
 
 		const header = <ScreenHeader
 			folderPickerOptions={this.folderPickerOptions()}
@@ -1859,7 +1858,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			undoButtonDisabled={!this.state.undoRedoButtonState.canUndo && this.state.undoRedoButtonState.canRedo}
 			onUndoButtonPress={this.screenHeader_undoButtonPress}
 			onRedoButtonPress={this.screenHeader_redoButtonPress}
-			showViewToggleButton={!!this.state.note && !this.state.note.deleted_time && !voiceTypingDialogShown && !editorView}
+			showViewToggleButton={!!this.state.note && !this.state.note.deleted_time && !editorView}
 			viewToggleIconName={this.state.mode === 'edit' ? 'ionicon book' : 'ionicon pencil'}
 			onViewTogglePress={this.toggleVisiblePanes}
 			title={getDisplayParentTitle(this.state.note, this.state.folder)}


### PR DESCRIPTION
This was a missing piece of logic which existed for the original floating edit button, which was not replicated on the new toggle view / edit button. There was also some logic on the original button to hide it when the voice typing dialog was open, but this is not necessary anymore, as the button is no longer covered by this dialog.

This fixes https://github.com/laurent22/joplin/issues/14452

### Testing

**See screenshots:**

<img width="410" height="898" alt="view1" src="https://github.com/user-attachments/assets/ab4bc4e6-2511-4ddc-8fe5-e4ee0e0757b4" />

<img width="411" height="897" alt="view2" src="https://github.com/user-attachments/assets/7eb69a7e-6c7d-498b-a8ef-1ecf238f1f36" />
