### PR TITLE
Desktop: Fixes #10795: Add WCAG 2.2 accessibility labels to Mermaid chart button

### DIFF
--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -3,7 +3,7 @@ import { RuleOptions } from '../../MdToHtml';
 export default {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	assets: function(theme: any) {
+	assets: function (theme: any) {
 		return [
 			{
 				name: 'mermaid.min.js',
@@ -56,16 +56,16 @@ export default {
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	plugin: function(markdownIt: any, ruleOptions: RuleOptions) {
+	plugin: function (markdownIt: any, ruleOptions: RuleOptions) {
 		// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-		const defaultRender: Function = markdownIt.renderer.rules.fence || function(tokens: any[], idx: number, options: any, env: any, self: any) {
+		const defaultRender: Function = markdownIt.renderer.rules.fence || function (tokens: any[], idx: number, options: any, env: any, self: any) {
 			return self.renderToken(tokens, idx, options, env, self);
 		};
 
 		const exportButtonMarkup = isDesktop(ruleOptions.platformName) ? exportGraphButton(ruleOptions) : '';
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		markdownIt.renderer.rules.fence = function(tokens: any[], idx: number, options: any, env: any, self: any) {
+		markdownIt.renderer.rules.fence = function (tokens: any[], idx: number, options: any, env: any, self: any) {
 			const token = tokens[idx];
 			if (token.info !== 'mermaid') return defaultRender(tokens, idx, options, env, self);
 
@@ -118,7 +118,7 @@ const exportGraphButton = (ruleOptions: RuleOptions) => {
 
 const downloadIcon = () => {
 	// https://www.svgrepo.com/svg/505363/download
-	return '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M20 15V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18L4 15M8 11L12 15M12 15L16 11M12 15V3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>';
+	return '<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M20 15V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18L4 15M8 11L12 15M12 15L16 11M12 15V3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>';
 };
 
 const isDesktop = (platformName?: string) => {

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -58,7 +58,7 @@ export default {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	plugin: function(markdownIt: any, ruleOptions: RuleOptions) {
 		// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-		const defaultRender: Function = markdownIt.renderer.rules.fence || function (tokens: any[], idx: number, options: any, env: any, self: any) {
+		const defaultRender: Function = markdownIt.renderer.rules.fence || function(tokens: any[], idx: number, options: any, env: any, self: any) {
 			return self.renderToken(tokens, idx, options, env, self);
 		};
 		const exportButtonMarkup = isDesktop(ruleOptions.platformName) ? exportGraphButton(ruleOptions) : '';

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -111,14 +111,14 @@ const exportGraphButton = (ruleOptions: RuleOptions) => {
 	// OnClick is handled in the renderer script
 	return `
 		<div class="mermaid-export-graph">
-			<button style="${style}" aria-label="Download Mermaid chart" title="Download Mermaid chart">${downloadIcon()}</button>
+			<button type="button" style="${style}" aria-label="Download Mermaid chart" title="Download Mermaid chart">${downloadIcon()}</button>
 		</div>
 	`;
 };
 
 const downloadIcon = () => {
 	// https://www.svgrepo.com/svg/505363/download
-	return '<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M20 15V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18L4 15M8 11L12 15M12 15L16 11M12 15V3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>';
+	return '<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><g stroke-width="0"></g><g stroke-linecap="round" stroke-linejoin="round"></g><g> <path d="M20 15V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18L4 15M8 11L12 15M12 15L16 11M12 15V3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></g></svg>';
 };
 
 const isDesktop = (platformName?: string) => {

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -3,7 +3,7 @@ import { RuleOptions } from '../../MdToHtml';
 export default {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	assets: function (theme: any) {
+	assets: function(theme: any) {
 		return [
 			{
 				name: 'mermaid.min.js',
@@ -56,16 +56,15 @@ export default {
 	},
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	plugin: function (markdownIt: any, ruleOptions: RuleOptions) {
+	plugin: function(markdownIt: any, ruleOptions: RuleOptions) {
 		// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
 		const defaultRender: Function = markdownIt.renderer.rules.fence || function (tokens: any[], idx: number, options: any, env: any, self: any) {
 			return self.renderToken(tokens, idx, options, env, self);
 		};
-
 		const exportButtonMarkup = isDesktop(ruleOptions.platformName) ? exportGraphButton(ruleOptions) : '';
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		markdownIt.renderer.rules.fence = function (tokens: any[], idx: number, options: any, env: any, self: any) {
+		markdownIt.renderer.rules.fence = function(tokens: any[], idx: number, options: any, env: any, self: any) {
 			const token = tokens[idx];
 			if (token.info !== 'mermaid') return defaultRender(tokens, idx, options, env, self);
 

--- a/packages/renderer/MdToHtml/rules/mermaid.ts
+++ b/packages/renderer/MdToHtml/rules/mermaid.ts
@@ -111,7 +111,7 @@ const exportGraphButton = (ruleOptions: RuleOptions) => {
 	// OnClick is handled in the renderer script
 	return `
 		<div class="mermaid-export-graph">
-			<button style="${style}" alt="Export mermaid graph">${downloadIcon()}</button>
+			<button style="${style}" aria-label="Download Mermaid chart" title="Download Mermaid chart">${downloadIcon()}</button>
 		</div>
 	`;
 };


### PR DESCRIPTION
Summary of Changes:
****Addresses an unchecked item in the WCAG 2.2 compliance tracking issue #10795. 

****Identified and removed the invalid alt attribute from the Mermaid chart download <button> element.

****Implemented aria-label="Download Mermaid chart" to ensure strict screen reader compliance.

****Added title="Download Mermaid chart" to provide a visible hover tooltip for standard pointer navigation.

AI Assistance Disclosure:
I utilized an AI coding agent (Google Antigravity) as an assistive tool during this PR. I used it to accelerate codebase navigation (locating the specific mermaid.ts renderer component) and to draft the initial attribute syntax. I took full ownership of the logic, manually auditing the AI's suggestions against WCAG 2.2 standards, correcting the HTML structure, and verifying the final implementation. I am fully prepared to discuss the underlying accessibility logic and React structure of this component.

Testing Note:
Due to hardware constraints on my local machine (timeout failures while compiling sharp and sqlite3 on an older Intel architecture), I am unable to build the full Electron desktop app locally to provide a visual screenshot of the new hover tooltip. However, the HTML attributes have been strictly applied according to WCAG 2.2 specs. I will rely on the CI pipeline to confirm the test suite passes.