### PR TITLE
Server: Fixes #14615: Fixed docker-compose server profile errors and localhost instructions

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -9,8 +9,8 @@
 #
 # APP_BASE_URL: This is the base public URL where the service will be running.
 #	- If Joplin Server needs to be accessible over the internet, configure APP_BASE_URL as follows: https://example.com/joplin. 
-#	- If Joplin Server does not need to be accessible over the internet, set the APP_BASE_URL to your server's hostname. 
-#     For Example: http://[hostname]:22300. The base URL can include the port.
+#	- If Joplin Server does not need to be accessible over the internet, set the APP_BASE_URL with your server's hostname. 
+#     E.g., if your server's hostname is localhost, set it to http://localhost:22300. The base URL can include the port.
 # APP_PORT: The local port on which the Docker container will listen. 
 #	- This would typically be mapped to port to 443 (TLS) with a reverse proxy.
 #	- If Joplin Server does not need to be accessible over the internet, the port can be mapped to 22300.
@@ -27,7 +27,7 @@ services:
             - full
             - server
         volumes:
-            - ./data/postgres:/var/lib/postgresql/data
+            - pgdata:/var/lib/postgresql/data
         networks:
             - app-network
         ports:
@@ -43,8 +43,11 @@ services:
             - full
             - server
         depends_on:
-            - db
-            - transcribe
+            db:
+                condition: service_started
+            transcribe:
+                condition: service_started
+                required: false
         ports:
             - "22300:22300"
         networks:
@@ -62,7 +65,7 @@ services:
             - POSTGRES_HOST=db
             - TRANSCRIBE_API_KEY=${TRANSCRIBE_API_KEY}
             - TRANSCRIBE_BASE_URL=http://transcribe:4567
-            - TRANSCRIBE_ENABLED=${TRANSCRIBE_ENABLED}
+            - TRANSCRIBE_ENABLED=${TRANSCRIBE_ENABLED:-0}
     transcribe-db:
         image: postgres:16
         profiles:
@@ -84,8 +87,8 @@ services:
         profiles:
             - full
         volumes:
-            - ${HTR_CLI_IMAGES_FOLDER}:/app/packages/transcribe/images
-            - ${HTR_CLI_MODELS_FOLDER}:/opt/models:ro
+            - ${HTR_CLI_IMAGES_FOLDER:-./data/images}:/app/packages/transcribe/images
+            - ${HTR_CLI_MODELS_FOLDER:-./data/models}:/opt/models:ro
         depends_on:
             - transcribe-db
         ports:
@@ -116,3 +119,5 @@ services:
             - HTR_CLI_IMAGES_FOLDER=/app/packages/transcribe/images
             - HTR_CLI_MODELS_FOLDER=/opt/models
 
+volumes:
+    pgdata:


### PR DESCRIPTION
## Description
Fixes #14615

This PR resolves infrastructure errors that prevented standalone `docker-compose.server.yml` deployment.

## Changes made
* **Added default fallback variables (`:-`)**: Added defaults for `${HTR_CLI_IMAGES_FOLDER}`, `${HTR_CLI_MODELS_FOLDER}`, and `${TRANSCRIBE_ENABLED}`.
* **Optional transcribe dependency**: Flagged the `transcribe` dependency within the `app` service with `required: false`.
* **Named Docker volumes**: Updated PostgreSQL binding to a standard `pgdata` named volume.

## Test Plan

## Manual Verification

### Profile: Server (Standalone)
1. Ran `docker compose --profile server up -d`.
2. Verified `app` and `db` containers launched successfully without `transcribe`.
3. Confirmed `app` container booted and database initialized via `pgdata`.

### Profile: Full (Standard)
1. Ran `docker compose --profile full up -d`.
2. Verified all containers (including `transcribe`) launched correctly with new fallbacks.
3. Confirmed no regression in standard multi-container setup.