### PR TITLE
Mobile, Desktop: Resolves #9481: Start sync when app opens or resumes

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -6,7 +6,7 @@ const shim: typeof ShimType = require('@joplin/lib/shim').default;
 import { isCallbackUrl } from '@joplin/lib/callbackUrlUtils';
 import { FileLocker } from '@joplin/utils/fs';
 import { IpcMessageHandler, IpcServer, Message, newHttpError, sendMessage, SendMessageOptions, startServer, stopServer } from '@joplin/utils/ipc';
-import { BrowserWindow, Tray, WebContents, screen, App, nativeTheme } from 'electron';
+import { BrowserWindow, Tray, WebContents, screen, App, nativeTheme, powerMonitor } from 'electron';
 import bridge from './bridge';
 import * as url from 'url';
 const path = require('path');
@@ -400,6 +400,15 @@ export default class ElectronAppWrapper {
 			webContents.on('focus', onFocus);
 		};
 		addWindowEventHandlers(this.win_.webContents);
+
+		// BrowserWindow 'focus' fires when the OS gives focus to the application window
+		// (i.e. coming from another app or from the taskbar), not on intra-app focus switches.
+		// We use a dedicated IPC channel so the renderer can trigger an immediate sync on
+		// OS-level focus gain without conflating it with the 'window-focused' channel that
+		// handles Joplin-internal window routing.
+		this.win_.on('focus', () => {
+			this.win_?.webContents.send('main-window-focused');
+		});
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		this.win_.on('close', (event: any) => {
@@ -891,6 +900,11 @@ export default class ElectronAppWrapper {
 		this.electronApp_.on('open-url', (event: any, url: string) => {
 			event.preventDefault();
 			void this.openCallbackUrl(url);
+		});
+
+		// When the OS wakes from sleep, notify the renderer so it can trigger an immediate sync.
+		powerMonitor.on('resume', () => {
+			this.win_?.webContents.send('system-resumed');
 		});
 	}
 

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -730,6 +730,23 @@ class Application extends BaseApplication {
 					});
 				}
 			});
