### PR TITLE
Desktop, Mobile: Resolves #12220: Add new option to disable the Joplin icon for internal note links

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -646,6 +646,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 				useCustomPdfViewer: props.useCustomPdfViewer,
 				noteId: props.noteId,
 				vendorDir: bridge().vendorDir(),
+				showNoteLinkIcon: props.showNoteLinkIcon,
 			}));
 
 			if (cancelled) return;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v5/CodeMirror.tsx
@@ -667,7 +667,7 @@ function CodeMirror(props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			shim.clearTimeout(timeoutId);
 		};
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
-	}, [props.content, props.contentKey, renderedBodyContentKey, props.contentMarkupLanguage, props.visiblePanes, props.resourceInfos, props.markupToHtml]);
+	}, [props.content, props.contentKey, renderedBodyContentKey, props.contentMarkupLanguage, props.visiblePanes, props.resourceInfos, props.markupToHtml, props.showNoteLinkIcon]);
 
 	useEffect(() => {
 		if (!webviewReady) return;

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -222,6 +222,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 				noteId: props.noteId,
 				vendorDir: bridge().vendorDir(),
 				globalSettings: getGlobalSettings(Setting),
+				showNoteLinkIcon: props.showNoteLinkIcon,
 			}));
 
 			if (cancelled) return;
@@ -244,7 +245,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 	}, [
 		props.content, props.contentKey, renderedBodyContentKey, props.contentMarkupLanguage,
 		props.visiblePanes, props.resourceInfos, props.markupToHtml, props.contentMaxWidth,
-		props.noteId, props.useCustomPdfViewer,
+		props.noteId, props.useCustomPdfViewer, props.showNoteLinkIcon,
 	]);
 
 	useEffect(() => {

--- a/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteEditor.tsx
@@ -474,6 +474,7 @@ function NoteEditorContent(props: NoteEditorProps) {
 		noteId: props.noteId,
 		watchedNoteFiles: props.watchedNoteFiles,
 		enableHtmlToMarkdownBanner: props.enableHtmlToMarkdownBanner,
+		showNoteLinkIcon: props.showNoteLinkIcon,
 	};
 
 	let editor = null;
@@ -767,6 +768,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 		searchResults: state.searchResults,
 		enableHtmlToMarkdownBanner: state.settings['editor.enableHtmlToMarkdownBanner'],
 		enableInEditorRendering: state.settings['editor.inlineRendering'],
+		showNoteLinkIcon: state.settings['notes.showNoteLinkIcon'],
 	};
 };
 

