### PR TITLE
Desktop: Resolves #12210: Translate Find and Replace dialog in Rich Text editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -705,8 +705,9 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			const containerWindow = editorContainerDom.defaultView as any;
+			const isDefaultEnglishLocale = ['en_US', 'en_GB'].includes(language);
 
-			if (!['en_US', 'en_GB'].includes(language)) {
+			if (!isDefaultEnglishLocale) {
 				await loadScript({
 					id: `tinyMceLang_${language}`,
 					src: `${bridge().vendorDir()}/lib/tinymce/langs/${language}.js`,
@@ -743,7 +744,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
-				language: ['en_US', 'en_GB'].includes(language) ? undefined : language,
+				language: isDefaultEnglishLocale ? undefined : language,
 				toolbar: toolbar.join(' '),
 				localization_function: _,
 				// See https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/#content_security_policy

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -735,7 +735,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
-				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `${bridge().vendorDir()}/lib/tinymce/langs/${language}`,
+				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `vendor/lib/tinymce/langs/${language}.js`,
+				language: ['en_US', 'en_GB'].includes(language) ? undefined : language,
 				toolbar: toolbar.join(' '),
 				localization_function: _,
 				// See https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/#content_security_policy

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -705,6 +705,14 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			const containerWindow = editorContainerDom.defaultView as any;
+
+			if (!['en_US', 'en_GB'].includes(language)) {
+				await loadScript({
+					id: `tinyMceLang_${language}`,
+					src: `${bridge().vendorDir()}/lib/tinymce/langs/${language}.js`,
+				}, editorContainerDom);
+			}
+
 			const editors = await containerWindow.tinymce.init({
 				selector: `#${editorContainer.id}`,
 
@@ -735,7 +743,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 				// Handle the first table row as table header.
 				// https://www.tiny.cloud/docs/plugins/table/#table_header_type
 				table_header_type: 'sectionCells',
-				language_url: ['en_US', 'en_GB'].includes(language) ? undefined : `vendor/lib/tinymce/langs/${language}.js`,
 				language: ['en_US', 'en_GB'].includes(language) ? undefined : language,
 				toolbar: toolbar.join(' '),
 				localization_function: _,

--- a/packages/lib/locales/en_US.json
+++ b/packages/lib/locales/en_US.json
@@ -1657,6 +1657,12 @@
 	"Find: ": [
 		""
 	],
+	"Find and Replace": [
+		""
+	],
+	"Find in selection": [
+		""
+	],
 	"Finishes recording": [
 		""
 	],


### PR DESCRIPTION
Fixes: #12210

### Problem
The Find and Replace dialog in the Rich Text editor always displayed in English regardless of the user's locale setting.

### Solution

Two missing options in tinymce.init() were causing the issue:

- language_url was missing the .js extension so TinyMCE could not load the vendor translation file
- language was never set so TinyMCE never activated the locale even if the file loaded

Also added two new source strings to `en_US.json` for Crowdin translation.

Video 

https://github.com/user-attachments/assets/9223801b-f536-4fbe-a68e-e45f28a2db61

Testing
Tested manually with es_ES locale. The Find and Replace dialog now displays correctly in Spanish.

