### PR TITLE
Chore: Link to GSoC pull request guidelines in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,7 @@
 
 Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md
 
-If this pull request is related to Google Summer of Code, please also read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md) and [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md).
+If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,12 @@
 <!--
 
-Please prefix the title with the platform you are targetting:
+Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md
+
+If this pull request is related to Google Summer of Code, please also read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md) and [AI policy](https://github.com/joplin/gsoc/blob/master/ai_policy.md).
+
+---
+
+**Pull request title**: Please prefix the title with the platform you are targetting.
 
 Here are some examples of good titles:
 
@@ -19,7 +25,5 @@ If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's 
 If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.
 
 Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.
-
-AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md
 
 -->


### PR DESCRIPTION
# Summary

This change adds a link to the GSoC pull request guidelines near the top of the pull request template. This should make the pull request guidelines easier to find.



<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->