--- a/packages/app-desktop/gui/NoteEditor/utils/types.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/types.ts
@@ -75,6 +75,7 @@ export interface NoteEditorProps {
 	bodyEditor: NoteBodyEditorType;
 	startupPluginsLoaded: boolean;
 	enableHtmlToMarkdownBanner: boolean;
+	showNoteLinkIcon: boolean;
 }
 
 export interface NoteBodyEditorRef {
@@ -156,6 +157,7 @@ export interface NoteBodyEditorProps {
 	useCustomPdfViewer: boolean;
 	watchedNoteFiles: string[];
 	enableHtmlToMarkdownBanner: boolean;
+	showNoteLinkIcon: boolean;
 }
 
 export interface NoteBodyEditorPropsAndRef extends NoteBodyEditorProps {

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -35,6 +35,7 @@ interface Props {
 	customCss: string;
 	scrollbarSize: ScrollbarSize;
 	fontFamily: string;
+	showNoteLinkIcon: boolean;
 }
 
 const useNoteContent = (
@@ -45,6 +46,7 @@ const useNoteContent = (
 	customCss: string,
 	scrollbarSize: ScrollbarSize,
 	fontFamily: string,
+	showNoteLinkIcon: boolean,
 ) => {
 	const [note, setNote] = useState<NoteEntity>(null);
 
@@ -75,6 +77,7 @@ const useNoteContent = (
 			resources: await shared.attachedResources(noteBody),
 			whiteBackgroundNoteRendering: markupLanguage === MarkupLanguage.Html,
 			globalSettings: getGlobalSettings(Setting),
+			showNoteLinkIcon,
 		});
 
 		viewerRef.current.setHtml(result.html, {
@@ -85,7 +88,7 @@ const useNoteContent = (
 	return note;
 };
 
-const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack, customCss, scrollbarSize, fontFamily }) => {
+const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack, customCss, scrollbarSize, fontFamily, showNoteLinkIcon }) => {
 	const helpButton_onClick = useCallback(() => {}, []);
 	const viewerRef = useRef<NoteViewerControl|null>(null);
 	const revisionListRef = useRef<HTMLSelectElement|null>(null);
@@ -96,7 +99,7 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 	const [deleting, setDeleting] = useState(false);
 
 	const note = useNoteContent(
-		viewerRef, currentRevId, revisions, themeId, customCss, scrollbarSize, fontFamily,
+		viewerRef, currentRevId, revisions, themeId, customCss, scrollbarSize, fontFamily, showNoteLinkIcon,
 	);
 
 	const viewer_domReady = useCallback(async () => {
@@ -229,6 +232,7 @@ const mapStateToProps = (state: AppState) => {
 		themeId: state.settings.theme,
 		scrollbarSize: state.settings['style.scrollbarSize'],
 		fontFamily: state.settings['style.viewer.fontFamily'],
+		showNoteLinkIcon: state.settings['notes.showNoteLinkIcon'],
 	};
 };
 

--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -83,7 +83,7 @@ const useNoteContent = (
 		viewerRef.current.setHtml(result.html, {
 			pluginAssets: result.pluginAssets,
 		});
-	}, [note, viewerRef]);
+	}, [note, viewerRef, markupToHtml, showNoteLinkIcon]);
 
 	return note;
 };

