### PR TITLE
Add Plugin page link to main website and Help website navbars

### DIFF
--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -15,6 +15,7 @@
 				{{> twitterLink}}
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
+				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>
 
 				<div class="dropdown language-switcher">
@@ -60,6 +61,7 @@
 						<div class="text-center menu-mobile-top">
 							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>
+							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
 							<a href="{{forumUrl}}" class="fw500 mobile-menu-link">Forum</a>
 						</div>
 

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -214,6 +214,12 @@ const config = {
 						label: 'Help',
 					},
 					{
+						to: process.env.WEBSITE_BASE_URL + '/plugins',
+						label: 'Plugins',
+						position: 'right',
+						target: '_self',
+					},
+					{
 						to: 'https://discourse.joplinapp.org',
 						label: 'Forum',
 						position: 'right',


### PR DESCRIPTION
Fixes #14619

The Plugin discovery website at `/plugins/` was missing from both the main website and the `/help` site navigation. This adds a "Plugins" link to both navbars, placed between "Help" and "Forum" for consistency

Changes:

- Added Plugins link to the main website navbar (desktop and mobile variants) in `navbar.mustache`
- Added Plugins link to the help site (Docusaurus) navbar in `docusaurus.config.js`