### PR TITLE
Desktop: Setup screen to allow choice of editor during setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -216,6 +216,8 @@ packages/app-desktop/gui/DropboxLoginScreen.js
 packages/app-desktop/gui/Dropdown/Dropdown.js
 packages/app-desktop/gui/EditFolderDialog/Dialog.js
 packages/app-desktop/gui/EditFolderDialog/IconSelector.js
+packages/app-desktop/gui/EditorModeSelector.js
+packages/app-desktop/gui/EditorModeSelectorDialog.js
 packages/app-desktop/gui/EmojiBox.js
 packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.js
 packages/app-desktop/gui/ErrorBoundary.js
@@ -527,6 +529,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useSyncDialogState.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.js
 packages/app-desktop/gui/dialogs.js
+packages/app-desktop/gui/editorModeSelectorStartup.test.js
+packages/app-desktop/gui/editorModeSelectorStartup.js
 packages/app-desktop/gui/hooks/useEffectDebugger.js
 packages/app-desktop/gui/hooks/useElementHeight.js
 packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js

--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,8 @@ packages/app-desktop/gui/DropboxLoginScreen.js
 packages/app-desktop/gui/Dropdown/Dropdown.js
 packages/app-desktop/gui/EditFolderDialog/Dialog.js
 packages/app-desktop/gui/EditFolderDialog/IconSelector.js
+packages/app-desktop/gui/EditorModeSelector.js
+packages/app-desktop/gui/EditorModeSelectorDialog.js
 packages/app-desktop/gui/EmojiBox.js
 packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.js
 packages/app-desktop/gui/ErrorBoundary.js
@@ -500,6 +502,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useSyncDialogState.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.js
 packages/app-desktop/gui/dialogs.js
+packages/app-desktop/gui/editorModeSelectorStartup.test.js
+packages/app-desktop/gui/editorModeSelectorStartup.js
 packages/app-desktop/gui/hooks/useEffectDebugger.js
 packages/app-desktop/gui/hooks/useElementHeight.js
 packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js

