### PR TITLE
Mobile: Fix iOS note swipe-back behavior in edit vs view mode (#14306)

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -7,7 +7,7 @@ import NoteBodyViewer from '../../NoteBodyViewer/NoteBodyViewer';
 import checkPermissions from '../../../utils/checkPermissions';
 import NoteEditor from '../../NoteEditor/NoteEditor';
 import * as React from 'react';
-import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions } from 'react-native';
+import { Keyboard, View, TextInput, StyleSheet, Linking, Share, NativeSyntheticEvent, useWindowDimensions, PanResponder, GestureResponderEvent, PanResponderGestureState } from 'react-native';
 import { Platform, PermissionsAndroid } from 'react-native';
 import { connect } from 'react-redux';
 import Note from '@joplin/lib/models/Note';
@@ -200,6 +200,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		return shared.noteComponent_change(this, 'body', saveEvent.body);
 	});
 	private refreshKey: number | undefined;
+	private edgeSwipeResponder: any;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static navigationOptions(): any {
@@ -358,6 +359,32 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		this.onUndoRedoDepthChange = this.onUndoRedoDepthChange.bind(this);
 		this.speechToTextDialog_onText = this.speechToTextDialog_onText.bind(this);
 		this.audioRecorderDialog_onDismiss = this.audioRecorderDialog_onDismiss.bind(this);
+
+		if (Platform.OS === 'ios') {
+			this.edgeSwipeResponder = PanResponder.create({
+				onMoveShouldSetPanResponder: (_evt: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+					const isFromLeftEdge = _evt.nativeEvent.pageX < 25;
+					const isHorizontalSwipe = Math.abs(gestureState.dx) > 20 && Math.abs(gestureState.dy) < 20;
+					return isFromLeftEdge && isHorizontalSwipe;
+				},
+				onPanResponderRelease: (_evt: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+					if (gestureState.dx > 80) {
+						this.handleSwipeBack();
+					}
+				},
+			});
+		}
+	}
+
+	private handleSwipeBack() {
+		if (this.state.mode === 'edit') {
+			this.toggleVisiblePanes();
+			return;
+		}
+
+		this.props.dispatch({
+			type: 'NAV_BACK',
+		});
 	}
 
 	private registerCommands() {
@@ -1873,7 +1900,12 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		/>;
 
 		return (
-			<View style={this.rootStyle(this.props.themeId).root}>
+			<View
+				style={this.rootStyle(this.props.themeId).root}
+				{...(Platform.OS === 'ios' && this.edgeSwipeResponder
+					? this.edgeSwipeResponder.panHandlers
+					: {})}
+			>
 				{!increaseSpaceForEditor && header}
 				{!increaseSpaceForEditor && titleComp}
 				{bodyComponent}


### PR DESCRIPTION
## Summary

Fixes swipe-back behavior on iOS in the Note screen.

Currently, swiping from the left edge while viewing or editing a note does not behave as expected.

This change adds a left-edge swipe gesture handler (iOS only) to the Note screen:

- If the note is in **edit mode**, a left-edge swipe exits edit mode (same behavior as tapping the view toggle button).
- If the note is in **view mode**, a left-edge swipe navigates back to the previous screen.

## Implementation Details

- Added an iOS-only `PanResponder` in `Note.tsx`
- Detects left-edge horizontal swipes
- Uses existing `toggleVisiblePanes()` command to exit edit mode
- Dispatches `NAV_BACK` when in view mode
- No changes to reducers, navigation architecture, or Android behavior

## Scope

- iOS only (`Platform.OS === 'ios'`)
- Affects only `packages/app-mobile/components/screens/Note/Note.tsx`
- Desktop and Android are not impacted

Fixes #14306