### PR TITLE
All: Fixes #14540: Prevent duplicate tag creation when Tag.save() is called without id

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -230,4 +230,27 @@ describe('models/Tag', () => {
 		expect(tag2).not.toBe(undefined);
 		expect(tag1).not.toStrictEqual(tag2);
 	});
+
+	it('should not create a duplicate when saving a tag with an existing title', async () => {
+		const tag1 = await Tag.save({ title: 'meeting' });
+		const tag2 = await Tag.save({ title: 'meeting' });
+		expect(tag2.id).toBe(tag1.id);
+
+		const allTags = await Tag.all();
+		const matching = allTags.filter(t => t.title === 'meeting');
+		expect(matching.length).toBe(1);
+	});
+
+	it('should associate note correctly when tag is reused via save', async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'note1', parent_id: folder1.id });
+
+		const tag1 = await Tag.save({ title: 'project' });
+		await Tag.addNote(tag1.id, note1.id);
+
+		// Save again with same title — should reuse tag1
+		const tag2 = await Tag.save({ title: 'project' });
+		expect(tag2.id).toBe(tag1.id);
+		expect(await Tag.hasNote(tag2.id, note1.id)).toBe(true);
+	});
 });

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -237,6 +237,19 @@ export default class Tag extends BaseItem {
 			}
 		}
 
+		// Prevent duplicate tags: when saving a new tag (no id) with a title
+		// that already exists, reuse the existing tag's id so the save
+		// proceeds as an update rather than creating a duplicate row.
+		if (!o.id && 'title' in o) {
+			o.title = (o.title || '').trim();
+			if (o.title) {
+				const existingTag = await Tag.loadByTitle(o.title);
+				if (existingTag) {
+					o.id = existingTag.id;
+				}
+			}
+		}
+
 		// eslint-disable-next-line promise/prefer-await-to-then -- Old code before rule was applied
 		return super.save(o, options).then((tag: TagEntity) => {
 			if (options.dispatchUpdateAction) {


### PR DESCRIPTION
## AI Assistance Disclosure

This change was developed with AI assistance for analysis and initial drafting.
All code has been manually reviewed and fully understood before submission.

---

Fixes #14540

## Summary

When `Tag.save()` is called without an `id` (new tag creation), there was no
guard preventing a duplicate row from being inserted if a tag with the same
title already existed.

This adds an unconditional check in `Tag.save()`: if a new tag (no `id`) has
a title matching an existing tag (case-insensitive), the existing tag's `id`
is assigned to the object so the save proceeds as an update rather than an
insert. This preserves the full `BaseModel.save()` lifecycle (timestamps,
dispatch, sync metadata).

## Changes

- `packages/lib/models/Tag.ts`: Added duplicate-prevention guard before `super.save()`
- `packages/lib/models/Tag.test.ts`: Added 2 tests verifying no duplicate creation and intact tag-note association

## Testing

All 12 Tag model tests pass. No existing tests were modified.