--- a/packages/app-desktop/app.reducer.ts
+++ b/packages/app-desktop/app.reducer.ts
@@ -18,6 +18,7 @@ export interface AppStateRoute {
 export enum AppStateDialogName {
 	SyncWizard = 'syncWizard',
 	MasterPassword = 'masterPassword',
+	EditorModeSelector = 'editorModeSelector',
 }
 
 export interface AppStateDialog {

--- a/packages/app-desktop/gui/EditorModeSelector.tsx
+++ b/packages/app-desktop/gui/EditorModeSelector.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { _ } from '@joplin/lib/locale';
+import styled from 'styled-components';
+
+export type EditorMode = 'markdown' | 'richText';
+
+interface Props {
+	value: EditorMode;
+	onChange: (value: EditorMode)=> void;
+}
+
+interface Option {
+	value: EditorMode;
+	label: string;
+	iconClassName: string;
+}
+
+const options: Option[] = [
+	{
+		value: 'richText',
+		label: _('Rich Text'),
+		iconClassName: 'fas fa-edit',
+	},
+	{
+		value: 'markdown',
+		label: _('Markdown'),
+		iconClassName: 'fab fa-markdown',
+	},
+];
+
+export default function EditorModeSelector(props: Props) {
+	return (
+		<Root>
+			<CardRow role='radiogroup' aria-label={_('Editor mode')}>
+				{options.map(option => {
+					const checked = option.value === props.value;
+					return (
+						<CardButton
+							key={option.value}
+							type='button'
+							role='radio'
+							aria-checked={checked}
+							tabIndex={checked ? 0 : -1}
+							onClick={() => props.onChange(option.value)}
+							$selected={checked}
+						>
+							<ModeIcon className={option.iconClassName} aria-hidden={true} />
+							<ModeLabel>{option.label}</ModeLabel>
+						</CardButton>
+					);
+				})}
+			</CardRow>
+		</Root>
+	);
+}
+
+const Root = styled.div`
+	padding-bottom: 10px;
+`;
+
+const CardRow = styled.div`
+	display: flex;
+	gap: 12px;
+`;
+
+const CardButton = styled.button<{ $selected: boolean }>`
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 18px;
+	border-radius: 6px;
+	cursor: pointer;
+	font: inherit;
+	color: ${props => props.theme.color};
+	border: 1px solid ${props => props.$selected ? props.theme.color : props.theme.dividerColor};
+	background-color: ${props => props.theme.backgroundColor3};
+	outline: ${props => props.$selected ? `2px solid ${props.theme.color}` : 'none'};
+	outline-offset: 1px;
+
+	&:hover {
+		background-color: ${props => props.theme.backgroundColorHover3 || props.theme.backgroundColor3};
+	}
+
+	&:active {
+		background-color: ${props => props.theme.backgroundColorActive3 || props.theme.backgroundColor3};
+	}
+`;
+
+const ModeIcon = styled.i`
+	font-size: 28px;
+	pointer-events: none;
+`;
+
+const ModeLabel = styled.span`
+	font-family: ${props => props.theme.fontFamily};
+`;

--- a/packages/app-desktop/gui/EditorModeSelectorDialog.tsx
+++ b/packages/app-desktop/gui/EditorModeSelectorDialog.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { _ } from '@joplin/lib/locale';
+import Setting from '@joplin/lib/models/Setting';
+import Dialog from '@joplin/lib/components/Dialog';
+import DialogButtonRow, { ClickEvent } from './DialogButtonRow';
+import DialogTitle from './DialogTitle';
+import EditorModeSelector, { EditorMode } from './EditorModeSelector';
+
+interface Props {
+	themeId: number;
+	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
+	dispatch: Function;
+}
+
+export const editorCodeViewFromMode = (mode: EditorMode) => {
+	return mode === 'markdown';
+};
+
+export const commitEditorModeSelection = (
+	// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
+	dispatch: Function,
+	mode: EditorMode,
+) => {
+	const editorCodeView = editorCodeViewFromMode(mode);
+	Setting.setValue('editor.codeView', editorCodeView);
+	Setting.setValue('editor.modeSelectorShown', true);
+
+	dispatch({ type: 'EDITOR_CODE_VIEW_CHANGE', value: editorCodeView });
+	dispatch({ type: 'DIALOG_CLOSE', name: 'editorModeSelector' });
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
+export const dismissEditorModeSelection = (dispatch: Function) => {
+	Setting.setValue('editor.modeSelectorShown', true);
+	dispatch({ type: 'DIALOG_CLOSE', name: 'editorModeSelector' });
+};
+
+export default function EditorModeSelectorDialog(props: Props) {
+	const [selectedMode, setSelectedMode] = useState<EditorMode>('richText');
+	const hasCommittedRef = useRef(false);
+	const hasDismissedRef = useRef(false);
+
+	const commit = useCallback(() => {
+		if (hasCommittedRef.current) return;
+		hasCommittedRef.current = true;
+		commitEditorModeSelection(props.dispatch, selectedMode);
+	}, [props.dispatch, selectedMode]);
+
+	const onButtonRowClick = useCallback((event: ClickEvent) => {
+		if (event.buttonName !== 'ok') return;
+		commit();
+	}, [commit]);
+
+	const dismiss = useCallback(() => {
+		if (hasCommittedRef.current || hasDismissedRef.current) return;
+		hasDismissedRef.current = true;
+		dismissEditorModeSelection(props.dispatch);
+	}, [props.dispatch]);
+
+	return (
+		<Dialog
+			onCancel={dismiss}
+			className='editor-mode-selector-dialog'
+			contentStyle={{
+				width: 720,
+				maxWidth: 'calc(100vw - 40px)',
+				alignSelf: 'center',
+				margin: 20,
+				padding: 24,
+			}}
+		>
+			<div className="dialog-root">
+				<DialogTitle title={_('Select your preferred editor mode')} />
+				<div className="dialog-content">
+					<p>{_('You can switch this later from the toolbar or menu.')}</p>
+					<EditorModeSelector value={selectedMode} onChange={setSelectedMode} />
+				</div>
+				<DialogButtonRow
+					themeId={props.themeId}
+					onClick={onButtonRowClick}
+					cancelButtonShow={false}
+				/>
+			</div>
+		</Dialog>
+	);
+}

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -31,6 +31,7 @@ import EditorWindow from './NoteEditor/EditorWindow';
 import SsoLoginScreen from './SsoLoginScreen/SsoLoginScreen';
 import SamlShared from '@joplin/lib/components/shared/SamlShared';
 import PopupNotificationProvider from './PopupNotification/PopupNotificationProvider';
+import openEditorModeSelector from './editorModeSelectorStartup';
 const { ThemeProvider, StyleSheetManager, createGlobalStyle } = require('styled-components');
 
 interface Props {
@@ -94,6 +95,10 @@ class RootComponent extends React.Component<Props, any> {
 		}
 
 		await WelcomeUtils.install(Setting.value('locale'), this.props.dispatch);
+
+		setTimeout(() => {
+			openEditorModeSelector(this.props.dispatch);
+		}, 0);
 	}
 
 	private renderModalMessage(props: ModalDialogProps) {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.tsx
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/utils/appDialogs.tsx
@@ -4,6 +4,7 @@ import SyncWizardDialog from '../../SyncWizard/Dialog';
 import MasterPasswordDialog from '../../MasterPasswordDialog/Dialog';
 import EditFolderDialog from '../../EditFolderDialog/Dialog';
 import PdfViewer from '../../PdfViewer';
+import EditorModeSelectorDialog from '../../EditorModeSelectorDialog';
 
 interface RegisteredDialogProps {
 	themeId: number;
@@ -42,6 +43,12 @@ const appDialogs: Record<string, RegisteredDialog> = {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		render: (props: RegisteredDialogProps, customProps: any) => {
 			return <PdfViewer key={props.key} dispatch={props.dispatch} themeId={props.themeId} {...customProps}/>;
+		},
+	},
+	editorModeSelector: {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		render: (props: RegisteredDialogProps, customProps: any) => {
+			return <EditorModeSelectorDialog key={props.key} dispatch={props.dispatch} themeId={props.themeId} {...customProps}/>;
 		},
 	},
 };

--- a/packages/app-desktop/gui/editorModeSelectorStartup.test.ts
+++ b/packages/app-desktop/gui/editorModeSelectorStartup.test.ts
@@ -1,0 +1,27 @@
+import Setting from '@joplin/lib/models/Setting';
+import openEditorModeSelector from './editorModeSelectorStartup';
+
+describe('openEditorModeSelectorIfNeeded', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	test('opens the dialog when the flag is false', () => {
+		jest.spyOn(Setting, 'keyExists').mockReturnValue(true);
+		jest.spyOn(Setting, 'value').mockReturnValue(false);
+		const dispatch = jest.fn();
+
+		expect(openEditorModeSelector(dispatch)).toBe(true);
+		expect(dispatch).toHaveBeenCalledWith({ type: 'DIALOG_OPEN', name: 'editorModeSelector' });
+	});
+
+	test('does not open the dialog when the flag is true', () => {
+		jest.spyOn(Setting, 'keyExists').mockReturnValue(true);
+		jest.spyOn(Setting, 'value').mockReturnValue(true);
+		const dispatch = jest.fn();
+
+		expect(openEditorModeSelector(dispatch)).toBe(false);
+		expect(dispatch).not.toHaveBeenCalled();
+	});
+
+});

--- a/packages/app-desktop/gui/editorModeSelectorStartup.ts
+++ b/packages/app-desktop/gui/editorModeSelectorStartup.ts
@@ -1,0 +1,21 @@
+import Setting from '@joplin/lib/models/Setting';
+
+// eslint-disable-next-line @typescript-eslint/ban-types -- Old code before rule was applied
+const openEditorModeSelector = (dispatch: Function) => {
+	try {
+		const hasModeSelectorFlag = Setting.keyExists('editor.modeSelectorShown');
+		if (!hasModeSelectorFlag) return false;
+		if (Setting.value('editor.modeSelectorShown')) return false;
+	} catch (_error) {
+		return false;
+	}
+
+	dispatch({
+		type: 'DIALOG_OPEN',
+		name: 'editorModeSelector',
+	});
+
+	return true;
+};
+
+export default openEditorModeSelector;

--- a/packages/app-desktop/gui/styles/editor-mode-selector-dialog.scss
+++ b/packages/app-desktop/gui/styles/editor-mode-selector-dialog.scss
@@ -1,0 +1,12 @@
+.dialog-modal-layer.editor-mode-selector-dialog {
+	align-items: center;
+
+	> .content {
+		min-width: min(560px, calc(100vw - 40px));
+		padding: 22px;
+	}
+
+	.dialog-content {
+		font-size: 15px;
+	}
+}

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -2,6 +2,7 @@
 @use './base-text.scss';
 @use './base-button.scss';
 @use './dialog-modal-layer.scss';
+@use './editor-mode-selector-dialog.scss';
 @use './user-webview-dialog.scss';
 @use './prompt-dialog.scss';
 @use './flat-button.scss';

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -101,6 +101,14 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			isGlobal: true,
 		},
 
+		'editor.modeSelectorShown': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.File,
+		},
+
 		'sync.openSyncWizard': {
 			value: null as boolean,
 			type: SettingItemType.Button,


### PR DESCRIPTION
### Resolves high priority issue #9432

## Summary

I have added a Dialog to the app setup sequence to allow users to choose the editor of their choice

## Problem Description

As outlined by the issue referenced, the end users need to be given a choice to choose their editor mode (Rich/Markdown) during the app setup sequence

## Solution Overview

- The RTE editor is the default selected option, as requested in the issue
- The dialog is placed at the center of the screen when user opens the app for the first time

The Issue referenced asks for screenshot of editor above the choice title (RTE/Markdown), however I was not sure what Markdown aspects should be shown in the screenshot. And I felt that the contributors would have a better idea and judgement to decide what to use

So for now, I added the fa-icons representing each above the text, instead of the screenshot

I will modify it to use the screenshot once I know what to add, or if anything else is desired

## Changes Involved

- A new setting `editor.modeSelectorShown` added to represent whether the editor choice was shown to the user during the setup

## Screenshots

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6edd6f92-955a-4427-8487-67bf94f675fb" />

## Test Plan

Unit test added (`desktop/gui/editorModeSelectorStartup.test.ts`) to test the dialog display behavior

## Environment Details

**Platform**: macOS
**Platform Version**: 26.3
**Build Version**: 25D125
