### PR TITLE
ci: configure explicit job timeouts in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,6 +8,7 @@ jobs:
   AssembleRelease:
     if: github.repository == 'laurent22/joplin'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Install Linux dependencies
         run: |

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -5,6 +5,7 @@ jobs:
     # We always process desktop release tags, because they also publish the release
     if: github.repository == 'laurent22/joplin'
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
 
       - uses: actions/checkout@v4

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -2,6 +2,7 @@ name: Joplin Continuous Integration
 on: [push, pull_request]
 jobs:
   Main:
+    timeout-minutes: 90
     # We always process server or desktop release tags, because they also publish the release
     if: github.repository == 'laurent22/joplin'
     runs-on: ${{ matrix.os }}
@@ -122,6 +123,7 @@ jobs:
           "${GITHUB_WORKSPACE}/.github/scripts/publish_docker_manifest.sh"
 
   ServerDockerImage:
+    timeout-minutes: 60
     if: github.repository == 'laurent22/joplin'
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,6 +7,7 @@ jobs:
     # Don't run on forks
     if: github.repository == 'laurent22/joplin'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2025]


### PR DESCRIPTION
Closes #14571

## 📝 Summary

Currently, several CI jobs in the Joplin repository rely on the default GitHub Actions timeout of **6 hours** because `timeout-minutes` is not explicitly configured.

If a job hangs (for example during dependency installation, test execution, or Docker/Android builds), the workflow may continue running for hours before failing. This wastes CI resources and delays feedback to contributors.

This PR introduces explicit timeout limits for major jobs to ensure workflows fail fast while still allowing sufficient time for normal execution.

---

## ❗ Problem

- CI jobs rely on GitHub Actions default timeout (**6 hours**)
- Hanging jobs can consume large amounts of CI minutes
- Slower feedback loop for contributors
- Unnecessary resource usage

---

## ✅ Solution

Add `timeout-minutes` configuration to key jobs across workflows in `.github/workflows`.

Timeout values are set **slightly above typical execution time** to allow normal variance while preventing excessive runtime during failures.

---

## 🔧 Changes

| Workflow | Job | Timeout |
|--------|--------|--------|
| `github-actions-main.yml` | `Main` | 90 minutes |
| `github-actions-main.yml` | `ServerDockerImage` | 60 minutes |
| `ui-tests.yml` | `Main` | 60 minutes |
| `build-android.yml` | `AssembleRelease` | 60 minutes |
| `build-macos-m1.yml` | `build` | 60 minutes |

Example:

```yaml
jobs:
  Main:
    timeout-minutes: 90