### PR TITLE
Desktop: Fixes #12401: copying from markdown preview including theme background colour

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -809,6 +809,8 @@
 			);
 		}));
 
+		// By default, Chromium inlines body styles (e.g. theme background color) into the clipboard HTML.
+		// Intercept the copy event and write only the selected content to bypass this behaviour.
 		document.addEventListener('copy', webviewLib.logEnabledEventHandler(e => {
 			const selection = window.getSelection();
 			if (!selection || selection.isCollapsed) return;

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -812,6 +812,7 @@
 		document.addEventListener('copy', webviewLib.logEnabledEventHandler(e => {
 			const selection = window.getSelection();
 			if (!selection || selection.isCollapsed) return;
+			if (selection.rangeCount === 0 || !e.clipboardData) return;
 
 			const range = selection.getRangeAt(0);
 			const wrapper = document.createElement('div');
@@ -823,7 +824,7 @@
 			let node = range.commonAncestorContainer;
 			if (node.nodeType === Node.TEXT_NODE) node = node.parentElement;
 
-			while (node && node.id !== 'rendered-md' && node.id !== 'joplin-container-content') {
+			while (node && node !== document.body && node.id !== 'rendered-md' && node.id !== 'joplin-container-content') {
 				if (inlineTags.has(node.tagName)) {
 					const el = node.cloneNode(false);
 					while (wrapper.firstChild) el.appendChild(wrapper.firstChild);

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -809,6 +809,34 @@
 			);
 		}));
 
+		document.addEventListener('copy', webviewLib.logEnabledEventHandler(e => {
+			const selection = window.getSelection();
+			if (!selection || selection.isCollapsed) return;
+
+			const range = selection.getRangeAt(0);
+			const wrapper = document.createElement('div');
+			wrapper.appendChild(range.cloneContents());
+
+			wrapper.querySelectorAll('style').forEach(s => s.remove());
+
+			const inlineTags = new Set(['STRONG', 'EM', 'CODE', 'S', 'DEL', 'INS', 'MARK', 'SUP', 'SUB', 'U', 'SPAN', 'A']);
+			let node = range.commonAncestorContainer;
+			if (node.nodeType === Node.TEXT_NODE) node = node.parentElement;
+
+			while (node && node.id !== 'rendered-md' && node.id !== 'joplin-container-content') {
+				if (inlineTags.has(node.tagName)) {
+					const el = node.cloneNode(false);
+					while (wrapper.firstChild) el.appendChild(wrapper.firstChild);
+					wrapper.appendChild(el);
+				}
+				node = node.parentElement;
+			}
+
+			e.clipboardData.setData('text/html', wrapper.innerHTML);
+			e.clipboardData.setData('text/plain', selection.toString());
+			e.preventDefault();
+		}));
+
 		let lastClientWidth_ = NaN, lastClientHeight_ = NaN, lastScrollTop_ = NaN;
 
 		window.addEventListener('resize', webviewLib.logEnabledEventHandler(() => {

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -418,8 +418,9 @@ test.describe('markdownEditor', () => {
 		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
 
 		await viewerFrame.locator('#rendered-md').click();
-		await mainWindow.keyboard.press('Control+a');
-		await mainWindow.keyboard.press('Control+c');
+		const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+		await mainWindow.keyboard.press(`${modifier}+a`);
+		await mainWindow.keyboard.press(`${modifier}+c`);
 
 		const clipboardHtml = await mainWindow.evaluate(() => {
 			const { clipboard } = require('electron');

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -405,8 +405,8 @@ test.describe('markdownEditor', () => {
 		await noteEditor.expectToHaveText('A');
 	});
 
-	test('copying from the preview pane should not include theme background color', async ({ mainWindow, electronApp }) => {
-		// Set dark theme so we know #1D2024 would be present in clipboard without the fix
+	test('copying from the preview pane should not include theme background color and should preserve bold formatting', async ({ mainWindow, electronApp }) => {
+		// Set dark theme so background-color would be present in clipboard without the fix
 		await setSettingValue(electronApp, mainWindow, 'theme', 2);
 
 		const mainScreen = await new MainScreen(mainWindow).setup();
@@ -415,36 +415,10 @@ test.describe('markdownEditor', () => {
 		await mainScreen.createNewNote('Test copy formatting');
 		const noteEditor = mainScreen.noteEditor;
 		await noteEditor.focusCodeMirrorEditor();
-		await mainWindow.keyboard.type('**bold text**');
+		await mainWindow.keyboard.type('**hello**');
 
 		const viewerFrame = noteEditor.getNoteViewerFrameLocator();
-		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
-
-		await viewerFrame.locator('#rendered-md').click();
-		const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
-		await mainWindow.keyboard.press(`${modifier}+a`);
-		await mainWindow.keyboard.press(`${modifier}+c`);
-
-		const clipboardHtml = await mainWindow.evaluate(() => {
-			const { clipboard } = require('electron');
-			return clipboard.readHTML();
-		});
-
-		// #1D2024 is the dark theme backgroundColor - it should not appear in clipboard
-		expect(clipboardHtml).not.toContain('#1D2024');
-	});
-
-	test('copying a bold word from the preview pane should preserve bold formatting', async ({ mainWindow }) => {
-		const mainScreen = await new MainScreen(mainWindow).setup();
-		await mainScreen.waitFor();
-
-		await mainScreen.createNewNote('Test bold copy');
-		const noteEditor = mainScreen.noteEditor;
-		await noteEditor.focusCodeMirrorEditor();
-		await mainWindow.keyboard.type('**bold text**');
-
-		const viewerFrame = noteEditor.getNoteViewerFrameLocator();
-		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
+		await expect(viewerFrame.locator('strong')).toHaveText('hello');
 
 		// Double-click selects the text node inside <strong>, not <strong> itself.
 		// Without the ancestor re-wrapping fix, <strong> would be dropped.
@@ -457,6 +431,8 @@ test.describe('markdownEditor', () => {
 			return clipboard.readHTML();
 		});
 
+		expect(clipboardHtml).toContain('hello');
+		expect(clipboardHtml).not.toMatch(/background-color\s*:/i);
 		expect(clipboardHtml).toContain('<strong>');
 	});
 });

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -405,7 +405,10 @@ test.describe('markdownEditor', () => {
 		await noteEditor.expectToHaveText('A');
 	});
 
-	test('copying from the preview pane should not include theme background color', async ({ mainWindow }) => {
+	test('copying from the preview pane should not include theme background color', async ({ mainWindow, electronApp }) => {
+		// Set dark theme so we know #1D2024 would be present in clipboard without the fix
+		await setSettingValue(electronApp, mainWindow, 'theme', 2);
+
 		const mainScreen = await new MainScreen(mainWindow).setup();
 		await mainScreen.waitFor();
 
@@ -427,7 +430,34 @@ test.describe('markdownEditor', () => {
 			return clipboard.readHTML();
 		});
 
-		expect(clipboardHtml).not.toContain('background-color');
+		// #1D2024 is the dark theme backgroundColor - it should not appear in clipboard
+		expect(clipboardHtml).not.toContain('#1D2024');
+	});
+	
+	test('copying a bold word from the preview pane should preserve bold formatting', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.waitFor();
+
+		await mainScreen.createNewNote('Test bold copy');
+		const noteEditor = mainScreen.noteEditor;
+		await noteEditor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('**bold text**');
+
+		const viewerFrame = noteEditor.getNoteViewerFrameLocator();
+		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
+
+		// Double-click selects just the word — selection lands on the text node inside
+		// <strong>, not <strong> itself. Without the ancestor re-wrapping fix, <strong>
+		// would be dropped by cloneContents() and this assertion would fail.
+		await viewerFrame.locator('strong').dblclick();
+		const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+		await mainWindow.keyboard.press(`${modifier}+c`);
+
+		const clipboardHtml = await mainWindow.evaluate(() => {
+			const { clipboard } = require('electron');
+			return clipboard.readHTML();
+		});
+
 		expect(clipboardHtml).toContain('<strong>');
 	});
 });

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -404,5 +404,29 @@ test.describe('markdownEditor', () => {
 		await activateMainMenuItem(electronApp, 'Redo');
 		await noteEditor.expectToHaveText('A');
 	});
-});
 
+	test('copying from the preview pane should not include theme background color', async ({ mainWindow }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.waitFor();
+
+		await mainScreen.createNewNote('Test copy formatting');
+		const noteEditor = mainScreen.noteEditor;
+		await noteEditor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('**bold text**');
+
+		const viewerFrame = noteEditor.getNoteViewerFrameLocator();
+		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
+
+		await viewerFrame.locator('#rendered-md').click();
+		await mainWindow.keyboard.press('Control+a');
+		await mainWindow.keyboard.press('Control+c');
+
+		const clipboardHtml = await mainWindow.evaluate(() => {
+			const { clipboard } = require('electron');
+			return clipboard.readHTML();
+		});
+
+		expect(clipboardHtml).not.toContain('background-color');
+		expect(clipboardHtml).toContain('<strong>');
+	});
+});

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -433,8 +433,8 @@ test.describe('markdownEditor', () => {
 		// #1D2024 is the dark theme backgroundColor - it should not appear in clipboard
 		expect(clipboardHtml).not.toContain('#1D2024');
 	});
-	
-	test('copying a bold word from the preview pane should preserve bold formatting', async ({ mainWindow, electronApp }) => {
+
+	test('copying a bold word from the preview pane should preserve bold formatting', async ({ mainWindow }) => {
 		const mainScreen = await new MainScreen(mainWindow).setup();
 		await mainScreen.waitFor();
 
@@ -446,9 +446,8 @@ test.describe('markdownEditor', () => {
 		const viewerFrame = noteEditor.getNoteViewerFrameLocator();
 		await expect(viewerFrame.locator('strong')).toHaveText('bold text');
 
-		// Double-click selects just the word — selection lands on the text node inside
-		// <strong>, not <strong> itself. Without the ancestor re-wrapping fix, <strong>
-		// would be dropped by cloneContents() and this assertion would fail.
+		// Double-click selects the text node inside <strong>, not <strong> itself.
+		// Without the ancestor re-wrapping fix, <strong> would be dropped.
 		await viewerFrame.locator('strong').dblclick();
 		const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
 		await mainWindow.keyboard.press(`${modifier}+c`);


### PR DESCRIPTION
Fixes: #12401
### AI Assistance Disclosure
AI was used to write the integration test based on existing test patterns.

I have reviewed all generated output carefully, understand every line of the code submitted, and verified the fix works correctly locally.

---

### **Fix:**
Copying from the markdown preview included the theme background color when pasting into other apps. The rich text editor already handled this correctly. This PR brings the markdown preview in line with the same behaviour, pasting gives clean formatted text without Joplin theme colors.

### **Test:**
Added an integration test that types bold text into the markdown editor, copies from the preview pane, and asserts the clipboard HTML contains <strong> but not background-color.
<img width="1715" height="448" alt="image" src="https://github.com/user-attachments/assets/78d4cf9e-aa47-4b04-b1fc-bd99684772f1" />
