### PR TITLE
Desktop: Fixes #14142: Fix search highlights breaking mermaid diagram rendering

### DIFF
--- a/packages/lib/markJsUtils.js
+++ b/packages/lib/markJsUtils.js
@@ -60,6 +60,15 @@ markJsUtils.markKeyword = (mark, keyword, stringUtils, extraOptions = null) => {
 				//
 				// https://github.com/joplin/plugin-abc-sheet-music
 				if (isInsideContainer(node, 'SVG')) return false;
+
+				// We exclude joplin-source because it contains the raw source
+				// for editable blocks (mermaid diagrams, etc.). If we highlight
+				// inside these elements, the <mark> tags corrupt the source code
+				// and cause rendering to fail when switching editors.
+				//
+				// https://github.com/laurent22/joplin/issues/14142
+				if (node.parentElement?.closest('.joplin-source')) return false;
+
 				return true;
 			},
 			...extraOptions,


### PR DESCRIPTION
Exclude 'joplin-source' elements from search highlighting.

When searching for a term inside a mermaid diagram, mark.js inserts '<mark>' tags into the hidden 'joplin-source' element. Switching from Rich Text Editor back to Markdown Viewer causes Turndown to read this corrupted source, breaking the mermaid syntax.

This follows the existing pattern for SVG exclusion and also protects other editable blocks (KaTeX, ABC notation, etc.).

Fixes #14142