### PR TITLE
Desktop: Fixes #14079: Improve updater error message on rate limit

### DIFF
--- a/packages/app-desktop/checkForUpdates.ts
+++ b/packages/app-desktop/checkForUpdates.ts
@@ -29,7 +29,13 @@ async function fetchLatestReleases() {
 
 	if (!response.ok) {
 		const responseText = await response.text();
-		throw new Error(`Cannot get latest release info: ${responseText.substr(0, 500)}`);
+		logger.error(`Cannot get latest release info (${response.status}): ${responseText.substr(0, 500)}`);
+
+		if ((response.status === 403 || response.status === 429) && responseText.includes('rate limit')) {
+			throw new Error(_('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.'));
+		}
+
+		throw new Error(_('Could not check for updates. Please try again later (Error %s).', String(response.status)));
 	}
 
 	return (await response.json()) as GitHubRelease[];

--- a/packages/app-desktop/checkForUpdates.ts
+++ b/packages/app-desktop/checkForUpdates.ts
@@ -4,7 +4,7 @@ import { _ } from '@joplin/lib/locale';
 import bridge from './services/bridge';
 import KvStore from '@joplin/lib/services/KvStore';
 import * as ArrayUtils from '@joplin/lib/ArrayUtils';
-import { CheckForUpdateOptions, extractVersionInfo, GitHubRelease } from './utils/checkForUpdatesUtils';
+import { CheckForUpdateOptions, extractVersionInfo, GitHubRelease, handleReleaseResponseError } from './utils/checkForUpdatesUtils';
 import { PackageInfo } from '@joplin/lib/versionInfo';
 import { compareVersions } from 'compare-versions';
 const packageInfo: PackageInfo = require('./packageInfo.js');
@@ -30,12 +30,7 @@ async function fetchLatestReleases() {
 	if (!response.ok) {
 		const responseText = await response.text();
 		logger.error(`Cannot get latest release info (${response.status}): ${responseText.substr(0, 500)}`);
-
-		if ((response.status === 403 || response.status === 429) && responseText.includes('rate limit')) {
-			throw new Error(_('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.'));
-		}
-
-		throw new Error(_('Could not check for updates. Please try again later (Error %s).', String(response.status)));
+		handleReleaseResponseError(response.status, responseText);
 	}
 
 	return (await response.json()) as GitHubRelease[];

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.ts
@@ -79,4 +79,28 @@ describe('AutoUpdaterService', () => {
 		expect(release).toBeDefined();
 		expect(() => service.getDownloadUrlForPlatform(release, 'linux', 'amd64')).toThrow('The AutoUpdaterService does not support the following platform: linux');
 	});
+
+	it('should throw a user-friendly error when rate limited', async () => {
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				ok: false,
+				status: 403,
+				text: () => Promise.resolve('{"message":"API rate limit exceeded for 1.2.3.4.","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}'),
+			}),
+		) as jest.Mock;
+
+		await expect(service.fetchLatestRelease(false)).rejects.toThrow('rate limit has been exceeded');
+	});
+
+	it('should throw a user-friendly error on generic HTTP failure', async () => {
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				ok: false,
+				status: 500,
+				text: () => Promise.resolve('Internal Server Error'),
+			}),
+		) as jest.Mock;
+
+		await expect(service.fetchLatestRelease(false)).rejects.toThrow('Error 500');
+	});
 });

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.test.ts
@@ -79,28 +79,4 @@ describe('AutoUpdaterService', () => {
 		expect(release).toBeDefined();
 		expect(() => service.getDownloadUrlForPlatform(release, 'linux', 'amd64')).toThrow('The AutoUpdaterService does not support the following platform: linux');
 	});
-
-	it('should throw a user-friendly error when rate limited', async () => {
-		global.fetch = jest.fn(() =>
-			Promise.resolve({
-				ok: false,
-				status: 403,
-				text: () => Promise.resolve('{"message":"API rate limit exceeded for 1.2.3.4.","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}'),
-			}),
-		) as jest.Mock;
-
-		await expect(service.fetchLatestRelease(false)).rejects.toThrow('rate limit has been exceeded');
-	});
-
-	it('should throw a user-friendly error on generic HTTP failure', async () => {
-		global.fetch = jest.fn(() =>
-			Promise.resolve({
-				ok: false,
-				status: 500,
-				text: () => Promise.resolve('Internal Server Error'),
-			}),
-		) as jest.Mock;
-
-		await expect(service.fetchLatestRelease(false)).rejects.toThrow('Error 500');
-	});
 });

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -115,7 +115,13 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 
 		if (!response.ok) {
 			const responseText = await response.text();
-			throw new Error(`Cannot get latest release info: ${responseText.substr(0, 500)}`);
+			this.logger_.error(`Cannot get latest release info (${response.status}): ${responseText.substr(0, 500)}`);
+
+			if ((response.status === 403 || response.status === 429) && responseText.includes('rate limit')) {
+				throw new Error('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.');
+			}
+
+			throw new Error(`Could not check for updates. Please try again later (Error ${response.status}).`);
 		}
 
 		const releases: GitHubRelease[] = await response.json();

