### PR TITLE
All: Resolves #9093: Delete .crypted files when the app starts

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -875,6 +875,11 @@ export default class BaseApplication {
 		await loadMasterKeysFromSettings(EncryptionService.instance());
 		DecryptionWorker.instance().on('resourceMetadataButNotBlobDecrypted', this.decryptionWorker_resourceMetadataButNotBlobDecrypted);
 
+		// We clean up leftover .crypted files from previous sessions. These
+		// files accumulate when decryption or sync upload completes but the
+		// .crypted temporary file is not removed.
+		await Resource.cleanupCryptedFiles();
+
 		ResourceFetcher.instance().setFileApi(() => {
 			return reg.syncTarget().fileApi();
 		});

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -775,6 +775,15 @@ export default class Synchronizer {
 									if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
 										await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
 									}
+
+									// We clean up the .crypted file that was
+									// created by fullPathForSyncUpload() for
+									// this upload. It is a temporary artifact
+									// and will be re-created on the next sync
+									// if needed.
+									if (resource.encryption_blob_encrypted) {
+										await Resource.fsDriver().remove(localResourceContentPath);
+									}
 								} catch (error) {
 									if (isCannotSyncError(error)) {
 										await handleCannotSyncItem(ItemClass, syncTargetId, local, error.message);

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -756,6 +756,8 @@ export default class Synchronizer {
 							} else {
 								try {
 									const remoteContentPath = resourceRemotePath(local.id);
+									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+									const wasBlobAlreadyEncrypted = !!(local as any).encryption_blob_encrypted;
 									const result = await Resource.fullPathForSyncUpload(local);
 									const resource = result.resource;
 									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -780,8 +782,13 @@ export default class Synchronizer {
 									// created by fullPathForSyncUpload() for
 									// this upload. It is a temporary artifact
 									// and will be re-created on the next sync
-									// if needed.
-									if (resource.encryption_blob_encrypted) {
+									// if needed. We only remove it if the blob
+									// was NOT already encrypted before the call
+									// to fullPathForSyncUpload(), which is what
+									// distinguishes a freshly-created temp file
+									// from a canonical pre-existing encrypted
+									// blob that we must not delete.
+									if (resource.encryption_blob_encrypted && !wasBlobAlreadyEncrypted) {
 										await Resource.fsDriver().remove(localResourceContentPath);
 									}
 								} catch (error) {

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -208,10 +208,15 @@ export default class Resource extends BaseItem {
 				// at all. It can happen for example when there's a crash between the moment the data
 				// is decrypted and the resource item is updated.
 				this.logger().warn(`Found a resource that was most likely already decrypted but was marked as encrypted. Marked it as decrypted: ${item.id}`);
-				this.fsDriver().move(encryptedPath, plainTextPath);
+				await this.fsDriver().move(encryptedPath, plainTextPath);
 			} else {
 				throw error;
 			}
+		}
+
+		// Clean up the .crypted file now that decryption is complete.
+		if (encryptedPath !== plainTextPath && await this.fsDriver().exists(encryptedPath)) {
+			await this.fsDriver().remove(encryptedPath);
 		}
 
 		decryptedItem.encryption_blob_encrypted = 0;
@@ -653,6 +658,34 @@ export default class Resource extends BaseItem {
 
 	public static load(id: string, options: LoadOptions = null): Promise<ResourceEntity> {
 		return super.load(id, options);
+	}
+
+	// We remove leftover .crypted files from the resources directory.
+	public static async cleanupCryptedFiles() {
+		const resourceDir = this.baseDirectoryPath();
+
+		if (!resourceDir || !await this.fsDriver().exists(resourceDir)) {
+			return;
+		}
+
+		const stats = await this.fsDriver().readDirStats(resourceDir);
+		let removedCount = 0;
+
+		for (const stat of stats) {
+			if (!stat.path.endsWith('.crypted')) continue;
+
+			const id = pathUtils.filename(stat.path);
+			const resource = await this.load(id);
+
+			if (!resource || !resource.encryption_blob_encrypted) {
+				await this.fsDriver().remove(`${resourceDir}/${stat.path}`);
+				removedCount++;
+			}
+		}
+
+		if (removedCount > 0) {
+			this.logger().info(`Resource.cleanupCryptedFiles: removed ${removedCount} leftover .crypted file(s)`);
+		}
 	}
 
 }

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -216,7 +216,11 @@ export default class Resource extends BaseItem {
 
 		// Clean up the .crypted file now that decryption is complete.
 		if (encryptedPath !== plainTextPath && await this.fsDriver().exists(encryptedPath)) {
-			await this.fsDriver().remove(encryptedPath);
+			try {
+				await this.fsDriver().remove(encryptedPath);
+			} catch (error) {
+				this.logger().warn(`Could not remove temporary encrypted file ${encryptedPath}: ${error.message}`);
+			}
 		}
 
 		decryptedItem.encryption_blob_encrypted = 0;
@@ -668,18 +672,28 @@ export default class Resource extends BaseItem {
 			return;
 		}
 
-		const stats = await this.fsDriver().readDirStats(resourceDir);
+		let stats = null;
+		try {
+			stats = await this.fsDriver().readDirStats(resourceDir);
+		} catch (error) {
+			this.logger().warn(`Resource.cleanupCryptedFiles: could not list ${resourceDir}: ${error.message}`);
+			return;
+		}
 		let removedCount = 0;
 
 		for (const stat of stats) {
 			if (!stat.path.endsWith('.crypted')) continue;
 
-			const id = pathUtils.filename(stat.path);
-			const resource = await this.load(id);
+			try {
+				const id = pathUtils.filename(stat.path);
+				const resource = await this.load(id);
 
-			if (!resource || !resource.encryption_blob_encrypted) {
-				await this.fsDriver().remove(`${resourceDir}/${stat.path}`);
-				removedCount++;
+				if (!resource || !resource.encryption_blob_encrypted) {
+					await this.fsDriver().remove(`${resourceDir}/${stat.path}`);
+					removedCount++;
+				}
+			} catch (error) {
+				this.logger().warn(`Resource.cleanupCryptedFiles: failed for ${stat.path}: ${error.message}`);
 			}
 		}
 


### PR DESCRIPTION
fixes #9093 

### AI Disclosure:
I used AI to understand the resource encryption/decryption flows. I also used AI to create a draft test to test the implementation.

### Problem: 
- When `Resource.decrypt()` decrypts an encrypted blob, it first renames the downloaded file to <id>.crypted before decrypting it into the final plaintext path. Similarly, Synchronizer creates temporary .crypted files during resource upload via `fullPathForSyncUpload()`.

- However, neither code path reliably removes the .crypted file on success. If the app crashes, is force-quit, or sync is interrupted mid-operation, the .crypted temporary file remains in the resource directory indefinitely. Over time, these stale files accumulate, wasting disk space and cluttering the resources folder.

### Fix:
I implemented a three step cleanup to safely remove .crypted files:
1. Inline cleanup after successful decrypt - When `Resource.decrypt()` completes successfully, immediately remove the temporary .crypted file.
2. Inline cleanup after successful upload - When Synchronizer finishes uploading an encrypted blob, immediately remove the .crypted temp file.
3. Startup maintenance sweep - Call `Resource.cleanupCryptedFiles()` during app startup to remove orphaned or stale .crypted files while preserving files still needed for pending decryption.

### Testing:
For testing I created a draft test file to check whether the functionalities are properly implemented. All checks passed. All existing tests also pass.