### PR TITLE
All: Fixes #9093: Delete leftover .crypted files during maintenance

### DIFF
--- a/packages/lib/services/ResourceService.test.ts
+++ b/packages/lib/services/ResourceService.test.ts
@@ -264,42 +264,44 @@ describe('services/ResourceService', () => {
 		expect((await NoteResource.all()).length).toBe(1);
 	});
 
-	it('should delete leftover .crypted files from the resource directory', async () => {
+	it('should delete leftover .crypted files only when the resource is not actively being decrypted', async () => {
 		const service = new ResourceService();
 		const resourceDir = Resource.baseDirectoryPath();
 
-		// Create a fake .crypted leftover file (simulates a crash during decryption)
-		const cryptedFilePath1 = `${resourceDir}/abc123def456abc123def456abc123de.crypted`;
-		const cryptedFilePath2 = `${resourceDir}/cafe1234cafe1234cafe1234cafe1234.crypted`;
-
-		// Also create a regular resource file that should NOT be deleted
+		// Attach a real resource so we can test both the safe-to-delete and skip cases
 		const folder = await Folder.save({ title: 'test folder' });
 		const note = await Note.save({ title: 'test note', parent_id: folder.id });
-		const noteWithResource = await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);
+		await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);
 		const resource = (await Resource.all())[0];
+
+		// Case 1: orphan .crypted file with no matching resource in DB — safe to delete
+		const orphanCryptedPath = `${resourceDir}/abc123def456abc123def456abc123de.crypted`;
+		await shim.fsDriver().writeFile(orphanCryptedPath, 'orphan data', 'utf8');
+
+		// Case 2: .crypted file whose resource is already decrypted (encryption_blob_encrypted = 0) — safe to delete
+		const decryptedResourceCryptedPath = `${resourceDir}/${resource.id}.crypted`;
+		await Resource.save({ id: resource.id, encryption_blob_encrypted: 0 }, { autoTimestamp: false });
+		await shim.fsDriver().writeFile(decryptedResourceCryptedPath, 'stale crypted data', 'utf8');
+
+		// Case 3: .crypted file whose resource is still marked encrypted — must NOT be deleted
+		const encryptedResource = await Resource.save({ title: 'encrypted', encryption_blob_encrypted: 1, mime: 'application/octet-stream', file_extension: '' });
+		const activeCryptedPath = `${resourceDir}/${encryptedResource.id}.crypted`;
+		await shim.fsDriver().writeFile(activeCryptedPath, 'active crypted data', 'utf8');
+
+		// Regular resource file should never be touched
 		const resourceFilePath = Resource.fullPath(resource);
 
-		// Write the fake .crypted files
-		await shim.fsDriver().writeFile(cryptedFilePath1, 'fake encrypted data 1', 'utf8');
-		await shim.fsDriver().writeFile(cryptedFilePath2, 'fake encrypted data 2', 'utf8');
-
-		// Verify they exist before cleanup
-		expect(await shim.fsDriver().exists(cryptedFilePath1)).toBe(true);
-		expect(await shim.fsDriver().exists(cryptedFilePath2)).toBe(true);
-		expect(await shim.fsDriver().exists(resourceFilePath)).toBe(true);
-
-		// Run the cleanup
 		await service.deleteCryptedFiles();
 
-		// .crypted files should be gone
-		expect(await shim.fsDriver().exists(cryptedFilePath1)).toBe(false);
-		expect(await shim.fsDriver().exists(cryptedFilePath2)).toBe(false);
+		// Orphan and already-decrypted .crypted files should be removed
+		expect(await shim.fsDriver().exists(orphanCryptedPath)).toBe(false);
+		expect(await shim.fsDriver().exists(decryptedResourceCryptedPath)).toBe(false);
 
-		// Regular resource file should be untouched
+		// Active decryption file must be preserved
+		expect(await shim.fsDriver().exists(activeCryptedPath)).toBe(true);
+
+		// Regular resource blob must be untouched
 		expect(await shim.fsDriver().exists(resourceFilePath)).toBe(true);
-
-		// Suppress unused variable warning
-		void noteWithResource;
 	});
 
 });

--- a/packages/lib/services/ResourceService.test.ts
+++ b/packages/lib/services/ResourceService.test.ts
@@ -264,4 +264,42 @@ describe('services/ResourceService', () => {
 		expect((await NoteResource.all()).length).toBe(1);
 	});
 
