### PR TITLE
Desktop: Resolves #13146: Add Windows ARM64 support.  Use standard desktop dist flow for Windows ARM64 local build

### DIFF
--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -288,31 +288,13 @@ if (-not $SkipDist) {
 		Invoke-NpmPkgSet -Assignment 'build.win.target[1].arch[0]=arm64'
 	}
 
-	if ($TargetArch -eq 'arm64') {
-		# Run explicit pipeline steps for ARM64 to avoid npx resolution quirks and
-		# preserve control over rebuild order.
-		Write-Host 'Running yarn run gulp before-dist ...'
-		Invoke-CorepackYarn -Args @('run', 'gulp', 'before-dist')
-
-		Write-Host 'Running yarn run gulp electronRebuild ...'
-		Invoke-CorepackYarn -Args @('run', 'gulp', 'electronRebuild')
-
-		$builderArgs = @('run', 'electron-builder', '--win', '--arm64')
-		if (-not $Publish) {
-			$builderArgs += '--publish=never'
-		}
-
-		Write-Host "Running yarn $($builderArgs -join ' ') ..."
-		Invoke-CorepackYarn -Args $builderArgs
-	} else {
-		$distArgs = @('dist', '--win', '--x64')
-		if (-not $Publish) {
-			$distArgs += '--publish=never'
-		}
-
-		Write-Host "Running yarn $($distArgs -join ' ') ..."
-		Invoke-CorepackYarn -Args $distArgs
+	$distArgs = @('dist', '--win', "--$TargetArch")
+	if (-not $Publish) {
+		$distArgs += '--publish=never'
 	}
+
+	Write-Host "Running yarn $($distArgs -join ' ') ..."
+	Invoke-CorepackYarn -Args $distArgs
 }
 
 Write-Host 'Build script completed.'

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -222,29 +222,6 @@ Ensure-NodeExecutableOnPath -NodeExePath $nodeExePath
 # Keep python explicit for node-gyp to reduce interpreter ambiguity on Windows.
 Set-PythonForBuild
 
-Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\node-gyp\lib\find-visualstudio.js')
-Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
-Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\node-gyp\lib\find-visualstudio.js')
-Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
-
-$sqliteBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
-	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\binding\.gyp$' }
-foreach ($file in $sqliteBindingFiles) {
-	Patch-Sqlite3BindingGypNodeAddonApi -FilePath $file.FullName
-}
-
-$sqliteDepsGypFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'sqlite3.gyp' -File -Recurse -ErrorAction SilentlyContinue |
-	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\deps\\sqlite3\.gyp$' }
-foreach ($file in $sqliteDepsGypFiles) {
-	Patch-Sqlite3DepsGypNodeExecutable -FilePath $file.FullName -NodeExePath $nodeExePath
-}
-
-$keytarBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
-	Where-Object { $_.FullName -match '\\node_modules\\keytar\\binding\.gyp$' }
-foreach ($file in $keytarBindingFiles) {
-	Patch-KeytarBindingGypNodeAddonApi -FilePath $file.FullName
-}
-
 if ($Clean) {
 	Write-Host 'Running git clean -xfd ...'
 	git clean -xfd
@@ -270,6 +247,29 @@ if (-not $SkipInstall) {
 	}
 
 	Invoke-CorepackYarn -Args $installArgs
+}
+
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
+
+$sqliteBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\binding\.gyp$' }
+foreach ($file in $sqliteBindingFiles) {
+	Patch-Sqlite3BindingGypNodeAddonApi -FilePath $file.FullName
+}
+
+$sqliteDepsGypFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'sqlite3.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\deps\\sqlite3\.gyp$' }
+foreach ($file in $sqliteDepsGypFiles) {
+	Patch-Sqlite3DepsGypNodeExecutable -FilePath $file.FullName -NodeExePath $nodeExePath
+}
+
+$keytarBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\keytar\\binding\.gyp$' }
+foreach ($file in $keytarBindingFiles) {
+	Patch-KeytarBindingGypNodeAddonApi -FilePath $file.FullName
 }
 
 if (-not $SkipDist) {

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -280,24 +280,30 @@ if (-not $SkipDist) {
 
 	$env:npm_config_arch = $TargetArch
 	$env:npm_config_target_arch = $TargetArch
+	$packageJsonPath = Join-Path $desktopPath 'package.json'
+	$packageJsonBackup = [System.IO.File]::ReadAllBytes($packageJsonPath)
 
-	Invoke-NpmPkgSet -Assignment 'build.win.artifactName=${productName}-${version}-${arch}.${ext}'
-	Invoke-NpmPkgSet -Assignment 'build.portable.artifactName=${productName}Portable-${version}-${arch}.${ext}'
+	try {
+		Invoke-NpmPkgSet -Assignment 'build.win.artifactName=${productName}-${version}-${arch}.${ext}'
+		Invoke-NpmPkgSet -Assignment 'build.portable.artifactName=${productName}Portable-${version}-${arch}.${ext}'
 
-	if ($TargetArch -eq 'arm64') {
-		Invoke-NpmPkgSet -Assignment 'build.win.target[0].target=nsis'
-		Invoke-NpmPkgSet -Assignment 'build.win.target[0].arch[0]=arm64'
-		Invoke-NpmPkgSet -Assignment 'build.win.target[1].target=portable'
-		Invoke-NpmPkgSet -Assignment 'build.win.target[1].arch[0]=arm64'
+		if ($TargetArch -eq 'arm64') {
+			Invoke-NpmPkgSet -Assignment 'build.win.target[0].target=nsis'
+			Invoke-NpmPkgSet -Assignment 'build.win.target[0].arch[0]=arm64'
+			Invoke-NpmPkgSet -Assignment 'build.win.target[1].target=portable'
+			Invoke-NpmPkgSet -Assignment 'build.win.target[1].arch[0]=arm64'
+		}
+
+		$distArgs = @('dist', '--win', "--$TargetArch")
+		if (-not $Publish) {
+			$distArgs += '--publish=never'
+		}
+
+		Write-Host "Running yarn $($distArgs -join ' ') ..."
+		Invoke-CorepackYarn -Args $distArgs
+	} finally {
+		[System.IO.File]::WriteAllBytes($packageJsonPath, $packageJsonBackup)
 	}
-
-	$distArgs = @('dist', '--win', "--$TargetArch")
-	if (-not $Publish) {
-		$distArgs += '--publish=never'
-	}
-
-	Write-Host "Running yarn $($distArgs -join ' ') ..."
-	Invoke-CorepackYarn -Args $distArgs
 }
 
 Write-Host 'Build script completed.'

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -194,17 +194,12 @@ function Ensure-NodeExecutableOnPath {
 		New-Item -Path $localBinPath -ItemType Directory -Force | Out-Null
 	}
 
-	if (-not (Test-Path $localNodeExe)) {
-		if (-not (Test-Path $NodeExePath)) {
-			throw "node executable not found at $NodeExePath"
-		}
-
-		Copy-Item -Path $NodeExePath -Destination $localNodeExe -Force
+	if (-not (Test-Path $NodeExePath)) {
+		throw "node executable not found at $NodeExePath"
 	}
 
-	if (-not (Test-Path $localNodeNoExt)) {
-		Copy-Item -Path $localNodeExe -Destination $localNodeNoExt -Force
-	}
+	Copy-Item -Path $NodeExePath -Destination $localNodeExe -Force
+	Copy-Item -Path $localNodeExe -Destination $localNodeNoExt -Force
 
 	if ($env:Path -notlike "$localBinPath;*") {
 		$env:Path = "$localBinPath;$($env:Path)"

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -225,6 +225,9 @@ Set-PythonForBuild
 if ($Clean) {
 	Write-Host 'Running git clean -xfd ...'
 	git clean -xfd
+	if ($LASTEXITCODE -ne 0) {
+		throw "git clean -xfd failed with exit code $LASTEXITCODE"
+	}
 }
 
 if (-not $SkipInstall) {

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -198,7 +198,12 @@ function Ensure-NodeExecutableOnPath {
 		throw "node executable not found at $NodeExePath"
 	}
 
-	Copy-Item -Path $NodeExePath -Destination $localNodeExe -Force
+	$resolvedNodeExe = [System.IO.Path]::GetFullPath($NodeExePath)
+	$resolvedLocalNodeExe = [System.IO.Path]::GetFullPath($localNodeExe)
+
+	if ($resolvedNodeExe -ne $resolvedLocalNodeExe) {
+		Copy-Item -Path $NodeExePath -Destination $localNodeExe -Force
+	}
 	Copy-Item -Path $localNodeExe -Destination $localNodeNoExt -Force
 
 	if ($env:Path -notlike "$localBinPath;*") {

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -286,13 +286,10 @@ if (-not $SkipDist) {
 	try {
 		Invoke-NpmPkgSet -Assignment 'build.win.artifactName=${productName}-${version}-${arch}.${ext}'
 		Invoke-NpmPkgSet -Assignment 'build.portable.artifactName=${productName}Portable-${version}-${arch}.${ext}'
-
-		if ($TargetArch -eq 'arm64') {
-			Invoke-NpmPkgSet -Assignment 'build.win.target[0].target=nsis'
-			Invoke-NpmPkgSet -Assignment 'build.win.target[0].arch[0]=arm64'
-			Invoke-NpmPkgSet -Assignment 'build.win.target[1].target=portable'
-			Invoke-NpmPkgSet -Assignment 'build.win.target[1].arch[0]=arm64'
-		}
+		Invoke-NpmPkgSet -Assignment 'build.win.target[0].target=nsis'
+		Invoke-NpmPkgSet -Assignment "build.win.target[0].arch[0]=$TargetArch"
+		Invoke-NpmPkgSet -Assignment 'build.win.target[1].target=portable'
+		Invoke-NpmPkgSet -Assignment "build.win.target[1].arch[0]=$TargetArch"
 
 		$distArgs = @('dist', '--win', "--$TargetArch")
 		if (-not $Publish) {

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -38,9 +38,6 @@ function Resolve-CommandPath {
 	throw "$Description not found in PATH. Tried: $($Names -join ', ')"
 }
 
-$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
-$npmPath = Resolve-CommandPath -Names @('npm.cmd', 'npm') -Description 'npm'
-
 # Run Yarn through corepack and stop on non-zero exit.
 function Invoke-CorepackYarn {
 	param(
@@ -215,6 +212,9 @@ function Ensure-NodeExecutableOnPath {
 }
 
 . (Join-Path $PSScriptRoot 'dev-shell-win-arm64.ps1') -Arch $TargetArch -HostArch $TargetArch -MsvsVersion $MsvsVersion -SetLocationToRepo
+
+$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
+$npmPath = Resolve-CommandPath -Names @('npm.cmd', 'npm') -Description 'npm'
 
 $nodeExePath = Resolve-CommandPath -Names @('node.exe', 'node') -Description 'node'
 Ensure-NodeExecutableOnPath -NodeExePath $nodeExePath

--- a/.github/scripts/build-clean-win-arm64.ps1
+++ b/.github/scripts/build-clean-win-arm64.ps1
@@ -1,0 +1,318 @@
+param(
+	[ValidateSet('arm64', 'x64')]
+	[string]$TargetArch = 'arm64',
+	[string]$MsvsVersion = '2022',
+	[switch]$Clean,
+	[switch]$Publish,
+	[switch]$ForceSourceBuild,
+	[switch]$SkipBuildScriptsInstall,
+	[switch]$SkipInstall,
+	[switch]$SkipDist
+)
+
+# Local Windows ARM64 build entrypoint.
+# Scope: current shell session only (no global machine mutation).
+# This script intentionally applies temporary node-gyp/native-module workarounds
+# for current upstream Windows ARM64 gaps in third-party dependencies.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$desktopPath = Join-Path $repoRoot 'packages\app-desktop'
+
+# Resolve a command from PATH and fail with a clear message if missing.
+function Resolve-CommandPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Names,
+		[Parameter(Mandatory = $true)]
+		[string]$Description
+	)
+
+	foreach ($name in $Names) {
+		$command = Get-Command $name -ErrorAction SilentlyContinue
+		if ($command -and $command.Source) {
+			return $command.Source
+		}
+	}
+
+	throw "$Description not found in PATH. Tried: $($Names -join ', ')"
+}
+
+$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
+$npmPath = Resolve-CommandPath -Names @('npm.cmd', 'npm') -Description 'npm'
+
+# Run Yarn through corepack and stop on non-zero exit.
+function Invoke-CorepackYarn {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Args
+	)
+
+	& $corepackPath yarn @Args
+	if ($LASTEXITCODE -ne 0) {
+		throw "yarn $($Args -join ' ') failed with exit code $LASTEXITCODE"
+	}
+}
+
+# Update package.json build keys using npm pkg set.
+function Invoke-NpmPkgSet {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Assignment
+	)
+
+	& $npmPath pkg set $Assignment
+	if ($LASTEXITCODE -ne 0) {
+		throw "npm pkg set $Assignment failed with exit code $LASTEXITCODE"
+	}
+}
+
+# Patch node-gyp to recognize VS major version 18 as 2022.
+function Patch-NodeGypVs18Support {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath
+	)
+
+	if (-not (Test-Path $FilePath)) {
+		return
+	}
+
+	$content = Get-Content -Raw -Path $FilePath
+	if ($content -match 'ret\.versionMajor === 18') {
+		return
+	}
+
+	# node-gyp currently maps VS major versions explicitly; add v18 -> 2022 mapping
+	# so local Visual Studio 18 dev shells are accepted.
+	$pattern = "if \(ret\.versionMajor === 17\) \{\r?\n\s+ret\.versionYear = 2022\r?\n\s+return ret\r?\n\s+\}"
+	$replacement = "$&`r`n    if (ret.versionMajor === 18) {`r`n      ret.versionYear = 2022`r`n      return ret`r`n    }"
+	$updated = [Regex]::Replace($content, $pattern, $replacement)
+
+	if ($updated -ne $content) {
+		Set-Content -Path $FilePath -Value $updated
+	}
+}
+
+# Select Python executable for node-gyp from common launchers.
+function Set-PythonForBuild {
+	$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+	if ($pythonCommand -and $pythonCommand.Source) {
+		$env:PYTHON = $pythonCommand.Source
+		$env:npm_config_python = $pythonCommand.Source
+		return
+	}
+
+	$pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+	if ($pyLauncher -and $pyLauncher.Source) {
+		$env:PYTHON = $pyLauncher.Source
+		$env:npm_config_python = $pyLauncher.Source
+	}
+}
+
+# Replace sqlite3 node-addon-api shell calls with direct local paths.
+function Patch-Sqlite3BindingGypNodeAddonApi {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath
+	)
+
+	if (-not (Test-Path $FilePath)) {
+		return
+	}
+
+	$content = Get-Content -Raw -Path $FilePath
+	$updated = $content
+
+	# Avoid `node -p` calls inside gyp evaluation. These can fail under nested
+	# electron-rebuild invocation on some Windows ARM64 setups.
+	$updated = $updated.Replace('"<!@(node -p \"require(''node-addon-api'').include\")"', '"<(module_root_dir)/../node-addon-api"')
+	$updated = $updated.Replace('"<!(node -p \"require(''node-addon-api'').gyp\")"', '"<(module_root_dir)/../node-addon-api/node_api.gyp:nothing"')
+
+	if ($updated -ne $content) {
+		Set-Content -Path $FilePath -Value $updated
+	}
+}
+
+# Force sqlite3 gyp action commands to use an absolute node path.
+function Patch-Sqlite3DepsGypNodeExecutable {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath,
+		[Parameter(Mandatory = $true)]
+		[string]$NodeExePath
+	)
+
+	if (-not (Test-Path $FilePath)) {
+		return
+	}
+
+	$content = Get-Content -Raw -Path $FilePath
+	$updated = $content
+	# Force an absolute node path for gyp-generated custom actions to avoid PATH
+	# lookup issues inside spawned MSBuild command environments.
+	$nodePathForGyp = $NodeExePath.Replace('\\', '/')
+	$updated = $updated.Replace("'action': ['node',", "'action': ['$nodePathForGyp',")
+	$updated = $updated.Replace("'action': ['node.exe',", "'action': ['$nodePathForGyp',")
+
+	if ($updated -ne $content) {
+		Set-Content -Path $FilePath -Value $updated
+	}
+}
+
+# Replace keytar node-addon-api shell include lookup with a local path.
+function Patch-KeytarBindingGypNodeAddonApi {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath
+	)
+
+	if (-not (Test-Path $FilePath)) {
+		return
+	}
+
+	$content = Get-Content -Raw -Path $FilePath
+	# Same rationale as sqlite3: resolve include path without shelling out to node.
+	$updated = $content.Replace('"<!(node -p \"require(''node-addon-api'').include_dir\")"', '"<(module_root_dir)/../node-addon-api"')
+
+	if ($updated -ne $content) {
+		Set-Content -Path $FilePath -Value $updated
+	}
+}
+
+# Ensure node executables exist in repo-local bin and are first on PATH.
+function Ensure-NodeExecutableOnPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$NodeExePath
+	)
+
+	# Provide both node.exe and extensionless node in a repo-local bin dir. Some
+	# gyp/MSBuild custom actions invoke one or the other depending on quoting.
+	$localBinPath = Join-Path $repoRoot '.local\bin'
+	$localNodeExe = Join-Path $localBinPath 'node.exe'
+	$localNodeNoExt = Join-Path $localBinPath 'node'
+
+	if (-not (Test-Path $localBinPath)) {
+		New-Item -Path $localBinPath -ItemType Directory -Force | Out-Null
+	}
+
+	if (-not (Test-Path $localNodeExe)) {
+		if (-not (Test-Path $NodeExePath)) {
+			throw "node executable not found at $NodeExePath"
+		}
+
+		Copy-Item -Path $NodeExePath -Destination $localNodeExe -Force
+	}
+
+	if (-not (Test-Path $localNodeNoExt)) {
+		Copy-Item -Path $localNodeExe -Destination $localNodeNoExt -Force
+	}
+
+	if ($env:Path -notlike "$localBinPath;*") {
+		$env:Path = "$localBinPath;$($env:Path)"
+	}
+}
+
+. (Join-Path $PSScriptRoot 'dev-shell-win-arm64.ps1') -Arch $TargetArch -HostArch $TargetArch -MsvsVersion $MsvsVersion -SetLocationToRepo
+
+$nodeExePath = Resolve-CommandPath -Names @('node.exe', 'node') -Description 'node'
+Ensure-NodeExecutableOnPath -NodeExePath $nodeExePath
+
+# Keep python explicit for node-gyp to reduce interpreter ambiguity on Windows.
+Set-PythonForBuild
+
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\app-desktop\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\node-gyp\lib\find-visualstudio.js')
+Patch-NodeGypVs18Support -FilePath (Join-Path $repoRoot 'packages\lib\node_modules\@electron\node-gyp\lib\find-visualstudio.js')
+
+$sqliteBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\binding\.gyp$' }
+foreach ($file in $sqliteBindingFiles) {
+	Patch-Sqlite3BindingGypNodeAddonApi -FilePath $file.FullName
+}
+
+$sqliteDepsGypFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'sqlite3.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\sqlite3\\deps\\sqlite3\.gyp$' }
+foreach ($file in $sqliteDepsGypFiles) {
+	Patch-Sqlite3DepsGypNodeExecutable -FilePath $file.FullName -NodeExePath $nodeExePath
+}
+
+$keytarBindingFiles = Get-ChildItem -Path (Join-Path $repoRoot 'packages') -Filter 'binding.gyp' -File -Recurse -ErrorAction SilentlyContinue |
+	Where-Object { $_.FullName -match '\\node_modules\\keytar\\binding\.gyp$' }
+foreach ($file in $keytarBindingFiles) {
+	Patch-KeytarBindingGypNodeAddonApi -FilePath $file.FullName
+}
+
+if ($Clean) {
+	Write-Host 'Running git clean -xfd ...'
+	git clean -xfd
+}
+
+if (-not $SkipInstall) {
+	# onenote-converter builds are handled by dedicated helper script to keep
+	# install fast and resilient in ARM64 local setups.
+	$env:SKIP_ONENOTE_CONVERTER_BUILD = '1'
+
+	if ($ForceSourceBuild) {
+		$env:npm_config_build_from_source = 'true'
+		$env:npm_config_fallback_to_build = 'true'
+	} else {
+		Remove-Item Env:npm_config_build_from_source -ErrorAction SilentlyContinue
+		Remove-Item Env:npm_config_fallback_to_build -ErrorAction SilentlyContinue
+	}
+
+	Write-Host 'Running yarn install ...'
+	$installArgs = @('install')
+	if ($SkipBuildScriptsInstall) {
+		$installArgs += '--mode=skip-build'
+	}
+
+	Invoke-CorepackYarn -Args $installArgs
+}
+
+if (-not $SkipDist) {
+	Set-Location $desktopPath
+
+	$env:npm_config_arch = $TargetArch
+	$env:npm_config_target_arch = $TargetArch
+
+	Invoke-NpmPkgSet -Assignment 'build.win.artifactName=${productName}-${version}-${arch}.${ext}'
+	Invoke-NpmPkgSet -Assignment 'build.portable.artifactName=${productName}Portable-${version}-${arch}.${ext}'
+
+	if ($TargetArch -eq 'arm64') {
+		Invoke-NpmPkgSet -Assignment 'build.win.target[0].target=nsis'
+		Invoke-NpmPkgSet -Assignment 'build.win.target[0].arch[0]=arm64'
+		Invoke-NpmPkgSet -Assignment 'build.win.target[1].target=portable'
+		Invoke-NpmPkgSet -Assignment 'build.win.target[1].arch[0]=arm64'
+	}
+
+	if ($TargetArch -eq 'arm64') {
+		# Run explicit pipeline steps for ARM64 to avoid npx resolution quirks and
+		# preserve control over rebuild order.
+		Write-Host 'Running yarn run gulp before-dist ...'
+		Invoke-CorepackYarn -Args @('run', 'gulp', 'before-dist')
+
+		Write-Host 'Running yarn run gulp electronRebuild ...'
+		Invoke-CorepackYarn -Args @('run', 'gulp', 'electronRebuild')
+
+		$builderArgs = @('run', 'electron-builder', '--win', '--arm64')
+		if (-not $Publish) {
+			$builderArgs += '--publish=never'
+		}
+
+		Write-Host "Running yarn $($builderArgs -join ' ') ..."
+		Invoke-CorepackYarn -Args $builderArgs
+	} else {
+		$distArgs = @('dist', '--win', '--x64')
+		if (-not $Publish) {
+			$distArgs += '--publish=never'
+		}
+
+		Write-Host "Running yarn $($distArgs -join ' ') ..."
+		Invoke-CorepackYarn -Args $distArgs
+	}
+}
+
+Write-Host 'Build script completed.'

