### PR TITLE
Mobile: Add ability to set per notebook sorting on mobile

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -608,10 +608,6 @@ packages/app-desktop/services/plugins/hooks/useViewIsReady.js
 packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js
 packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
-packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.js
-packages/app-desktop/services/sortOrder/PerFolderSortOrderService.js
-packages/app-desktop/services/sortOrder/notesSortOrderUtils.test.js
-packages/app-desktop/services/sortOrder/notesSortOrderUtils.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/bundleJs.js
 packages/app-desktop/tools/copy7Zip.js
@@ -1673,6 +1669,10 @@ packages/lib/services/share/ShareService.test.js
 packages/lib/services/share/ShareService.js
 packages/lib/services/share/invitationRespond.js
 packages/lib/services/share/reducer.js
+packages/lib/services/sortOrder/PerFolderSortOrderService.test.js
+packages/lib/services/sortOrder/PerFolderSortOrderService.js
+packages/lib/services/sortOrder/notesSortOrderUtils.test.js
+packages/lib/services/sortOrder/notesSortOrderUtils.js
 packages/lib/services/spellChecker/SpellCheckerService.js
 packages/lib/services/spellChecker/SpellCheckerServiceDriverBase.js
 packages/lib/services/style/cssToTheme.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -581,10 +581,6 @@ packages/app-desktop/services/plugins/hooks/useViewIsReady.js
 packages/app-desktop/services/plugins/hooks/useWebviewToPluginMessages.js
 packages/app-desktop/services/plugins/types.js
 packages/app-desktop/services/restart.js
-packages/app-desktop/services/sortOrder/PerFolderSortOrderService.test.js
-packages/app-desktop/services/sortOrder/PerFolderSortOrderService.js
-packages/app-desktop/services/sortOrder/notesSortOrderUtils.test.js
-packages/app-desktop/services/sortOrder/notesSortOrderUtils.js
 packages/app-desktop/services/spellChecker/SpellCheckerServiceDriverNative.js
 packages/app-desktop/tools/bundleJs.js
 packages/app-desktop/tools/copy7Zip.js
@@ -1646,6 +1642,10 @@ packages/lib/services/share/ShareService.test.js
 packages/lib/services/share/ShareService.js
 packages/lib/services/share/invitationRespond.js
 packages/lib/services/share/reducer.js
+packages/lib/services/sortOrder/PerFolderSortOrderService.test.js
+packages/lib/services/sortOrder/PerFolderSortOrderService.js
+packages/lib/services/sortOrder/notesSortOrderUtils.test.js
+packages/lib/services/sortOrder/notesSortOrderUtils.js
 packages/lib/services/spellChecker/SpellCheckerService.js
 packages/lib/services/spellChecker/SpellCheckerServiceDriverBase.js
 packages/lib/services/style/cssToTheme.test.js

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -43,7 +43,7 @@ const electronContextMenu = require('./services/electron-context-menu');
 // Commands that are not tied to any particular component.
 // The runtime for these commands can be loaded when the app starts.
 
-import PerFolderSortOrderService from './services/sortOrder/PerFolderSortOrderService';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 import ShareService from '@joplin/lib/services/share/ShareService';
 import checkForUpdates from './checkForUpdates';
 import { AppState } from './app.reducer';

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -6,7 +6,7 @@ import Button, { ButtonLevel, ButtonSize, buttonSizePx } from '../Button/Button'
 import CommandService from '@joplin/lib/services/CommandService';
 import { runtime as focusSearchRuntime } from './commands/focusSearch';
 import Note from '@joplin/lib/models/Note';
-import { notesSortOrderNextField } from '../../services/sortOrder/notesSortOrderUtils';
+import { notesSortOrderNextField } from '@joplin/lib/services/sortOrder/notesSortOrderUtils';
 import { _ } from '@joplin/lib/locale';
 import { connect } from 'react-redux';
 import styled from 'styled-components';

--- a/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/hooks/useOnRenderItem.tsx
@@ -18,7 +18,7 @@ import { FolderEntity } from '@joplin/lib/services/database/types';
 import InteropService from '@joplin/lib/services/interop/InteropService';
 import InteropServiceHelper from '../../../InteropServiceHelper';
 import Setting from '@joplin/lib/models/Setting';
