### PR TITLE
Desktop: Fixes #14142: Fix search highlights breaking mermaid diagram rendering

### DIFF
--- a/packages/app-desktop/gui/note-viewer/index.html
+++ b/packages/app-desktop/gui/note-viewer/index.html
@@ -510,7 +510,7 @@
 			CSS.highlights.clear();
 			if (!mark_) {
 				mark_ = new Mark(document.getElementById('joplin-container-content'), {
-					exclude: ['img'],
+					exclude: ['img','pre.mermaid'],
 					acrossElements: true,
 				});
 			}

--- a/packages/lib/markJsUtils.js
+++ b/packages/lib/markJsUtils.js
@@ -13,6 +13,15 @@ const isInsideContainer = (node, tagName) => {
 	return false;
 };
 
+const isInsideMermaidElement = (node) => {
+	while (node) {
+		if (node.tagName && node.tagName.toLowerCase() === 'pre' &&
+			node.classList && node.classList.contains('mermaid')) return true;
+		node = node.parentNode;
+	}
+	return false;
+};
+
 markJsUtils.markKeyword = (mark, keyword, stringUtils, extraOptions = null) => {
 	if (typeof keyword === 'string') {
 		keyword = {
@@ -60,6 +69,9 @@ markJsUtils.markKeyword = (mark, keyword, stringUtils, extraOptions = null) => {
 				//
 				// https://github.com/joplin/plugin-abc-sheet-music
 				if (isInsideContainer(node, 'SVG')) return false;
+				// Mermaid reads its source from the raw text of <pre class="mermaid">.
+				// Injecting <mark> tags corrupts the syntax and breaks rendering.
+				if (isInsideMermaidElement(node)) return false;
 				return true;
 			},
 			...extraOptions,


### PR DESCRIPTION
Fixes #14142
When a search term appears inside a mermaid code block, mark.js was injecting `<mark>` tags into the diagram source. Mermaid reads its diagram definition from the raw text content of `<pre class="mermaid">`, so those extra HTML tags corrupted the syntax and caused the diagram to silently fail after switching editors.

Fix:
- `markJsUtils.js`: added `isInsideMermaidElement` filter so mark.js skips any text inside a mermaid block
- `note-viewer/index.html`: added `pre.mermaid` to the mark.js `exclude` list as an additional guard

https://github.com/user-attachments/assets/45012e42-a424-43e9-a600-33f311732528


AI disclosure
I used AI to fix some syntax errors and search about any other optimal approach to make it more robust.