--- a/.github/scripts/build-onenote-win-arm64-local.ps1
+++ b/.github/scripts/build-onenote-win-arm64-local.ps1
@@ -1,0 +1,119 @@
+param(
+	[ValidateSet('arm64', 'x64')]
+	[string]$TargetArch = 'arm64',
+	[string]$MsvsVersion = '2022',
+	[string]$CargoInstallRoot,
+	[switch]$ForceWasmPackInstall,
+	[switch]$SkipInstall,
+	[switch]$Release
+)
+
+# Builds onenote-converter in a local/session-scoped Windows ARM64 setup.
+# No global PATH/toolchain changes are required.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+# Resolve a command from PATH and fail clearly when unavailable.
+function Resolve-CommandPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Names,
+		[Parameter(Mandatory = $true)]
+		[string]$Description
+	)
+
+	foreach ($name in $Names) {
+		$command = Get-Command $name -ErrorAction SilentlyContinue
+		if ($command -and $command.Source) {
+			return $command.Source
+		}
+	}
+
+	throw "$Description not found in PATH. Tried: $($Names -join ', ')"
+}
+
+$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
+
+if (-not $CargoInstallRoot) {
+	# Keep Rust-installed helpers under repo-local path for reproducibility.
+	$CargoInstallRoot = Join-Path $repoRoot '.local\cargo-tools'
+}
+
+# Execute a command and throw on non-zero exit code.
+function Invoke-Checked {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath,
+		[Parameter(Mandatory = $false)]
+		[string[]]$Args = @()
+	)
+
+	& $FilePath @Args
+	if ($LASTEXITCODE -ne 0) {
+		throw "$FilePath $($Args -join ' ') failed with exit code $LASTEXITCODE"
+	}
+}
+
+# Run Yarn through corepack with checked command execution.
+function Invoke-CorepackYarn {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Args
+	)
+
+	$allArgs = @('yarn') + $Args
+	Invoke-Checked -FilePath $corepackPath -Args $allArgs
+}
+
+. (Join-Path $PSScriptRoot 'dev-shell-win-arm64.ps1') -Arch $TargetArch -HostArch $TargetArch -MsvsVersion $MsvsVersion -SetLocationToRepo
+
+$cargoCommand = Get-Command cargo -ErrorAction SilentlyContinue
+if (-not $cargoCommand) {
+	throw 'cargo was not found in PATH for this session. Install Rust (rustup) first, then rerun this script.'
+}
+
+New-Item -ItemType Directory -Force -Path $CargoInstallRoot | Out-Null
+
+$localCargoBin = Join-Path $CargoInstallRoot 'bin'
+$localWasmPackPath = Join-Path $localCargoBin 'wasm-pack.exe'
+
+if ($ForceWasmPackInstall -or -not (Test-Path $localWasmPackPath)) {
+	Write-Host "Installing repo-local wasm-pack to $CargoInstallRoot ..."
+	Invoke-Checked -FilePath $cargoCommand.Source -Args @('install', 'wasm-pack', '--locked', '--root', $CargoInstallRoot)
+}
+
+if (-not (Test-Path $localWasmPackPath)) {
+	throw "wasm-pack was not found at $localWasmPackPath after installation"
+}
+
+if (-not (($env:Path -split ';') -contains $localCargoBin)) {
+	$env:Path = "$localCargoBin;$env:Path"
+}
+
+$env:WASM_PACK_BIN = $localWasmPackPath.Replace('\\', '/')
+
+# build.js supports WASM_PACK_BIN so we can bypass global wasm-pack resolution.
+
+Write-Host "Using wasm-pack: $localWasmPackPath"
+
+$env:npm_config_arch = $TargetArch
+$env:npm_config_target_arch = $TargetArch
+
+if (-not $SkipInstall) {
+	Write-Host 'Installing dependencies without build scripts ...'
+	Invoke-CorepackYarn -Args @('install', '--mode=skip-build')
+}
+
+Set-Location (Join-Path $repoRoot 'packages\onenote-converter')
+
+if ($Release) {
+	$env:IS_CONTINUOUS_INTEGRATION = '1'
+	Write-Host 'Building onenote-converter release profile ...'
+	Invoke-CorepackYarn -Args @('build')
+} else {
+	Write-Host 'Building onenote-converter dev profile ...'
+	Invoke-CorepackYarn -Args @('buildDev')
+}
+
+Write-Host 'OneNote converter local build completed.'

