### PR TITLE
Web: Link to the official web app when attempting to sync with Joplin Cloud

### DIFF
--- a/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
+++ b/packages/app-mobile/components/SyncWizard/SyncWizard.tsx
@@ -11,6 +11,7 @@ import NavService from '@joplin/lib/services/NavService';
 import { Platform, StyleSheet, View } from 'react-native';
 import CardButton from '../buttons/CardButton';
 import Setting from '@joplin/lib/models/Setting';
+import shim from '@joplin/lib/shim';
 
 interface Props {
 	dispatch: Dispatch;
@@ -47,12 +48,14 @@ const styles = StyleSheet.create({
 	},
 });
 
+const isAppJoplinCloud = () => {
+	return Platform.OS === 'web' && location.origin === 'https://app.joplincloud.com';
+};
+
 const useShouldShowOtherButton = () => {
-	// Always show "other" on non-web platforms
-	if (Platform.OS !== 'web') return true;
 	// Don't show "other" when hosted on Joplin Cloud (other sync
 	// targets can still be selected from settings).
-	return location.origin !== 'https://app.joplincloud.com';
+	return !isAppJoplinCloud();
 };
 
 interface SyncProviderProps {
@@ -102,7 +105,15 @@ const SyncWizard: React.FC<Props> = ({ themeId, visible, dispatch }) => {
 
 	const onSelectJoplinCloud = useCallback(async () => {
 		onDismiss();
-		await NavService.go('JoplinCloudLogin');
+		if (Platform.OS === 'web' && !isAppJoplinCloud()) {
+			if (await shim.showConfirmationDialog(
+				_('Self-hosted instances of the Joplin web app cannot sync with Joplin Cloud. Open the official web app?'),
+			)) {
+				await shim.openUrl('https://app.joplincloud.com/');
+			}
+		} else {
+			await NavService.go('JoplinCloudLogin');
+		}
 	}, [onDismiss]);
 
 	const onSelectOtherTarget = useCallback(async () => {


### PR DESCRIPTION
# Summary

The Joplin Cloud sync option is broken in self-hosted instances of the Joplin web app due to CORS restrictions. This pull request updates the web app's sync wizard to open `app.joplincloud.com` when clicking the "Joplin Cloud" link.

# Screen recording

**Web**:

[screen recording: clicking on the "synchronize" button, then "joplin cloud"](https://github.com/user-attachments/assets/17f8fea2-dc82-4a05-a18b-c939d16c5129)


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->