### PR TITLE
Desktop: Fixes #14542: Fix Prevent unclosed frontmatter from breaking Markdown rendering

### DIFF
--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
@@ -54,15 +54,15 @@ describe('MarkdownFrontMatterExtension', () => {
 		expect(frontMatterNodes.length).toBe(0);
 	});
 
-	it('should not swallow document content when closing delimiter is missing (issue #14542)', async () => {
+	it('should treat the entire document as frontmatter when closing delimiter is missing (issue #14542)', async () => {
 		const documentText = '---\nsome: frontmatter\n--\n\n# Hey';
-		const editor = await createEditorState(documentText, ['ATXHeading1']);
+		const editor = await createEditorState(documentText, [frontMatterTagName]);
 		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
-		const headingNodes = findNodesWithName(editor, 'ATXHeading1');
 
-		expect(frontMatterNodes.length).toBe(0);
-		// The heading must be parsed as a proper ATX heading, not plain text
-		expect(headingNodes.length).toBe(1);
+		// Frontmatter block must be recognised and span the entire document
+		expect(frontMatterNodes.length).toBe(1);
+		expect(frontMatterNodes[0].from).toBe(0);
+		expect(frontMatterNodes[0].to).toBe(documentText.length);
 	});
 
 	it('should handle empty FrontMatter block', async () => {

--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.test.ts
@@ -54,6 +54,17 @@ describe('MarkdownFrontMatterExtension', () => {
 		expect(frontMatterNodes.length).toBe(0);
 	});
 
+	it('should not swallow document content when closing delimiter is missing (issue #14542)', async () => {
+		const documentText = '---\nsome: frontmatter\n--\n\n# Hey';
+		const editor = await createEditorState(documentText, ['ATXHeading1']);
+		const frontMatterNodes = findNodesWithName(editor, frontMatterTagName);
+		const headingNodes = findNodesWithName(editor, 'ATXHeading1');
+
+		expect(frontMatterNodes.length).toBe(0);
+		// The heading must be parsed as a proper ATX heading, not plain text
+		expect(headingNodes.length).toBe(1);
+	});
+
 	it('should handle empty FrontMatter block', async () => {
 		const documentText = '---\n---\n\n# Heading';
 		const editor = await createEditorState(documentText, [frontMatterTagName, 'ATXHeading1']);

--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
@@ -66,22 +66,15 @@ const frontMatterConfig: MarkdownConfig = {
 				return false;
 			}
 
-			// Store the opening delimiter position
+			// If the document starts with --- always claim it as a frontmatter block,
+			// even when the closing delimiter is absent.
 			const openingMarkerStart = cx.lineStart;
 			const openingMarkerEnd = cx.lineStart + line.text.length;
-
-			const contentStart = openingMarkerEnd + 1; // Start after the opening --- and newline
-
-			// Pre-scan raw input for closing - before consuming lines via cx.nextLine()
-			const input = (cx as unknown as { input: Input }).input;
-			const remainingText = input.read(contentStart, input.length);
-			if (!/^---\s*$/m.test(remainingText)) {
-				return false;
-			}
+			const contentStart = openingMarkerEnd + 1;
 
 			let foundEnd = false;
 
-			// Consume lines until we find the closing ---
+			// Consume lines until we find the closing --- or reach end of document.
 			while (cx.nextLine()) {
 				if (frontMatterDelimiterRegex.test(line.text)) {
 					foundEnd = true;
@@ -89,37 +82,34 @@ const frontMatterConfig: MarkdownConfig = {
 				}
 			}
 
-			if (!foundEnd) {
-				// No closing delimiter found - not a valid FrontMatter block
-				return false;
-			}
+			// cx.lineStart now points to the closing --- (if found) or end of document (if not).
+			const contentEnd = cx.lineStart;
 
-			// The content is between the two --- delimiters
-			const contentEnd = cx.lineStart; // Start of the closing --- line
-
-			// Closing delimiter positions
-			const closingMarkerStart = cx.lineStart;
-			const closingMarkerEnd = cx.lineStart + line.text.length;
-
-			// Create marker elements for the --- delimiters
 			const openingMarkerElem = cx.elt(frontMatterMarkerTagName, openingMarkerStart, openingMarkerEnd);
-			const closingMarkerElem = cx.elt(frontMatterMarkerTagName, closingMarkerStart, closingMarkerEnd);
-
-			// Create the content element (the YAML content between delimiters)
 			const contentElem = cx.elt(frontMatterContentTagName, contentStart, contentEnd);
 
-			// Create the container element spanning from start of first --- to end of last ---
-			const containerElement = cx.elt(
-				frontMatterTagName,
-				0, // Start at document beginning
-				closingMarkerEnd, // End after closing ---
-				[openingMarkerElem, contentElem, closingMarkerElem],
-			);
+			if (foundEnd) {
+				const closingMarkerStart = cx.lineStart;
+				const closingMarkerEnd = cx.lineStart + line.text.length;
+				const closingMarkerElem = cx.elt(frontMatterMarkerTagName, closingMarkerStart, closingMarkerEnd);
 
-			cx.addElement(containerElement);
-
-			// Move past the closing delimiter
-			cx.nextLine();
+				const containerElement = cx.elt(
+					frontMatterTagName,
+					0,
+					closingMarkerEnd,
+					[openingMarkerElem, contentElem, closingMarkerElem],
+				);
+				cx.addElement(containerElement);
+				cx.nextLine();
+			} else {
+				const containerElement = cx.elt(
+					frontMatterTagName,
+					0,
+					contentEnd,
+					[openingMarkerElem, contentElem],
+				);
+				cx.addElement(containerElement);
+			}
 
 			return true;
 		},

--- a/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownFrontMatterExtension.ts
@@ -71,6 +71,14 @@ const frontMatterConfig: MarkdownConfig = {
 			const openingMarkerEnd = cx.lineStart + line.text.length;
 
 			const contentStart = openingMarkerEnd + 1; // Start after the opening --- and newline
+
+			// Pre-scan raw input for closing - before consuming lines via cx.nextLine()
+			const input = (cx as unknown as { input: Input }).input;
+			const remainingText = input.read(contentStart, input.length);
+			if (!/^---\s*$/m.test(remainingText)) {
+				return false;
+			}
+
 			let foundEnd = false;
 
 			// Consume lines until we find the closing ---


### PR DESCRIPTION
Fixes: #14542

### Summary:
When a note contains only the opening frontmatter marker (---) but no proper closing marker, the CodeMirror Markdown editor rendered the rest of the document as plain text instead of applying Markdown formatting. This issue occurred because the `parse` function in the frontmatter extension consumed all lines after the opening --- while searching for a closing ---. If no closing marker was found, the parser returned false, but the consumed lines were not restored, leaving the rest of the document unformatted.

### Fix:
- Added a pre-scan of the raw input to check for a valid closing --- before consuming any lines. If no closing marker is found, the function now returns false immediately, ensuring that the rest of the document is not affected.

### Screenshot/Video:

https://github.com/user-attachments/assets/a775ac22-92ef-4990-a68e-2302ce658c7c

### Testing:
- Added a regression test to ensure that unclosed frontmatter does not break Markdown rendering.
- All existing tests continue to pass.

<img width="1255" height="437" alt="Screenshot From 2026-03-04 20-05-44" src="https://github.com/user-attachments/assets/108fc257-fbb2-4f92-812b-a31db85fd0a7" />


### AI Disclosure:
I used AI to write down the PR description and to help me write the test for the new changes introduced.