### PR TITLE
fixes #11793 : uses consistent padding in plugin info dialog

### DIFF
--- a/packages/app-mobile/components/DismissibleDialog.tsx
+++ b/packages/app-mobile/components/DismissibleDialog.tsx
@@ -57,6 +57,7 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogVaria
 			},
 			closeButton: {
 				margin: 0,
+				marginRight: -8,
 			},
 			// Ensure that the close button is aligned with the center of the header:
 			// Make its container smaller and center it.
@@ -91,8 +92,8 @@ const useStyles = (themeId: number, containerStyle: ViewStyle, size: DialogVaria
 			dialogSurface: {
 				borderRadius: 24,
 				backgroundColor: theme.backgroundColor,
-				paddingHorizontal: 16,
-				paddingVertical: 24,
+				paddingHorizontal: theme.margin,
+				paddingVertical: theme.margin,
 				...dialogSizing,
 			},
 		});

--- a/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/plugins/PluginInfoModal.tsx
@@ -39,8 +39,6 @@ const styles = (() => {
 		display: 'flex',
 		flexDirection: 'column',
 		gap: 20,
-		marginLeft: 10,
-		marginRight: 10,
 	};
 	return StyleSheet.create({
 		descriptionText: {
@@ -64,7 +62,7 @@ const styles = (() => {
 			flexDirection: 'row',
 			justifyContent: 'space-between',
 			alignItems: 'center',
-			padding: 10,
+			paddingVertical: 10,
 			marginTop: 12,
 			marginBottom: 14,
 		},
@@ -123,7 +121,7 @@ const PluginInfoModalContent: React.FC<Props> = props => {
 	});
 
 	const aboutPlugin = (
-		<Card mode='outlined' style={{ margin: 8 }} testID='plugin-card'>
+		<Card mode='outlined' style={{ marginVertical: 8 }} testID='plugin-card'>
 			<Card.Content>
 				<PluginTitle manifest={manifest}/>
 				<Text variant='bodyMedium'>{_('by %s', manifest.author)}</Text>


### PR DESCRIPTION
- [x] Divider lines shortened — removed extra horizontal margins from content so dividers no longer extend beyond buttons and card
- [x] Close button moved to the right — added `marginRight: -8` to offset IconButton's internal padding
- [x] Bottom gap uses same padding — changed `paddingVertical` from `24` to `theme.margin`
- [x] Space above close button uses same padding 
- [x] Close button may need to be moved down 
<img width="799" height="717" alt="joplin_issue_new" src="https://github.com/user-attachments/assets/4e33abce-148b-42c5-8479-903a831d0708" />
