### PR TITLE
Mobile: Add ability to set per notebook sorting on mobile (old)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -936,6 +936,7 @@ packages/app-mobile/services/e2ee/RSA.react-native.web.js
 packages/app-mobile/services/e2ee/crypto.js
 packages/app-mobile/services/plugins/PlatformImplementation.js
 packages/app-mobile/services/profiles/index.js
+packages/app-mobile/services/sortOrder/PerFolderSortOrderService.js
 packages/app-mobile/services/voiceTyping/VoiceTyping.js
 packages/app-mobile/services/voiceTyping/utils/unzip.android.js
 packages/app-mobile/services/voiceTyping/utils/unzip.js

--- a/.gitignore
+++ b/.gitignore
@@ -909,6 +909,7 @@ packages/app-mobile/services/e2ee/RSA.react-native.web.js
 packages/app-mobile/services/e2ee/crypto.js
 packages/app-mobile/services/plugins/PlatformImplementation.js
 packages/app-mobile/services/profiles/index.js
+packages/app-mobile/services/sortOrder/PerFolderSortOrderService.js
 packages/app-mobile/services/voiceTyping/VoiceTyping.js
 packages/app-mobile/services/voiceTyping/utils/unzip.android.js
 packages/app-mobile/services/voiceTyping/utils/unzip.js

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -20,6 +20,7 @@ import { DialogContext, DialogControl } from '../../DialogManager';
 import { useContext } from 'react';
 import { MenuChoice } from '../../DialogManager/types';
 import NewNoteButton from './NewNoteButton';
