### PR TITLE
All: Fixes #14630: underline disappearing from ++insert++ syntax when cursor is on that line

### DIFF
--- a/packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.ts
@@ -28,17 +28,20 @@ left    | right
 		expect(codeBlock.parentElement.classList.contains('.cm-tableRow'));
 	});
 
-	it('should decorate ++insert++ spans', async () => {
+	test.each([
+		0,
+		'before ++'.length + 1,
+	])('should decorate ++insert++ spans when the caret is at %i', async cursorPos => {
 		const editorText = 'before ++inserted++ after';
 		const editor = await createTestEditor(
 			editorText,
-			EditorSelection.cursor(0),
+			EditorSelection.cursor(cursorPos),
 			['Insert'],
 			[decoratorExtension],
 		);
 
 		const insertSpan = editor.contentDOM.querySelector('.cm-insert');
 		expect(insertSpan).not.toBeNull();
-		expect(insertSpan.textContent).toContain('inserted');
+		expect(insertSpan?.textContent).toContain('inserted');
 	});
 });

--- a/packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.ts
+++ b/packages/editor/CodeMirror/extensions/markdownDecorationExtension.test.ts
@@ -27,4 +27,18 @@ left    | right
 		expect(codeBlock.textContent).toBe('`foo`');
 		expect(codeBlock.parentElement.classList.contains('.cm-tableRow'));
 	});
+
+	it('should decorate ++insert++ spans', async () => {
+		const editorText = 'before ++inserted++ after';
+		const editor = await createTestEditor(
+			editorText,
+			EditorSelection.cursor(0),
+			['Insert'],
+			[decoratorExtension],
+		);
+
+		const insertSpan = editor.contentDOM.querySelector('.cm-insert');
+		expect(insertSpan).not.toBeNull();
+		expect(insertSpan.textContent).toContain('inserted');
+	});
 });

--- a/packages/editor/CodeMirror/extensions/markdownDecorationExtension.ts
+++ b/packages/editor/CodeMirror/extensions/markdownDecorationExtension.ts
@@ -116,6 +116,10 @@ const strikethroughDecoration = Decoration.mark({
 	attributes: { class: 'cm-strike' },
 });
 
+const insertDecoration = Decoration.mark({
+	attributes: { class: 'cm-insert' },
+});
+
 const nodeNameToLineDecoration: Record<string, Decoration> = {
 	'FencedCode': codeBlockDecoration,
 	'CodeBlock': codeBlockDecoration,
@@ -150,6 +154,7 @@ const nodeNameToMarkDecoration: Record<string, Decoration> = {
 	'HorizontalRule': horizontalRuleDecoration,
 	'TaskMarker': taskMarkerDecoration,
 	'Strikethrough': strikethroughDecoration,
+	'Insert': insertDecoration,
 	'Highlight': markDecoration,
 };
 

--- a/packages/editor/CodeMirror/theme.ts
+++ b/packages/editor/CodeMirror/theme.ts
@@ -187,6 +187,9 @@ const createTheme = (theme: EditorTheme): Extension[] => {
 		'& .cm-strike': {
 			textDecoration: 'line-through',
 		},
+		'& .cm-insert': {
+			textDecoration: 'underline',
+		},
 
 		// Applying font size changes with CSS rather than the theme below works
 		// around an issue where the border for code blocks in headings was too


### PR DESCRIPTION
> [!note]
> AI Disclosure: This change was made using an LLM, and then reviewed and verified with manual testing

## Problem

Fixes https://github.com/laurent22/joplin/issues/14630

When `++insert++` syntax is enabled (which applies an underline decoration to text) and render markup is enabled, placing the cursor on the same line as that text would remove the underline effect. 

Other inline formatting like strikethrough was working as expected, so I compared the `++insert++` implementation to strikethrough and found that the difference was that `++insert++` only had decorations applied via `addFormattingClasses` (used by the render markup functionality), whereas strikethrough and other inline formatting also has an always-on decoration path via markdownDecorationExtension.ts and theme styling in theme.ts (used for syntax highlighting the raw markdown)

> [!note]
> This markdownDecorationExtension.ts/theme.ts styling is necessary for the formatting effect to be applied when render markup is disabled, so this change also fixes the issue where the underline wasn't shown when render markup was disabled

## Solution

Include styling for `++insert++` in `markdownDecorationExtension.ts` and `theme.ts`, consistent with the other inline formatting implementations

## Example behavior

### Before

#### render markup enabled:

![before](https://github.com/user-attachments/assets/321ecd63-9fb6-471a-be4c-b2e7854781c2)

#### render markup disabled:

<img width="445" height="141" alt="image" src="https://github.com/user-attachments/assets/39dfae2b-e208-44c2-b146-20f7f00cc1bc" />

### After

#### render markup enabled:

![after](https://github.com/user-attachments/assets/22a6e5cf-d9f6-4a1b-b30a-2dd3ebcd4aef)

#### render markup disabled:

<img width="519" height="173" alt="image" src="https://github.com/user-attachments/assets/8adde62c-7828-4bb5-afc3-e23bea170d58" />


## Test Plan

Tested the following in the desktop and web app:

- [x] Verify that insert does not lose its underline decoration when cursor is on that line. Tested with and without render markup enabled.
- [x] Verify that ++ characters are revealed (but underline formatting remains) when cursor is directly on the ++insert++ content
- [x] Test toggling insert syntax on/off under Tools | Options | Markdown and verifty that ++insert++ is only rendered when that setting is enabled
- [x] Spot checked other inline formatting (bold, italic, strikethrough, highlight, inline code, inline html) and didn't see any issues