### PR TITLE
All: Fixes #9093: Delete orphan .crypted files at startup

### DIFF
--- a/packages/lib/BaseApplication.ts
+++ b/packages/lib/BaseApplication.ts
@@ -784,6 +784,14 @@ export default class BaseApplication {
 		await migratePpk();
 		await handleSyncStartupOperation();
 
+		// Clean up orphaned .crypted files from previous sessions.
+		// Must run after DB is ready but before resource services start.
+		try {
+			await Resource.deleteOrphanedCryptedFiles();
+		} catch (error) {
+			appLogger.warn('Failed to clean up .crypted files:', error);
+		}
+
 		appLogger.info(`Client ID: ${Setting.value('clientId')}`);
 
 		BaseItem.syncShareCache = parseShareCache(Setting.value('sync.shareCache'));

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -761,7 +761,6 @@ export default class Synchronizer {
 									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 									local = resource as any;
 									const localResourceContentPath = result.path;
-									const isTemporaryCryptedFile = result.isTemporary;
 
 									if (resource.size >= 10 * 1000 * 1000) {
 										logger.warn(`Uploading a large resource (resourceId: ${local.id}, size:${resource.size} bytes) which may tie up the sync process.`);
@@ -772,15 +771,9 @@ export default class Synchronizer {
 									// that case, it means the resource metadata
 									// (title, filename, etc.) has been changed,
 									// but not the data blob.
-									try {
-										const syncItem = await BaseItem.syncItem(syncTargetId, resource.id, { fields: ['sync_time', 'force_sync'] });
-										if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
-											await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
-										}
-									} finally {
-										if (isTemporaryCryptedFile) {
-											await Resource.removeCryptedFile(localResourceContentPath);
-										}
+									const syncItem = await BaseItem.syncItem(syncTargetId, resource.id, { fields: ['sync_time', 'force_sync'] });
+									if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
+										await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
 									}
 								} catch (error) {
 									if (isCannotSyncError(error)) {

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -761,6 +761,7 @@ export default class Synchronizer {
 									// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 									local = resource as any;
 									const localResourceContentPath = result.path;
+									const isTemporaryCryptedFile = result.isTemporary;
 
 									if (resource.size >= 10 * 1000 * 1000) {
 										logger.warn(`Uploading a large resource (resourceId: ${local.id}, size:${resource.size} bytes) which may tie up the sync process.`);
@@ -771,9 +772,21 @@ export default class Synchronizer {
 									// that case, it means the resource metadata
 									// (title, filename, etc.) has been changed,
 									// but not the data blob.
-									const syncItem = await BaseItem.syncItem(syncTargetId, resource.id, { fields: ['sync_time', 'force_sync'] });
-									if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
-										await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
+									try {
+										const syncItem = await BaseItem.syncItem(syncTargetId, resource.id, { fields: ['sync_time', 'force_sync'] });
+										if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
+											await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
+										}
+									} finally {
+										// Clean up temp .crypted file created by fullPathForSyncUpload()
+										// in all exit paths: successful upload, skipped upload, or error.
+										if (isTemporaryCryptedFile) {
+											try {
+												await shim.fsDriver().remove(localResourceContentPath);
+											} catch (cleanupError) {
+												logger.warn(`Failed to remove temp .crypted file after sync upload: ${cleanupError.message}`);
+											}
+										}
 									}
 								} catch (error) {
 									if (isCannotSyncError(error)) {

--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -778,14 +778,8 @@ export default class Synchronizer {
 											await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
 										}
 									} finally {
-										// Clean up temp .crypted file created by fullPathForSyncUpload()
-										// in all exit paths: successful upload, skipped upload, or error.
 										if (isTemporaryCryptedFile) {
-											try {
-												await shim.fsDriver().remove(localResourceContentPath);
-											} catch (cleanupError) {
-												logger.warn(`Failed to remove temp .crypted file after sync upload: ${cleanupError.message}`);
-											}
+											await Resource.removeCryptedFile(localResourceContentPath);
 										}
 									}
 								} catch (error) {

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -219,7 +219,7 @@ export default class Resource extends BaseItem {
 
 		// Clean up the .crypted file now that decryption is complete and
 		// encryption_blob_encrypted = 0 has been persisted to the database.
-		if (encryptedPath !== plainTextPath) {
+		if (encryptedPath !== plainTextPath && await this.fsDriver().exists(encryptedPath)) {
 			try {
 				await this.fsDriver().remove(encryptedPath);
 			} catch (error) {

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -217,19 +217,31 @@ export default class Resource extends BaseItem {
 		decryptedItem.encryption_blob_encrypted = 0;
 		const savedItem = await super.save(decryptedItem, { autoTimestamp: false });
 
-		await this.removeCryptedFile(encryptedPath);
-
-
 		return savedItem;
 	}
 
-	// Best-effort removal of a .crypted file. Used after decryption completes
-	// and after sync upload to clean up temporary encrypted artifacts.
+	// Tries to remove a .crypted file, logs a warning on failure.
 	public static async removeCryptedFile(cryptedPath: string) {
 		try {
 			await this.fsDriver().remove(cryptedPath);
 		} catch (error) {
 			this.logger().warn(`Failed to remove .crypted file ${cryptedPath}: ${error.message}`);
+		}
+	}
+
+	// Deletes .crypted files whose resource is missing or already decrypted.
+	public static async deleteOrphanedCryptedFiles() {
+		const resourceDir = this.baseDirectoryPath();
+		const files = await this.fsDriver().readDirStats(resourceDir);
+		const cryptedFiles = files.filter((f: { path: string }) => f.path.endsWith('.crypted'));
+
+		for (const file of cryptedFiles) {
+			const resourceId = file.path.replace('.crypted', '');
+			const resource = await this.load(resourceId);
+
+			if (!resource || !resource.encryption_blob_encrypted) {
+				await this.removeCryptedFile(`${resourceDir}/${file.path}`);
+			}
 		}
 	}
 
@@ -247,19 +259,17 @@ export default class Resource extends BaseItem {
 		if (!getEncryptionEnabled() || !itemCanBeEncrypted(resource as any, share)) {
 			// Normally not possible since itemsThatNeedSync should only return decrypted items
 			if (resource.encryption_blob_encrypted) throw new Error('Trying to access encrypted resource but encryption is currently disabled');
-			return { path: plainTextPath, resource: resource, isTemporary: false };
+			return { path: plainTextPath, resource: resource };
 		}
 
 		const encryptedPath = this.fullPath(resource, true);
-		if (resource.encryption_blob_encrypted) return { path: encryptedPath, resource: resource, isTemporary: false };
+		if (resource.encryption_blob_encrypted) return { path: encryptedPath, resource: resource };
 
 		try {
 			await this.encryptionService().encryptFile(plainTextPath, encryptedPath, {
 				masterKeyId: share && share.master_key_id ? share.master_key_id : '',
 			});
 		} catch (error) {
-			await this.removeCryptedFile(encryptedPath);
-
 			if (error.code === 'ENOENT') {
 				throw new JoplinError(
 					`Trying to encrypt resource but only metadata is present: ${error.toString()}`, 'fileNotFound',
@@ -270,7 +280,7 @@ export default class Resource extends BaseItem {
 
 		const resourceCopy = { ...resource };
 		resourceCopy.encryption_blob_encrypted = 1;
-		return { path: encryptedPath, resource: resourceCopy, isTemporary: true };
+		return { path: encryptedPath, resource: resourceCopy };
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -208,14 +208,26 @@ export default class Resource extends BaseItem {
 				// at all. It can happen for example when there's a crash between the moment the data
 				// is decrypted and the resource item is updated.
 				this.logger().warn(`Found a resource that was most likely already decrypted but was marked as encrypted. Marked it as decrypted: ${item.id}`);
-				this.fsDriver().move(encryptedPath, plainTextPath);
+				await this.fsDriver().move(encryptedPath, plainTextPath);
 			} else {
 				throw error;
 			}
 		}
 
 		decryptedItem.encryption_blob_encrypted = 0;
-		return super.save(decryptedItem, { autoTimestamp: false });
+		const savedItem = await super.save(decryptedItem, { autoTimestamp: false });
+
+		// Clean up the .crypted file now that decryption is complete and
+		// encryption_blob_encrypted = 0 has been persisted to the database.
+		if (encryptedPath !== plainTextPath) {
+			try {
+				await this.fsDriver().remove(encryptedPath);
+			} catch (error) {
+				this.logger().warn(`Failed to remove .crypted file after decryption: ${error.message}`);
+			}
+		}
+
+		return savedItem;
 	}
 
 	// Prepare the resource by encrypting it if needed.
@@ -232,17 +244,26 @@ export default class Resource extends BaseItem {
 		if (!getEncryptionEnabled() || !itemCanBeEncrypted(resource as any, share)) {
 			// Normally not possible since itemsThatNeedSync should only return decrypted items
 			if (resource.encryption_blob_encrypted) throw new Error('Trying to access encrypted resource but encryption is currently disabled');
-			return { path: plainTextPath, resource: resource };
+			return { path: plainTextPath, resource: resource, isTemporary: false };
 		}
 
 		const encryptedPath = this.fullPath(resource, true);
-		if (resource.encryption_blob_encrypted) return { path: encryptedPath, resource: resource };
+		if (resource.encryption_blob_encrypted) return { path: encryptedPath, resource: resource, isTemporary: false };
 
 		try {
 			await this.encryptionService().encryptFile(plainTextPath, encryptedPath, {
 				masterKeyId: share && share.master_key_id ? share.master_key_id : '',
 			});
 		} catch (error) {
+			// Clean up partial .crypted file if encryption failed mid-write
+			try {
+				if (await this.fsDriver().exists(encryptedPath)) {
+					await this.fsDriver().remove(encryptedPath);
+				}
+			} catch (_) {
+				// Best-effort cleanup
+			}
+
 			if (error.code === 'ENOENT') {
 				throw new JoplinError(
 					`Trying to encrypt resource but only metadata is present: ${error.toString()}`, 'fileNotFound',
@@ -253,7 +274,7 @@ export default class Resource extends BaseItem {
 
 		const resourceCopy = { ...resource };
 		resourceCopy.encryption_blob_encrypted = 1;
-		return { path: encryptedPath, resource: resourceCopy };
+		return { path: encryptedPath, resource: resourceCopy, isTemporary: true };
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -217,17 +217,22 @@ export default class Resource extends BaseItem {
 		decryptedItem.encryption_blob_encrypted = 0;
 		const savedItem = await super.save(decryptedItem, { autoTimestamp: false });
 
-		// Clean up the .crypted file now that decryption is complete and
-		// encryption_blob_encrypted = 0 has been persisted to the database.
-		if (encryptedPath !== plainTextPath && await this.fsDriver().exists(encryptedPath)) {
-			try {
-				await this.fsDriver().remove(encryptedPath);
-			} catch (error) {
-				this.logger().warn(`Failed to remove .crypted file after decryption: ${error.message}`);
-			}
-		}
+		await this.removeCryptedFile(encryptedPath);
+
 
 		return savedItem;
+	}
+
+	// Best-effort removal of a .crypted file. Used after decryption completes
+	// and after sync upload to clean up temporary encrypted artifacts.
+	public static async removeCryptedFile(cryptedPath: string) {
+		try {
+			if (await this.fsDriver().exists(cryptedPath)) {
+				await this.fsDriver().remove(cryptedPath);
+			}
+		} catch (error) {
+			this.logger().warn(`Failed to remove .crypted file ${cryptedPath}: ${error.message}`);
+		}
 	}
 
 	// Prepare the resource by encrypting it if needed.

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -265,8 +265,8 @@ export default class Resource extends BaseItem {
 				if (await this.fsDriver().exists(encryptedPath)) {
 					await this.fsDriver().remove(encryptedPath);
 				}
-			} catch (_) {
-				// Best-effort cleanup
+			} catch (error) {
+				this.logger().warn('Failed to clean up partial .crypted file:', error);
 			}
 
 			if (error.code === 'ENOENT') {

--- a/packages/lib/models/Resource.ts
+++ b/packages/lib/models/Resource.ts
@@ -227,9 +227,7 @@ export default class Resource extends BaseItem {
 	// and after sync upload to clean up temporary encrypted artifacts.
 	public static async removeCryptedFile(cryptedPath: string) {
 		try {
-			if (await this.fsDriver().exists(cryptedPath)) {
-				await this.fsDriver().remove(cryptedPath);
-			}
+			await this.fsDriver().remove(cryptedPath);
 		} catch (error) {
 			this.logger().warn(`Failed to remove .crypted file ${cryptedPath}: ${error.message}`);
 		}
@@ -260,14 +258,7 @@ export default class Resource extends BaseItem {
 				masterKeyId: share && share.master_key_id ? share.master_key_id : '',
 			});
 		} catch (error) {
-			// Clean up partial .crypted file if encryption failed mid-write
-			try {
-				if (await this.fsDriver().exists(encryptedPath)) {
-					await this.fsDriver().remove(encryptedPath);
-				}
-			} catch (error) {
-				this.logger().warn('Failed to clean up partial .crypted file:', error);
-			}
+			await this.removeCryptedFile(encryptedPath);
 
 			if (error.code === 'ENOENT') {
 				throw new JoplinError(

--- a/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
@@ -317,7 +317,7 @@ describe('Synchronizer.e2ee', () => {
 		expect(await allSyncTargetItemsEncrypted()).toBe(true);
 	}));
 
-	it('should upload encrypted resource, but it should not mark the blob as encrypted locally, and should clean up temp .crypted file', (async () => {
+	it('should upload encrypted resource, and .crypted file should be cleaned up by startup sweep', (async () => {
 		while (insideBeforeEach) await time.msleep(100);
 
 		const folder1 = await Folder.save({ title: 'folder1' });
@@ -329,19 +329,19 @@ describe('Synchronizer.e2ee', () => {
 		await synchronizerStart();
 
 		const resource1 = (await Resource.all())[0];
-		// Resource should remain decrypted locally
 		expect(resource1.encryption_blob_encrypted).toBe(0);
 
-		// The temp .crypted file created for upload should have been cleaned up
 		const cryptedPath = Resource.fullPath(resource1, true);
-		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
-
-		// The plaintext resource file should still exist
 		const plainTextPath = Resource.fullPath(resource1);
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(true);
+		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
+
+		await Resource.deleteOrphanedCryptedFiles();
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
 		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
 	}));
 
-	it('should clean up .crypted file after resource decryption', (async () => {
+	it('should clean up .crypted file after resource decryption via startup sweep', (async () => {
 		while (insideBeforeEach) await time.msleep(100);
 
 		const folder1 = await Folder.save({ title: 'folder1' });
@@ -358,14 +358,11 @@ describe('Synchronizer.e2ee', () => {
 		Setting.setObjectValue('encryption.passwordCache', masterKey.id, '123456');
 		await loadMasterKeysFromSettings(encryptionService());
 
-		// Decrypt the metadata first (but blob can't be decrypted yet since not fetched)
 		await decryptionWorker().start();
 
 		let resource1 = (await Resource.all())[0];
-		// Metadata is decrypted but blob is still marked as encrypted since it hasn't been fetched
 		expect(resource1.encryption_blob_encrypted).toBe(1);
 
-		// Now fetch and decrypt the blob
 		const resourceFetcher = newResourceFetcher(synchronizer());
 		resourceFetcher.queueDownload_(resource1.id);
 		await resourceFetcher.waitForAllFinished();
@@ -375,13 +372,47 @@ describe('Synchronizer.e2ee', () => {
 		resource1 = await Resource.load(resource1.id);
 		expect(resource1.encryption_blob_encrypted).toBe(0);
 
-		// The .crypted file should have been cleaned up after decryption
 		const cryptedPath = Resource.fullPath(resource1, true);
-		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
-
-		// The decrypted plaintext file should exist
 		const plainTextPath = Resource.fullPath(resource1);
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(true);
 		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
+
+		await Resource.deleteOrphanedCryptedFiles();
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
+		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
+	}));
+
+	it('startup sweep should preserve .crypted files for resources still marked as encrypted', (async () => {
+		while (insideBeforeEach) await time.msleep(100);
+
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
+		await shim.attachFileToNote(note1, `${supportDir}/photo.jpg`);
+		const masterKey = await loadEncryptionMasterKey();
+		await setupAndEnableEncryption(encryptionService(), masterKey, '123456');
+		await loadMasterKeysFromSettings(encryptionService());
+		await synchronizerStart();
+
+		await switchClient(2);
+
+		await synchronizerStart();
+		Setting.setObjectValue('encryption.passwordCache', masterKey.id, '123456');
+		await loadMasterKeysFromSettings(encryptionService());
+
+		await decryptionWorker().start();
+
+		const resource1 = (await Resource.all())[0];
+		expect(resource1.encryption_blob_encrypted).toBe(1);
+
+		const resourceFetcher = newResourceFetcher(synchronizer());
+		resourceFetcher.queueDownload_(resource1.id);
+		await resourceFetcher.waitForAllFinished();
+
+		const cryptedPath = Resource.fullPath(resource1, true);
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(true);
+
+		await Resource.deleteOrphanedCryptedFiles();
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(true);
 	}));
 
 	it('should decrypt the resource metadata, but not try to decrypt the file, if it is not present', (async () => {

--- a/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.e2ee.test.ts
@@ -317,7 +317,7 @@ describe('Synchronizer.e2ee', () => {
 		expect(await allSyncTargetItemsEncrypted()).toBe(true);
 	}));
 
-	it('should upload encrypted resource, but it should not mark the blob as encrypted locally', (async () => {
+	it('should upload encrypted resource, but it should not mark the blob as encrypted locally, and should clean up temp .crypted file', (async () => {
 		while (insideBeforeEach) await time.msleep(100);
 
 		const folder1 = await Folder.save({ title: 'folder1' });
@@ -326,10 +326,62 @@ describe('Synchronizer.e2ee', () => {
 		const masterKey = await loadEncryptionMasterKey();
 		await setupAndEnableEncryption(encryptionService(), masterKey, '123456');
 		await loadMasterKeysFromSettings(encryptionService());
-		// await synchronizerStart();
+		await synchronizerStart();
 
-		// const resource1 = (await Resource.all())[0];
-		// expect(resource1.encryption_blob_encrypted).toBe(0);
+		const resource1 = (await Resource.all())[0];
+		// Resource should remain decrypted locally
+		expect(resource1.encryption_blob_encrypted).toBe(0);
+
+		// The temp .crypted file created for upload should have been cleaned up
+		const cryptedPath = Resource.fullPath(resource1, true);
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
+
+		// The plaintext resource file should still exist
+		const plainTextPath = Resource.fullPath(resource1);
+		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
+	}));
+
+	it('should clean up .crypted file after resource decryption', (async () => {
+		while (insideBeforeEach) await time.msleep(100);
+
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'ma note', parent_id: folder1.id });
+		await shim.attachFileToNote(note1, `${supportDir}/photo.jpg`);
+		const masterKey = await loadEncryptionMasterKey();
+		await setupAndEnableEncryption(encryptionService(), masterKey, '123456');
+		await loadMasterKeysFromSettings(encryptionService());
+		await synchronizerStart();
+
+		await switchClient(2);
+
+		await synchronizerStart();
+		Setting.setObjectValue('encryption.passwordCache', masterKey.id, '123456');
+		await loadMasterKeysFromSettings(encryptionService());
+
+		// Decrypt the metadata first (but blob can't be decrypted yet since not fetched)
+		await decryptionWorker().start();
+
+		let resource1 = (await Resource.all())[0];
+		// Metadata is decrypted but blob is still marked as encrypted since it hasn't been fetched
+		expect(resource1.encryption_blob_encrypted).toBe(1);
+
+		// Now fetch and decrypt the blob
+		const resourceFetcher = newResourceFetcher(synchronizer());
+		resourceFetcher.queueDownload_(resource1.id);
+		await resourceFetcher.waitForAllFinished();
+
+		await decryptionWorker().start();
+
+		resource1 = await Resource.load(resource1.id);
+		expect(resource1.encryption_blob_encrypted).toBe(0);
+
+		// The .crypted file should have been cleaned up after decryption
+		const cryptedPath = Resource.fullPath(resource1, true);
+		expect(await shim.fsDriver().exists(cryptedPath)).toBe(false);
+
+		// The decrypted plaintext file should exist
+		const plainTextPath = Resource.fullPath(resource1);
+		expect(await shim.fsDriver().exists(plainTextPath)).toBe(true);
 	}));
 
 	it('should decrypt the resource metadata, but not try to decrypt the file, if it is not present', (async () => {


### PR DESCRIPTION
Fixes #9093

**Problem**

`.crypted` files accumulate in the resource directory and are never cleaned up. They get created during decryption (`Resource.decrypt` renames the blob to `.crypted` before decrypting) and during sync upload (`fullPathForSyncUpload` encrypts to a temp `.crypted` file for upload).

Also, the `move()` call in the `invalidIdentifier` error fallback of `Resource.decrypt()` was not awaited.

**Solution**

Startup sweep that deletes orphaned `.crypted` files before resource services start. Not all `.crypted` files are safe to delete,  encrypted blobs that haven't been decrypted yet are also stored as `.crypted` - so the sweep checks the resource table and only removes files where the resource is already decrypted (`encryption_blob_encrypted = 0`) or missing from the database entirely. Wrapped in try/catch so cleanup failures don't block startup.

Also fixed the un-awaited `fsDriver().move()`.

**Test Plan**

- Added tests for startup sweep: cleanup after upload, cleanup after decrypt, and preservation of still-encrypted blobs
- All 19 `Synchronizer.e2ee` tests pass

**AI Assistance Disclosure**

Used AI to explore codebase and for PR text. All code was reviewed, understood, and validated manually.