+import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSortOrderService';
 
 interface Props {
 	dispatch: Dispatch;
@@ -41,6 +42,7 @@ interface Props {
 	selectedTagId: string;
 	selectedSmartFilterId: string;
 	notesParentType: string;
+	perFolderSortOrders: Record<string, string | boolean>;
 }
 
 interface State {
@@ -74,20 +76,31 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 		const buttons: MenuChoice<IdType>[] = [];
 		const sortNoteOptions = Setting.enumOptions('notes.sortOrder.field');
 
+		const hasPerFolderSortOrder = this.props.notesParentType === 'Folder' &&
+			this.props.selectedFolderId &&
+			PerFolderSortOrderService.isSet(this.props.selectedFolderId);
+
+		const perFolderSortOrder = hasPerFolderSortOrder
+			? PerFolderSortOrderService.get(this.props.selectedFolderId)
+			: null;
+
+		const currentField = perFolderSortOrder?.field ?? Setting.value('notes.sortOrder.field');
+		const currentReverse = perFolderSortOrder?.reverse ?? Setting.value('notes.sortOrder.reverse');
+
 		for (const field in sortNoteOptions) {
 			if (!sortNoteOptions.hasOwnProperty(field)) continue;
 			buttons.push({
 				text: sortNoteOptions[field],
 				iconChecked: 'fas fa-circle',
-				checked: Setting.value('notes.sortOrder.field') === field,
+				checked: currentField === field,
 				id: { name: 'notes.sortOrder.field', value: field },
 			});
 		}
 
 		buttons.push({
 			text: `[ ${Setting.settingMetadata('notes.sortOrder.reverse').label()} ]`,
-			checked: Setting.value('notes.sortOrder.reverse'),
-			id: { name: 'notes.sortOrder.reverse', value: !Setting.value('notes.sortOrder.reverse') },
+			checked: currentReverse,
+			id: { name: 'notes.sortOrder.reverse', value: !currentReverse },
 		});
 
 		buttons.push({
@@ -105,7 +118,14 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 		const r = await this.props.dialogManager.showMenu(Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
 		if (!r) return;
 
-		Setting.setValue(r.name, r.value);
+		if (hasPerFolderSortOrder && (r.name === 'notes.sortOrder.field' || r.name === 'notes.sortOrder.reverse')) {
+			const newField = r.name === 'notes.sortOrder.field' ? r.value as string : currentField;
+			const newReverse = r.name === 'notes.sortOrder.reverse' ? r.value as boolean : currentReverse;
+			PerFolderSortOrderService.setPerFolderSortOrder(this.props.selectedFolderId, newField, newReverse);
+			await this.refreshNotes();
+		} else {
+			Setting.setValue(r.name, r.value);
+		}
 	};
 
 	public styles() {
@@ -136,16 +156,41 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 	}
 
 	public async componentDidUpdate(prevProps: Props) {
-		if (prevProps.notesOrder !== this.props.notesOrder || prevProps.selectedFolderId !== this.props.selectedFolderId || prevProps.selectedTagId !== this.props.selectedTagId || prevProps.selectedSmartFilterId !== this.props.selectedSmartFilterId || prevProps.notesParentType !== this.props.notesParentType || prevProps.uncompletedTodosOnTop !== this.props.uncompletedTodosOnTop || prevProps.showCompletedTodos !== this.props.showCompletedTodos) {
+		if (prevProps.notesOrder !== this.props.notesOrder || prevProps.selectedFolderId !== this.props.selectedFolderId || prevProps.selectedTagId !== this.props.selectedTagId || prevProps.selectedSmartFilterId !== this.props.selectedSmartFilterId || prevProps.notesParentType !== this.props.notesParentType || prevProps.uncompletedTodosOnTop !== this.props.uncompletedTodosOnTop || prevProps.showCompletedTodos !== this.props.showCompletedTodos || prevProps.perFolderSortOrders !== this.props.perFolderSortOrders) {
+			PerFolderSortOrderService.reloadPerFolderSortOrders();
 			await this.refreshNotes(this.props);
 		}
+	}
+
+	private getNotesOrder(props: Props): PreviewsOrder[] {
+		if (props.notesParentType === 'Folder' && props.selectedFolderId) {
+			const perFolderSortOrder = PerFolderSortOrderService.get(props.selectedFolderId);
+			if (perFolderSortOrder) {
+				if (perFolderSortOrder.field === 'order') {
+					return [
+						{ by: 'order', dir: 'DESC' },
+						{ by: 'user_created_time', dir: 'DESC' },
+					];
+				} else {
+					return [
+						{
+							by: perFolderSortOrder.field,
+							dir: perFolderSortOrder.reverse ? 'DESC' : 'ASC',
+						},
+					];
+				}
+			}
+		}
+		return props.notesOrder;
 	}
 
 	public async refreshNotes(props: Props|null = null) {
 		if (props === null) props = this.props;
 
+		const notesOrder = this.getNotesOrder(props);
+
 		const options = {
-			order: props.notesOrder,
+			order: notesOrder,
 			uncompletedTodosOnTop: props.uncompletedTodosOnTop,
 			showCompletedTodos: props.showCompletedTodos,
 			caseInsensitive: true,
@@ -305,6 +350,7 @@ const NotesScreen = connect((state: AppState) => {
 		themeId: state.settings.theme,
 		noteSelectionEnabled: state.noteSelectionEnabled,
 		notesOrder: stateUtils.notesOrder(state.settings),
+		perFolderSortOrders: state.settings['notes.perFolderSortOrders'] ?? {},
 	};
 })(NotesScreenWrapper);
 

--- a/packages/app-mobile/components/screens/folder.tsx
+++ b/packages/app-mobile/components/screens/folder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text, Switch } from 'react-native';
 import { connect } from 'react-redux';
 import Folder from '@joplin/lib/models/Folder';
 import BaseModel from '@joplin/lib/BaseModel';
@@ -13,6 +13,8 @@ import TextInput from '../TextInput';
 import { FolderEntity } from '@joplin/lib/services/database/types';
 import { AppState } from '../../utils/types';
 import { Dispatch } from 'redux';
+import PerFolderSortOrderService from '../../services/sortOrder/PerFolderSortOrderService';
+import { themeStyle } from '../global-style';
 
 interface Props {
 	folderId: string;
@@ -25,6 +27,8 @@ interface Props {
 interface State {
 	folder: FolderEntity;
 	lastSavedFolder: FolderEntity|null;
+	useOwnSortOrder: boolean;
+	lastSavedUseOwnSortOrder: boolean;
 }
 
 class FolderScreenComponent extends BaseScreenComponent<Props, State> {
@@ -34,6 +38,8 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 		this.state = {
 			folder: Folder.new(),
 			lastSavedFolder: null,
+			useOwnSortOrder: false,
+			lastSavedUseOwnSortOrder: false,
 		};
 	}
 
@@ -43,13 +49,18 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 			this.setState({
 				folder: folder,
 				lastSavedFolder: { ...folder },
+				useOwnSortOrder: false,
+				lastSavedUseOwnSortOrder: false,
 			});
 		} else {
+			const useOwnSortOrder = PerFolderSortOrderService.isSet(this.props.folderId);
 			// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
 			void Folder.load(this.props.folderId).then(folder => {
 				this.setState({
 					folder: folder,
 					lastSavedFolder: { ...folder },
+					useOwnSortOrder: useOwnSortOrder,
+					lastSavedUseOwnSortOrder: useOwnSortOrder,
 				});
 			});
 		}
@@ -59,7 +70,9 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 		if (!this.state.folder || !this.state.lastSavedFolder) return false;
 		const diff = BaseModel.diffObjects(this.state.folder, this.state.lastSavedFolder);
 		delete diff.type_;
-		return !!Object.getOwnPropertyNames(diff).length;
+		const folderModified = !!Object.getOwnPropertyNames(diff).length;
+		const sortOrderModified = this.state.useOwnSortOrder !== this.state.lastSavedUseOwnSortOrder;
+		return folderModified || sortOrderModified;
 	}
 
 	private folderComponent_change(propName: keyof FolderEntity, propValue: string) {
@@ -80,6 +93,9 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 		this.folderComponent_change('parent_id', parent);
 	}
 
+	private useOwnSortOrder_change(value: boolean) {
+		this.setState({ useOwnSortOrder: value });
+	}
 
 	private async saveFolderButton_press() {
 		let folder = { ...this.state.folder };
@@ -92,9 +108,14 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 			return;
 		}
 
+		if (this.state.useOwnSortOrder !== this.state.lastSavedUseOwnSortOrder) {
+			PerFolderSortOrderService.set(folder.id, this.state.useOwnSortOrder);
+		}
+
 		this.setState({
 			lastSavedFolder: { ...folder },
 			folder: folder,
+			lastSavedUseOwnSortOrder: this.state.useOwnSortOrder,
 		});
 
 		this.props.dispatch({
@@ -106,6 +127,23 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 
 	public override render() {
 		const saveButtonDisabled = !this.isModified() || !this.state.folder.title;
+		const theme = themeStyle(this.props.themeId);
+
+		const renderOwnSortOrderToggle = () => {
+			if (!this.props.folderId) return null;
+
+			return (
+				<View style={styles.sortOrderContainer}>
+					<Text style={{ color: theme.color, flex: 1 }}>{_('Use own sort order')}</Text>
+					<Switch
+						value={this.state.useOwnSortOrder}
+						onValueChange={value => this.useOwnSortOrder_change(value)}
+						trackColor={{ false: theme.dividerColor }}
+						accessibilityLabel={_('Use own sort order')}
+					/>
+				</View>
+			);
+		};
 
 		return (
 			<View style={this.rootStyle(this.props.themeId).root}>
@@ -129,6 +167,7 @@ class FolderScreenComponent extends BaseScreenComponent<Props, State> {
 						darkText
 					/>
 				</View>
+				{renderOwnSortOrderToggle()}
 				<View style={{ flex: 1 }} />
 			</View>
 		);
@@ -146,6 +185,14 @@ export default connect((state: AppState) => {
 const styles = StyleSheet.create({
 	folderPickerContainer: {
 		height: 46,
+		paddingLeft: 14,
+		paddingRight: 14,
+		paddingTop: 12,
+		paddingBottom: 12,
+	},
+	sortOrderContainer: {
+		flexDirection: 'row',
+		alignItems: 'center',
 		paddingLeft: 14,
 		paddingRight: 14,
 		paddingTop: 12,

--- a/packages/app-mobile/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/app-mobile/services/sortOrder/PerFolderSortOrderService.ts
@@ -1,0 +1,90 @@
+import Setting from '@joplin/lib/models/Setting';
+
+const SUFFIX_FIELD = '$field';
+const SUFFIX_REVERSE = '$reverse';
+
+export interface SortOrder {
+	field: string;
+	reverse: boolean;
+}
+
+interface SortOrderPool {
+	[key: string]: string | boolean;
+}
+
+export default class PerFolderSortOrderService {
+
+	private static perFolderSortOrders: SortOrderPool = null;
+
+	public static isSet(folderId: string): boolean {
+		this.loadPerFolderSortOrders();
+		return folderId && this.perFolderSortOrders && this.perFolderSortOrders.hasOwnProperty(folderId + SUFFIX_FIELD);
+	}
+
+	public static get(folderId: string): SortOrder | undefined {
+		this.loadPerFolderSortOrders();
+		if (folderId && this.perFolderSortOrders) {
+			const field = this.perFolderSortOrders[folderId + SUFFIX_FIELD] as string;
+			const reverse = this.perFolderSortOrders[folderId + SUFFIX_REVERSE] as boolean;
+			if (field) return { field, reverse };
+		}
+		return undefined;
+	}
+
+	public static set(folderId: string, enabled: boolean) {
+		if (!folderId) return;
+
+		this.loadPerFolderSortOrders();
+
+		if (enabled) {
+			const field = Setting.value('notes.sortOrder.field');
+			const reverse = Setting.value('notes.sortOrder.reverse');
+			this.setPerFolderSortOrder(folderId, field, reverse);
+		} else {
+			this.deletePerFolderSortOrder(folderId);
+		}
+	}
+
+	public static setPerFolderSortOrder(folderId: string, field: string, reverse: boolean) {
+		this.loadPerFolderSortOrders();
+		const old = this.get(folderId);
+		let dirty = false;
+		if (!(old?.field === field)) {
+			this.perFolderSortOrders[folderId + SUFFIX_FIELD] = field;
+			dirty = true;
+		}
+		if (!(old?.reverse === reverse)) {
+			this.perFolderSortOrders[folderId + SUFFIX_REVERSE] = reverse;
+			dirty = true;
+		}
+		if (dirty) {
+			Setting.setValue('notes.perFolderSortOrders', { ...this.perFolderSortOrders });
+		}
+	}
+
+	private static deletePerFolderSortOrder(folderId: string) {
+		this.loadPerFolderSortOrders();
+		let dirty = false;
+		if (this.perFolderSortOrders.hasOwnProperty(folderId + SUFFIX_FIELD)) {
+			delete this.perFolderSortOrders[folderId + SUFFIX_FIELD];
+			dirty = true;
+		}
+		if (this.perFolderSortOrders.hasOwnProperty(folderId + SUFFIX_REVERSE)) {
+			delete this.perFolderSortOrders[folderId + SUFFIX_REVERSE];
+			dirty = true;
+		}
+		if (dirty) {
+			Setting.setValue('notes.perFolderSortOrders', { ...this.perFolderSortOrders });
+		}
+	}
+
+	private static loadPerFolderSortOrders() {
+		if (this.perFolderSortOrders === null) {
+			this.perFolderSortOrders = { ...Setting.value('notes.perFolderSortOrders') };
+		}
+	}
+
+	public static reloadPerFolderSortOrders() {
+		this.perFolderSortOrders = { ...Setting.value('notes.perFolderSortOrders') };
+	}
+}

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -884,7 +884,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'folder',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.perFolderSortOrders': {
 			value: {} as Record<string, string | boolean>,
@@ -892,7 +892,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'folder',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.sharedSortOrder': {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code from before rule was applied.


### PR DESCRIPTION
The desktop app has the ability to set separate sorting for individual notebooks, which override the global sorting which has been set by the user. This is possible via the 'Toggle own sort order' context menu option when right clicking a notebook, and then changing the sorting field and / or direction with that notebook selected. This specific notebook sorting is only stored locally and is not synced to other clients (unlike note ordering when using the custom sort option). The mobile app currently lacks this feature, so this PR introduces the feature on mobile, to also allow local sorting overrides for individual notebooks.

A 'Use own sort order' setting toggle has been added to the edit notebook dialog available when long pressing a notebook and pressing edit. When this has been set on a notebook, the sorting field and / or direction will be unaffected when changing the global sorting, but the last sorting options set for that notebook will be retained.

<img width="250" height="897" alt="Capture" src="https://github.com/user-attachments/assets/1f0cda5d-b6f4-4cb2-8cf0-36fbe956a007" />

The new PerFolderSortOrderService is derived from the matching file in the app-desktop module, but I kept this as a separate service, because the original service is stateful and makes use of a 'notes.sharedSortOrder' setting, which is not necessary for the mobile implementation.

### Testing

See video, demonstrating adding and removing separate sorting to multiple notebooks on the mobile app. I also verified the sort order persists after app restart:

https://github.com/user-attachments/assets/172cf51f-35fe-4c5f-8229-d46818fdf143

The trash folder, all notes folder and conflicts folder do not allow accessing an edit notebook screen, and therefore the user cannot toggle the use own sort order option for those folders
