### PR TITLE
Desktop: Fixes #14522: App fails to restart on Linux AppImage

### DIFF
--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -583,6 +583,11 @@ export class Bridge {
 				execPath: process.env.PORTABLE_EXECUTABLE_FILE,
 			};
 			app.relaunch(options);
+		} else if (process.env.APPIMAGE) {
+			app.relaunch({
+				execPath: process.env.APPIMAGE,
+				args: ['--appimage-extract-and-run'],
+			});
 		} else if (this.altInstanceId_) {
 			// Couldn't get it to work using relaunch() - it would just "close" the app, but it
 			// would still be open in the tray except unusable. Or maybe it reopens it quickly but

--- a/packages/app-desktop/bridge.ts
+++ b/packages/app-desktop/bridge.ts
@@ -583,7 +583,7 @@ export class Bridge {
 				execPath: process.env.PORTABLE_EXECUTABLE_FILE,
 			};
 			app.relaunch(options);
-		} else if (process.env.APPIMAGE) {
+		} else if (process.env.APPIMAGE && !this.altInstanceId_) {
 			app.relaunch({
 				execPath: process.env.APPIMAGE,
 				args: ['--appimage-extract-and-run'],


### PR DESCRIPTION
Electron's `app.relaunch()` doesn't work with AppImage because the extracted binary path doesn't match the original `.AppImage` file. This causes the app to exit without relaunching on actions like profile switching or locale changes.

The fix checks `process.env.APPIMAGE` (set automatically by the AppImage runtime) and passes it as `execPath`, matching the existing portable build workaround.

See: https://github.com/electron-userland/electron-builder/issues/4650