### PR TITLE
Desktop: Resolves #8611: Add toggle button to hide/show sync panel

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useState, useCallback } from 'react';
-import { StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton, StyledRoot, StyledSyncReportToggle } from './styles';
+import { useCallback } from 'react';
+import { StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton, StyledRoot } from './styles';
 import { ButtonLevel } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
 import Synchronizer from '@joplin/lib/Synchronizer';
@@ -11,6 +11,8 @@ import { connect } from 'react-redux';
 import { themeStyle } from '@joplin/lib/theme';
 import { Dispatch } from 'redux';
 import FolderAndTagList from './FolderAndTagList';
+import Setting from '@joplin/lib/models/Setting';
+import time from '@joplin/lib/time';
 
 
 interface Props {
@@ -21,6 +23,7 @@ interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	syncReport: any;
 	syncStarted: boolean;
+	syncReportLogExpanded: boolean;
 }
 
 const SidebarComponent = (props: Props) => {
@@ -53,44 +56,48 @@ const SidebarComponent = (props: Props) => {
 		resourceFetcherText = _('Fetching resources: %d/%d', props.resourceFetcher.fetchingCount, props.resourceFetcher.toFetchCount);
 	}
 
-	const [syncReportExpanded, setSyncReportExpanded] = useState(false);
+	const syncReportExpanded = props.syncReportLogExpanded;
 
 	const toggleSyncReport = useCallback(() => {
-		setSyncReportExpanded(prev => !prev);
-	}, []);
+		Setting.setValue('syncReportLogExpanded', !syncReportExpanded);
+	}, [syncReportExpanded]);
 
 	const lines = Synchronizer.reportToLines(props.syncReport);
 	if (resourceFetcherText) lines.push(resourceFetcherText);
 	if (decryptionReportText) lines.push(decryptionReportText);
 
+	const completedTime = props.syncReport && props.syncReport.completedTime
+		? time.formatMsToLocal(props.syncReport.completedTime)
+		: null;
+
 	const syncButton = renderSynchronizeButton(props.syncStarted ? 'cancel' : 'sync');
 
