### PR TITLE
Mobile: Fixes #14152: Fix font-size inconsistency of code block and inline code 

### DIFF
--- a/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/RichTextEditor.tsx
@@ -27,6 +27,7 @@ function useCss(themeId: number, editorCss: string): string {
 
 			:root {
 				background-color: ${theme.backgroundColor};
+				font-size: 13pt;
 			}
 
 			body {
@@ -41,7 +42,6 @@ function useCss(themeId: number, editorCss: string): string {
 				padding-bottom: 1px;
 				padding-top: 10px;
 
-				font-size: 13pt;
 				font-family: ${JSON.stringify(theme.fontFamily)}, sans-serif;
 			}
 

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -48,12 +48,16 @@ const useMessenger = (props: UseMessengerProps) => {
 
 	const markupRenderingSettings = useRef<RenderOptions>(null);
 	const baseTheme = props.settings.themeData;
+	const fontSizeUnits = baseTheme.fontSizeUnits ?? 'px';
+	// Use `rem` instead of `em` for noteViewerFontSize to avoid inconsistent font sizing
+	// in monospace elements (browsers default to 13px for monospace, not the usual 16px)
+	const effectiveFontSizeUnits = fontSizeUnits === 'em' ? 'rem' : fontSizeUnits;
 	markupRenderingSettings.current = {
 		themeId: props.themeId,
 		highlightedKeywords: [],
 		resources: props.noteResources,
 		themeOverrides: {
-			noteViewerFontSize: `${baseTheme.fontSize}${baseTheme.fontSizeUnits ?? 'px'}`,
+			noteViewerFontSize: `${baseTheme.fontSize}${effectiveFontSizeUnits}`,
 		},
 		noteHash: '',
 		initialScrollPercent: 0,

--- a/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts
@@ -48,16 +48,12 @@ const useMessenger = (props: UseMessengerProps) => {
 
 	const markupRenderingSettings = useRef<RenderOptions>(null);
 	const baseTheme = props.settings.themeData;
-	const fontSizeUnits = baseTheme.fontSizeUnits ?? 'px';
-	// Use `rem` instead of `em` for noteViewerFontSize to avoid inconsistent font sizing
-	// in monospace elements (browsers default to 13px for monospace, not the usual 16px)
-	const effectiveFontSizeUnits = fontSizeUnits === 'em' ? 'rem' : fontSizeUnits;
 	markupRenderingSettings.current = {
 		themeId: props.themeId,
 		highlightedKeywords: [],
 		resources: props.noteResources,
 		themeOverrides: {
-			noteViewerFontSize: `${baseTheme.fontSize}${effectiveFontSizeUnits}`,
+			noteViewerFontSize: `${baseTheme.fontSize}${baseTheme.fontSizeUnits ?? 'px'}`,
 		},
 		noteHash: '',
 		initialScrollPercent: 0,


### PR DESCRIPTION
## Summary

Code blocks in the mobile rich text editor used a noticeably smaller font than the viewer and markdown editor.

Ref. issue:  [#14152](https://github.com/laurent22/joplin/issues/14152)

 Two issues were causing this:


1. **Body font-size was relative instead of absolute** - The rich text editor passed `noteViewerFontSize` as `0.9375em` (converted from the user's `15px` setting via `15/16`). This [em](cci:1://file:///d:/Joplin_test/packages/lib/models/settings/builtInMetadata.ts:63:1-75:3) value resolved against the iframe's root `<html>` font-size (~13px), producing `body { font-size: 12.1875px }` instead of the expected `15px`. Code blocks and inline code inherited this smaller base, compounding the size reduction.

2. **Inline code was reduced to 90% of body** - [defaultNoteStyle.js](cci:7://file:///d:/Joplin_test/packages/renderer/defaultNoteStyle.js:0:0-0:0) set `codeFontSize: '.9em'`, making inline code 10% smaller than body text across both the viewer and rich text editor.

## Changes

### Fix 1: [packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts](cci:7://file:///d:/Joplin_test/packages/app-mobile/contentScripts/richTextEditorBundle/useWebViewSetup.ts:0:0-0:0)

Read the raw pixel value from `Setting.value('style.editor.fontSize')` instead of using the em-converted `baseTheme.fontSize`. This matches how the viewer passes its font size (`useRerenderHandler.ts:130`), producing an absolute `body { font-size: 15px }`.

### Fix 2: [packages/renderer/defaultNoteStyle.js](cci:7://file:///d:/Joplin_test/packages/renderer/defaultNoteStyle.js:0:0-0:0)

Changed `codeFontSize` from `'.9em'` to `'1em'` so inline code matches the body font-size. The `.9em` default was originally a design choice to compensate for monospace fonts appearing visually larger, but on mobile the reduction was noticeable and inconsistent with user expectations.

## Testing

Tested on web and Android emulator.
 
#### Rich text:

  - body font-size: `15px`
  - code block font-size: `15px`
  - inline code font-size: `15px`
####  Viewer:
  - body font-size: `16px`
  - code block font-size: `16px`
  - inline code font-size: `16px`
  
#### Screenshots(after fix):

#### Rich text
<img width="362" height="802" alt="Rich text output" src="https://github.com/user-attachments/assets/b4068302-b50a-4e70-a800-7f7f0cd388c5" />

#### Viewer
<img width="358" height="797" alt="Viewer output" src="https://github.com/user-attachments/assets/0eb8a496-20ae-473c-82bc-554eaffd1855" />