### PR TITLE
CLI: Fixes #13158: Fix null crash in e2ee decrypt command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1434,6 +1434,7 @@ packages/lib/services/AlarmServiceDriverNode.js
 packages/lib/services/BaseService.js
 packages/lib/services/CommandService.test.js
 packages/lib/services/CommandService.js
+packages/lib/services/DecryptionWorker.test.js
 packages/lib/services/DecryptionWorker.js
 packages/lib/services/ExternalEditWatcher.js
 packages/lib/services/ExternalEditWatcher/utils.js

--- a/.gitignore
+++ b/.gitignore
@@ -1407,6 +1407,7 @@ packages/lib/services/AlarmServiceDriverNode.js
 packages/lib/services/BaseService.js
 packages/lib/services/CommandService.test.js
 packages/lib/services/CommandService.js
+packages/lib/services/DecryptionWorker.test.js
 packages/lib/services/DecryptionWorker.js
 packages/lib/services/ExternalEditWatcher.js
 packages/lib/services/ExternalEditWatcher/utils.js

--- a/packages/lib/services/DecryptionWorker.test.ts
+++ b/packages/lib/services/DecryptionWorker.test.ts
@@ -18,7 +18,8 @@ describe('services/DecryptionWorker', () => {
 		]);
 
 		for (const result of results) {
-			expect(result).not.toBeNull();
+			expect(result === null).toBe(false);
+			expect(result === undefined).toBe(false);
 			expect(result).toHaveProperty('error');
 		}
 	});

--- a/packages/lib/services/DecryptionWorker.test.ts
+++ b/packages/lib/services/DecryptionWorker.test.ts
@@ -1,0 +1,25 @@
+import { setupDatabaseAndSynchronizer, switchClient, decryptionWorker } from '../testing/test-utils';
+
+describe('services/DecryptionWorker', () => {
+
+	beforeEach(async () => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+	});
+
+	it('concurrent start() calls should not crash with null result', async () => {
+		const worker = decryptionWorker();
+
+		// Both calls should return a valid DecryptionResult, even if the
+		// queue skips one task due to concurrency.
+		const results = await Promise.all([
+			worker.start(),
+			worker.start(),
+		]);
+
+		for (const result of results) {
+			expect(result).not.toBeNull();
+			expect(result).toHaveProperty('error');
+		}
+	});
+});

--- a/packages/lib/services/DecryptionWorker.test.ts
+++ b/packages/lib/services/DecryptionWorker.test.ts
@@ -7,7 +7,7 @@ describe('services/DecryptionWorker', () => {
 		await switchClient(1);
 	});
 
-	it('concurrent start() calls should not crash with null result', async () => {
+	it('should not return null when a call to .start is cancelled', async () => {
 		const worker = decryptionWorker();
 
 		// Both calls should return a valid DecryptionResult, even if the

--- a/packages/lib/services/DecryptionWorker.ts
+++ b/packages/lib/services/DecryptionWorker.ts
@@ -349,6 +349,15 @@ export default class DecryptionWorker {
 		if (lastError) {
 			throw lastError;
 		}
+
+		// If this task was skipped due to a concurrent start() call, return an empty
+		// DecryptionResult instead of null. AsyncActionQueue drops earlier tasks when
+		// multiple are queued, but start() guarantees Promise<DecryptionResult> and
+		// must not resolve null.
+		if (!output) {
+			return { error: null, decryptedItemCount: 0, skippedItemCount: 0 };
+		}
+
 		return output;
 	}
 


### PR DESCRIPTION
### AI Assistance Disclosure
AI tools are used to:

- Understand the Issue deeply
- Understand the Codebase folders involved in the issue
- For commands to test the fix
- Improving wording in PR description


### Problem & Fix
When running `joplin e2ee decrypt`, the command can crash with:
`TypeError: Cannot read properties of null (reading 'error')`
`DecryptionWorker.start()` queues a task on `AsyncActionQueue` and awaits `processAllNow()`. If two concurrent `start()` calls are queued at the same time, the queue's `canSkipTaskHandler` drops earlier tasks and executes only the last one. As a result, the first caller's `output` remains null, violating the declared return type `Promise<DecryptionResult>`, and `command-e2ee.ts` crashes when accessing `result.error`.

Since the concurrent invocation already executes the decryption task, returning an empty result for the skipped call preserves correctness while maintaining the non-null return contract.

### Testing
A regression test was added that fires two concurrent` start()` calls via `Promise.all` and asserts neither result is null.

A 1 second delay was temporarily injected at the start of the queued task inside `start()` to widen the concurrency window and reliably trigger the race condition.

Before fix (with delay, no null guard):

The test fails with `Received: null`, confirming the first concurrent call gets its task skipped and returns null to the caller.
<img width="973" height="632" alt="Screenshot 2026-02-25 at 6 15 08 PM" src="https://github.com/user-attachments/assets/f6474453-80de-4f6b-8e2c-69494a542c45" />


After fix (with delay, null guard applied):

The test passes. Both concurrent calls return a valid DecryptionResult.
<img width="1114" height="328" alt="Screenshot 2026-02-25 at 6 21 41 PM" src="https://github.com/user-attachments/assets/7449a08a-7dd8-4571-aca2-4b24e19fa2f2" />

The delay was then removed and the test was run again to confirm it passes cleanly without artificial timing. [Screenshot looks similar]
<img width="1008" height="250" alt="Screenshot 2026-02-25 at 6 23 13 PM" src="https://github.com/user-attachments/assets/0a307bb4-6cab-4ad9-b8f8-3fdbe661bd85" />

Fixes #13158