-import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSortOrderService';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 import { getFolderCallbackUrl, getTagCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import { PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import { MenuItemLocation } from '@joplin/lib/services/plugins/api/types';

--- a/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
+++ b/packages/app-desktop/gui/Sidebar/listItemComponents/AllNotesItem.tsx
@@ -6,7 +6,7 @@ import bridge from '../../../services/bridge';
 import Setting from '@joplin/lib/models/Setting';
 import MenuUtils from '@joplin/lib/services/commands/MenuUtils';
 import CommandService from '@joplin/lib/services/CommandService';
-import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSortOrderService';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 import { connect } from 'react-redux';
 import EmptyExpandLink from './EmptyExpandLink';
 import ListItemWrapper, { ItemSelectionState, ListItemRef } from './ListItemWrapper';

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderField.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderField.ts
@@ -1,5 +1,5 @@
 import { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
-import { setNotesSortOrder } from '../../../services/sortOrder/notesSortOrderUtils';
+import { setNotesSortOrder } from '@joplin/lib/services/sortOrder/notesSortOrderUtils';
 import { _ } from '@joplin/lib/locale';
 
 export const declaration: CommandDeclaration = {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderReverse.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/toggleNotesSortOrderReverse.ts
@@ -1,7 +1,7 @@
 import { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
 import Setting from '@joplin/lib/models/Setting';
 import { _ } from '@joplin/lib/locale';
-import { setNotesSortOrder } from '../../../services/sortOrder/notesSortOrderUtils';
+import { setNotesSortOrder } from '@joplin/lib/services/sortOrder/notesSortOrderUtils';
 
 export const declaration: CommandDeclaration = {
 	name: 'toggleNotesSortOrderReverse',

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/togglePerFolderSortOrder.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/togglePerFolderSortOrder.ts
@@ -1,6 +1,6 @@
 import { CommandContext, CommandDeclaration, CommandRuntime } from '@joplin/lib/services/CommandService';
 import { _ } from '@joplin/lib/locale';
-import PerFolderSortOrderService from '../../../services/sortOrder/PerFolderSortOrderService';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 
 export const declaration: CommandDeclaration = {
 	name: 'togglePerFolderSortOrder',

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -121,6 +121,10 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 
 		if (r.name === 'perFolderSortOrder') {
 			PerFolderSortOrderService.set(currentFolderId, r.value as boolean);
+		} else if (r.name === 'notes.sortOrder.field' || r.name === 'notes.sortOrder.reverse') {
+			Setting.setValue(r.name, r.value);
+			// Update the appropriate sort order storage based on whether per-folder sort is enabled
+			PerFolderSortOrderService.onSortOrderChange(currentFolderId);
 		} else {
 			Setting.setValue(r.name, r.value);
 		}

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -105,20 +105,21 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 		});
 
 		const showPerFolderToggle = this.shouldShowPerFolderSortToggle();
+		const currentFolderId = this.getCurrentFolderIdForSort();
+		const perFolderSortOrderIsSet = PerFolderSortOrderService.isSet(currentFolderId);
+
 		if (showPerFolderToggle) {
-			const currentFolderId = this.getCurrentFolderIdForSort();
-			const isSet = PerFolderSortOrderService.isSet(currentFolderId);
 			buttons.push({
 				text: `[ ${_('Use own sort order')} ]`,
-				checked: isSet,
-				id: { name: 'perFolderSortOrder', value: !isSet },
+				checked: perFolderSortOrderIsSet,
+				id: { name: 'perFolderSortOrder', value: !perFolderSortOrderIsSet },
 			});
 		}
 
 		const r = await this.props.dialogManager.showMenu(Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
 		if (!r) return;
 
-		if (showPerFolderToggle) {
+		if (showPerFolderToggle && perFolderSortOrderIsSet) {
 			const currentFolderId = this.getCurrentFolderIdForSort();
 			PerFolderSortOrderService.set(currentFolderId, r.value as boolean);
 		} else {

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -13,13 +13,15 @@ import { _ } from '@joplin/lib/locale';
 import { BaseScreenComponent } from '../../base-screen';
 import { AppState } from '../../../utils/types';
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
-import { itemIsInTrash } from '@joplin/lib/services/trash';
+import { getTrashFolderId, itemIsInTrash } from '@joplin/lib/services/trash';
 import AccessibleView from '../../accessibility/AccessibleView';
 import { Dispatch } from 'redux';
 import { DialogContext, DialogControl } from '../../DialogManager';
 import { useContext } from 'react';
 import { MenuChoice } from '../../DialogManager/types';
 import NewNoteButton from './NewNoteButton';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
+const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
 
 interface Props {
 	dispatch: Dispatch;
@@ -70,7 +72,7 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 	};
 
 	private sortButton_press = async () => {
-		type IdType = { name: string; value: string|boolean };
+		type IdType = { name: string; value: string|boolean; isPerFolderToggle?: boolean };
 		const buttons: MenuChoice<IdType>[] = [];
 		const sortNoteOptions = Setting.enumOptions('notes.sortOrder.field');
 
@@ -102,11 +104,62 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 			id: { name: 'showCompletedTodos', value: !Setting.value('showCompletedTodos') },
 		});
 
+		// Show "use own sort order" toggle for folders and the All Notes smart filter,
+		// but not for tags, conflicts folder, or trash folder.
+		const showPerFolderToggle = this.shouldShowPerFolderSortToggle();
+		if (showPerFolderToggle) {
+			const currentFolderId = this.getCurrentFolderIdForSort();
+			const isSet = PerFolderSortOrderService.isSet(currentFolderId);
+			buttons.push({
+				text: `[ ${_('Use own sort order')} ]`,
+				checked: isSet,
+				id: { name: 'perFolderSortOrder', value: !isSet, isPerFolderToggle: true },
+			});
+		}
+
 		const r = await this.props.dialogManager.showMenu(Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
 		if (!r) return;
 
-		Setting.setValue(r.name, r.value);
+		if (r.isPerFolderToggle) {
+			const currentFolderId = this.getCurrentFolderIdForSort();
+			PerFolderSortOrderService.set(currentFolderId, r.value as boolean);
+		} else {
+			Setting.setValue(r.name, r.value);
+		}
 	};
+
+	private shouldShowPerFolderSortToggle(): boolean {
+		// Only show for folders and the All Notes smart filter
+		// Don't show for tags, conflicts folder, or trash folder
+		if (this.props.notesParentType === 'Tag') {
+			return false;
+		}
+
+		if (this.props.notesParentType === 'Folder') {
+			const folderId = this.props.selectedFolderId;
+			// Don't show for conflicts folder or trash folder
+			if (folderId === Folder.conflictFolderId() || folderId === getTrashFolderId()) {
+				return false;
+			}
+			return true;
+		}
+
+		if (this.props.notesParentType === 'SmartFilter') {
+			// Only show for All Notes smart filter
+			return this.props.selectedSmartFilterId === ALL_NOTES_FILTER_ID;
+		}
+
+		return false;
+	}
+
+	private getCurrentFolderIdForSort(): string {
+		if (this.props.notesParentType === 'Folder') {
+			return this.props.selectedFolderId;
+		} else if (this.props.notesParentType === 'SmartFilter') {
+			return this.props.selectedSmartFilterId;
+		}
+		return '';
+	}
 
 	public styles() {
 		if (!this.styles_) this.styles_ = {};

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -106,21 +106,20 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 
 		const showPerFolderToggle = this.shouldShowPerFolderSortToggle();
 		const currentFolderId = this.getCurrentFolderIdForSort();
-		const perFolderSortOrderIsSet = PerFolderSortOrderService.isSet(currentFolderId);
 
 		if (showPerFolderToggle) {
+			const isSet = PerFolderSortOrderService.isSet(currentFolderId);
 			buttons.push({
 				text: `[ ${_('Use own sort order')} ]`,
-				checked: perFolderSortOrderIsSet,
-				id: { name: 'perFolderSortOrder', value: !perFolderSortOrderIsSet },
+				checked: isSet,
+				id: { name: 'perFolderSortOrder', value: !isSet },
 			});
 		}
 
 		const r = await this.props.dialogManager.showMenu(Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
 		if (!r) return;
 
-		if (showPerFolderToggle && perFolderSortOrderIsSet) {
-			const currentFolderId = this.getCurrentFolderIdForSort();
+		if (r.name === 'perFolderSortOrder') {
 			PerFolderSortOrderService.set(currentFolderId, r.value as boolean);
 		} else {
 			Setting.setValue(r.name, r.value);

--- a/packages/app-mobile/components/screens/Notes/Notes.tsx
+++ b/packages/app-mobile/components/screens/Notes/Notes.tsx
@@ -72,7 +72,7 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 	};
 
 	private sortButton_press = async () => {
-		type IdType = { name: string; value: string|boolean; isPerFolderToggle?: boolean };
+		type IdType = { name: string; value: string|boolean };
 		const buttons: MenuChoice<IdType>[] = [];
 		const sortNoteOptions = Setting.enumOptions('notes.sortOrder.field');
 
@@ -104,8 +104,6 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 			id: { name: 'showCompletedTodos', value: !Setting.value('showCompletedTodos') },
 		});
 
-		// Show "use own sort order" toggle for folders and the All Notes smart filter,
-		// but not for tags, conflicts folder, or trash folder.
 		const showPerFolderToggle = this.shouldShowPerFolderSortToggle();
 		if (showPerFolderToggle) {
 			const currentFolderId = this.getCurrentFolderIdForSort();
@@ -113,14 +111,14 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 			buttons.push({
 				text: `[ ${_('Use own sort order')} ]`,
 				checked: isSet,
-				id: { name: 'perFolderSortOrder', value: !isSet, isPerFolderToggle: true },
+				id: { name: 'perFolderSortOrder', value: !isSet },
 			});
 		}
 
 		const r = await this.props.dialogManager.showMenu(Setting.settingMetadata('notes.sortOrder.field').label(), buttons);
 		if (!r) return;
 
-		if (r.isPerFolderToggle) {
+		if (showPerFolderToggle) {
 			const currentFolderId = this.getCurrentFolderIdForSort();
 			PerFolderSortOrderService.set(currentFolderId, r.value as boolean);
 		} else {
@@ -128,25 +126,17 @@ class NotesScreenComponent extends BaseScreenComponent<ComponentProps, State> {
 		}
 	};
 
+	// Show "use own sort order" toggle for folders and the All Notes smart filter,
+	// but not for tags, conflicts folder, or trash folder.
 	private shouldShowPerFolderSortToggle(): boolean {
-		// Only show for folders and the All Notes smart filter
-		// Don't show for tags, conflicts folder, or trash folder
-		if (this.props.notesParentType === 'Tag') {
-			return false;
+		const { notesParentType, selectedFolderId, selectedSmartFilterId } = this.props;
+
+		if (notesParentType === 'Folder') {
+			return selectedFolderId !== Folder.conflictFolderId() && selectedFolderId !== getTrashFolderId();
 		}
 
-		if (this.props.notesParentType === 'Folder') {
-			const folderId = this.props.selectedFolderId;
-			// Don't show for conflicts folder or trash folder
-			if (folderId === Folder.conflictFolderId() || folderId === getTrashFolderId()) {
-				return false;
-			}
-			return true;
-		}
-
-		if (this.props.notesParentType === 'SmartFilter') {
-			// Only show for All Notes smart filter
-			return this.props.selectedSmartFilterId === ALL_NOTES_FILTER_ID;
+		if (notesParentType === 'SmartFilter') {
+			return selectedSmartFilterId === ALL_NOTES_FILTER_ID;
 		}
 
 		return false;

--- a/packages/app-mobile/utils/buildStartupTasks.ts
+++ b/packages/app-mobile/utils/buildStartupTasks.ts
@@ -92,6 +92,7 @@ import shim from '@joplin/lib/shim';
 import { Platform } from 'react-native';
 import VoiceTyping from '../services/voiceTyping/VoiceTyping';
 import whisper from '../services/voiceTyping/whisper';
+import PerFolderSortOrderService from '@joplin/lib/services/sortOrder/PerFolderSortOrderService';
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -389,6 +390,9 @@ const buildStartupTasks = (
 		});
 	});
 	addTask('buildStartupTasks/clear shared files cache', clearSharedFilesCache);
+	addTask('buildStartupTasks/initialize PerFolderSortOrderService', async () => {
+		PerFolderSortOrderService.initialize();
+	});
 	addTask('buildStartupTasks/go: initial route', async () => {
 		const folder = await getInitialActiveFolder();
 

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -900,7 +900,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			type: SettingItemType.Object,
 			section: 'folder',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'folders.sortOrder.field': {
 			value: 'title',

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -863,7 +863,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'note',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.perFieldReverse': {
 			value: {
@@ -876,7 +876,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'note',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.perFolderSortOrderEnabled': {
 			value: true,

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -884,7 +884,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'folder',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.perFolderSortOrders': {
 			value: {} as Record<string, string | boolean>,
@@ -892,7 +892,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			storage: SettingStorage.File,
 			section: 'folder',
 			public: false,
-			appTypes: [AppType.Cli, AppType.Desktop],
+			appTypes: [AppType.Cli, AppType.Desktop, AppType.Mobile],
 		},
 		'notes.sharedSortOrder': {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partially refactored old code from before rule was applied.

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.test.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.test.ts
@@ -1,17 +1,16 @@
 import PerFolderSortOrderService from './PerFolderSortOrderService';
 import { setNotesSortOrder } from './notesSortOrderUtils';
-import Setting from '@joplin/lib/models/Setting';
-import { AppState, createAppDefaultState } from '../../app.reducer';
-import { serializeNotesParent } from '@joplin/lib/reducer';
-import eventManager from '@joplin/lib/eventManager';
-const { shimInit } = require('@joplin/lib/shim-init-node.js');
-const { ALL_NOTES_FILTER_ID } = require('@joplin/lib/reserved-ids');
+import Setting from '../../models/Setting';
+import { defaultState, serializeNotesParent, State } from '../../reducer';
+import eventManager from '../../eventManager';
+const { shimInit } = require('../../shim-init-node.js');
+const { ALL_NOTES_FILTER_ID } = require('../../reserved-ids');
 
 const folderId1 = 'aa012345678901234567890123456789';
 const folderId2 = 'bb012345678901234567890123456789';
 
-let appState: AppState|null = null;
-const updateAppState = (update: Partial<AppState>) => {
+let appState: State = null;
+const updateAppState = (update: Partial<State>) => {
 	appState = { ...appState, ...update };
 	eventManager.appStateEmit(appState);
 };
@@ -40,7 +39,7 @@ describe('PerFolderSortOrderService', () => {
 	beforeEach(() => {
 		PerFolderSortOrderService.initialize();
 		Setting.setValue('notes.perFolderSortOrderEnabled', true);
-		updateAppState(createAppDefaultState({}));
+		updateAppState(defaultState);
 		switchToFolder(folderId1);
 	});
 	afterEach(() => {
@@ -157,7 +156,7 @@ describe('PerFolderSortOrderService', () => {
 		PerFolderSortOrderService.initialize();
 		Setting.setValue('notes.perFolderSortOrderEnabled', true);
 
-		updateAppState(createAppDefaultState({}));
+		updateAppState(defaultState);
 		switchToAllNotes();
 
 		// Navigating to the notebook must restore shared sort (title), not All Notes' sort

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
@@ -101,7 +101,15 @@ export default class PerFolderSortOrderService {
 		} else {
 			PerFolderSortOrderService.deletePerFolderSortOrder(targetId);
 			this.loadSharedSortOrder();
-			setNotesSortOrder(this.sharedSortOrder.field, this.sharedSortOrder.reverse);
+
+			const field = this.sharedSortOrder.field;
+			let reverse: boolean;
+			if (Setting.value('notes.perFieldReversalEnabled')) {
+				reverse = this.sharedSortOrder[field] as boolean;
+			} else {
+				reverse = this.sharedSortOrder.reverse;
+			}
+			setNotesSortOrder(field, reverse);
 		}
 	}
 

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
@@ -84,24 +84,29 @@ export default class PerFolderSortOrderService {
 			if (newOwn === targetOwn) return;
 		}
 		if (newOwn) {
-			let field: string, reverse: boolean;
-			if (!this.isSet(selectedId)) {
-				field = Setting.value('notes.sortOrder.field');
-				reverse = Setting.value('notes.sortOrder.reverse');
-			} else {
-				field = this.sharedSortOrder.field;
-				if (Setting.value('notes.perFieldReversalEnabled')) {
-					reverse = this.sharedSortOrder[field] as boolean;
-				} else {
-					reverse = this.sharedSortOrder.reverse;
-				}
-			}
+			const field = Setting.value('notes.sortOrder.field');
+			const reverse = Setting.value('notes.sortOrder.reverse');
+			this.setSharedSortOrder(field, reverse);
 			PerFolderSortOrderService.setPerFolderSortOrder(targetId, field, reverse);
 		} else {
 			PerFolderSortOrderService.deletePerFolderSortOrder(targetId);
+			this.loadSharedSortOrder();
+			setNotesSortOrder(this.sharedSortOrder.field, this.sharedSortOrder.reverse);
 		}
 	}
 
+	public static onSortOrderChange(folderId: string) {
+		if (!folderId) return;
+		const field = Setting.value('notes.sortOrder.field');
+		const reverse = Setting.value('notes.sortOrder.reverse');
+		if (this.isSet(folderId)) {
+			// Folder has per-folder sort enabled, update its entry
+			this.setPerFolderSortOrder(folderId, field, reverse);
+		} else {
+			// Folder uses shares sort, update the shared sort
+			this.setSharedSortOrder(field, reverse);
+		}
+	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static onFolderSelectionMayChange(cause: string, event: any) {

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
@@ -100,28 +100,33 @@ export default class PerFolderSortOrderService {
 			PerFolderSortOrderService.setPerFolderSortOrder(targetId, field, reverse);
 		} else {
 			PerFolderSortOrderService.deletePerFolderSortOrder(targetId);
-			this.loadSharedSortOrder();
+			if (targetId === selectedId) {
+				this.loadSharedSortOrder();
 
-			const field = this.sharedSortOrder.field;
-			let reverse: boolean;
-			if (Setting.value('notes.perFieldReversalEnabled')) {
-				reverse = this.sharedSortOrder[field] as boolean;
-			} else {
-				reverse = this.sharedSortOrder.reverse;
+				const field = this.sharedSortOrder.field;
+				let reverse: boolean;
+				if (Setting.value('notes.perFieldReversalEnabled')) {
+					reverse = this.sharedSortOrder[field] as boolean;
+				} else {
+					reverse = this.sharedSortOrder.reverse;
+				}
+				setNotesSortOrder(field, reverse);
 			}
-			setNotesSortOrder(field, reverse);
 		}
 	}
 
 	public static onSortOrderChange(folderId: string) {
-		if (!folderId) return;
 		const field = Setting.value('notes.sortOrder.field');
 		const reverse = Setting.value('notes.sortOrder.reverse');
+		if (!folderId) {
+			this.setSharedSortOrder(field, reverse);
+			return;
+		}
 		if (this.isSet(folderId)) {
 			// Folder has per-folder sort enabled, update its entry
 			this.setPerFolderSortOrder(folderId, field, reverse);
 		} else {
-			// Folder uses shares sort, update the shared sort
+			// Folder uses shared sort, update the shared sort
 			this.setSharedSortOrder(field, reverse);
 		}
 	}

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
@@ -1,7 +1,7 @@
-import Setting from '@joplin/lib/models/Setting';
-import eventManager from '@joplin/lib/eventManager';
+import Setting from '../../models/Setting';
+import eventManager from '../../eventManager';
 import { notesSortOrderFieldArray, setNotesSortOrder } from './notesSortOrderUtils';
-import { parseNotesParent } from '@joplin/lib/reducer';
+import { parseNotesParent } from '../../reducer';
 
 const SUFFIX_FIELD = '$field';
 const SUFFIX_REVERSE = '$reverse';

--- a/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
+++ b/packages/lib/services/sortOrder/PerFolderSortOrderService.ts
@@ -84,8 +84,18 @@ export default class PerFolderSortOrderService {
 			if (newOwn === targetOwn) return;
 		}
 		if (newOwn) {
-			const field = Setting.value('notes.sortOrder.field');
-			const reverse = Setting.value('notes.sortOrder.reverse');
+			let field: string, reverse: boolean;
+			if (!this.isSet(selectedId)) {
+				field = Setting.value('notes.sortOrder.field');
+				reverse = Setting.value('notes.sortOrder.reverse');
+			} else {
+				field = this.sharedSortOrder.field;
+				if (Setting.value('notes.perFieldReversalEnabled')) {
+					reverse = this.sharedSortOrder[field] as boolean;
+				} else {
+					reverse = this.sharedSortOrder.reverse;
+				}
+			}
 			this.setSharedSortOrder(field, reverse);
 			PerFolderSortOrderService.setPerFolderSortOrder(targetId, field, reverse);
 		} else {

--- a/packages/lib/services/sortOrder/notesSortOrderUtils.test.ts
+++ b/packages/lib/services/sortOrder/notesSortOrderUtils.test.ts
@@ -1,6 +1,6 @@
 import { notesSortOrderNextField, setNotesSortOrder } from './notesSortOrderUtils';
-import Setting from '@joplin/lib/models/Setting';
-const { shimInit } = require('@joplin/lib/shim-init-node.js');
+import Setting from '../../models/Setting';
+const { shimInit } = require('../../shim-init-node.js');
 
 describe('notesSortOrderUtils', () => {
 

--- a/packages/lib/services/sortOrder/notesSortOrderUtils.ts
+++ b/packages/lib/services/sortOrder/notesSortOrderUtils.ts
@@ -1,4 +1,4 @@
-import Setting from '@joplin/lib/models/Setting';
+import Setting from '../../models/Setting';
 
 let fields: string[] = null;
 let perFieldReverse: { [field: string]: boolean } = null;


### PR DESCRIPTION
The desktop app has the ability to set separate sorting for individual notebooks, which override the global sorting which has been set by the user. This is possible via the 'Toggle own sort order' context menu option when right clicking a notebook, and then changing the sorting field and / or direction with that notebook selected. This specific notebook sorting is only stored locally and is not synced to other clients (unlike note ordering when using the custom sort option). The mobile app currently lacks this feature, so this PR introduces the feature on mobile, to also allow local sorting overrides for individual notebooks.

A 'Use own sort order' toggle has been added to the sort note dialog available on the note list for eligible screens. When this has been set on a notebook, the sorting field and / or direction will be unaffected when changing the global sorting, but the last sorting options set for that notebook will be retained. The new sorting option is available for all notebooks (including trashed ones) and the all notes notebook, and is hidden for the trash, tags and the conflicts folder.

This availability of the option matches the desktop app, except it additionally allows toggling own sort order on trashed notebooks, which logically should be an option, given that the own sort order will still be effective if enabled before trashing the notebook.

<img width="250" height="897" alt="Capture" src="https://github.com/user-attachments/assets/6d10948b-7b36-45f1-aef0-dedf32c5595c" />

This is an improved version of https://github.com/laurent22/joplin/pull/14514, which reuses the existing PerFolderSortOrderService and adds the new toggle option to a more logical and discoverable location, also allowing own sort order to be used on the all notes notebook, like the desktop app allows.

### Testing

I tested adding and removing separate sorting to multiple notebooks (toggling the sorting field and reverse option) on the mobile app and retested the scenarios on the desktop app. I also verified the sort order persists after app restart and it works for trashed notebooks.

**Video on mobile:**

https://github.com/user-attachments/assets/d5236a93-fcb0-48aa-9689-572eb42e5bf6

**Video on desktop:**

https://github.com/user-attachments/assets/03e9bf93-c1f6-4b00-be72-95fdaf7d2a36

