### PR TITLE
Desktop: Fixes #14078: prevent HTML blocks from being escaped on Markdown<->RTE switch

### DIFF
--- a/packages/app-cli/tests/html_to_md/html_in_md.html
+++ b/packages/app-cli/tests/html_to_md/html_in_md.html
@@ -4,3 +4,4 @@
 <div><span>Line</span> 5</div>
 <p>Line 6</p>
 <div class="jop-noMdConv">Markdown <strong>inside</strong></div>
+<div class="jop-noMdConv" style="color:red">**bold** and _italic_</div>

--- a/packages/app-cli/tests/html_to_md/html_in_md.md
+++ b/packages/app-cli/tests/html_to_md/html_in_md.md
@@ -6,4 +6,4 @@ Line 5
 
 Line 6
 
-<div>Markdown **inside**</div>
+<div>Markdown **inside**</div><div style="color:red">**bold** and _italic_</div>

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -840,6 +840,14 @@ rules.joplinHtmlInMarkdown = {
     return node && node.classList && node.classList.contains('jop-noMdConv') && node.nodeName !== 'TABLE';
   },
 
+  escapeContent: function () {
+    // Do not escape content inside HTML blocks - content is raw HTML/Markdown
+    // that must be preserved as-is. Without this, switching between Markdown
+    // and Rich Text editors adds extra backslashes on every switch.
+    // Fixes: https://github.com/laurent22/joplin/issues/14078
+    return false;
+  },
+
   replacement: function (content, node) {
     node.classList.remove('jop-noMdConv');
     const nodeName = node.nodeName.toLowerCase();


### PR DESCRIPTION
## Summary
Fixes #14078

HTML blocks with inline CSS were getting corrupted (backslashes added repeatedly) on every MD↔RTE switch.

## Root Cause
`rules.joplinHtmlInMarkdown` in `commonmark-rules.js` was missing `escapeContent: false`, causing Turndown to escape markdown special characters inside `jop-noMdConv` blocks on every switch.

## Fix
Added `escapeContent: false` to `rules.joplinHtmlInMarkdown`.

## Testing
**Before fix:** switching MD↔RTE repeatedly would corrupt HTML blocks.
**After fix:** HTML blocks remain intact across multiple switches 

<img width="1603" height="597" alt="Screenshot 2026-03-04 023415" src="https://github.com/user-attachments/assets/e736d81a-7a81-4c58-bff6-a3255d20c6cc" />
Original HTML block in Markdown editor

<img width="1594" height="488" alt="Screenshot 2026-03-04 023435" src="https://github.com/user-attachments/assets/4c7fc50d-45c0-4f67-bd2d-a90a2cc3196a" />
Same block rendered correctly in RTE

<img width="1599" height="712" alt="Screenshot 2026-03-04 023452" src="https://github.com/user-attachments/assets/c76125ab-6caa-4941-8db4-26def0e24d3e" />
Known limitation- editing inside RTE still causes normalization (separate issue, out of scope)

## Known Limitation
If user directly edits an HTML block inside RTE, `jop-noMdConv` class is lost at ProseMirror level causing normalization. This is a separate deeper issue.

Note: Fix approach inspired by @varunsiravuri's earlier work on this issue.