### PR TITLE
Desktop: Fixes #14525: Show only relevant options in context menu when right-clicking a note link

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -11,14 +11,11 @@ import type CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl'
 import bridge from '../../../../../services/bridge';
 import Setting from '@joplin/lib/models/Setting';
 import Resource from '@joplin/lib/models/Resource';
-import BaseItem from '@joplin/lib/models/BaseItem';
-import BaseModel from '@joplin/lib/BaseModel';
-import { ContextMenuItemType, ContextMenuOptions, buildMenuItems, handleEditorContextMenuFilter } from '../../../utils/contextMenuUtils';
+import { ContextMenuItemType, ContextMenuOptions, buildMenuItems, handleEditorContextMenuFilter, resolveContextMenuItemType } from '../../../utils/contextMenuUtils';
 import { menuItems } from '../../../utils/contextMenu';
 import isItemId from '@joplin/lib/models/utils/isItemId';
 import { extractResourceUrls } from '@joplin/lib/urlUtils';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
-import { reg } from '@joplin/lib/registry';
 
 export type ResourceMarkupType = 'image' | 'file';
 
@@ -186,18 +183,8 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 		const showResourceContextMenu = async (resourceId: string, type: ResourceMarkupType) => {
 			const menu = new Menu();
-			let itemType: ContextMenuItemType;
-			if (type === 'image') {
-				itemType = ContextMenuItemType.Image;
-			} else {
-				try {
-					const item = await BaseItem.loadItemById(resourceId);
-					itemType = item?.type_ === BaseModel.TYPE_NOTE ? ContextMenuItemType.NoteLink : ContextMenuItemType.Resource;
-				} catch (error) {
-					reg.logger().warn('useContextMenu: failed to load item for context menu, defaulting to Resource', error);
-					itemType = ContextMenuItemType.Resource;
-				}
-			}
+			const baseType = type === 'image' ? ContextMenuItemType.Image : ContextMenuItemType.Resource;
+			const itemType = await resolveContextMenuItemType(baseType, resourceId);
 			const contextMenuOptions: ContextMenuOptions = {
 				itemType,
 				resourceId,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -11,6 +11,8 @@ import type CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl'
 import bridge from '../../../../../services/bridge';
 import Setting from '@joplin/lib/models/Setting';
 import Resource from '@joplin/lib/models/Resource';
+import BaseItem from '@joplin/lib/models/BaseItem';
+import BaseModel from '@joplin/lib/BaseModel';
 import { ContextMenuItemType, ContextMenuOptions, buildMenuItems, handleEditorContextMenuFilter } from '../../../utils/contextMenuUtils';
 import { menuItems } from '../../../utils/contextMenu';
 import isItemId from '@joplin/lib/models/utils/isItemId';
@@ -183,8 +185,15 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 		const showResourceContextMenu = async (resourceId: string, type: ResourceMarkupType) => {
 			const menu = new Menu();
+			let itemType: ContextMenuItemType;
+			if (type === 'image') {
+				itemType = ContextMenuItemType.Image;
+			} else {
+				const item = await BaseItem.loadItemById(resourceId);
+				itemType = item?.type_ === BaseModel.TYPE_NOTE ? ContextMenuItemType.NoteLink : ContextMenuItemType.Resource;
+			}
 			const contextMenuOptions: ContextMenuOptions = {
-				itemType: type === 'image' ? ContextMenuItemType.Image : ContextMenuItemType.Resource,
+				itemType,
 				resourceId,
 				filename: null,
 				mime: null,

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -18,6 +18,7 @@ import { menuItems } from '../../../utils/contextMenu';
 import isItemId from '@joplin/lib/models/utils/isItemId';
 import { extractResourceUrls } from '@joplin/lib/urlUtils';
 import { WindowIdContext } from '../../../../NewWindowOrIFrame';
+import { reg } from '@joplin/lib/registry';
 
 export type ResourceMarkupType = 'image' | 'file';
 
@@ -189,8 +190,13 @@ const useContextMenu = (props: ContextMenuProps) => {
 			if (type === 'image') {
 				itemType = ContextMenuItemType.Image;
 			} else {
-				const item = await BaseItem.loadItemById(resourceId);
-				itemType = item?.type_ === BaseModel.TYPE_NOTE ? ContextMenuItemType.NoteLink : ContextMenuItemType.Resource;
+				try {
+					const item = await BaseItem.loadItemById(resourceId);
+					itemType = item?.type_ === BaseModel.TYPE_NOTE ? ContextMenuItemType.NoteLink : ContextMenuItemType.Resource;
+				} catch (error) {
+					reg.logger().warn('useContextMenu: failed to load item for context menu, defaulting to Resource', error);
+					itemType = ContextMenuItemType.Resource;
+				}
 			}
 			const contextMenuOptions: ContextMenuOptions = {
 				itemType,

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -103,9 +103,16 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 				}
 			},
 			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => (
-				(!options.textToCopy && (itemType === ContextMenuItemType.Image || itemType === ContextMenuItemType.Resource))
+				(!options.textToCopy && (itemType === ContextMenuItemType.Image || itemType === ContextMenuItemType.Resource || itemType === ContextMenuItemType.NoteLink))
 				|| (!!options.linkToOpen && itemType === ContextMenuItemType.Link)
 			),
+		},
+		openNoteInNewWindow: {
+			label: _('Open in new window'),
+			onAction: async (options: ContextMenuOptions) => {
+				await CommandService.instance().execute('openNoteInNewWindow', options.resourceId);
+			},
+			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.NoteLink,
 		},
 		saveAs: {
 			label: _('Save as...'),

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -110,6 +110,10 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 		openNoteInNewWindow: {
 			label: _('Open in new window'),
 			onAction: async (options: ContextMenuOptions) => {
+				if (!options.resourceId) {
+					void shim.showErrorDialog(_('Could not open note: no note ID found.'));
+					return;
+				}
 				await CommandService.instance().execute('openNoteInNewWindow', options.resourceId);
 			},
 			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.NoteLink,

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -110,10 +110,6 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 		openNoteInNewWindow: {
 			label: _('Open in new window'),
 			onAction: async (options: ContextMenuOptions) => {
-				if (!options.resourceId) {
-					void shim.showErrorDialog(_('Could not open note: no note ID found.'));
-					return;
-				}
 				await CommandService.instance().execute('openNoteInNewWindow', options.resourceId);
 			},
 			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.NoteLink,

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts
@@ -6,12 +6,27 @@ import { ContextMenuItemType, EditContextMenuFilterObject } from '@joplin/lib/se
 import eventManager from '@joplin/lib/eventManager';
 import CommandService from '@joplin/lib/services/CommandService';
 import { type MenuItem as MenuItemType } from 'electron';
+import BaseItem from '@joplin/lib/models/BaseItem';
+import { ModelType } from '@joplin/lib/BaseModel';
 
 const MenuItem = bridge().MenuItem;
 const logger = Logger.create('contextMenuUtils');
 
 // Re-export for backward compatibility
 export { ContextMenuItemType };
+
+// Resolves whether a resource-type item is actually a note link.
+// Falls back to Resource on error or if the item is not found.
+export const resolveContextMenuItemType = async (itemType: ContextMenuItemType, resourceId: string): Promise<ContextMenuItemType> => {
+	if (itemType !== ContextMenuItemType.Resource || !resourceId) return itemType;
+	try {
+		const item = await BaseItem.loadItemById(resourceId);
+		if (item?.type_ === ModelType.Note) return ContextMenuItemType.NoteLink;
+	} catch (error) {
+		logger.warn('resolveContextMenuItemType: failed to load item, defaulting to Resource', error);
+	}
+	return ContextMenuItemType.Resource;
+};
 
 export interface ContextMenuOptions {
 	itemType: ContextMenuItemType;

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -52,9 +52,13 @@ export default function useMessageHandler(
 			let itemType = arg0 && arg0.type;
 			const resourceId = arg0.resourceId;
 			if (itemType === ContextMenuItemType.Resource && resourceId) {
-				const item = await BaseItem.loadItemById(resourceId);
-				if (item?.type_ === BaseModel.TYPE_NOTE) {
-					itemType = ContextMenuItemType.NoteLink;
+				try {
+					const item = await BaseItem.loadItemById(resourceId);
+					if (item?.type_ === BaseModel.TYPE_NOTE) {
+						itemType = ContextMenuItemType.NoteLink;
+					}
+				} catch (error) {
+					reg.logger().warn('useMessageHandler: failed to load item for context menu, defaulting to Resource', error);
 				}
 			}
 			const menu = await contextMenu({

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -6,9 +6,7 @@ import PostMessageService from '@joplin/lib/services/PostMessageService';
 import ResourceFetcher from '@joplin/lib/services/ResourceFetcher';
 import { reg } from '@joplin/lib/registry';
 import bridge from '../../../services/bridge';
-import BaseItem from '@joplin/lib/models/BaseItem';
-import BaseModel from '@joplin/lib/BaseModel';
-import { ContextMenuItemType } from './contextMenuUtils';
+import { resolveContextMenuItemType } from './contextMenuUtils';
 
 export default function useMessageHandler(
 	scrollWhenReadyRef: RefObject<ScrollOptions|null>,
@@ -49,18 +47,8 @@ export default function useMessageHandler(
 			if (s.length < 2) throw new Error(`Invalid message: ${msg}`);
 			void ResourceFetcher.instance().markForDownload(s[1]);
 		} else if (msg === 'contextMenu') {
-			let itemType = arg0 && arg0.type;
 			const resourceId = arg0.resourceId;
-			if (itemType === ContextMenuItemType.Resource && resourceId) {
-				try {
-					const item = await BaseItem.loadItemById(resourceId);
-					if (item?.type_ === BaseModel.TYPE_NOTE) {
-						itemType = ContextMenuItemType.NoteLink;
-					}
-				} catch (error) {
-					reg.logger().warn('useMessageHandler: failed to load item for context menu, defaulting to Resource', error);
-				}
-			}
+			const itemType = await resolveContextMenuItemType(arg0 && arg0.type, resourceId);
 			const menu = await contextMenu({
 				itemType,
 				resourceId: resourceId,

--- a/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/useMessageHandler.ts
@@ -6,6 +6,9 @@ import PostMessageService from '@joplin/lib/services/PostMessageService';
 import ResourceFetcher from '@joplin/lib/services/ResourceFetcher';
 import { reg } from '@joplin/lib/registry';
 import bridge from '../../../services/bridge';
+import BaseItem from '@joplin/lib/models/BaseItem';
+import BaseModel from '@joplin/lib/BaseModel';
+import { ContextMenuItemType } from './contextMenuUtils';
 
 export default function useMessageHandler(
 	scrollWhenReadyRef: RefObject<ScrollOptions|null>,
@@ -46,9 +49,17 @@ export default function useMessageHandler(
 			if (s.length < 2) throw new Error(`Invalid message: ${msg}`);
 			void ResourceFetcher.instance().markForDownload(s[1]);
 		} else if (msg === 'contextMenu') {
+			let itemType = arg0 && arg0.type;
+			const resourceId = arg0.resourceId;
+			if (itemType === ContextMenuItemType.Resource && resourceId) {
+				const item = await BaseItem.loadItemById(resourceId);
+				if (item?.type_ === BaseModel.TYPE_NOTE) {
+					itemType = ContextMenuItemType.NoteLink;
+				}
+			}
 			const menu = await contextMenu({
-				itemType: arg0 && arg0.type,
-				resourceId: arg0.resourceId,
+				itemType,
+				resourceId: resourceId,
 				filename: arg0.filename,
 				mime: arg0.mime,
 				linkToOpen: null,

--- a/packages/lib/services/plugins/api/types.ts
+++ b/packages/lib/services/plugins/api/types.ts
@@ -443,6 +443,7 @@ export enum ContextMenuItemType {
 	Resource = 'resource',
 	Text = 'text',
 	Link = 'link',
+	NoteLink = 'noteLink',
 }
 
 export interface EditContextMenuFilterObject {


### PR DESCRIPTION
Closes #14525 

## Summary

Right-clicking a link to another Joplin note showed irrelevant context menu options meant for images/attachments (Save as, Recognize handwritten image, Reveal file in folder, View OCR text, Copy path to clipboard).

## Root Cause
The context menu did not differentiate between a note link (`joplin://` protocol) and an image/attachment. All resource types shared the same context menu options.

## Fix
- Added `NoteLink` to `ContextMenuItemType` enum to distinguish note links from attachments
- In the **Markdown editor** (`CodeMirror/utils/useContextMenu.ts`): when right-clicking a `:/noteId` link, asynchronously load the item and set type to `NoteLink` if it is a note
- In the **Markdown preview pane** (`utils/useMessageHandler.ts`): when the preview sends `type: 'resource'`, asynchronously load the item and upgrade to `NoteLink` if it is a note
- Added note-relevant options: **Open**, **Open in new window** — all attachment-specific options (`Save as`, `Reveal in folder`, `OCR`, `Copy path`, etc.) are naturally excluded as their `isActive` guards only match `Image` or `Resource`

## Testing
1. Create a link to another Joplin note (`Alt + Shift + L`)
2. Switch to Markdown editor or Markdown preview pane
3. Right-click the note link
4. Verify only note-relevant options appear: **Open**, **Open in new window**
5. Right-click an image/attachment and verify its options are unchanged

## Demo
<!-- Add screen recording showing the fix in action -->

Markdown Editor
<img width="437" height="405" alt="image" src="https://github.com/user-attachments/assets/ffc3149d-ffd4-4e19-b841-b684b639a73c" />

Markdown Preview Pane
<img width="424" height="579" alt="image" src="https://github.com/user-attachments/assets/6bae09a5-b9a1-427c-a2c0-dfb3cb61c342" />