-	// Toggle to show/hide the sync panel
-	const toggleButton = (
-		<StyledSyncReportToggle
+	// Show toggle when there are log lines or a completed timestamp
+	const hasContent = lines.length > 0 || completedTime;
+
+	// Toggle to show/hide sync log output
+	const toggleButton = hasContent ? (
+		<button
+			className="sidebar-sync-toggle"
 			onClick={toggleSyncReport}
 			aria-expanded={syncReportExpanded}
-			aria-label={syncReportExpanded ? _('Hide synchronisation panel') : _('Show synchronisation panel')}
-			title={syncReportExpanded ? _('Hide synchronisation panel') : _('Show synchronisation panel')}
+			aria-label={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
+			title={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 		>
 			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
-		</StyledSyncReportToggle>
-	);
+			{!syncReportExpanded && completedTime ? <span className="timestamp">{_('Last sync: %s', completedTime)}</span> : ''}
+		</button>
+	) : null;
 
-	// Sync panel (report + button), only visible when expanded
-	const syncPanelContent = syncReportExpanded ? (
-		<>
-			{lines.length > 0 && (
-				<StyledSyncReport key="sync_report">
-					{lines.map((line, i) => (
-						<StyledSyncReportText key={i}>
-							{line}
-						</StyledSyncReportText>
-					))}
-				</StyledSyncReport>
-			)}
-			{syncButton}
-		</>
+	// Sync log output, only visible when expanded
+	const syncReportComp = (syncReportExpanded && lines.length > 0) ? (
+		<StyledSyncReport key="sync_report">
+			{lines.map((line, i) => (
+				<StyledSyncReportText key={i}>
+					{line}
+				</StyledSyncReportText>
+			))}
+		</StyledSyncReport>
 	) : null;
 
 	return (
@@ -98,7 +105,8 @@ const SidebarComponent = (props: Props) => {
 			<div style={{ flex: 1 }}><FolderAndTagList /></div>
 			<div style={{ flex: 0, padding: theme.mainPadding }}>
 				{toggleButton}
-				{syncPanelContent}
+				{syncReportComp}
+				{syncButton}
 			</div>
 		</StyledRoot>
 	);
@@ -116,6 +124,7 @@ const mapStateToProps = (state: AppState) => {
 		collapsedFolderIds: state.collapsedFolderIds,
 		decryptionWorker: state.decryptionWorker,
 		resourceFetcher: state.resourceFetcher,
+		syncReportLogExpanded: state.settings.syncReportLogExpanded,
 	};
 };
 

--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton, StyledRoot } from './styles';
+import { useState, useCallback } from 'react';
+import { StyledSyncReportText, StyledSyncReport, StyledSynchronizeButton, StyledRoot, StyledSyncReportToggle } from './styles';
 import { ButtonLevel } from '../Button/Button';
 import CommandService from '@joplin/lib/services/CommandService';
 import Synchronizer from '@joplin/lib/Synchronizer';
@@ -52,32 +53,52 @@ const SidebarComponent = (props: Props) => {
 		resourceFetcherText = _('Fetching resources: %d/%d', props.resourceFetcher.fetchingCount, props.resourceFetcher.toFetchCount);
 	}
 
+	const [syncReportExpanded, setSyncReportExpanded] = useState(false);
+
+	const toggleSyncReport = useCallback(() => {
+		setSyncReportExpanded(prev => !prev);
+	}, []);
+
 	const lines = Synchronizer.reportToLines(props.syncReport);
 	if (resourceFetcherText) lines.push(resourceFetcherText);
 	if (decryptionReportText) lines.push(decryptionReportText);
-	const syncReportText = [];
-	for (let i = 0; i < lines.length; i++) {
-		syncReportText.push(
-			<StyledSyncReportText key={i}>
-				{lines[i]}
-			</StyledSyncReportText>,
-		);
-	}
 
 	const syncButton = renderSynchronizeButton(props.syncStarted ? 'cancel' : 'sync');
 
-	const syncReportComp = !syncReportText.length ? null : (
-		<StyledSyncReport key="sync_report">
-			{syncReportText}
-		</StyledSyncReport>
+	// Toggle to show/hide the sync panel
+	const toggleButton = (
+		<StyledSyncReportToggle
+			onClick={toggleSyncReport}
+			aria-expanded={syncReportExpanded}
+			aria-label={syncReportExpanded ? _('Hide synchronisation panel') : _('Show synchronisation panel')}
+			title={syncReportExpanded ? _('Hide synchronisation panel') : _('Show synchronisation panel')}
+		>
+			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
+		</StyledSyncReportToggle>
 	);
+
+	// Sync panel (report + button), only visible when expanded
+	const syncPanelContent = syncReportExpanded ? (
+		<>
+			{lines.length > 0 && (
+				<StyledSyncReport key="sync_report">
+					{lines.map((line, i) => (
+						<StyledSyncReportText key={i}>
+							{line}
+						</StyledSyncReportText>
+					))}
+				</StyledSyncReport>
+			)}
+			{syncButton}
+		</>
+	) : null;
 
 	return (
 		<StyledRoot className='sidebar _scrollbar2' role='navigation' aria-label={_('Sidebar')}>
-			<div style={{ flex: 1 }}><FolderAndTagList/></div>
+			<div style={{ flex: 1 }}><FolderAndTagList /></div>
 			<div style={{ flex: 0, padding: theme.mainPadding }}>
-				{syncReportComp}
-				{syncButton}
+				{toggleButton}
+				{syncPanelContent}
 			</div>
 		</StyledRoot>
 	);

--- a/packages/app-desktop/gui/Sidebar/style.scss
+++ b/packages/app-desktop/gui/Sidebar/style.scss
@@ -7,3 +7,4 @@
 @use 'styles/sidebar-spacer-item.scss';
 @use 'styles/sidebar-header-button.scss';
 @use 'styles/sidebar-sync-button.scss';
+@use 'styles/sidebar-sync-toggle.scss';

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -117,6 +117,25 @@ export const StyledSyncReportText = styled.div`
 	width: 100%;
 `;
 
+export const StyledSyncReportToggle = styled.button`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: none;
+	border: none;
+	color: ${(props: StyleProps) => props.theme.color2};
+	opacity: 0.5;
+	cursor: pointer;
+	padding: 4px 0;
+	width: 100%;
+	font-size: ${(props: StyleProps) => Math.round(props.theme.fontSize * 1.6)}px;
+	transition: opacity 0.2s;
+	&:hover {
+		opacity: 1;
+	}
+`;
+
+
 // Workaround sidebar rendering bug on Linux Intel GPU.
 // https://github.com/laurent22/joplin/issues/7506
 export const StyledSpanFix = styled.span`

--- a/packages/app-desktop/gui/Sidebar/styles/index.ts
+++ b/packages/app-desktop/gui/Sidebar/styles/index.ts
@@ -117,25 +117,6 @@ export const StyledSyncReportText = styled.div`
 	width: 100%;
 `;
 
-export const StyledSyncReportToggle = styled.button`
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: none;
-	border: none;
-	color: ${(props: StyleProps) => props.theme.color2};
-	opacity: 0.5;
-	cursor: pointer;
-	padding: 4px 0;
-	width: 100%;
-	font-size: ${(props: StyleProps) => Math.round(props.theme.fontSize * 1.6)}px;
-	transition: opacity 0.2s;
-	&:hover {
-		opacity: 1;
-	}
-`;
-
-
 // Workaround sidebar rendering bug on Linux Intel GPU.
 // https://github.com/laurent22/joplin/issues/7506
 export const StyledSpanFix = styled.span`

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
@@ -1,0 +1,23 @@
+.sidebar-sync-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: none;
+	border: none;
+	color: var(--joplin-color2);
+	opacity: 0.5;
+	cursor: pointer;
+	padding: 4px 0;
+	width: 100%;
+	font-size: calc(var(--joplin-font-size) * 1.6);
+	transition: opacity 0.2s;
+
+	&:hover {
+		opacity: 1;
+	}
+
+	>.timestamp {
+		font-size: 0.6em;
+		margin-left: 6px;
+	}
+}

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1460,6 +1460,7 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 		noteVisiblePanes: { value: ['editor', 'viewer'], type: SettingItemType.Array, storage: SettingStorage.File, isGlobal: true, public: false, appTypes: [AppType.Desktop] },
 		tagHeaderIsExpanded: { value: true, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },
 		folderHeaderIsExpanded: { value: true, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },
+		syncReportLogExpanded: { value: false, type: SettingItemType.Bool, public: false, appTypes: [AppType.Desktop] },
 		editor: { value: '', type: SettingItemType.String, subType: 'file_path_and_args', storage: SettingStorage.File, isGlobal: true, public: true, appTypes: [AppType.Cli, AppType.Desktop], label: () => _('Text editor command'), description: () => _('The editor command (may include arguments) that will be used to open a note. If none is provided it will try to auto-detect the default editor.') },
 		'export.pdfPageSize': { value: 'A4', type: SettingItemType.String, advanced: true, storage: SettingStorage.File, isGlobal: true, isEnum: true, public: true, appTypes: [AppType.Desktop], label: () => _('Page size for PDF export'), options: () => {
 			return {


### PR DESCRIPTION
Resolves #8611 
 Adds a collapsible toggle (▾/▴) to the sidebar sync panel. The panel (sync report + Synchronise button) is hidden by default. Clicking the toggle arrow reveals it.

**Behaviour:**
- Collapsed (default): Only ▴ arrow visible
- Expanded: ▾ arrow + sync report text + Synchronise button

**Screenshots:**

Collapsed:
<img width="1018" height="913" alt="Screenshot 2026-03-06 at 8 15 34 AM" src="https://github.com/user-attachments/assets/46438e28-a144-486f-b961-754635920cd9" />


Expanded:
<img width="1015" height="914" alt="Screenshot 2026-03-06 at 8 15 52 AM" src="https://github.com/user-attachments/assets/cd1cbae4-d108-4a56-871d-53271b61cc9c" />

