### PR TITLE
Mobile: Fix #14534: Call unmount() in Note.test.tsx tests to suppress act() warnings

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -378,14 +378,16 @@ describe('screens/Note', () => {
 		[['viewer']],
 		[['editor']],
 	])('should initialize in the correct mode when noteVisiblePanes is %j', async (panes) => {
-		await setupNoteWithPanes(panes);
+		const { unmount } = await setupNoteWithPanes(panes);
 		await expectToBeEditing(panes.includes('editor'));
+		unmount();
 	});
 
 	it('should show toggle button', async () => {
-		await setupNoteWithPanes(['viewer']);
+		const { unmount } = await setupNoteWithPanes(['viewer']);
 		const toggleButton = await screen.findByLabelText('Toggle view/edit');
 		expect(toggleButton).toBeVisible();
+		unmount();
 	});
 
 	it.each([
@@ -394,11 +396,12 @@ describe('screens/Note', () => {
 	])('should switch modes when toggle button is pressed', async (panes) => {
 		const initialEditing = panes.includes('editor');
 		const expectedEditing = !initialEditing;
-		await setupNoteWithPanes(panes);
+		const { unmount } = await setupNoteWithPanes(panes);
 		await expectToBeEditing(initialEditing);
 		const toggleButton = await screen.findByLabelText('Toggle view/edit');
 		fireEvent.press(toggleButton);
 		await expectToBeEditing(expectedEditing);
+		unmount();
 	});
 
 	it('should always start in edit mode for provisional notes regardless of noteVisiblePanes', async () => {
@@ -414,10 +417,11 @@ describe('screens/Note', () => {
 			note: note,
 			provisional: true,
 		});
-		render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 		const titleInput = await screen.findByDisplayValue('Provisional note');
 		expect(titleInput).toBeVisible();
 		await expectToBeEditing(true);
+		unmount();
 	});
 
 	it.each([
@@ -441,12 +445,13 @@ describe('screens/Note', () => {
 		await act(async () => {
 			await openExistingNote(noteId);
 		});
-		render(<WrappedNoteScreen />);
+		const secondRender = render(<WrappedNoteScreen />);
 		const titleInput = await screen.findByDisplayValue('Test note');
 		expect(titleInput).toBeVisible();
 		// Should still be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);
+		secondRender.unmount();
 	});
 
 	it.each([
@@ -476,12 +481,13 @@ describe('screens/Note', () => {
 		await act(async () => {
 			await openExistingNote(note2Id);
 		});
-		render(<WrappedNoteScreen />);
+		const render2 = render(<WrappedNoteScreen />);
 		const titleInput2 = await screen.findByDisplayValue('Note 2');
 		expect(titleInput2).toBeVisible();
 		// Note 2 should be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);
+		render2.unmount();
 	});
 
 	it('should set the initial editor cursor location to the specified hash', async () => {

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -35,10 +35,10 @@ interface WrapperProps {
 
 let store: Store<AppState>;
 
-const mockNavigation = { state: { } };
+const mockNavigation = { state: {} };
 const WrappedNoteScreen: React.FC<WrapperProps> = _props => {
 	return <TestProviderStack store={store}>
-		<NoteScreen navigation={mockNavigation}/>
+		<NoteScreen navigation={mockNavigation} />
 	</TestProviderStack>;
 };
 
@@ -445,13 +445,13 @@ describe('screens/Note', () => {
 		await act(async () => {
 			await openExistingNote(noteId);
 		});
-		const secondRender = render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 		const titleInput = await screen.findByDisplayValue('Test note');
 		expect(titleInput).toBeVisible();
 		// Should still be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);
-		secondRender.unmount();
+		unmount();
 	});
 
 	it.each([
@@ -481,13 +481,13 @@ describe('screens/Note', () => {
 		await act(async () => {
 			await openExistingNote(note2Id);
 		});
-		const render2 = render(<WrappedNoteScreen />);
+		const { unmount } = render(<WrappedNoteScreen />);
 		const titleInput2 = await screen.findByDisplayValue('Note 2');
 		expect(titleInput2).toBeVisible();
 		// Note 2 should be in the same mode
 		await expectToBeEditing(panes.includes('editor'));
 		expect(store.getState().noteVisiblePanes).toEqual(panes);
-		render2.unmount();
+		unmount();
 	});
 
 	it('should set the initial editor cursor location to the specified hash', async () => {

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -35,10 +35,10 @@ interface WrapperProps {
 
 let store: Store<AppState>;
 
-const mockNavigation = { state: {} };
+const mockNavigation = { state: { } };
 const WrappedNoteScreen: React.FC<WrapperProps> = _props => {
 	return <TestProviderStack store={store}>
-		<NoteScreen navigation={mockNavigation} />
+		<NoteScreen navigation={mockNavigation}/>
 	</TestProviderStack>;
 };
 


### PR DESCRIPTION
Fixes #14534 

Several tests in `Note.test.tsx` were missing a call to `unmount()` at the end. This caused React Native's `Animated` timers to fire state updates after the test had already exited outside any `act()` wrapper, producing the warning:
"An update to Animated(View) inside a test was not wrapped in act(...)"

Fix: store the render result and call `unmount()` at the end of each affected test, already used in the other tests in the file.

AI Disclosure
I did not use any AI tools while working on this PR. All changes and implementations were done manually.