### PR TITLE
Desktop: Fixes #13883: Secondary windows no longer follow primary selection after moving notes

### DIFF
--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -927,8 +927,8 @@ describe('reducer', () => {
 	});
 	// Regression test for #13883.
 	it.each([
-		[undefined],
-		[false],
+		undefined,
+		false,
 	])('should not change selected note in background window when active window note moves folders (preserveSelection: %j)', async (
 		preserveSelectionOption,
 	) => {

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -787,7 +787,6 @@ describe('reducer', () => {
 		}
 	});
 
-	// Regression test for #10589.
 	it.each([
 		[true, false],
 		[undefined, false],
@@ -925,7 +924,7 @@ describe('reducer', () => {
 		expect(state.windowId).toBe(defaultWindowId);
 		expect(state.selectedNoteIds).toEqual([notes[0].id]);
 	});
-	// Regression test for #13883.
+
 	it.each([
 		undefined,
 		false,

--- a/packages/lib/reducer.test.ts
+++ b/packages/lib/reducer.test.ts
@@ -925,4 +925,44 @@ describe('reducer', () => {
 		expect(state.windowId).toBe(defaultWindowId);
 		expect(state.selectedNoteIds).toEqual([notes[0].id]);
 	});
+	// Regression test for #13883.
+	it.each([
+		[undefined],
+		[false],
+	])('should not change selected note in background window when active window note moves folders (preserveSelection: %j)', async (
+		preserveSelectionOption,
+	) => {
+		const folders = await createNTestFolders(2);
+		const notes = await createNTestNotes(3, folders[0]);
+
+		// select the 1st folder and the 1st note in the primary window
+		let state = initTestState(folders, 0, notes, [0]);
+
+		// open note[2] in a background (secondary) window
+		const secondaryWindowId = 'window1';
+		state = createBackgroundWindow(state, secondaryWindowId, notes[2], notes);
+
+		// background window should be on notes[2]
+		expect(state.backgroundWindows[secondaryWindowId].selectedNoteIds).toEqual([notes[2].id]);
+
+		BaseModel.dispatch = jest.fn((action: unknown) => {
+			state = reducer(state, action);
+		});
+
+		// move notes[0] (selected in primary window) to a different folder
+		await Note.moveToFolder(
+			state.selectedNoteIds[0],
+			folders[1].id,
+			{ dispatchOptions: { preserveSelection: preserveSelectionOption } },
+		);
+
+		expect(BaseModel.dispatch).toHaveBeenCalled();
+
+		// primary window should have switched away from the moved note
+		expect(state.notes.every(n => n.id !== notes[0].id)).toBe(true);
+
+		// background window should still be on notes[2], not have jumped to whatever
+		// the primary window selected next
+		expect(state.backgroundWindows[secondaryWindowId].selectedNoteIds).toEqual([notes[2].id]);
+	});
 });

--- a/packages/lib/reducer.ts
+++ b/packages/lib/reducer.ts
@@ -1178,7 +1178,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 		case 'NOTE_UPDATE_ONE':
 			{
 				const modNote: NoteEntity = action.note;
-				const handleWindowState = (windowDraft: Draft<WindowState>) => {
+				const handleWindowState = (windowDraft: Draft<WindowState>, isActiveWindow: boolean) => {
 					const isViewingAllNotes = (windowDraft.notesParentType === 'SmartFilter' && windowDraft.selectedSmartFilterId === ALL_NOTES_FILTER_ID);
 					const isViewingConflictFolder = windowDraft.notesParentType === 'Folder' && windowDraft.selectedFolderId === Folder.conflictFolderId();
 
@@ -1239,7 +1239,7 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 					// a new note should be selected.
 					// In some cases, however, the selection needs to be preserved (e.g. the mobile app).
 					const preserveSelection = action.preserveSelection ?? draft.allowSelectionInOtherFolders;
-					if (noteFolderHasChanged && !preserveSelection) {
+					if (noteFolderHasChanged && !preserveSelection && isActiveWindow) {
 						let newIndex = movedNotePreviousIndex;
 						if (newIndex >= newNotes.length) newIndex = newNotes.length - 1;
 						if (!newNotes.length) newIndex = -1;
@@ -1264,9 +1264,9 @@ const reducer = produce((draft: Draft<State> = defaultState, action: any) => {
 					}
 				};
 
-				handleWindowState(draft);
+				handleWindowState(draft, true);
 				for (const backgroundWindow of Object.values(draft.backgroundWindows)) {
-					handleWindowState(backgroundWindow);
+					handleWindowState(backgroundWindow, false);
 				}
 			}
 			break;


### PR DESCRIPTION

**Problem:**

Secondary windows change to the primary's new selected note when moving notes between folders (shared global selection state).

**Solution:**

Skip selection update in background/secondary windows (`isActiveWindow = false`) when handling note move/folder change.

Fixes #13883

<img width="1915" height="947" alt="screenshot-2026-02-28_03-59-43" src="https://github.com/user-attachments/assets/ba5fbcc6-59a8-4ddc-ad7c-b0c33dde0470" />
