### PR TITLE
Desktop: Fixes #12313: Prevent All Notes sort order from overwriting shared notebook sort on relaunch

### DIFF
--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -140,17 +140,9 @@ describe('PerFolderSortOrderService', () => {
 	});
 
 	test('should not let All Notes sort bleed into shared sort order on relaunch', () => {
-		// Simulates the relaunch scenario described in the bug:
-		// 1. User sets notebook (no own sort) to Alphabetical
-		// 2. User enables own sort for All Notes and sets it to Date Modified
-		// 3. User closes Joplin with All Notes as the last selected view
-		// 4. On relaunch, notebook should still sort Alphabetically, not by Date Modified
-
-		// Step 1: set shared sort as Alphabetical while on folderId1 (no own sort)
 		switchToFolder(folderId1);
 		setNotesSortOrder('title', false);
 
-		// Step 2: enable own sort for All Notes and set it to Date Modified
 		switchToAllNotes();
 		PerFolderSortOrderService.set(ALL_NOTES_FILTER_ID, true);
 		setNotesSortOrder('user_updated_time', true);
@@ -158,21 +150,17 @@ describe('PerFolderSortOrderService', () => {
 		expect(PerFolderSortOrderService.isSet(ALL_NOTES_FILTER_ID)).toBe(true);
 		expect(Setting.value('notes.sortOrder.field')).toBe('user_updated_time');
 
-		// Step 3: simulate relaunch with All Notes as the last selected view.
-		// activeFolderId only persists folder IDs (not smart filter IDs), so it
-		// still holds folderId1. notesParent correctly persists All Notes.
+		// Simulate relaunch: activeFolderId holds the last notebook, notesParent holds All Notes
 		Setting.setValue('activeFolderId', folderId1);
 		Setting.setValue('notesParent', serializeNotesParent({ type: 'SmartFilter', selectedItemId: ALL_NOTES_FILTER_ID }));
 
-		// Re-initialize as if the app just started
 		PerFolderSortOrderService.initialize();
 		Setting.setValue('notes.perFolderSortOrderEnabled', true);
 
-		// Step 4: app restores All Notes — simulate the first state change on startup
 		updateAppState(createAppDefaultState({}));
 		switchToAllNotes();
 
-		// Navigate to folderId1 (no own sort) — must use shared sort (Alphabetical), not All Notes' sort
+		// Navigating to the notebook must restore shared sort (title), not All Notes' sort
 		switchToFolder(folderId1);
 		expect(Setting.value('notes.sortOrder.field')).toBe('title');
 		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -2,6 +2,7 @@ import PerFolderSortOrderService from './PerFolderSortOrderService';
 import { setNotesSortOrder } from './notesSortOrderUtils';
 import Setting from '@joplin/lib/models/Setting';
 import { AppState, createAppDefaultState } from '../../app.reducer';
+import { serializeNotesParent } from '@joplin/lib/reducer';
 import eventManager from '@joplin/lib/eventManager';
 const { shimInit } = require('@joplin/lib/shim-init-node.js');
 const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
@@ -136,5 +137,44 @@ describe('PerFolderSortOrderService', () => {
 
 		expect(Setting.value('notes.sortOrder.field')).toBe('user_updated_time');
 		expect(Setting.value('notes.sortOrder.reverse')).toBe(true);
+	});
+
+	test('should not let All Notes sort bleed into shared sort order on relaunch', () => {
+		// Simulates the relaunch scenario described in the bug:
+		// 1. User sets notebook (no own sort) to Alphabetical
+		// 2. User enables own sort for All Notes and sets it to Date Modified
+		// 3. User closes Joplin with All Notes as the last selected view
+		// 4. On relaunch, notebook should still sort Alphabetically, not by Date Modified
+
+		// Step 1: set shared sort as Alphabetical while on folderId1 (no own sort)
+		switchToFolder(folderId1);
+		setNotesSortOrder('title', false);
+
+		// Step 2: enable own sort for All Notes and set it to Date Modified
+		switchToAllNotes();
+		PerFolderSortOrderService.set(ALL_NOTES_FILTER_ID, true);
+		setNotesSortOrder('user_updated_time', true);
+
+		expect(PerFolderSortOrderService.isSet(ALL_NOTES_FILTER_ID)).toBe(true);
+		expect(Setting.value('notes.sortOrder.field')).toBe('user_updated_time');
+
+		// Step 3: simulate relaunch with All Notes as the last selected view.
+		// activeFolderId only persists folder IDs (not smart filter IDs), so it
+		// still holds folderId1. notesParent correctly persists All Notes.
+		Setting.setValue('activeFolderId', folderId1);
+		Setting.setValue('notesParent', serializeNotesParent({ type: 'SmartFilter', selectedItemId: ALL_NOTES_FILTER_ID }));
+
+		// Re-initialize as if the app just started
+		PerFolderSortOrderService.initialize();
+		Setting.setValue('notes.perFolderSortOrderEnabled', true);
+
+		// Step 4: app restores All Notes — simulate the first state change on startup
+		updateAppState(createAppDefaultState({}));
+		switchToAllNotes();
+
+		// Navigate to folderId1 (no own sort) — must use shared sort (Alphabetical), not All Notes' sort
+		switchToFolder(folderId1);
+		expect(Setting.value('notes.sortOrder.field')).toBe('title');
+		expect(Setting.value('notes.sortOrder.reverse')).toBe(false);
 	});
 });

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
@@ -45,16 +45,13 @@ export default class PerFolderSortOrderService {
 		eventManager.appStateOn('notesParentType', this.onFolderSelectionMayChange.bind(this, 'notesParentType'));
 		eventManager.appStateOn('selectedFolderId', this.onFolderSelectionMayChange.bind(this, 'selectedFolderId'));
 		eventManager.appStateOn('selectedSmartFilterId', this.onFolderSelectionMayChange.bind(this, 'selectedSmartFilterId'));
-		this.previousFolderId = Setting.value('activeFolderId');
-
-		// activeFolderId is only saved for folder selections, not smart filters
-		// (e.g. All Notes). Use notesParent, which is persisted for all view
-		// types, so the correct previousFolderId is restored on relaunch.
-		// Without this, closing with All Notes selected would cause its per-folder
-		// sort to bleed into the shared sort order used by other notebooks.
+		// notesParent persists the last view type (including smart filters like All Notes),
+		// unlike activeFolderId which only tracks folder selections.
 		const notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
 		if (notesParent.type === 'Folder' || notesParent.type === 'SmartFilter') {
 			this.previousFolderId = notesParent.selectedItemId;
+		} else {
+			this.previousFolderId = null;
 		}
 	}
 

--- a/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/app-desktop/services/sortOrder/PerFolderSortOrderService.ts
@@ -1,6 +1,7 @@
 import Setting from '@joplin/lib/models/Setting';
 import eventManager from '@joplin/lib/eventManager';
 import { notesSortOrderFieldArray, setNotesSortOrder } from './notesSortOrderUtils';
+import { parseNotesParent } from '@joplin/lib/reducer';
 
 const SUFFIX_FIELD = '$field';
 const SUFFIX_REVERSE = '$reverse';
@@ -45,6 +46,16 @@ export default class PerFolderSortOrderService {
 		eventManager.appStateOn('selectedFolderId', this.onFolderSelectionMayChange.bind(this, 'selectedFolderId'));
 		eventManager.appStateOn('selectedSmartFilterId', this.onFolderSelectionMayChange.bind(this, 'selectedSmartFilterId'));
 		this.previousFolderId = Setting.value('activeFolderId');
+
+		// activeFolderId is only saved for folder selections, not smart filters
+		// (e.g. All Notes). Use notesParent, which is persisted for all view
+		// types, so the correct previousFolderId is restored on relaunch.
+		// Without this, closing with All Notes selected would cause its per-folder
+		// sort to bleed into the shared sort order used by other notebooks.
+		const notesParent = parseNotesParent(Setting.value('notesParent'), Setting.value('activeFolderId'));
+		if (notesParent.type === 'Folder' || notesParent.type === 'SmartFilter') {
+			this.previousFolderId = notesParent.selectedItemId;
+		}
 	}
 
 	public static isSet(folderId: string): boolean {


### PR DESCRIPTION
Closes #12313 

## Summary

Closing Joplin with "All Notes" selected caused its sort order to corrupt the shared sort used by regular notebooks on next launch.

## Root Cause
`activeFolderId` is only updated on `FOLDER_SELECT` actions - not `SMART_FILTER_SELECT`. So after selecting All Notes, `activeFolderId` still held the last notebook ID. `PerFolderSortOrderService.initialize()` used this to set `previousFolderId`, so the first state event on startup incorrectly treated the transition as "leaving a no-sort notebook" and overwrote the shared sort order with All Notes' per-folder sort.

## Fix
In `PerFolderSortOrderService.ts`: read `notesParent` (which is persisted for all view types including smart filters) instead of relying solely on `activeFolderId`. When the last view was a SmartFilter, `previousFolderId` is now correctly set to `ALL_NOTES_FILTER_ID`, so `onFolderSelectionMayChange` saves All Notes' sort to its own per-folder entry - not the shared sort order.

## Testing
1. Right-click All Notes → enable Toggle own sort order
2. Set All Notes sort to Date Modified
3. Navigate to a note book → set sort to Alphabetical
4. Select All Notes as the last active view
5. Close and reopen Joplin
6. Navigate to the notebook → verify sort is still Alphabetical

## Demo

https://github.com/user-attachments/assets/557fd7fa-a912-489c-ac13-1f020c0434ec
