### PR TITLE
Mobile: Fix tapping rendered image scrolling to cursor position

### DIFF
--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -101,7 +101,7 @@ class ImageWidget extends WidgetType {
 		return true;
 	}
 
-	public toDOM(_view: EditorView) {
+	public toDOM(view: EditorView) {
 		const container = document.createElement('div');
 		container.classList.add(imageClassName);
 		container.dataset.sourceFrom = String(this.sourceFrom_);
@@ -112,6 +112,16 @@ class ImageWidget extends WidgetType {
 		container.appendChild(image);
 		this.updateDOM(container);
 
+		const sourceFrom = this.sourceFrom_;
+		container.addEventListener('mousedown', (e) => {
+			e.preventDefault();
+			const pos = Math.min(sourceFrom, view.state.doc.length);
+			view.dispatch({
+				selection: { anchor: view.state.doc.lineAt(pos).from },
+				scrollIntoView: false,
+			});
+		});
+
 		return container;
 	}
 
@@ -121,6 +131,10 @@ class ImageWidget extends WidgetType {
 
 	public get estimatedHeight() {
 		return imageHeightCache.get(this.cacheKey) ?? -1;
+	}
+
+	public ignoreEvent() {
+		return true;
 	}
 }
 

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -115,8 +115,7 @@ class ImageWidget extends WidgetType {
 		container.addEventListener('mousedown', (e) => {
 			if (e.button !== 0) return;
 			e.preventDefault();
-			const sourceFrom = Number(container.dataset.sourceFrom);
-			const pos = Math.min(sourceFrom, view.state.doc.length);
+			const pos = Math.min(view.posAtDOM(container), view.state.doc.length);
 			view.dispatch({
 				selection: { anchor: view.state.doc.lineAt(pos).from },
 				scrollIntoView: false,

--- a/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
+++ b/packages/editor/CodeMirror/extensions/rendering/renderBlockImages.ts
@@ -112,9 +112,10 @@ class ImageWidget extends WidgetType {
 		container.appendChild(image);
 		this.updateDOM(container);
 
-		const sourceFrom = this.sourceFrom_;
 		container.addEventListener('mousedown', (e) => {
+			if (e.button !== 0) return;
 			e.preventDefault();
+			const sourceFrom = Number(container.dataset.sourceFrom);
 			const pos = Math.min(sourceFrom, view.state.doc.length);
 			view.dispatch({
 				selection: { anchor: view.state.doc.lineAt(pos).from },


### PR DESCRIPTION
Fixes #14555 

## Problem

On mobile, tapping a rendered image in the markdown editor causes the view to scroll to the current cursor position. For example, if the cursor is at the top of a long note and you scroll down to tap an image, the view jumps back to the top where the cursor was.

This happens because the mobile editor runs inside a WebView that natively scrolls to the cursor whenever a tap occurs inside the contenteditable area. Unlike desktop where CodeMirror manages its own scroll container, on mobile the WebView controls scrolling and this can't be prevented from JavaScript.

**Before fix:**

https://github.com/user-attachments/assets/803bf311-b93c-4a10-899d-c0937b9b0bfc


## Fix

Added a `mousedown` handler on the image widget that moves the cursor to the image's line on tap. Since the WebView scrolls to the cursor after a tap, placing the cursor at the image's line means the view "scrolls" to where the image already is, so no visible jump occurs.

Also added `ignoreEvent()` returning `true` to prevent CodeMirror from processing the tap separately.

The change is a small addition to `ImageWidget` in `renderBlockImages.ts`, no new files or dependencies.


**Why this approach?**

There were a few options considered:

Prevent cursor movement entirely on image tap : Not feasible on mobile. The WebView natively scrolls to the cursor on any tap inside the contenteditable. If the cursor stays at a distant position, the view jumps there. There's no way to suppress this from JavaScript since the WebView controls scrolling at the native level.

Move cursor to nearest visible text : Would require calculating which text line is closest to the tap coordinates, adding complexity. The result would also be inconsistent depending on the note layout and where around the image the user taps.

**Move cursor to the image's line (chosen approach)** : Simple, consistent, and predictable. The cursor always lands at the same place regardless of where on the image you tap. Since the image markup line is at the image's position in the document, the WebView's scroll to cursor behavior becomes a no op (it "scrolls" to where the image already is). This also aligns with the desktop editor, which moves the cursor to the image line on right-click (PR #14209).

**After fix:**

https://github.com/user-attachments/assets/280acc04-ecf8-478f-aafc-6f2919b84c62


### Tests
All 206 editor tests pass with no regressions (yarn test in packages/editor)
<img width="603" height="749" alt="Screenshot 2026-03-05 at 3 33 13 PM" src="https://github.com/user-attachments/assets/1446b035-d9b8-4d14-b7f6-6e4dba1470cb" />

### AI Assistance Disclosure
AI tools are used to:
- Improve wording in PR description