--- a/.github/scripts/build-sqlite3-win-arm64-local.ps1
+++ b/.github/scripts/build-sqlite3-win-arm64-local.ps1
@@ -96,7 +96,7 @@ function Patch-Sqlite3ActionProject {
 	$updated = $content
 	# Generated vcxproj can emit `call node` patterns that fail to resolve in
 	# some MSBuild contexts. Force absolute node path for custom action command.
-	$xmlNodePath = $NodeExePath.Replace('\\', '\\\\')
+	$xmlNodePath = $NodeExePath.Replace('\', '\\')
 	$updated = $updated -replace 'call call &quot;node&quot;', "call &quot;$xmlNodePath&quot;"
 	$updated = $updated -replace 'call &quot;node&quot;', "call &quot;$xmlNodePath&quot;"
 
@@ -104,7 +104,8 @@ function Patch-Sqlite3ActionProject {
 		Set-Content -Path $actionProject.FullName -Value $updated
 	}
 
-	$solutionPath = Join-Path (Split-Path $actionProject.Directory.FullName -Parent) 'binding.sln'
+	$actionProjectDir = Split-Path $actionProject.FullName -Parent
+	$solutionPath = Join-Path (Split-Path $actionProjectDir -Parent) 'binding.sln'
 	if (-not (Test-Path $solutionPath)) {
 		throw "Could not find sqlite3 solution at $solutionPath"
 	}

--- a/.github/scripts/build-sqlite3-win-arm64-local.ps1
+++ b/.github/scripts/build-sqlite3-win-arm64-local.ps1
@@ -1,0 +1,170 @@
+param(
+	[ValidateSet('arm64', 'x64')]
+	[string]$TargetArch = 'arm64',
+	[string]$MsvsVersion = '2022',
+	[switch]$SkipInstall
+)
+
+# Builds sqlite3 native bindings for desktop in a local/session-scoped ARM64 setup.
+# Includes targeted runtime patching for current node-gyp/gyp edge cases.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$corepackPath = $null
+$desktopNodeModulesPath = Join-Path $repoRoot 'packages\app-desktop\node_modules'
+$sqlite3Path = Join-Path $desktopNodeModulesPath 'sqlite3'
+$nodeGypVsFile = Join-Path $desktopNodeModulesPath 'node-gyp\lib\find-visualstudio.js'
+
+# Resolve a command path from PATH with a descriptive error when missing.
+function Resolve-CommandPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Names,
+		[Parameter(Mandatory = $true)]
+		[string]$Description
+	)
+
+	foreach ($name in $Names) {
+		$command = Get-Command $name -ErrorAction SilentlyContinue
+		if ($command -and $command.Source) {
+			return $command.Source
+		}
+	}
+
+	throw "$Description not found in PATH. Tried: $($Names -join ', ')"
+}
+
+$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
+$nodeExePath = Resolve-CommandPath -Names @('node.exe', 'node') -Description 'node'
+
+# Run Yarn through corepack and fail on non-zero exit.
+function Invoke-CorepackYarn {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Args
+	)
+
+	& $corepackPath yarn @Args
+	if ($LASTEXITCODE -ne 0) {
+		throw "yarn $($Args -join ' ') failed with exit code $LASTEXITCODE"
+	}
+}
+
+# Patch node-gyp VS mapping so version 18 is accepted as 2022.
+function Patch-NodeGypVs18Support {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$FilePath
+	)
+
+	if (-not (Test-Path $FilePath)) {
+		throw "node-gyp VS detection file not found: $FilePath"
+	}
+
+	$content = Get-Content -Raw -Path $FilePath
+	if ($content -match 'ret\.versionMajor === 18') {
+		return
+	}
+
+	$pattern = "if \(ret\.versionMajor === 17\) \{\r?\n\s+ret\.versionYear = 2022\r?\n\s+return ret\r?\n\s+\}"
+	$replacement = "$&`r`n    if (ret.versionMajor === 18) {`r`n      ret.versionYear = 2022`r`n      return ret`r`n    }"
+	$updated = [Regex]::Replace($content, $pattern, $replacement)
+
+	if ($updated -eq $content) {
+		throw 'Could not patch node-gyp VS18 mapping (expected block not found).'
+	}
+
+	Set-Content -Path $FilePath -Value $updated
+}
+
+# Patch generated sqlite3 vcxproj custom action to use absolute node path.
+function Patch-Sqlite3ActionProject {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$Sqlite3Root,
+		[Parameter(Mandatory = $true)]
+		[string]$NodeExePath
+	)
+
+	$actionProjects = Get-ChildItem -Path (Join-Path $Sqlite3Root 'build-tmp-napi-v*\deps\action_before_build.vcxproj') -ErrorAction SilentlyContinue
+	if (-not $actionProjects -or $actionProjects.Count -eq 0) {
+		throw 'Could not find sqlite3 action_before_build.vcxproj to patch.'
+	}
+
+	$actionProject = $actionProjects | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+	$content = Get-Content -Raw -Path $actionProject.FullName
+	$updated = $content
+	# Generated vcxproj can emit `call node` patterns that fail to resolve in
+	# some MSBuild contexts. Force absolute node path for custom action command.
+	$xmlNodePath = $NodeExePath.Replace('\\', '\\\\')
+	$updated = $updated -replace 'call call &quot;node&quot;', "call &quot;$xmlNodePath&quot;"
+	$updated = $updated -replace 'call &quot;node&quot;', "call &quot;$xmlNodePath&quot;"
+
+	if ($updated -ne $content) {
+		Set-Content -Path $actionProject.FullName -Value $updated
+	}
+
+	$solutionPath = Join-Path (Split-Path $actionProject.Directory.FullName -Parent) 'binding.sln'
+	if (-not (Test-Path $solutionPath)) {
+		throw "Could not find sqlite3 solution at $solutionPath"
+	}
+
+	return $solutionPath
+}
+
+# Locate MSBuild from the current developer shell environment.
+function Find-MsBuild {
+	$msbuildCommand = Get-Command MSBuild.exe -ErrorAction SilentlyContinue
+	if ($msbuildCommand -and $msbuildCommand.Source) {
+		return $msbuildCommand.Source
+	}
+
+	throw 'Could not find MSBuild executable for Visual Studio.'
+}
+
+. (Join-Path $PSScriptRoot 'dev-shell-win-arm64.ps1') -Arch $TargetArch -HostArch $TargetArch -MsvsVersion $MsvsVersion -SetLocationToRepo
+
+if (-not $SkipInstall) {
+	Write-Host 'Installing dependencies without build scripts ...'
+	Invoke-CorepackYarn -Args @('install', '--mode=skip-build')
+}
+
+Patch-NodeGypVs18Support -FilePath $nodeGypVsFile
+
+Set-Location $sqlite3Path
+
+Remove-Item Env:CC -ErrorAction SilentlyContinue
+Remove-Item Env:CXX -ErrorAction SilentlyContinue
+Remove-Item Env:CC_aarch64_pc_windows_msvc -ErrorAction SilentlyContinue
+Remove-Item Env:CXX_aarch64_pc_windows_msvc -ErrorAction SilentlyContinue
+
+$env:GYP_MSVS_VERSION = $MsvsVersion
+$env:npm_config_msvs_version = $MsvsVersion
+
+Write-Host 'Running sqlite3 node-pre-gyp install --fallback-to-build ...'
+node ..\@mapbox\node-pre-gyp\bin\node-pre-gyp install --fallback-to-build
+$installExit = $LASTEXITCODE
+
+if ($installExit -eq 0) {
+	Write-Host 'sqlite3 build completed successfully without MSBuild patch.'
+	Write-Host 'sqlite3 local ARM64 build completed.'
+	return
+}
+
+Write-Host "node-pre-gyp install failed with exit code $installExit; applying sqlite3 MSBuild action patch and retrying ..."
+
+$solutionPath = Patch-Sqlite3ActionProject -Sqlite3Root $sqlite3Path -NodeExePath $nodeExePath
+$msbuildPath = Find-MsBuild
+
+& $msbuildPath $solutionPath '/clp:Verbosity=minimal' '/nologo' '/nodeReuse:false' '/p:Configuration=Release;Platform=ARM64'
+if ($LASTEXITCODE -ne 0) {
+	throw "MSBuild failed with exit code $LASTEXITCODE"
+}
+
+$outputNode = Join-Path $sqlite3Path 'lib\binding\napi-v6-win32-unknown-arm64\node_sqlite3.node'
+if (-not (Test-Path $outputNode)) {
+	throw "sqlite3 output file not found: $outputNode"
+}
+
+Write-Host "sqlite3 output: $outputNode"
+Write-Host 'sqlite3 local ARM64 build completed.'

