### PR TITLE
Mobile: Fixes #14286: Add support for opening folder links

### DIFF
--- a/packages/app-mobile/commands/openItem.ts
+++ b/packages/app-mobile/commands/openItem.ts
@@ -9,6 +9,7 @@ import { BaseItemEntity } from '@joplin/lib/services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import showResource from './util/showResource';
 import { isCallbackUrl, parseCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import NavService from '@joplin/lib/services/NavService';
 
 const logger = Logger.create('openItemCommand');
 
@@ -22,8 +23,14 @@ const openItemById = async (itemId: string, hash?: string) => {
 
 	if (item.type_ === ModelType.Note) {
 		await goToNote(itemId, hash);
+
 	} else if (item.type_ === ModelType.Resource) {
 		await showResource(item);
+
+	} else if (item.type_ === ModelType.Folder) {
+		// ✅ Added support for opening folder links on mobile
+		await NavService.go('Notes', { folderId: item.id });
+
 	} else {
 		throw new Error(`Unsupported item type for links: ${item.type_}`);
 	}


### PR DESCRIPTION
### Summary

This PR fixes an issue where links to folders (:/folder-id) open correctly on desktop but fail on mobile.

### Changes

- Added support for `ModelType.Folder` in `openItemById`
- Navigates to the corresponding folder using `NavService.go('Notes', { folderId })`

### Testing

This change has not been fully tested on a physical device.
Please let me know if any adjustments are required.