+	it('should delete leftover .crypted files from the resource directory', async () => {
+		const service = new ResourceService();
+		const resourceDir = Resource.baseDirectoryPath();
+
+		// Create a fake .crypted leftover file (simulates a crash during decryption)
+		const cryptedFilePath1 = `${resourceDir}/abc123def456abc123def456abc123de.crypted`;
+		const cryptedFilePath2 = `${resourceDir}/cafe1234cafe1234cafe1234cafe1234.crypted`;
+
+		// Also create a regular resource file that should NOT be deleted
+		const folder = await Folder.save({ title: 'test folder' });
+		const note = await Note.save({ title: 'test note', parent_id: folder.id });
+		const noteWithResource = await shim.attachFileToNote(note, `${supportDir}/photo.jpg`);
+		const resource = (await Resource.all())[0];
+		const resourceFilePath = Resource.fullPath(resource);
+
+		// Write the fake .crypted files
+		await shim.fsDriver().writeFile(cryptedFilePath1, 'fake encrypted data 1', 'utf8');
+		await shim.fsDriver().writeFile(cryptedFilePath2, 'fake encrypted data 2', 'utf8');
+
+		// Verify they exist before cleanup
+		expect(await shim.fsDriver().exists(cryptedFilePath1)).toBe(true);
+		expect(await shim.fsDriver().exists(cryptedFilePath2)).toBe(true);
+		expect(await shim.fsDriver().exists(resourceFilePath)).toBe(true);
+
+		// Run the cleanup
+		await service.deleteCryptedFiles();
+
+		// .crypted files should be gone
+		expect(await shim.fsDriver().exists(cryptedFilePath1)).toBe(false);
+		expect(await shim.fsDriver().exists(cryptedFilePath2)).toBe(false);
+
+		// Regular resource file should be untouched
+		expect(await shim.fsDriver().exists(resourceFilePath)).toBe(true);
+
+		// Suppress unused variable warning
+		void noteWithResource;
+	});
+
 });

