### PR TITLE
Desktop: Fix viewer word count including text from hidden elements (#12877)

### DIFF
--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -50,6 +50,14 @@ describe('htmlUtils', () => {
 			'<div>visible <span style="display: none">hidden</span> also visible</div>',
 			'visible also visible',
 		],
+		[
+			'<div style="visibility: hidden">hidden <span style="visibility: visible">shown</span></div>',
+			'shown',
+		],
+		[
+			'<div style="display: none"><span style="visibility: visible">still hidden</span></div>',
+			'',
+		],
 	])('should exclude text in hidden elements (case %#)', (input, expected) => {
 		const actual = htmlUtils.stripHtml(input);
 		expect(actual).toBe(expected);

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -58,6 +58,10 @@ describe('htmlUtils', () => {
 			'<div style="display: none"><span style="visibility: visible">still hidden</span></div>',
 			'',
 		],
+		[
+			'<div style="visibility: hidden">a <span style="visibility: visible">b</span> c</div>',
+			'b',
+		],
 	])('should exclude text in hidden elements (case %#)', (input, expected) => {
 		const actual = htmlUtils.stripHtml(input);
 		expect(actual).toBe(expected);

--- a/packages/renderer/htmlUtils.test.ts
+++ b/packages/renderer/htmlUtils.test.ts
@@ -29,6 +29,32 @@ describe('htmlUtils', () => {
 		}
 	});
 
+	test.each([
+		[
+			'<div style="display: none">hidden</div> visible',
+			' visible',
+		],
+		[
+			'<span style="visibility: hidden">hidden</span> visible',
+			' visible',
+		],
+		[
+			'<div style="display:none"><span>nested hidden</span></div> visible',
+			' visible',
+		],
+		[
+			'<div style="display: none">hidden</div><div style="display: none">also hidden</div> visible',
+			' visible',
+		],
+		[
+			'<div>visible <span style="display: none">hidden</span> also visible</div>',
+			'visible also visible',
+		],
+	])('should exclude text in hidden elements (case %#)', (input, expected) => {
+		const actual = htmlUtils.stripHtml(input);
+		expect(actual).toBe(expected);
+	});
+
 	test('should extract the HTML body', () => {
 		const testCases: [string, string][] = [
 			[

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -137,28 +137,53 @@ class HtmlUtils {
 	public stripHtml(html: string) {
 		const output: string[] = [];
 
-		const tagStack: string[] = [];
+		interface TagStackEntry {
+			name: string;
+			hidden: boolean;
+		}
+
+		const tagStack: TagStackEntry[] = [];
+		// Tracks depth of hidden elements (display:none or visibility:hidden).
+		// When > 0, all text content is suppressed.
+		let hiddenDepth = 0;
 
 		const currentTag = () => {
 			if (!tagStack.length) return '';
-			return tagStack[tagStack.length - 1];
+			return tagStack[tagStack.length - 1].name;
+		};
+
+		const isHiddenStyle = (attribs: Record<string, string>) => {
+			const style = attribs?.style;
+			if (!style) return false;
+			return /display\s*:\s*none/i.test(style) || /visibility\s*:\s*hidden/i.test(style);
 		};
 
 		const disallowedTags = ['script', 'style', 'head', 'iframe', 'frameset', 'frame', 'object', 'base'];
 
 		const parser = new htmlparser2.Parser({
 
-			onopentag: (name: string) => {
-				tagStack.push(name.toLowerCase());
+			onopentag: (name: string, attribs: Record<string, string>) => {
+				const hidden = isHiddenStyle(attribs);
+				tagStack.push({ name: name.toLowerCase(), hidden });
+				if (hidden) {
+					hiddenDepth++;
+				}
 			},
 
 			ontext: (decodedText: string) => {
 				if (disallowedTags.includes(currentTag())) return;
+				if (hiddenDepth > 0) return;
 				output.push(decodedText);
 			},
 
 			onclosetag: (name: string) => {
-				if (currentTag() === name.toLowerCase()) tagStack.pop();
+				const entry = tagStack.length ? tagStack[tagStack.length - 1] : null;
+				if (entry && entry.name === name.toLowerCase()) {
+					if (entry.hidden) {
+						hiddenDepth = Math.max(0, hiddenDepth - 1);
+					}
+					tagStack.pop();
+				}
 			},
 
 		}, { decodeEntities: true });

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -139,49 +139,63 @@ class HtmlUtils {
 
 		interface TagStackEntry {
 			name: string;
-			hidden: boolean;
+			displayNone: boolean;
+			visibilityHidden: boolean;
 		}
 
 		const tagStack: TagStackEntry[] = [];
-		// Tracks depth of hidden elements (display:none or visibility:hidden).
-		// When > 0, all text content is suppressed.
-		let hiddenDepth = 0;
+		// display:none hides the element and all descendants unconditionally.
+		let displayNoneDepth = 0;
+		// visibility:hidden hides text, but a child with visibility:visible
+		// can override it. We track inherited depth separately.
+		let visibilityHiddenDepth = 0;
 
 		const currentTag = () => {
 			if (!tagStack.length) return '';
 			return tagStack[tagStack.length - 1].name;
 		};
 
-		const isHiddenStyle = (attribs: Record<string, string>) => {
-			const style = attribs?.style;
-			if (!style) return false;
-			return /display\s*:\s*none/i.test(style) || /visibility\s*:\s*hidden/i.test(style);
-		};
+		const hasDisplayNone = (style: string) => /display\s*:\s*none/i.test(style);
+		const hasVisibilityHidden = (style: string) => /visibility\s*:\s*hidden/i.test(style);
+		const hasVisibilityVisible = (style: string) => /visibility\s*:\s*visible/i.test(style);
 
 		const disallowedTags = ['script', 'style', 'head', 'iframe', 'frameset', 'frame', 'object', 'base'];
 
 		const parser = new htmlparser2.Parser({
 
 			onopentag: (name: string, attribs: Record<string, string>) => {
-				const hidden = isHiddenStyle(attribs);
-				tagStack.push({ name: name.toLowerCase(), hidden });
-				if (hidden) {
-					hiddenDepth++;
+				const style = attribs?.style ?? '';
+				const isDisplayNone = hasDisplayNone(style);
+				// visibility:visible on a child resets inherited visibility:hidden
+				let isVisibilityHidden = false;
+				if (hasVisibilityHidden(style)) {
+					isVisibilityHidden = true;
+				} else if (hasVisibilityVisible(style) && visibilityHiddenDepth > 0) {
+					isVisibilityHidden = false;
+					visibilityHiddenDepth = 0;
 				}
+
+				tagStack.push({
+					name: name.toLowerCase(),
+					displayNone: isDisplayNone,
+					visibilityHidden: isVisibilityHidden,
+				});
+
+				if (isDisplayNone) displayNoneDepth++;
+				if (isVisibilityHidden) visibilityHiddenDepth++;
 			},
 
 			ontext: (decodedText: string) => {
 				if (disallowedTags.includes(currentTag())) return;
-				if (hiddenDepth > 0) return;
+				if (displayNoneDepth > 0 || visibilityHiddenDepth > 0) return;
 				output.push(decodedText);
 			},
 
 			onclosetag: (name: string) => {
 				const entry = tagStack.length ? tagStack[tagStack.length - 1] : null;
 				if (entry && entry.name === name.toLowerCase()) {
-					if (entry.hidden) {
-						hiddenDepth = Math.max(0, hiddenDepth - 1);
-					}
+					if (entry.displayNone) displayNoneDepth = Math.max(0, displayNoneDepth - 1);
+					if (entry.visibilityHidden) visibilityHiddenDepth = Math.max(0, visibilityHiddenDepth - 1);
 					tagStack.pop();
 				}
 			},

--- a/packages/renderer/htmlUtils.ts
+++ b/packages/renderer/htmlUtils.ts
@@ -140,14 +140,18 @@ class HtmlUtils {
 		interface TagStackEntry {
 			name: string;
 			displayNone: boolean;
-			visibilityHidden: boolean;
+			// Tracks the visibility state this element introduced.
+			// 'hidden' = this element set visibility:hidden
+			// 'visible' = this element overrode an ancestor's visibility:hidden
+			// null = this element didn't change visibility
+			visibilityChange: 'hidden' | 'visible' | null;
+			// The visibilityHiddenDepth before this element was opened,
+			// used to restore state when a visibility:visible element closes.
+			savedVisibilityDepth: number;
 		}
 
 		const tagStack: TagStackEntry[] = [];
-		// display:none hides the element and all descendants unconditionally.
 		let displayNoneDepth = 0;
-		// visibility:hidden hides text, but a child with visibility:visible
-		// can override it. We track inherited depth separately.
 		let visibilityHiddenDepth = 0;
 
 		const currentTag = () => {
@@ -166,23 +170,26 @@ class HtmlUtils {
 			onopentag: (name: string, attribs: Record<string, string>) => {
 				const style = attribs?.style ?? '';
 				const isDisplayNone = hasDisplayNone(style);
-				// visibility:visible on a child resets inherited visibility:hidden
-				let isVisibilityHidden = false;
+
+				let visibilityChange: 'hidden' | 'visible' | null = null;
+				const savedVisibilityDepth = visibilityHiddenDepth;
+
 				if (hasVisibilityHidden(style)) {
-					isVisibilityHidden = true;
+					visibilityChange = 'hidden';
+					visibilityHiddenDepth++;
 				} else if (hasVisibilityVisible(style) && visibilityHiddenDepth > 0) {
-					isVisibilityHidden = false;
+					visibilityChange = 'visible';
 					visibilityHiddenDepth = 0;
 				}
 
 				tagStack.push({
 					name: name.toLowerCase(),
 					displayNone: isDisplayNone,
-					visibilityHidden: isVisibilityHidden,
+					visibilityChange,
+					savedVisibilityDepth,
 				});
 
 				if (isDisplayNone) displayNoneDepth++;
-				if (isVisibilityHidden) visibilityHiddenDepth++;
 			},
 
 			ontext: (decodedText: string) => {
@@ -195,7 +202,9 @@ class HtmlUtils {
 				const entry = tagStack.length ? tagStack[tagStack.length - 1] : null;
 				if (entry && entry.name === name.toLowerCase()) {
 					if (entry.displayNone) displayNoneDepth = Math.max(0, displayNoneDepth - 1);
-					if (entry.visibilityHidden) visibilityHiddenDepth = Math.max(0, visibilityHiddenDepth - 1);
+					if (entry.visibilityChange) {
+						visibilityHiddenDepth = entry.savedVisibilityDepth;
+					}
 					tagStack.pop();
 				}
 			},


### PR DESCRIPTION
### Problem

The "Viewer" word count in the Statistics dialog counts words inside `display: none` and `visibility: hidden` elements. These words aren't visible in the rendered note so they shouldn't contribute to the count

### Summary

The `stripHtml` function in the renderer extracts text by walking HTML nodes. It already skipped content inside `<script> `and `<style>` tags but had no awareness of inline CSS visibility. Updated it to check for `display: none` and `visibility: hidden` in the style attribute. When a hidden element is found, all text inside it including nested children is excluded using a depth counter.

### Tests

Added 5 test cases to `htmlUtils.test.ts` covering `display: none`, `visibility: hidden,` nested hidden elements, multiple hidden siblings, and inline hidden spans. Existing `stripHtml` and `MarkupToHtml` tests still pass with no regressions

### Before

https://github.com/user-attachments/assets/214ca75b-6699-48c6-9079-31bf7e28eb4b

---
### After

https://github.com/user-attachments/assets/cb12cf3e-d137-44ef-8ee2-14fd146fd490


EDIT : Updated the PR description after manual testing
