### PR TITLE
Desktop: Fixes #14500: Fixes zh_TW locale detection on first start

### DIFF
--- a/packages/lib/locale.test.ts
+++ b/packages/lib/locale.test.ts
@@ -7,6 +7,8 @@ describe('locale', () => {
 			['fr', ['fr_FR', 'en_GB'], 'fr_FR'],
 			['pt-br', ['fr_FR', 'en_GB', 'pt_BR'], 'pt_BR'],
 			['ro', ['fr_FR', 'en_GB', 'pt_BR'], 'en_GB'],
+			['zh-TW', ['en_GB', 'zh_CN', 'zh_TW'], 'zh_TW'],
+			['zh-CN', ['en_GB', 'zh_CN', 'zh_TW'], 'zh_CN'],
 		];
 
 		for (const [input, locales, expected] of testCases) {

--- a/packages/lib/locale.ts
+++ b/packages/lib/locale.ts
@@ -553,6 +553,11 @@ function supportedLocalesToLanguages(options: SupportedLocalesToLanguagesOptions
 
 function closestSupportedLocale(canonicalName: string, defaultToEnglish = true, locales: string[] = null) {
 	locales = locales === null ? supportedLocales() : locales;
+
+	// Normalize the locale name: system locales often use hyphens (e.g. "zh-TW")
+	// but Joplin's supported locales use underscores (e.g. "zh_TW").
+	canonicalName = canonicalName.replace(/-/g, '_');
+
 	if (locales.indexOf(canonicalName) >= 0) return canonicalName;
 
 	const requiredLanguage = languageCodeOnly(canonicalName).toLowerCase();


### PR DESCRIPTION
Fixes #14500

Problem 
On macOS, Electron returns locales with hyphens (e.g. zh-TW) but our locale list uses underscores (zh_TW).
So the exact match fails and the fallback loop grabs zh_CN first since it appears earlier in the list.

Solution
Fixed by normalizing hyphens to underscores before matching.

Added tests for both zh-TW and zh-CN.