### PR TITLE
Fixes #12793: Prevent a failing plugin from blocking other plugins

### DIFF
--- a/packages/app-desktop/integration-tests/pluginApi.spec.ts
+++ b/packages/app-desktop/integration-tests/pluginApi.spec.ts
@@ -206,5 +206,26 @@ test.describe('pluginApi', () => {
 
 		await expect(panelLocator).not.toBeVisible();
 	});
+
+	// Regression test for https://github.com/laurent22/joplin/issues/12793
+	test('a plugin that crashes before register() should not block other plugins', async ({ startAppWithPlugins }) => {
+		// Load a crashing plugin alongside a working plugin. If the fix works,
+		// startAppWithPlugins completes because startup-plugins-loaded fires.
+		// Without the fix, this test would timeout because allPluginsStarted
+		// never becomes true.
+		const { app, mainWindow } = await startAppWithPlugins([
+			'resources/test-plugins/crashBeforeRegister.js',
+			'resources/test-plugins/execCommand.js',
+		]);
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('Test note');
+
+		// Verify the working plugin is functional
+		const editor = mainScreen.noteEditor;
+		await editor.focusCodeMirrorEditor();
+		await mainWindow.keyboard.type('Should be overwritten.');
+		await mainScreen.goToAnything.runCommand(app, 'testUpdateEditorText');
+		await editor.expectToHaveText('PASS');
+	});
 });
 

--- a/packages/app-desktop/integration-tests/resources/test-plugins/crashBeforeRegister.js
+++ b/packages/app-desktop/integration-tests/resources/test-plugins/crashBeforeRegister.js
@@ -1,0 +1,22 @@
+// Allows referencing the Joplin global:
+/* eslint-disable no-undef */
+
+// Allows the `joplin-manifest` block comment:
+/* eslint-disable multiline-comment-style */
+
+/* joplin-manifest:
+{
+	"id": "org.joplinapp.plugins.example.crashBeforeRegister",
+	"manifest_version": 1,
+	"app_min_version": "3.1",
+	"name": "Crash Before Register",
+	"description": "Plugin that crashes before calling register()",
+	"version": "1.0.0",
+	"author": "",
+	"homepage_url": "https://joplinapp.org"
+}
+*/
+
+// Crash before calling joplin.plugins.register()
+// This tests the fix for https://github.com/laurent22/joplin/issues/12793
+throw new Error('Simulated plugin crash before register()');

--- a/packages/app-desktop/services/plugins/PluginRunner.ts
+++ b/packages/app-desktop/services/plugins/PluginRunner.ts
@@ -168,6 +168,15 @@ export default class PluginRunner extends BasePluginRunner {
 					promise.resolve(message.result);
 				}
 			} else {
+				// Handle notification that a plugin failed to start before
+				// calling register(). Emit 'started' so allPluginsStarted
+				// is not blocked. See: https://github.com/laurent22/joplin/issues/12793
+				if (message.path === '__pluginFailedToStart__') {
+					logger.error(`Plugin "${plugin.id}" failed to start:`, message.args?.[0]);
+					plugin.emit('started');
+					return;
+				}
+
 				const mappedArgs = mapEventIdsToHandlers(plugin.id, message.args);
 				const fullPath = `joplin.${message.path}`;
 

--- a/packages/app-desktop/services/plugins/PluginRunner.ts
+++ b/packages/app-desktop/services/plugins/PluginRunner.ts
@@ -173,6 +173,7 @@ export default class PluginRunner extends BasePluginRunner {
 				// is not blocked. See: https://github.com/laurent22/joplin/issues/12793
 				if (message.path === '__pluginFailedToStart__') {
 					logger.error(`Plugin "${plugin.id}" failed to start:`, message.args?.[0]);
+					plugin.running = false;
 					plugin.emit('started');
 					return;
 				}

--- a/packages/app-desktop/services/plugins/plugin_index.js
+++ b/packages/app-desktop/services/plugins/plugin_index.js
@@ -130,10 +130,38 @@
 		console.warn('Unhandled plugin message:', message);
 	});
 
+	// Track whether the plugin has called joplin.plugins.register().
+	// If the plugin script throws before register() is called, the 'started'
+	// event will never fire, which blocks other plugins from working.
+	// See: https://github.com/laurent22/joplin/issues/12793
+	let registerCalled = false;
+
+	const originalTarget = target;
+	const wrappedTarget = (path, args) => {
+		if (path === 'plugins.register') {
+			registerCalled = true;
+		}
+		return originalTarget(path, args);
+	};
+
+	// Catch unhandled errors from the plugin script. If the plugin throws
+	// before calling register(), notify the host so it can unblock startup.
+	window.onerror = (message) => {
+		if (!registerCalled) {
+			console.error(`Plugin "${pluginId}" threw an error before registering:`, message);
+			ipcRendererSend('pluginMessage', {
+				target: 'mainWindow',
+				pluginId: pluginId,
+				path: '__pluginFailedToStart__',
+				args: [String(message)],
+			});
+		}
+	};
+
 	const pluginScriptPath = urlParams.get('pluginScript');
 	const script = document.createElement('script');
 	script.src = pluginScriptPath;
 	document.head.appendChild(script);
 
