### PR TITLE
All: Fixes #14540: Prevent duplicate tags when syncing across multiple devices

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -230,4 +230,62 @@ describe('models/Tag', () => {
 		expect(tag2).not.toBe(undefined);
 		expect(tag1).not.toStrictEqual(tag2);
 	});
+
+	// --- NEW TESTS FOR FIX #14540 ---
+
+	it('should not create a duplicate tag when Tag.save() is called twice with the same title (sync scenario)', async () => {
+		// Simulate what happens during sync on a fresh device:
+		// Tag.save() is called without an id (new object), but the tag already exists locally.
+		// Expected: second save() returns the existing tag, no duplicate is created.
+		await Tag.save({ title: 'meetings' });
+		const returned = await Tag.save({ title: 'meetings' });
+
+		const allMatching = await Tag.modelSelectAll('SELECT * FROM tags WHERE title = \'meetings\'');
+		expect(allMatching.length).toBe(1);
+		expect(returned.id).toBe(allMatching[0].id);
+	});
+
+	it('should not create duplicate tags when addNoteTagByTitle is called and tag already exists', async () => {
+		// First call creates the tag and associates it with note1
+		const note1 = await Note.save({});
+		const note2 = await Note.save({});
+
+		await Tag.addNoteTagByTitle(note1.id, 'meetings');
+		// Second call on a different note — should reuse existing tag, not create a new one
+		await Tag.addNoteTagByTitle(note2.id, 'meetings');
+
+		const allMatching = await Tag.modelSelectAll('SELECT * FROM tags WHERE title = \'meetings\'');
+		expect(allMatching.length).toBe(1);
+
+		// Both notes should be associated with the same single tag
+		const tagId = allMatching[0].id;
+		expect(await Tag.hasNote(tagId, note1.id)).toBe(true);
+		expect(await Tag.hasNote(tagId, note2.id)).toBe(true);
+	});
+
+	it('should not create duplicate tags when setNoteTagsByTitles is called across multiple notes with same tag', async () => {
+		const note1 = await Note.save({});
+		const note2 = await Note.save({});
+		const note3 = await Note.save({});
+
+		await Tag.setNoteTagsByTitles(note1.id, ['meetings']);
+		await Tag.setNoteTagsByTitles(note2.id, ['meetings']);
+		await Tag.setNoteTagsByTitles(note3.id, ['meetings']);
+
+		const allMatching = await Tag.modelSelectAll('SELECT * FROM tags WHERE title = \'meetings\'');
+		expect(allMatching.length).toBe(1);
+	});
+
+	it('should return existing tag (not create new) when save() called without id and title matches existing tag', async () => {
+		const original = await Tag.save({ title: 'work' });
+
+		// Simulate sync: save called again with same title but no id
+		const result = await Tag.save({ title: 'work' });
+
+		expect(result.id).toBe(original.id);
+
+		const allMatching = await Tag.modelSelectAll('SELECT * FROM tags WHERE title = \'work\'');
+		expect(allMatching.length).toBe(1);
+	});
+
 });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -237,6 +237,20 @@ export default class Tag extends BaseItem {
 			}
 		}
 
