### PR TITLE
Desktop: Fixes #14627: use resourceUrl() for base64 images in pasteAsMarkdown

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -1,8 +1,9 @@
 import Setting from '@joplin/lib/models/Setting';
-import { processPastedHtml } from './resourceHandling';
+import { processImagesInPastedHtml, processPastedHtml } from './resourceHandling';
 import markupLanguageUtils from '@joplin/lib/markupLanguageUtils';
 import HtmlToMd from '@joplin/lib/HtmlToMd';
 import { HtmlToMarkdownHandler, MarkupToHtmlHandler } from './types';
+import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 
 const createTestMarkupConverters = () => {
 	const markupToHtml: MarkupToHtmlHandler = async (markupLanguage, markup, options) => {
@@ -110,5 +111,32 @@ describe('resourceHandling', () => {
 			// The alt text after normalization must not contain literal newlines
 			expect(result).not.toMatch(/alt="[^"]*\n/);
 		}
+	});
+
+	describe('processImagesInPastedHtml - base64', () => {
+		beforeEach(async () => {
+			await setupDatabaseAndSynchronizer(1);
+			await switchClient(1);
+		});
+
+		// 1x1 transparent PNG — smallest valid base64-encoded image for testing
+		const minimalPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+		it('should convert base64 image to :/resourceId when useInternalUrls is true', async () => {
+			// Regression test: base64 branch was hardcoding file:// and ignoring useInternalUrls
+			const html = `<img src="data:image/png;base64,${minimalPng}"/>`;
+			const result = await processImagesInPastedHtml(html, { useInternalUrls: true });
+			expect(result).toMatch(/src=":\/[a-f0-9]+"/);
+			expect(result).not.toContain('file://');
+			expect(result).not.toContain('data:');
+		});
+
+		it('should convert base64 image to file:// when useInternalUrls is false', async () => {
+			// Ensures base64 data is always replaced with a short path regardless of mode
+			const html = `<img src="data:image/png;base64,${minimalPng}"/>`;
+			const result = await processImagesInPastedHtml(html, { useInternalUrls: false });
+			expect(result).toContain('file://');
+			expect(result).not.toContain('data:');
+		});
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -113,30 +113,20 @@ describe('resourceHandling', () => {
 		}
 	});
 
-	describe('processImagesInPastedHtml - base64', () => {
-		beforeEach(async () => {
-			await setupDatabaseAndSynchronizer(1);
-			await switchClient(1);
-		});
-
-		// 1x1 transparent PNG — smallest valid base64-encoded image for testing
-		const minimalPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-
-		it('should convert base64 image to :/resourceId when useInternalUrls is true', async () => {
-			// Regression test: base64 branch was hardcoding file:// and ignoring useInternalUrls
-			const html = `<img src="data:image/png;base64,${minimalPng}"/>`;
-			const result = await processImagesInPastedHtml(html, { useInternalUrls: true });
-			expect(result).toMatch(/src=":\/[a-f0-9]+"/);
-			expect(result).not.toContain('file://');
-			expect(result).not.toContain('data:');
-		});
-
-		it('should convert base64 image to file:// when useInternalUrls is false', async () => {
-			// Ensures base64 data is always replaced with a short path regardless of mode
-			const html = `<img src="data:image/png;base64,${minimalPng}"/>`;
-			const result = await processImagesInPastedHtml(html, { useInternalUrls: false });
-			expect(result).toContain('file://');
-			expect(result).not.toContain('data:');
-		});
+	// Regression test: base64 branch was hardcoding file:// and ignoring useInternalUrls
+	// 1x1 transparent PNG — smallest valid base64-encoded image for testing
+	const minimalPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+	
+	test.each([
+		{ useInternalUrls: true, expectMatch: /src=":\/[a-f0-9]+"/, expectAbsent: 'file://' },
+		{ useInternalUrls: false, expectMatch: /src="file:\/\//, expectAbsent: 'data:' },
+	])('should convert base64 image using resourceUrl (useInternalUrls=$useInternalUrls)', async ({ useInternalUrls, expectMatch, expectAbsent }) => {
+		await setupDatabaseAndSynchronizer(1);
+		await switchClient(1);
+		const html = `<img src="data:image/png;base64,${minimalPng}"/>`;
+		const result = await processImagesInPastedHtml(html, { useInternalUrls });
+		expect(result).toMatch(expectMatch);
+		expect(result).not.toContain(expectAbsent);
+		expect(result).not.toContain('data:');
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -116,7 +116,7 @@ describe('resourceHandling', () => {
 	// Regression test: base64 branch was hardcoding file:// and ignoring useInternalUrls
 	// 1x1 transparent PNG — smallest valid base64-encoded image for testing
 	const minimalPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-	
+
 	test.each([
 		{ useInternalUrls: true, expectMatch: /src=":\/[a-f0-9]+"/, expectAbsent: 'file://' },
 		{ useInternalUrls: false, expectMatch: /src="file:\/\//, expectAbsent: 'data:' },

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -185,7 +185,7 @@ export const processImagesInPastedHtml = async (html: string, options: ProcessIm
 					// Word encodes base64 with MIME line breaks every ~76 chars.
 					// Strip whitespace before decoding, then save as a Joplin resource
 					// so Turndown's outerHTML (used for images with width/height) gets
-					// a short file:// URL instead of 200KB of base64.
+					// a short URL instead of 200KB of base64.
 					const cleanSrc = imageSrc.replace(/\s/g, '');
 					const dataUrlMatch = cleanSrc.match(/^data:([^;]+);base64,(.+)$/);
 					if (dataUrlMatch) {
@@ -196,7 +196,7 @@ export const processImagesInPastedHtml = async (html: string, options: ProcessIm
 						try {
 							await shim.fsDriver().writeFile(filePath, base64Data, 'base64');
 							const createdResource = await shim.createResourceFromPath(filePath);
-							mappedResources[imageSrc] = `file://${encodeURI(Resource.fullPath(createdResource))}`;
+							mappedResources[imageSrc] = resourceUrl(createdResource);
 						} catch (writeError) {
 							writeError.message = `processPastedHtml: Failed to write or create resource from pasted image: ${writeError.message}`;
 							throw writeError;


### PR DESCRIPTION
Closes #14627 

## Summary

Base64 images pasted via "Paste as Markdown" were generating `file://` paths instead of Joplin resource links (`:/resourceId`).

## Root Cause
The base64 branch in `resourceHandling.ts` bypassed `resourceUrl()` and hardcoded `file://` directly. All other image types correctly use `resourceUrl()`.

## Fix
One line change — use `resourceUrl(createdResource)` instead of hardcoded `file://` path.

## Demo
<img width="489" height="254" alt="image" src="https://github.com/user-attachments/assets/e2881d9e-ae3e-41e3-b771-e04a72c23a68" />