### PR TITLE
Docs: Fixes: #14619: add plugin website link to /help

### DIFF
--- a/readme/index.md
+++ b/readme/index.md
@@ -14,7 +14,7 @@ Joplin is "offline first", which means you always have all your data on your pho
 
 The notes can be securely [synchronised](https://github.com/laurent22/joplin/blob/dev/readme/apps/sync/index.md) using [end-to-end encryption](https://github.com/laurent22/joplin/blob/dev/readme/apps/sync/e2ee.md) with various cloud services including Nextcloud, Dropbox, OneDrive and [Joplin Cloud](https://joplinapp.org/plans/).
 
-Full text search is available on all platforms to quickly find the information you need. The app can be customised using plugins and themes, and you can also easily create your own.
+Full text search is available on all platforms to quickly find the information you need. The app can be customised using [plugins](https://joplinapp.org/plugins/) and themes, and you can also easily create your own.
 
 The application is available for Windows, Linux, macOS, Android and iOS. A [Web Clipper](https://github.com/laurent22/joplin/blob/dev/readme/apps/clipper.md), to save web pages and screenshots from your browser, is also available for [Firefox](https://addons.mozilla.org/firefox/addon/joplin-web-clipper/) and [Chrome](https://chrome.google.com/webstore/detail/joplin-web-clipper/alofnhikmmkdbbbgpnglcpdollgjjfek?hl=en-GB).
 


### PR DESCRIPTION
**Fixes:**  #14619 
### Summary:
Adds back the link to the Plugin website on the /help site. The link appears to have been removed or missing previously, which prevented users from navigating to the Plugin website from the help pages.

### Screenshot of Changes Made:

https://github.com/user-attachments/assets/8276e9c8-0778-432b-b705-4ce69390fa6f

