### PR TITLE
Desktop: Fixes #14621: Application crashes when deleting a notebook

### DIFF
--- a/packages/app-desktop/gui/NoteList/utils/useScroll.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useScroll.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Size } from '@joplin/utils/types';
-import { useCallback, useState, useRef, useMemo } from 'react';
+import { useCallback, useState, useRef, useMemo, useLayoutEffect } from 'react';
 
 const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, listSize: Size, listRef: React.MutableRefObject<HTMLDivElement>) => {
 	const [scrollTop, setScrollTop] = useState(0);
@@ -13,11 +13,15 @@ const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, list
 	// Refs for values that makeItemIndexVisible reads at call-time.
 	// This keeps the callback reference stable across renders
 	const noteCountRef = useRef(noteCount);
-	noteCountRef.current = noteCount;
 	const scrollTopRef = useRef(scrollTop);
-	scrollTopRef.current = scrollTop;
 	const maxScrollTopRef = useRef(maxScrollTop);
-	maxScrollTopRef.current = maxScrollTop;
+
+	useLayoutEffect(() => {
+		noteCountRef.current = noteCount;
+		scrollTopRef.current = scrollTop;
+		maxScrollTopRef.current = maxScrollTop;
+	});
+
 
 	// This ugly hack is necessary because setting scrollTop at a high
 	// frequency, while scrolling with the keyboard, is unreliable - the

--- a/packages/app-desktop/gui/NoteList/utils/useScroll.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useScroll.ts
@@ -10,6 +10,15 @@ const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, list
 		return Math.max(0, itemSize.height * noteCount - listSize.height);
 	}, [itemSize.height, noteCount, listSize.height]);
 
+	// Refs for values that makeItemIndexVisible reads at call-time.
+	// This keeps the callback reference stable across renders
+	const noteCountRef = useRef(noteCount);
+	noteCountRef.current = noteCount;
+	const scrollTopRef = useRef(scrollTop);
+	scrollTopRef.current = scrollTop;
+	const maxScrollTopRef = useRef(maxScrollTop);
+	maxScrollTopRef.current = maxScrollTop;
+
 	// This ugly hack is necessary because setting scrollTop at a high
 	// frequency, while scrolling with the keyboard, is unreliable - the
 	// property will appear to be set (reading it back gives the correct value),
@@ -60,11 +69,15 @@ const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, list
 	// }, []);
 
 	const makeItemIndexVisible = useCallback((itemIndex: number) => {
-		const lineTopFloat = scrollTop / itemSize.height;
+		const currentScrollTop = scrollTopRef.current;
+		const currentNoteCount = noteCountRef.current;
+		const currentMaxScrollTop = maxScrollTopRef.current;
+
+		const lineTopFloat = currentScrollTop / itemSize.height;
 		const topFloat = lineTopFloat * itemsPerLine;
-		const lineBottomFloat = (scrollTop + listSize.height - itemSize.height) / itemSize.height;
+		const lineBottomFloat = (currentScrollTop + listSize.height - itemSize.height) / itemSize.height;
 		const bottomFloat = lineBottomFloat * itemsPerLine;
-		const top = Math.min(noteCount - 1, Math.floor(topFloat) + 1);
+		const top = Math.min(currentNoteCount - 1, Math.floor(topFloat) + 1);
 		const bottom = Math.max(0, Math.floor(bottomFloat));
 
 		if (itemIndex >= top && itemIndex <= bottom) return;
@@ -79,13 +92,13 @@ const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, list
 		}
 
 		if (newScrollTop < 0) newScrollTop = 0;
-		if (newScrollTop > maxScrollTop) newScrollTop = maxScrollTop;
+		if (newScrollTop > currentMaxScrollTop) newScrollTop = currentMaxScrollTop;
 
 		setScrollTop(newScrollTop);
 		listRef.current.scrollTop = newScrollTop;
 		lastScrollSetTime.current = Date.now();
 		// setScrollTopLikeYouMeanIt(newScrollTop);
-	}, [itemsPerLine, noteCount, itemSize.height, scrollTop, listSize.height, maxScrollTop, listRef]); // , setScrollTopLikeYouMeanIt]);
+	}, [itemsPerLine, itemSize.height, listSize.height, listRef]); // , setScrollTopLikeYouMeanIt]);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const onScroll = useCallback((event: any) => {

