### PR TITLE
Desktop: Fix UI freeze when closing plugin dialog with Escape key

### DIFF
--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -88,6 +88,7 @@ test.describe('pluginApi', () => {
 			const mainScreen = await new MainScreen(mainWindow).setup();
 			await mainScreen.createNewNote('Test note');
 
+			// WebView isolation is currently behind a feature flag:
 			await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
 
 			await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -2,6 +2,7 @@
 import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
 import { msleep, Second } from '@joplin/utils/time';
+import setSettingValue from './util/setSettingValue';
 
 test.describe('pluginApi', () => {
 	test('the editor.setText command should update the current note (use RTE: false)', async ({ startAppWithPlugins }) => {
@@ -78,6 +79,39 @@ test.describe('pluginApi', () => {
 		// Submitting the dialog should include form data in the output
 		await mainScreen.dialog.getByRole('button', { name: 'Okay' }).click();
 		await expectVisible(false);
+	});
+
+	test('should dismiss a plugin dialog when clicking Cancel with isolated iframes', async ({ startAppWithPlugins }) => {
+		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/dialogs.js']);
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('Test note');
+
+		await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
+
+		await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');
+		const dialogContent = mainScreen.dialog.locator('iframe').contentFrame();
+		await dialogContent.locator('p').waitFor();
+
+		await mainScreen.dialog.getByRole('button', { name: 'Cancel' }).click();
+		await expect(mainScreen.dialog).toBeHidden();
+
+		await mainScreen.noteEditor.expectToHaveText('cancel');
+	});
+
+	// Regression test for #13718
+	test('should dismiss a plugin dialog when pressing Escape with isolated iframes', async ({ startAppWithPlugins }) => {
+		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/dialogs.js']);
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('Test note');
+
+		await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
+
+		await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');
+		const dialogContent = mainScreen.dialog.locator('iframe').contentFrame();
+		await dialogContent.locator('p').waitFor();
+
+		await mainWindow.keyboard.press('Escape');
+		await expect(mainScreen.dialog).toBeHidden();
 	});
 
 	test('should be possible to create multiple toasts with the same text from a plugin', async ({ startAppWithPlugins }) => {

--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -81,38 +81,28 @@ test.describe('pluginApi', () => {
 		await expectVisible(false);
 	});
 
-	test('should dismiss a plugin dialog when clicking Cancel with isolated iframes', async ({ startAppWithPlugins }) => {
-		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/dialogs.js']);
-		const mainScreen = await new MainScreen(mainWindow).setup();
-		await mainScreen.createNewNote('Test note');
+	// Regression tests for #13718
+	for (const method of ['Cancel button', 'Escape key'] as const) {
+		test(`should dismiss a plugin dialog via ${method} with isolated iframes`, async ({ startAppWithPlugins }) => {
+			const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/dialogs.js']);
+			const mainScreen = await new MainScreen(mainWindow).setup();
+			await mainScreen.createNewNote('Test note');
 
-		await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
+			await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
 
-		await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');
-		const dialogContent = mainScreen.dialog.locator('iframe').contentFrame();
-		await dialogContent.locator('p').waitFor();
+			await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');
+			const dialogContent = mainScreen.dialog.locator('iframe').contentFrame();
+			await dialogContent.locator('p').waitFor();
 
-		await mainScreen.dialog.getByRole('button', { name: 'Cancel' }).click();
-		await expect(mainScreen.dialog).toBeHidden();
+			if (method === 'Cancel button') {
+				await mainScreen.dialog.getByRole('button', { name: 'Cancel' }).click();
+			} else {
+				await mainWindow.keyboard.press('Escape');
+			}
 
-		await mainScreen.noteEditor.expectToHaveText('cancel');
-	});
-
-	// Regression test for #13718
-	test('should dismiss a plugin dialog when pressing Escape with isolated iframes', async ({ startAppWithPlugins }) => {
-		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/dialogs.js']);
-		const mainScreen = await new MainScreen(mainWindow).setup();
-		await mainScreen.createNewNote('Test note');
-
-		await setSettingValue(app, mainWindow, 'featureFlag.plugins.isolatePluginWebViews', true);
-
-		await mainScreen.goToAnything.runCommand(app, 'showTestDialogWithDismiss');
-		const dialogContent = mainScreen.dialog.locator('iframe').contentFrame();
-		await dialogContent.locator('p').waitFor();
-
-		await mainWindow.keyboard.press('Escape');
-		await expect(mainScreen.dialog).toBeHidden();
-	});
+			await expect(mainScreen.dialog).toBeHidden();
+		});
+	}
 
 	test('should be possible to create multiple toasts with the same text from a plugin', async ({ startAppWithPlugins }) => {
 		const { app, mainWindow } = await startAppWithPlugins(['resources/test-plugins/showToast.js']);

--- a/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/dialogs.js
@@ -48,6 +48,21 @@ joplin.plugins.register({
 			},
 		});
 
+		const dismissDialogHandle = await dialogs.create('test-dialog-with-dismiss');
+		await dialogs.setHtml(dismissDialogHandle, '<p>Press Escape to dismiss</p>');
+		await dialogs.setButtons(dismissDialogHandle, [
+			{ id: 'ok', title: 'Okay' },
+			{ id: 'cancel', title: 'Cancel' },
+		]);
+		await joplin.commands.register({
+			name: 'showTestDialogWithDismiss',
+			label: 'showTestDialogWithDismiss',
+			execute: async () => {
+				const result = await joplin.views.dialogs.open(dismissDialogHandle);
+				await joplin.commands.execute('editor.setText', result.id);
+			},
+		});
+
 		await joplin.commands.register({
 			name: 'getTestDialogVisibility',
 			label: 'Returns the dialog visibility state',

--- a/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
+++ b/packages/app-desktop/services/plugins/UserWebviewDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import { ButtonSpec, DialogResult } from '@joplin/lib/services/plugins/api/types';
 import PluginService from '@joplin/lib/services/plugins/PluginService';
 import WebviewController from '@joplin/lib/services/plugins/WebviewController';
@@ -76,8 +76,16 @@ export default function UserWebviewDialog(props: Props) {
 		if (webviewRef.current) focus('UserWebviewDialog', webviewRef.current);
 	}, []);
 
+	// When the iframe is isolated (security setting enabled), keyboard events
+	// like Escape don't reach the iframe content. We let the native <dialog>
+	// handle Escape by passing onCancel, but only when there's a dismiss button.
+	// https://github.com/laurent22/joplin/issues/13718
+	const onCancel = useMemo(() => {
+		return findDismissButton(buttons) ? onDismiss : undefined;
+	}, [buttons, onDismiss]);
+
 	return (
-		<Dialog className={`user-webview-dialog ${props.fitToContent ? '-fit' : ''}`}>
+		<Dialog className={`user-webview-dialog ${props.fitToContent ? '-fit' : ''}`} onCancel={onCancel}>
 			<div className='user-dialog-wrapper'>
 				<UserWebview
 					ref={webviewRef}


### PR DESCRIPTION
fixes #13718

### Problem
When the "Improve plugin panel, editor, and dialog security" setting is enabled, plugin dialogs load their content through an isolated protocol. The problem is that keyboard events like Escape never reach the iframe in this mode, so the iframe's dismiss handler never fires. 

At the same time, the native dialog element's cancel event was always being suppressed because no cancel handler was wired up. This left the modal stuck open and trapping all focus, making the entire UI appear frozen until you switched to another window and back.
### Fix
The fix is to pass the dismiss callback as the cancel handler on the Dialog component, but only when the dialog actually has a dismiss button. This way the native Escape handling kicks in properly regardless of whether the iframe is isolated or not.

Before and after recordings below:
### Before:

https://github.com/user-attachments/assets/72415ff5-664b-476e-9cdb-4e1e48094e14


### After:

https://github.com/user-attachments/assets/5f44c15e-f667-413f-9e9b-02b7dcc63bd9