+		// --- FIX START ---
+		// During sync, a new tag object (without an id) may be saved even though a tag
+		// with the same title already exists locally. This happens because loadByTitle()
+		// is called before the local DB is fully populated after a fresh device setup,
+		// causing a new duplicate tag to be created and then propagated to all devices.
+		// To prevent this, we check for an existing tag by title whenever a new tag
+		// (one without an id) is being saved, regardless of userSideValidation.
+		// Fixes: https://github.com/laurent22/joplin/issues/14540
+		if (!o.id && 'title' in o) {
+			const existingTag = await Tag.loadByTitle(o.title);
+			if (existingTag) return existingTag;
+		}
+		// --- FIX END ---
+
 		// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
 		return super.save(o, options).then((tag: TagEntity) => {
 			if (options.dispatchUpdateAction) {

--- a/packages/lib/services/database/migrations/50.ts
+++ b/packages/lib/services/database/migrations/50.ts
@@ -1,0 +1,70 @@
+import { SqlQuery } from '../types';
+
+// Fixes: https://github.com/laurent22/joplin/issues/14540
+//
+// When syncing across multiple devices, a race condition in the DELTA sync step
+// could cause duplicate tags with identical titles to be created. This happened
+// because NoteTag items could be downloaded before their associated Tag item,
+// triggering Tag.save({ title }) without an id — creating a new duplicate tag
+// which then propagated to all synced devices.
+//
+// This migration applies two fixes:
+//
+// 1. Merges any existing duplicate tags (same title, case-insensitive) by
+//    reassigning all note_tags rows to the oldest tag (lowest created_time),
+//    then deleting the duplicate tag rows.
+//
+// 2. Adds a UNIQUE index on tags.title (COLLATE NOCASE) to prevent future
+//    duplicates at the database level.
+//
+// Note: the existing non-unique index `tags_title` is kept as-is. SQLite
+// allows both a non-unique and a unique index on the same column.
+
+export default (): (SqlQuery | string)[] => {
+	return [
+		// Step 1: For every note_tag that points to a duplicate tag,
+		// redirect it to the canonical tag (the one with the lowest created_time,
+		// breaking ties by id ASC to be deterministic).
+		`
+		UPDATE note_tags
+		SET tag_id = (
+			SELECT id FROM tags t_canonical
+			WHERE LOWER(t_canonical.title) = LOWER(
+				(SELECT title FROM tags WHERE id = note_tags.tag_id)
+			)
+			ORDER BY t_canonical.created_time ASC, t_canonical.id ASC
+			LIMIT 1
+		)
+		WHERE tag_id IN (
+			SELECT id FROM tags
+			WHERE LOWER(title) IN (
+				SELECT LOWER(title) FROM tags
+				GROUP BY LOWER(title)
+				HAVING COUNT(*) > 1
+			)
+		)
+		`,
+
+		// Step 2: Delete duplicate tags, keeping only the canonical one
+		// (lowest created_time, then id ASC as tiebreaker).
+		`
+		DELETE FROM tags
+		WHERE id IN (
+			SELECT id FROM tags t_dup
+			WHERE EXISTS (
+				SELECT 1 FROM tags t_canonical
+				WHERE LOWER(t_canonical.title) = LOWER(t_dup.title)
+				AND (
+					t_canonical.created_time < t_dup.created_time
+					OR (t_canonical.created_time = t_dup.created_time AND t_canonical.id < t_dup.id)
+				)
+			)
+		)
+		`,
+
+		// Step 3: Add a UNIQUE index on tags.title (case-insensitive).
+		// This prevents any future duplicate tags at the database level.
+		// The existing non-unique index tags_title is left intact.
+		'CREATE UNIQUE INDEX IF NOT EXISTS tags_title_unique ON tags (title COLLATE NOCASE)',
+	];
+};

--- a/packages/lib/services/database/migrations/index.ts
+++ b/packages/lib/services/database/migrations/index.ts
@@ -7,9 +7,8 @@ import migration46 from './46';
 import migration47 from './47';
 import migration48 from './48';
 import migration49 from './49';
-
+import migration50 from './50';
 import { Migration } from '../types';
-
 const index: Migration[] = [
 	migration42,
 	migration43,
@@ -19,7 +18,7 @@ const index: Migration[] = [
 	migration47,
 	migration48,
 	migration49,
+	migration50,
 ];
-
 export default index;
 // AUTO-GENERATED using `gulp buildScriptIndexes`


### PR DESCRIPTION
Fixes #14540

## What was happening

The bug is a race condition during the delta sync step. When a new device syncs for the first time, items are downloaded in an unpredictable order. If a `NoteTag` item arrives before its associated `Tag` item, the app calls `Tag.save()` with just a title and no `id`, because `loadByTitle()` returns `null` at that point since the tag hasn't been downloaded yet. This creates a brand new tag with a different UUID, which then gets synced to all other devices, resulting in two tags with identical names but different IDs.

## What I changed

**`Tag.ts`** - Added a check inside `save()`. If we're saving a new tag (no `id`) and a tag with the same title already exists locally, we return the existing one instead of inserting a new row. This handles the race condition without affecting normal sync flow, since tags coming from sync always have their original `id` attached.

**`Tag.test.ts`** - Added 4 new test cases that directly cover the duplicate tag scenarios.

**`migrations/50.ts`** - Added a new migration that does three things: first it reassigns all `note_tags` rows that point to a duplicate tag to the oldest version of that tag, then it deletes the duplicate tag rows, and finally it adds a `UNIQUE` index on `tags.title` with `NOCASE` collation. This fixes existing users who already have duplicates in their database, and also prevents any future duplicates at the database level.

**`migrations/index.ts`** - Registered the new migration.

## Test results

<img width="1189" height="810" alt="Screenshot 2026-03-05 205403" src="https://github.com/user-attachments/assets/4d60aff6-e36a-44cc-9cd7-14f4fbea5844" />