### PR TITLE
Desktop: Fixes #14196: Fix file:// links with backslashes for Windows UNC paths

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
@@ -30,19 +30,27 @@ export const runtime = (): CommandRuntime => {
 				} else {
 					void bridge().openExternal(link);
 				}
-			} else if (urlProtocol(link)) {
-				if (link.indexOf('file://') === 0) {
-					// When using the file:// protocol, openPath doesn't work (does
-					// nothing) with URL-encoded paths.
-					//
-					// shell.openPath seems to work with file:// urls on Windows,
-					// but doesn't on macOS, so we need to convert it to a path
-					// before passing it to openPath.
-					const decodedPath = fileUriToPath(urlDecode(link), shim.platformName());
-					void bridge().openItem(decodedPath);
-				} else {
-					void bridge().openExternal(link);
+			} else if (link.indexOf('file://') === 0) {
+				// When using the file:// protocol, openPath doesn't work (does
+				// nothing) with URL-encoded paths.
+				//
+				// shell.openPath seems to work with file:// urls on Windows,
+				// but doesn't on macOS, so we need to convert it to a path
+				// before passing it to openPath.
+				let decoded = urlDecode(link);
+
+				// On Windows, UNC paths like file://\\server\share have backslashes
+				// right after file:// which makes the URL invalid. Convert them
+				// to forward slashes so fileUriToPath can handle them correctly.
+				// https://github.com/laurent22/joplin/issues/14196
+				if (decoded.startsWith('file://\\')) {
+					decoded = `file://${decoded.substring(7).replace(/\\/g, '/')}`;
 				}
+
+				const decodedPath = fileUriToPath(decoded, shim.platformName());
+				void bridge().openItem(decodedPath);
+			} else if (urlProtocol(link)) {
+				void bridge().openExternal(link);
 			} else {
 				bridge().showErrorMessageBox(_('Unsupported link or message: %s', link));
 			}

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
@@ -37,17 +37,21 @@ export const runtime = (): CommandRuntime => {
 				// shell.openPath seems to work with file:// urls on Windows,
 				// but doesn't on macOS, so we need to convert it to a path
 				// before passing it to openPath.
-				let decoded = urlDecode(link);
+				const decoded = urlDecode(link);
+				const afterProtocol = decoded.substring(7);
 
-				// On Windows, UNC paths like file://\\server\share have backslashes
-				// right after file:// which makes the URL invalid. Convert them
-				// to forward slashes so fileUriToPath can handle them correctly.
+				// Normalize backslashes to forward slashes so fileUriToPath can
+				// handle them correctly. This covers UNC paths like
+				// file://\\server\share and paths like file:///path\to\share.
+				// We skip this when the path starts with a drive letter (e.g.
+				// file://C:\path) because replacing would cause fileUriToPath
+				// to misinterpret the drive letter as a hostname.
 				// https://github.com/laurent22/joplin/issues/14196
-				if (decoded.startsWith('file://\\')) {
-					decoded = `file://${decoded.substring(7).replace(/\\/g, '/')}`;
-				}
+				const normalized = /^[a-zA-Z][:|]/.test(afterProtocol)
+					? decoded
+					: `file://${afterProtocol.replace(/\\/g, '/')}`;
 
-				const decodedPath = fileUriToPath(decoded, shim.platformName());
+				const decodedPath = fileUriToPath(normalized, shim.platformName());
 				void bridge().openItem(decodedPath);
 			} else if (urlProtocol(link)) {
 				void bridge().openExternal(link);

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/openItem.ts
@@ -37,21 +37,17 @@ export const runtime = (): CommandRuntime => {
 				// shell.openPath seems to work with file:// urls on Windows,
 				// but doesn't on macOS, so we need to convert it to a path
 				// before passing it to openPath.
-				const decoded = urlDecode(link);
-				const afterProtocol = decoded.substring(7);
+				let decoded = urlDecode(link);
 
-				// Normalize backslashes to forward slashes so fileUriToPath can
-				// handle them correctly. This covers UNC paths like
-				// file://\\server\share and paths like file:///path\to\share.
-				// We skip this when the path starts with a drive letter (e.g.
-				// file://C:\path) because replacing would cause fileUriToPath
-				// to misinterpret the drive letter as a hostname.
+				// On Windows, UNC paths like file://\\server\share have backslashes
+				// right after file:// which makes the URL invalid. Convert them
+				// to forward slashes so fileUriToPath can handle them correctly.
 				// https://github.com/laurent22/joplin/issues/14196
-				const normalized = /^[a-zA-Z][:|]/.test(afterProtocol)
-					? decoded
-					: `file://${afterProtocol.replace(/\\/g, '/')}`;
+				if (decoded.startsWith('file://\\')) {
+					decoded = `file://${decoded.substring(7).replace(/\\/g, '/')}`;
+				}
 
-				const decodedPath = fileUriToPath(normalized, shim.platformName());
+				const decodedPath = fileUriToPath(decoded, shim.platformName());
 				void bridge().openItem(decodedPath);
 			} else if (urlProtocol(link)) {
 				void bridge().openExternal(link);

--- a/packages/utils/url.test.ts
+++ b/packages/utils/url.test.ts
@@ -28,6 +28,17 @@ describe('utils/url', () => {
 		expect(fileUriToPath('file:///c:/AUTOEXEC.BAT', 'win32')).toBe('c:\\AUTOEXEC.BAT');
 	}));
 
+	it('should handle Windows UNC paths with forward slashes', () => {
+		// UNC path file://\\server\share after backslash-to-slash normalization
+		// becomes file:////server/share which fileUriToPath should handle correctly.
+		// https://github.com/laurent22/joplin/issues/14196
+		expect(fileUriToPath('file:////server01/share/path/to/file.txt', 'win32'))
+			.toBe('\\\\server01\\share\\path\\to\\file.txt');
+
+		expect(fileUriToPath('file:////server01/path/to/file%20with%20spaces.txt', 'win32'))
+			.toBe('\\\\server01\\path\\to\\file with spaces.txt');
+	});
+
 	it('should correctly identify https and http URLs', () => {
 		expect(isHttpOrHttpsUrl('https://example.com')).toBe(true);
 		expect(isHttpOrHttpsUrl('http://example.com')).toBe(true);


### PR DESCRIPTION
### Summary
Clicking a link like `file://\\server01\path\to\file` on Windows used to show an "Unsupported link or message" error. This happened because markdown-it encodes backslashes to `%5C`, producing URLs like `file://%5C%5Cserver01%5Cpath...` which the `new URL()` constructor rejects since backslashes aren't valid in a hostname position.

The fix moves the `file://` protocol check before the `urlProtocol()` call so these URLs no longer need to go through `new URL()`. After URL decoding, if the decoded path has backslashes right after `file:// `(indicating a Windows UNC path), they get normalized to forward slashes before being handed to `fileUriToPath`, which already handles `file:////server/share` correctly.

Local Windows paths like `file://C:\path\to\file` are not affected since they don't start with a backslash after `file://`.

### Fix 

**Before**
<img width="1512" height="802" alt="Screenshot 2026-03-03 at 8 54 46 PM" src="https://github.com/user-attachments/assets/254dea6f-1960-4405-a2d2-49fd44def932" />

**After**
[Video Link](https://docs.google.com/videos/d/177DYbRwzyX9uuAAZzpNvJE7sF8kUmeU34fTKezKBlAE/edit?usp=sharing)
{uploaded video in link since file size > 10MB}
### Test plan

- Verified on Windows that UNC path links no longer show the "Unsupported link or message" error dialog
- Verified on Windows that local file paths (`file://C:\...` and `file:///C:/...`) still open correctly
- Added unit tests for `fileUriToPath` covering UNC paths with spaces and without
- All existing `url.test.ts` tests continue to pass
<img width="816" height="314" alt="Screenshot 2026-03-03 at 8 38 12 PM" src="https://github.com/user-attachments/assets/1cb2acbc-ec03-4417-bddf-0b9ad644efc3" />

### AI Assistance Disclosure
AI tools are used to:
- Improve wording in PR description