### PR TITLE
Desktop: fixes #8277: Added the pdf viewer for the Rich text editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -277,6 +277,8 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorVa
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/enableTextAreaTab.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/joplinCommandToTinyMceCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js

--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,8 @@ packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/v6/utils/useSyncEditorVa
 packages/app-desktop/gui/NoteEditor/NoteBody/PlainEditor/PlainEditor.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/styles/index.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.js
+packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/enableTextAreaTab.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/joplinCommandToTinyMceCommands.js
 packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/setupToolbarButtons.js

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -750,10 +750,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					'media-src \'self\' blob: data: *', // Audio and video players
 
 					// Disallow certain unused features
-					// file: is required for local PDF iframes from the resource directory.
-					// This is scoped to Electron where file:// access is already sandboxed
-					// to allowedFilePrefixes — arbitrary local HTML cannot be framed from web content.
-					'child-src https://*.youtube.com https://*.youtube-nocookie.com file:', // Allow YouTube embeds and local PDF iframes
+					'child-src https://*.youtube.com https://*.youtube-nocookie.com joplin-content://*', // Allow YouTube embeds and PDF iframes
 					'object-src \'none\'', // Objects can be used for script injection
 					'form-action \'none\'', // No submitting forms
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -33,6 +33,7 @@ import { DropHandler } from '../../utils/useDropHandler';
 import Logger from '@joplin/utils/Logger';
 import useWebViewApi from './utils/useWebViewApi';
 import useLinkTooltips from './utils/useLinkTooltips';
+import { embedPdfLinks, ensureTrailingEditableParagraph, restorePdfEmbedsToLinks } from './utils/embedPdf';
 import { focus } from '@joplin/lib/utils/focusHandler';
 const md5 = require('md5');
 const { clipboard } = require('electron');
