### PR TITLE
fix: correct window centering when display not found

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -270,9 +270,12 @@ export default class ElectronAppWrapper {
 		);
 
 		if (!screen.getDisplayMatching(this.win_.getBounds())) {
-			const { width: windowWidth, height: windowHeight } = this.win_.getBounds();
-			const { width: primaryDisplayWidth, height: primaryDisplayHeight } = screen.getPrimaryDisplay().workArea;
-			this.win_.setPosition(primaryDisplayWidth / 2 - windowWidth, primaryDisplayHeight / 2 - windowHeight);
+    		const { width: windowWidth, height: windowHeight } = this.win_.getBounds();
+    		const { width: primaryDisplayWidth, height: primaryDisplayHeight } = screen.getPrimaryDisplay().workArea;
+    		this.win_.setPosition(
+					Math.round((primaryDisplayWidth - windowWidth) / 2),
+        			Math.round((primaryDisplayHeight - windowHeight) / 2)
+			);
 		}
 
 		let unresponsiveTimeout: ReturnType<typeof setTimeout>|null = null;


### PR DESCRIPTION
Fixes #14089

## Problem
When Joplin reopens, the saved window position from window-state-prod.json 
was being overridden by incorrect centering math in the getDisplayMatching check.

## Fix
Corrected the window centering formula from:
primaryDisplayWidth / 2 - windowWidth
to:
Math.round((primaryDisplayWidth - windowWidth) / 2)

This ensures the window is properly centered on the primary display when 
the saved position is on a display that is no longer available.

## Testing
- Moved window to a specific position
- Quit Joplin properly
- Reopened Joplin
- Window opened in the same position