### PR TITLE
Mobile: Prevent race condition when refreshing note contents on mobile

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -714,8 +714,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			const explicitReloadRequired = !editorPlugin && this.props.editorNoteReloadTimeRequest > this.state.noteLastLoadTime;
 
 			if (explicitReloadRequired) {
-				void shared.reloadNote(this);
-				this.refreshKey = this.props.editorNoteReloadTimeRequest;
+				void this.reloadNoteAndUpdateRefreshKey();
 			}
 
 			if (explicitReloadRequired || (editorPlugin && editorPluginIdsChanged)) {
@@ -768,6 +767,11 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			type: 'SET_NOTE_EDITOR_VISIBLE',
 			visible: false,
 		});
+	}
+
+	private async reloadNoteAndUpdateRefreshKey() {
+		await shared.reloadNote(this);
+		this.refreshKey = this.props.editorNoteReloadTimeRequest;
 	}
 
 	private title_changeText(text: string) {


### PR DESCRIPTION
When doing further testing for the Secure Notes plugin, I found the change in https://github.com/laurent22/joplin/pull/14444 was no longer working for the Rich Text Editor. This is because there is a possible race condition when triggering the remount of the editor, if remount completes before the reloading of the note does.

This PR addresses the issue by awaiting the reloadNote call before updating the refreshKey.

### Testing

For testing I verified that the refresh is consistently working with the Rich Text Editor, when repeating my tests using a modified version of the Secure Notes plugin.