--- a/packages/app-desktop/gui/NoteList/utils/useScroll.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useScroll.ts
@@ -98,7 +98,7 @@ const useScroll = (itemsPerLine: number, noteCount: number, itemSize: Size, list
 		listRef.current.scrollTop = newScrollTop;
 		lastScrollSetTime.current = Date.now();
 		// setScrollTopLikeYouMeanIt(newScrollTop);
-	}, [itemsPerLine, itemSize.height, listSize.height, listRef]); // , setScrollTopLikeYouMeanIt]);
+	}, [itemsPerLine, itemSize.height, listSize.height, listRef]);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const onScroll = useCallback((event: any) => {

--- a/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
@@ -1,18 +1,12 @@
 import * as React from 'react';
 import { Size } from '@joplin/utils/types';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ItemFlow } from '@joplin/lib/services/plugins/api/noteListType';
 
 const useItemElement = (
 	rootElement: HTMLDivElement, noteId: string, noteHtml: string, focusVisible: boolean, style: React.CSSProperties, itemSize: Size, onClick: React.MouseEventHandler<HTMLDivElement>, onDoubleClick: React.MouseEventHandler<HTMLDivElement>, flow: ItemFlow,
 ) => {
 	const [itemElement, setItemElement] = useState<HTMLDivElement>(null);
-
-	// Use refs for event handlers so that changes to onClick/onDoubleClick don't
-	const onClickRef = useRef(onClick);
-	const onDoubleClickRef = useRef(onDoubleClick);
-	onClickRef.current = onClick;
-	onDoubleClickRef.current = onDoubleClick;
 
 	useEffect(() => {
 		if (!rootElement) return () => {};
@@ -28,9 +22,9 @@ const useItemElement = (
 		element.style.height = `${itemSize.height}px`;
 		element.innerHTML = noteHtml;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we're mixing React synthetic events with DOM events which ideally should not be done but it is fine in this particular case
-		element.addEventListener('click', (e) => onClickRef.current(e as any));
+		element.addEventListener('click', onClick as any);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we're mixing React synthetic events with DOM events which ideally should not be done but it is fine in this particular case
-		element.addEventListener('dblclick', (e) => onDoubleClickRef.current(e as any));
+		element.addEventListener('dblclick', onDoubleClick as any);
 
 		rootElement.appendChild(element);
 
@@ -39,7 +33,7 @@ const useItemElement = (
 		return () => {
 			element.remove();
 		};
-	}, [rootElement, itemSize, noteHtml, noteId, style, flow]);
+	}, [rootElement, itemSize, noteHtml, noteId, style, onClick, onDoubleClick, flow]);
 
 	useEffect(() => {
 		if (!itemElement) return;

--- a/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useItemElement.ts
@@ -1,12 +1,18 @@
 import * as React from 'react';
 import { Size } from '@joplin/utils/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ItemFlow } from '@joplin/lib/services/plugins/api/noteListType';
 
 const useItemElement = (
 	rootElement: HTMLDivElement, noteId: string, noteHtml: string, focusVisible: boolean, style: React.CSSProperties, itemSize: Size, onClick: React.MouseEventHandler<HTMLDivElement>, onDoubleClick: React.MouseEventHandler<HTMLDivElement>, flow: ItemFlow,
 ) => {
 	const [itemElement, setItemElement] = useState<HTMLDivElement>(null);
+
+	// Use refs for event handlers so that changes to onClick/onDoubleClick don't
+	const onClickRef = useRef(onClick);
+	const onDoubleClickRef = useRef(onDoubleClick);
+	onClickRef.current = onClick;
+	onDoubleClickRef.current = onDoubleClick;
 
 	useEffect(() => {
 		if (!rootElement) return () => {};
@@ -22,9 +28,9 @@ const useItemElement = (
 		element.style.height = `${itemSize.height}px`;
 		element.innerHTML = noteHtml;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we're mixing React synthetic events with DOM events which ideally should not be done but it is fine in this particular case
-		element.addEventListener('click', onClick as any);
+		element.addEventListener('click', (e) => onClickRef.current(e as any));
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- we're mixing React synthetic events with DOM events which ideally should not be done but it is fine in this particular case
-		element.addEventListener('dblclick', onDoubleClick as any);
+		element.addEventListener('dblclick', (e) => onDoubleClickRef.current(e as any));
 
 		rootElement.appendChild(element);
 
@@ -33,7 +39,7 @@ const useItemElement = (
 		return () => {
 			element.remove();
 		};
-	}, [rootElement, itemSize, noteHtml, noteId, style, onClick, onDoubleClick, flow]);
+	}, [rootElement, itemSize, noteHtml, noteId, style, flow]);
 
 	useEffect(() => {
 		if (!itemElement) return;

--- a/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ListRenderer, ListRendererDependency, NoteListColumns } from '@joplin/lib/services/plugins/api/noteListType';
 import Note from '@joplin/lib/models/Note';
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
@@ -25,6 +25,12 @@ const hashContent = (content: any) => {
 
 export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listRenderer: ListRenderer, highlightedWords: string[], itemIndex: number, columns: NoteListColumns) => {
 	const [renderedNote, setRenderedNote] = useState<RenderedNote>(null);
+
+	// Use a ref for the hash check so that renderedNote doesn't need to be in
+	// the effect dependency array — having state in its own deps array causes
+	// cascading re-renders (especially under React 19's stricter update loop
+	// detection) when notes are deleted rapidly.
+	const renderedNoteRef = useRef<RenderedNote>(null);
 
 	let dependencies = columns && columns.length ? columns.map(c => c.name) as ListRendererDependency[] : [];
 	if (listRenderer.dependencies) dependencies = dependencies.concat(listRenderer.dependencies);
@@ -58,7 +64,7 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 				folder ? folder.title : '',
 			]);
 
-			if (renderedNote && renderedNote.hash === viewHash) return null;
+			if (renderedNoteRef.current && renderedNoteRef.current.hash === viewHash) return null;
 
 			const noteTitleHtml = getNoteTitleHtml(highlightedWords, Note.displayTitle(note));
 
@@ -84,7 +90,7 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 
 			if (event.cancelled) return null;
 
-			setRenderedNote({
+			const newRenderedNote = {
 				id: note.id,
 				hash: viewHash,
 				html: renderTemplate(
@@ -93,11 +99,15 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 					listRenderer.itemValueTemplates,
 					view,
 				),
-			});
+			};
+			renderedNoteRef.current = newRenderedNote;
+			setRenderedNote(newRenderedNote);
 		};
 
 		void renderNote();
-	}, [note, isSelected, isWatched, listRenderer, renderedNote, columns]);
+	// renderedNote is intentionally excluded: the ref (renderedNoteRef) is used
+	// for the hash check to avoid putting state in its own dependency array.
+	}, [note, isSelected, isWatched, listRenderer, columns]);
 
 	return renderedNote;
 };