-	globalObject.joplin = sandboxProxy(target);
+	globalObject.joplin = sandboxProxy(wrappedTarget);
 })(window);

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -570,7 +570,17 @@ export default class PluginService extends BaseService {
 
 		plugin.running = true;
 		const pluginApi = new Global(this.platformImplementation_, plugin, this.store_);
-		return this.runner_.run(plugin, pluginApi);
+		try {
+			await this.runner_.run(plugin, pluginApi);
+		} catch (error) {
+			logger.error(`Plugin "${plugin.id}" failed to start:`, error);
+			// Mark as started so this failed plugin doesn't block
+			// allPluginsStarted and prevent other plugins from working.
+			// See: https://github.com/laurent22/joplin/issues/12793
+			this.startedPlugins_[plugin.id] = true;
+			plugin.off('started', onStarted);
+			plugin.running = false;
+		}
 	}
 
 	public async installPluginFromRepo(repoApi: RepositoryApi, pluginId: string): Promise<Plugin> {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,7 +34,7 @@ export interface Plugins {
 }
 
 export interface SettingAndValue {
-	[settingName: string]: string | number | boolean;
+	[settingName: string]: string|number|boolean;
 }
 
 export interface DefaultPluginSettings {
@@ -81,7 +81,7 @@ function makePluginId(source: string): string {
 	return uslug(source).substr(0, 32);
 }
 
-type LoadedPluginsChangeListener = () => void;
+type LoadedPluginsChangeListener = ()=> void;
 
 export default class PluginService extends BaseService {
 
@@ -143,7 +143,7 @@ export default class PluginService extends BaseService {
 		this.isSafeMode_ = v;
 	}
 
-	public addLoadedPluginsChangeListener(listener: () => void) {
+	public addLoadedPluginsChangeListener(listener: ()=> void) {
 		this.pluginsChangeListeners_.push(listener);
 
 		return {
@@ -211,7 +211,7 @@ export default class PluginService extends BaseService {
 		return this.pluginById(id).manifest?.name ?? 'Unknown';
 	}
 
-	public viewControllerByViewId(id: string): ViewController | null {
+	public viewControllerByViewId(id: string): ViewController|null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);
 		}

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,7 +34,7 @@ export interface Plugins {
 }
 
 export interface SettingAndValue {
-	[settingName: string]: string|number|boolean;
+	[settingName: string]: string | number | boolean;
 }
 
 export interface DefaultPluginSettings {
@@ -81,7 +81,7 @@ function makePluginId(source: string): string {
 	return uslug(source).substr(0, 32);
 }
 
-type LoadedPluginsChangeListener = ()=> void;
+type LoadedPluginsChangeListener = () => void;
 
 export default class PluginService extends BaseService {
 
@@ -143,7 +143,7 @@ export default class PluginService extends BaseService {
 		this.isSafeMode_ = v;
 	}
 
-	public addLoadedPluginsChangeListener(listener: ()=> void) {
+	public addLoadedPluginsChangeListener(listener: () => void) {
 		this.pluginsChangeListeners_.push(listener);
 
 		return {
@@ -211,7 +211,7 @@ export default class PluginService extends BaseService {
 		return this.pluginById(id).manifest?.name ?? 'Unknown';
 	}
 
-	public viewControllerByViewId(id: string): ViewController|null {
+	public viewControllerByViewId(id: string): ViewController | null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);
 		}

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -34,7 +34,7 @@ export interface Plugins {
 }
 
 export interface SettingAndValue {
-	[settingName: string]: string|number|boolean;
+	[settingName: string]: string | number | boolean;
 }
 
 export interface DefaultPluginSettings {
@@ -211,7 +211,7 @@ export default class PluginService extends BaseService {
 		return this.pluginById(id).manifest?.name ?? 'Unknown';
 	}
 
-	public viewControllerByViewId(id: string): ViewController|null {
+	public viewControllerByViewId(id: string): ViewController | null {
 		for (const [, plugin] of Object.entries(this.plugins_)) {
 			if (plugin.hasViewController(id)) return plugin.viewController(id);
 		}
@@ -570,7 +570,17 @@ export default class PluginService extends BaseService {
 
 		plugin.running = true;
 		const pluginApi = new Global(this.platformImplementation_, plugin, this.store_);
-		return this.runner_.run(plugin, pluginApi);
+		try {
+			await this.runner_.run(plugin, pluginApi);
+		} catch (error) {
+			logger.error(`Plugin "${plugin.id}" failed to start:`, error);
+			// Mark as started so this failed plugin doesn't block
+			// allPluginsStarted and prevent other plugins from working.
+			// See: https://github.com/laurent22/joplin/issues/12793
+			this.startedPlugins_[plugin.id] = true;
+			plugin.off('started', onStarted);
+			plugin.running = false;
+		}
 	}
 
 	public async installPluginFromRepo(repoApi: RepositoryApi, pluginId: string): Promise<Plugin> {

--- a/packages/lib/services/plugins/PluginService.ts
+++ b/packages/lib/services/plugins/PluginService.ts
@@ -81,7 +81,7 @@ function makePluginId(source: string): string {
 	return uslug(source).substr(0, 32);
 }
 
-type LoadedPluginsChangeListener = ()=> void;
+type LoadedPluginsChangeListener = () => void;
 
 export default class PluginService extends BaseService {
 
@@ -143,7 +143,7 @@ export default class PluginService extends BaseService {
 		this.isSafeMode_ = v;
 	}
 
-	public addLoadedPluginsChangeListener(listener: ()=> void) {
+	public addLoadedPluginsChangeListener(listener: () => void) {
 		this.pluginsChangeListeners_.push(listener);
 
 		return {

--- a/packages/lib/services/plugins/loadPlugins.test.ts
+++ b/packages/lib/services/plugins/loadPlugins.test.ts
@@ -7,6 +7,7 @@ import reducer, { State, defaultState } from '../../reducer';
 import { Action, createStore } from 'redux';
 import MockPlatformImplementation from './testing/MockPlatformImplementation';
 import createTestPlugin from '../../testing/plugins/createTestPlugin';
+import Plugin from './Plugin';
 
 const createMockReduxStore = () => {
 	return createStore((state: State = defaultState, action: Action<string>) => {
@@ -133,5 +134,53 @@ describe('loadPlugins', () => {
 		// if not enabled previously.
 		expect(pluginRunner.stopCalledTimes).toBe(disabledCount + enabledCount);
 		expect([...pluginRunner.runningPluginIds].sort()).toMatchObject(expectedRunningIds);
+	});
+
+	test('should not block allPluginsStarted when a plugin fails to start', async () => {
+		// This tests the fix for https://github.com/laurent22/joplin/issues/12793
+		// When a plugin crashes before calling register(), it should not block
+		// other plugins from working.
+
+		const goodPluginId = 'joplin.test.good.plugin';
+		await createTestPlugin({
+			...defaultManifestProperties,
+			id: goodPluginId,
+			name: 'Good Plugin',
+		});
+
+		const badPluginId = 'joplin.test.bad.plugin';
+		await createTestPlugin({
+			...defaultManifestProperties,
+			id: badPluginId,
+			name: 'Bad Plugin',
+		});
+
+		// Create a mock runner that throws for the bad plugin
+		// and emits 'started' for good plugins (matching real behavior).
+		const failingPluginRunner = new MockPluginRunner();
+		const originalRun = failingPluginRunner.run.bind(failingPluginRunner);
+		failingPluginRunner.run = async (plugin: Plugin) => {
+			if (plugin.manifest.id === badPluginId) {
+				throw new Error('Simulated plugin crash before register()');
+			}
+			await originalRun(plugin);
+			// Simulate what JoplinPlugins.register() does after onStart()
+			plugin.emit('started');
+		};
+
+		const store = createMockReduxStore();
+		const service = PluginService.instance();
+		service.initialize('2.3.4', platformImplementation, failingPluginRunner, store);
+
+		await service.loadAndRunPlugins(Setting.value('pluginDir'), Setting.value('plugins.states'));
+
+		// The bad plugin failed, but allPluginsStarted should still be true
+		// because the fix marks failed plugins as "started".
+		expect(service.allPluginsStarted).toBe(true);
+
+		// The good plugin should still be running
+		expect(failingPluginRunner.runningPluginIds).toContain(goodPluginId);
+		// The bad plugin should not be running
+		expect(failingPluginRunner.runningPluginIds).not.toContain(badPluginId);
 	});
 });


### PR DESCRIPTION
Ai Disclosure 
Used it to write tests and help me navigate the codebase 

fixes : #12793 

Problem 
if a plugin crashes during the startup before it acutally get the chances to call [register()], joplin never realize that - it just wait forever 
the app tracks all plugins and only enables certain features once every plugin has reported started and so if even one pluhin crashes silently the signal never comes and (startupPluginLoaded) stays false permanently. 
and in the process breaking other perfectly healthy plugins

Solution
add error handling around  plugin runner excution so that if a plugin fails to start, it start, it gets marked as done instead of staying stuck forver
on desktop plugins run in isolated browser windows so crashed there are invisble to the main app   so added an error handler inside the plugin sandbox 