### PR TITLE
CI: Add top-level permissions to workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,6 +2,10 @@ name: automerge
 on:
   schedule:
     - cron: '*/10 * * * *'
+
+permissions:
+  contents: read
+
 jobs:
 
   # This job will make the action fail if any of the checks hasn't passed
@@ -15,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - id: automerge
         name: automerge

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   AssembleRelease:
     if: github.repository == 'laurent22/joplin'

--- a/.github/workflows/build-macos-m1.yml
+++ b/.github/workflows/build-macos-m1.yml
@@ -5,11 +5,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   Main:
     # We always process desktop release tags, because they also publish the release
     if: github.repository == 'laurent22/joplin'
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
 
       - uses: actions/checkout@v4

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,8 +1,15 @@
 name: Check pull request title
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      statuses: write
     steps:
       - uses: Slashgear/action-check-pr-title@v4.3.0
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,10 +5,17 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   CLAAssistant:
     if: github.repository == 'laurent22/joplin'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/comment-on-failure.yml
+++ b/.github/workflows/comment-on-failure.yml
@@ -7,8 +7,14 @@ on:
       - Build macOS M1
     types: [ completed ]
 
+permissions:
+  contents: read
+
 jobs:
   comment-failure:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: quipper/comment-failure-action@v0.1.1

--- a/.github/workflows/github-actions-main.yml
+++ b/.github/workflows/github-actions-main.yml
@@ -5,11 +5,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   Main:
     # We always process server or desktop release tags, because they also publish the release
     if: github.repository == 'laurent22/joplin'
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         # Do not use unbuntu-latest because it causes `The operation was canceled` failures:


### PR DESCRIPTION
**Description**

Fixes #14588 

This PR enforces the least-privilege principle across GitHub Action workflows in the repository by restricting the default token scope.

- Added an explicit top-level `permissions: contents: read` block to all workflow files lacking one. This restricts the default token to read-only access globally.
- Added necessary job-level `permissions:` overrides for specific jobs within those workflows that require elevated permissions (e.g., publishing releases, commenting on PRs, merging PRs, publishing statuses).

This aligns the CI configurations with GitHub's current security best practices, significantly tightening security and minimizing the potential blast radius if third-party actions or dependencies are ever compromised.

**Testing**
This modifies CI workflow [yml](cci:7://file:///c:/Users/BIT/Desktop/joplin/.github/workflows/cla.yml:0:0-0:0) files. It does not introduce functional changes to the codebase itself. Testing involves verifying that the modified workflows (like `github-actions-main`, `build-macos-m1`, `check-pr-title`, etc.) can continue to run successfully on their respective triggers.
