### PR TITLE
Mobile: Fixes #14507: Enable follow link tooltip in markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -356,6 +356,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			inlineRenderingEnabled: Setting.value('editor.inlineRendering'),
 			imageRenderingEnabled: Setting.value('editor.imageRendering'),
 			highlightActiveLine: Setting.value('editor.highlightActiveLine'),
+			showLinkTooltip: Setting.value('editor.showLinkTooltip'),
 			themeData: {
 				...styles.globalTheme,
 				marginLeft: 0,

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -287,6 +287,7 @@ const useEditorSettings = (props: Props) => {
 		useExternalSearch: true,
 		readOnly: props.readOnly,
 		highlightActiveLine,
+		showLinkTooltip: Setting.value('editor.showLinkTooltip'),
 
 		keymap: EditorKeymap.Default,
 		preferMacShortcuts: shim.mobilePlatform() === 'ios',

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -37,7 +37,8 @@ import overwriteModeExtension from './extensions/overwriteModeExtension';
 import handleLinkEditRequests, { showLinkEditor } from './utils/handleLinkEditRequests';
 import selectedNoteIdExtension, { setNoteIdEffect } from './extensions/selectedNoteIdExtension';
 import ctrlKeyStateClassExtension from './extensions/modifierKeyCssExtension';
-import followLinkTooltip from './extensions/links/followLinkTooltipExtension';
+import ctrlClickLinksExtension from './extensions/links/ctrlClickLinksExtension';
+import { linkTooltipOnly } from './extensions/links/followLinkTooltipExtension';
 import { RenderedContentContext } from './extensions/rendering/types';
 import ctrlClickCheckboxExtension from './extensions/ctrlClickCheckboxExtension';
 import editorSettingsExtension, { setEditorSettingsEffect } from './extensions/editorSettingsExtension';
@@ -176,6 +177,7 @@ const createEditor = (
 
 	const historyCompartment = new Compartment();
 	const dynamicConfig = new Compartment();
+	const linkTooltipCompartment = new Compartment();
 
 	// Give the default keymap low precedence so that it is overridden
 	// by extensions with default precedence.
@@ -259,9 +261,16 @@ const createEditor = (
 				EditorState.allowMultipleSelections.of(true),
 				rectangularSelection(),
 				drawSelection(),
-				followLinkTooltip(link => {
+				ctrlClickLinksExtension(link => {
 					props.onEvent({ kind: EditorEventType.FollowLink, link });
 				}),
+				linkTooltipCompartment.of(
+					props.settings.showLinkTooltip
+						? linkTooltipOnly(link => {
+							props.onEvent({ kind: EditorEventType.FollowLink, link });
+						})
+						: [],
+				),
 				ctrlClickCheckboxExtension(),
 
 				highlightSpecialChars(),
@@ -350,6 +359,13 @@ const createEditor = (
 				effects: [
 					dynamicConfig.reconfigure(
 						configFromSettings(newSettings, context),
+					),
+					linkTooltipCompartment.reconfigure(
+						newSettings.showLinkTooltip
+							? linkTooltipOnly(link => {
+								props.onEvent({ kind: EditorEventType.FollowLink, link });
+							})
+							: [],
 					),
 					setEditorSettingsEffect.of(newSettings),
 				],

--- a/packages/editor/CodeMirror/createEditor.ts
+++ b/packages/editor/CodeMirror/createEditor.ts
@@ -37,7 +37,7 @@ import overwriteModeExtension from './extensions/overwriteModeExtension';
 import handleLinkEditRequests, { showLinkEditor } from './utils/handleLinkEditRequests';
 import selectedNoteIdExtension, { setNoteIdEffect } from './extensions/selectedNoteIdExtension';
 import ctrlKeyStateClassExtension from './extensions/modifierKeyCssExtension';
-import ctrlClickLinksExtension from './extensions/links/ctrlClickLinksExtension';
+import followLinkTooltip from './extensions/links/followLinkTooltipExtension';
 import { RenderedContentContext } from './extensions/rendering/types';
 import ctrlClickCheckboxExtension from './extensions/ctrlClickCheckboxExtension';
 import editorSettingsExtension, { setEditorSettingsEffect } from './extensions/editorSettingsExtension';
@@ -259,7 +259,7 @@ const createEditor = (
 				EditorState.allowMultipleSelections.of(true),
 				rectangularSelection(),
 				drawSelection(),
-				ctrlClickLinksExtension(link => {
+				followLinkTooltip(link => {
 					props.onEvent({ kind: EditorEventType.FollowLink, link });
 				}),
 				ctrlClickCheckboxExtension(),

--- a/packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.ts
+++ b/packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.ts
@@ -83,4 +83,48 @@ const followLinkTooltip = (onOpenExternalLink: OnOpenLink) => {
 	];
 };
 
+// Returns only the tooltip field + theme, without ctrlClickLinksExtension
+// or referenceLinkStateField. Use this when ctrlClickLinksExtension is
+// already loaded separately to avoid duplicate StateField registration.
+export const linkTooltipOnly = (onOpenExternalLink: OnOpenLink) => {
+	const onOpenLink = (link: string, view: EditorView) => {
+		openLink(link, view, onOpenExternalLink);
+	};
+
+	const followLinkTooltipField = StateField.define<readonly Tooltip[]>({
+		create: state => getLinkTooltips(onOpenLink, state),
+		update: (tooltips, transaction) => {
+			if (!transaction.docChanged && !transaction.selection) {
+				return tooltips;
+			}
+
+			return getLinkTooltips(onOpenLink, transaction.state);
+		},
+		provide: field => {
+			const tooltipsFromState = (state: EditorState) => state.field(field);
+			return showTooltip.computeN([field], tooltipsFromState);
+		},
+	});
+
+	return [
+		EditorView.theme({
+			'& .cm-md-link-tooltip > button': {
+				backgroundColor: 'transparent',
+				border: 'transparent',
+				fontSize: 'inherit',
+
+				whiteSpace: 'pre',
+				maxWidth: '95vw',
+				textOverflow: 'ellipsis',
+				overflowX: 'hidden',
+
+				textDecoration: 'underline',
+				cursor: 'pointer',
+				color: 'var(--joplin-url-color)',
+			},
+		}),
+		followLinkTooltipField,
+	];
+};
+
 export default followLinkTooltip;

--- a/packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.ts
+++ b/packages/editor/CodeMirror/extensions/links/followLinkTooltipExtension.ts
@@ -83,6 +83,7 @@ const followLinkTooltip = (onOpenExternalLink: OnOpenLink) => {
 	];
 };
 
+// Duplicated from `followLinkTooltip` in this file.
 // Returns only the tooltip field + theme, without ctrlClickLinksExtension
 // or referenceLinkStateField. Use this when ctrlClickLinksExtension is
 // already loaded separately to avoid duplicate StateField registration.

--- a/packages/editor/testing/createEditorSettings.ts
+++ b/packages/editor/testing/createEditorSettings.ts
@@ -15,6 +15,7 @@ const createEditorSettings = (themeId: number) => {
 		tabMovesFocus: false,
 		inlineRenderingEnabled: true,
 		highlightActiveLine: false,
+		showLinkTooltip: false,
 
 		keymap: EditorKeymap.Default,
 		preferMacShortcuts: false,

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -215,6 +215,7 @@ export interface EditorSettings {
 	imageRenderingEnabled: boolean;
 	readOnly: boolean;
 	highlightActiveLine: boolean;
+	showLinkTooltip: boolean;
 
 	indentWithTabs: boolean;
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1542,6 +1542,17 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			section: 'editor',
 			storage: SettingStorage.File,
 		},
+		'editor.showLinkTooltip': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: true,
+			section: 'editor',
+			appTypes: [AppType.Desktop, AppType.Mobile],
+			label: () => _('Markdown editor: Show link tooltip'),
+			description: () => _('Shows a clickable tooltip when the cursor is on a link, allowing you to follow it without switching to view mode.'),
+			storage: SettingStorage.File,
+			isGlobal: true,
+		},
 		'editor.highlightActiveLine': {
 			value: false,
 			type: SettingItemType.Bool,


### PR DESCRIPTION
Fixes #14507

## What

On mobile, the markdown editor has no way to follow links in edit mode. Users must switch to view mode, which is inconvenient - especially for long notes where you lose your scroll position.

## How

A `followLinkTooltipExtension` already exists in the codebase but was never wired in, as noted on the [forum discussion](https://discourse.joplinapp.org/t/add-ability-to-follow-hyperlinks-and-markdown-links-on-mobile-markdown-editor/48633).

This replaces `ctrlClickLinksExtension` with `followLinkTooltip` in `createEditor.ts`. When the cursor is on a link, a clickable tooltip appears that can be tapped to follow the link.

Since `followLinkTooltip` internally bundles `ctrlClickLinksExtension`, Ctrl+Click on desktop still works.

## Testing

- Existing unit test passes 
- Tested on Android - tooltip appears on cursor placement, tapping follows the link 

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/13351b79-bf29-472c-ac83-2ad497b71a5b) | ![after](https://github.com/user-attachments/assets/4a6e4117-4f87-44f8-a6a9-c5373e72de40) |
| No tooltip -no way to follow links in edit mode | Cursor on link shows clickable `URL` tooltip |