--- a/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
+++ b/packages/app-desktop/services/autoUpdater/AutoUpdaterService.ts
@@ -4,7 +4,7 @@ import path = require('path');
 import Logger, { LoggerWrapper } from '@joplin/utils/Logger';
 import type ShimType from '@joplin/lib/shim';
 const shim: typeof ShimType = require('@joplin/lib/shim').default;
-import { GitHubRelease, GitHubReleaseAsset } from '../../utils/checkForUpdatesUtils';
+import { GitHubRelease, GitHubReleaseAsset, handleReleaseResponseError } from '../../utils/checkForUpdatesUtils';
 import * as semver from 'semver';
 
 export enum AutoUpdaterEvents {
@@ -116,12 +116,7 @@ export default class AutoUpdaterService implements AutoUpdaterServiceInterface {
 		if (!response.ok) {
 			const responseText = await response.text();
 			this.logger_.error(`Cannot get latest release info (${response.status}): ${responseText.substr(0, 500)}`);
-
-			if ((response.status === 403 || response.status === 429) && responseText.includes('rate limit')) {
-				throw new Error('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.');
-			}
-
-			throw new Error(`Could not check for updates. Please try again later (Error ${response.status}).`);
+			handleReleaseResponseError(response.status, responseText);
 		}
 
 		const releases: GitHubRelease[] = await response.json();

--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -127,7 +127,7 @@ describe('checkForUpdates', () => {
 		};
 
 		const releaseData = releaseDataWithExtension('-arm64.DMG');
-		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, {});
+		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, { });
 
 		// Should match, with uppercase .DMG
 		expect(releaseInfo).toMatchObject({
@@ -139,7 +139,7 @@ describe('checkForUpdates', () => {
 
 		// Should not match when the extension is invalid
 		expect(
-			extractVersionInfo([releaseDataWithExtension('-arm64.dmG')], 'darwin', 'arm64', false, {}),
+			extractVersionInfo([releaseDataWithExtension('-arm64.dmG')], 'darwin', 'arm64', false, { }),
 		).toMatchObject({
 			version: '2.12.4',
 			downloadUrl: null,

--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -148,28 +148,13 @@ describe('checkForUpdates', () => {
 		});
 	});
 
-	it('should throw rate limit error for 403 with rate limit text', () => {
-		expect(() => handleReleaseResponseError(403, '{"message":"API rate limit exceeded"}'))
-			.toThrow('rate limit has been exceeded');
-	});
-
-	it('should throw rate limit error for 429 with rate limit text', () => {
-		expect(() => handleReleaseResponseError(429, 'Rate Limit reached'))
-			.toThrow('rate limit has been exceeded');
-	});
-
-	it('should detect rate limit case-insensitively', () => {
-		expect(() => handleReleaseResponseError(403, 'Rate LIMIT exceeded'))
-			.toThrow('rate limit has been exceeded');
-	});
-
-	it('should throw generic error for non-rate-limit errors', () => {
-		expect(() => handleReleaseResponseError(500, 'Internal Server Error'))
-			.toThrow('Error 500');
-	});
-
-	it('should throw generic error for 403 without rate limit text', () => {
-		expect(() => handleReleaseResponseError(403, 'Forbidden'))
-			.toThrow('Error 403');
+	test.each([
+		[403, '{"message":"API rate limit exceeded"}', 'rate limit has been exceeded', 'rate limit error for 403 with rate limit JSON'],
+		[429, 'Rate Limit reached', 'rate limit has been exceeded', 'rate limit error for 429 with rate limit text'],
+		[403, 'Rate LIMIT exceeded', 'rate limit has been exceeded', 'case-insensitive rate limit detection'],
+		[500, 'Internal Server Error', 'Error 500', 'generic error for non-rate-limit status'],
+		[403, 'Forbidden', 'Error 403', 'generic error for 403 without rate limit text'],
+	])('should throw expected error for %s (%s)', (status, body, expectedError, _description) => {
+		expect(() => handleReleaseResponseError(status, body)).toThrow(expectedError);
 	});
 });

--- a/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.test.ts
@@ -1,4 +1,4 @@
-import { extractVersionInfo, Release, Platform, Architecture, GitHubRelease } from './checkForUpdatesUtils';
+import { extractVersionInfo, Release, Platform, Architecture, GitHubRelease, handleReleaseResponseError } from './checkForUpdatesUtils';
 import { releases1, releases2 } from './checkForUpdatesUtilsTestData';
 
 describe('checkForUpdates', () => {
@@ -127,7 +127,7 @@ describe('checkForUpdates', () => {
 		};
 
 		const releaseData = releaseDataWithExtension('-arm64.DMG');
-		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, { });
+		const releaseInfo = extractVersionInfo([releaseData], 'darwin', 'arm64', false, {});
 
 		// Should match, with uppercase .DMG
 		expect(releaseInfo).toMatchObject({
@@ -139,7 +139,7 @@ describe('checkForUpdates', () => {
 
 		// Should not match when the extension is invalid
 		expect(
-			extractVersionInfo([releaseDataWithExtension('-arm64.dmG')], 'darwin', 'arm64', false, { }),
+			extractVersionInfo([releaseDataWithExtension('-arm64.dmG')], 'darwin', 'arm64', false, {}),
 		).toMatchObject({
 			version: '2.12.4',
 			downloadUrl: null,
@@ -148,4 +148,28 @@ describe('checkForUpdates', () => {
 		});
 	});
 
+	it('should throw rate limit error for 403 with rate limit text', () => {
+		expect(() => handleReleaseResponseError(403, '{"message":"API rate limit exceeded"}'))
+			.toThrow('rate limit has been exceeded');
+	});
+
+	it('should throw rate limit error for 429 with rate limit text', () => {
+		expect(() => handleReleaseResponseError(429, 'Rate Limit reached'))
+			.toThrow('rate limit has been exceeded');
+	});
+
+	it('should detect rate limit case-insensitively', () => {
+		expect(() => handleReleaseResponseError(403, 'Rate LIMIT exceeded'))
+			.toThrow('rate limit has been exceeded');
+	});
+
+	it('should throw generic error for non-rate-limit errors', () => {
+		expect(() => handleReleaseResponseError(500, 'Internal Server Error'))
+			.toThrow('Error 500');
+	});
+
+	it('should throw generic error for 403 without rate limit text', () => {
+		expect(() => handleReleaseResponseError(403, 'Forbidden'))
+			.toThrow('Error 403');
+	});
 });

--- a/packages/app-desktop/utils/checkForUpdatesUtils.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.ts
@@ -139,3 +139,14 @@ export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform
 
 	return output;
 };
+
+// Throws a user-friendly error based on the HTTP response status and body.
+// Detects rate-limit errors (403/429) with case-insensitive matching and
+// throws a specific message; otherwise throws a generic error with the status code.
+export const handleReleaseResponseError = (status: number, responseText: string): never => {
+	if ((status === 403 || status === 429) && responseText.toLowerCase().includes('rate limit')) {
+		throw new Error('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.');
+	}
+
+	throw new Error(`Could not check for updates. Please try again later (Error ${status}).`);
+};

--- a/packages/app-desktop/utils/checkForUpdatesUtils.ts
+++ b/packages/app-desktop/utils/checkForUpdatesUtils.ts
@@ -140,9 +140,6 @@ export const extractVersionInfo = (releases: GitHubRelease[], platform: Platform
 	return output;
 };
 
-// Throws a user-friendly error based on the HTTP response status and body.
-// Detects rate-limit errors (403/429) with case-insensitive matching and
-// throws a specific message; otherwise throws a generic error with the status code.
 export const handleReleaseResponseError = (status: number, responseText: string): never => {
 	if ((status === 403 || status === 429) && responseText.toLowerCase().includes('rate limit')) {
 		throw new Error('Could not check for updates. The server rate limit has been exceeded — this is a temporary issue, please try again later.');


### PR DESCRIPTION
Fixes #14079

When the GitHub API rate limit is hit during an update check, users currently see the raw JSON response which isn't very helpful. This replaces it with a friendly message letting them know it's temporary and to try again later. Other HTTP errors also get a clean message now instead of a raw dump. The full response is still logged for debugging.

Added tests for both cases.