+
+			// Trigger an immediate sync when the main window gains OS-level focus (i.e. the user
+			// switches back to Joplin from another application) or when the system wakes from sleep.
+			// A 30-second cool-down prevents duplicate syncs during rapid focus-in/focus-out cycles.
+			const MIN_FOCUS_SYNC_INTERVAL_MS = 30_000;
+			let lastFocusSyncTime = 0;
+
+			const scheduleResumeSync = () => {
+				const now = Date.now();
+				if (now - lastFocusSyncTime > MIN_FOCUS_SYNC_INTERVAL_MS) {
+					lastFocusSyncTime = now;
+					void reg.scheduleSync(0);
+				}
+			};
+
+			ipcRenderer.on('main-window-focused', scheduleResumeSync);
+			ipcRenderer.on('system-resumed', scheduleResumeSync);
 		});
 
 		addTask('app/initPluginService', () => this.initPluginService());

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -734,12 +734,12 @@ class Application extends BaseApplication {
 			// Trigger an immediate sync when the main window gains OS-level focus (i.e. the user
 			// switches back to Joplin from another application) or when the system wakes from sleep.
 			// A 30-second cool-down prevents duplicate syncs during rapid focus-in/focus-out cycles.
-			const MIN_FOCUS_SYNC_INTERVAL_MS = 30_000;
+			const minResumeSyncIntervalMs = 30_000;
 			let lastFocusSyncTime = 0;
 
 			const scheduleResumeSync = () => {
 				const now = Date.now();
-				if (now - lastFocusSyncTime > MIN_FOCUS_SYNC_INTERVAL_MS) {
+				if (now - lastFocusSyncTime > minResumeSyncIntervalMs) {
 					lastFocusSyncTime = now;
 					void reg.scheduleSync(0);
 				}

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -322,13 +322,10 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 			PoorManIntervals.update();
 
 			// Trigger sync immediately when the app becomes active (resume from background/lock screen).
-			// Guard: only transition from non-active → active, and respect a 30-second cool-down to
+			// Only run when the app becomes active, with a 30-second minimum interval
 			// prevent sync spam on rapid lock/unlock cycles.
 			const minResumeSyncIntervalMs = 30_000;
-			if (
-				this.previousAppState_ !== 'active' &&
-				nextAppState === 'active'
-			) {
+			if (nextAppState === 'active') {
 				const elapsed = Date.now() - this.lastResumeSyncTime_;
 				if (elapsed > minResumeSyncIntervalMs) {
 					logger.info(`onAppStateChange_: App became active - scheduling immediate sync (elapsed since last resume sync: ${elapsed}ms)`);
@@ -336,7 +333,7 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 
 					void reg.scheduleSync(0, null, true);
 				} else {
-					logger.info(`onAppStateChange_: App became active but skipping sync - cool-down not elapsed (${elapsed}ms < ${minResumeSyncIntervalMs}ms)`);
+					logger.info(`onAppStateChange_: App became active but skipping sync - minimum interval not reached (${elapsed}ms < ${minResumeSyncIntervalMs}ms)`);
 				}
 			}
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -296,7 +296,6 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 	private unsubscribeNetInfoHandler_: NetInfoSubscription|undefined;
 	private unsubscribeNewShareListener_: UnsubscribeShareListener|undefined;
 	private onAppStateChange_: (nextAppState: AppStateStatus)=> void;
-	private previousAppState_: AppStateStatus = RNAppState.currentState;
 	private lastResumeSyncTime_ = 0;
 	private backButtonHandler_: BackButtonHandler;
 	private handleNewShare_: ()=> void;
@@ -318,7 +317,6 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 		};
 
 		this.onAppStateChange_ = (nextAppState: AppStateStatus) => {
-			logger.info(`onAppStateChange_: ${this.previousAppState_} => ${nextAppState}`);
 			PoorManIntervals.update();
 
 			// Trigger sync immediately when the app becomes active (resume from background/lock screen).
@@ -336,8 +334,6 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 					logger.info(`onAppStateChange_: App became active but skipping sync - minimum interval not reached (${elapsed}ms < ${minResumeSyncIntervalMs}ms)`);
 				}
 			}
-
-			this.previousAppState_ = nextAppState;
 		};
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -327,7 +327,7 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 			const minResumeSyncIntervalMs = 30_000;
 			if (nextAppState === 'active') {
 				const elapsed = Date.now() - this.lastResumeSyncTime_;
-				if (elapsed > minResumeSyncIntervalMs) {
+				if (elapsed >= minResumeSyncIntervalMs) {
 					logger.info(`onAppStateChange_: App became active - scheduling immediate sync (elapsed since last resume sync: ${elapsed}ms)`);
 					this.lastResumeSyncTime_ = Date.now();
 

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -19,7 +19,7 @@ import SyncTargetJoplinServer from '@joplin/lib/SyncTargetJoplinServer';
 import SyncTargetJoplinCloud from '@joplin/lib/SyncTargetJoplinCloud';
 import SyncTargetOneDrive from '@joplin/lib/SyncTargetOneDrive';
 import { Keyboard, BackHandler, Animated, StatusBar, Platform, Dimensions } from 'react-native';
-import { AppState as RNAppState, EmitterSubscription, View, Text, Linking, NativeEventSubscription, Appearance, ActivityIndicator } from 'react-native';
+import { AppState as RNAppState, AppStateStatus, EmitterSubscription, View, Text, Linking, NativeEventSubscription, Appearance, ActivityIndicator } from 'react-native';
 import getResponsiveValue from './components/getResponsiveValue';
 import NetInfo, { NetInfoSubscription } from '@react-native-community/netinfo';
 const DropdownAlert = require('react-native-dropdownalert').default;
@@ -295,7 +295,9 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 	private unsubscribeScreenWidthChangeHandler_: EmitterSubscription|undefined;
 	private unsubscribeNetInfoHandler_: NetInfoSubscription|undefined;
 	private unsubscribeNewShareListener_: UnsubscribeShareListener|undefined;
-	private onAppStateChange_: ()=> void;
+	private onAppStateChange_: (nextAppState: AppStateStatus)=> void;
+	private previousAppState_: AppStateStatus = RNAppState.currentState;
+	private lastResumeSyncTime_ = 0;
 	private backButtonHandler_: BackButtonHandler;
 	private handleNewShare_: ()=> void;
 	private handleOpenURL_: (event: unknown)=> void;
@@ -315,8 +317,30 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 			return this.backButtonHandler();
 		};
 
-		this.onAppStateChange_ = () => {
+		this.onAppStateChange_ = (nextAppState: AppStateStatus) => {
+			logger.info(`onAppStateChange_: ${this.previousAppState_} => ${nextAppState}`);
 			PoorManIntervals.update();
+
+			// Trigger sync immediately when the app becomes active (resume from background/lock screen).
+			// Guard: only transition from non-active → active, and respect a 30-second cool-down to
+			// prevent sync spam on rapid lock/unlock cycles.
+			const MIN_RESUME_SYNC_INTERVAL_MS = 30_000;
+			if (
+				this.previousAppState_ !== 'active' &&
+				nextAppState === 'active'
+			) {
+				const elapsed = Date.now() - this.lastResumeSyncTime_;
+				if (elapsed > MIN_RESUME_SYNC_INTERVAL_MS) {
+					logger.info(`onAppStateChange_: App became active - scheduling immediate sync (elapsed since last resume sync: ${elapsed}ms)`);
+					this.lastResumeSyncTime_ = Date.now();
+
+					void reg.scheduleSync(0, null, true);
+				} else {
+					logger.info(`onAppStateChange_: App became active but skipping sync - cool-down not elapsed (${elapsed}ms < ${MIN_RESUME_SYNC_INTERVAL_MS}ms)`);
+				}
+			}
+
+			this.previousAppState_ = nextAppState;
 		};
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied

--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -324,19 +324,19 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 			// Trigger sync immediately when the app becomes active (resume from background/lock screen).
 			// Guard: only transition from non-active → active, and respect a 30-second cool-down to
 			// prevent sync spam on rapid lock/unlock cycles.
-			const MIN_RESUME_SYNC_INTERVAL_MS = 30_000;
+			const minResumeSyncIntervalMs = 30_000;
 			if (
 				this.previousAppState_ !== 'active' &&
 				nextAppState === 'active'
 			) {
 				const elapsed = Date.now() - this.lastResumeSyncTime_;
-				if (elapsed > MIN_RESUME_SYNC_INTERVAL_MS) {
+				if (elapsed > minResumeSyncIntervalMs) {
 					logger.info(`onAppStateChange_: App became active - scheduling immediate sync (elapsed since last resume sync: ${elapsed}ms)`);
 					this.lastResumeSyncTime_ = Date.now();
 
 					void reg.scheduleSync(0, null, true);
 				} else {
-					logger.info(`onAppStateChange_: App became active but skipping sync - cool-down not elapsed (${elapsed}ms < ${MIN_RESUME_SYNC_INTERVAL_MS}ms)`);
+					logger.info(`onAppStateChange_: App became active but skipping sync - cool-down not elapsed (${elapsed}ms < ${minResumeSyncIntervalMs}ms)`);
 				}
 			}
 


### PR DESCRIPTION
## AI Assistance Disclosure

AI tools were used to help understand the current synchronisation implementation and assist during the implementation of this change.

I tested the changes locally on both Desktop and Mobile and fully understand the implementation.

---

Resolves #9481

## Problem

Currently synchronisation does not reliably start when the application becomes active.

Examples:

- When the mobile app resumes from the background, synchronisation may not start until the next sync interval.
- When the desktop application is opened or brought back to the foreground, it may wait for the scheduled sync interval before syncing.

---

## Solution

Trigger synchronisation immediately when the application becomes active.

### Mobile
- Detect when the app transitions from **background → active**
- Trigger a sync immediately on resume
- A guard interval prevents repeated syncs during rapid lock/unlock cycles

### Desktop
Desktop now triggers sync in two OS-level situations:

1. **Application window gains OS focus**
   - When the user switches back to Joplin from another application
2. **System resumes from sleep**

---

## Test Plan

Manual testing was performed using the Desktop development build and the iOS simulator with **OneDrive** as the sync target.

### Cross-device behaviour

The following behaviour was verified:

1. Desktop inactive → changes on iOS
2. iOS inactive → changes on Desktop

Steps:

1. Keep one device inactive (background or minimized)
2. Make changes on the other device and sync
3. Bring the inactive device to the foreground

Result:

- Synchronisation starts immediately when the app becomes active
- Latest changes are fetched without waiting for the scheduled sync interval

Demo video:

https://github.com/user-attachments/assets/20373fde-bf5f-47d2-9808-0e0ae844aeeb