--- a/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
@@ -26,10 +26,7 @@ const hashContent = (content: any) => {
 export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listRenderer: ListRenderer, highlightedWords: string[], itemIndex: number, columns: NoteListColumns) => {
 	const [renderedNote, setRenderedNote] = useState<RenderedNote>(null);
 
-	// Use a ref for the hash check so that renderedNote doesn't need to be in
-	// the effect dependency array — having state in its own deps array causes
-	// cascading re-renders (especially under React 19's stricter update loop
-	// detection) when notes are deleted rapidly.
+	// Use a ref for the hash check so that renderedNote doesn't need to be in the effect dependency array
 	const renderedNoteRef = useRef<RenderedNote>(null);
 
 	let dependencies = columns && columns.length ? columns.map(c => c.name) as ListRendererDependency[] : [];
@@ -105,8 +102,6 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 		};
 
 		void renderNote();
-	// renderedNote is intentionally excluded: the ref (renderedNoteRef) is used
-	// for the hash check to avoid putting state in its own dependency array.
 	}, [note, isSelected, isWatched, listRenderer, columns]);
 
 	return renderedNote;

--- a/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
@@ -61,7 +61,11 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 				folder ? folder.title : '',
 			]);
 
-			if (renderedNoteRef.current && renderedNoteRef.current.hash === viewHash) return null;
+			if (
+				renderedNoteRef.current
+				&& renderedNoteRef.current.id === note.id
+				&& renderedNoteRef.current.hash === viewHash
+			) return null;
 
 			const noteTitleHtml = getNoteTitleHtml(highlightedWords, Note.displayTitle(note));
 
