### PR TITLE
Desktop: Fix #12385 Copy and paste from markdown preview includes search highlight effect

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -35,6 +35,10 @@
 		ul ul, ul ol, ol ul, ol ol   {
 			margin-bottom: 0px;			
 		}
+		::highlight(search-results) {
+    		background-color: #f7d26e;
+    		color: black;
+		}
 	</style>
 </head>
 
@@ -519,7 +523,8 @@
 
 			let selectedElement = null;
 			let elementIndex = 0;
-
+			
+			const allRanges = [];
 			const markKeywordOptions = {};
 
 			if ('separateWordSearch' in options) markKeywordOptions.separateWordSearch = options.separateWordSearch;
@@ -527,9 +532,17 @@
 			try {
 				for (const keyword of keywords) {
 					markJsUtils.markKeyword(mark_, keyword, {
-						pregQuote: pregQuote,
-						replaceRegexDiacritics: replaceRegexDiacritics,
-					}, markKeywordOptions);
+                        pregQuote: pregQuote,
+                        replaceRegexDiacritics: replaceRegexDiacritics,
+                    }, {
+                        ...markKeywordOptions,
+                        element: 'mark-ghost',
+                        each: (node) => {
+                            const range = new Range();
+                            range.selectNodeContents(node);
+                            allRanges.push(range);
+                        }
+                    });
 				}
 			} catch (error) {
 				if (error.name !== 'SyntaxError') {
@@ -539,6 +552,10 @@
 				// when the input is really big, this catch is here to avoid the application crashing
 				// https://github.com/laurent22/joplin/issues/7634
 				console.error('Error while trying to highlight words from search: ', error);
+			}
+			if (allRanges.length > 0) {
+				const searchResultsHighlight = new Highlight(...allRanges);
+            	CSS.highlights.set("search-results", searchResultsHighlight);
 			}
 		}
 

--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -507,7 +507,7 @@
 			if (!options) options = {};
 
 			// TODO: Add support for scriptType on mobile and CLI
-
+			CSS.highlights.clear();
 			if (!mark_) {
 				mark_ = new Mark(document.getElementById('joplin-container-content'), {
 					exclude: ['img'],

--- a/packages/app-desktop/integration-tests/markdownEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/markdownEditor.spec.ts
@@ -161,7 +161,7 @@ test.describe('markdownEditor', () => {
 		const viewer = noteEditor.getNoteViewerFrameLocator();
 		await expect(viewer.locator('h1')).toHaveText('Testing');
 
-		const matches = viewer.locator('mark');
+		const matches = viewer.locator('mark-ghost');
 		await expect(matches).toHaveCount(0);
 
 		await mainWindow.keyboard.press(process.platform === 'darwin' ? 'Meta+f' : 'Control+f');


### PR DESCRIPTION
fixed #12385 
## AI Disclosure
I used AI to understand the problem deeply. Also, assisted in drafting the initial implementation of note-viewer/index.html and this PR. 
## Root Cause
The current search highlighting relies on mark.js. mark.js modifies the DOM by inserting mark tags, which is the root cause of the copy-paste bug.
## Fix
I have migrated the rendering logic to the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API), which allows highlighting text without altering the DOM structure.

### Implementation Details:
- Changed the temporary marking tag to mark-ghost to avoid styling conflicts.

- These temporary tags are used as anchors to create Range objects.

- The actual visual highlighting is now handled by the CSS Custom Highlight API

## Testing
Manual:
1. Switch to markdown editor (preview mode)
2. use the search box above the note list to search for some text that's in the body of a note
3. Select the note from the search results
4. Select text from the note and copy it
5. Paste into application that accepts HTML formatting
6. Verify that pasted text won't be highlighted.
https://github.com/user-attachments/assets/18394a00-3abd-4d17-8ebf-332eed5da0df


