### PR TITLE
Fix: normalize hyphenated locale codes to resolve zh-TW correctly

### DIFF
--- a/packages/lib/locale.test.ts
+++ b/packages/lib/locale.test.ts
@@ -15,6 +15,27 @@ describe('locale', () => {
 		}
 	});
 
+	// Regression test for https://github.com/laurent22/joplin/issues/14500
+	// macOS provides locale codes with hyphens (e.g. "zh-TW") but Joplin stores
+	// them with underscores ("zh_TW"). Without normalization, "zh-TW" falls
+	// through to the language-only loop and incorrectly returns "zh_CN".
+	it('should normalize hyphenated locale codes from the OS to underscore format', () => {
+		const testCases: [string, string[], string][] = [
+			// The core bug: zh-TW must resolve to zh_TW, NOT zh_CN
+			['zh-TW', ['zh_CN', 'zh_TW', 'en_GB'], 'zh_TW'],
+			// zh-CN should still work correctly
+			['zh-CN', ['zh_CN', 'zh_TW', 'en_GB'], 'zh_CN'],
+			// Other common macOS hyphenated codes should also work
+			['en-GB', ['en_GB', 'fr_FR'], 'en_GB'],
+			['pt-BR', ['pt_BR', 'en_GB'], 'pt_BR'],
+		];
+
+		for (const [input, locales, expected] of testCases) {
+			const actual = closestSupportedLocale(input, true, locales);
+			expect(actual).toBe(expected);
+		}
+	});
+
 	it('should translate plurals - en_GB', () => {
 		setLocale('en_GB');
 		expect(_n('Copy Shareable Link', 'Copy Shareable Links', 1)).toBe('Copy Shareable Link');

--- a/packages/lib/locale.ts
+++ b/packages/lib/locale.ts
@@ -553,6 +553,13 @@ function supportedLocalesToLanguages(options: SupportedLocalesToLanguagesOptions
 
 function closestSupportedLocale(canonicalName: string, defaultToEnglish = true, locales: string[] = null) {
 	locales = locales === null ? supportedLocales() : locales;
+
+	// Normalize hyphens to underscores so that locale codes provided by the OS
+	// (e.g. "zh-TW" on macOS) match Joplin's stored locale format ("zh_TW").
+	// Without this, "zh-TW" falls through to the language-only loop and
+	// incorrectly returns "zh_CN" instead of "zh_TW". See: #14500
+	canonicalName = canonicalName.replace(/-/g, '_');
+
 	if (locales.indexOf(canonicalName) >= 0) return canonicalName;
 
 	const requiredLanguage = languageCodeOnly(canonicalName).toLowerCase();


### PR DESCRIPTION
## Summary
Fixes #14500

## What was wrong
macOS provides locale codes using hyphens (e.g. `zh-TW`) but Joplin's supported locales list uses underscores (`zh_TW`). In [closestSupportedLocale()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Joplin_GSOC/joplin/packages/lib/locale.ts:553:0-573:1),
the exact-match check fails for `zh-TW` because `zh-TW !== zh_TW`, so the function falls through to the language-only loop which returns the first `zh_*` locale found — which happens to be `zh_CN` — instead of the correct `zh_TW`.

## Fix
Normalize hyphens to underscores at the top of [closestSupportedLocale()](cci:1://file:///Users/shivamchaudhary/Programming_Projects/Joplin_GSOC/joplin/packages/lib/locale.ts:553:0-573:1)
before any comparison is made. This is a one-line fix.

## Testing
- Added regression tests in [locale.test.ts](cci:7://file:///Users/shivamchaudhary/Programming_Projects/Joplin_GSOC/joplin/packages/lib/locale.test.ts:0:0-0:0) covering `zh-TW → zh_TW` (the
  core bug), plus `zh-CN`, `en-GB`, and `pt-BR`.
- All 13 locale tests pass.
- To reproduce the original bug: set macOS system language to Chinese (Traditional),
  open Joplin fresh — it would show Simplified Chinese. After the fix, it shows
  Traditional Chinese correctly.