@@ -102,7 +106,7 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 		};
 
 		void renderNote();
-	}, [note, isSelected, isWatched, listRenderer, columns]);
+	}, [note, isSelected, isWatched, listRenderer, highlightedWords, itemIndex, columns]);
 
 	return renderedNote;
 };

--- a/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
+++ b/packages/app-desktop/gui/NoteListItem/utils/useRenderedNote.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { ListRenderer, ListRendererDependency, NoteListColumns } from '@joplin/lib/services/plugins/api/noteListType';
 import Note from '@joplin/lib/models/Note';
 import { FolderEntity, NoteEntity, TagEntity } from '@joplin/lib/services/database/types';
@@ -25,9 +25,6 @@ const hashContent = (content: any) => {
 
 export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listRenderer: ListRenderer, highlightedWords: string[], itemIndex: number, columns: NoteListColumns) => {
 	const [renderedNote, setRenderedNote] = useState<RenderedNote>(null);
-
-	// Use a ref for the hash check so that renderedNote doesn't need to be in the effect dependency array
-	const renderedNoteRef = useRef<RenderedNote>(null);
 
 	let dependencies = columns && columns.length ? columns.map(c => c.name) as ListRendererDependency[] : [];
 	if (listRenderer.dependencies) dependencies = dependencies.concat(listRenderer.dependencies);
@@ -61,11 +58,7 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 				folder ? folder.title : '',
 			]);
 
-			if (
-				renderedNoteRef.current
-				&& renderedNoteRef.current.id === note.id
-				&& renderedNoteRef.current.hash === viewHash
-			) return null;
+			if (renderedNote && renderedNote.hash === viewHash) return null;
 
 			const noteTitleHtml = getNoteTitleHtml(highlightedWords, Note.displayTitle(note));
 
@@ -91,7 +84,7 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 
 			if (event.cancelled) return null;
 
-			const newRenderedNote = {
+			setRenderedNote({
 				id: note.id,
 				hash: viewHash,
 				html: renderTemplate(
@@ -100,13 +93,11 @@ export default (note: NoteEntity, isSelected: boolean, isWatched: boolean, listR
 					listRenderer.itemValueTemplates,
 					view,
 				),
-			};
-			renderedNoteRef.current = newRenderedNote;
-			setRenderedNote(newRenderedNote);
+			});
 		};
 
 		void renderNote();
-	}, [note, isSelected, isWatched, listRenderer, highlightedWords, itemIndex, columns]);
+	}, [note, isSelected, isWatched, listRenderer, renderedNote, highlightedWords, itemIndex, columns]);
 
 	return renderedNote;
 };


### PR DESCRIPTION
**Fixes:** #14621

### Summary:
Fixes a crash ("Maximum update depth exceeded") that occurs when deleting a notebook with many notes. The issue is caused by infinite cascading state updates in React 19 due to overly broad effect dependency arrays.

### Fix:
**useItemElement.ts:**
- Store `onClick` and `onDoubleClick` handlers in `useRef` instead of including them directly in the effect dependency array
- DOM event listeners now call handlers through refs, ensuring the element is not recreated when handler references change
- Removed `onClick` and `onDoubleClick` from the effect deps; only keep stable dependencies (`rootElement`, `itemSize`, `noteHtml`, `noteId`, `style`, `flow`)

**useRenderedNote.ts:**
- Introduced `renderedNoteRef` to track the previous rendered note's hash for deduplication
- Removed `renderedNote` from the `useAsyncEffect` dependency array (having state in its own deps causes re-runs after every `setState` call)
- Hash comparison now reads from the ref instead of relying on dependency tracking

### Screenshots:
https://github.com/user-attachments/assets/5214d7c8-8be1-4d04-b798-a680a601494f


### Testing
- I tested it locally after creating a notebook with 200 notes in it and deleting it.
- All relevant tests pass without fail.
<img width="1053" height="320" alt="Screenshot From 2026-03-08 04-47-48" src="https://github.com/user-attachments/assets/ec17791b-8f8a-4145-9387-badc886bf23c" />
 
### AI Disclosure:
- I used AI to locate the files relevant to the issue.
- I used AI to improve the vocabulary of the PR description.