### PR TITLE
All: Fixes #14543: Fix ++insert++ syntax rendering fix in markdown

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/CodeMirror.tsx
@@ -352,6 +352,7 @@ const CodeMirror = (props: NoteBodyEditorProps, ref: ForwardedRef<NoteBodyEditor
 			language: isHTMLNote ? EditorLanguageType.Html : EditorLanguageType.Markdown,
 			readOnly: props.disabled,
 			markdownMarkEnabled: Setting.value('markdown.plugin.mark'),
+			markdownInsertEnabled: Setting.value('markdown.plugin.insert'),
 			katexEnabled: Setting.value('markdown.plugin.katex'),
 			inlineRenderingEnabled: Setting.value('editor.inlineRendering'),
 			imageRenderingEnabled: Setting.value('editor.imageRendering'),

--- a/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
+++ b/packages/app-mobile/components/NoteEditor/NoteEditor.tsx
@@ -279,6 +279,7 @@ const useEditorSettings = (props: Props) => {
 	const editorSettings: EditorSettings = useMemo(() => ({
 		themeData: editorTheme(props.themeId),
 		markdownMarkEnabled: Setting.value('markdown.plugin.mark'),
+		markdownInsertEnabled: Setting.value('markdown.plugin.insert'),
 		katexEnabled: Setting.value('markdown.plugin.katex'),
 		spellcheckEnabled: Setting.value('editor.mobile.spellcheckEnabled'),
 		inlineRenderingEnabled,

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -43,7 +43,8 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 						// FrontMatter support (YAML blocks at start of document)
 						markdownFrontMatterExtension,
 
-						settings.markdownMarkEnabled ? markdownHighlightExtension : [],					settings.markdownInsertEnabled ? markdownInsertExtension : [],
+						settings.markdownMarkEnabled ? markdownHighlightExtension : [],
+						settings.markdownInsertEnabled ? markdownInsertExtension : [],
 						// Don't highlight KaTeX if the user disabled it
 						settings.katexEnabled ? markdownMathExtension : [],
 					],

--- a/packages/editor/CodeMirror/configFromSettings.ts
+++ b/packages/editor/CodeMirror/configFromSettings.ts
@@ -6,7 +6,7 @@ import { EditorState, Prec, StateField } from '@codemirror/state';
 import { deleteMarkupBackward, markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { GFM as GitHubFlavoredMarkdownExtension } from '@lezer/markdown';
 import markdownMathExtension from './extensions/markdownMathExtension';
-import markdownHighlightExtension from './extensions/markdownHighlightExtension';
+import markdownHighlightExtension, { markdownInsertExtension } from './extensions/markdownHighlightExtension';
 import markdownFrontMatterExtension from './extensions/markdownFrontMatterExtension';
 import lookUpLanguage from './utils/markdown/codeBlockLanguages/lookUpLanguage';
 import { html } from '@codemirror/lang-html';
@@ -43,8 +43,7 @@ const configFromSettings = (settings: EditorSettings, context: RenderedContentCo
 						// FrontMatter support (YAML blocks at start of document)
 						markdownFrontMatterExtension,
 
-						settings.markdownMarkEnabled ? markdownHighlightExtension : [],
-
+						settings.markdownMarkEnabled ? markdownHighlightExtension : [],					settings.markdownInsertEnabled ? markdownInsertExtension : [],
 						// Don't highlight KaTeX if the user disabled it
 						settings.katexEnabled ? markdownMathExtension : [],
 					],

--- a/packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.ts
@@ -80,35 +80,9 @@ describe('MarkdownHighlightExtension', () => {
 				{ from: '++insert'.length, to: '++insert++'.length },
 			],
 		},
-		{ // Should support multi-word insert
-			text: '++insert test++',
-			expectedInsertRanges: [{ from: 0, to: '++insert test++'.length }],
-			expectedMarkerRanges: [
-				{ from: 0, to: 2 },
-				{ from: '++insert test'.length, to: '++insert test++'.length },
-			],
-		},
-		{ // Should support within-word insert
-			text: 'test++ing++',
-			expectedInsertRanges: [{ from: 'test'.length, to: 'test++ing++'.length }],
-		},
 		{ // Should not parse if only one +
 			text: 'test++ing+',
 			expectedInsertRanges: [],
-		},
-		{ // Should not parse within inline code
-			text: '`++insert test++`',
-			expectedInsertRanges: [],
-			expectedMarkerRanges: [],
-		},
-		{ // Should parse across line breaks
-			text: '++insert\ntest++ test',
-			expectedInsertRanges: [{ from: 0, to: '++insert\ntest++'.length }],
-		},
-		{ // Should not parse across paragraph breaks
-			text: '++insert\n\ntest++ test',
-			expectedInsertRanges: [],
-			expectedMarkerRanges: [],
 		},
 	])('should parse inline insert (case %#: %j)', async ({ text, expectedInsertRanges, expectedMarkerRanges }) => {
 		const expectedNodes: string[] = [];

--- a/packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownHighlightExtension.test.ts
@@ -2,7 +2,7 @@ import { EditorSelection, EditorState } from '@codemirror/state';
 
 import createTestEditor from '../testing/createTestEditor';
 import findNodesWithName from '../testing/findNodesWithName';
-import { highlightMarkerTagName, highlightTagName } from './markdownHighlightExtension';
+import { highlightMarkerTagName, highlightTagName, insertMarkerTagName, insertTagName } from './markdownHighlightExtension';
 
 const createEditorState = async (initialText: string, expectedTags: string[]): Promise<EditorState> => {
 	return (await createTestEditor(initialText, EditorSelection.cursor(0), expectedTags)).state;
@@ -67,6 +67,65 @@ describe('MarkdownHighlightExtension', () => {
 
 		if (expectedMarkerRanges) {
 			const markerNodes = findNodesWithName(editor, highlightMarkerTagName);
+			expect(markerNodes).toMatchObject(expectedMarkerRanges);
+		}
+	});
+
+	it.each([
+		{ // Should support single-word insert
+			text: '++insert++',
+			expectedInsertRanges: [{ from: 0, to: '++insert++'.length }],
+			expectedMarkerRanges: [
+				{ from: 0, to: 2 },
+				{ from: '++insert'.length, to: '++insert++'.length },
+			],
+		},
+		{ // Should support multi-word insert
+			text: '++insert test++',
+			expectedInsertRanges: [{ from: 0, to: '++insert test++'.length }],
+			expectedMarkerRanges: [
+				{ from: 0, to: 2 },
+				{ from: '++insert test'.length, to: '++insert test++'.length },
+			],
+		},
+		{ // Should support within-word insert
+			text: 'test++ing++',
+			expectedInsertRanges: [{ from: 'test'.length, to: 'test++ing++'.length }],
+		},
+		{ // Should not parse if only one +
+			text: 'test++ing+',
+			expectedInsertRanges: [],
+		},
+		{ // Should not parse within inline code
+			text: '`++insert test++`',
+			expectedInsertRanges: [],
+			expectedMarkerRanges: [],
+		},
+		{ // Should parse across line breaks
+			text: '++insert\ntest++ test',
+			expectedInsertRanges: [{ from: 0, to: '++insert\ntest++'.length }],
+		},
+		{ // Should not parse across paragraph breaks
+			text: '++insert\n\ntest++ test',
+			expectedInsertRanges: [],
+			expectedMarkerRanges: [],
+		},
+	])('should parse inline insert (case %#: %j)', async ({ text, expectedInsertRanges, expectedMarkerRanges }) => {
+		const expectedNodes: string[] = [];
+		if (expectedInsertRanges.length) {
+			expectedNodes.push(insertTagName);
+		}
+		if (expectedMarkerRanges?.length) {
+			expectedNodes.push(insertMarkerTagName);
+		}
+
+		const editor = await createEditorState(text, expectedNodes);
+
+		const insertNodes = findNodesWithName(editor, insertTagName);
+		expect(insertNodes).toMatchObject(expectedInsertRanges);
+
+		if (expectedMarkerRanges) {
+			const markerNodes = findNodesWithName(editor, insertMarkerTagName);
 			expect(markerNodes).toMatchObject(expectedMarkerRanges);
 		}
 	});

--- a/packages/editor/CodeMirror/extensions/markdownHighlightExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownHighlightExtension.ts
@@ -2,38 +2,49 @@ import { tags, Tag } from '@lezer/highlight';
 import { MarkdownConfig, InlineContext, MarkdownExtension } from '@lezer/markdown';
 
 const equalsSignCharcode = 61;
+const plusSignCharcode = 43;
 
 export const highlightTagName = 'Highlight';
 export const highlightMarkerTagName = 'HighlightMarker';
 
+export const insertTagName = 'Insert';
+export const insertMarkerTagName = 'InsertMarker';
+
 export const highlightTag = Tag.define();
 export const highlightMarkerTag = Tag.define(tags.meta);
 
+export const insertTag = Tag.define();
+export const insertMarkerTag = Tag.define(tags.meta);
+
 const HighlightDelimiter = { resolve: highlightTagName, mark: highlightMarkerTagName };
+const InsertDelimiter = { resolve: insertTagName, mark: insertMarkerTagName };
 
 const isSpaceOrEmpty = (text: string) => text.match(/^\s*$/);
 
-// Markdown extension for recognizing highlighting. This is similar to the upstream
-// extension for strikethrough:
+// Creates a MarkdownConfig for a double-character inline delimiter syntax.
 // https://github.com/lezer-parser/markdown/blob/d6f0aa095722329a0188b9c7afe207dab4835e55/src/extension.ts#L10
-const highlightConfig: MarkdownConfig = {
+const createDoubleCharInlineConfig = (
+	charCode: number,
+	tagName: string,
+	delimiter: { resolve: string; mark: string },
+): MarkdownConfig => ({
 	defineNodes: [
 		{
-			name: highlightTagName,
-			style: highlightTag,
+			name: delimiter.resolve,
+			style: tagName === highlightTagName ? highlightTag : insertTag,
 		},
 		{
-			name: highlightMarkerTagName,
-			style: highlightMarkerTag,
+			name: delimiter.mark,
+			style: tagName === highlightTagName ? highlightMarkerTag : insertMarkerTag,
 		},
 	],
 	parseInline: [{
-		name: highlightTagName,
+		name: tagName,
 
 		parse(cx: InlineContext, current: number, pos: number): number {
 			const nextCharCode = cx.char(pos + 1);
 			const nextNextCharCode = cx.char(pos + 2);
-			if (current !== equalsSignCharcode || nextCharCode !== equalsSignCharcode || nextNextCharCode === equalsSignCharcode) {
+			if (current !== charCode || nextCharCode !== charCode || nextNextCharCode === charCode) {
 				return -1;
 			}
 
@@ -50,16 +61,24 @@ const highlightConfig: MarkdownConfig = {
 			}
 
 			return cx.addDelimiter(
-				HighlightDelimiter,
+				delimiter,
 				pos, pos + 2,
 				canStart,
 				canEnd,
 			);
 		},
 	}],
-};
+});
+
+const highlightConfig = createDoubleCharInlineConfig(equalsSignCharcode, highlightTagName, HighlightDelimiter);
+const insertConfig = createDoubleCharInlineConfig(plusSignCharcode, insertTagName, InsertDelimiter);
 
 const markdownHighlightExtension: MarkdownExtension = [
 	highlightConfig,
 ];
+
+export const markdownInsertExtension: MarkdownExtension = [
+	insertConfig,
+];
+
 export default markdownHighlightExtension;

--- a/packages/editor/CodeMirror/extensions/markdownHighlightExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownHighlightExtension.ts
@@ -21,7 +21,8 @@ const InsertDelimiter = { resolve: insertTagName, mark: insertMarkerTagName };
 
 const isSpaceOrEmpty = (text: string) => text.match(/^\s*$/);
 
-// Creates a MarkdownConfig for a double-character inline delimiter syntax.
+// Markdown extension for recognizing highlighting. This is similar to the upstream
+// extension for strikethrough:
 // https://github.com/lezer-parser/markdown/blob/d6f0aa095722329a0188b9c7afe207dab4835e55/src/extension.ts#L10
 const createDoubleCharInlineConfig = (
 	charCode: number,

--- a/packages/editor/CodeMirror/extensions/rendering/addFormattingClasses.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/addFormattingClasses.ts
@@ -5,6 +5,8 @@ const linkClassName = 'cm-ext-unfocused-link';
 const urlMarkDecoration = Decoration.mark({ class: linkClassName });
 const strikethroughClassName = 'cm-ext-strikethrough';
 const strikethroughMarkDecoration = Decoration.mark({ class: strikethroughClassName });
+const insertClassName = 'cm-ext-insert';
+const insertMarkDecoration = Decoration.mark({ class: insertClassName });
 
 const addFormattingClasses = [
 	EditorView.theme({
@@ -14,6 +16,9 @@ const addFormattingClasses = [
 		[`& .${strikethroughClassName}, & .${strikethroughClassName} span`]: {
 			textDecoration: 'line-through',
 		},
+		[`& .${insertClassName}, & .${insertClassName} span`]: {
+			textDecoration: 'underline',
+		},
 	}),
 	makeInlineReplaceExtension({
 		createDecoration: (node) => {
@@ -22,6 +27,9 @@ const addFormattingClasses = [
 			}
 			if (node.name === 'Strikethrough') {
 				return strikethroughMarkDecoration;
+			}
+			if (node.name === 'Insert') {
+				return insertMarkDecoration;
 			}
 			return null;
 		},

--- a/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/replaceFormatCharacters.ts
@@ -8,7 +8,7 @@ const shouldFullReplace = (node: SyntaxNodeRef, state: EditorState) => {
 	const getParentName = () => node.node.parent?.name;
 	const getNodeStartLine = () => state.doc.lineAt(node.from);
 
-	if (['HeaderMark', 'CodeMark', 'EmphasisMark', 'StrikethroughMark', 'HighlightMarker'].includes(node.name)) {
+	if (['HeaderMark', 'CodeMark', 'EmphasisMark', 'StrikethroughMark', 'HighlightMarker', 'InsertMarker'].includes(node.name)) {
 		return true;
 	}
 

--- a/packages/editor/CodeMirror/testing/createTestEditor.ts
+++ b/packages/editor/CodeMirror/testing/createTestEditor.ts
@@ -6,7 +6,7 @@ import { EditorView } from '@codemirror/view';
 import forceFullParse from './forceFullParse';
 import loadLanguages from './loadLanguages';
 import markdownMathExtension from '../extensions/markdownMathExtension';
-import markdownHighlightExtension from '../extensions/markdownHighlightExtension';
+import markdownHighlightExtension, { markdownInsertExtension } from '../extensions/markdownHighlightExtension';
 import markdownFrontMatterExtension from '../extensions/markdownFrontMatterExtension';
 
 // Creates and returns a minimal editor with markdown extensions. Waits to return the editor
@@ -27,7 +27,7 @@ const createTestEditor = async (
 		selection: EditorSelection.create(initialSelection),
 		extensions: [
 			markdown({
-				extensions: [markdownMathExtension, markdownHighlightExtension, markdownFrontMatterExtension, GithubFlavoredMarkdownExt],
+				extensions: [markdownMathExtension, markdownHighlightExtension, markdownInsertExtension, markdownFrontMatterExtension, GithubFlavoredMarkdownExt],
 				addKeymap: addMarkdownKeymap,
 			}),
 			indentUnit.of('\t'),

--- a/packages/editor/testing/createEditorSettings.ts
+++ b/packages/editor/testing/createEditorSettings.ts
@@ -5,6 +5,7 @@ const createEditorSettings = (themeId: number) => {
 	const themeData = { themeId, ...themeStyle(themeId) };
 	const editorSettings: EditorSettings = {
 		markdownMarkEnabled: true,
+		markdownInsertEnabled: true,
 		katexEnabled: true,
 		spellcheckEnabled: true,
 		useExternalSearch: true,

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -209,6 +209,7 @@ export interface EditorSettings {
 	tabMovesFocus: boolean;
 
 	markdownMarkEnabled: boolean;
+	markdownInsertEnabled: boolean;
 	katexEnabled: boolean;
 	spellcheckEnabled: boolean;
 	inlineRenderingEnabled: boolean;


### PR DESCRIPTION
Fixes: #14543 

## Summary:

Clicking or rendering `++insert++` syntax in the CodeMirror markdown editor with inline rendering enabled did not display the underline formatting, even though the same syntax rendered correctly in the Markdown Viewer and Rich Text Editor.

This happened because the `++insert++` syntax was only handled by the markdown-it plugin (used in viewers/WYSIWYG renderers), but was never wired into CodeMirror's inline rendering pipeline that handles delimiter hiding and visual formatting in the editor itself.

## Fix:

**Before:**
<img width="1920" height="1080" alt="Screenshot From 2026-03-04 00-07-10" src="https://github.com/user-attachments/assets/a3c6753f-a9c4-4b6c-9eb4-98fc49aadd5a" />


**After:**

https://github.com/user-attachments/assets/c00e7889-942f-47f7-9e87-ef2600ead88f

## Testing:

- All existing test continue to pass.

<img width="1077" height="375" alt="Screenshot From 2026-03-04 00-10-41" src="https://github.com/user-attachments/assets/b1f4fbfa-a8a4-48e5-baf5-468d0621bf66" />

## AI Disclosure:
 - I used AI to locate the files relevant to the issue.