### PR TITLE
 CLI: Fix trailing spaces in ls -l output

### DIFF
--- a/packages/app-cli/app/cli-utils.js
+++ b/packages/app-cli/app/cli-utils.js
@@ -31,9 +31,14 @@ cliUtils.printArray = function(logFunction, rows) {
 		const line = [];
 		for (let col = 0; col < colWidths.length; col++) {
 			const item = rows[row][col];
-			const width = colWidths[col];
-			const dir = colAligns[col] === ALIGN_LEFT ? stringPadding.RIGHT : stringPadding.LEFT;
-			line.push(stringPadding(item, width, ' ', dir));
+			const isLastCol = col === colWidths.length - 1;
+			if (isLastCol) {
+				line.push(item !== null && item !== undefined ? item.toString() : '');
+			} else {
+				const width = colWidths[col];
+				const dir = colAligns[col] === ALIGN_LEFT ? stringPadding.RIGHT : stringPadding.LEFT;
+				line.push(stringPadding(item, width, ' ', dir));
+			}
 		}
 		logFunction(line.join(' '));
 	}

--- a/packages/app-cli/app/cli-utils.js
+++ b/packages/app-cli/app/cli-utils.js
@@ -33,7 +33,7 @@ cliUtils.printArray = function(logFunction, rows) {
 			const item = rows[row][col];
 			const isLastCol = col === colWidths.length - 1;
 			if (isLastCol) {
-				line.push(item !== null && item !== undefined ? item.toString() : '');
+				line.push(item ? item.toString() : '');
 			} else {
 				const width = colWidths[col];
 				const dir = colAligns[col] === ALIGN_LEFT ? stringPadding.RIGHT : stringPadding.LEFT;


### PR DESCRIPTION
fixes #14067

The `printArray` function in cli-utils was right-padding every column to its max width, including the last column (title) since nothing comes after it this just added unnecessary trailing spaces to every line

Now the last column is printed as is without padding, the short output format (`ls` without `-l`) also benefits from this since it goes through the same code path.

### After fix
<img width="659" height="81" alt="Screenshot 2026-03-04 at 11 54 19 AM" src="https://github.com/user-attachments/assets/1da54d2c-dd91-4763-887d-87c5f7f64e6e" />