--- a/.github/scripts/dev-shell-win-arm64.ps1
+++ b/.github/scripts/dev-shell-win-arm64.ps1
@@ -1,0 +1,59 @@
+param(
+	[ValidateSet('arm64', 'x64')]
+	[string]$Arch = 'arm64',
+	[ValidateSet('arm64', 'x64')]
+	[string]$HostArch = 'arm64',
+	[string]$MsvsVersion = '2022',
+	[switch]$Quiet,
+	[switch]$SetLocationToRepo
+)
+
+# Configures a Visual Studio developer shell for this terminal session only.
+# Intended for local ARM64 build workflows without global environment changes.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+$vsDevShellCandidates = @(
+	' C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1'.Trim(),
+	' C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\Launch-VsDevShell.ps1'.Trim()
+)
+
+$vsDevShell = $vsDevShellCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $vsDevShell) {
+	throw 'Could not find Launch-VsDevShell.ps1. Install VS 2022 Build Tools or Visual Studio with C++ workload.'
+}
+
+$nodeCommand = Get-Command node -ErrorAction SilentlyContinue
+$nodeBinDir = if ($nodeCommand -and $nodeCommand.Source) { Split-Path -Parent $nodeCommand.Source } else { $null }
+
+if ($Quiet) {
+	& $vsDevShell -Arch $Arch -HostArch $HostArch 1>$null 2>$null 3>$null 4>$null 5>$null 6>$null
+} else {
+	& $vsDevShell -Arch $Arch -HostArch $HostArch
+}
+
+$pathEntries = @(
+	"$env:USERPROFILE\.cargo\bin",
+	$nodeBinDir
+)
+
+foreach ($entry in $pathEntries) {
+	if ((Test-Path $entry) -and -not (($env:Path -split ';') -contains $entry)) {
+		$env:Path = "$entry;$env:Path"
+	}
+}
+
+$env:GYP_MSVS_VERSION = $MsvsVersion
+$env:npm_config_msvs_version = $MsvsVersion
+
+if ($SetLocationToRepo) {
+	Set-Location $repoRoot
+}
+
+if (-not $Quiet) {
+	Write-Host "Repo root: $repoRoot"
+	Write-Host "Using VS DevShell: $vsDevShell"
+	Write-Host "Arch=$Arch HostArch=$HostArch msvs_version=$MsvsVersion"
+	Write-Host 'Session configured. No global machine settings were modified.'
+}

