### PR TITLE
CI: Add concurrency block to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,6 +4,10 @@
 name: react-native-android-build-apk
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   AssembleRelease:
     if: github.repository == 'laurent22/joplin'

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -1,5 +1,10 @@
 name: Build macOS M1
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Main:
     # We always process desktop release tags, because they also publish the release

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -1,5 +1,10 @@
 name: Joplin Continuous Integration
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Main:
     # We always process server or desktop release tags, because they also publish the release

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,5 +1,10 @@
 name: Joplin UI tests
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
### Description
Fixes #14568
This PR adds concurrency blocks to the repository's heavy CI workflows. By doing this, GitHub Actions will automatically cancel any in-progress runs when a new commit is pushed to the same branch or PR. This ensures only the most recent commit is built and tested.
This provides the following benefits:
1. **Saves Organization CI Minutes:** Prevents the waste of runner minutes (especially on expensive M1 and Windows runners).
2. **Reduces Wait Times:** Clears the action queues faster so all contributors can receive quicker CI feedback.
3. No impact on differing branches because the concurrency configuration is scoped by `${{ github.workflow }}-${{ github.ref }}`.
The following files were updated:
- [.github/workflows/github-actions-main.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/github-actions-main.yml:0:0-0:0)
- [.github/workflows/ui-tests.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/ui-tests.yml:0:0-0:0)
- [.github/workflows/build-macos-m1.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/build-macos-m1.yml:0:0-0:0)
- [.github/workflows/build-android.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/build-android.yml:0:0-0:0)
### Testing
No application logic was altered. The testing comes from verifying that pushing multiple commits to this PR sequentially correctly cancels the older, outdated jobs in the Actions tab.