### PR TITLE
Fix SMTP TLS mode mismatch on port 587 causing ESOCKET / wrong version number

### DIFF
--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -1,0 +1,14 @@
+import { mailerSecurityForPort } from './config';
+import { MailerSecurity } from './env';
+
+describe('config', () => {
+
+	it('should use starttls for port 587 when security is tls', () => {
+		expect(mailerSecurityForPort(587, MailerSecurity.Tls)).toBe(MailerSecurity.Starttls);
+	});
+
+	it('should use tls for port 465 when security is starttls', () => {
+		expect(mailerSecurityForPort(465, MailerSecurity.Starttls)).toBe(MailerSecurity.Tls);
+	});
+
+});

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -11,4 +11,17 @@ describe('config', () => {
 		expect(mailerSecurityForPort(465, MailerSecurity.Starttls)).toBe(MailerSecurity.Tls);
 	});
 
+	it('should keep starttls for port 587 when security is already starttls', () => {
+		expect(mailerSecurityForPort(587, MailerSecurity.Starttls)).toBe(MailerSecurity.Starttls);
+	});
+
+	it('should keep tls for port 465 when security is already tls', () => {
+		expect(mailerSecurityForPort(465, MailerSecurity.Tls)).toBe(MailerSecurity.Tls);
+	});
+
+	it('should not modify security for non-standard ports', () => {
+		expect(mailerSecurityForPort(25, MailerSecurity.Tls)).toBe(MailerSecurity.Tls);
+		expect(mailerSecurityForPort(2525, MailerSecurity.Starttls)).toBe(MailerSecurity.Starttls);
+	});
+
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -2,7 +2,7 @@ import { rtrimSlashes } from '@joplin/lib/path-utils';
 import { Config, DatabaseConfig, DatabaseConfigClient, Env, MailerConfig, LdapConfig, RouteType, StripeConfig, SamlConfig } from './utils/types';
 import * as pathUtils from 'path';
 import { loadStripeConfig, StripePublicConfig } from '@joplin/lib/utils/joplinCloud';
-import { EnvVariables } from './env';
+import { EnvVariables, MailerSecurity } from './env';
 import parseStorageDriverConnectionString from './models/items/storage/parseStorageConnectionString';
 
 interface PackageJson {
@@ -84,12 +84,20 @@ function databaseConfigFromEnv(runningInDocker: boolean, env: EnvVariables, slav
 	};
 }
 
+export function mailerSecurityForPort(port: number, security: MailerSecurity): MailerSecurity {
+	if (port === 587 && security === MailerSecurity.Tls) return MailerSecurity.Starttls;
+	if (port === 465 && security === MailerSecurity.Starttls) return MailerSecurity.Tls;
+	return security;
+}
+
 function mailerConfigFromEnv(env: EnvVariables): MailerConfig {
+
+	const security = mailerSecurityForPort(env.MAILER_PORT, env.MAILER_SECURITY);
 	return {
 		enabled: env.MAILER_ENABLED,
 		host: env.MAILER_HOST,
 		port: env.MAILER_PORT,
-		security: env.MAILER_SECURITY,
+		security,
 		authUser: env.MAILER_AUTH_USER,
 		authPassword: env.MAILER_AUTH_PASSWORD,
 		noReplyName: env.MAILER_NOREPLY_NAME,


### PR DESCRIPTION
---

### Fixes #14487

### Problem

When configured with:

* `MAILER_PORT=587`
* `MAILER_SECURITY=tls`

the mailer failed with `ESOCKET` / `wrong version number` errors, preventing emails (e.g., password reset) from being sent.

**Cause:** Port 587 uses STARTTLS, but `tls` enabled implicit TLS (`secure: true`), causing a protocol mismatch.

---

### Solution

Auto-correct invalid port/security combinations:

* 587 + `tls` → `starttls`
* 465 + `starttls` → `tls`
* Other combinations unchanged

Implemented via `mailerSecurityForPort()` and applied in `mailerConfigFromEnv()`.

---

### Impact

* Fixes Gmail/SMTP failures on port 587
* Preserves existing valid configurations
* Avoids guessing for non-standard ports

---

### Tests

* Added unit tests for port/security correction logic
* Manual test confirms emails send successfully with 587 

---

https://github.com/user-attachments/assets/7723bdba-8b64-4f64-93c1-180071a15f49

