### PR TITLE
Desktop: Fix sidebar scroll jump when expanding/collapsing folders

### DIFF
--- a/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
@@ -33,6 +33,9 @@ const useScrollToSelectionHandler = (
 	selectedIndexRef.current = selectedIndex;
 
 	useEffect(() => {
+		// Skip scrolling if the selected item hasn't actually changed. When a folder is
+		// expanded or collapsed the selected item's index may shift, but its key stays
+		// the same — in that case we don't want to scroll the view.
 		if (selectedItemKey === lastSelectedItemKey.current) {
 			return;
 		}

--- a/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
+++ b/packages/app-desktop/gui/Sidebar/hooks/useFocusHandler.ts
@@ -28,12 +28,16 @@ const useScrollToSelectionHandler = (
 			return lastSelectedItemKey.current;
 		}
 	}, [listItems, selectedIndex]);
-	lastSelectedItemKey.current = selectedItemKey;
 
 	const selectedIndexRef = useRef(selectedIndex);
 	selectedIndexRef.current = selectedIndex;
 
 	useEffect(() => {
+		if (selectedItemKey === lastSelectedItemKey.current) {
+			return;
+		}
+		lastSelectedItemKey.current = selectedItemKey;
+
 		if (!itemListRef.current || !selectedItemKey) return;
 
 		const hasFocus = !!itemListRef.current.container.contains(document.activeElement);

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -65,19 +65,31 @@ const isElementVisibleInContainer = (element: HTMLElement, container: HTMLElemen
 
 const focusListItem = (item: HTMLElement|null) => {
 	if (item) {
+		const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
 		const itemList = item.closest('.item-list');
+		const activeTreeItem = activeElement?.closest('[role="treeitem"]');
+		const focusWasLost = activeElement === document.body;
 
-		// If the item is scrolled out of view, skip focusing it entirely.
-		// Without this guard, a re-render (e.g. after expanding/collapsing a folder)
-		// would focus the selected item and cause the browser to scroll it into view,
-		// producing an unexpected "scroll jump" back to the selection.
-		if (itemList instanceof HTMLElement && !isElementVisibleInContainer(item, itemList)) {
+		// If the currently focused element is a tree item inside the same list,
+		// the user is navigating with the keyboard — always allow focus to move
+		// to the newly selected item so arrow-key scrolling is not interrupted.
+		const isKeyboardNavigating = !!activeTreeItem && itemList?.contains(activeTreeItem);
+
+		// Avoid disturbing scroll while user is manually scrolling through the list.
+		// However, if focus was lost (activeElement -> <body>), or the user is
+		// navigating with the keyboard, allow re-focusing even when the selected
+		// item is currently out of view.
+		if (itemList instanceof HTMLElement && !isElementVisibleInContainer(item, itemList) && !focusWasLost && !isKeyboardNavigating) {
 			return;
 		}
 
-		// preventScroll: true avoids a secondary scroll caused by the focus() call
-		// itself when the item is near the edge of the visible area.
-		focus('useOnRenderItem', item, { preventScroll: true });
+		// Move focus only if needed: either focus was lost, or selection changed
+		// to a different tree item.
+		if (focusWasLost || activeTreeItem !== item) {
+			// preventScroll: true avoids a secondary scroll caused by the focus() call
+			// itself when the item is near the edge of the visible area.
+			focus('useOnRenderItem', item, { preventScroll: true });
+		}
 	}
 };
 
@@ -381,7 +393,12 @@ const useOnRenderItem = (props: Props) => {
 			multipleItemsSelected: props.selectedIndexes.length > 1,
 		};
 
-		const focusInList = document.hasFocus() && props.containerRef.current?.contains(document.activeElement);
+		const sidebarContainsFocus = props.containerRef.current?.contains(document.activeElement);
+		// Focus moves to <body> when the previously-focused element is removed
+		// from the DOM (e.g. scrolled out of the virtualized list). We still
+		// want to restore focus to the newly-selected item in that case.
+		const focusLostFromDom = document.activeElement === document.body;
+		const focusInList = document.hasFocus() && (sidebarContainsFocus || focusLostFromDom);
 		const anchorRef = (focusInList && primarySelected) ? focusListItem : noFocusListItem;
 
 		if (item.kind === ListItemType.Tag) {

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -54,12 +54,25 @@ type ItemContextMenuListener = MouseEventHandler<HTMLElement>;
 
 const menuUtils = new MenuUtils(CommandService.instance());
 
+const isElementVisibleInContainer = (element: HTMLElement, container: HTMLElement) => {
+	const elementRect = element.getBoundingClientRect();
+	const containerRect = container.getBoundingClientRect();
+
+	return elementRect.bottom > containerRect.top && elementRect.top < containerRect.bottom;
+};
+
 const focusListItem = (item: HTMLElement|null) => {
 	if (item) {
-		// Avoid scrolling to the selected item when refocusing the note list. Such a refocus
-		// can happen if the note list rerenders and the selection is scrolled out of view and
-		// can cause scroll to change unexpectedly.
-		focus('useOnRenderItem', item, { preventScroll: true });
+		const tree = item.closest('[role="tree"]');
+		const itemList = item.closest('.item-list');
+
+		if (itemList instanceof HTMLElement && !isElementVisibleInContainer(item, itemList)) {
+			return;
+		}
+
+		if (tree && !tree.contains(document.activeElement)) {
+			focus('useOnRenderItem', item, { preventScroll: true });
+		}
 	}
 };
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -63,16 +63,13 @@ const isElementVisibleInContainer = (element: HTMLElement, container: HTMLElemen
 
 const focusListItem = (item: HTMLElement|null) => {
 	if (item) {
-		const tree = item.closest('[role="tree"]');
 		const itemList = item.closest('.item-list');
 
 		if (itemList instanceof HTMLElement && !isElementVisibleInContainer(item, itemList)) {
 			return;
 		}
 
-		if (tree && !tree.contains(document.activeElement)) {
-			focus('useOnRenderItem', item, { preventScroll: true });
-		}
+		focus('useOnRenderItem', item, { preventScroll: true });
 	}
 };
 

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -54,6 +54,8 @@ type ItemContextMenuListener = MouseEventHandler<HTMLElement>;
 
 const menuUtils = new MenuUtils(CommandService.instance());
 
+// Checks whether an element is at least partially visible within a scrollable
+// container by comparing their bounding rectangles.
 const isElementVisibleInContainer = (element: HTMLElement, container: HTMLElement) => {
 	const elementRect = element.getBoundingClientRect();
 	const containerRect = container.getBoundingClientRect();
@@ -65,10 +67,16 @@ const focusListItem = (item: HTMLElement|null) => {
 	if (item) {
 		const itemList = item.closest('.item-list');
 
+		// If the item is scrolled out of view, skip focusing it entirely.
+		// Without this guard, a re-render (e.g. after expanding/collapsing a folder)
+		// would focus the selected item and cause the browser to scroll it into view,
+		// producing an unexpected "scroll jump" back to the selection.
 		if (itemList instanceof HTMLElement && !isElementVisibleInContainer(item, itemList)) {
 			return;
 		}
 
+		// preventScroll: true avoids a secondary scroll caused by the focus() call
+		// itself when the item is near the edge of the visible area.
 		focus('useOnRenderItem', item, { preventScroll: true });
 	}
 };


### PR DESCRIPTION
Fixes #13679 

* Fixed scroll-to-selection triggering on folder expand/collapse instead of only on actual selection changes
* Fixed focus handler restoring focus to off-screen items, causing the sidebar to jump
* Implemented visibility check to skip focusing items outside the visible scroll area