### PR TITLE
Fixes #14143: Preserve scroll position when undo/redo in TinyMCE editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -122,6 +122,8 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 	const editorRef = useRef<Editor>(null);
 	editorRef.current = editor;
 
+	const patchedUndoManagerRef = useRef<Editor['undoManager'] | null>(null);
+
 	const styles = styles_(props);
 	// const theme = themeStyle(props.themeId);
 
@@ -1512,6 +1514,44 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 		};
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [props.onWillChange, props.onChange, props.contentMarkupLanguage, props.contentOriginalCss, editor]);
+
+	useEffect(() => {
+		if (!editor) {
+			patchedUndoManagerRef.current = null;
+			return () => {};
+		}
+
+		const undoManager = editor.undoManager;
+		if (patchedUndoManagerRef.current === undoManager) {
+			return () => {};
+		}
+
+		const win = editor.getWin();
+		if (!win) return () => {};
+
+		const originalUndo = undoManager.undo.bind(undoManager);
+		const originalRedo = undoManager.redo.bind(undoManager);
+
+		const saveAndRestoreScroll = (fn: ()=> ReturnType<typeof originalUndo>) => {
+			const scrollX = win.scrollX;
+			const scrollY = win.scrollY;
+			const result = fn();
+			win.scrollTo(scrollX, scrollY);
+			return result;
+		};
+
+		undoManager.undo = () => saveAndRestoreScroll(originalUndo);
+		undoManager.redo = () => saveAndRestoreScroll(originalRedo);
+		patchedUndoManagerRef.current = undoManager;
+
+		return () => {
+			if (patchedUndoManagerRef.current === undoManager) {
+				undoManager.undo = originalUndo;
+				undoManager.redo = originalRedo;
+				patchedUndoManagerRef.current = null;
+			}
+		};
+	}, [editor]);
 
 	// -----------------------------------------------------------------------------------------
 	// Destroy the editor when unmounting


### PR DESCRIPTION
###  Desktop: Preserve scroll position when undo/redo in TinyMCE editor . Fixes #14143

---

### This PR fixes an issue where the editor viewport jumps when performing undo or redo operations in the rich text editor while editing very long lines.

---- 

When undo or redo is triggered, the editor may reposition the viewport in a way that causes the current editing position to move out of view. 

---

To resolve this, undo and redo operations are wrapped so that the editor's scroll position is preserved during the operation. The implementation works as follows:

- Capture the current scroll position of the editor.
- Execute the original TinyMCE undo or redo operation.
- Restore the scroll position immediately after the operation completes.


This change does not modify TinyMCE's internal behaviour and only ensures that the editor scroll position remains consistent during undo and redo operations.

---


https://github.com/user-attachments/assets/867914e9-180e-48ea-9862-22beaf89836a

