### PR TITLE
Desktop: Fixes #14386: Title bar color mismatch with selected theme

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -65,6 +65,7 @@ import OcrDriverBase from '@joplin/lib/services/ocr/OcrDriverBase';
 import PerformanceLogger from '@joplin/lib/PerformanceLogger';
 import Note from '@joplin/lib/models/Note';
 import Resource from '@joplin/lib/models/Resource';
+import { nativeTheme } from 'electron';
 
 const perfLogger = PerformanceLogger.create();
 
@@ -176,6 +177,7 @@ class Application extends BaseApplication {
 
 		if (this.hasGui() && ((action.type === 'SETTING_UPDATE_ONE' && ['themeAutoDetect', 'theme', 'preferredLightTheme', 'preferredDarkTheme'].includes(action.key)) || action.type === 'SETTING_UPDATE_ALL')) {
 			this.handleThemeAutoDetect();
+			this.updateNativeTitleBarTheme();
 		}
 
 		if (action.type === 'PLUGIN_ADD') {
@@ -194,6 +196,29 @@ class Application extends BaseApplication {
 			Setting.setValue('theme', Setting.value('preferredDarkTheme'));
 		} else {
 			Setting.setValue('theme', Setting.value('preferredLightTheme'));
+		}
+	}
+
+	public updateNativeTitleBarTheme() {
+		// 1. If auto-detect is on, let the OS decide
+		if (Setting.value('themeAutoDetect')) {
+			nativeTheme.themeSource = 'system';
+			return;
+		}
+
+		// 2. If auto-detect is off, grab the current Joplin theme
+		const currentTheme = Setting.value('theme');
+		const darkThemes = [
+			Setting.value('preferredDarkTheme'),
+			2, // Setting.THEME_DARK
+			22, // Setting.THEME_OLED_DARK
+		];
+
+		// 3. Force the Windows/macOS title bar to match
+		if (darkThemes.includes(currentTheme)) {
+			nativeTheme.themeSource = 'dark';
+		} else {
+			nativeTheme.themeSource = 'light';
 		}
 	}
 


### PR DESCRIPTION
Fixes #14386

### Description
This PR resolves the issue where the native Windows/macOS title bar remained white when Joplin's internal dark theme was enabled. 

It implements `nativeTheme.themeSource` from Electron directly in `app.ts`. When the user changes their theme or toggles `themeAutoDetect`, it forces the OS-level title bar to sync with Joplin's internal state (Light, Dark, or OLED Dark), while still respecting the auto-detect system preference if enabled.

### AI Assistance Disclosure
**What parts were generated/modified:** The logic within `app.ts` to utilize Electron's `nativeTheme.themeSource` to sync the OS title bar with Joplin's internal theme.
**How AI was used:** I used AI as an interactive tutor to help me understand Electron's native UI APIs, bypass the IPC bridge, and safely hook the `updateNativeTitleBarTheme` logic into the existing settings event listener without breaking the auto-detect feature. 
**Confirmation:** I have manually reviewed the generated logic, fully understand how the `nativeTheme` API interacts with the user settings, and have locally compiled and tested the fix to confirm it works perfectly.