### PR TITLE
Desktop: Fixes #13140: Normalize img alt line breaks and convert data: URLs when pasting from Word

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -63,4 +63,52 @@ describe('resourceHandling', () => {
 		const html = `<img src="file://${encodeURI(Setting.value('resourceDir'))}/resource.png" alt="test"/>`;
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
 	});
+
+	it('should normalize HTML-encoded newlines in image alt attributes', async () => {
+		// Word encodes newlines in alt text as &#10; HTML entities. These must be
+		// normalized to spaces before Turndown processes the HTML, otherwise
+		// node.outerHTML (returned verbatim for images with width/height) embeds
+		// literal newlines that break Markdown raw HTML block parsing.
+		const resourceSrc = `file://${encodeURI(Setting.value('resourceDir'))}/resource.png`;
+		const testCases: [string, string][] = [
+			// HTML entity newlines (Word clipboard format: &#10; = LF)
+			[
+				`<img src="${resourceSrc}" alt="A screenshot&#10;&#10;AI-generated content."/>`,
+				`<img src="${resourceSrc}" alt="A screenshot AI-generated content."/>`,
+			],
+			// Literal newlines in the raw HTML attribute value
+			[
+				`<img src="${resourceSrc}" alt="hello\nworld"/>`,
+				`<img src="${resourceSrc}" alt="hello world"/>`,
+			],
+		];
+
+		for (const [html, expected] of testCases) {
+			expect(await processPastedHtml(html, null, null)).toBe(expected);
+		}
+	});
+
+	it('should render Word-pasted images with newlines in alt as img elements, not broken text', async () => {
+		// When Word pastes an image with width/height attributes and &#10; in the alt,
+		// Turndown returns node.outerHTML verbatim (preserveImageTagsWithSize=true).
+		// Without normalization, literal newlines inside the Markdown raw HTML block
+		// would terminate the block early, causing the <img> to render as plain text.
+		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
+		const resourceSrc = `file://${encodeURI(Setting.value('resourceDir'))}/resource.png`;
+
+		const testCases = [
+			// Word-style: width/height present, alt has &#10; entities
+			`<img width="625" height="284" src="${resourceSrc}" alt="A screenshot&#10;&#10;AI-generated content."/>`,
+			// Multiple consecutive newline entities collapsed to single space
+			`<img width="100" height="100" src="${resourceSrc}" alt="line1&#10;&#13;&#10;line2"/>`,
+		];
+
+		for (const html of testCases) {
+			const result = await processPastedHtml(html, htmlToMd, markupToHtml);
+			// The image must be rendered as an <img> element, not as escaped/broken text
+			expect(result).toContain('<img');
+			// The alt text after normalization must not contain literal newlines
+			expect(result).not.toMatch(/alt="[^"]*\n/);
+		}
+	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -177,6 +177,8 @@ const processImagesInPastedHtml = async (html: string) => {
 							await shim.fsDriver().writeFile(filePath, base64Data, 'base64');
 							const createdResource = await shim.createResourceFromPath(filePath);
 							mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+						} catch (writeError) {
+							throw new Error(`processPastedHtml: Failed to write or create resource from pasted image: ${writeError.message}`);
 						} finally {
 							try {
 								await shim.fsDriver().remove(filePath);

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -162,7 +162,24 @@ const processImagesInPastedHtml = async (html: string) => {
 						mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
 					}
 				} else if (imageSrc.startsWith('data:')) {
-					mappedResources[imageSrc] = imageSrc;
+					// Word encodes base64 with MIME line breaks every ~76 chars.
+					// Strip whitespace before decoding, then save as a Joplin resource
+					// so Turndown's outerHTML (used for images with width/height) gets
+					// a short file:// URL instead of 200KB of base64.
+					const cleanSrc = imageSrc.replace(/\s/g, '');
+					const dataUrlMatch = cleanSrc.match(/^data:([^;]+);base64,(.+)$/);
+					if (dataUrlMatch) {
+						const mimeType = dataUrlMatch[1];
+						const base64Data = dataUrlMatch[2];
+						const fileExt = mimeUtils.toFileExtension(mimeType) || 'bin';
+						const filePath = `${Setting.value('tempDir')}/${md5(Date.now() + Math.random())}.${fileExt}`;
+						await shim.fsDriver().writeFile(filePath, base64Data, 'base64');
+						const createdResource = await shim.createResourceFromPath(filePath);
+						await shim.fsDriver().remove(filePath);
+						mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+					} else {
+						mappedResources[imageSrc] = imageSrc;
+					}
 				} else {
 					downloadImages.push(downloadImage(imageSrc));
 				}
@@ -187,6 +204,23 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	html = html.replace(/[\u202F\u00A0]/g, ' ');
 
 	html = await processImagesInPastedHtml(html);
+
+	// Word encodes newlines in alt attributes as HTML entities (&#10; &#13; &#xA; etc.).
+	// These get decoded to literal newline characters by JSDOM when Turndown processes
+	// the HTML. With preserveImageTagsWithSize=true, Turndown returns node.outerHTML
+	// verbatim — embedding literal newlines inside an HTML attribute value, which
+	// breaks the Markdown raw HTML block (a blank line ends the block, making the
+	// parser treat the <img> as plain text). Normalize them to spaces here.
+	html = html.replace(/(\balt=)(["'])([\s\S]*?)\2/gi, (_m, prefix, quote, altText) => {
+		// Replace HTML-encoded newlines/control chars and literal ones with a space
+		// eslint-disable-next-line no-control-regex
+		const normalized = altText
+			.replace(/&#(?:1[0-3]|[0-9]);|&#x[0-9a-fA-F]{1,2};/g, ' ')
+			.replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ')
+			.replace(/ {2,}/g, ' ')
+			.trim();
+		return `${prefix}${quote}${normalized}${quote}`;
+	});
 
 	// TinyMCE can accept any type of HTML, including HTML that may not be preserved once saved as
 	// Markdown. For example the content may have a dark background which would be supported by

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -174,18 +174,18 @@ const processImagesInPastedHtml = async (html: string) => {
 						const fileExt = mimeUtils.toFileExtension(mimeType) || 'bin';
 						const filePath = `${Setting.value('tempDir')}/${md5(Date.now() + Math.random())}.${fileExt}`;
 						try {
-              await shim.fsDriver().writeFile(filePath, base64Data, "base64");
-              const createdResource = await shim.createResourceFromPath(filePath);
-              mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
-            } finally {
-              try {
-                if (await shim.fsDriver().exists(filePath)) {
-                  await shim.fsDriver().remove(filePath);
-                }
-              } catch (cleanupError) {
-                logger.warn("processPastedHtml: Error removing temporary file.", cleanupError);
-              }
-            }
+							await shim.fsDriver().writeFile(filePath, base64Data, 'base64');
+							const createdResource = await shim.createResourceFromPath(filePath);
+							mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+						} finally {
+							try {
+								if (await shim.fsDriver().exists(filePath)) {
+									await shim.fsDriver().remove(filePath);
+								}
+							} catch (cleanupError) {
+								logger.warn('processPastedHtml: Error removing temporary file.', cleanupError);
+							}
+						}
 					} else {
 						mappedResources[imageSrc] = imageSrc;
 					}
@@ -221,18 +221,18 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	// breaks the Markdown raw HTML block (a blank line ends the block, making the
 	// parser treat the <img> as plain text). Normalize them to spaces here.
 	html = html.replace(
-    /(\balt\s*=\s*)(["'])([\s\S]*?)\2/gi,
-    (_m, prefix, quote, altText) => {
-      // Replace HTML-encoded newlines/control chars and literal ones with a space
-      // eslint-disable-next-line no-control-regex
-      const normalized = altText
-        .replace(/&#(?:10|13);|&#x(?:0*[aAdD]);/gi, " ")
-        .replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, " ")
-        .replace(/ {2,}/g, " ")
-        .trim();
-      return `${prefix}${quote}${normalized}${quote}`;
-    },
-  );
+		/(\balt\s*=\s*)(["'])([\s\S]*?)\2/gi,
+		(_m, prefix, quote, altText) => {
+			// Replace HTML-encoded newlines/control chars and literal ones with a space
+			const normalized = altText
+				.replace(/&#(?:10|13);|&#x(?:0*[aAdD]);/gi, ' ')
+				// eslint-disable-next-line no-control-regex
+				.replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ')
+				.replace(/ {2,}/g, ' ')
+				.trim();
+			return `${prefix}${quote}${normalized}${quote}`;
+		},
+	);
 
 	// TinyMCE can accept any type of HTML, including HTML that may not be preserved once saved as
 	// Markdown. For example the content may have a dark background which would be supported by

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -173,10 +173,19 @@ const processImagesInPastedHtml = async (html: string) => {
 						const base64Data = dataUrlMatch[2];
 						const fileExt = mimeUtils.toFileExtension(mimeType) || 'bin';
 						const filePath = `${Setting.value('tempDir')}/${md5(Date.now() + Math.random())}.${fileExt}`;
-						await shim.fsDriver().writeFile(filePath, base64Data, 'base64');
-						const createdResource = await shim.createResourceFromPath(filePath);
-						await shim.fsDriver().remove(filePath);
-						mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+						try {
+              await shim.fsDriver().writeFile(filePath, base64Data, "base64");
+              const createdResource = await shim.createResourceFromPath(filePath);
+              mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+            } finally {
+              try {
+                if (await shim.fsDriver().exists(filePath)) {
+                  await shim.fsDriver().remove(filePath);
+                }
+              } catch (cleanupError) {
+                logger.warn("processPastedHtml: Error removing temporary file.", cleanupError);
+              }
+            }
 					} else {
 						mappedResources[imageSrc] = imageSrc;
 					}
@@ -211,16 +220,19 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 	// verbatim — embedding literal newlines inside an HTML attribute value, which
 	// breaks the Markdown raw HTML block (a blank line ends the block, making the
 	// parser treat the <img> as plain text). Normalize them to spaces here.
-	html = html.replace(/(\balt=)(["'])([\s\S]*?)\2/gi, (_m, prefix, quote, altText) => {
-		// Replace HTML-encoded newlines/control chars and literal ones with a space
-		// eslint-disable-next-line no-control-regex
-		const normalized = altText
-			.replace(/&#(?:1[0-3]|[0-9]);|&#x[0-9a-fA-F]{1,2};/g, ' ')
-			.replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ')
-			.replace(/ {2,}/g, ' ')
-			.trim();
-		return `${prefix}${quote}${normalized}${quote}`;
-	});
+	html = html.replace(
+    /(\balt\s*=\s*)(["'])([\s\S]*?)\2/gi,
+    (_m, prefix, quote, altText) => {
+      // Replace HTML-encoded newlines/control chars and literal ones with a space
+      // eslint-disable-next-line no-control-regex
+      const normalized = altText
+        .replace(/&#(?:10|13);|&#x(?:0*[aAdD]);/gi, " ")
+        .replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, " ")
+        .replace(/ {2,}/g, " ")
+        .trim();
+      return `${prefix}${quote}${normalized}${quote}`;
+    },
+  );
 
 	// TinyMCE can accept any type of HTML, including HTML that may not be preserved once saved as
 	// Markdown. For example the content may have a dark background which would be supported by

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -179,9 +179,7 @@ const processImagesInPastedHtml = async (html: string) => {
 							mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
 						} finally {
 							try {
-								if (await shim.fsDriver().exists(filePath)) {
-									await shim.fsDriver().remove(filePath);
-								}
+								await shim.fsDriver().remove(filePath);
 							} catch (cleanupError) {
 								logger.warn('processPastedHtml: Error removing temporary file.', cleanupError);
 							}

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -225,6 +225,7 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 			const normalized = altText
 				.replace(/&#(?:10|13);|&#x(?:0*[aAdD]);/gi, ' ')
 				// eslint-disable-next-line no-control-regex
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional sanitisation of control chars
 				.replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ')
 				.replace(/ {2,}/g, ' ')
 				.trim();

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -178,7 +178,8 @@ const processImagesInPastedHtml = async (html: string) => {
 							const createdResource = await shim.createResourceFromPath(filePath);
 							mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
 						} catch (writeError) {
-							throw new Error(`processPastedHtml: Failed to write or create resource from pasted image: ${writeError.message}`);
+							writeError.message = `processPastedHtml: Failed to write or create resource from pasted image: ${writeError.message}`;
+							throw writeError;
 						} finally {
 							try {
 								await shim.fsDriver().remove(filePath);

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -224,8 +224,8 @@ export async function processPastedHtml(html: string, htmlToMd: HtmlToMarkdownHa
 			// Replace HTML-encoded newlines/control chars and literal ones with a space
 			const normalized = altText
 				.replace(/&#(?:10|13);|&#x(?:0*[aAdD]);/gi, ' ')
-				// eslint-disable-next-line no-control-regex
 				// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional sanitisation of control chars
+				// eslint-disable-next-line no-control-regex
 				.replace(/[\r\n\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ')
 				.replace(/ {2,}/g, ' ')
 				.trim();


### PR DESCRIPTION
Closes #13140 

## Summary

Pasting an image from Microsoft Word into the Rich Text editor resulted in raw base64 text being shown instead of the image.

## Root Cause
Two issues:
1. Word adds AI-generated alt text with line breaks (`\n`) — e.g. `alt="A computer screen shot\n\nAI-generated content may be incorrect."` — which broke image rendering.
2. `data:` URLs were not being converted to Joplin resources, leaving raw base64 embedded in the Markdown.

## Fix
1. Normalize img alt text on paste — strip line breaks and control characters
2. Convert `data:` URLs to Joplin resources to prevent raw base64 in Markdown

## Testing
1. Open `image-test.docx` in Microsoft Word, copy content and paste into Joplin Rich Text editor
2. Alternatively open `word-html.html` in a browser, copy and paste into Joplin Rich Text editor
3. Verify image renders correctly and no raw base64 appears in Markdown editor

## Demo

https://github.com/user-attachments/assets/acccc57e-229a-47c9-9c98-be318643b984