### PR TITLE
Desktop: Fix OneNote zip import path when .one files are at root level

### DIFF
--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -8,6 +8,7 @@ import { join, resolve, normalize, sep, extname, basename, relative, dirname } f
 import Logger from '@joplin/utils/Logger';
 import { uuidgen } from '../../uuid';
 import shim from '../../shim';
+import { unique } from '../../ArrayUtils';
 
 const logger = Logger.create('InteropService_Importer_OneNote');
 
@@ -18,7 +19,7 @@ export type SvgXml = {
 
 type PageResolutionResult = { path: string };
 type PageIdMap = {
-	get: (pageId: string | null)=> PageResolutionResult | null;
+	get: (pageId: string|null)=> PageResolutionResult|null;
 };
 
 type NativeOneNoteConverter = (notebookPath: string, outputDirectory: string, baseDir: string)=> Promise<void>;
@@ -82,19 +83,21 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			return result;
 		}
 
-		const oneNoteEntries = files.filter(file =>
+		const notebookFiles = files.filter(file =>
 			['.one', '.onepkg', '.onetoc2'].includes(extname(file.path).toLowerCase()) &&
 			basename(file.path) !== 'OneNote_RecycleBin.onetoc2',
 		);
-		const topLevelEntries = [...new Set(oneNoteEntries.map(file => this.getEntryDirectory(unzipTempDirectory, file.path)))];
-		const baseFolder = topLevelEntries.length === 1 ? topLevelEntries[0] : '';
-		const baseFolderIsFile = ['.one', '.onepkg', '.onetoc2'].includes(extname(baseFolder).toLowerCase());
+
+		const topLevelEntries = unique(notebookFiles.map(file => this.getEntryDirectory(unzipTempDirectory, file.path)));
+		if (topLevelEntries.length > 1) {
+			throw new Error(`OneNote zip contains files from multiple top-level directories: ${JSON.stringify(topLevelEntries)}`);
+		}
+
+		const baseFolder = topLevelEntries[0] ?? '';
+		const baseFolderStat = baseFolder ? await shim.fsDriver().stat(join(unzipTempDirectory, baseFolder)) : null;
+		const baseFolderIsFile = baseFolderStat ? !baseFolderStat.isDirectory() : false;
 		const notebookBaseDir = !baseFolder || baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
 		const outputDirectory2 = !baseFolder || baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
-
-		const notebookFiles = files.filter(e => {
-			return extname(e.path) !== '.onetoc2' && basename(e.path) !== 'OneNote_RecycleBin.onetoc2';
-		});
 
 		const oneNoteConverter = getOneNoteConverter();
 
@@ -168,7 +171,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		}
 
 		return {
-			get: (id: string | null) => {
+			get: (id: string|null) => {
 				// Accepting null input matches the behavior of a JavaScript Map's .get method
 				// and simplifies handling 'not found' edge cases:
 				if (!id) return null;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -83,8 +83,10 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		}
 
 		const baseFolder = this.getEntryDirectory(unzipTempDirectory, files[0].path);
-		const notebookBaseDir = join(unzipTempDirectory, baseFolder, sep);
-		const outputDirectory2 = join(tempOutputDirectory, baseFolder);
+		// If baseFolder has a file extension, files are at the root of the zip (no subfolder).
+		const baseFolderIsFile = extname(baseFolder) !== '';
+		const notebookBaseDir = baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
+		const outputDirectory2 = baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
 
 		const notebookFiles = files.filter(e => {
 			return extname(e.path) !== '.onetoc2' && basename(e.path) !== 'OneNote_RecycleBin.onetoc2';

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -84,7 +84,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 
 		const baseFolder = this.getEntryDirectory(unzipTempDirectory, files[0].path);
 		// If baseFolder has a file extension, files are at the root of the zip (no subfolder).
-		const baseFolderIsFile = extname(baseFolder) !== '';
+		const baseFolderIsFile = ['.one', '.onepkg', '.onetoc2'].includes(extname(baseFolder).toLowerCase());
 		const notebookBaseDir = baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
 		const outputDirectory2 = baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
 

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -89,16 +89,21 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		);
 
 		const topLevelEntries = unique(notebookFiles.map(file => this.getEntryDirectory(unzipTempDirectory, file.path)));
-		if (topLevelEntries.length > 1) {
-			throw new Error(`OneNote zip contains files from multiple top-level directories: ${JSON.stringify(topLevelEntries)}`);
+
+		let baseFolder = '';
+		for (const entry of topLevelEntries) {
+			if (!entry) continue;
+			const stat = await shim.fsDriver().stat(join(unzipTempDirectory, entry));
+			if (stat?.isDirectory()) {
+				if (baseFolder) {
+					throw new Error(`OneNote zip contains files from multiple top-level directories: ${JSON.stringify(topLevelEntries)}`);
+				}
+				baseFolder = entry;
+			}
 		}
 
-		const baseFolder = topLevelEntries[0] ?? '';
-		const baseFolderStat = baseFolder ? await shim.fsDriver().stat(join(unzipTempDirectory, baseFolder)) : null;
-		const baseFolderIsFile = baseFolderStat ? !baseFolderStat.isDirectory() : false;
-		const notebookBaseDir = !baseFolder || baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
-		const outputDirectory2 = !baseFolder || baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
-
+		const notebookBaseDir = !baseFolder ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
+		const outputDirectory2 = !baseFolder ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
 		const oneNoteConverter = getOneNoteConverter();
 
 		logger.info('Extracting OneNote to HTML');

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -18,7 +18,7 @@ export type SvgXml = {
 
 type PageResolutionResult = { path: string };
 type PageIdMap = {
-	get: (pageId: string|null)=> PageResolutionResult|null;
+	get: (pageId: string | null)=> PageResolutionResult | null;
 };
 
 type NativeOneNoteConverter = (notebookPath: string, outputDirectory: string, baseDir: string)=> Promise<void>;
@@ -82,12 +82,15 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 			return result;
 		}
 
-		const baseFolder = this.getEntryDirectory(unzipTempDirectory, files[0].path);
-		// If the first notebook file is directly at the archive root (no subfolder),
-		// use unzipTempDirectory as the base instead of joining with baseFolder.
+		const oneNoteEntries = files.filter(file =>
+			['.one', '.onepkg', '.onetoc2'].includes(extname(file.path).toLowerCase()) &&
+			basename(file.path) !== 'OneNote_RecycleBin.onetoc2',
+		);
+		const topLevelEntries = [...new Set(oneNoteEntries.map(file => this.getEntryDirectory(unzipTempDirectory, file.path)))];
+		const baseFolder = topLevelEntries.length === 1 ? topLevelEntries[0] : '';
 		const baseFolderIsFile = ['.one', '.onepkg', '.onetoc2'].includes(extname(baseFolder).toLowerCase());
-		const notebookBaseDir = baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
-		const outputDirectory2 = baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
+		const notebookBaseDir = !baseFolder || baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
+		const outputDirectory2 = !baseFolder || baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);
 
 		const notebookFiles = files.filter(e => {
 			return extname(e.path) !== '.onetoc2' && basename(e.path) !== 'OneNote_RecycleBin.onetoc2';
@@ -165,7 +168,7 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		}
 
 		return {
-			get: (id: string|null)=>{
+			get: (id: string | null) => {
 				// Accepting null input matches the behavior of a JavaScript Map's .get method
 				// and simplifies handling 'not found' edge cases:
 				if (!id) return null;

--- a/packages/lib/services/interop/InteropService_Importer_OneNote.ts
+++ b/packages/lib/services/interop/InteropService_Importer_OneNote.ts
@@ -83,7 +83,8 @@ export default class InteropService_Importer_OneNote extends InteropService_Impo
 		}
 
 		const baseFolder = this.getEntryDirectory(unzipTempDirectory, files[0].path);
-		// If baseFolder has a file extension, files are at the root of the zip (no subfolder).
+		// If the first notebook file is directly at the archive root (no subfolder),
+		// use unzipTempDirectory as the base instead of joining with baseFolder.
 		const baseFolderIsFile = ['.one', '.onepkg', '.onetoc2'].includes(extname(baseFolder).toLowerCase());
 		const notebookBaseDir = baseFolderIsFile ? join(unzipTempDirectory, sep) : join(unzipTempDirectory, baseFolder, sep);
 		const outputDirectory2 = baseFolderIsFile ? tempOutputDirectory : join(tempOutputDirectory, baseFolder);


### PR DESCRIPTION
## Related
Related to #14223

## Problem
When importing a `.zip` file where `.one` files are at the root level (no subfolder), the output path was incorrectly constructed. `getEntryDirectory` returned the first `.one` filename (e.g. `not-truncated.one`) as the base folder. This caused all sections to fail with an IO error- even valid ones.

## Solution
Filter all actual OneNote entries (`.one`, `.onepkg`, `.onetoc2`) from the file list and compute their common top-level directory. If all entries share a single top-level directory that is itself a OneNote file (root-level zip), use `unzipTempDirectory` directly as the base. This avoids false positives from dotted directory names and non-OneNote files appearing first in the archive.

## Test
The existing test `should report failure, but continue importing other sections` now passes:
- Truncated section fails gracefully -> `onError` called once
- Normal section imports successfully -> `['Test note', 'Test section']`