### PR TITLE
CI: Add workflow_dispatch trigger to allow manual CI test runs

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -2,7 +2,7 @@
 # tell us automatically if something got broken when a dependency was changed.
 
 name: react-native-android-build-apk
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -1,5 +1,5 @@
 name: Build macOS M1
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -1,5 +1,5 @@
 name: Joplin Continuous Integration
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,5 +1,5 @@
 name: Joplin UI tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Description

Fixes #14585

This pull request addresses the lack of manual triggers in the continuous integration pipelines by adding the `workflow_dispatch` trigger to the core GitHub Actions workflows ([github-actions-main.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/github-actions-main.yml:0:0-0:0), [ui-tests.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/ui-tests.yml:0:0-0:0), [build-android.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/build-android.yml:0:0-0:0), [build-macos-m1.yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/build-macos-m1.yml:0:0-0:0)). 

**Benefits of this change:**
- **Saves Time / Better Retry Mechanism:** Allows maintainers and contributors to manually restart a previously failed CI pipeline (e.g., due to temporary network timeouts when fetching dependencies or flaky tests) directly from the GitHub Actions UI without needing to push an empty commit or close/reopen a PR.
- **Workflow Debugging:** Developers can now manually run and test structural modifications made to `.github/workflows/` scripts directly on their feature branches without creating dummy Pull Requests.
- **On-Demand Builds:** Maintainers can quickly trigger standalone debug builds for platforms like Android or macOS from any specific branch directly in the GitHub UI.

### Testing
- Validated that the `workflow_dispatch` trigger has been correctly added to the `on:` block of the targeted files.
- Confirmed that this addition does not break the YAML syntax. 
- Because this is a purely additive structural change, it preserves the existing automated `push` and `pull_request` behaviors with zero risk.
