### PR TITLE
 Desktop: Fixes #14468: Note not moving from panel when clicked

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -327,9 +327,9 @@ interface ConnectProps {
 }
 
 const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
-	const selectedFolder: FolderEntity = state.notesParentType === 'Folder' ? Folder.byId(state.folders, state.selectedFolderId) : null;
-	const userId = state.settings['sync.userId'];
 	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
+	const selectedFolder: FolderEntity = windowState.notesParentType === 'Folder' ? Folder.byId(state.folders, windowState.selectedFolderId) : null;
+	const userId = state.settings['sync.userId'];
 
 	return {
 		notes: windowState.notes,
@@ -337,7 +337,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		selectedNoteIds: windowState.selectedNoteIds,
 		selectedFolderId: windowState.selectedFolderId,
 		themeId: state.settings.theme,
-		notesParentType: state.notesParentType,
+		notesParentType: windowState.notesParentType,
 		searches: state.searches,
 		selectedSearchId: windowState.selectedSearchId,
 		watchedNoteFiles: state.watchedNoteFiles,
@@ -346,11 +346,11 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		noteSortOrder: state.settings['notes.sortOrder.field'],
 		uncompletedTodosOnTop: state.settings.uncompletedTodosOnTop,
 		showCompletedTodos: state.settings.showCompletedTodos,
-		highlightedWords: state.highlightedWords,
+		highlightedWords: windowState.highlightedWords,
 		plugins: state.pluginService.plugins,
 		customCss: state.customViewerCss,
 		focusedField: state.focusedField,
-		parentFolderIsReadOnly: state.notesParentType === 'Folder' && selectedFolder ? itemIsReadOnlySync(ModelType.Folder, ItemChange.SOURCE_UNSPECIFIED, selectedFolder as ItemSlice, userId, state.shareService) : false,
+		parentFolderIsReadOnly: windowState.notesParentType === 'Folder' && selectedFolder ? itemIsReadOnlySync(ModelType.Folder, ItemChange.SOURCE_UNSPECIFIED, selectedFolder as ItemSlice, userId, state.shareService) : false,
 		selectedFolderInTrash: itemIsInTrash(selectedFolder),
 	};
 };

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -1,5 +1,5 @@
 import { setupDatabaseAndSynchronizer, switchClient, createNTestNotes, createNTestFolders, createNTestTags } from './testing/test-utils';
-import reducer, { defaultState, defaultWindowId, MAX_HISTORY, State } from './reducer';
+import reducer, { defaultState, defaultWindowId, MAX_HISTORY, State, stateUtils } from './reducer';
 import { BaseItemEntity, FolderEntity, NoteEntity, TagEntity } from './services/database/types';
 import Note from './models/Note';
 import BaseModel from './BaseModel';
@@ -924,5 +924,49 @@ describe('reducer', () => {
 		// The other window should be focused
 		expect(state.windowId).toBe(defaultWindowId);
 		expect(state.selectedNoteIds).toEqual([notes[0].id]);
+	});
+
+	it('should provide correct per-window state via windowStateById after WINDOW_FOCUS swap', async () => {
+		const folders = await createNTestFolders(2);
+		const notes1 = await createNTestNotes(3, folders[0]);
+		const notes2 = await createNTestNotes(3, folders[1]);
+		let state = initTestState(folders, 0, notes1, [0]);
+
+		// Main window is viewing folder[0]
+		expect(state.notesParentType).toBe('Folder');
+		expect(state.selectedFolderId).toBe(folders[0].id);
+
+		// Open a secondary window with a note from folder[1]
+		const secondaryWindowId = 'window-secondary';
+		state = createBackgroundWindow(state, secondaryWindowId, notes2[0], notes2);
+
+		// Before focus swap: each window should have its own state
+		const mainBefore = stateUtils.windowStateById(state, defaultWindowId);
+		expect(mainBefore.notesParentType).toBe('Folder');
+		expect(mainBefore.selectedFolderId).toBe(folders[0].id);
+
+		const secondaryBefore = stateUtils.windowStateById(state, secondaryWindowId);
+		expect(secondaryBefore.notesParentType).toBe('Folder');
+		expect(secondaryBefore.selectedFolderId).toBe(notes2[0].parent_id);
+
+		// Focus the secondary window (this swaps the states)
+		state = reducer(state, { type: 'WINDOW_FOCUS', windowId: secondaryWindowId });
+
+		// After focus swap: windowStateById should still return correct state for each window
+		const mainAfterSwap = stateUtils.windowStateById(state, defaultWindowId);
+		expect(mainAfterSwap.notesParentType).toBe('Folder');
+		expect(mainAfterSwap.selectedFolderId).toBe(folders[0].id);
+
+		const secondaryAfterSwap = stateUtils.windowStateById(state, secondaryWindowId);
+		expect(secondaryAfterSwap.notesParentType).toBe('Folder');
+		expect(secondaryAfterSwap.selectedFolderId).toBe(notes2[0].parent_id);
+
+		// Focus back to main window
+		state = reducer(state, { type: 'WINDOW_FOCUS', windowId: defaultWindowId });
+
+		// After switching back: main window state should still be correct
+		const mainFinal = stateUtils.windowStateById(state, defaultWindowId);
+		expect(mainFinal.notesParentType).toBe('Folder');
+		expect(mainFinal.selectedFolderId).toBe(folders[0].id);
 	});
 });


### PR DESCRIPTION
Fixes #14468

## Problem
When a note is opened in a new window and the user switches focus between windows, clicking a note in the main window's note list doesn't update the editor panel.

This happens because `NoteList2`'s [mapStateToProps](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/app-desktop/gui/NoteList/NoteList2.tsx:328:0-355:2) reads `notesParentType`, `highlightedWords`, and `parentFolderIsReadOnly` from the top-level state instead of per-window state. When `WINDOW_FOCUS` fires, the reducer's [handleFocus](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:959:1-978:3) swaps the WindowState properties — it copies the secondary window's properties into the top-level [state](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:455:0-460:1) and moves the main window's properties into `backgroundWindows`. So each NoteList2 instance ends up reading the wrong window's values, causing incorrect `parentFolderIsReadOnly` computation (which can block drag-and-drop and note interactions) and wrong `notesParentType` (which breaks `useMoveNote` behavior).

## Solution
Read `notesParentType`, `highlightedWords`, and `parentFolderIsReadOnly` from [windowState](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:415:1-423:2) (via `stateUtils.windowStateById()`) instead of the top-level [state](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:455:0-460:1). [windowStateById](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:415:1-423:2) returns [state](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:455:0-460:1) itself if it's the focused window, or `state.backgroundWindows[windowId]` otherwise — so each NoteList2 always reads its own window's state regardless of which window is currently focused. This is consistent with how `NoteEditor` already handles multi-window state.

Low-risk change — only affects [mapStateToProps](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/app-desktop/gui/NoteList/NoteList2.tsx:328:0-355:2) in [NoteList2.tsx](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/app-desktop/gui/NoteList/NoteList2.tsx:0:0-0:0).

## Test Plan
- Added a reducer test verifying that [windowStateById](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/lib/reducer.ts:415:1-423:2) returns correct per-window `notesParentType` and `selectedFolderId` after `WINDOW_FOCUS` swaps.
- Manual: Open a note in a new window → switch focus between windows → verify note selection works correctly in the main window's note list.