@@ -186,7 +187,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		return {
 			content: async () => {
 				if (!editorRef.current) return '';
-				return prop_htmlToMarkdownRef.current(props.contentMarkupLanguage, editorRef.current.getContent(), props.contentOriginalCss);
+				return prop_htmlToMarkdownRef.current(props.contentMarkupLanguage, restorePdfEmbedsToLinks(editorRef.current.getContent()), props.contentOriginalCss);
 			},
 			resetScroll: () => {
 				if (editor) editor.getWin().scrollTo(0, 0);
@@ -749,7 +750,10 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					'media-src \'self\' blob: data: *', // Audio and video players
 
 					// Disallow certain unused features
-					'child-src https://*.youtube.com https://*.youtube-nocookie.com', // Allow YouTube embeds
+					// file: is required for local PDF iframes from the resource directory.
+					// This is scoped to Electron where file:// access is already sandboxed
+					// to allowedFilePrefixes — arbitrary local HTML cannot be framed from web content.
+					'child-src https://*.youtube.com https://*.youtube-nocookie.com file:', // Allow YouTube embeds and local PDF iframes
 					'object-src \'none\'', // Objects can be used for script injection
 					'form-action \'none\'', // No submitting forms
 
@@ -922,6 +926,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 						for (const code of codeElements) {
 							code.setAttribute('spellcheck', 'false');
 						}
+						embedPdfLinks(editor);
+						ensureTrailingEditableParagraph(editor);
 					};
 
 					editor.on('SetContent', () => {
@@ -1235,7 +1241,7 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		nextOnChangeEventInfo.current = null;
 
 		resetLinkTooltips();
-		const contentMd = await prop_htmlToMarkdownRef.current(info.contentMarkupLanguage, info.editor.getContent(), info.contentOriginalCss);
+		const contentMd = await prop_htmlToMarkdownRef.current(info.contentMarkupLanguage, restorePdfEmbedsToLinks(info.editor.getContent()), info.contentOriginalCss);
 
 		lastOnChangeEventInfo.current.content = contentMd;
 		lastOnChangeEventInfo.current.resourceInfos = await attachedResources(contentMd);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
@@ -13,28 +13,15 @@ const createMockEditor = (bodyHtml: string): Editor => {
 };
 
 describe('embedPdf', () => {
-	test('isPdfUrl: detects a simple file:// PDF URL', () => {
-		expect(isPdfUrl('file:///path/to/file.pdf')).toBe(true);
-	});
-
-	test('isPdfUrl: is case-insensitive', () => {
-		expect(isPdfUrl('file:///path/to/FILE.PDF')).toBe(true);
-	});
-
-	test('isPdfUrl: ignores query strings', () => {
-		expect(isPdfUrl('file:///path/to/file.pdf?v=1')).toBe(true);
-	});
-
-	test('isPdfUrl: ignores fragments', () => {
-		expect(isPdfUrl('file:///path/to/file.pdf#page=2')).toBe(true);
-	});
-
-	test('isPdfUrl: returns false for a non-PDF URL', () => {
-		expect(isPdfUrl('file:///path/to/image.png')).toBe(false);
-	});
-
-	test('isPdfUrl: handles a relative path via fallback', () => {
-		expect(isPdfUrl('documents/report.pdf')).toBe(true);
+	test.each<[string, string, boolean]>([
+		['detects a simple file:// PDF URL', 'file:///path/to/file.pdf', true],
+		['is case-insensitive', 'file:///path/to/FILE.PDF', true],
+		['ignores query strings', 'file:///path/to/file.pdf?v=1', true],
+		['ignores fragments', 'file:///path/to/file.pdf#page=2', true],
+		['returns false for a non-PDF URL', 'file:///path/to/image.png', false],
+		['handles a relative path via fallback', 'documents/report.pdf', true],
+	])('isPdfUrl: %s', (_, url, expected) => {
+		expect(isPdfUrl(url)).toBe(expected);
 	});
 
 	test('embedPdfLinks: replaces a PDF link that is the sole child of <p> with a wrapper div', () => {
@@ -92,6 +79,20 @@ describe('embedPdf', () => {
 		const wrapper = editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper');
 		expect(wrapper).not.toBeNull();
 		expect(wrapper?.getAttribute('data-joplin-restore-tag')).toBe('h2');
+	});
+
+	test('embedPdfLinks: sets iframe src to a joplin-content:// URL for file:// links', () => {
+		const editor = createMockEditor('<p><a href="file:///path/to/a.pdf">a.pdf</a></p>');
+		embedPdfLinks(editor);
+		const iframe = editor.dom.doc.querySelector<HTMLIFrameElement>('iframe');
+		expect(iframe?.getAttribute('src')).toBe('joplin-content://note-viewer/path/to/a.pdf');
+	});
+
+	test('embedPdfLinks: preserves non-file:// links in iframe src unchanged', () => {
+		const editor = createMockEditor('<p><a href="joplin-content://note-viewer/path/to/a.pdf">a.pdf</a></p>');
+		embedPdfLinks(editor);
+		const iframe = editor.dom.doc.querySelector<HTMLIFrameElement>('iframe');
+		expect(iframe?.getAttribute('src')).toBe('joplin-content://note-viewer/path/to/a.pdf');
 	});
 
 	test('ensureTrailingEditableParagraph: appends a sentinel <p> when the last element is a joplin-editable block', () => {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
@@ -1,0 +1,172 @@
+import type { Editor } from 'tinymce';
+import {
+	isPdfUrl,
+	embedPdfLinks,
+	ensureTrailingEditableParagraph,
+	restorePdfEmbedsToLinks,
+} from './embedPdf';
+
+const createMockEditor = (bodyHtml: string): Editor => {
+	const doc = document.implementation.createHTMLDocument('');
+	doc.body.innerHTML = bodyHtml;
+	return { dom: { doc } } as unknown as Editor;
+};
+
+describe('embedPdf', () => {
+	describe('isPdfUrl', () => {
+		test('detects a simple file:// PDF URL', () => {
+			expect(isPdfUrl('file:///path/to/file.pdf')).toBe(true);
+		});
+
+		test('is case-insensitive', () => {
+			expect(isPdfUrl('file:///path/to/FILE.PDF')).toBe(true);
+		});
+
+		test('ignores query strings', () => {
+			expect(isPdfUrl('file:///path/to/file.pdf?v=1')).toBe(true);
+		});
+
+		test('ignores fragments', () => {
+			expect(isPdfUrl('file:///path/to/file.pdf#page=2')).toBe(true);
+		});
+
+		test('returns false for a non-PDF URL', () => {
+			expect(isPdfUrl('file:///path/to/image.png')).toBe(false);
+		});
+
+		test('handles a relative path via fallback', () => {
+			expect(isPdfUrl('documents/report.pdf')).toBe(true);
+		});
+	});
+
+	describe('embedPdfLinks', () => {
+		test('replaces a PDF link that is the sole child of <p> with a wrapper div', () => {
+			const editor = createMockEditor('<p><a href="file:///a.pdf">a.pdf</a></p>');
+			embedPdfLinks(editor);
+			const body = editor.dom.doc.body;
+			expect(body.querySelector('p')).toBeNull();
+			const wrapper = body.querySelector('.joplin-pdf-embed-wrapper');
+			expect(wrapper).not.toBeNull();
+			expect(wrapper?.getAttribute('contenteditable')).toBe('false');
+		});
+
+		test('the wrapper contains a hidden anchor with original attributes', () => {
+			const editor = createMockEditor('<p><a href="file:///a.pdf" title="My PDF">a.pdf</a></p>');
+			embedPdfLinks(editor);
+			const hidden = editor.dom.doc.querySelector<HTMLAnchorElement>('a[data-joplin-pdf-hidden]');
+			expect(hidden).not.toBeNull();
+			expect(hidden?.getAttribute('title')).toBe('My PDF');
+			expect(hidden?.style.display).toBe('none');
+		});
+
+		test('replaces only the anchor when it has sibling text content', () => {
+			const editor = createMockEditor('<p>See <a href="file:///a.pdf">a.pdf</a> here</p>');
+			embedPdfLinks(editor);
+			// The <p> must survive because it contains more than just the anchor.
+			expect(editor.dom.doc.querySelector('p')).not.toBeNull();
+			expect(editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper')).not.toBeNull();
+		});
+
+		test('does not double-wrap an already-wrapped anchor', () => {
+			const editor = createMockEditor(
+				'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false">' +
+				'<iframe src="file:///a.pdf"></iframe>' +
+				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+				'</div>',
+			);
+			embedPdfLinks(editor);
+			const wrappers = editor.dom.doc.querySelectorAll('.joplin-pdf-embed-wrapper');
+			expect(wrappers.length).toBe(1);
+		});
+
+		test('leaves non-PDF links untouched', () => {
+			const original = '<p><a href="file:///image.png">image</a></p>';
+			const editor = createMockEditor(original);
+			embedPdfLinks(editor);
+			expect(editor.dom.doc.body.innerHTML).toBe(original);
+		});
+
+		test('replaces a PDF link that is the sole child of <h2>', () => {
+			const editor = createMockEditor('<h2><a href="file:///a.pdf">a.pdf</a></h2>');
+			embedPdfLinks(editor);
+			expect(editor.dom.doc.querySelector('h2')).toBeNull();
+			expect(editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper')).not.toBeNull();
+		});
+	});
+
+	describe('ensureTrailingEditableParagraph', () => {
+		test('appends a sentinel <p> when the last element is a joplin-editable block', () => {
+			const editor = createMockEditor(
+				'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false"></div>',
+			);
+			ensureTrailingEditableParagraph(editor);
+			const last = editor.dom.doc.body.lastElementChild;
+			expect(last?.tagName).toBe('P');
+			expect(last?.getAttribute('data-joplin-cursor-spacer')).toBe('true');
+		});
+
+		test('does nothing when the last element is already editable', () => {
+			const editor = createMockEditor('<p>Some text</p>');
+			ensureTrailingEditableParagraph(editor);
+			expect(editor.dom.doc.body.children.length).toBe(1);
+		});
+
+		test('does nothing on an empty body', () => {
+			const editor = createMockEditor('');
+			ensureTrailingEditableParagraph(editor);
+			expect(editor.dom.doc.body.children.length).toBe(0);
+		});
+	});
+
+	describe('restorePdfEmbedsToLinks', () => {
+		test('replaces a wrapper with <p><a href="...">...</a></p>', () => {
+			const input =
+				'<div class="joplin-pdf-embed-wrapper">' +
+				'<iframe src="file:///a.pdf"></iframe>' +
+				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+				'</div>';
+			const result = restorePdfEmbedsToLinks(input);
+			const doc = new DOMParser().parseFromString(result, 'text/html');
+			expect(doc.querySelector('.joplin-pdf-embed-wrapper')).toBeNull();
+			const anchor = doc.querySelector<HTMLAnchorElement>('p > a');
+			expect(anchor).not.toBeNull();
+			expect(anchor?.getAttribute('href')).toBe('file:///a.pdf');
+			expect(anchor?.hasAttribute('data-joplin-pdf-hidden')).toBe(false);
+			expect(anchor?.style.display).toBe('');
+		});
+
+		test('removes an empty cursor-spacer paragraph', () => {
+			const result = restorePdfEmbedsToLinks('<p data-joplin-cursor-spacer="true"><br></p>');
+			const doc = new DOMParser().parseFromString(result, 'text/html');
+			expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
+			expect(doc.body.innerHTML.trim()).toBe('');
+		});
+
+		test('keeps a spacer paragraph that has user content, stripping only the attribute', () => {
+			const result = restorePdfEmbedsToLinks(
+				'<p data-joplin-cursor-spacer="true">User typed this</p>',
+			);
+			const doc = new DOMParser().parseFromString(result, 'text/html');
+			expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
+			expect(doc.body.textContent).toContain('User typed this');
+		});
+
+		test('leaves unrelated HTML unchanged', () => {
+			const input = '<p>Hello <strong>world</strong></p>';
+			expect(restorePdfEmbedsToLinks(input)).toBe(input);
+		});
+
+		test('preserves original inline styles on the anchor when restoring', () => {
+			const input =
+				'<div class="joplin-pdf-embed-wrapper">' +
+				'<iframe src="file:///a.pdf"></iframe>' +
+				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="color:red;display:none">a.pdf</a>' +
+				'</div>';
+			const result = restorePdfEmbedsToLinks(input);
+			const doc = new DOMParser().parseFromString(result, 'text/html');
+			const anchor = doc.querySelector<HTMLAnchorElement>('a');
+			expect(anchor?.style.color).toBe('red');
+			expect(anchor?.style.display).toBe('');
+		});
+	});
+});

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
@@ -13,160 +13,187 @@ const createMockEditor = (bodyHtml: string): Editor => {
 };
 
 describe('embedPdf', () => {
-	describe('isPdfUrl', () => {
-		test('detects a simple file:// PDF URL', () => {
-			expect(isPdfUrl('file:///path/to/file.pdf')).toBe(true);
-		});
-
-		test('is case-insensitive', () => {
-			expect(isPdfUrl('file:///path/to/FILE.PDF')).toBe(true);
-		});
-
-		test('ignores query strings', () => {
-			expect(isPdfUrl('file:///path/to/file.pdf?v=1')).toBe(true);
-		});
-
-		test('ignores fragments', () => {
-			expect(isPdfUrl('file:///path/to/file.pdf#page=2')).toBe(true);
-		});
-
-		test('returns false for a non-PDF URL', () => {
-			expect(isPdfUrl('file:///path/to/image.png')).toBe(false);
-		});
-
-		test('handles a relative path via fallback', () => {
-			expect(isPdfUrl('documents/report.pdf')).toBe(true);
-		});
+	test('isPdfUrl: detects a simple file:// PDF URL', () => {
+		expect(isPdfUrl('file:///path/to/file.pdf')).toBe(true);
 	});
 
-	describe('embedPdfLinks', () => {
-		test('replaces a PDF link that is the sole child of <p> with a wrapper div', () => {
-			const editor = createMockEditor('<p><a href="file:///a.pdf">a.pdf</a></p>');
-			embedPdfLinks(editor);
-			const body = editor.dom.doc.body;
-			expect(body.querySelector('p')).toBeNull();
-			const wrapper = body.querySelector('.joplin-pdf-embed-wrapper');
-			expect(wrapper).not.toBeNull();
-			expect(wrapper?.getAttribute('contenteditable')).toBe('false');
-		});
-
-		test('the wrapper contains a hidden anchor with original attributes', () => {
-			const editor = createMockEditor('<p><a href="file:///a.pdf" title="My PDF">a.pdf</a></p>');
-			embedPdfLinks(editor);
-			const hidden = editor.dom.doc.querySelector<HTMLAnchorElement>('a[data-joplin-pdf-hidden]');
-			expect(hidden).not.toBeNull();
-			expect(hidden?.getAttribute('title')).toBe('My PDF');
-			expect(hidden?.style.display).toBe('none');
-		});
-
-		test('replaces only the anchor when it has sibling text content', () => {
-			const editor = createMockEditor('<p>See <a href="file:///a.pdf">a.pdf</a> here</p>');
-			embedPdfLinks(editor);
-			// The <p> must survive because it contains more than just the anchor.
-			expect(editor.dom.doc.querySelector('p')).not.toBeNull();
-			expect(editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper')).not.toBeNull();
-		});
-
-		test('does not double-wrap an already-wrapped anchor', () => {
-			const editor = createMockEditor(
-				'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false">' +
-				'<iframe src="file:///a.pdf"></iframe>' +
-				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
-				'</div>',
-			);
-			embedPdfLinks(editor);
-			const wrappers = editor.dom.doc.querySelectorAll('.joplin-pdf-embed-wrapper');
-			expect(wrappers.length).toBe(1);
-		});
-
-		test('leaves non-PDF links untouched', () => {
-			const original = '<p><a href="file:///image.png">image</a></p>';
-			const editor = createMockEditor(original);
-			embedPdfLinks(editor);
-			expect(editor.dom.doc.body.innerHTML).toBe(original);
-		});
-
-		test('replaces a PDF link that is the sole child of <h2>', () => {
-			const editor = createMockEditor('<h2><a href="file:///a.pdf">a.pdf</a></h2>');
-			embedPdfLinks(editor);
-			expect(editor.dom.doc.querySelector('h2')).toBeNull();
-			expect(editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper')).not.toBeNull();
-		});
+	test('isPdfUrl: is case-insensitive', () => {
+		expect(isPdfUrl('file:///path/to/FILE.PDF')).toBe(true);
 	});
 
-	describe('ensureTrailingEditableParagraph', () => {
-		test('appends a sentinel <p> when the last element is a joplin-editable block', () => {
-			const editor = createMockEditor(
-				'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false"></div>',
-			);
-			ensureTrailingEditableParagraph(editor);
-			const last = editor.dom.doc.body.lastElementChild;
-			expect(last?.tagName).toBe('P');
-			expect(last?.getAttribute('data-joplin-cursor-spacer')).toBe('true');
-		});
-
-		test('does nothing when the last element is already editable', () => {
-			const editor = createMockEditor('<p>Some text</p>');
-			ensureTrailingEditableParagraph(editor);
-			expect(editor.dom.doc.body.children.length).toBe(1);
-		});
-
-		test('does nothing on an empty body', () => {
-			const editor = createMockEditor('');
-			ensureTrailingEditableParagraph(editor);
-			expect(editor.dom.doc.body.children.length).toBe(0);
-		});
+	test('isPdfUrl: ignores query strings', () => {
+		expect(isPdfUrl('file:///path/to/file.pdf?v=1')).toBe(true);
 	});
 
-	describe('restorePdfEmbedsToLinks', () => {
-		test('replaces a wrapper with <p><a href="...">...</a></p>', () => {
-			const input =
-				'<div class="joplin-pdf-embed-wrapper">' +
-				'<iframe src="file:///a.pdf"></iframe>' +
-				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
-				'</div>';
-			const result = restorePdfEmbedsToLinks(input);
-			const doc = new DOMParser().parseFromString(result, 'text/html');
-			expect(doc.querySelector('.joplin-pdf-embed-wrapper')).toBeNull();
-			const anchor = doc.querySelector<HTMLAnchorElement>('p > a');
-			expect(anchor).not.toBeNull();
-			expect(anchor?.getAttribute('href')).toBe('file:///a.pdf');
-			expect(anchor?.hasAttribute('data-joplin-pdf-hidden')).toBe(false);
-			expect(anchor?.style.display).toBe('');
-		});
+	test('isPdfUrl: ignores fragments', () => {
+		expect(isPdfUrl('file:///path/to/file.pdf#page=2')).toBe(true);
+	});
 
-		test('removes an empty cursor-spacer paragraph', () => {
-			const result = restorePdfEmbedsToLinks('<p data-joplin-cursor-spacer="true"><br></p>');
-			const doc = new DOMParser().parseFromString(result, 'text/html');
-			expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
-			expect(doc.body.innerHTML.trim()).toBe('');
-		});
+	test('isPdfUrl: returns false for a non-PDF URL', () => {
+		expect(isPdfUrl('file:///path/to/image.png')).toBe(false);
+	});
 
-		test('keeps a spacer paragraph that has user content, stripping only the attribute', () => {
-			const result = restorePdfEmbedsToLinks(
-				'<p data-joplin-cursor-spacer="true">User typed this</p>',
-			);
-			const doc = new DOMParser().parseFromString(result, 'text/html');
-			expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
-			expect(doc.body.textContent).toContain('User typed this');
-		});
+	test('isPdfUrl: handles a relative path via fallback', () => {
+		expect(isPdfUrl('documents/report.pdf')).toBe(true);
+	});
 
-		test('leaves unrelated HTML unchanged', () => {
-			const input = '<p>Hello <strong>world</strong></p>';
-			expect(restorePdfEmbedsToLinks(input)).toBe(input);
-		});
+	test('embedPdfLinks: replaces a PDF link that is the sole child of <p> with a wrapper div', () => {
+		const editor = createMockEditor('<p><a href="file:///a.pdf">a.pdf</a></p>');
+		embedPdfLinks(editor);
+		const body = editor.dom.doc.body;
+		expect(body.querySelector('p')).toBeNull();
+		const wrapper = body.querySelector('.joplin-pdf-embed-wrapper');
+		expect(wrapper).not.toBeNull();
+		expect(wrapper?.getAttribute('contenteditable')).toBe('false');
+		expect(wrapper?.getAttribute('data-joplin-restore-tag')).toBe('p');
+	});
 
-		test('preserves original inline styles on the anchor when restoring', () => {
-			const input =
-				'<div class="joplin-pdf-embed-wrapper">' +
-				'<iframe src="file:///a.pdf"></iframe>' +
-				'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="color:red;display:none">a.pdf</a>' +
-				'</div>';
-			const result = restorePdfEmbedsToLinks(input);
-			const doc = new DOMParser().parseFromString(result, 'text/html');
-			const anchor = doc.querySelector<HTMLAnchorElement>('a');
-			expect(anchor?.style.color).toBe('red');
-			expect(anchor?.style.display).toBe('');
-		});
+	test('embedPdfLinks: the wrapper contains a hidden anchor with original attributes', () => {
+		const editor = createMockEditor('<p><a href="file:///a.pdf" title="My PDF">a.pdf</a></p>');
+		embedPdfLinks(editor);
+		const hidden = editor.dom.doc.querySelector<HTMLAnchorElement>('a[data-joplin-pdf-hidden]');
+		expect(hidden).not.toBeNull();
+		expect(hidden?.getAttribute('title')).toBe('My PDF');
+		expect(hidden?.style.display).toBe('none');
+	});
+
+	test('embedPdfLinks: sets restore-tag to "inline" when anchor has sibling text content', () => {
+		const editor = createMockEditor('<p>See <a href="file:///a.pdf">a.pdf</a> here</p>');
+		embedPdfLinks(editor);
+		expect(editor.dom.doc.querySelector('p')).not.toBeNull();
+		const wrapper = editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper');
+		expect(wrapper).not.toBeNull();
+		expect(wrapper?.getAttribute('data-joplin-restore-tag')).toBe('inline');
+	});
+
+	test('embedPdfLinks: does not double-wrap an already-wrapped anchor', () => {
+		const editor = createMockEditor(
+			'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false">' +
+			'<iframe src="file:///a.pdf"></iframe>' +
+			'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+			'</div>',
+		);
+		embedPdfLinks(editor);
+		const wrappers = editor.dom.doc.querySelectorAll('.joplin-pdf-embed-wrapper');
+		expect(wrappers.length).toBe(1);
+	});
+
+	test('embedPdfLinks: leaves non-PDF links untouched', () => {
+		const original = '<p><a href="file:///image.png">image</a></p>';
+		const editor = createMockEditor(original);
+		embedPdfLinks(editor);
+		expect(editor.dom.doc.body.innerHTML).toBe(original);
+	});
+
+	test('embedPdfLinks: replaces a PDF link that is the sole child of <h2> and stores restore-tag', () => {
+		const editor = createMockEditor('<h2><a href="file:///a.pdf">a.pdf</a></h2>');
+		embedPdfLinks(editor);
+		expect(editor.dom.doc.querySelector('h2')).toBeNull();
+		const wrapper = editor.dom.doc.querySelector('.joplin-pdf-embed-wrapper');
+		expect(wrapper).not.toBeNull();
+		expect(wrapper?.getAttribute('data-joplin-restore-tag')).toBe('h2');
+	});
+
+	test('ensureTrailingEditableParagraph: appends a sentinel <p> when the last element is a joplin-editable block', () => {
+		const editor = createMockEditor(
+			'<div class="joplin-editable joplin-pdf-embed-wrapper" contenteditable="false"></div>',
+		);
+		ensureTrailingEditableParagraph(editor);
+		const last = editor.dom.doc.body.lastElementChild;
+		expect(last?.tagName).toBe('P');
+		expect(last?.getAttribute('data-joplin-cursor-spacer')).toBe('true');
+	});
+
+	test('ensureTrailingEditableParagraph: does nothing when the last element is already editable', () => {
+		const editor = createMockEditor('<p>Some text</p>');
+		ensureTrailingEditableParagraph(editor);
+		expect(editor.dom.doc.body.children.length).toBe(1);
+	});
+
+	test('ensureTrailingEditableParagraph: does nothing on an empty body', () => {
+		const editor = createMockEditor('');
+		ensureTrailingEditableParagraph(editor);
+		expect(editor.dom.doc.body.children.length).toBe(0);
+	});
+
+	test('restorePdfEmbedsToLinks: restores a block wrapper to its original tag', () => {
+		const input =
+			'<div class="joplin-pdf-embed-wrapper" data-joplin-restore-tag="p">' +
+			'<iframe src="file:///a.pdf"></iframe>' +
+			'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+			'</div>';
+		const result = restorePdfEmbedsToLinks(input);
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		expect(doc.querySelector('.joplin-pdf-embed-wrapper')).toBeNull();
+		const anchor = doc.querySelector<HTMLAnchorElement>('p > a');
+		expect(anchor).not.toBeNull();
+		expect(anchor?.getAttribute('href')).toBe('file:///a.pdf');
+		expect(anchor?.hasAttribute('data-joplin-pdf-hidden')).toBe(false);
+		expect(anchor?.style.display).toBe('');
+	});
+
+	test('restorePdfEmbedsToLinks: restores an h2 wrapper back to <h2>', () => {
+		const input =
+			'<div class="joplin-pdf-embed-wrapper" data-joplin-restore-tag="h2">' +
+			'<iframe src="file:///a.pdf"></iframe>' +
+			'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+			'</div>';
+		const result = restorePdfEmbedsToLinks(input);
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		expect(doc.querySelector('.joplin-pdf-embed-wrapper')).toBeNull();
+		const anchor = doc.querySelector<HTMLAnchorElement>('h2 > a');
+		expect(anchor).not.toBeNull();
+		expect(anchor?.getAttribute('href')).toBe('file:///a.pdf');
+	});
+
+	test('restorePdfEmbedsToLinks: restores an inline wrapper back to a bare anchor', () => {
+		const input =
+			'<p>See </p>' +
+			'<div class="joplin-pdf-embed-wrapper" data-joplin-restore-tag="inline">' +
+			'<iframe src="file:///a.pdf"></iframe>' +
+			'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="display:none">a.pdf</a>' +
+			'</div>' +
+			'<p> here</p>';
+		const result = restorePdfEmbedsToLinks(input);
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		expect(doc.querySelector('.joplin-pdf-embed-wrapper')).toBeNull();
+		// The anchor replaces the wrapper in-place — it becomes a direct body child.
+		const anchor = doc.querySelector<HTMLAnchorElement>('body > a');
+		expect(anchor).not.toBeNull();
+		expect(anchor?.getAttribute('href')).toBe('file:///a.pdf');
+	});
+
+	test('restorePdfEmbedsToLinks: removes an empty cursor-spacer paragraph', () => {
+		const result = restorePdfEmbedsToLinks('<p data-joplin-cursor-spacer="true"><br></p>');
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
+		expect(doc.body.innerHTML.trim()).toBe('');
+	});
+
+	test('restorePdfEmbedsToLinks: keeps a spacer paragraph that has user content, stripping only the attribute', () => {
+		const result = restorePdfEmbedsToLinks(
+			'<p data-joplin-cursor-spacer="true">User typed this</p>',
+		);
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		expect(doc.querySelector('[data-joplin-cursor-spacer]')).toBeNull();
+		expect(doc.body.textContent).toContain('User typed this');
+	});
+
+	test('restorePdfEmbedsToLinks: leaves unrelated HTML unchanged', () => {
+		const input = '<p>Hello <strong>world</strong></p>';
+		expect(restorePdfEmbedsToLinks(input)).toBe(input);
+	});
+
+	test('restorePdfEmbedsToLinks: preserves original inline styles on the anchor when restoring', () => {
+		const input =
+			'<div class="joplin-pdf-embed-wrapper" data-joplin-restore-tag="p">' +
+			'<iframe src="file:///a.pdf"></iframe>' +
+			'<a href="file:///a.pdf" data-joplin-pdf-hidden="true" style="color:red;display:none">a.pdf</a>' +
+			'</div>';
+		const result = restorePdfEmbedsToLinks(input);
+		const doc = new DOMParser().parseFromString(result, 'text/html');
+		const anchor = doc.querySelector<HTMLAnchorElement>('a');
+		expect(anchor?.style.color).toBe('red');
+		expect(anchor?.style.display).toBe('');
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.test.ts
@@ -105,6 +105,24 @@ describe('embedPdf', () => {
 		expect(last?.getAttribute('data-joplin-cursor-spacer')).toBe('true');
 	});
 
+	test('ensureTrailingEditableParagraph: appends a sentinel <p> when the wrapper is the last child of a block element', () => {
+		const editor = createMockEditor('');
+		const doc = editor.dom.doc;
+		const p = doc.createElement('p');
+		p.appendChild(doc.createTextNode('Some text'));
+		p.appendChild(doc.createElement('br'));
+		const wrapper = doc.createElement('div');
+		wrapper.className = 'joplin-editable joplin-pdf-embed-wrapper';
+		wrapper.setAttribute('contenteditable', 'false');
+		p.appendChild(wrapper);
+		doc.body.appendChild(p);
+
+		ensureTrailingEditableParagraph(editor);
+		const last = doc.body.lastElementChild;
+		expect(last?.tagName).toBe('P');
+		expect(last?.getAttribute('data-joplin-cursor-spacer')).toBe('true');
+	});
+
 	test('ensureTrailingEditableParagraph: does nothing when the last element is already editable', () => {
 		const editor = createMockEditor('<p>Some text</p>');
 		ensureTrailingEditableParagraph(editor);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
@@ -18,7 +18,6 @@ export const embedPdfLinks = (editorInstance: Editor): void => {
 	for (const anchor of doc.querySelectorAll<HTMLAnchorElement>('a[href]')) {
 		const href = anchor.getAttribute('href');
 		if (!href || !isPdfUrl(href)) continue;
-		// Guard against double-wrapping when SetContent fires more than once.
 		if (anchor.closest('.joplin-pdf-embed-wrapper')) continue;
 
 		const wrapper = doc.createElement('div');
@@ -53,8 +52,10 @@ export const embedPdfLinks = (editorInstance: Editor): void => {
 			);
 
 		if (isOnlyChildOfBlock && parent.parentNode) {
+			wrapper.setAttribute('data-joplin-restore-tag', parent.tagName.toLowerCase());
 			parent.parentNode.replaceChild(wrapper, parent);
 		} else {
+			wrapper.setAttribute('data-joplin-restore-tag', 'inline');
 			anchor.parentNode?.replaceChild(wrapper, anchor);
 		}
 	}
@@ -78,10 +79,10 @@ export const ensureTrailingEditableParagraph = (editorInstance: Editor): void =>
 	body.appendChild(p);
 };
 
-// Reverses embedPdfLinks before save. Re-wraps the recovered anchor in <p>
-// because embedPdfLinks replaced the whole parent <p> with the wrapper div.
-// Empty cursor-spacer paragraphs from ensureTrailingEditableParagraph are
-// removed; non-empty ones have only their sentinel attribute stripped.
+// Reverses embedPdfLinks before save. Restores the anchor into the original
+// block element (stored in data-joplin-restore-tag) or inline if the anchor
+// had siblings. Empty cursor-spacer paragraphs are removed; non-empty ones
+// have only their sentinel attribute stripped.
 export const restorePdfEmbedsToLinks = (html: string): string => {
 	const parser = new DOMParser();
 	const doc = parser.parseFromString(html, 'text/html');
@@ -94,9 +95,14 @@ export const restorePdfEmbedsToLinks = (html: string): string => {
 		if (!hiddenAnchor.getAttribute('style')) {
 			hiddenAnchor.removeAttribute('style');
 		}
-		const p = doc.createElement('p');
-		p.appendChild(hiddenAnchor);
-		wrapper.parentNode.replaceChild(p, wrapper);
+		const restoreTag = wrapper.getAttribute('data-joplin-restore-tag') ?? 'p';
+		if (restoreTag === 'inline') {
+			wrapper.parentNode.replaceChild(hiddenAnchor, wrapper);
+		} else {
+			const block = doc.createElement(restoreTag);
+			block.appendChild(hiddenAnchor);
+			wrapper.parentNode.replaceChild(block, wrapper);
+		}
 	}
 
 	for (const spacer of doc.querySelectorAll<HTMLElement>('[data-joplin-cursor-spacer]')) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
@@ -1,0 +1,114 @@
+import type { Editor } from 'tinymce';
+
+export const isPdfUrl = (url: string): boolean => {
+	try {
+		return new URL(url).pathname.toLowerCase().endsWith('.pdf');
+	} catch {
+		// URL constructor rejects relative paths and some resource URIs —
+		// fall back to a plain string check.
+		return url.toLowerCase().split('?')[0].split('#')[0].endsWith('.pdf');
+	}
+};
+
+// Transforms <a href="...pdf"> links into non-editable iframe wrappers for
+// inline rendering. A hidden <a> is preserved inside the wrapper so that
+// restorePdfEmbedsToLinks can reconstruct the original link on save.
+export const embedPdfLinks = (editorInstance: Editor): void => {
+	const doc = editorInstance.dom.doc;
+	for (const anchor of doc.querySelectorAll<HTMLAnchorElement>('a[href]')) {
+		const href = anchor.getAttribute('href');
+		if (!href || !isPdfUrl(href)) continue;
+		// Guard against double-wrapping when SetContent fires more than once.
+		if (anchor.closest('.joplin-pdf-embed-wrapper')) continue;
+
+		const wrapper = doc.createElement('div');
+		wrapper.className = 'joplin-editable joplin-pdf-embed-wrapper';
+		wrapper.setAttribute('contenteditable', 'false');
+
+		const iframe = doc.createElement('iframe');
+		iframe.src = href;
+		iframe.className = 'joplin-pdf-embed';
+		iframe.setAttribute('width', '100%');
+		iframe.setAttribute('height', '500');
+		iframe.style.cssText = 'border:none;display:block;';
+
+		const hiddenAnchor = anchor.cloneNode(true) as HTMLAnchorElement;
+		hiddenAnchor.setAttribute('data-joplin-pdf-hidden', 'true');
+		hiddenAnchor.style.display = 'none';
+
+		wrapper.appendChild(iframe);
+		wrapper.appendChild(hiddenAnchor);
+
+		// Replace the parent block rather than just the anchor to avoid
+		// producing <p><div>...</div></p>, which is invalid HTML and
+		// causes TinyMCE to misplace the caret.
+		const parent = anchor.parentElement;
+		const blockTags = ['P', 'LI', 'TD', 'TH', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'DD', 'DT', 'CAPTION'];
+		const isOnlyChildOfBlock =
+			parent !== null &&
+			blockTags.includes(parent.tagName) &&
+			Array.from(parent.childNodes).every(
+				n => n === anchor ||
+					(n.nodeType === Node.TEXT_NODE && !n.textContent?.trim()),
+			);
+
+		if (isOnlyChildOfBlock && parent.parentNode) {
+			parent.parentNode.replaceChild(wrapper, parent);
+		} else {
+			anchor.parentNode?.replaceChild(wrapper, anchor);
+		}
+	}
+};
+
+// Appends a sentinel <p> when the last element in the editor body is a
+// non-editable block, so TinyMCE always has a valid caret target below the
+// last embed.
+export const ensureTrailingEditableParagraph = (editorInstance: Editor): void => {
+	const body = editorInstance.dom.doc.body;
+	if (!body) return;
+	const lastChild = body.lastElementChild;
+	if (!lastChild) return;
+	const isNonEditable =
+		lastChild.classList.contains('joplin-editable') ||
+		lastChild.getAttribute('contenteditable') === 'false';
+	if (!isNonEditable) return;
+	const p = editorInstance.dom.doc.createElement('p');
+	p.setAttribute('data-joplin-cursor-spacer', 'true');
+	p.appendChild(editorInstance.dom.doc.createElement('br'));
+	body.appendChild(p);
+};
+
+// Reverses embedPdfLinks before save. Re-wraps the recovered anchor in <p>
+// because embedPdfLinks replaced the whole parent <p> with the wrapper div.
+// Empty cursor-spacer paragraphs from ensureTrailingEditableParagraph are
+// removed; non-empty ones have only their sentinel attribute stripped.
+export const restorePdfEmbedsToLinks = (html: string): string => {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(html, 'text/html');
+
+	for (const wrapper of doc.querySelectorAll('.joplin-pdf-embed-wrapper')) {
+		const hiddenAnchor = wrapper.querySelector<HTMLAnchorElement>('a[data-joplin-pdf-hidden]');
+		if (!hiddenAnchor || !wrapper.parentNode) continue;
+		hiddenAnchor.removeAttribute('data-joplin-pdf-hidden');
+		hiddenAnchor.style.removeProperty('display');
+		if (!hiddenAnchor.getAttribute('style')) {
+			hiddenAnchor.removeAttribute('style');
+		}
+		const p = doc.createElement('p');
+		p.appendChild(hiddenAnchor);
+		wrapper.parentNode.replaceChild(p, wrapper);
+	}
+
+	for (const spacer of doc.querySelectorAll<HTMLElement>('[data-joplin-cursor-spacer]')) {
+		spacer.removeAttribute('data-joplin-cursor-spacer');
+		const hasOnlyBr =
+			!spacer.textContent?.trim() &&
+			(spacer.children.length === 0 ||
+				(spacer.children.length === 1 && spacer.children[0].tagName === 'BR'));
+		if (hasOnlyBr) {
+			spacer.parentNode?.removeChild(spacer);
+		}
+	}
+
+	return doc.body.innerHTML;
+};

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
@@ -10,6 +10,11 @@ export const isPdfUrl = (url: string): boolean => {
 	}
 };
 
+const toContentProtocolUrl = (href: string): string => {
+	if (!href.startsWith('file://')) return href;
+	return `joplin-content://note-viewer${new URL(href).pathname}`;
+};
+
 // Transforms <a href="...pdf"> links into non-editable iframe wrappers for
 // inline rendering. A hidden <a> is preserved inside the wrapper so that
 // restorePdfEmbedsToLinks can reconstruct the original link on save.
@@ -25,7 +30,7 @@ export const embedPdfLinks = (editorInstance: Editor): void => {
 		wrapper.setAttribute('contenteditable', 'false');
 
 		const iframe = doc.createElement('iframe');
-		iframe.src = href;
+		iframe.src = toContentProtocolUrl(href);
 		iframe.className = 'joplin-pdf-embed';
 		iframe.setAttribute('width', '100%');
 		iframe.setAttribute('height', '500');

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/embedPdf.ts
@@ -74,10 +74,19 @@ export const ensureTrailingEditableParagraph = (editorInstance: Editor): void =>
 	if (!body) return;
 	const lastChild = body.lastElementChild;
 	if (!lastChild) return;
-	const isNonEditable =
-		lastChild.classList.contains('joplin-editable') ||
-		lastChild.getAttribute('contenteditable') === 'false';
-	if (!isNonEditable) return;
+
+	const isNonEditable = (el: Element): boolean =>
+		el.classList.contains('joplin-editable') ||
+		el.getAttribute('contenteditable') === 'false';
+
+	// The wrapper may be a direct body child, or nested inside a block when the
+	// PDF link had sibling content (e.g. <p>text<br><div wrapper></div></p>).
+	const needsSentinel =
+		isNonEditable(lastChild) ||
+		(lastChild.lastElementChild !== null && isNonEditable(lastChild.lastElementChild));
+
+	if (!needsSentinel) return;
+
 	const p = editorInstance.dom.doc.createElement('p');
 	p.setAttribute('data-joplin-cursor-spacer', 'true');
 	p.appendChild(editorInstance.dom.doc.createElement('br'));

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -8,7 +8,7 @@
 				default-src 'self' joplin-content://* ;
 				connect-src 'self' * http://* https://* joplin-content://* blob: ;
 				style-src 'unsafe-inline' 'self' blob: joplin-content://* https://* http://* ;
-				child-src 'self' joplin-content://* https://*.youtube.com https://*.youtube-nocookie.com ;
+				child-src 'self' joplin-content://* https://*.youtube.com https://*.youtube-nocookie.com file: ;
 				script-src 'self' joplin-plugin://* joplin-content://* ;
 				media-src 'self' * blob: data: https://* http://* joplin-content://* ;
 				img-src 'self' blob: data: http://* https://* joplin-content://* ;

--- a/packages/app-desktop/index.html
+++ b/packages/app-desktop/index.html
@@ -8,7 +8,7 @@
 				default-src 'self' joplin-content://* ;
 				connect-src 'self' * http://* https://* joplin-content://* blob: ;
 				style-src 'unsafe-inline' 'self' blob: joplin-content://* https://* http://* ;
-				child-src 'self' joplin-content://* https://*.youtube.com https://*.youtube-nocookie.com file: ;
+				child-src 'self' joplin-content://* https://*.youtube.com https://*.youtube-nocookie.com ;
 				script-src 'self' joplin-plugin://* joplin-content://* ;
 				media-src 'self' * blob: data: https://* http://* joplin-content://* ;
 				img-src 'self' blob: data: http://* https://* joplin-content://* ;

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -281,5 +281,49 @@ test.describe('richTextEditor', () => {
 		await expect(editorBody).toHaveText('');
 	});
 
-});
+	test('should render PDF attachments inline and round-trip back to markdown correctly', async ({ electronApp, mainWindow }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('PDF embed test');
+		const editor = mainScreen.noteEditor;
 
+		await editor.focusCodeMirrorEditor();
+		await setFilePickerResponse(electronApp, [join(__dirname, 'resources', 'small-pdf.pdf')]);
+		await editor.attachFileButton.click();
+
+		const resourceLinkExpression = /\[.*\]\(:\/(\w+)\)/;
+		await expect.poll(async () => editor.codeMirrorEditor.innerText()).toMatch(resourceLinkExpression);
+		const markdownBefore = await editor.codeMirrorEditor.innerText();
+		const resourceId = markdownBefore.match(resourceLinkExpression)[1];
+
+		await editor.toggleEditorsButton.click();
+		await editor.richTextEditor.waitFor();
+
+		const rteFrame = editor.getRichTextFrameLocator();
+
+		// The PDF link must be replaced with an iframe embed — not a plain link.
+		await rteFrame.locator('iframe.joplin-pdf-embed').waitFor();
+
+		// No raw <a href="...pdf"> (without the hidden marker) must be visible.
+		await expect(rteFrame.locator('a[href$=".pdf"]:not([data-joplin-pdf-hidden])')).not.toBeAttached();
+
+		// Click the spacer paragraph to position the cursor after the PDF.
+		const sentinelP = rteFrame.locator('p[data-joplin-cursor-spacer="true"]');
+		await sentinelP.click();
+		await mainWindow.keyboard.type('After PDF');
+
+		await expect(editor.getRichTextEditorBody()).toContainText('After PDF');
+
+		await editor.toggleEditorsButton.click();
+		await editor.codeMirrorEditor.waitFor();
+
+		await expect.poll(async () => editor.codeMirrorEditor.innerText()).toContain('After PDF');
+
+		const markdownAfter = await editor.codeMirrorEditor.innerText();
+
+		expect(markdownAfter).toContain(`:/${resourceId}`);
+		expect(markdownAfter).not.toContain('<iframe');
+		expect(markdownAfter).not.toContain('data-joplin-pdf-hidden');
+		expect(markdownAfter).not.toContain('joplin-pdf-embed');
+		expect(markdownAfter).toContain('After PDF');
+	});
+});

--- a/packages/app-desktop/integration-tests/richTextEditor.spec.ts
+++ b/packages/app-desktop/integration-tests/richTextEditor.spec.ts
@@ -304,7 +304,7 @@ test.describe('richTextEditor', () => {
 		await rteFrame.locator('iframe.joplin-pdf-embed').waitFor();
 
 		// No raw <a href="...pdf"> (without the hidden marker) must be visible.
-		await expect(rteFrame.locator('a[href$=".pdf"]:not([data-joplin-pdf-hidden])')).not.toBeAttached();
+		await expect(rteFrame.locator(`a[href=":/${resourceId}"]:not([data-joplin-pdf-hidden])`)).not.toBeAttached();
 
 		// Click the spacer paragraph to position the cursor after the PDF.
 		const sentinelP = rteFrame.locator('p[data-joplin-cursor-spacer="true"]');


### PR DESCRIPTION
Fixes: #8277

AI Disclosure:
AI was used to assist during the development of this PR. It helped identify edge cases in the PDF embed logic, debug Playwright test issues, and review the correctness of the embed/restore functions. All suggestions were reviewed, tested, and verified.

PDF attachments now render as embedded viewers in the Rich Text Editor(RTE), matching the existing behaviour in the Markdown preview pane.

Before: A PDF attachment appeared as a plain link in the RTE.
After: It renders as an inline PDF viewer.

When a note opens in the RTE, any PDF link is swapped out for an <iframe> so it renders inline. The original link is kept hidden inside the wrapper. When the note is saved, the <iframe> is swapped back for the original link before the Markdown is written, so the Markdown source never changes.

video
https://github.com/user-attachments/assets/711a3196-dd55-4101-888a-d627350c7c12

Testing
- 22 unit tests covering embed, restore, and edge cases
- 1 integration test