--- a/.github/scripts/dev-shell-win-arm64.ps1
+++ b/.github/scripts/dev-shell-win-arm64.ps1
@@ -14,12 +14,29 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 
-$vsDevShellCandidates = @(
-	' C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1'.Trim(),
-	' C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\Launch-VsDevShell.ps1'.Trim()
-)
+function Resolve-VsDevShellPath {
+	$vswherePath = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+	if (Test-Path $vswherePath) {
+		$installationPath = & $vswherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+		if ($installationPath) {
+			$devShellPath = Join-Path $installationPath 'Common7\Tools\Launch-VsDevShell.ps1'
+			if (Test-Path $devShellPath) {
+				return $devShellPath
+			}
+		}
+	}
 
-$vsDevShell = $vsDevShellCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+	$vsDevShellCandidates = @(
+		'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Launch-VsDevShell.ps1',
+		'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1',
+		'C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\Tools\Launch-VsDevShell.ps1',
+		'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1'
+	)
+
+	return $vsDevShellCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
+$vsDevShell = Resolve-VsDevShellPath
 if (-not $vsDevShell) {
 	throw 'Could not find Launch-VsDevShell.ps1. Install VS 2022 Build Tools or Visual Studio with C++ workload.'
 }

--- a/.github/scripts/install-audit-win-arm64.ps1
+++ b/.github/scripts/install-audit-win-arm64.ps1
@@ -1,0 +1,146 @@
+param(
+	[ValidateSet('arm64', 'x64')]
+	[string]$TargetArch = 'arm64',
+	[string]$MsvsVersion = '2022',
+	[switch]$JsonOutput,
+	[switch]$SkipInstall
+)
+
+# Installs dependencies in a session-only ARM64 dev shell and reports
+# dependency chains for known native blockers.
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+# Resolve a command from PATH and fail with a descriptive message.
+function Resolve-CommandPath {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Names,
+		[Parameter(Mandatory = $true)]
+		[string]$Description
+	)
+
+	foreach ($name in $Names) {
+		$command = Get-Command $name -ErrorAction SilentlyContinue
+		if ($command -and $command.Source) {
+			return $command.Source
+		}
+	}
+
+	throw "$Description not found in PATH. Tried: $($Names -join ', ')"
+}
+
+$corepackPath = Resolve-CommandPath -Names @('corepack.cmd', 'corepack') -Description 'corepack'
+
+# Run Yarn through corepack with optional output suppression.
+function Invoke-CorepackYarn {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Args,
+		[switch]$Quiet
+	)
+
+	if ($Quiet) {
+		& $corepackPath yarn @Args 1>$null 2>$null 3>$null 4>$null 5>$null 6>$null
+	} else {
+		& $corepackPath yarn @Args
+	}
+
+	if ($LASTEXITCODE -ne 0) {
+		throw "yarn $($Args -join ' ') failed with exit code $LASTEXITCODE"
+	}
+}
+
+# Run Yarn through corepack and return command output lines.
+function Get-CorepackYarnOutput {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string[]]$Args
+	)
+
+	$rawOutput = & $corepackPath yarn @Args
+	if ($LASTEXITCODE -ne 0) {
+		throw "yarn $($Args -join ' ') failed with exit code $LASTEXITCODE"
+	}
+
+	if ($null -eq $rawOutput) {
+		return @()
+	}
+
+	return @($rawOutput)
+}
+
+# Parse Yarn why --json output into structured entries.
+function Get-YarnWhyEntries {
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$PackageName
+	)
+
+	$lines = Get-CorepackYarnOutput -Args @('why', $PackageName, '--json')
+	$entries = @()
+
+	foreach ($line in $lines) {
+		$lineString = "$line".Trim()
+		if (-not $lineString.StartsWith('{')) {
+			continue
+		}
+
+		try {
+			$entry = $lineString | ConvertFrom-Json
+			$entries += $entry
+		} catch {
+			# Ignore lines that are not valid JSON objects.
+		}
+	}
+
+	return $entries
+}
+
+. (Join-Path $PSScriptRoot 'dev-shell-win-arm64.ps1') -Arch $TargetArch -HostArch $TargetArch -MsvsVersion $MsvsVersion -Quiet:$JsonOutput -SetLocationToRepo
+
+$env:SKIP_ONENOTE_CONVERTER_BUILD = '1'
+$env:npm_config_arch = $TargetArch
+$env:npm_config_target_arch = $TargetArch
+Remove-Item Env:npm_config_build_from_source -ErrorAction SilentlyContinue
+Remove-Item Env:npm_config_fallback_to_build -ErrorAction SilentlyContinue
+
+if (-not $SkipInstall) {
+	if (-not $JsonOutput) {
+		Write-Host 'Running dependency install without build scripts...'
+	}
+	# skip-build mode is intentional to gather dependency state without triggering
+	# native postinstall failures during diagnostics.
+	Invoke-CorepackYarn -Args @('install', '--mode=skip-build') -Quiet:$JsonOutput
+}
+
+if ($JsonOutput) {
+	$sqlite3Entries = Get-YarnWhyEntries -PackageName 'sqlite3'
+	$wasmPackEntries = Get-YarnWhyEntries -PackageName 'wasm-pack'
+
+	$result = [ordered]@{
+		timestamp = (Get-Date).ToUniversalTime().ToString('o')
+		targetArch = $TargetArch
+		msvsVersion = $MsvsVersion
+		skipInstall = [bool]$SkipInstall
+		dependencies = [ordered]@{
+			sqlite3 = $sqlite3Entries
+			'wasm-pack' = $wasmPackEntries
+		}
+	}
+
+	$result | ConvertTo-Json -Depth 12
+	return
+}
+
+Write-Host ''
+Write-Host 'Dependency audit: sqlite3'
+Invoke-CorepackYarn -Args @('why', 'sqlite3')
+
+Write-Host ''
+Write-Host 'Dependency audit: wasm-pack'
+Invoke-CorepackYarn -Args @('why', 'wasm-pack')
+
+Write-Host ''
+Write-Host 'Audit completed.'

