### PR TITLE
Desktop: Fixes #12401: copying from markdown preview including theme background colour

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -809,6 +809,34 @@
 			);
 		}));
 
+		document.addEventListener('copy', webviewLib.logEnabledEventHandler(e => {
+			const selection = window.getSelection();
+			if (!selection || selection.isCollapsed) return;
+
+			const range = selection.getRangeAt(0);
+			const wrapper = document.createElement('div');
+			wrapper.appendChild(range.cloneContents());
+
+			wrapper.querySelectorAll('style').forEach(s => s.remove());
+
+			const inlineTags = new Set(['STRONG', 'EM', 'CODE', 'S', 'DEL', 'INS', 'MARK', 'SUP', 'SUB', 'U', 'SPAN', 'A']);
+			let node = range.commonAncestorContainer;
+			if (node.nodeType === Node.TEXT_NODE) node = node.parentElement;
+
+			while (node && node.id !== 'rendered-md' && node.id !== 'joplin-container-content') {
+				if (inlineTags.has(node.tagName)) {
+					const el = node.cloneNode(false);
+					while (wrapper.firstChild) el.appendChild(wrapper.firstChild);
+					wrapper.appendChild(el);
+				}
+				node = node.parentElement;
+			}
+
+			e.clipboardData.setData('text/html', wrapper.innerHTML);
+			e.clipboardData.setData('text/plain', selection.toString());
+			e.preventDefault();
+		}));
+
 		let lastClientWidth_ = NaN, lastClientHeight_ = NaN, lastScrollTop_ = NaN;
 
 		window.addEventListener('resize', webviewLib.logEnabledEventHandler(() => {


### PR DESCRIPTION
Fixes #12401

Copying from the Markdown preview and pasting into Google Docs or Word was including Joplin’s theme background color. In dark themes, this made the pasted text invisible.

This happens because Chromium’s clipboard serializer inlines body styles into the copied HTML.

Fix:
Intercept the copy event and write a clean HTML fragment to the clipboard, bypassing Chromium’s default serializer (same approach as the rich text editor).

Also handled:

- Ctrl+A – Removes the injected `<style>` block so theme CSS isn’t copied.

- Double-click bold/italic word – Restores missing `<strong>/<em>` wrappers when only the text node is selected.


https://github.com/user-attachments/assets/0169cd27-f7ab-47d4-84a4-e16c929b48e7


