### PR TITLE
Desktop: Fixes #14396: Prevent stray ** markers when pasting from Google Docs

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -63,4 +63,28 @@ describe('resourceHandling', () => {
 		const html = `<img src="file://${encodeURI(Setting.value('resourceDir'))}/resource.png" alt="test"/>`;
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
 	});
+
+	it('should process Google Docs mixed content without producing **', async () => {
+		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
+
+		const html = `
+			<meta charset='utf-8'>
+			<meta charset="utf-8">
+			<b style="font-weight:normal;" id="docs-internal-guid-xyz">
+				<p>Lauren Ipsum is a name that suggests a person, perhaps someone who is a writer.</p>
+				<h1>Lauren Ipsum is a name that suggests</h1>
+				<p>Lauren Ipsum is a name that suggests a person, perhaps someone who is a writer.</p>
+				<br />
+			</b>
+			`;
+
+		const result = await processPastedHtml(html, htmlToMd, markupToHtml);
+
+		// No markdown bold artifacts
+		expect(result).not.toContain('**');
+
+		// Heading preserved
+		expect(result).toContain('<h1');
+		expect(result).toContain('Lauren Ipsum is a name that suggests');
+	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -64,19 +64,27 @@ describe('resourceHandling', () => {
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
 	});
 
-	it('should process Google Docs mixed content without producing **', async () => {
+	it('should process Google Docs mixed content with line breaks without producing artifacts', async () => {
 		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
 
 		const html = `
-			<meta charset='utf-8'>
-			<meta charset="utf-8">
-			<b style="font-weight:normal;" id="docs-internal-guid-xyz">
-				<p>Lauren Ipsum is a name that suggests a person, perhaps someone who is a writer.</p>
-				<h1>Lauren Ipsum is a name that suggests</h1>
-				<p>Lauren Ipsum is a name that suggests a person, perhaps someone who is a writer.</p>
-				<br />
-			</b>
-			`;
+		<meta charset='utf-8'>
+		<meta charset="utf-8">
+		<b style="font-weight:normal;" id="docs-internal-guid-xyz">
+			<p>
+				Lauren Ipsum is a name that suggests a person
+				<br class="kix-line-break">
+				perhaps someone who is a writer.
+			</p>
+			<h1>Lauren Ipsum is a name that suggests</h1>
+			<p>
+				Lauren Ipsum is a name that suggests a person
+				<br>
+				perhaps someone who is a writer.
+			</p>
+			<br />
+		</b>
+	`;
 
 		const result = await processPastedHtml(html, htmlToMd, markupToHtml);
 
@@ -86,5 +94,11 @@ describe('resourceHandling', () => {
 		// Heading preserved
 		expect(result).toContain('<h1');
 		expect(result).toContain('Lauren Ipsum is a name that suggests');
+
+		// Ensure text content remains intact
+		expect(result).toContain('perhaps someone who is a writer');
+
+		// Ensure no literal <br> text artifacts appear
+		expect(result).not.toContain('&lt;br');
 	});
 });

--- a/packages/lib/HtmlToMd.ts
+++ b/packages/lib/HtmlToMd.ts
@@ -18,7 +18,7 @@ export interface ParseOptions {
 
 export default class HtmlToMd {
 
-	public parse(html: string|HTMLElement, options: ParseOptions = {}) {
+	public parse(html: string | HTMLElement, options: ParseOptions = {}) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const turndownOpts: any = {
 			headingStyle: 'atx',
@@ -62,6 +62,23 @@ export default class HtmlToMd {
 			};
 		}
 		const turndown = new TurndownService(turndownOpts);
+
+		turndown.addRule('ignoreGoogleDocsWrapper', {
+			filter: (node: Element) => {
+				if (!node.nodeName) return false;
+
+				const tag = node.nodeName.toLowerCase();
+				if (tag !== 'b' && tag !== 'strong') return false;
+
+				const style = node.getAttribute && node.getAttribute('style');
+				if (!style) return false;
+
+				// Only ignore if it is fake bold
+				return /font-weight\s*:\s*(normal|400)\b/i.test(style);
+			},
+			replacement: (content: string) => content,
+		});
+
 		turndown.use(turndownPluginGfm);
 		turndown.remove('script');
 		turndown.remove('style');


### PR DESCRIPTION
## AI Assistance Disclosure
Parts of this pull request were drafted with the help of an AI assistant, including structuring the explanation and writing test cases based on the implemented changes. All code and tests have been reviewed and verified manually.

---

## Problem

When content copied from **Google Docs** is pasted into Joplin’s **Rich Text editor**, stray `**` lines appear in the pasted content even when the copied text does not contain bold formatting.

Google Docs wraps copied content inside a wrapper element like:

<b style="font-weight: normal">

During the paste pipeline, this HTML is converted to Markdown using **Turndown**. Because the wrapper uses a `<b>` tag, Turndown interprets it as bold formatting and generates Markdown bold markers (`**`). Since this wrapper does not represent real bold text, these markers appear as literal `**` lines in the resulting note.

As a result:
- Extra `**` lines appear in the Rich Text editor and Markdown view
- Paragraph spacing may change
- The pasted content does not match the original formatting from Google Docs

This behaviour can be reproduced by copying plain text paragraphs from Google Docs and pasting them into the Rich Text editor.

Fixes #14396.

---

## Solution

This pull request adds a **Turndown rule** to ignore fake bold wrappers generated by Google Docs.

The rule detects `<b>` or `<strong>` elements that explicitly specify:

font-weight: normal  
font-weight: 400

These values indicate that the element is **not actually bold**, but only used as a wrapper by Google Docs. The rule unwraps these elements during HTML → Markdown conversion, preventing Turndown from generating Markdown bold markers (`**`).

After this change:

- Google Docs wrapper elements no longer produce stray `**`
- The pasted content structure remains intact
- Paragraphs and headings are preserved correctly

---

## Screenshots

### Before
- Content copied from Google Docs
- Stray `**` lines appearing in the Rich Text editor or Markdown view after pasting

<img width="883" height="613" alt="docs" src="https://github.com/user-attachments/assets/e3885b5f-1672-4641-a653-1dbde62340c9" />
<img width="726" height="562" alt="bug" src="https://github.com/user-attachments/assets/5cf0e1f6-c853-4f6a-b9fa-33706a30daf5" />

### After
- The same content pasted from Google Docs
- No stray `**` markers
- Paragraphs and headings preserved correctly

<img width="989" height="459" alt="solved" src="https://github.com/user-attachments/assets/dc9f2d45-a920-4457-9a76-1e0f71723285" />

---

## Testing

Added unit tests to ensure the paste pipeline correctly handles Google Docs wrapper elements.

The tests simulate HTML content copied from Google Docs and verify that:

- No `**` markers are generated during conversion
- Paragraphs remain intact
- Headings remain intact
- Mixed content (paragraphs and headings) inside the wrapper is processed correctly

Tests were added in:

packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts

All tests pass locally.
<img width="1192" height="299" alt="testSuccess" src="https://github.com/user-attachments/assets/7b8556f0-7f94-41ff-a223-607e67ee4ea2" />