--- a/packages/app-desktop/tools/electronRebuild.js
+++ b/packages/app-desktop/tools/electronRebuild.js
@@ -1,7 +1,14 @@
 const execCommand = require('./execCommand');
 
+const targetArch = () => {
+	const envArch = process.env.npm_config_arch || process.env.NPM_CONFIG_ARCH || process.env.npm_config_target_arch || process.env.NPM_CONFIG_TARGET_ARCH;
+	if (envArch) return envArch.toLowerCase();
+
+	return process.arch.toLowerCase();
+};
+
 const isArm64 = () => {
-	return process.arch === 'arm64';
+	return targetArch() === 'arm64';
 };
 
 const isWindows = () => {

--- a/packages/app-desktop/tools/electronRebuild.js
+++ b/packages/app-desktop/tools/electronRebuild.js
@@ -1,7 +1,7 @@
 const execCommand = require('./execCommand');
 
 const isArm64 = () => {
-	return process.platform === 'arm64';
+	return process.arch === 'arm64';
 };
 
 const isWindows = () => {
@@ -27,7 +27,9 @@ async function main() {
 	// https://github.com/electron/node-abi/tree/master/test
 	const forceAbiArgs = '--force-abi 142';
 
-	if (isWindows()) {
+	if (isWindows() && isArm64()) {
+		console.info(await execCommand(['yarn', 'run', 'electron-rebuild', forceAbiArgs, '--arch arm64'].join(' ')));
+	} else if (isWindows()) {
 		// Cannot run this in parallel, or the 64-bit version might end up
 		// with 32-bit files and vice-versa
 		console.info(await execCommand(['yarn', 'run', 'electron-rebuild', forceAbiArgs, '--arch ia32'].join(' ')));

--- a/packages/onenote-converter/tools/build.js
+++ b/packages/onenote-converter/tools/build.js
@@ -28,8 +28,16 @@ async function main() {
 		return;
 	}
 
+	const wasmPackBin = process.env.WASM_PACK_BIN || 'wasm-pack';
 
-	const buildCommand = `wasm-pack build --target nodejs --${argv.profile} ./renderer`;
+	const buildCommand = [
+		wasmPackBin,
+		'build',
+		'--target',
+		'nodejs',
+		`--${argv.profile}`,
+		'./renderer',
+	];
 
 	await execCommand(buildCommand);
 

--- a/packages/tools/cspell/dictionary2.txt
+++ b/packages/tools/cspell/dictionary2.txt
@@ -228,6 +228,7 @@ msgfmt
 msgmerge
 msgstr
 msleep
+Msvs
 mtext
 mult
 multicursor
@@ -250,6 +251,7 @@ mytest
 mytoken
 myvalue
 nanoid
+napi
 Naveen
 Navier
 naviji

--- a/readme/dev/windows-arm64-local-build.md
+++ b/readme/dev/windows-arm64-local-build.md
@@ -1,0 +1,96 @@
+# Windows ARM64 local build (session-only)
+
+This workflow is designed to avoid changing global machine configuration.
+
+## What it does
+
+- Uses a Visual Studio Developer Shell for the current terminal session.
+- Adds Rust and Node tools to `PATH` only for the current terminal session.
+- Sets `node-gyp` Visual Studio selection only for the current terminal session.
+- Sets `SKIP_ONENOTE_CONVERTER_BUILD=1` during install to avoid requiring `wasm-pack` on unsupported ARM64 environments.
+- Sets `npm_config_build_from_source=true` and `npm_config_fallback_to_build=true` during install so native modules (notably `sqlite3`) compile locally when no prebuilt binary exists.
+- Supports ARM64 or x64 build target selection.
+
+## Files
+
+- `.github/scripts/dev-shell-win-arm64.ps1`
+- `.github/scripts/build-clean-win-arm64.ps1`
+- `.github/scripts/install-audit-win-arm64.ps1`
+- `.github/scripts/build-onenote-win-arm64-local.ps1`
+- `.github/scripts/build-sqlite3-win-arm64-local.ps1`
+
+`dev-shell-win-arm64.ps1` also supports `-Quiet` to suppress session setup logs.
+
+## Usage
+
+From repository root (`D:/projects/joplin`):
+
+```powershell
+# Configure this terminal only (no global changes)
+.\.github\scripts\dev-shell-win-arm64.ps1 -Arch arm64 -HostArch arm64 -MsvsVersion 2022 -SetLocationToRepo
+
+# Install dependencies and run Windows ARM64 dist build (no publish)
+.\.github\scripts\build-clean-win-arm64.ps1 -TargetArch arm64
+```
+
+For x64 on the same machine:
+
+```powershell
+.\.github\scripts\build-clean-win-arm64.ps1 -TargetArch x64
+```
+
+## Optional flags
+
+`build-clean-win-arm64.ps1` supports:
+
+- `-Clean` to run `git clean -xfd` before install
+- `-Publish` to allow publishing during `yarn dist`
+- `-SkipInstall` to skip `yarn install`
+- `-SkipBuildScriptsInstall` to run `yarn install --mode=skip-build` (installs dependencies without native postinstall/build steps)
+- `-ForceSourceBuild` to force native module source compilation during install
+- `-SkipDist` to only prepare the session/install
+- `-MsvsVersion 2022` to choose Visual Studio version for `node-gyp`
+
+Recommended for a non-invasive local setup on Windows ARM64:
+
+```powershell
+.\.github\scripts\build-clean-win-arm64.ps1 -TargetArch arm64 -SkipBuildScriptsInstall -SkipDist
+```
+
+To install dependencies (without running native build scripts) and print dependency chains for native blockers:
+
+```powershell
+.\.github\scripts\install-audit-win-arm64.ps1 -TargetArch arm64
+```
+
+For CI/log parsing, output a single JSON document:
+
+```powershell
+.\.github\scripts\install-audit-win-arm64.ps1 -TargetArch arm64 -JsonOutput
+```
+
+To compile the OneNote converter blocker in a session-only way (repo-local `wasm-pack`, no global PATH changes):
+
+```powershell
+.\.github\scripts\build-onenote-win-arm64-local.ps1 -TargetArch arm64
+```
+
+`packages/onenote-converter/tools/build.js` now supports `WASM_PACK_BIN` to force a specific `wasm-pack` executable path (used by the script above).
+
+To compile the sqlite3 blocker for desktop in a session-only way:
+
+```powershell
+.\.github\scripts\build-sqlite3-win-arm64-local.ps1 -TargetArch arm64
+```
+
+This script applies local compatibility workarounds for Visual Studio 18 + `node-gyp` and for the generated sqlite3 MSBuild action command, then builds `node_sqlite3.node` for `napi-v6-win32-unknown-arm64`.
+
+Optional flags:
+
+- `-ForceWasmPackInstall` to reinstall local `wasm-pack`
+- `-SkipInstall` to skip `yarn install --mode=skip-build`
+- `-Release` to build release profile (sets `IS_CONTINUOUS_INTEGRATION=1` in-session)
+
+## Notes
+
+Current known blockers on native Windows ARM64 in this repo are third-party dependencies (`wasm-pack` and `sqlite3` toolchain compatibility). These scripts keep setup reproducible while those upstream issues are handled.

--- a/readme/dev/windows-arm64-local-build.md
+++ b/readme/dev/windows-arm64-local-build.md
@@ -9,6 +9,7 @@ This workflow is designed to avoid changing global machine configuration.
 - Sets `node-gyp` Visual Studio selection only for the current terminal session.
 - Sets `SKIP_ONENOTE_CONVERTER_BUILD=1` during install to avoid requiring `wasm-pack` on unsupported ARM64 environments.
 - Sets `npm_config_build_from_source=true` and `npm_config_fallback_to_build=true` during install so native modules (notably `sqlite3`) compile locally when no prebuilt binary exists.
+- Uses the standard desktop build CLI (`yarn dist --win --<arch>`) for both ARM64 and x64.
 - Supports ARM64 or x64 build target selection.
 
 ## Files

--- a/readme/dev/windows-arm64-local-build.md
+++ b/readme/dev/windows-arm64-local-build.md
@@ -8,7 +8,7 @@ This workflow is designed to avoid changing global machine configuration.
 - Adds Rust and Node tools to `PATH` only for the current terminal session.
 - Sets `node-gyp` Visual Studio selection only for the current terminal session.
 - Sets `SKIP_ONENOTE_CONVERTER_BUILD=1` during install to avoid requiring `wasm-pack` on unsupported ARM64 environments.
-- Sets `npm_config_build_from_source=true` and `npm_config_fallback_to_build=true` during install so native modules (notably `sqlite3`) compile locally when no prebuilt binary exists.
+- When `-ForceSourceBuild` is set, sets `npm_config_build_from_source=true` and `npm_config_fallback_to_build=true` during install so native modules (notably `sqlite3`) compile locally when no prebuilt binary exists.
 - Uses the standard desktop build CLI (`yarn dist --win --<arch>`) for both ARM64 and x64.
 - Supports ARM64 or x64 build target selection.
 

--- a/readme/dev/windows-arm64-local-build.md
+++ b/readme/dev/windows-arm64-local-build.md
@@ -77,6 +77,12 @@ To compile the OneNote converter blocker in a session-only way (repo-local `wasm
 
 `packages/onenote-converter/tools/build.js` now supports `WASM_PACK_BIN` to force a specific `wasm-pack` executable path (used by the script above).
 
+Optional flags for `build-onenote-win-arm64-local.ps1`:
+
+- `-ForceWasmPackInstall` to reinstall local `wasm-pack`
+- `-SkipInstall` to skip `yarn install --mode=skip-build`
+- `-Release` to build release profile (sets `IS_CONTINUOUS_INTEGRATION=1` in-session)
+
 To compile the sqlite3 blocker for desktop in a session-only way:
 
 ```powershell
@@ -84,12 +90,6 @@ To compile the sqlite3 blocker for desktop in a session-only way:
 ```
 
 This script applies local compatibility workarounds for Visual Studio 18 + `node-gyp` and for the generated sqlite3 MSBuild action command, then builds `node_sqlite3.node` for `napi-v6-win32-unknown-arm64`.
-
-Optional flags:
-
-- `-ForceWasmPackInstall` to reinstall local `wasm-pack`
-- `-SkipInstall` to skip `yarn install --mode=skip-build`
-- `-Release` to build release profile (sets `IS_CONTINUOUS_INTEGRATION=1` in-session)
 
 ## Notes
 


### PR DESCRIPTION
## Problem
Windows ARM64 local desktop builds did not follow the same standard packaging flow as other Windows targets, which made local validation and troubleshooting inconsistent. This could produce confusing behavior across repeated local runs and cross-architecture scenarios.

## Solution
- Unified Windows local dist invocation to use the standard flow for both targets: `yarn dist --win --<arch>`.
- Moved `corepack`/`npm` path resolution to run after dev-shell initialization so PATH-provided tools are available.
- Reordered native patch application to occur after install so patches target actual installed files.
- Added explicit `git clean` exit-code handling.
- Prevented persistent `package.json` mutations by restoring the file after temporary `npm pkg set` overrides.
- Updated target-specific rebuild selection to prefer target architecture environment variables (falling back to host architecture only when target vars are absent).
- Clarified docs that source-build env vars are conditional on `-ForceSourceBuild`.

## Test Plan
- Ran ARM64 local flow:
  - `./.github/scripts/build-clean-win-arm64.ps1 -TargetArch arm64 -SkipInstall`
  - Confirmed standard invocation path: `yarn dist --win --arm64 --publish=never`
- Ran x64 local flow:
  - `./.github/scripts/build-clean-win-arm64.ps1 -TargetArch x64 -SkipInstall`
  - Confirmed standard invocation path: `yarn dist --win --x64 --publish=never`
- Verified expected Windows artifacts are produced for both architectures in local dist output.
- Verified script behavior changes requested in review comments:
  - command resolution occurs after dev-shell setup,
  - patching occurs after install,
  - temporary build config overrides do not persist,
  - arch selection for rebuild uses target architecture variables.

## Notes
- Local repeated runs may still encounter an external file-lock issue on `app.asar` in unpacked output directories; this appears environmental and outside the scope of this flow-unification change.