--- a/packages/lib/services/ResourceService.ts
+++ b/packages/lib/services/ResourceService.ts
@@ -151,39 +151,48 @@ export default class ResourceService extends BaseService {
 
 	// Deletes any leftover .crypted files from the resource directory.
 	// These files are created by Resource.decrypt() when it renames the encrypted
-	// blob before decrypting it, but they are never cleaned up if the app crashes
-	// or is interrupted mid-decryption. It is safe to delete them on startup since
-	// the original encrypted blob is no longer needed once decryption completes.
+	// blob before decrypting it, but are never cleaned up if the app crashes
+	// mid-decryption. To avoid deleting a file that is actively being decrypted,
+	// we only remove files whose corresponding resource has already been successfully
+	// decrypted (encryption_blob_encrypted = 0) or no longer exists in the database.
 	public async deleteCryptedFiles() {
 		const resourceDir = Resource.baseDirectoryPath();
-		if (!resourceDir) {
-			this.logger().warn('ResourceService::deleteCryptedFiles: Resource directory not set, skipping cleanup');
+		if (!resourceDir) return;
+
+		let stats;
+		try {
+			const dirExists = await shim.fsDriver().exists(resourceDir);
+			if (!dirExists) return;
+			stats = await shim.fsDriver().readDirStats(resourceDir);
+		} catch (error) {
+			this.logger().warn(`ResourceService::deleteCryptedFiles: Could not read resource directory: ${error.message}`);
 			return;
 		}
 
-		const dirExists = await shim.fsDriver().exists(resourceDir);
-		if (!dirExists) return;
-
-		const stats = await shim.fsDriver().readDirStats(resourceDir);
 		let deletedCount = 0;
 
 		for (const stat of stats) {
-			if (stat.path.endsWith('.crypted')) {
-				const fullPath = `${resourceDir}/${stat.path}`;
-				try {
-					await shim.fsDriver().remove(fullPath);
-					deletedCount++;
-					this.logger().info(`ResourceService::deleteCryptedFiles: Deleted leftover encrypted file: ${stat.path}`);
-				} catch (error) {
-					this.logger().warn(`ResourceService::deleteCryptedFiles: Could not delete ${fullPath}: ${error.message}`);
-				}
+			if (!stat.path.endsWith('.crypted')) continue;
+
+			// The filename is "<resource_id>.crypted" — extract the ID to check DB state.
+			const resourceId = stat.path.slice(0, -'.crypted'.length);
+			const resource = await Resource.load(resourceId);
+
+			// Skip if the resource is still marked as encrypted — decryption may be in progress.
+			if (resource && resource.encryption_blob_encrypted) continue;
+
+			const fullPath = `${resourceDir}/${stat.path}`;
+			try {
+				await shim.fsDriver().remove(fullPath);
+				deletedCount++;
+				this.logger().info(`ResourceService::deleteCryptedFiles: Deleted leftover file: ${stat.path}`);
+			} catch (error) {
+				this.logger().warn(`ResourceService::deleteCryptedFiles: Could not delete ${fullPath}: ${error.message}`);
 			}
 		}
 
 		if (deletedCount > 0) {
 			this.logger().info(`ResourceService::deleteCryptedFiles: Cleaned up ${deletedCount} leftover .crypted file(s)`);
-		} else {
-			this.logger().info('ResourceService::deleteCryptedFiles: No leftover .crypted files found');
 		}
 	}
 

--- a/packages/lib/services/ResourceService.ts
+++ b/packages/lib/services/ResourceService.ts
@@ -149,6 +149,44 @@ export default class ResourceService extends BaseService {
 		task.onEnd();
 	}
 
+	// Deletes any leftover .crypted files from the resource directory.
+	// These files are created by Resource.decrypt() when it renames the encrypted
+	// blob before decrypting it, but they are never cleaned up if the app crashes
+	// or is interrupted mid-decryption. It is safe to delete them on startup since
+	// the original encrypted blob is no longer needed once decryption completes.
+	public async deleteCryptedFiles() {
+		const resourceDir = Resource.baseDirectoryPath();
+		if (!resourceDir) {
+			this.logger().warn('ResourceService::deleteCryptedFiles: Resource directory not set, skipping cleanup');
+			return;
+		}
+
+		const dirExists = await shim.fsDriver().exists(resourceDir);
+		if (!dirExists) return;
+
+		const stats = await shim.fsDriver().readDirStats(resourceDir);
+		let deletedCount = 0;
+
+		for (const stat of stats) {
+			if (stat.path.endsWith('.crypted')) {
+				const fullPath = `${resourceDir}/${stat.path}`;
+				try {
+					await shim.fsDriver().remove(fullPath);
+					deletedCount++;
+					this.logger().info(`ResourceService::deleteCryptedFiles: Deleted leftover encrypted file: ${stat.path}`);
+				} catch (error) {
+					this.logger().warn(`ResourceService::deleteCryptedFiles: Could not delete ${fullPath}: ${error.message}`);
+				}
+			}
+		}
+
+		if (deletedCount > 0) {
+			this.logger().info(`ResourceService::deleteCryptedFiles: Cleaned up ${deletedCount} leftover .crypted file(s)`);
+		} else {
+			this.logger().info('ResourceService::deleteCryptedFiles: No leftover .crypted files found');
+		}
+	}
+
 	private static async autoSetFileSize(resourceId: string, filePath: string, waitTillExists = true) {
 		const itDoes = await shim.fsDriver().waitTillExists(filePath, waitTillExists ? 10000 : 0);
 		if (!itDoes) {
@@ -172,6 +210,7 @@ export default class ResourceService extends BaseService {
 		try {
 			await this.indexNoteResources();
 			await this.deleteOrphanResources();
+			await this.deleteCryptedFiles();
 		} finally {
 			this.maintenanceCalls_.pop();
 		}


### PR DESCRIPTION
Fixes #9093

When `Resource.decrypt()` decrypts an encrypted blob, it first renames the file to `<id>.crypted` before decrypting it into the final plaintext path. If the app crashes or is interrupted mid-decryption, the `.crypted` file is never removed and accumulates in the resource directory indefinitely.

This adds a `deleteCryptedFiles()` method to `ResourceService` that scans the resource directory for any leftover `.crypted` files and removes them. It is called from `maintenance()`, which already runs ~30 seconds after startup and every 4 hours — making cleanup automatic without any risk of deleting files that are actively in use.

**Changes:**
- `ResourceService.ts` — added `deleteCryptedFiles()` and wired it into `maintenance()`
- `ResourceService.test.ts` — added test to verify `.crypted` files are deleted while regular resource files are untouched
