### PR TITLE
Desktop, Mobile: Fix issue where the revision service does not start on the first launch of the app (3.6 regression)

### DIFF
--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -640,16 +640,19 @@ class Application extends BaseApplication {
 				void AlarmService.updateAllNotifications();
 				RevisionService.instance().runInBackground();
 			} else {
-				// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
-				void reg.scheduleSync(1000).then(() => {
-					// Wait for the first sync before updating the notifications, since synchronisation
-					// might change the notifications.
-					void AlarmService.updateAllNotifications();
+				setTimeout(() => {
+					// Schedule sync with a delay of 0 and wrap with the desired timeout, as shim.setTimeout may not fire on first run or after an upgrade
+					// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
+					void reg.scheduleSync(0).then(() => {
+						// Wait for the first sync before updating the notifications, since synchronisation
+						// might change the notifications.
+						void AlarmService.updateAllNotifications();
 
-					void DecryptionWorker.instance().scheduleStart();
+						void DecryptionWorker.instance().scheduleStart();
 
-					RevisionService.instance().runInBackground();
-				});
+						RevisionService.instance().runInBackground();
+					});
+				}, 1000);
 			}
 
 			this.startRotatingLogMaintenance(Setting.value('profileDir'));

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -436,18 +436,21 @@ const buildStartupTasks = (
 		// start almost immediately to get the latest data.
 		// doWifiConnectionCheck set to true so initial sync
 		// doesn't happen on mobile data
-		// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
-		void reg.scheduleSync(100, null, true).then(() => {
-			// Wait for the first sync before updating the notifications, since synchronisation
-			// might change the notifications.
-			void AlarmService.updateAllNotifications();
+		setTimeout(() => {
+			// Schedule sync with a delay of 0 and wrap with the desired timeout, as shim.setTimeout may not fire on first run or after an upgrade
+			// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
+			void reg.scheduleSync(0, null, true).then(() => {
+				// Wait for the first sync before updating the notifications, since synchronisation
+				// might change the notifications.
+				void AlarmService.updateAllNotifications();
 
-			void DecryptionWorker.instance().scheduleStart();
+				void DecryptionWorker.instance().scheduleStart();
 
-			// Collect revisions more frequently on mobile because it doesn't auto-save
-			// and it cannot collect anything when the app is not active.
-			RevisionService.instance().runInBackground(1000 * 30);
-		});
+				// Collect revisions more frequently on mobile because it doesn't auto-save
+				// and it cannot collect anything when the app is not active.
+				RevisionService.instance().runInBackground(1000 * 30);
+			});
+		}, 100);
 	});
 	addTask('buildStartupTasks/set up welcome utils', async () => {
 		await WelcomeUtils.install(Setting.value('locale'), dispatch);


### PR DESCRIPTION
PR https://github.com/laurent22/joplin/pull/14394 made a change to the revision service so that the service would start only after the first sync has completed, or on app initialisation if sync is not enabled. After testing the Android 3.6.13 pre-release, I found that the revision service does not start at all, if the app is run for the first time, and this turned out to be an issue on desktop as well.

From debugging the issue, I found that the callback of the shim.setTimeout call within scheduleSync was not being fired after the given delay, but this was only the case on the first launch of the app. This issue occurs likely due to the initial startup taking longer than usual, as it sets up the database and performs migrations, and it possibly would be an issue after performing app upgrades as well.

To resolve the issue, I have changed the startup tasks for desktop and mobile to always call scheduleSync with a delay of 0 (so shim.setTimeout within the function is not used) and put the delay in a wrapping setTimeout call instead.

### Testing

I have verified that the revision service works both on the first run (with app data cleared) and subsequent runs using the release build of the desktop app and the dev build of the mobile app. Verification was done by checking for relevant entries in the log:

<img width="437" height="249" alt="revisionlog" src="https://github.com/user-attachments/assets/21b1d091-bd46-4713-ae65-9a33934afea9" />

<img width="413" height="840" alt="revisionlog2" src="https://github.com/user-attachments/assets/f0166b81-2965-42ef-9095-152c74ff1819" />