--- a/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
+++ b/packages/app-mobile/components/NoteBodyViewer/NoteBodyViewer.tsx
@@ -34,6 +34,7 @@ interface Props {
 	onScroll: OnScrollCallback;
 	onLoadEnd?: ()=> void;
 	pluginStates: PluginStates;
+	showNoteLinkIcon: boolean;
 }
 
 const onJoplinLinkClick = async (message: string) => {
@@ -84,6 +85,7 @@ function NoteBodyViewer(props: Props) {
 		initialScrollPercent: props.initialScrollPercent,
 
 		paddingBottom: props.paddingBottom,
+		showNoteLinkIcon: props.showNoteLinkIcon,
 	});
 
 	const onLoadEnd = useCallback(() => {
@@ -115,4 +117,5 @@ export default connect((state: AppState) => ({
 	themeId: state.settings.theme,
 	fontSize: state.settings['style.viewer.fontSize'],
 	pluginStates: state.pluginService.plugins,
+	showNoteLinkIcon: state.settings['notes.showNoteLinkIcon'],
 }))(NoteBodyViewer);

--- a/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
+++ b/packages/app-mobile/components/NoteBodyViewer/hooks/useRerenderHandler.ts
@@ -27,6 +27,7 @@ interface Props {
 	initialScrollPercent: number|undefined;
 
 	paddingBottom: number;
+	showNoteLinkIcon: boolean;
 }
 
 const onlyCheckboxHasChangedHack = (previousBody: string, newBody: string) => {
@@ -100,7 +101,7 @@ const useRerenderHandler = (props: Props) => {
 	const effectDependencies = [
 		props.noteBody, props.noteMarkupLanguage, props.renderer, props.highlightedKeywords,
 		props.noteHash, props.noteResources, props.themeId, props.paddingBottom, resourceDownloadRerenderCounter,
-		props.fontSize,
+		props.fontSize, props.showNoteLinkIcon,
 	];
 	const previousDeps = usePrevious(effectDependencies, []);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -138,6 +139,7 @@ const useRerenderHandler = (props: Props) => {
 			// instead.
 			initialScrollPercent: (previousHash && hashChanged) ? undefined : props.initialScrollPercent,
 			noteHash: props.noteHash,
+			showNoteLinkIcon: props.showNoteLinkIcon,
 		};
 
 		try {

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.test.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.test.ts
@@ -21,6 +21,7 @@ const defaultRendererSettings: RenderSettings = {
 
 	pluginSettings: {},
 	requestPluginSetting: () => { },
+	showNoteLinkIcon: true,
 };
 
 const makeRenderer = (options: Partial<RendererSetupOptions>) => {

--- a/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/contentScript/Renderer.ts
@@ -27,6 +27,7 @@ export interface RenderSettings {
 
 	splitted?: boolean; // Move CSS into a separate output
 	mapsToLine?: boolean; // Sourcemaps
+	showNoteLinkIcon?: boolean;
 
 	createEditPopupSyntax: string;
 	destroyEditPopupSyntax: string;
@@ -136,6 +137,7 @@ export default class Renderer {
 			splitted: settings.splitted,
 			mapsToLine: settings.mapsToLine,
 			whiteBackgroundNoteRendering: markup.language === MarkupLanguage.Html,
+			showNoteLinkIcon: settings.showNoteLinkIcon,
 			globalSettings: settings.globalSettings,
 		};
 

--- a/packages/app-mobile/contentScripts/rendererBundle/types.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/types.ts
@@ -71,6 +71,7 @@ export interface RenderOptions {
 	// Forwarded renderer settings
 	splitted?: boolean;
 	mapsToLine?: boolean;
+	showNoteLinkIcon?: boolean;
 }
 
 type CancelEvent = { cancelled: boolean };

--- a/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
+++ b/packages/app-mobile/contentScripts/rendererBundle/useWebViewSetup.ts
@@ -240,6 +240,7 @@ const useWebViewSetup = (props: Props): Result => {
 					}
 				},
 				removeUnusedPluginAssets: options.removeUnusedPluginAssets,
+				showNoteLinkIcon: options.showNoteLinkIcon,
 				globalSettings: {
 					'markdown.plugin.abc.options': Setting.value('markdown.plugin.abc.options'),
 				},

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2084,6 +2084,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'note',
 			public: true,
+			isGlobal: true,
 			label: () => _('Show Joplin icon for note links'),
 			appTypes: [AppType.Desktop, AppType.Mobile],
 		},

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -2077,6 +2077,16 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			isGlobal: false,
 		},
+
+		'notes.showNoteLinkIcon': {
+			value: true,
+			type: SettingItemType.Bool,
+			storage: SettingStorage.File,
+			section: 'note',
+			public: true,
+			label: () => _('Show Joplin icon for note links'),
+			appTypes: [AppType.Desktop, AppType.Mobile],
+		},
 	} satisfies Record<string, SettingItem>;
 
 	for (const [key, md] of Object.entries(output)) {

--- a/packages/renderer/MdToHtml.ts
+++ b/packages/renderer/MdToHtml.ts
@@ -210,6 +210,8 @@ export interface RuleOptions {
 	allowedFilePrefixes?: string[];
 
 	platformName?: string;
+
+	showNoteLinkIcon?: boolean;
 }
 
 export default class MdToHtml implements MarkupRenderer {

--- a/packages/renderer/MdToHtml/linkReplacement.test.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.test.ts
@@ -79,6 +79,7 @@ describe('linkReplacement', () => {
 		expect(linkHtml).toContain('ontouchend');
 		expect(linkHtml).toContain('ontouchcancel');
 	});
+
 	test('should show Joplin Icon for internal link by default', () => {
 		const resourceId = 'e6afba55bdf74568ac94f8d1e3578d2c';
 		const linkHtml = linkReplacement(`:/${resourceId}`, {

--- a/packages/renderer/MdToHtml/linkReplacement.test.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.test.ts
@@ -79,4 +79,23 @@ describe('linkReplacement', () => {
 		expect(linkHtml).toContain('ontouchend');
 		expect(linkHtml).toContain('ontouchcancel');
 	});
+	test('should show Joplin Icon for internal link by default', () => {
+		const resourceId = 'e6afba55bdf74568ac94f8d1e3578d2c';
+		const linkHtml = linkReplacement(`:/${resourceId}`, {
+			ResourceModel: defaultResourceModel,
+			resources: {},
+			showNoteLinkIcon: true,
+		}).html;
+		expect(linkHtml).toContain('<span class="resource-icon fa-joplin"></span>');
+	});
+
+	test('should not include Joplin Icon for internal link if configuration is not enabled', () => {
+		const resourceId = 'e6afba55bdf74568ac94f8d1e3578d2c';
+		const linkHtml = linkReplacement(`:/${resourceId}`, {
+			ResourceModel: defaultResourceModel,
+			resources: {},
+			showNoteLinkIcon: false,
+		}).html;
+		expect(linkHtml).not.toContain('<span class="resource-icon fa-joplin"></span>');
+	});
 });

--- a/packages/renderer/MdToHtml/linkReplacement.ts
+++ b/packages/renderer/MdToHtml/linkReplacement.ts
@@ -16,6 +16,7 @@ export interface Options {
 	postMessageSyntax?: string;
 	enableLongPress?: boolean;
 	itemIdToUrl?: ItemIdToUrlHandler;
+	showNoteLinkIcon?: boolean;
 }
 
 export interface LinkReplacementResult {
@@ -35,6 +36,7 @@ export default function(href: string, options: Options = null): LinkReplacementR
 	options.plainResourceRendering ??= false;
 	options.postMessageSyntax ??= 'postMessage';
 	options.enableLongPress ??= false;
+	options.showNoteLinkIcon ??= true;
 
 	const resourceHrefInfo = urlUtils.parseResourceUrl(href);
 	const isResourceUrl = options.resources && !!resourceHrefInfo;
@@ -74,12 +76,16 @@ export default function(href: string, options: Options = null): LinkReplacementR
 			if (resourceHrefInfo.hash) href += `#${resourceHrefInfo.hash}`;
 			resourceIdAttr = `data-resource-id='${resourceId}'`;
 
-			const iconType = mime ? getClassNameForMimeType(mime) : 'fa-joplin';
-
+			let iconType;
+			if (mime) {
+				iconType = getClassNameForMimeType(mime);
+			} else {
+				iconType = options.showNoteLinkIcon ? 'fa-joplin' : '';
+			}
 			// Icons are defined in lib/renderers/noteStyle using inline svg
 			// The icons are taken from fork-awesome but use the font-awesome naming scheme in order
 			// to be more compatible with the getClass library
-			icon = `<span class="resource-icon ${iconType}"></span>`;
+			icon = iconType ? `<span class="resource-icon ${iconType}"></span>` : '';
 		}
 	} else {
 		// If the link is a plain URL (as opposed to a resource link), set the href to the actual

--- a/packages/renderer/MdToHtml/rules/link_open.ts
+++ b/packages/renderer/MdToHtml/rules/link_open.ts
@@ -23,6 +23,7 @@ function plugin(markdownIt: any, ruleOptions: RuleOptions) {
 			postMessageSyntax: ruleOptions.postMessageSyntax,
 			enableLongPress: ruleOptions.enableLongPress,
 			itemIdToUrl: ruleOptions.itemIdToUrl,
+			showNoteLinkIcon: ruleOptions.showNoteLinkIcon,
 		});
 
 		ruleOptions.context.currentLinks.push({

--- a/packages/renderer/types.ts
+++ b/packages/renderer/types.ts
@@ -92,6 +92,8 @@ export interface RenderOptions {
 
 	platformName?: string;
 
+	showNoteLinkIcon?: boolean;
+
 	// HtmlToHtml only
 	whiteBackgroundNoteRendering?: boolean;
 


### PR DESCRIPTION
fixes: #12220

Add an option to show or hide the Joplin icon on internal note links.

<img width="1504" height="623" alt="image" src="https://github.com/user-attachments/assets/d5a149e3-c2f7-4d84-b9d5-178318d16f3f" />

https://github.com/user-attachments/assets/b39f4d41-98fb-4da7-9b12-08a22d1a1d53

