### PR TITLE
Server: Fixes #14594: Improve error message for malformed storage connection strings

### DIFF
--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -9,7 +9,7 @@ describe('config', () => {
 			STORAGE_DRIVER: 'Type=InvalidType',
 			RUNNING_IN_DOCKER: 0,
 			DB_CLIENT: 'sqlite',
-		} as EnvVariables;
+		} as unknown as EnvVariables;
 
 		await expect(async () => initConfig(Env.Dev, env)).rejects.toThrow('Invalid configuration for STORAGE_DRIVER');
 	});
@@ -19,7 +19,7 @@ describe('config', () => {
 			STORAGE_DRIVER_FALLBACK: 'Path=/only/path/no/type',
 			RUNNING_IN_DOCKER: 0,
 			DB_CLIENT: 'sqlite',
-		} as EnvVariables;
+		} as unknown as EnvVariables;
 
 		await expect(async () => initConfig(Env.Dev, env)).rejects.toThrow('Invalid configuration for STORAGE_DRIVER_FALLBACK');
 	});

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -1,0 +1,27 @@
+import { initConfig } from './config';
+import { Env } from './utils/types';
+import { EnvVariables } from './env';
+
+describe('config', () => {
+
+	it('should throw an error with the environment variable name when STORAGE_DRIVER is malformed', async () => {
+		const env = {
+			STORAGE_DRIVER: 'Type=InvalidType',
+			RUNNING_IN_DOCKER: 0,
+			DB_CLIENT: 'sqlite',
+		} as EnvVariables;
+
+		await expect(async () => initConfig(Env.Dev, env)).rejects.toThrow('Invalid configuration for STORAGE_DRIVER');
+	});
+
+	it('should throw an error with the environment variable name when STORAGE_DRIVER_FALLBACK is malformed', async () => {
+		const env = {
+			STORAGE_DRIVER_FALLBACK: 'Path=/only/path/no/type',
+			RUNNING_IN_DOCKER: 0,
+			DB_CLIENT: 'sqlite',
+		} as EnvVariables;
+
+		await expect(async () => initConfig(Env.Dev, env)).rejects.toThrow('Invalid configuration for STORAGE_DRIVER_FALLBACK');
+	});
+
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -188,8 +188,9 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 	const parseStorageDriver = (envVarValue: string, envVarName: string) => {
 		try {
 			return parseStorageDriverConnectionString(envVarValue);
-		} catch (error: any) {
-			throw new Error(`Invalid configuration for ${envVarName}: ${error.message}`);
+		} catch (error: unknown) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			throw new Error(`Invalid configuration for ${envVarName}: ${errorMessage}`);
 		}
 	};
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -185,6 +185,14 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 	const forkVersion = packageJson.joplinServer?.forkVersion;
 	const dbConfig = databaseConfigFromEnv(runningInDocker_, env, false);
 
+	const parseStorageDriver = (envVarValue: string, envVarName: string) => {
+		try {
+			return parseStorageDriverConnectionString(envVarValue);
+		} catch (error: any) {
+			throw new Error(`Invalid configuration for ${envVarName}: ${error.message}`);
+		}
+	};
+
 	config_ = {
 		...env,
 		appVersion: forkVersion ? forkVersion : packageJson.version,
@@ -221,8 +229,8 @@ export async function initConfig(envType: Env, env: EnvVariables, overrides: any
 		// auth provider URL, the cookies won't be set property. "Lax" solves this and this is what
 		// most web apps use these days. It is still reasonably secure.
 		cookieSameSite: isUsingExternalAuth(env) ? 'lax' : true,
-		storageDriver: parseStorageDriverConnectionString(env.STORAGE_DRIVER),
-		storageDriverFallback: parseStorageDriverConnectionString(env.STORAGE_DRIVER_FALLBACK),
+		storageDriver: parseStorageDriver(env.STORAGE_DRIVER, 'STORAGE_DRIVER'),
+		storageDriverFallback: parseStorageDriver(env.STORAGE_DRIVER_FALLBACK, 'STORAGE_DRIVER_FALLBACK'),
 		itemSizeHardLimit: 250000000, // Beyond this the Postgres driver will crash the app
 		maxTimeDrift: env.MAX_TIME_DRIFT,
 		ldap: ldapConfigFromEnv(env),


### PR DESCRIPTION
### Problem

When a user provides a malformed storage connection string (such as missing the `Type=` parameter in `STORAGE_DRIVER` or `STORAGE_DRIVER_FALLBACK`), the server crashes on startup with a vague `Type must be specified` error and a generic stack trace. This leaves the user unsure exactly which environment variable caused the issue, making debugging their configuration difficult.

### Solution

The calls to `parseStorageDriverConnectionString` in [packages/server/src/config.ts](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/server/src/config.ts:0:0-0:0) are now wrapped in a `try...catch` block. If a validation error is caught, it catches the error and throws a new one that explicitly includes the name of the offending environment variable (e.g., `Invalid configuration for STORAGE_DRIVER: ...`). This allows the server to provide clear, actionable feedback when an environment variable configuration error occurs. 

Additionally, we have added new test cases within [packages/server/src/config.test.ts](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/server/src/config.test.ts:0:0-0:0) to explicitly verify this startup validation behavior per the GSoC requirements.

### Test Plan

*   Automated tests added: Created [config.test.ts](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/joplin/packages/server/src/config.test.ts:0:0-0:0) to assert the server throws the correct modified errors on startup when mocked `STORAGE_DRIVER` values are malformed.
*   Verified locally: If `STORAGE_DRIVER` or `STORAGE_DRIVER_FALLBACK` is malformed, the server now fails specifically stating which environment variable caused the error: `Invalid configuration for STORAGE_DRIVER: In connection string ... Type must be specified` rather than a generic error.
