### PR TITLE
Web: Resolves #13493 New versions of @sqlite.org/wasm break the web app

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1478,6 +1478,7 @@ packages/lib/services/database/migrations/46.js
 packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
+packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/.gitignore
+++ b/.gitignore
@@ -1451,6 +1451,7 @@ packages/lib/services/database/migrations/46.js
 packages/lib/services/database/migrations/47.js
 packages/lib/services/database/migrations/48.js
 packages/lib/services/database/migrations/49.js
+packages/lib/services/database/migrations/50.js
 packages/lib/services/database/migrations/index.js
 packages/lib/services/database/sqlStringToLines.js
 packages/lib/services/database/types.js

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -109,7 +109,7 @@
     "@react-native/babel-preset": "0.81.6",
     "@react-native/metro-config": "0.81.6",
     "@react-native/typescript-config": "0.81.6",
-    "@sqlite.org/sqlite-wasm": "3.46.0-build2",
+    "@sqlite.org/sqlite-wasm": "3.51.2-build6",
     "@testing-library/react-native": "13.2.0",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.14",

--- a/packages/lib/JoplinDatabase.ts
+++ b/packages/lib/JoplinDatabase.ts
@@ -131,13 +131,13 @@ export interface TableField {
 }
 
 export default class JoplinDatabase extends Database {
-
 	public static TYPE_INT = 1;
 	public static TYPE_TEXT = 2;
 	public static TYPE_NUMERIC = 3;
 
 	private initialized_ = false;
 	private tableFields_: Record<string, TableField[]> = null;
+	private ftsVersion_ = 0;
 	private version_: number = null;
 	private tableFieldNames_: Record<string, string[]> = {};
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -159,7 +159,7 @@ export default class JoplinDatabase extends Database {
 	}
 
 	public tableFieldNames(tableName: string) {
-		if (this.tableFieldNames_[tableName]) return this.tableFieldNames_[tableName].slice();
+		if (this.tableFieldNames_[tableName]) { return this.tableFieldNames_[tableName].slice(); }
 
 		const tf = this.tableFields(tableName);
 		const output = [];
@@ -176,12 +176,15 @@ export default class JoplinDatabase extends Database {
 		if (options === null) options = {};
 
 		if (!this.tableFields_) throw new Error('Fields have not been loaded yet');
-		if (!this.tableFields_[tableName]) throw new Error(`Unknown table: ${tableName}`);
+		if (!this.tableFields_[tableName]) { throw new Error(`Unknown table: ${tableName}`); }
 		const output = this.tableFields_[tableName].slice();
 
 		if (options.includeDescription) {
 			for (let i = 0; i < output.length; i++) {
-				output[i].description = this.fieldDescription(tableName, output[i].name);
+				output[i].description = this.fieldDescription(
+					tableName,
+					output[i].name,
+				);
 			}
 		}
 
@@ -221,9 +224,15 @@ export default class JoplinDatabase extends Database {
 		queries.push('DELETE FROM settings WHERE key="sync.6.context"');
 		queries.push('DELETE FROM settings WHERE key="sync.7.context"');
 
-		queries.push('DELETE FROM settings WHERE key="revisionService.lastProcessedChangeId"');
-		queries.push('DELETE FROM settings WHERE key="resourceService.lastProcessedChangeId"');
-		queries.push('DELETE FROM settings WHERE key="searchEngine.lastProcessedChangeId"');
+		queries.push(
+			'DELETE FROM settings WHERE key="revisionService.lastProcessedChangeId"',
+		);
+		queries.push(
+			'DELETE FROM settings WHERE key="resourceService.lastProcessedChangeId"',
+		);
+		queries.push(
+			'DELETE FROM settings WHERE key="searchEngine.lastProcessedChangeId"',
+		);
 
 		await this.transactionExecBatch(queries);
 	}
@@ -257,12 +266,18 @@ export default class JoplinDatabase extends Database {
 		if (!this.tableDescriptions_) {
 			this.tableDescriptions_ = {
 				notes: {
-					parent_id: sp('ID of the notebook that contains this note. Change this ID to move the note to a different notebook.'),
+					parent_id: sp(
+						'ID of the notebook that contains this note. Change this ID to move the note to a different notebook.',
+					),
 					body: sp('The note body, in Markdown. May also contain HTML.'),
 					is_conflict: sp('Tells whether the note is a conflict or not.'),
 					is_todo: sp('Tells whether this note is a todo or not.'),
-					todo_due: sp('When the todo is due. An alarm will be triggered on that date.'),
-					todo_completed: sp('Tells whether todo is completed or not. This is a timestamp in milliseconds.'),
+					todo_due: sp(
+						'When the todo is due. An alarm will be triggered on that date.',
+					),
+					todo_completed: sp(
+						'Tells whether todo is completed or not. This is a timestamp in milliseconds.',
+					),
 					source_url: sp('The full URL where the note comes from.'),
 					is_shared: sp('Whether the note is published.'),
 				},
@@ -272,7 +287,8 @@ export default class JoplinDatabase extends Database {
 				item_changes: {
 					type: 'The type of change - either 1 (created), 2 (updated) or 3 (deleted)',
 					created_time: 'When the event was generated',
-					item_type: 'The item type (see table above for the list of item types)',
+					item_type:
+            'The item type (see table above for the list of item types)',
 					item_id: 'The item ID',
 					before_change_item: 'Unused',
 					source: 'Unused',
@@ -285,11 +301,26 @@ export default class JoplinDatabase extends Database {
 				const n = baseItems[i];
 				const singular = n.substr(0, n.length - 1);
 				this.tableDescriptions_[n].title = sp('The %s title.', singular);
-				this.tableDescriptions_[n].created_time = sp('When the %s was created.', singular);
-				this.tableDescriptions_[n].updated_time = sp('When the %s was last updated.', singular);
-				this.tableDescriptions_[n].user_created_time = sp('When the %s was created. It may differ from created_time as it can be manually set by the user.', singular);
-				this.tableDescriptions_[n].user_updated_time = sp('When the %s was last updated. It may differ from updated_time as it can be manually set by the user.', singular);
-				this.tableDescriptions_[n].share_id = sp('The ID of the Joplin Server/Cloud share containing the %s. Empty if not shared.', singular);
+				this.tableDescriptions_[n].created_time = sp(
+					'When the %s was created.',
+					singular,
+				);
+				this.tableDescriptions_[n].updated_time = sp(
+					'When the %s was last updated.',
+					singular,
+				);
+				this.tableDescriptions_[n].user_created_time = sp(
+					'When the %s was created. It may differ from created_time as it can be manually set by the user.',
+					singular,
+				);
+				this.tableDescriptions_[n].user_updated_time = sp(
+					'When the %s was last updated. It may differ from updated_time as it can be manually set by the user.',
+					singular,
+				);
+				this.tableDescriptions_[n].share_id = sp(
+					'The ID of the Joplin Server/Cloud share containing the %s. Empty if not shared.',
+					singular,
+				);
 			}
 		}
 
@@ -311,14 +342,18 @@ export default class JoplinDatabase extends Database {
 		const countFieldsNotesFts = await this.countFields('notes_fts');
 		const countFieldsItemsFts = await this.countFields('items_fts');
 		if (countFieldsNotesFts !== countFieldsItemsFts) {
-			throw new Error(`\`notes_fts\` (${countFieldsNotesFts} fields) must have the same number of fields as \`items_fts\` (${countFieldsItemsFts} fields) for the search engine BM25 algorithm to work`);
+			throw new Error(
+				`\`notes_fts\` (${countFieldsNotesFts} fields) must have the same number of fields as \`items_fts\` (${countFieldsItemsFts} fields) for the search engine BM25 algorithm to work`,
+			);
 		}
 
 		interface TableRow {
 			name: string;
 		}
 
-		const tableRows: TableRow[] = await this.selectAll('SELECT name FROM sqlite_master WHERE type=\'table\'');
+		const tableRows: TableRow[] = await this.selectAll(
+			'SELECT name FROM sqlite_master WHERE type=\'table\'',
+		);
 
 		for (let i = 0; i < tableRows.length; i++) {
 			let pragmas: Row[] = [];
@@ -338,7 +373,12 @@ export default class JoplinDatabase extends Database {
 					const item = pragmas[i];
 					// In SQLite, if the default value is a string it has double quotes around it, so remove them here
 					let defaultValue = item.dflt_value;
-					if (typeof defaultValue === 'string' && defaultValue.length >= 2 && defaultValue[0] === '"' && defaultValue[defaultValue.length - 1] === '"') {
+					if (
+						typeof defaultValue === 'string' &&
+            defaultValue.length >= 2 &&
+            defaultValue[0] === '"' &&
+            defaultValue[defaultValue.length - 1] === '"'
+					) {
 						defaultValue = defaultValue.substr(1, defaultValue.length - 2);
 					}
 					const q = Database.insertQuery('table_fields', {
@@ -350,12 +390,17 @@ export default class JoplinDatabase extends Database {
 					queries.push(q);
 				}
 			} catch (error) {
-				error.message = `On table: ${tableName}: Pragma: ${JSON.stringify(pragmas)}: ${error.message}`;
+				error.message = `On table: ${tableName}: Pragma: ${JSON.stringify(
+					pragmas,
+				)}: ${error.message}`;
 				throw error;
 			}
 		}
 
-		queries.push({ sql: 'UPDATE version SET table_fields_version = ?', params: [newVersion] });
+		queries.push({
+			sql: 'UPDATE version SET table_fields_version = ?',
+			params: [newVersion],
+		});
 		await this.transactionExecBatch(queries);
 	}
 
@@ -374,9 +419,17 @@ export default class JoplinDatabase extends Database {
 		// must be set in the synchronizer too.
 
 		// Note: v16 and v17 don't do anything. They were used to debug an issue.
-		const existingDatabaseVersions = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41];
+		const existingDatabaseVersions = [
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+			21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+			39, 40, 41,
+		];
 
-		for (let i = 0; i < migrations.length; i++) existingDatabaseVersions.push(existingDatabaseVersions[existingDatabaseVersions.length - 1] + 1);
+		for (let i = 0; i < migrations.length; i++) {
+			existingDatabaseVersions.push(
+				existingDatabaseVersions[existingDatabaseVersions.length - 1] + 1,
+			);
+		}
 
 		let currentVersionIndex = existingDatabaseVersions.indexOf(fromVersion);
 
@@ -384,15 +437,17 @@ export default class JoplinDatabase extends Database {
 		// version of the database, so that migration is not run in this case.
 		if (currentVersionIndex < 0) {
 			throw new Error(
-				'Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n'
-				+ `Joplin version: ${shim.appVersion()}\n`
-				+ `Profile version: ${fromVersion}\n`
-				+ `Expected version: ${existingDatabaseVersions[existingDatabaseVersions.length - 1]}`);
+				'Unknown profile version. Most likely this is an old version of Joplin, while the profile was created by a newer version. Please upgrade Joplin at https://joplinapp.org and try again.\n' +
+          `Joplin version: ${shim.appVersion()}\n` +
+          `Profile version: ${fromVersion}\n` +
+          `Expected version: ${existingDatabaseVersions[existingDatabaseVersions.length - 1]
+          }`,
+			);
 		}
 
 		this.logger().info(`Upgrading database from version ${fromVersion}`);
 
-		if (currentVersionIndex === existingDatabaseVersions.length - 1) return fromVersion;
+		if (currentVersionIndex === existingDatabaseVersions.length - 1) { return fromVersion; }
 
 		let latestVersion = fromVersion;
 
@@ -400,7 +455,7 @@ export default class JoplinDatabase extends Database {
 			const targetVersion = existingDatabaseVersions[currentVersionIndex + 1];
 			this.logger().info(`Converting database to version ${targetVersion}`);
 
-			let queries: (SqlQuery|string)[] = [];
+			let queries: (SqlQuery | string)[] = [];
 
 			if (targetVersion === 1) {
 				queries = this.wrapQueries(sqlStringToLines(structureSql));
@@ -419,42 +474,69 @@ export default class JoplinDatabase extends Database {
 
 				queries.push({ sql: 'DROP TABLE deleted_items' });
 				queries.push({ sql: sqlStringToLines(newTableSql)[0] });
-				queries.push({ sql: 'CREATE INDEX deleted_items_sync_target ON deleted_items (sync_target)' });
+				queries.push({
+					sql: 'CREATE INDEX deleted_items_sync_target ON deleted_items (sync_target)',
+				});
 			}
 
 			if (targetVersion === 3) {
-				queries = this.alterColumnQueries('settings', { key: 'TEXT PRIMARY KEY', value: 'TEXT' });
+				queries = this.alterColumnQueries('settings', {
+					key: 'TEXT PRIMARY KEY',
+					value: 'TEXT',
+				});
 			}
 
 			if (targetVersion === 4) {
-				queries.push('INSERT INTO settings (`key`, `value`) VALUES (\'sync.3.context\', (SELECT `value` FROM settings WHERE `key` = \'sync.context\'))');
+				queries.push(
+					'INSERT INTO settings (`key`, `value`) VALUES (\'sync.3.context\', (SELECT `value` FROM settings WHERE `key` = \'sync.context\'))',
+				);
 				queries.push('DELETE FROM settings WHERE `key` = \'sync.context\'');
 			}
 
 			if (targetVersion === 5) {
-				const tableNames = ['notes', 'folders', 'tags', 'note_tags', 'resources'];
+				const tableNames = [
+					'notes',
+					'folders',
+					'tags',
+					'note_tags',
+					'resources',
+				];
 				for (let i = 0; i < tableNames.length; i++) {
 					const n = tableNames[i];
-					queries.push(`ALTER TABLE ${n} ADD COLUMN user_created_time INT NOT NULL DEFAULT 0`);
-					queries.push(`ALTER TABLE ${n} ADD COLUMN user_updated_time INT NOT NULL DEFAULT 0`);
+					queries.push(
+						`ALTER TABLE ${n} ADD COLUMN user_created_time INT NOT NULL DEFAULT 0`,
+					);
+					queries.push(
+						`ALTER TABLE ${n} ADD COLUMN user_updated_time INT NOT NULL DEFAULT 0`,
+					);
 					queries.push(`UPDATE ${n} SET user_created_time = created_time`);
 					queries.push(`UPDATE ${n} SET user_updated_time = updated_time`);
-					queries.push(`CREATE INDEX ${n}_user_updated_time ON ${n} (user_updated_time)`);
+					queries.push(
+						`CREATE INDEX ${n}_user_updated_time ON ${n} (user_updated_time)`,
+					);
 				}
 			}
 
 			if (targetVersion === 6) {
-				queries.push('CREATE TABLE alarms (id INTEGER PRIMARY KEY AUTOINCREMENT, note_id TEXT NOT NULL, trigger_time INT NOT NULL)');
+				queries.push(
+					'CREATE TABLE alarms (id INTEGER PRIMARY KEY AUTOINCREMENT, note_id TEXT NOT NULL, trigger_time INT NOT NULL)',
+				);
 				queries.push('CREATE INDEX alarm_note_id ON alarms (note_id)');
 			}
 
 			if (targetVersion === 7) {
-				queries.push('ALTER TABLE resources ADD COLUMN file_extension TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN file_extension TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 8) {
-				queries.push('ALTER TABLE sync_items ADD COLUMN sync_disabled INT NOT NULL DEFAULT "0"');
-				queries.push('ALTER TABLE sync_items ADD COLUMN sync_disabled_reason TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE sync_items ADD COLUMN sync_disabled INT NOT NULL DEFAULT "0"',
+				);
+				queries.push(
+					'ALTER TABLE sync_items ADD COLUMN sync_disabled_reason TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 9) {
@@ -470,16 +552,32 @@ export default class JoplinDatabase extends Database {
 					);
 				`;
 				queries.push(sqlStringToLines(newTableSql)[0]);
-				const tableNames = ['notes', 'folders', 'tags', 'note_tags', 'resources'];
+				const tableNames = [
+					'notes',
+					'folders',
+					'tags',
+					'note_tags',
+					'resources',
+				];
 				for (let i = 0; i < tableNames.length; i++) {
 					const n = tableNames[i];
-					queries.push(`ALTER TABLE ${n} ADD COLUMN encryption_cipher_text TEXT NOT NULL DEFAULT ""`);
-					queries.push(`ALTER TABLE ${n} ADD COLUMN encryption_applied INT NOT NULL DEFAULT 0`);
-					queries.push(`CREATE INDEX ${n}_encryption_applied ON ${n} (encryption_applied)`);
+					queries.push(
+						`ALTER TABLE ${n} ADD COLUMN encryption_cipher_text TEXT NOT NULL DEFAULT ""`,
+					);
+					queries.push(
+						`ALTER TABLE ${n} ADD COLUMN encryption_applied INT NOT NULL DEFAULT 0`,
+					);
+					queries.push(
+						`CREATE INDEX ${n}_encryption_applied ON ${n} (encryption_applied)`,
+					);
 				}
 
-				queries.push('ALTER TABLE sync_items ADD COLUMN force_sync INT NOT NULL DEFAULT 0');
-				queries.push('ALTER TABLE resources ADD COLUMN encryption_blob_encrypted INT NOT NULL DEFAULT 0');
+				queries.push(
+					'ALTER TABLE sync_items ADD COLUMN force_sync INT NOT NULL DEFAULT 0',
+				);
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN encryption_blob_encrypted INT NOT NULL DEFAULT 0',
+				);
 			}
 
 			const upgradeVersion10 = () => {
@@ -504,15 +602,28 @@ export default class JoplinDatabase extends Database {
 				`;
 
 				queries.push(sqlStringToLines(itemChangesTable)[0]);
-				queries.push('CREATE INDEX item_changes_item_id ON item_changes (item_id)');
-				queries.push('CREATE INDEX item_changes_created_time ON item_changes (created_time)');
-				queries.push('CREATE INDEX item_changes_item_type ON item_changes (item_type)');
+				queries.push(
+					'CREATE INDEX item_changes_item_id ON item_changes (item_id)',
+				);
+				queries.push(
+					'CREATE INDEX item_changes_created_time ON item_changes (created_time)',
+				);
+				queries.push(
+					'CREATE INDEX item_changes_item_type ON item_changes (item_type)',
+				);
 
 				queries.push(sqlStringToLines(noteResourcesTable)[0]);
-				queries.push('CREATE INDEX note_resources_note_id ON note_resources (note_id)');
-				queries.push('CREATE INDEX note_resources_resource_id ON note_resources (resource_id)');
+				queries.push(
+					'CREATE INDEX note_resources_note_id ON note_resources (note_id)',
+				);
+				queries.push(
+					'CREATE INDEX note_resources_resource_id ON note_resources (resource_id)',
+				);
 
-				queries.push({ sql: 'INSERT INTO item_changes (item_type, item_id, type, created_time) SELECT 1, id, 1, ? FROM notes', params: [Date.now()] });
+				queries.push({
+					sql: 'INSERT INTO item_changes (item_type, item_id, type, created_time) SELECT 1, id, 1, ? FROM notes',
+					params: [Date.now()],
+				});
 			};
 
 			if (targetVersion === 10) {
@@ -529,13 +640,22 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 12) {
-				queries.push('ALTER TABLE folders ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE folders ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 13) {
-				queries.push('ALTER TABLE resources ADD COLUMN fetch_status INT NOT NULL DEFAULT "2"');
-				queries.push('ALTER TABLE resources ADD COLUMN fetch_error TEXT NOT NULL DEFAULT ""');
-				queries.push({ sql: 'UPDATE resources SET fetch_status = ?', params: [Resource.FETCH_STATUS_DONE] });
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN fetch_status INT NOT NULL DEFAULT "2"',
+				);
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN fetch_error TEXT NOT NULL DEFAULT ""',
+				);
+				queries.push({
+					sql: 'UPDATE resources SET fetch_status = ?',
+					params: [Resource.FETCH_STATUS_DONE],
+				});
 			}
 
 			if (targetVersion === 14) {
@@ -550,10 +670,16 @@ export default class JoplinDatabase extends Database {
 
 				queries.push(sqlStringToLines(resourceLocalStates)[0]);
 
-				queries.push('INSERT INTO resource_local_states SELECT null, id, fetch_status, fetch_error FROM resources');
+				queries.push(
+					'INSERT INTO resource_local_states SELECT null, id, fetch_status, fetch_error FROM resources',
+				);
 
-				queries.push('CREATE INDEX resource_local_states_resource_id ON resource_local_states (resource_id)');
-				queries.push('CREATE INDEX resource_local_states_resource_fetch_status ON resource_local_states (fetch_status)');
+				queries.push(
+					'CREATE INDEX resource_local_states_resource_id ON resource_local_states (resource_id)',
+				);
+				queries.push(
+					'CREATE INDEX resource_local_states_resource_fetch_status ON resource_local_states (fetch_status)',
+				);
 
 				queries = queries.concat(
 					this.alterColumnQueries('resources', {
@@ -574,8 +700,12 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 15) {
-				queries.push('CREATE VIRTUAL TABLE notes_fts USING fts4(content="notes", notindexed="id", id, title, body)');
-				queries.push('INSERT INTO notes_fts(docid, id, title, body) SELECT rowid, id, title, body FROM notes WHERE is_conflict = 0 AND encryption_applied = 0');
+				queries.push(
+					'CREATE VIRTUAL TABLE notes_fts USING fts4(content="notes", notindexed="id", id, title, body)',
+				);
+				queries.push(
+					'INSERT INTO notes_fts(docid, id, title, body) SELECT rowid, id, title, body FROM notes WHERE is_conflict = 0 AND encryption_applied = 0',
+				);
 
 				// Keep the content tables (notes) and the FTS table (notes_fts) in sync.
 				// More info at https://www.sqlite.org/fts3.html#_external_content_fts4_tables_
@@ -608,7 +738,9 @@ export default class JoplinDatabase extends Database {
 
 				queries.push(sqlStringToLines(notesNormalized)[0]);
 
-				queries.push('CREATE INDEX notes_normalized_id ON notes_normalized (id)');
+				queries.push(
+					'CREATE INDEX notes_normalized_id ON notes_normalized (id)',
+				);
 
 				queries.push('DROP TRIGGER IF EXISTS notes_fts_before_update');
 				queries.push('DROP TRIGGER IF EXISTS notes_fts_before_delete');
@@ -616,7 +748,9 @@ export default class JoplinDatabase extends Database {
 				queries.push('DROP TRIGGER IF EXISTS notes_after_insert');
 				queries.push('DROP TABLE IF EXISTS notes_fts');
 
-				queries.push('CREATE VIRTUAL TABLE notes_fts USING fts4(content="notes_normalized", notindexed="id", id, title, body)');
+				queries.push(
+					'CREATE VIRTUAL TABLE notes_fts USING fts4(content="notes_normalized", notindexed="id", id, title, body)',
+				);
 
 				// Keep the content tables (notes) and the FTS table (notes_fts) in sync.
 				// More info at https://www.sqlite.org/fts3.html#_external_content_fts4_tables_
@@ -657,14 +791,26 @@ export default class JoplinDatabase extends Database {
 				`;
 				queries.push(sqlStringToLines(newTableSql)[0]);
 
-				queries.push('CREATE INDEX revisions_parent_id ON revisions (parent_id)');
-				queries.push('CREATE INDEX revisions_item_type ON revisions (item_type)');
+				queries.push(
+					'CREATE INDEX revisions_parent_id ON revisions (parent_id)',
+				);
+				queries.push(
+					'CREATE INDEX revisions_item_type ON revisions (item_type)',
+				);
 				queries.push('CREATE INDEX revisions_item_id ON revisions (item_id)');
-				queries.push('CREATE INDEX revisions_item_updated_time ON revisions (item_updated_time)');
-				queries.push('CREATE INDEX revisions_updated_time ON revisions (updated_time)');
+				queries.push(
+					'CREATE INDEX revisions_item_updated_time ON revisions (item_updated_time)',
+				);
+				queries.push(
+					'CREATE INDEX revisions_updated_time ON revisions (updated_time)',
+				);
 
-				queries.push('ALTER TABLE item_changes ADD COLUMN source INT NOT NULL DEFAULT 1');
-				queries.push('ALTER TABLE item_changes ADD COLUMN before_change_item TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE item_changes ADD COLUMN source INT NOT NULL DEFAULT 1',
+				);
+				queries.push(
+					'ALTER TABLE item_changes ADD COLUMN before_change_item TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 20) {
@@ -678,12 +824,16 @@ export default class JoplinDatabase extends Database {
 				`;
 				queries.push(sqlStringToLines(newTableSql)[0]);
 
-				queries.push('ALTER TABLE resources ADD COLUMN `size` INT NOT NULL DEFAULT -1');
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN `size` INT NOT NULL DEFAULT -1',
+				);
 				queries.push(addMigrationFile(20));
 			}
 
 			if (targetVersion === 21) {
-				queries.push('ALTER TABLE sync_items ADD COLUMN item_location INT NOT NULL DEFAULT 1');
+				queries.push(
+					'ALTER TABLE sync_items ADD COLUMN item_location INT NOT NULL DEFAULT 1',
+				);
 			}
 
 			if (targetVersion === 22) {
@@ -697,8 +847,12 @@ export default class JoplinDatabase extends Database {
 				`;
 				queries.push(sqlStringToLines(newTableSql)[0]);
 
-				queries.push('CREATE INDEX resources_to_download_resource_id ON resources_to_download (resource_id)');
-				queries.push('CREATE INDEX resources_to_download_updated_time ON resources_to_download (updated_time)');
+				queries.push(
+					'CREATE INDEX resources_to_download_resource_id ON resources_to_download (resource_id)',
+				);
+				queries.push(
+					'CREATE INDEX resources_to_download_updated_time ON resources_to_download (updated_time)',
+				);
 			}
 
 			if (targetVersion === 23) {
@@ -717,7 +871,9 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 24) {
-				queries.push('ALTER TABLE notes ADD COLUMN `markup_language` INT NOT NULL DEFAULT 1'); // 1: Markdown, 2: HTML
+				queries.push(
+					'ALTER TABLE notes ADD COLUMN `markup_language` INT NOT NULL DEFAULT 1',
+				); // 1: Markdown, 2: HTML
 			}
 
 			if (targetVersion === 25) {
@@ -731,10 +887,18 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 26) {
-				const tableNames = ['notes', 'folders', 'tags', 'note_tags', 'resources'];
+				const tableNames = [
+					'notes',
+					'folders',
+					'tags',
+					'note_tags',
+					'resources',
+				];
 				for (let i = 0; i < tableNames.length; i++) {
 					const n = tableNames[i];
-					queries.push(`ALTER TABLE ${n} ADD COLUMN is_shared INT NOT NULL DEFAULT 0`);
+					queries.push(
+						`ALTER TABLE ${n} ADD COLUMN is_shared INT NOT NULL DEFAULT 0`,
+					);
 				}
 			}
 
@@ -747,7 +911,9 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 29) {
-				queries.push('ALTER TABLE version ADD COLUMN table_fields_version INT NOT NULL DEFAULT 0');
+				queries.push(
+					'ALTER TABLE version ADD COLUMN table_fields_version INT NOT NULL DEFAULT 0',
+				);
 			}
 
 			if (targetVersion === 30) {
@@ -791,7 +957,9 @@ export default class JoplinDatabase extends Database {
 				// This empty version is due to the revert of the hierarchical tag feature
 				// We need to keep the version for the users who have upgraded using
 				// the pre-release
-				queries.push('ALTER TABLE tags ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE tags ADD COLUMN parent_id TEXT NOT NULL DEFAULT ""',
+				);
 				// Drop the tag note count view, instead compute note count on the fly
 				// queries.push('DROP VIEW tags_with_note_count');
 				// queries.push(addMigrationFile(31));
@@ -819,7 +987,6 @@ export default class JoplinDatabase extends Database {
 				queries.push('DROP TABLE notes_normalized');
 				queries.push('DROP TABLE notes_fts');
 
-
 				const notesNormalized = `
 					CREATE TABLE notes_normalized (
 						id TEXT NOT NULL,
@@ -839,20 +1006,40 @@ export default class JoplinDatabase extends Database {
 
 				queries.push(sqlStringToLines(notesNormalized)[0]);
 
-				queries.push('CREATE INDEX notes_normalized_id ON notes_normalized (id)');
+				queries.push(
+					'CREATE INDEX notes_normalized_id ON notes_normalized (id)',
+				);
 
-				queries.push('CREATE INDEX notes_normalized_user_created_time ON notes_normalized (user_created_time)');
-				queries.push('CREATE INDEX notes_normalized_user_updated_time ON notes_normalized (user_updated_time)');
-				queries.push('CREATE INDEX notes_normalized_is_todo ON notes_normalized (is_todo)');
-				queries.push('CREATE INDEX notes_normalized_todo_completed ON notes_normalized (todo_completed)');
-				queries.push('CREATE INDEX notes_normalized_parent_id ON notes_normalized (parent_id)');
-				queries.push('CREATE INDEX notes_normalized_latitude ON notes_normalized (latitude)');
-				queries.push('CREATE INDEX notes_normalized_longitude ON notes_normalized (longitude)');
-				queries.push('CREATE INDEX notes_normalized_altitude ON notes_normalized (altitude)');
-				queries.push('CREATE INDEX notes_normalized_source_url ON notes_normalized (source_url)');
+				queries.push(
+					'CREATE INDEX notes_normalized_user_created_time ON notes_normalized (user_created_time)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_user_updated_time ON notes_normalized (user_updated_time)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_is_todo ON notes_normalized (is_todo)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_todo_completed ON notes_normalized (todo_completed)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_parent_id ON notes_normalized (parent_id)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_latitude ON notes_normalized (latitude)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_longitude ON notes_normalized (longitude)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_altitude ON notes_normalized (altitude)',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_source_url ON notes_normalized (source_url)',
+				);
 
-				const tableFields = 'id, title, body, user_created_time, user_updated_time, is_todo, todo_completed, parent_id, latitude, longitude, altitude, source_url';
-
+				const tableFields =
+          'id, title, body, user_created_time, user_updated_time, is_todo, todo_completed, parent_id, latitude, longitude, altitude, source_url';
 
 				const newVirtualTableSql = `
 					CREATE VIRTUAL TABLE notes_fts USING fts4(
@@ -868,9 +1055,7 @@ export default class JoplinDatabase extends Database {
 						notindexed="altitude",
 						notindexed="source_url",
 						${tableFields}
-					);`
-				;
-
+					);`;
 				queries.push(sqlStringToLines(newVirtualTableSql)[0]);
 
 				queries.push(`
@@ -893,20 +1078,32 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 34) {
-				queries.push('CREATE VIRTUAL TABLE search_aux USING fts4aux(notes_fts)');
+				queries.push(
+					'CREATE VIRTUAL TABLE search_aux USING fts4aux(notes_fts)',
+				);
 				queries.push('CREATE VIRTUAL TABLE notes_spellfix USING spellfix1');
 			}
 
 			if (targetVersion === 35) {
-				queries.push('ALTER TABLE notes_normalized ADD COLUMN todo_due INT NOT NULL DEFAULT 0');
-				queries.push('CREATE INDEX notes_normalized_todo_due ON notes_normalized (todo_due)');
+				queries.push(
+					'ALTER TABLE notes_normalized ADD COLUMN todo_due INT NOT NULL DEFAULT 0',
+				);
+				queries.push(
+					'CREATE INDEX notes_normalized_todo_due ON notes_normalized (todo_due)',
+				);
 				queries.push(addMigrationFile(35));
 			}
 
 			if (targetVersion === 36) {
-				queries.push('ALTER TABLE folders ADD COLUMN share_id TEXT NOT NULL DEFAULT ""');
-				queries.push('ALTER TABLE notes ADD COLUMN share_id TEXT NOT NULL DEFAULT ""');
-				queries.push('ALTER TABLE resources ADD COLUMN share_id TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE folders ADD COLUMN share_id TEXT NOT NULL DEFAULT ""',
+				);
+				queries.push(
+					'ALTER TABLE notes ADD COLUMN share_id TEXT NOT NULL DEFAULT ""',
+				);
+				queries.push(
+					'ALTER TABLE resources ADD COLUMN share_id TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 38) {
@@ -922,17 +1119,27 @@ export default class JoplinDatabase extends Database {
 			}
 
 			if (targetVersion === 39) {
-				queries.push('ALTER TABLE `notes` ADD COLUMN conflict_original_id TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE `notes` ADD COLUMN conflict_original_id TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 40) {
-				queries.push('ALTER TABLE `folders` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""');
-				queries.push('ALTER TABLE `notes` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""');
-				queries.push('ALTER TABLE `resources` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE `folders` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""',
+				);
+				queries.push(
+					'ALTER TABLE `notes` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""',
+				);
+				queries.push(
+					'ALTER TABLE `resources` ADD COLUMN master_key_id TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion === 41) {
-				queries.push('ALTER TABLE `folders` ADD COLUMN icon TEXT NOT NULL DEFAULT ""');
+				queries.push(
+					'ALTER TABLE `folders` ADD COLUMN icon TEXT NOT NULL DEFAULT ""',
+				);
 			}
 
 			if (targetVersion > 41) {
@@ -942,7 +1149,10 @@ export default class JoplinDatabase extends Database {
 				queries = queries.concat(migrationQueries);
 			}
 
-			const updateVersionQuery = { sql: 'UPDATE version SET version = ?', params: [targetVersion] };
+			const updateVersionQuery = {
+				sql: 'UPDATE version SET version = ?',
+				params: [targetVersion],
+			};
 
 			queries.push(updateVersionQuery);
 
@@ -954,8 +1164,16 @@ export default class JoplinDatabase extends Database {
 				// migration is not repeated on next upgrade.
 				let saveVersionAgain = false;
 
-				if (targetVersion === 15 || targetVersion === 18 || targetVersion === 33) {
-					this.logger().warn('Could not upgrade to database v15 or v18 or v33 - FTS feature will not be used', error);
+				if (
+					targetVersion === 15 ||
+          targetVersion === 18 ||
+          targetVersion === 33 ||
+          targetVersion === 50
+				) {
+					this.logger().warn(
+						'Could not upgrade to database v15 or v18 or v33 or v50 - FTS feature will not be used',
+						error,
+					);
 					saveVersionAgain = true;
 				} else if (targetVersion === 34) {
 					// if (!shim.isTestingEnv()) this.logger().warn('Could not upgrade to database v34 - fuzzy search will not be used', error);
@@ -965,7 +1183,9 @@ export default class JoplinDatabase extends Database {
 				}
 
 				if (saveVersionAgain) {
-					this.logger().info('Migration failed with fallback and will not be repeated - saving version number');
+					this.logger().info(
+						'Migration failed with fallback and will not be repeated - saving version number',
+					);
 					await this.transactionExecBatch([updateVersionQuery]);
 				}
 			}
@@ -1006,6 +1226,26 @@ export default class JoplinDatabase extends Database {
 		return this.version_;
 	}
 
+	public async detectFtsVersion(): Promise<number> {
+		try {
+			const row = await this.selectOne(
+				'SELECT sql FROM sqlite_master WHERE name = \'notes_fts\'',
+			);
+			if (!row || !row.sql) return 0;
+			const sql: string = row.sql;
+			if (sql.indexOf('fts5') >= 0) return 5;
+			if (sql.indexOf('fts4') >= 0) return 4;
+			if (sql.indexOf('fts3') >= 0) return 3;
+			return 0;
+		} catch (_e) {
+			return 0;
+		}
+	}
+
+	public ftsVersion() {
+		return this.ftsVersion_;
+	}
+
 	public async initialize() {
 		this.logger().info('Checking for database schema update...');
 
@@ -1014,7 +1254,10 @@ export default class JoplinDatabase extends Database {
 			// Will throw if the database has not been created yet, but this is handled below
 			versionRow = await this.selectOne('SELECT * FROM version LIMIT 1');
 		} catch (error) {
-			if (error.message && error.message.indexOf('no such table: version') >= 0) {
+			if (
+				error.message &&
+        error.message.indexOf('no such table: version') >= 0
+			) {
 				// Ignore
 			} else {
 				this.logger().info(error);
@@ -1022,24 +1265,32 @@ export default class JoplinDatabase extends Database {
 		}
 
 		const version = !versionRow ? 0 : versionRow.version;
-		const tableFieldsVersion = !versionRow ? 0 : versionRow.table_fields_version;
+		const tableFieldsVersion = !versionRow
+			? 0
+			: versionRow.table_fields_version;
 		this.version_ = version;
 		this.logger().info('Current database version', versionRow);
 
 		const newVersion = await this.upgradeDatabase(version);
 		this.version_ = newVersion;
 
-		this.logger().info(`New version: ${newVersion}. Previously recorded version: ${tableFieldsVersion}`);
+		this.ftsVersion_ = await this.detectFtsVersion();
+		this.logger().info(`FTS version: ${this.ftsVersion_}`);
 
-		if (newVersion !== tableFieldsVersion) await this.refreshTableFields(newVersion);
+		this.logger().info(
+			`New version: ${newVersion}. Previously recorded version: ${tableFieldsVersion}`,
+		);
+
+		if (newVersion !== tableFieldsVersion) { await this.refreshTableFields(newVersion); }
 
 		this.tableFields_ = {};
 
 		const rows = await this.selectAll('SELECT * FROM table_fields');
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		for (let i = 0; i < rows.length; i++) {
 			const row = rows[i];
-			if (!this.tableFields_[row.table_name]) this.tableFields_[row.table_name] = [];
+			if (!this.tableFields_[row.table_name]) { this.tableFields_[row.table_name] = []; }
 			this.tableFields_[row.table_name].push({
 				name: row.field_name,
 				type: row.field_type,

--- a/packages/lib/services/database/migrations/50.ts
+++ b/packages/lib/services/database/migrations/50.ts
@@ -1,0 +1,240 @@
+import sqlStringToLines from '../sqlStringToLines';
+import { SqlQuery } from '../types';
+
+// Migrates FTS4 virtual tables to FTS5. Newer versions of @sqlite.org/sqlite-wasm
+// (>= 3.50.4-build1) no longer include FTS3/FTS4 and only include FTS5.
+// See: https://sqlite.org/forum/forumpost/a2e090e3a0
+export default (): (SqlQuery | string)[] => {
+	const queries: (SqlQuery | string)[] = [];
+
+	// Drop existing FTS4 triggers for notes
+	queries.push('DROP TRIGGER IF EXISTS notes_fts_before_update');
+	queries.push('DROP TRIGGER IF EXISTS notes_fts_before_delete');
+	queries.push('DROP TRIGGER IF EXISTS notes_after_update');
+	queries.push('DROP TRIGGER IF EXISTS notes_after_insert');
+
+	// Drop existing FTS4 triggers for items
+	queries.push('DROP TRIGGER IF EXISTS items_fts_before_update');
+	queries.push('DROP TRIGGER IF EXISTS items_fts_before_delete');
+	queries.push('DROP TRIGGER IF EXISTS items_after_update');
+	queries.push('DROP TRIGGER IF EXISTS items_after_insert');
+
+	// Drop existing FTS4 virtual tables
+	queries.push('DROP TABLE IF EXISTS search_aux');
+	queries.push('DROP TABLE IF EXISTS notes_fts');
+	queries.push('DROP TABLE IF EXISTS items_fts');
+
+	// Drop FTS4 shadow tables explicitly. When the FTS4 module is not available
+	// (e.g. newer @sqlite.org/sqlite-wasm), DROP TABLE on the virtual table
+	// may not clean up shadow tables, which would conflict with FTS5 shadow
+	// table names.
+	queries.push('DROP TABLE IF EXISTS notes_fts_content');
+	queries.push('DROP TABLE IF EXISTS notes_fts_segments');
+	queries.push('DROP TABLE IF EXISTS notes_fts_segdir');
+	queries.push('DROP TABLE IF EXISTS notes_fts_stat');
+	queries.push('DROP TABLE IF EXISTS notes_fts_docsize');
+
+	queries.push('DROP TABLE IF EXISTS items_fts_content');
+	queries.push('DROP TABLE IF EXISTS items_fts_segments');
+	queries.push('DROP TABLE IF EXISTS items_fts_segdir');
+	queries.push('DROP TABLE IF EXISTS items_fts_stat');
+	queries.push('DROP TABLE IF EXISTS items_fts_docsize');
+
+	// Create notes_normalized if it doesn't exist. It may be missing if
+	// migration 33 failed (e.g. FTS4 was not available on web).
+	const notesNormalized = `
+		CREATE TABLE IF NOT EXISTS notes_normalized (
+			id TEXT NOT NULL,
+			title TEXT NOT NULL DEFAULT "",
+			body TEXT NOT NULL DEFAULT "",
+			user_created_time INT NOT NULL DEFAULT 0,
+			user_updated_time INT NOT NULL DEFAULT 0,
+			is_todo INT NOT NULL DEFAULT 0,
+			todo_completed INT NOT NULL DEFAULT 0,
+			parent_id TEXT NOT NULL DEFAULT "",
+			latitude NUMERIC NOT NULL DEFAULT 0,
+			longitude NUMERIC NOT NULL DEFAULT 0,
+			altitude NUMERIC NOT NULL DEFAULT 0,
+			source_url TEXT NOT NULL DEFAULT "",
+			todo_due INT NOT NULL DEFAULT 0
+		);
+	`;
+
+	queries.push(sqlStringToLines(notesNormalized)[0]);
+
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_id ON notes_normalized (id)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_user_created_time ON notes_normalized (user_created_time)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_user_updated_time ON notes_normalized (user_updated_time)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_is_todo ON notes_normalized (is_todo)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_todo_completed ON notes_normalized (todo_completed)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_parent_id ON notes_normalized (parent_id)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_latitude ON notes_normalized (latitude)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_longitude ON notes_normalized (longitude)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_altitude ON notes_normalized (altitude)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_source_url ON notes_normalized (source_url)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS notes_normalized_todo_due ON notes_normalized (todo_due)',
+	);
+
+	// Create items_normalized if it doesn't exist. It may be missing if
+	// migration 45 failed (e.g. FTS4 was not available on web).
+	const itemsNormalized = `
+		CREATE TABLE IF NOT EXISTS items_normalized (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			title TEXT NOT NULL DEFAULT "",
+			body TEXT NOT NULL DEFAULT "",
+			item_id TEXT NOT NULL,
+			item_type INT NOT NULL,
+			user_updated_time INT NOT NULL DEFAULT 0,
+			reserved1 INT NULL,
+			reserved2 INT NULL,
+			reserved3 INT NULL,
+			reserved4 INT NULL,
+			reserved5 INT NULL,
+			reserved6 INT NULL
+		);
+	`;
+
+	queries.push(sqlStringToLines(itemsNormalized)[0]);
+
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS items_normalized_id ON items_normalized (id)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS items_normalized_item_id ON items_normalized (item_id)',
+	);
+	queries.push(
+		'CREATE INDEX IF NOT EXISTS items_normalized_item_type ON items_normalized (item_type)',
+	);
+
+	// Create FTS5 virtual table for notes
+	const noteTableFields =
+    'id, title, body, user_created_time, user_updated_time, is_todo, todo_completed, parent_id, latitude, longitude, altitude, source_url';
+
+	const notesFts5 = `
+		CREATE VIRTUAL TABLE notes_fts USING fts5(
+			id UNINDEXED,
+			title,
+			body,
+			user_created_time UNINDEXED,
+			user_updated_time UNINDEXED,
+			is_todo UNINDEXED,
+			todo_completed UNINDEXED,
+			parent_id UNINDEXED,
+			latitude UNINDEXED,
+			longitude UNINDEXED,
+			altitude UNINDEXED,
+			source_url UNINDEXED,
+			content='notes_normalized',
+			content_rowid='rowid'
+		);
+	`;
+
+	queries.push(sqlStringToLines(notesFts5)[0]);
+
+	// FTS5 triggers for notes. FTS5 uses a special "delete" command
+	// instead of DELETE FROM for content-sync tables.
+	queries.push(`
+		CREATE TRIGGER notes_fts_before_update BEFORE UPDATE ON notes_normalized BEGIN
+			INSERT INTO notes_fts(notes_fts, rowid, ${noteTableFields})
+			VALUES('delete', old.rowid, old.id, old.title, old.body, old.user_created_time, old.user_updated_time, old.is_todo, old.todo_completed, old.parent_id, old.latitude, old.longitude, old.altitude, old.source_url);
+		END`);
+	queries.push(`
+		CREATE TRIGGER notes_fts_before_delete BEFORE DELETE ON notes_normalized BEGIN
+			INSERT INTO notes_fts(notes_fts, rowid, ${noteTableFields})
+			VALUES('delete', old.rowid, old.id, old.title, old.body, old.user_created_time, old.user_updated_time, old.is_todo, old.todo_completed, old.parent_id, old.latitude, old.longitude, old.altitude, old.source_url);
+		END`);
+	queries.push(`
+		CREATE TRIGGER notes_after_update AFTER UPDATE ON notes_normalized BEGIN
+			INSERT INTO notes_fts(rowid, ${noteTableFields}) SELECT rowid, ${noteTableFields} FROM notes_normalized WHERE new.rowid = notes_normalized.rowid;
+		END`);
+	queries.push(`
+		CREATE TRIGGER notes_after_insert AFTER INSERT ON notes_normalized BEGIN
+			INSERT INTO notes_fts(rowid, ${noteTableFields}) SELECT rowid, ${noteTableFields} FROM notes_normalized WHERE new.rowid = notes_normalized.rowid;
+		END`);
+
+	// Create FTS5 virtual table for items
+	const itemTableFields =
+    'id, title, body, item_id, item_type, user_updated_time, reserved1, reserved2, reserved3, reserved4, reserved5, reserved6';
+
+	const itemsFts5 = `
+		CREATE VIRTUAL TABLE items_fts USING fts5(
+			id UNINDEXED,
+			title,
+			body,
+			item_id UNINDEXED,
+			item_type UNINDEXED,
+			user_updated_time UNINDEXED,
+			reserved1 UNINDEXED,
+			reserved2 UNINDEXED,
+			reserved3 UNINDEXED,
+			reserved4 UNINDEXED,
+			reserved5 UNINDEXED,
+			reserved6 UNINDEXED,
+			content='items_normalized',
+			content_rowid='rowid'
+		);
+	`;
+
+	queries.push(sqlStringToLines(itemsFts5)[0]);
+
+	// FTS5 triggers for items
+	queries.push(`
+		CREATE TRIGGER items_fts_before_update BEFORE UPDATE ON items_normalized BEGIN
+			INSERT INTO items_fts(items_fts, rowid, ${itemTableFields})
+			VALUES('delete', old.rowid, old.id, old.title, old.body, old.item_id, old.item_type, old.user_updated_time, old.reserved1, old.reserved2, old.reserved3, old.reserved4, old.reserved5, old.reserved6);
+		END`);
+	queries.push(`
+		CREATE TRIGGER items_fts_before_delete BEFORE DELETE ON items_normalized BEGIN
+			INSERT INTO items_fts(items_fts, rowid, ${itemTableFields})
+			VALUES('delete', old.rowid, old.id, old.title, old.body, old.item_id, old.item_type, old.user_updated_time, old.reserved1, old.reserved2, old.reserved3, old.reserved4, old.reserved5, old.reserved6);
+		END`);
+	queries.push(`
+		CREATE TRIGGER items_after_update AFTER UPDATE ON items_normalized BEGIN
+			INSERT INTO items_fts(rowid, ${itemTableFields}) SELECT rowid, ${itemTableFields} FROM items_normalized WHERE new.rowid = items_normalized.rowid;
+		END`);
+	queries.push(`
+		CREATE TRIGGER items_after_insert AFTER INSERT ON items_normalized BEGIN
+			INSERT INTO items_fts(rowid, ${itemTableFields}) SELECT rowid, ${itemTableFields} FROM items_normalized WHERE new.rowid = items_normalized.rowid;
+		END`);
+
+	// Reset search engine indexing to force re-index with the new FTS5 tables
+	queries.push({
+		sql: 'UPDATE settings SET value = \'0\' WHERE key = \'searchEngine.initialIndexingDone\'',
+		params: [],
+	});
+	queries.push({
+		sql: 'UPDATE settings SET value = \'0\' WHERE key = \'searchEngine.lastProcessedChangeId\'',
+		params: [],
+	});
+	queries.push({
+		sql: 'UPDATE settings SET value = \'\' WHERE key = \'searchEngine.lastProcessedResource\'',
+		params: [],
+	});
+	queries.push({
+		sql: 'UPDATE settings SET value = \'-1\' WHERE key = \'db.ftsEnabled\'',
+		params: [],
+	});
+
+	return queries;
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -7,6 +7,7 @@ import migration46 from './46';
 import migration47 from './47';
 import migration48 from './48';
 import migration49 from './49';
+import migration50 from './50';
 
 import { Migration } from '../types';
 
@@ -19,6 +20,7 @@ const index: Migration[] = [
 	migration47,
 	migration48,
 	migration49,
+	migration50,
 ];
 
 export default index;

--- a/packages/lib/services/search/SearchEngine.ts
+++ b/packages/lib/services/search/SearchEngine.ts
@@ -45,11 +45,14 @@ export interface ProcessResultsRow {
 	id: string;
 	parent_id: string;
 	title: string;
-	offsets: string;
+	offsets?: string;
 	item_id: string;
 	user_updated_time: number;
 	user_created_time: number;
-	matchinfo: Buffer;
+	matchinfo?: Buffer;
+	rank?: number;
+	title_matched?: number;
+	body_matched?: number;
 	item_type?: ModelType;
 	fields?: string[];
 	weight?: number;
@@ -83,9 +86,9 @@ export interface ParsedQuery {
 }
 
 export default class SearchEngine {
-
 	public static instance_: SearchEngine = null;
-	public static relevantFields = 'id, title, body, user_created_time, user_updated_time, is_todo, todo_completed, todo_due, parent_id, latitude, longitude, altitude, source_url';
+	public static relevantFields =
+		'id, title, body, user_created_time, user_updated_time, is_todo, todo_completed, todo_due, parent_id, latitude, longitude, altitude, source_url';
 	public static SEARCH_TYPE_AUTO = SearchType.Auto;
 	public static SEARCH_TYPE_BASIC = SearchType.Basic;
 	public static SEARCH_TYPE_NONLATIN_SCRIPT = SearchType.Nonlatin;
@@ -137,8 +140,10 @@ export default class SearchEngine {
 	}
 
 	private async doInitialNoteIndexing_() {
-		const notes = await this.db().selectAll<NoteEntity>('SELECT id FROM notes WHERE is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0');
-		const noteIds = notes.map(n => n.id);
+		const notes = await this.db().selectAll<NoteEntity>(
+			'SELECT id FROM notes WHERE is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0',
+		);
+		const noteIds = notes.map((n) => n.id);
 
 		const lastChangeId = await ItemChange.lastChangeId();
 
@@ -150,17 +155,34 @@ export default class SearchEngine {
 			const notes = await Note.modelSelectAll(`
 				SELECT ${SearchEngine.relevantFields}
 				FROM notes
-				WHERE id IN (${BaseModel.escapeIdsForSql(currentIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`);
+				WHERE id IN (${BaseModel.escapeIdsForSql(
+		currentIds,
+	)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`);
 			const queries = [];
 
 			for (let i = 0; i < notes.length; i++) {
 				const note = notes[i];
 				const n = this.normalizeNote_(note);
-				queries.push({ sql: `
+				queries.push({
+					sql: `
 				INSERT INTO notes_normalized(${SearchEngine.relevantFields})
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				params: [n.id, n.title, n.body, n.user_created_time, n.user_updated_time, n.is_todo, n.todo_completed, n.todo_due, n.parent_id, n.latitude, n.longitude, n.altitude, n.source_url] },
-				);
+					params: [
+						n.id,
+						n.title,
+						n.body,
+						n.user_created_time,
+						n.user_updated_time,
+						n.is_todo,
+						n.todo_completed,
+						n.todo_due,
+						n.parent_id,
+						n.latitude,
+						n.longitude,
+						n.altitude,
+						n.source_url,
+					],
+				});
 			}
 
 			await this.db().transactionExecBatch(queries);
@@ -176,7 +198,10 @@ export default class SearchEngine {
 			try {
 				await this.syncTables();
 			} catch (error) {
-				this.logger().error('SearchEngine::scheduleSyncTables: Error while syncing tables:', error);
+				this.logger().error(
+					'SearchEngine::scheduleSyncTables: Error while syncing tables:',
+					error,
+				);
 			}
 			this.scheduleSyncTablesIID_ = null;
 		}, 10000);
@@ -232,28 +257,54 @@ export default class SearchEngine {
 
 				const queries = [];
 
-				const noteIds = changes.map(a => a.item_id);
+				const noteIds = changes.map((a) => a.item_id);
 				const notes = await Note.modelSelectAll(`
 					SELECT ${SearchEngine.relevantFields}
-					FROM notes WHERE id IN (${Note.escapeIdsForSql(noteIds)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`,
-				);
+					FROM notes WHERE id IN (${Note.escapeIdsForSql(
+		noteIds,
+	)}) AND is_conflict = 0 AND encryption_applied = 0 AND deleted_time = 0`);
 
 				for (let i = 0; i < changes.length; i++) {
 					const change = changes[i];
 
-					if (change.type === ItemChange.TYPE_CREATE || change.type === ItemChange.TYPE_UPDATE) {
-						queries.push({ sql: 'DELETE FROM notes_normalized WHERE id = ?', params: [change.item_id] });
+					if (
+						change.type === ItemChange.TYPE_CREATE ||
+            change.type === ItemChange.TYPE_UPDATE
+					) {
+						queries.push({
+							sql: 'DELETE FROM notes_normalized WHERE id = ?',
+							params: [change.item_id],
+						});
 						const note = this.noteById_(notes, change.item_id);
 						if (note) {
 							const n = this.normalizeNote_(note);
-							queries.push({ sql: `
+							queries.push({
+								sql: `
 							INSERT INTO notes_normalized(${SearchEngine.relevantFields})
 							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-							params: [change.item_id, n.title, n.body, n.user_created_time, n.user_updated_time, n.is_todo, n.todo_completed, n.todo_due, n.parent_id, n.latitude, n.longitude, n.altitude, n.source_url] });
+								params: [
+									change.item_id,
+									n.title,
+									n.body,
+									n.user_created_time,
+									n.user_updated_time,
+									n.is_todo,
+									n.todo_completed,
+									n.todo_due,
+									n.parent_id,
+									n.latitude,
+									n.longitude,
+									n.altitude,
+									n.source_url,
+								],
+							});
 							report.inserted++;
 						}
 					} else if (change.type === ItemChange.TYPE_DELETE) {
-						queries.push({ sql: 'DELETE FROM notes_normalized WHERE id = ?', params: [change.item_id] });
+						queries.push({
+							sql: 'DELETE FROM notes_normalized WHERE id = ?',
+							params: [change.item_id],
+						});
 						report.deleted++;
 					} else {
 						throw new Error(`Invalid change type: ${change.type}`);
@@ -267,7 +318,10 @@ export default class SearchEngine {
 				await Setting.saveAll();
 			}
 		} catch (error) {
-			this.logger().error('SearchEngine: Error while processing changes:', error);
+			this.logger().error(
+				'SearchEngine: Error while processing changes:',
+				error,
+			);
 		}
 
 		await ItemChangeUtils.deleteProcessedChanges();
@@ -277,7 +331,11 @@ export default class SearchEngine {
 			updated_time: number;
 		}
 
-		const lastProcessedResource: LastProcessedResource = !Setting.value('searchEngine.lastProcessedResource') ? { updated_time: 0, id: '' } : JSON.parse(Setting.value('searchEngine.lastProcessedResource'));
+		const lastProcessedResource: LastProcessedResource = !Setting.value(
+			'searchEngine.lastProcessedResource',
+		)
+			? { updated_time: 0, id: '' }
+			: JSON.parse(Setting.value('searchEngine.lastProcessedResource'));
 
 		this.logger().info('Updating items_normalized from', lastProcessedResource);
 
@@ -299,10 +357,7 @@ export default class SearchEngine {
 				for (const resource of resources) {
 					queries.push({
 						sql: 'DELETE FROM items_normalized WHERE item_id = ? AND item_type = ?',
-						params: [
-							resource.id,
-							ModelType.Resource,
-						],
+						params: [resource.id, ModelType.Resource],
 					});
 
 					queries.push({
@@ -325,14 +380,27 @@ export default class SearchEngine {
 				}
 
 				await this.db().transactionExecBatch(queries);
-				Setting.setValue('searchEngine.lastProcessedResource', JSON.stringify(lastProcessedResource));
+				Setting.setValue(
+					'searchEngine.lastProcessedResource',
+					JSON.stringify(lastProcessedResource),
+				);
 				await Setting.saveAll();
 			}
 		} catch (error) {
-			this.logger().error('SearchEngine: Error while processing resources:', error);
+			this.logger().error(
+				'SearchEngine: Error while processing resources:',
+				error,
+			);
 		}
 
-		this.logger().info(sprintf('SearchEngine: Updated FTS table in %dms. Inserted: %d. Deleted: %d', Date.now() - startTime, report.inserted, report.deleted));
+		this.logger().info(
+			sprintf(
+				'SearchEngine: Updated FTS table in %dms. Inserted: %d. Deleted: %d',
+				Date.now() - startTime,
+				report.inserted,
+				report.deleted,
+			),
+		);
 
 		this.isIndexing_ = false;
 		syncTask.onEnd();
@@ -355,7 +423,8 @@ export default class SearchEngine {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private fieldNamesFromOffsets_(offsets: any[]) {
-		const notesNormalizedFieldNames = this.db().tableFieldNames('notes_normalized');
+		const notesNormalizedFieldNames =
+      this.db().tableFieldNames('notes_normalized');
 		const occurrenceCount = Math.floor(offsets.length / 4);
 		const output: string[] = [];
 		for (let i = 0; i < occurrenceCount; i++) {
@@ -384,7 +453,7 @@ export default class SearchEngine {
 
 		if (rows.length === 0) return;
 
-		const matchInfo = rows.map(row => new Uint32Array(row.matchinfo.buffer));
+		const matchInfo = rows.map((row) => new Uint32Array(row.matchinfo.buffer));
 		const generalInfo = matchInfo[0];
 
 		const K1 = 1.2;
@@ -402,8 +471,8 @@ export default class SearchEngine {
 		const avgBodyTokens = generalInfo[5];
 		const avgTokens = [null, avgTitleTokens, avgBodyTokens]; // we only need cols 1 and 2
 
-		const numTitleTokens = matchInfo.map(m => m[4 + numColumns]); // l
-		const numBodyTokens = matchInfo.map(m => m[5 + numColumns]);
+		const numTitleTokens = matchInfo.map((m) => m[4 + numColumns]); // l
+		const numBodyTokens = matchInfo.map((m) => m[5 + numColumns]);
 		const numTokens = [null, numTitleTokens, numBodyTokens];
 
 		// In byte size, we have for notes_normalized:
@@ -413,37 +482,35 @@ export default class SearchEngine {
 		// n 1
 		// a 12
 		// l 12
-		const X = matchInfo.map(m => m.slice(1 + 1 + 1 + numColumns + numColumns)); // x
+		const X = matchInfo.map((m) =>
+			m.slice(1 + 1 + 1 + numColumns + numColumns),
+		); // x
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const hitsThisRow = (array: any, c: number, p: number) => array[3 * (c + p * numColumns) + 0];
+		const hitsThisRow = (array: any, c: number, p: number) =>
+			array[3 * (c + p * numColumns) + 0];
 		// const hitsAllRows = (array, c, p) => array[3 * (c + p*NUM_COLS) + 1];
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const docsWithHits = (array: any, c: number, p: number) => array[3 * (c + p * numColumns) + 2];
+		const docsWithHits = (array: any, c: number, p: number) =>
+			array[3 * (c + p * numColumns) + 2];
 
-		const IDF = (n: number, N: number) => Math.max(Math.log(((N - n + 0.5) / (n + 0.5)) + 1), 0);
+		const IDF = (n: number, N: number) =>
+			Math.max(Math.log((N - n + 0.5) / (n + 0.5) + 1), 0);
 
 		// https://en.wikipedia.org/wiki/Okapi_BM25
-		const BM25 = (idf: number, freq: number, numTokens: number, avgTokens: number) => {
+		const BM25 = (
+			idf: number,
+			freq: number,
+			numTokens: number,
+			avgTokens: number,
+		) => {
 			if (avgTokens === 0) {
 				return 0; // To prevent division by zero
 			}
-			return idf * (freq * (K1 + 1)) / (freq + K1 * (1 - B + B * (numTokens / avgTokens)));
-		};
-
-		const msSinceEpoch = Math.round(new Date().getTime());
-		const msPerDay = 86400000;
-		const weightForDaysSinceLastUpdate = (row: ProcessResultsRow) => {
-			// BM25 weights typically range 0-10, and last updated date should weight similarly, though prioritizing recency logarithmically.
-			// An alpha of 200 ensures matches in the last week will show up front (11.59) and often so for matches within 2 weeks (5.99),
-			// but is much less of a factor at 30 days (2.84) or very little after 90 days (0.95), focusing mostly on content at that point.
-			if (!row.user_updated_time) {
-				return 0;
-			}
-
-			const alpha = 200;
-			const daysSinceLastUpdate = (msSinceEpoch - row.user_updated_time) / msPerDay;
-			return alpha * Math.log(1 + 1 / Math.max(daysSinceLastUpdate, 0.5));
+			return (
+				(idf * (freq * (K1 + 1))) /
+        (freq + K1 * (1 - B + B * (numTokens / avgTokens)))
+			);
 		};
 
 		for (let i = 0; i < rows.length; i++) {
@@ -451,23 +518,62 @@ export default class SearchEngine {
 			row.weight = 0;
 			for (let j = 0; j < numPhrases; j++) {
 				// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-				columns.forEach(column => {
+				columns.forEach((column) => {
 					const rowsWithHits = docsWithHits(X[i], column, j);
 					const frequencyHits = hitsThisRow(X[i], column, j);
 					const idf = IDF(rowsWithHits, numRows);
 
-					row.weight += BM25(idf, frequencyHits, numTokens[column][i], avgTokens[column]);
+					row.weight += BM25(
+						idf,
+						frequencyHits,
+						numTokens[column][i],
+						avgTokens[column],
+					);
 				});
 			}
 
-			row.weight += weightForDaysSinceLastUpdate(row);
+			row.weight += this.weightForDaysSinceLastUpdate_(row);
 		}
+	}
+
+	private weightForDaysSinceLastUpdate_(row: ProcessResultsRow) {
+		// BM25 weights typically range 0-10, and last updated date should weight similarly, though prioritizing recency logarithmically.
+		// An alpha of 200 ensures matches in the last week will show up front (11.59) and often so for matches within 2 weeks (5.99),
+		// but is much less of a factor at 30 days (2.84) or very little after 90 days (0.95), focusing mostly on content at that point.
+		if (!row.user_updated_time) {
+			return 0;
+		}
+
+		const msSinceEpoch = Math.round(new Date().getTime());
+		const msPerDay = 86400000;
+		const alpha = 200;
+		const daysSinceLastUpdate =
+      (msSinceEpoch - row.user_updated_time) / msPerDay;
+		return alpha * Math.log(1 + 1 / Math.max(daysSinceLastUpdate, 0.5));
+	}
+
+	private processFts5Results_(rows: ProcessResultsRow[]) {
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i];
+			// FTS5 rank is negative BM25, so negate it
+			row.weight = -(row.rank || 0);
+			row.weight += this.weightForDaysSinceLastUpdate_(row);
+			row.fields = this.detectMatchedFieldsFts5_(row);
+		}
+	}
+
+	private detectMatchedFieldsFts5_(row: ProcessResultsRow): string[] {
+		const fields: string[] = [];
+		if (row.title_matched) fields.push('title');
+		if (row.body_matched) fields.push('body');
+		return fields;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private processBasicSearchResults_(rows: any[], parsedQuery: any) {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const valueRegexs = parsedQuery.keys.includes('_') ? parsedQuery.terms['_'].map((term: any) => term.valueRegex || term.value) : [];
+		const valueRegexs = parsedQuery.keys.includes('_')
+			? parsedQuery.terms['_'].map((term: string | ComplexTerm) => (typeof term === 'string' ? term : (term.valueRegex || term.value)))
+			: [];
 		const isTitleSearch = parsedQuery.keys.includes('title');
 		const isOnlyTitle = parsedQuery.keys.length === 1 && isTitleSearch;
 
@@ -481,17 +587,24 @@ export default class SearchEngine {
 				body: !isOnlyTitle,
 			};
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			row.fields = Object.keys(matchedFields).filter((key: any) => matchedFields[key]);
+			row.fields = Object.keys(matchedFields).filter(
+				(key: string) => matchedFields[key],
+			);
 			row.weight = 0;
 			row.fuzziness = 0;
 		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	private processResults_(rows: ProcessResultsRow[], parsedQuery: any, isBasicSearchResults = false) {
+	private processResults_(
+		rows: ProcessResultsRow[],
+		parsedQuery: ParsedQuery,
+		isBasicSearchResults = false,
+	) {
 		if (isBasicSearchResults) {
 			this.processBasicSearchResults_(rows, parsedQuery);
+		} else if (this.db().ftsVersion() >= 5) {
+			this.processFts5Results_(rows);
 		} else {
 			this.calculateWeightBM25_(rows);
 			for (let i = 0; i < rows.length; i++) {
@@ -531,7 +644,10 @@ export default class SearchEngine {
 
 		let regexString = pregQuote(term);
 		if (regexString[regexString.length - 1] === '*') {
-			regexString = `${regexString.substr(0, regexString.length - 2)}[^${pregQuote(' \t\n\r,.,+-*?!={}<>|:"\'()[]')}]` + '*?';
+			regexString =
+				`${regexString.substr(0, regexString.length - 2)}[^${pregQuote(
+					' \t\n\r,.,+-*?!={}<>|:"\'()[]',
+				)}]` + '*?';
 			// regexString = regexString.substr(0, regexString.length - 2) + '.*?';
 		}
 
@@ -539,8 +655,8 @@ export default class SearchEngine {
 	}
 
 	public async parseQuery(query: string): Promise<ParsedQuery> {
-
-		const trimQuotes = (str: string) => str.startsWith('"') ? str.substr(1, str.length - 2) : str;
+		const trimQuotes = (str: string) =>
+			str.startsWith('"') ? str.substr(1, str.length - 2) : str;
 
 		let allTerms: Term[] = [];
 
@@ -554,11 +670,17 @@ export default class SearchEngine {
 			console.warn(error);
 		}
 
-		const textTerms = allTerms.filter(x => x.name === 'text' && !x.negated).map(x => trimQuotes(x.value));
-		const titleTerms = allTerms.filter(x => x.name === 'title' && !x.negated).map(x => trimQuotes(x.value));
-		const bodyTerms = allTerms.filter(x => x.name === 'body' && !x.negated).map(x => trimQuotes(x.value));
+		const textTerms = allTerms
+			.filter((x) => x.name === 'text' && !x.negated)
+			.map((x) => trimQuotes(x.value));
+		const titleTerms = allTerms
+			.filter((x) => x.name === 'title' && !x.negated)
+			.map((x) => trimQuotes(x.value));
+		const bodyTerms = allTerms
+			.filter((x) => x.name === 'body' && !x.negated)
+			.map((x) => trimQuotes(x.value));
 
-		const terms: Terms = { _: textTerms, 'title': titleTerms, 'body': bodyTerms };
+		const terms: Terms = { _: textTerms, title: titleTerms, body: bodyTerms };
 
 		// Filter terms:
 		// - Convert wildcards to regex
@@ -587,9 +709,18 @@ export default class SearchEngine {
 				}
 
 				if (term.indexOf('*') >= 0) {
-					terms[col][i] = { type: 'regex', value: term, scriptType: scriptType(term), valueRegex: this.queryTermToRegex(term) };
+					terms[col][i] = {
+						type: 'regex',
+						value: term,
+						scriptType: scriptType(term),
+						valueRegex: this.queryTermToRegex(term),
+					};
 				} else {
-					terms[col][i] = { type: 'text', value: term, scriptType: scriptType(term) };
+					terms[col][i] = {
+						type: 'text',
+						value: term,
+						scriptType: scriptType(term),
+					};
 				}
 			}
 
@@ -611,7 +742,7 @@ export default class SearchEngine {
 		// diacritics.
 		//
 
-		allTerms = allTerms.map(x => {
+		allTerms = allTerms.map((x) => {
 			if (x.name === 'text' || x.name === 'title' || x.name === 'body') {
 				return { ...x, value: this.normalizeText_(x.value) };
 			}
@@ -623,7 +754,7 @@ export default class SearchEngine {
 			keys: keys,
 			terms: terms, // text terms
 			allTerms: allTerms,
-			any: !!allTerms.find(term => term.name === 'any'),
+			any: !!allTerms.find((term) => term.name === 'any'),
 		};
 	}
 
@@ -664,7 +795,10 @@ export default class SearchEngine {
 			// We log additional information to help determine the cause of the issue.
 			//
 			// See https://discourse.joplinapp.org/t/search-not-working-on-ios/35754
-			this.logger().error(`Error while normalizing text for note ${note.id}:`, error);
+			this.logger().error(
+				`Error while normalizing text for note ${note.id}:`,
+				error,
+			);
 
 			// Unnormalized text can break the search engine, specifically NUL characters.
 			// Thus, we remove the text entirely.
@@ -685,7 +819,9 @@ export default class SearchEngine {
 			if ((parsedQuery.terms as any)[key].length === 0) continue;
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const term = (parsedQuery.terms as any)[key].map((x: Term) => x.value).join(' ');
+			const term = (parsedQuery.terms as any)[key]
+				.map((x: Term) => x.value)
+				.join(' ');
 			if (key === '_') searchOptions.anywherePattern = `*${term}*`;
 			if (key === 'title') searchOptions.titlePattern = `*${term}*`;
 			if (key === 'body') searchOptions.bodyPattern = `*${term}*`;
@@ -696,8 +832,8 @@ export default class SearchEngine {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private determineSearchType_(query: string, preferredSearchType: any) {
-		if (preferredSearchType === SearchEngine.SEARCH_TYPE_BASIC) return SearchEngine.SEARCH_TYPE_BASIC;
-		if (preferredSearchType === SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT) return SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT;
+		if (preferredSearchType === SearchEngine.SEARCH_TYPE_BASIC) { return SearchEngine.SEARCH_TYPE_BASIC; }
+		if (preferredSearchType === SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT) { return SearchEngine.SEARCH_TYPE_NONLATIN_SCRIPT; }
 
 		// If preferredSearchType is "fts" we auto-detect anyway
 		// because it's not always supported.
@@ -710,7 +846,12 @@ export default class SearchEngine {
 			console.warn(error);
 		}
 
-		const textQuery = allTerms.filter(x => x.name === 'text' || x.name === 'title' || x.name === 'body').map(x => x.value).join(' ');
+		const textQuery = allTerms
+			.filter(
+				(x) => x.name === 'text' || x.name === 'title' || x.name === 'body',
+			)
+			.map((x) => x.value)
+			.join(' ');
 		const st = scriptType(textQuery);
 
 		if (!Setting.value('db.ftsEnabled')) {
@@ -725,7 +866,9 @@ export default class SearchEngine {
 		return SearchEngine.SEARCH_TYPE_FTS;
 	}
 
-	private async searchFromItemIds(searchString: string): Promise<ProcessResultsRow[]> {
+	private async searchFromItemIds(
+		searchString: string,
+	): Promise<ProcessResultsRow[]> {
 		let itemId = '';
 
 		if (isCallbackUrl(searchString)) {
@@ -764,7 +907,10 @@ export default class SearchEngine {
 		return [];
 	}
 
-	public async search(searchString: string, options: SearchOptions = null): Promise<ProcessResultsRow[]> {
+	public async search(
+		searchString: string,
+		options: SearchOptions = null,
+	): Promise<ProcessResultsRow[]> {
 		if (!searchString) return [];
 
 		options = {
@@ -774,7 +920,10 @@ export default class SearchEngine {
 			...options,
 		};
 
-		const searchType = this.determineSearchType_(searchString, options.searchType);
+		const searchType = this.determineSearchType_(
+			searchString,
+			options.searchType,
+		);
 		const parsedQuery = await this.parseQuery(searchString);
 
 		let rows: ProcessResultsRow[] = [];
@@ -793,12 +942,14 @@ export default class SearchEngine {
 			// https://github.com/laurent22/joplin/issues/1075#issuecomment-459258856
 
 			if (options.appendWildCards) {
-				parsedQuery.allTerms = parsedQuery.allTerms.map(t => {
+				parsedQuery.allTerms = parsedQuery.allTerms.map((t) => {
 					if (t.name === 'text' && !t.wildcard) {
 						t = {
 							...t,
 							wildcard: true,
-							value: t.value.endsWith('"') ? `${t.value.substring(0, t.value.length - 1)}*"` : `${t.value}*`,
+							value: t.value.endsWith('"')
+								? `${t.value.substring(0, t.value.length - 1)}*"`
+								: `${t.value}*`,
 						};
 					}
 					return t;
@@ -806,13 +957,19 @@ export default class SearchEngine {
 			}
 
 			const useFts = searchType === SearchEngine.SEARCH_TYPE_FTS;
+			const ftsVersion = this.db().ftsVersion();
 			try {
-				const { query, params } = queryBuilder(parsedQuery.allTerms, useFts);
-
+				const { query, params } = queryBuilder(
+					parsedQuery.allTerms,
+					useFts,
+					ftsVersion,
+				);
 				rows = await this.db().selectAll<ProcessResultsRow>(query, params);
-				const queryHasFilters = !!parsedQuery.allTerms.find(t => t.name !== 'text');
+				const queryHasFilters = !!parsedQuery.allTerms.find(
+					(t) => t.name !== 'text',
+				);
 
-				rows = rows.map(r => {
+				rows = rows.map((r) => {
 					return {
 						...r,
 						item_type: ModelType.Note,
@@ -820,34 +977,60 @@ export default class SearchEngine {
 				});
 
 				if (!queryHasFilters && Setting.value('ocr.searchInExtractedContent')) {
-					const toSearch = parsedQuery.allTerms.map(t => t.value).join(' ');
+					const toSearch = parsedQuery.allTerms.map((t) => t.value).join(' ');
 
 					let itemRows: ProcessResultsRow[] = [];
 
 					try {
-						itemRows = await this.db().selectAll<ProcessResultsRow>(`
-							SELECT
-								id,
-								title,
-								user_updated_time,
-								offsets(items_fts) AS offsets,
-								matchinfo(items_fts, 'pcnalx') AS matchinfo,
-								item_id,
-								item_type
-							FROM items_fts
-							WHERE title MATCH ? OR body MATCH ?
-						`, [toSearch, toSearch]);
+						if (ftsVersion >= 5) {
+							itemRows = await this.db().selectAll<ProcessResultsRow>(
+								`
+								SELECT
+									id,
+									title,
+									user_updated_time,
+									rank,
+									instr(highlight(items_fts, 1, X'1F', X'1E'), X'1F') AS title_matched,
+									instr(highlight(items_fts, 2, X'1F', X'1E'), X'1F') AS body_matched,
+									item_id,
+									item_type
+								FROM items_fts
+								WHERE items_fts MATCH ?
+							`,
+								[toSearch],
+							);
+						} else {
+							itemRows = await this.db().selectAll<ProcessResultsRow>(
+								`
+								SELECT
+									id,
+									title,
+									user_updated_time,
+									offsets(items_fts) AS offsets,
+									matchinfo(items_fts, 'pcnalx') AS matchinfo,
+									item_id,
+									item_type
+								FROM items_fts
+								WHERE title MATCH ? OR body MATCH ?
+							`,
+								[toSearch, toSearch],
+							);
+						}
 					} catch (error) {
 						// Android <= 25 doesn't support the following syntax:
 						//    WHERE title MATCH ? OR body MATCH ?
 						// Thus, we skip resource search on these devices.
-						if (!error.message?.includes?.('unable to use function MATCH in the requested context')) {
+						if (
+							!error.message?.includes?.(
+								'unable to use function MATCH in the requested context',
+							)
+						) {
 							throw error;
 						}
 					}
 
 					const resourcesToNotes = await NoteResource.associatedResourceNotes(
-						itemRows.map(r => r.item_id),
+						itemRows.map((r) => r.item_id),
 						{
 							fields: ['note_id', 'parent_id', 'deleted_time'],
 						},
@@ -863,15 +1046,17 @@ export default class SearchEngine {
 						itemRow.parent_id = note ? note.parent_id : null;
 					}
 
-					if (!options.includeOrphanedResources) itemRows = itemRows.filter(r => !!r.id);
-					itemRows = itemRows.filter(r => !deletedNoteIds.includes(r.id));
+					if (!options.includeOrphanedResources) { itemRows = itemRows.filter((r) => !!r.id); }
+					itemRows = itemRows.filter((r) => !deletedNoteIds.includes(r.id));
 
 					rows = rows.concat(itemRows);
 				}
 
 				this.processResults_(rows as ProcessResultsRow[], parsedQuery, !useFts);
 			} catch (error) {
-				this.logger().warn(`Cannot execute MATCH query: ${searchString}: ${error.message}`);
+				this.logger().warn(
+					`Cannot execute MATCH query: ${searchString}: ${error.message}`,
+				);
 				rows = [];
 			}
 		}

--- a/packages/lib/services/search/queryBuilder.ts
+++ b/packages/lib/services/search/queryBuilder.ts
@@ -23,7 +23,14 @@ enum Requirement {
 	INCLUSION = 'INCLUSION',
 }
 
-const _notebookFilter = (notebooks: string[], requirement: Requirement, conditions: string[], params: string[], withs: string[], useFts: boolean) => {
+const _notebookFilter = (
+	notebooks: string[],
+	requirement: Requirement,
+	conditions: string[],
+	params: string[],
+	withs: string[],
+	useFts: boolean,
+) => {
 	if (notebooks.length === 0) return;
 
 	const likes = [];
@@ -33,7 +40,10 @@ const _notebookFilter = (notebooks: string[], requirement: Requirement, conditio
 
 	const relevantFolders = likes.join(' OR ');
 
-	const viewName = requirement === Requirement.EXCLUSION ? 'notebooks_not_in_scope' : 'notebooks_in_scope';
+	const viewName =
+		requirement === Requirement.EXCLUSION
+			? 'notebooks_not_in_scope'
+			: 'notebooks_in_scope';
 	const withInNotebook = `
 	${viewName}(id)
 	AS (
@@ -61,25 +71,52 @@ const _notebookFilter = (notebooks: string[], requirement: Requirement, conditio
 		ON ${viewName}.id=${tableName}.parent_id
 	)`;
 
-
 	withs.push(withInNotebook);
 	params.push(...notebooks);
 	conditions.push(where);
-
 };
 
-const notebookFilter = (terms: Term[], conditions: string[], params: string[], withs: string[], useFts: boolean) => {
-	const notebooksToInclude = terms.filter(x => x.name === 'notebook' && !x.negated).map(x => x.value);
-	_notebookFilter(notebooksToInclude, Requirement.INCLUSION, conditions, params, withs, useFts);
+const notebookFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	withs: string[],
+	useFts: boolean,
+) => {
+	const notebooksToInclude = terms
+		.filter((x) => x.name === 'notebook' && !x.negated)
+		.map((x) => x.value);
+	_notebookFilter(
+		notebooksToInclude,
+		Requirement.INCLUSION,
+		conditions,
+		params,
+		withs,
+		useFts,
+	);
 
-	const notebooksToExclude = terms.filter(x => x.name === 'notebook' && x.negated).map(x => x.value);
-	_notebookFilter(notebooksToExclude, Requirement.EXCLUSION, conditions, params, withs, useFts);
+	const notebooksToExclude = terms
+		.filter((x) => x.name === 'notebook' && x.negated)
+		.map((x) => x.value);
+	_notebookFilter(
+		notebooksToExclude,
+		Requirement.EXCLUSION,
+		conditions,
+		params,
+		withs,
+		useFts,
+	);
 };
 
-
-
-const getOperator = (requirement: Requirement, relation: Relation): Operation => {
-	if (relation === 'AND' && requirement === 'INCLUSION') { return Operation.INTERSECT; } else { return Operation.UNION; }
+const getOperator = (
+	requirement: Requirement,
+	relation: Relation,
+): Operation => {
+	if (relation === 'AND' && requirement === 'INCLUSION') {
+		return Operation.INTERSECT;
+	} else {
+		return Operation.UNION;
+	}
 };
 
 const filterByTableName = (
@@ -95,7 +132,7 @@ const filterByTableName = (
 ) => {
 	const operator: Operation = getOperator(requirement, relation);
 
-	const values = terms.map(x => x.value);
+	const values = terms.map((x) => x.value);
 
 	let withCondition = null;
 
@@ -126,14 +163,12 @@ const filterByTableName = (
 		AS (
 			${requiredNotesQuery}
 		)`;
-
 	} else {
 		const requiredNotes = [];
 		for (let i = 0; i < values.length; i++) {
 			requiredNotes.push(noteIDs);
 		}
 		const requiredNotesQuery = requiredNotes.join(` ${operator} `);
-
 
 		// Notes with any/all values depending upon relation and requirement
 		withCondition = `
@@ -150,7 +185,9 @@ const filterByTableName = (
 	// Get the ROWIDs that satisfy the condition so we can filter the result
 	const targetTableName = useFts ? 'notes_normalized' : 'notes';
 	const whereCondition = `
-	${relation} ROWID ${(relation === 'AND' && requirement === 'EXCLUSION') ? 'NOT' : ''}
+	${relation} ROWID ${
+	relation === 'AND' && requirement === 'EXCLUSION' ? 'NOT' : ''
+}
 	IN (
 		SELECT ${targetTableName}.ROWID
 		FROM notes_with_${requirement}_${tableName}
@@ -163,8 +200,14 @@ const filterByTableName = (
 	conditions.push(whereCondition);
 };
 
-
-const resourceFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, withs: string[], useFts: boolean) => {
+const resourceFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	withs: string[],
+	useFts: boolean,
+) => {
 	const tableName = 'resources';
 
 	const resourceIDs = `
@@ -178,19 +221,50 @@ const resourceFilter = (terms: Term[], conditions: string[], params: string[], r
 	WHERE note_resources.is_associated=1
 	AND note_resources.resource_id IN (${resourceIDs})`;
 
-	const requiredResources = terms.filter(x => x.name === 'resource' && !x.negated);
-	const excludedResources = terms.filter(x => x.name === 'resource' && x.negated);
+	const requiredResources = terms.filter(
+		(x) => x.name === 'resource' && !x.negated,
+	);
+	const excludedResources = terms.filter(
+		(x) => x.name === 'resource' && x.negated,
+	);
 
 	if (requiredResources.length > 0) {
-		filterByTableName(requiredResources, conditions, params, relation, noteIDsWithResource, Requirement.INCLUSION, withs, tableName, useFts);
+		filterByTableName(
+			requiredResources,
+			conditions,
+			params,
+			relation,
+			noteIDsWithResource,
+			Requirement.INCLUSION,
+			withs,
+			tableName,
+			useFts,
+		);
 	}
 
 	if (excludedResources.length > 0) {
-		filterByTableName(excludedResources, conditions, params, relation, noteIDsWithResource, Requirement.EXCLUSION, withs, tableName, useFts);
+		filterByTableName(
+			excludedResources,
+			conditions,
+			params,
+			relation,
+			noteIDsWithResource,
+			Requirement.EXCLUSION,
+			withs,
+			tableName,
+			useFts,
+		);
 	}
 };
 
-const tagFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, withs: string[], useFts: boolean) => {
+const tagFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	withs: string[],
+	useFts: boolean,
+) => {
 	const tableName = 'tags';
 
 	const tagIDs = `
@@ -204,19 +278,46 @@ const tagFilter = (terms: Term[], conditions: string[], params: string[], relati
 	FROM note_tags
 	WHERE note_tags.tag_id IN (${tagIDs})`;
 
-	const requiredTags = terms.filter(x => x.name === 'tag' && !x.negated);
-	const excludedTags = terms.filter(x => x.name === 'tag' && x.negated);
+	const requiredTags = terms.filter((x) => x.name === 'tag' && !x.negated);
+	const excludedTags = terms.filter((x) => x.name === 'tag' && x.negated);
 
 	if (requiredTags.length > 0) {
-		filterByTableName(requiredTags, conditions, params, relation, noteIDsWithTag, Requirement.INCLUSION, withs, tableName, useFts);
+		filterByTableName(
+			requiredTags,
+			conditions,
+			params,
+			relation,
+			noteIDsWithTag,
+			Requirement.INCLUSION,
+			withs,
+			tableName,
+			useFts,
+		);
 	}
 
 	if (excludedTags.length > 0) {
-		filterByTableName(excludedTags, conditions, params, relation, noteIDsWithTag, Requirement.EXCLUSION, withs, tableName, useFts);
+		filterByTableName(
+			excludedTags,
+			conditions,
+			params,
+			relation,
+			noteIDsWithTag,
+			Requirement.EXCLUSION,
+			withs,
+			tableName,
+			useFts,
+		);
 	}
 };
 
-const genericFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, fieldName: string, useFts: boolean) => {
+const genericFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	fieldName: string,
+	useFts: boolean,
+) => {
 	if (fieldName === 'iscompleted' || fieldName === 'type') {
 		// Faster query when values can only take two distinct values
 		biConditionalFilter(terms, conditions, relation, fieldName, useFts);
@@ -233,12 +334,14 @@ const genericFilter = (terms: Term[], conditions: string[], params: string[], re
 		} else if (fieldName === 'id') {
 			return `id ${term.negated ? 'NOT' : ''} LIKE ?`;
 		} else {
-			return `${tableName}.${fieldName === 'date' ? `user_${term.name}_time` : `${term.name}`} ${term.negated ? '<' : '>='} ?`;
+			return `${tableName}.${
+				fieldName === 'date' ? `user_${term.name}_time` : `${term.name}`
+			} ${term.negated ? '<' : '>='} ?`;
 		}
 	};
 
 	// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-	terms.forEach(term => {
+	terms.forEach((term) => {
 		conditions.push(`
 		${relation} ( ${term.name === 'due' ? 'is_todo IS 1 AND ' : ''} ROWID IN (
 			SELECT ROWID
@@ -249,23 +352,39 @@ const genericFilter = (terms: Term[], conditions: string[], params: string[], re
 	});
 };
 
-const biConditionalFilter = (terms: Term[], conditions: string[], relation: Relation, filterName: string, useFts: boolean) => {
-	const getCondition = (filterName: string, value: string, relation: Relation) => {
-		const tableName = useFts ? (relation === 'AND' ? 'notes_fts' : 'notes_normalized') : 'notes';
+const biConditionalFilter = (
+	terms: Term[],
+	conditions: string[],
+	relation: Relation,
+	filterName: string,
+	useFts: boolean,
+) => {
+	const getCondition = (
+		filterName: string,
+		value: string,
+		relation: Relation,
+	) => {
+		const tableName = useFts
+			? relation === 'AND'
+				? 'notes_fts'
+				: 'notes_normalized'
+			: 'notes';
 		if (filterName === 'type') {
 			return `${tableName}.is_todo IS ${value === 'todo' ? 1 : 0}`;
 		} else if (filterName === 'iscompleted') {
-			return `${tableName}.is_todo IS 1 AND ${tableName}.todo_completed IS ${value === '1' ? 'NOT 0' : '0'}`;
+			return `${tableName}.is_todo IS 1 AND ${tableName}.todo_completed IS ${
+				value === '1' ? 'NOT 0' : '0'
+			}`;
 		} else {
 			throw new Error('Invalid filter name.');
 		}
 	};
 
-	const values = terms.map(x => x.value);
+	const values = terms.map((x) => x.value);
 
 	// AND and OR are handled differently because FTS restricts how OR can be used.
 	// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-	values.forEach(value => {
+	values.forEach((value) => {
 		if (relation === 'AND') {
 			conditions.push(`
 			AND ${getCondition(filterName, value, relation)}`);
@@ -286,29 +405,74 @@ const biConditionalFilter = (terms: Term[], conditions: string[], relation: Rela
 	});
 };
 
-const noteIdFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
-	const noteIdTerms = terms.filter(x => x.name === 'id');
+const noteIdFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
+	const noteIdTerms = terms.filter((x) => x.name === 'id');
 	genericFilter(noteIdTerms, conditions, params, relation, 'id', useFts);
 };
 
-
-const typeFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
-	const typeTerms = terms.filter(x => x.name === 'type');
+const typeFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
+	const typeTerms = terms.filter((x) => x.name === 'type');
 	genericFilter(typeTerms, conditions, params, relation, 'type', useFts);
 };
 
-const completedFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
-	const completedTerms = terms.filter(x => x.name === 'iscompleted');
-	genericFilter(completedTerms, conditions, params, relation, 'iscompleted', useFts);
+const completedFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
+	const completedTerms = terms.filter((x) => x.name === 'iscompleted');
+	genericFilter(
+		completedTerms,
+		conditions,
+		params,
+		relation,
+		'iscompleted',
+		useFts,
+	);
 };
 
-
-const locationFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
-	const locationTerms = terms.filter(x => x.name === 'latitude' || x.name === 'longitude' || x.name === 'altitude');
-	genericFilter(locationTerms, conditions, params, relation, 'location', useFts);
+const locationFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
+	const locationTerms = terms.filter(
+		(x) =>
+			x.name === 'latitude' || x.name === 'longitude' || x.name === 'altitude',
+	);
+	genericFilter(
+		locationTerms,
+		conditions,
+		params,
+		relation,
+		'location',
+		useFts,
+	);
 };
 
-const dateFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
+const dateFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
 	const getUnixMs = (date: string): string => {
 		const yyyymmdd = /^[0-9]{8}$/;
 		const yyyymm = /^[0-9]{6}$/;
@@ -327,30 +491,64 @@ const dateFilter = (terms: Term[], conditions: string[], params: string[], relat
 			const timeDirection = match[2]; // + or -
 			const num = Number(match[3]); // eg. 1, 12, 15
 
-			if (timeDirection === '+') { return time.goForwardInTime(Date.now(), num, timeUnit); } else { return time.goBackInTime(Date.now(), num, timeUnit); }
+			if (timeDirection === '+') {
+				return time.goForwardInTime(Date.now(), num, timeUnit);
+			} else {
+				return time.goBackInTime(Date.now(), num, timeUnit);
+			}
 		} else {
 			throw new Error('Invalid date format!');
 		}
 	};
 
-	const dateTerms = terms.filter(x => x.name === 'created' || x.name === 'updated' || x.name === 'due');
-	const unixDateTerms = dateTerms.map(term => { return { ...term, value: getUnixMs(term.value) }; });
+	const dateTerms = terms.filter(
+		(x) => x.name === 'created' || x.name === 'updated' || x.name === 'due',
+	);
+	const unixDateTerms = dateTerms.map((term) => {
+		return { ...term, value: getUnixMs(term.value) };
+	});
 	genericFilter(unixDateTerms, conditions, params, relation, 'date', useFts);
 };
 
-const sourceUrlFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
-	const urlTerms = terms.filter(x => x.name === 'sourceurl');
+const sourceUrlFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+) => {
+	const urlTerms = terms.filter((x) => x.name === 'sourceurl');
 	genericFilter(urlTerms, conditions, params, relation, 'sourceurl', useFts);
 };
 
-const trimQuotes = (str: string) => str.startsWith('"') && str.endsWith('"') ? str.substr(1, str.length - 2) : str;
+const trimQuotes = (str: string) =>
+	str.startsWith('"') && str.endsWith('"')
+		? str.substr(1, str.length - 2)
+		: str;
 
-const textFilter = (terms: Term[], conditions: string[], params: string[], relation: Relation, useFts: boolean) => {
+const textFilter = (
+	terms: Term[],
+	conditions: string[],
+	params: string[],
+	relation: Relation,
+	useFts: boolean,
+	ftsVersion = 4,
+) => {
+	const fixValue = (value: string) => {
+		if (ftsVersion >= 5) {
+			// FTS5 does not support prefix queries inside double quotes.
+			// Strip quotes around terms that contain wildcards so that
+			// prefix matching works correctly.
+			return value.replace(/"([^"]*\*[^"]*)"/g, '$1');
+		}
+		return value;
+	};
+
 	const createLikeMatch = (term: Term, negate: boolean) => {
 		const query = `${relation} ${negate ? 'NOT' : ''} (
-			${(term.name === 'text' || term.name === 'body') ? 'notes.body LIKE ? ' : ''}
+			${term.name === 'text' || term.name === 'body' ? 'notes.body LIKE ? ' : ''}
 			${term.name === 'text' ? 'OR' : ''}
-			${(term.name === 'text' || term.name === 'title') ? 'notes.title LIKE ? ' : ''})`;
+			${term.name === 'text' || term.name === 'title' ? 'notes.title LIKE ? ' : ''})`;
 
 		conditions.push(query);
 		const param = `%${trimQuotes(term.value).replace(/\*/, '%')}%`;
@@ -358,21 +556,31 @@ const textFilter = (terms: Term[], conditions: string[], params: string[], relat
 		if (term.name === 'text') params.push(param);
 	};
 
-	const addExcludeTextConditions = (excludedTerms: Term[], conditions: string[], params: string[], relation: Relation) => {
+	const addExcludeTextConditions = (
+		excludedTerms: Term[],
+		conditions: string[],
+		params: string[],
+		relation: Relation,
+	) => {
 		if (useFts) {
-			const type = excludedTerms[0].name === 'text' ? '' : `.${excludedTerms[0].name}`;
+			const columnPrefix =
+        excludedTerms[0].name === 'text' ? '' : `${excludedTerms[0].name}:`;
 			if (relation === 'AND') {
 				conditions.push(`
 				AND ROWID NOT IN (
 					SELECT ROWID
 					FROM notes_fts
-					WHERE notes_fts${type} MATCH ?
+					WHERE notes_fts MATCH ?
 				)`);
-				params.push(excludedTerms.map(x => x.value).join(' OR '));
+				params.push(
+					fixValue(
+						excludedTerms.map((x) => `${columnPrefix}${x.value}`).join(' OR '),
+					),
+				);
 			}
 			if (relation === 'OR') {
 				// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-				excludedTerms.forEach(term => {
+				excludedTerms.forEach((term) => {
 					conditions.push(`
 					OR ROWID IN (
 						SELECT *
@@ -382,45 +590,54 @@ const textFilter = (terms: Term[], conditions: string[], params: string[], relat
 								EXCEPT
 								SELECT ROWID
 								FROM notes_fts
-								WHERE notes_fts${type} MATCH ?
+								WHERE notes_fts MATCH ?
 						)
 					)`);
-					params.push(term.value);
+					params.push(fixValue(`${columnPrefix}${term.value}`));
 				});
 			}
 		} else {
 			// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-			excludedTerms.forEach(term => {
+			excludedTerms.forEach((term) => {
 				createLikeMatch(term, true);
 			});
 		}
 	};
 
-	const allTerms = terms.filter(x => x.name === 'title' || x.name === 'body' || x.name === 'text');
+	const allTerms = terms.filter(
+		(x) => x.name === 'title' || x.name === 'body' || x.name === 'text',
+	);
 
-	const includedTerms = allTerms.filter(x => !x.negated);
+	const includedTerms = allTerms.filter((x) => !x.negated);
 	if (includedTerms.length > 0) {
 		if (useFts) {
 			conditions.push(`${relation} notes_fts MATCH ?`);
-			const termsToMatch = includedTerms.map(term => {
+			const termsToMatch = includedTerms.map((term) => {
 				if (term.name === 'text') return term.value;
 				else return `${term.name}:${term.value}`;
 			});
-			const matchQuery = (relation === 'OR') ? termsToMatch.join(' OR ') : termsToMatch.join(' ');
-			params.push(matchQuery);
+			const matchQuery =
+        relation === 'OR' ? termsToMatch.join(' OR ') : termsToMatch.join(' ');
+			params.push(fixValue(matchQuery));
 		} else {
 			// eslint-disable-next-line github/array-foreach -- Old code before rule was applied
-			includedTerms.forEach(term => {
+			includedTerms.forEach((term) => {
 				createLikeMatch(term, false);
 			});
 		}
 	}
 
-	const excludedTextTerms = allTerms.filter(x => x.name === 'text' && x.negated);
-	const excludedTitleTerms = allTerms.filter(x => x.name === 'title' && x.negated);
-	const excludedBodyTerms = allTerms.filter(x => x.name === 'body' && x.negated);
+	const excludedTextTerms = allTerms.filter(
+		(x) => x.name === 'text' && x.negated,
+	);
+	const excludedTitleTerms = allTerms.filter(
+		(x) => x.name === 'title' && x.negated,
+	);
+	const excludedBodyTerms = allTerms.filter(
+		(x) => x.name === 'body' && x.negated,
+	);
 
-	if ((excludedTextTerms.length > 0)) {
+	if (excludedTextTerms.length > 0) {
 		addExcludeTextConditions(excludedTextTerms, conditions, params, relation);
 	}
 
@@ -434,17 +651,23 @@ const textFilter = (terms: Term[], conditions: string[], params: string[], relat
 };
 
 const getDefaultRelation = (terms: Term[]): Relation => {
-	const anyTerm = terms.find(term => term.name === 'any');
-	if (anyTerm) { return (anyTerm.value === '1') ? Relation.OR : Relation.AND; }
+	const anyTerm = terms.find((term) => term.name === 'any');
+	if (anyTerm) {
+		return anyTerm.value === '1' ? Relation.OR : Relation.AND;
+	}
 	return Relation.AND;
 };
 
 const getConnective = (terms: Term[], relation: Relation): string => {
-	const notebookTerm = terms.find(x => x.name === 'notebook');
-	return (!notebookTerm && (relation === 'OR')) ? 'ROWID=-1' : '1'; // ROWID=-1 acts as 0 (something always false)
+	const notebookTerm = terms.find((x) => x.name === 'notebook');
+	return !notebookTerm && relation === 'OR' ? 'ROWID=-1' : '1'; // ROWID=-1 acts as 0 (something always false)
 };
 
-export default function queryBuilder(terms: Term[], useFts: boolean) {
+export default function queryBuilder(
+	terms: Term[],
+	useFts: boolean,
+	ftsVersion = 4,
+) {
 	const queryParts: string[] = [];
 	const params: string[] = [];
 	const withs: string[] = [];
@@ -457,7 +680,16 @@ export default function queryBuilder(terms: Term[], useFts: boolean) {
 	SELECT
 	${tableName}.id,
 	${tableName}.title,
-	${useFts ? 'offsets(notes_fts) AS offsets, matchinfo(notes_fts, \'pcnalx\') AS matchinfo,' : ''}
+	${
+	useFts && ftsVersion >= 5
+		? 'rank, instr(highlight(notes_fts, 1, X\'1F\', X\'1E\'), X\'1F\') AS title_matched, instr(highlight(notes_fts, 2, X\'1F\', X\'1E\'), X\'1F\') AS body_matched,'
+		: ''
+}
+	${
+	useFts && ftsVersion < 5
+		? 'offsets(notes_fts) AS offsets, matchinfo(notes_fts, \'pcnalx\') AS matchinfo,'
+		: ''
+}
 	${tableName}.user_created_time,
 	${tableName}.user_updated_time,
 	${tableName}.is_todo,
@@ -474,8 +706,7 @@ export default function queryBuilder(terms: Term[], useFts: boolean) {
 
 	resourceFilter(terms, queryParts, params, relation, withs, useFts);
 
-	textFilter(terms, queryParts, params, relation, useFts);
-
+	textFilter(terms, queryParts, params, relation, useFts, ftsVersion);
 
 	typeFilter(terms, queryParts, params, relation, useFts);
 
@@ -489,14 +720,25 @@ export default function queryBuilder(terms: Term[], useFts: boolean) {
 
 	let query;
 	if (withs.length > 0) {
-		if (terms.find(x => x.name === 'notebook') && terms.find(x => x.name === 'any')) {
+		if (
+			terms.find((x) => x.name === 'notebook') &&
+      terms.find((x) => x.name === 'any')
+		) {
 			// The notebook filter should be independent of the any filter.
 			// So we're first finding the OR of other filters and then combining them with the notebook filter using AND
 			// in-required-notebook AND (condition #1 OR condition #2  OR ... )
-			const queryString = `${queryParts.slice(0, 2).join(' ')} AND ROWID IN ( SELECT ROWID FROM notes_fts WHERE 1=0 ${queryParts.slice(2).join(' ')})`;
+			const queryString = `${queryParts
+				.slice(0, 2)
+				.join(
+					' ',
+				)} AND ROWID IN ( SELECT ROWID FROM notes_fts WHERE 1=0 ${queryParts
+				.slice(2)
+				.join(' ')})`;
 			query = ['WITH RECURSIVE', withs.join(','), queryString].join(' ');
 		} else {
-			query = ['WITH RECURSIVE', withs.join(','), queryParts.join(' ')].join(' ');
+			query = ['WITH RECURSIVE', withs.join(','), queryParts.join(' ')].join(
+				' ',
+			);
 		}
 	} else {
 		query = queryParts.join(' ');

--- a/packages/tools/cspell/dictionary4.txt
+++ b/packages/tools/cspell/dictionary4.txt
@@ -257,3 +257,5 @@ armor
 clearsign
 ligne
 payant
+UNINDEXED
+instr


### PR DESCRIPTION
## Web: Resolves #13493  New versions of @sqlite.org/wasm break the web app


### Summary

Newer versions of `@sqlite.org/sqlite-wasm` (>= 3.50.4-build1) removed FTS3/FTS4 support, breaking the web app's search functionality. This PR migrates the full-text search system from FTS4 to FTS5 and bumps the SQLite WASM dependency to `3.51.2-build6`.

### Changes

**Database migration (`50.ts`)**
- Drops FTS4 triggers, virtual tables, and shadow tables
- Creates FTS5 virtual tables (`notes_fts`, `items_fts`) with `content=` sync mode and `UNINDEXED` columns
- Creates content-sync triggers (before_update, before_delete, after_update, after_insert) for both tables
- Resets `searchEngine.initialIndexingDone` and `db.ftsEnabled` settings to force re-indexing

**FTS version detection (`JoplinDatabase.ts`)**
- Adds `detectFtsVersion()` method that inspects `sqlite_master` to determine FTS3/4/5
- Exposes `ftsVersion()` getter for use by the search engine

**Query building (`queryBuilder.ts`)**
- Accepts `ftsVersion` parameter to generate version-appropriate SQL
- FTS5: Uses `rank` (built-in BM25), `highlight()` + `instr()` for field detection
- FTS4: Preserves existing `offsets()` + `matchinfo()` path
- FTS5: Strips double quotes around wildcard terms (FTS5 doesn't support prefix queries inside quotes)
- Uses column-prefix syntax (`title:term`) instead of `.column` syntax for MATCH queries

**Search engine (`SearchEngine.ts`)**
- Adds `processFts5Results_()` using FTS5's negative BM25 rank
- Adds `detectMatchedFieldsFts5_()` using highlight marker detection
- Extracts `weightForDaysSinceLastUpdate_()` as a reusable class method
- Routes to FTS5 or FTS4 processing based on detected version
- Updates OCR/resource search queries for FTS5 compatibility

**Other**
- Bumps `@sqlite.org/sqlite-wasm` from `3.46.0-build2` to `3.51.2-build6`
- Adds `UNINDEXED` and `instr` to spellcheck dictionary
- Updates `.gitignore` / `.eslintignore` for migration build output

### Backward compatibility

- Existing FTS4 installations continue to work until the migration runs
- If the migration fails (e.g., FTS5 not available), the error is caught and FTS is gracefully disabled (same pattern as migrations 15, 18, 33)
- `queryBuilder` defaults to FTS4 behavior when `ftsVersion` is not provided

### Testing

All 32 SearchEngine tests pass (including resources and utils).