### PR TITLE
Desktop: Show splash screen during app startup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -160,6 +160,7 @@ packages/app-cli/tests/services/plugins/defaultPluginsUtils.js
 packages/app-cli/tests/services/plugins/sandboxProxy.js
 packages/app-cli/tests/testUtils.js
 packages/app-cli/tools/populateDatabase.js
+packages/app-desktop/ElectronAppWrapper.test.js
 packages/app-desktop/ElectronAppWrapper.js
 packages/app-desktop/InteropServiceHelper.js
 packages/app-desktop/app.reducer.test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -638,6 +638,7 @@ packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
+packages/app-desktop/utils/shouldShowSplash.js
 packages/app-desktop/utils/sourceMapSetup.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js

--- a/.gitignore
+++ b/.gitignore
@@ -611,6 +611,7 @@ packages/app-desktop/utils/isSafeToOpen.test.js
 packages/app-desktop/utils/isSafeToOpen.js
 packages/app-desktop/utils/restartInSafeModeFromMain.test.js
 packages/app-desktop/utils/restartInSafeModeFromMain.js
+packages/app-desktop/utils/shouldShowSplash.js
 packages/app-desktop/utils/sourceMapSetup.js
 packages/app-desktop/utils/window/types.js
 packages/app-mobile/PluginAssetsLoader.js

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ packages/app-cli/tests/services/plugins/defaultPluginsUtils.js
 packages/app-cli/tests/services/plugins/sandboxProxy.js
 packages/app-cli/tests/testUtils.js
 packages/app-cli/tools/populateDatabase.js
+packages/app-desktop/ElectronAppWrapper.test.js
 packages/app-desktop/ElectronAppWrapper.js
 packages/app-desktop/InteropServiceHelper.js
 packages/app-desktop/app.reducer.test.js

--- a/packages/app-desktop/ElectronAppWrapper.test.ts
+++ b/packages/app-desktop/ElectronAppWrapper.test.ts
@@ -1,0 +1,279 @@
+import { mkdtemp, writeFile, remove } from 'fs-extra';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Mock Electron modules used by ElectronAppWrapper
+jest.mock('electron', () => ({
+	BrowserWindow: jest.fn().mockImplementation(() => ({
+		loadFile: jest.fn().mockResolvedValue(undefined),
+		destroy: jest.fn(),
+		isDestroyed: jest.fn().mockReturnValue(false),
+		show: jest.fn(),
+		hide: jest.fn(),
+		webContents: {
+			on: jest.fn(),
+			send: jest.fn(),
+			isCrashed: jest.fn().mockReturnValue(false),
+			setZoomFactor: jest.fn(),
+			session: { webRequest: { onBeforeSendHeaders: jest.fn() } },
+			openDevTools: jest.fn(),
+		},
+		on: jest.fn(),
+		once: jest.fn(),
+		getBounds: jest.fn().mockReturnValue({ width: 800, height: 600 }),
+	})),
+	screen: {
+		getPrimaryDisplay: jest.fn().mockReturnValue({
+			workArea: { width: 1920, height: 1080 },
+		}),
+		getDisplayMatching: jest.fn().mockReturnValue(true),
+	},
+	ipcMain: {
+		on: jest.fn(),
+		once: jest.fn(),
+	},
+	dialog: {
+		showMessageBox: jest.fn().mockResolvedValue({ response: 0 }),
+	},
+	nativeTheme: {
+		shouldUseDarkColors: false,
+	},
+	app: {
+		isReady: jest.fn().mockReturnValue(true),
+		on: jest.fn(),
+		quit: jest.fn(),
+		setAsDefaultProtocolClient: jest.fn(),
+		getName: jest.fn().mockReturnValue('joplin-desktop'),
+		setName: jest.fn(),
+		getPath: jest.fn().mockReturnValue('/tmp'),
+	},
+}));
+
+const fs = require('fs-extra');
+
+describe('ElectronAppWrapper splash screen', () => {
+
+	let profileDir: string;
+
+	beforeEach(async () => {
+		profileDir = await mkdtemp(join(tmpdir(), 'splash-test-'));
+	});
+
+	afterEach(async () => {
+		await remove(profileDir);
+	});
+
+	describe('settings.json reading for startMinimized', () => {
+
+		test('should decide to show splash when settings.json does not exist', () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			let showSplash = true;
+
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(true);
+		});
+
+		test('should decide to show splash when startMinimized is false', async () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			await writeFile(settingsPath, JSON.stringify({
+				startMinimized: false,
+				showTrayIcon: true,
+			}));
+
+			let showSplash = true;
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(true);
+		});
+
+		test('should decide to show splash when showTrayIcon is false', async () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			await writeFile(settingsPath, JSON.stringify({
+				startMinimized: true,
+				showTrayIcon: false,
+			}));
+
+			let showSplash = true;
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(true);
+		});
+
+		test('should skip splash when both startMinimized and showTrayIcon are true', async () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			await writeFile(settingsPath, JSON.stringify({
+				startMinimized: true,
+				showTrayIcon: true,
+			}));
+
+			let showSplash = true;
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(false);
+		});
+
+		test('should show splash when settings.json is malformed', async () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			await writeFile(settingsPath, '{ invalid json !!!');
+
+			let showSplash = true;
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(true);
+		});
+
+		test('should show splash when settings.json is empty object', async () => {
+			const settingsPath = join(profileDir, 'settings.json');
+			await writeFile(settingsPath, '{}');
+
+			let showSplash = true;
+			if (fs.pathExistsSync(settingsPath)) {
+				try {
+					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+					if (settings && settings.startMinimized && settings.showTrayIcon) {
+						showSplash = false;
+					}
+				} catch (_e) {
+					// Ignore
+				}
+			}
+
+			expect(showSplash).toBe(true);
+		});
+	});
+
+	describe('destroySplashWindow idempotency', () => {
+
+		test('should safely handle null splashWindow', () => {
+			// Simulates calling destroySplashWindow when no splash was created
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+			const context: any = { splashWindow_: null };
+
+			const destroySplashWindow = function(this: typeof context) {
+				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+					this.splashWindow_.destroy();
+				}
+				this.splashWindow_ = null;
+			};
+
+			// Should not throw
+			expect(() => destroySplashWindow.call(context)).not.toThrow();
+			expect(context.splashWindow_).toBeNull();
+		});
+
+		test('should destroy splash window and set to null', () => {
+			const mockDestroy = jest.fn();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+			const context: any = {
+				splashWindow_: {
+					isDestroyed: jest.fn().mockReturnValue(false),
+					destroy: mockDestroy,
+				},
+			};
+
+			const destroySplashWindow = function(this: typeof context) {
+				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+					this.splashWindow_.destroy();
+				}
+				this.splashWindow_ = null;
+			};
+
+			destroySplashWindow.call(context);
+			expect(mockDestroy).toHaveBeenCalledTimes(1);
+			expect(context.splashWindow_).toBeNull();
+		});
+
+		test('should not call destroy if already destroyed', () => {
+			const mockDestroy = jest.fn();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+			const context: any = {
+				splashWindow_: {
+					isDestroyed: jest.fn().mockReturnValue(true),
+					destroy: mockDestroy,
+				},
+			};
+
+			const destroySplashWindow = function(this: typeof context) {
+				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+					this.splashWindow_.destroy();
+				}
+				this.splashWindow_ = null;
+			};
+
+			destroySplashWindow.call(context);
+			expect(mockDestroy).not.toHaveBeenCalled();
+			expect(context.splashWindow_).toBeNull();
+		});
+
+		test('should handle multiple calls safely', () => {
+			const mockDestroy = jest.fn();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+			const context: any = {
+				splashWindow_: {
+					isDestroyed: jest.fn().mockReturnValue(false),
+					destroy: mockDestroy,
+				},
+			};
+
+			const destroySplashWindow = function(this: typeof context) {
+				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+					this.splashWindow_.destroy();
+				}
+				this.splashWindow_ = null;
+			};
+
+			destroySplashWindow.call(context);
+			destroySplashWindow.call(context);
+			destroySplashWindow.call(context);
+
+			expect(mockDestroy).toHaveBeenCalledTimes(1);
+			expect(context.splashWindow_).toBeNull();
+		});
+	});
+});

--- a/packages/app-desktop/ElectronAppWrapper.test.ts
+++ b/packages/app-desktop/ElectronAppWrapper.test.ts
@@ -1,55 +1,7 @@
 import { mkdtemp, writeFile, remove } from 'fs-extra';
 import { tmpdir } from 'os';
 import { join } from 'path';
-
-// Mock Electron modules used by ElectronAppWrapper
-jest.mock('electron', () => ({
-	BrowserWindow: jest.fn().mockImplementation(() => ({
-		loadFile: jest.fn().mockResolvedValue(undefined),
-		destroy: jest.fn(),
-		isDestroyed: jest.fn().mockReturnValue(false),
-		show: jest.fn(),
-		hide: jest.fn(),
-		webContents: {
-			on: jest.fn(),
-			send: jest.fn(),
-			isCrashed: jest.fn().mockReturnValue(false),
-			setZoomFactor: jest.fn(),
-			session: { webRequest: { onBeforeSendHeaders: jest.fn() } },
-			openDevTools: jest.fn(),
-		},
-		on: jest.fn(),
-		once: jest.fn(),
-		getBounds: jest.fn().mockReturnValue({ width: 800, height: 600 }),
-	})),
-	screen: {
-		getPrimaryDisplay: jest.fn().mockReturnValue({
-			workArea: { width: 1920, height: 1080 },
-		}),
-		getDisplayMatching: jest.fn().mockReturnValue(true),
-	},
-	ipcMain: {
-		on: jest.fn(),
-		once: jest.fn(),
-	},
-	dialog: {
-		showMessageBox: jest.fn().mockResolvedValue({ response: 0 }),
-	},
-	nativeTheme: {
-		shouldUseDarkColors: false,
-	},
-	app: {
-		isReady: jest.fn().mockReturnValue(true),
-		on: jest.fn(),
-		quit: jest.fn(),
-		setAsDefaultProtocolClient: jest.fn(),
-		getName: jest.fn().mockReturnValue('joplin-desktop'),
-		setName: jest.fn(),
-		getPath: jest.fn().mockReturnValue('/tmp'),
-	},
-}));
-
-const fs = require('fs-extra');
+import shouldShowSplash from './utils/shouldShowSplash';
 
 describe('ElectronAppWrapper splash screen', () => {
 
@@ -63,217 +15,113 @@ describe('ElectronAppWrapper splash screen', () => {
 		await remove(profileDir);
 	});
 
-	describe('settings.json reading for startMinimized', () => {
-
-		test('should decide to show splash when settings.json does not exist', () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			let showSplash = true;
-
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(true);
-		});
-
-		test('should decide to show splash when startMinimized is false', async () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			await writeFile(settingsPath, JSON.stringify({
-				startMinimized: false,
-				showTrayIcon: true,
-			}));
-
-			let showSplash = true;
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(true);
-		});
-
-		test('should decide to show splash when showTrayIcon is false', async () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			await writeFile(settingsPath, JSON.stringify({
-				startMinimized: true,
-				showTrayIcon: false,
-			}));
-
-			let showSplash = true;
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(true);
-		});
-
-		test('should skip splash when both startMinimized and showTrayIcon are true', async () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			await writeFile(settingsPath, JSON.stringify({
-				startMinimized: true,
-				showTrayIcon: true,
-			}));
-
-			let showSplash = true;
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(false);
-		});
-
-		test('should show splash when settings.json is malformed', async () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			await writeFile(settingsPath, '{ invalid json !!!');
-
-			let showSplash = true;
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(true);
-		});
-
-		test('should show splash when settings.json is empty object', async () => {
-			const settingsPath = join(profileDir, 'settings.json');
-			await writeFile(settingsPath, '{}');
-
-			let showSplash = true;
-			if (fs.pathExistsSync(settingsPath)) {
-				try {
-					const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-					if (settings && settings.startMinimized && settings.showTrayIcon) {
-						showSplash = false;
-					}
-				} catch (_e) {
-					// Ignore
-				}
-			}
-
-			expect(showSplash).toBe(true);
-		});
+	test.each([
+		['settings.json does not exist', undefined, true],
+		['startMinimized is false', { startMinimized: false, showTrayIcon: true }, true],
+		['showTrayIcon is false', { startMinimized: true, showTrayIcon: false }, true],
+		['both startMinimized and showTrayIcon are true', { startMinimized: true, showTrayIcon: true }, false],
+		['settings.json is empty object', {}, true],
+	])('shouldShowSplash when %s', async (_label, settings, expected) => {
+		if (settings !== undefined) {
+			await writeFile(join(profileDir, 'settings.json'), JSON.stringify(settings));
+		}
+		expect(shouldShowSplash(profileDir)).toBe(expected);
 	});
 
-	describe('destroySplashWindow idempotency', () => {
+	test('shouldShowSplash when settings.json is malformed', async () => {
+		await writeFile(join(profileDir, 'settings.json'), '{ invalid json !!!');
+		expect(shouldShowSplash(profileDir)).toBe(true);
+	});
 
-		test('should safely handle null splashWindow', () => {
-			// Simulates calling destroySplashWindow when no splash was created
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
-			const context: any = { splashWindow_: null };
+	test('destroySplashWindow should safely handle null splashWindow', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+		const context: any = { splashWindow_: null };
 
-			const destroySplashWindow = function(this: typeof context) {
-				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
-					this.splashWindow_.destroy();
-				}
-				this.splashWindow_ = null;
-			};
+		// Duplicated from ElectronAppWrapper.destroySplashWindow for
+		// isolated testing without Electron dependencies.
+		const destroySplashWindow = function(this: typeof context) {
+			if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+				this.splashWindow_.destroy();
+			}
+			this.splashWindow_ = null;
+		};
 
-			// Should not throw
-			expect(() => destroySplashWindow.call(context)).not.toThrow();
-			expect(context.splashWindow_).toBeNull();
-		});
+		expect(() => destroySplashWindow.call(context)).not.toThrow();
+		expect(context.splashWindow_).toBeNull();
+	});
 
-		test('should destroy splash window and set to null', () => {
-			const mockDestroy = jest.fn();
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
-			const context: any = {
-				splashWindow_: {
-					isDestroyed: jest.fn().mockReturnValue(false),
-					destroy: mockDestroy,
-				},
-			};
+	test('destroySplashWindow should destroy window and set to null', () => {
+		const mockDestroy = jest.fn();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+		const context: any = {
+			splashWindow_: {
+				isDestroyed: jest.fn().mockReturnValue(false),
+				destroy: mockDestroy,
+			},
+		};
 
-			const destroySplashWindow = function(this: typeof context) {
-				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
-					this.splashWindow_.destroy();
-				}
-				this.splashWindow_ = null;
-			};
+		// Duplicated from ElectronAppWrapper.destroySplashWindow for
+		// isolated testing without Electron dependencies.
+		const destroySplashWindow = function(this: typeof context) {
+			if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+				this.splashWindow_.destroy();
+			}
+			this.splashWindow_ = null;
+		};
 
-			destroySplashWindow.call(context);
-			expect(mockDestroy).toHaveBeenCalledTimes(1);
-			expect(context.splashWindow_).toBeNull();
-		});
+		destroySplashWindow.call(context);
+		expect(mockDestroy).toHaveBeenCalledTimes(1);
+		expect(context.splashWindow_).toBeNull();
+	});
 
-		test('should not call destroy if already destroyed', () => {
-			const mockDestroy = jest.fn();
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
-			const context: any = {
-				splashWindow_: {
-					isDestroyed: jest.fn().mockReturnValue(true),
-					destroy: mockDestroy,
-				},
-			};
+	test('destroySplashWindow should skip destroy if already destroyed', () => {
+		const mockDestroy = jest.fn();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+		const context: any = {
+			splashWindow_: {
+				isDestroyed: jest.fn().mockReturnValue(true),
+				destroy: mockDestroy,
+			},
+		};
 
-			const destroySplashWindow = function(this: typeof context) {
-				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
-					this.splashWindow_.destroy();
-				}
-				this.splashWindow_ = null;
-			};
+		// Duplicated from ElectronAppWrapper.destroySplashWindow for
+		// isolated testing without Electron dependencies.
+		const destroySplashWindow = function(this: typeof context) {
+			if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+				this.splashWindow_.destroy();
+			}
+			this.splashWindow_ = null;
+		};
 
-			destroySplashWindow.call(context);
-			expect(mockDestroy).not.toHaveBeenCalled();
-			expect(context.splashWindow_).toBeNull();
-		});
+		destroySplashWindow.call(context);
+		expect(mockDestroy).not.toHaveBeenCalled();
+		expect(context.splashWindow_).toBeNull();
+	});
 
-		test('should handle multiple calls safely', () => {
-			const mockDestroy = jest.fn();
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
-			const context: any = {
-				splashWindow_: {
-					isDestroyed: jest.fn().mockReturnValue(false),
-					destroy: mockDestroy,
-				},
-			};
+	test('destroySplashWindow should handle multiple calls safely', () => {
+		const mockDestroy = jest.fn();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing internal state
+		const context: any = {
+			splashWindow_: {
+				isDestroyed: jest.fn().mockReturnValue(false),
+				destroy: mockDestroy,
+			},
+		};
 
-			const destroySplashWindow = function(this: typeof context) {
-				if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
-					this.splashWindow_.destroy();
-				}
-				this.splashWindow_ = null;
-			};
+		// Duplicated from ElectronAppWrapper.destroySplashWindow for
+		// isolated testing without Electron dependencies.
+		const destroySplashWindow = function(this: typeof context) {
+			if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+				this.splashWindow_.destroy();
+			}
+			this.splashWindow_ = null;
+		};
 
-			destroySplashWindow.call(context);
-			destroySplashWindow.call(context);
-			destroySplashWindow.call(context);
+		destroySplashWindow.call(context);
+		destroySplashWindow.call(context);
+		destroySplashWindow.call(context);
 
-			expect(mockDestroy).toHaveBeenCalledTimes(1);
-			expect(context.splashWindow_).toBeNull();
-		});
+		expect(mockDestroy).toHaveBeenCalledTimes(1);
+		expect(context.splashWindow_).toBeNull();
 	});
 });

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -18,6 +18,7 @@ import { _ } from '@joplin/lib/locale';
 import restartInSafeModeFromMain from './utils/restartInSafeModeFromMain';
 import handleCustomProtocols, { CustomProtocolHandlers } from './utils/customProtocols/handleCustomProtocols';
 import { clearTimeout, setTimeout } from 'timers';
+import shouldShowSplash from './utils/shouldShowSplash';
 import { resolve } from 'path';
 import { defaultWindowId } from '@joplin/lib/reducer';
 import { msleep, Second } from '@joplin/utils/time';
@@ -922,20 +923,7 @@ export default class ElectronAppWrapper {
 		// Show splash screen while the main window loads, but skip it
 		// when the user has configured the app to start minimized in
 		// the tray — no point showing a splash they don't want to see.
-		// Both settings use SettingStorage.File so they are available
-		// in the main process via settings.json.
-		let showSplash = true;
-		const settingsPath = path.join(this.profilePath_, 'settings.json');
-		if (fs.pathExistsSync(settingsPath)) {
-			try {
-				const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-				if (settings && settings.startMinimized && settings.showTrayIcon) {
-					showSplash = false;
-				}
-			} catch (_e) {
-				// Ignore — show splash on any parse error
-			}
-		}
+		const showSplash = shouldShowSplash(this.profilePath_);
 
 		if (showSplash) {
 			this.createSplashWindow();

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -56,6 +56,7 @@ export default class ElectronAppWrapper {
 	private isEndToEndTesting_: boolean;
 
 	private win_: BrowserWindow = null;
+	private splashWindow_: BrowserWindow = null;
 	private mainWindowHidden_ = true;
 	private pluginWindows_: PluginWindows = {};
 	private secondaryWindows_: Map<SecondaryWindowId, SecondaryWindowData> = new Map();
@@ -174,6 +175,9 @@ export default class ElectronAppWrapper {
 	// Assumes that the renderer process may be in an invalid state and so cannot
 	// be accessed.
 	public async handleAppFailure(errorMessage: string, canIgnore: boolean, isTesting?: boolean) {
+		// Ensure the splash screen is dismissed so the error dialog is visible
+		this.destroySplashWindow();
+
 		await bridge().captureException(new Error(errorMessage));
 
 		const buttons = [];
@@ -205,6 +209,46 @@ export default class ElectronAppWrapper {
 		} else if (response === exitIndex) {
 			process.exit(1);
 		}
+	}
+
+	private createSplashWindow() {
+		const splashWidth = 320;
+		const splashHeight = 240;
+		const primaryDisplay = screen.getPrimaryDisplay();
+		const { width, height } = primaryDisplay.workArea;
+
+		this.splashWindow_ = new BrowserWindow({
+			width: splashWidth,
+			height: splashHeight,
+			x: Math.round((width - splashWidth) / 2),
+			y: Math.round((height - splashHeight) / 2),
+			frame: false,
+			transparent: false,
+			alwaysOnTop: true,
+			resizable: false,
+			show: false,
+			skipTaskbar: true,
+			backgroundColor: '#1D2B40',
+			webPreferences: {
+				nodeIntegration: false,
+				contextIsolation: true,
+			},
+		});
+
+		this.splashWindow_.once('ready-to-show', () => {
+			if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+				this.splashWindow_.show();
+			}
+		});
+
+		void this.splashWindow_.loadFile(path.join(__dirname, 'splash.html'));
+	}
+
+	public destroySplashWindow() {
+		if (this.splashWindow_ && !this.splashWindow_.isDestroyed()) {
+			this.splashWindow_.destroy();
+		}
+		this.splashWindow_ = null;
 	}
 
 	public createWindow() {
@@ -249,7 +293,10 @@ export default class ElectronAppWrapper {
 			//
 			// On Linux/GNOME, however, the window doesn't show correctly if show is false initially:
 			// https://github.com/laurent22/joplin/issues/8256
-			show: debugEarlyBugs || shim.isGNOME(),
+			//
+			// When the splash screen is active, keep the main window hidden so it
+			// doesn't appear as a dark rectangle behind the splash.
+			show: this.splashWindow_ ? false : (debugEarlyBugs || shim.isGNOME()),
 		};
 
 		// Linux icon workaround for bug https://github.com/electron-userland/electron-builder/issues/2098
@@ -872,8 +919,48 @@ export default class ElectronAppWrapper {
 
 		await this.fixLinuxAccessibility_();
 
+		// Show splash screen while the main window loads, but skip it
+		// when the user has configured the app to start minimized in
+		// the tray — no point showing a splash they don't want to see.
+		// Both settings use SettingStorage.File so they are available
+		// in the main process via settings.json.
+		let showSplash = true;
+		const settingsPath = path.join(this.profilePath_, 'settings.json');
+		if (fs.pathExistsSync(settingsPath)) {
+			try {
+				const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+				if (settings && settings.startMinimized && settings.showTrayIcon) {
+					showSplash = false;
+				}
+			} catch (_e) {
+				// Ignore — show splash on any parse error
+			}
+		}
+
+		if (showSplash) {
+			this.createSplashWindow();
+		}
+
 		this.customProtocolHandlers_ = handleCustomProtocols();
 		this.createWindow();
+
+		// Safety timeout: if the renderer never sends 'hide-splash'
+		// (e.g. due to a crash or startup error), destroy the splash
+		// after 30 seconds so it doesn't block the error dialog.
+		let splashTimeout: ReturnType<typeof setTimeout> | null = null;
+		if (showSplash) {
+			splashTimeout = setTimeout(() => {
+				this.destroySplashWindow();
+				if (this.win_ && !this.win_.isDestroyed()) this.win_.show();
+			}, 30 * 1000);
+		}
+
+		// Listen for the renderer to signal that the app is ready,
+		// then destroy splash and show the main window.
+		ipcMain.once('hide-splash', () => {
+			if (splashTimeout) clearTimeout(splashTimeout);
+			this.destroySplashWindow();
+		});
 
 		this.electronApp_.on('before-quit', () => {
 			this.willQuitApp_ = true;

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -597,6 +597,9 @@ class Application extends BaseApplication {
 		addTask('app/updateTray', () => this.updateTray());
 
 		addTask('app/set main window state', () => {
+			// Hide the splash screen now that the app is ready
+			ipcRenderer.send('hide-splash');
+
 			if (Setting.value('startMinimized') && Setting.value('showTrayIcon')) {
 				bridge().mainWindow().hide();
 			} else {

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -778,6 +778,7 @@ class Application extends BaseApplication {
 
 		if (Setting.value('sync.upgradeState') === Setting.SYNC_UPGRADE_STATE_MUST_DO) {
 			reg.logger().info('app.start: doing upgradeSyncTarget action');
+			ipcRenderer.send('hide-splash');
 			bridge().mainWindow().show();
 			startupTask.onEnd();
 

--- a/packages/app-desktop/integration-tests/util/getMainWindow.ts
+++ b/packages/app-desktop/integration-tests/util/getMainWindow.ts
@@ -1,7 +1,30 @@
-import { ElectronApplication } from '@playwright/test';
+import { ElectronApplication, Page } from '@playwright/test';
 
+// The app may open a splash screen (splash.html) before the main
+// window (index.html). This helper waits for the actual main window.
 const getMainWindow = async (electronApp: ElectronApplication) => {
-	return await electronApp.firstWindow();
+	const isMainWindow = (page: Page) => page.url().includes('index.html');
+
+	for (const page of electronApp.windows()) {
+		if (isMainWindow(page)) return page;
+	}
+
+	return new Promise<Page>((resolve) => {
+		const onWindow = async (page: Page) => {
+			try {
+				// cspell:disable-next-line
+				await page.waitForLoadState('domcontentloaded');
+			} catch {
+				// Window closed before load (e.g. splash dismissed)
+				return;
+			}
+			if (isMainWindow(page)) {
+				electronApp.off('window', onWindow);
+				resolve(page);
+			}
+		};
+		electronApp.on('window', onWindow);
+	});
 };
 
 export default getMainWindow;

--- a/packages/app-desktop/splash.html
+++ b/packages/app-desktop/splash.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<title>Joplin</title>
+	<style>
+		* {
+			margin: 0;
+			padding: 0;
+			box-sizing: border-box;
+		}
+
+		body {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			height: 100vh;
+			background-color: #1D2B40;
+			overflow: hidden;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+		}
+
+		.splash-container {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 20px;
+		}
+
+		.splash-logo {
+			width: 96px;
+			height: 96px;
+			animation: fadeIn 0.4s ease-out;
+		}
+
+		.splash-title {
+			color: #ffffff;
+			font-size: 28px;
+			font-weight: 300;
+			letter-spacing: 4px;
+			animation: fadeIn 0.4s ease-out 0.1s both;
+		}
+
+		.splash-loader {
+			width: 40px;
+			height: 4px;
+			margin-top: 8px;
+			border-radius: 2px;
+			background-color: rgba(255, 255, 255, 0.15);
+			overflow: hidden;
+			animation: fadeIn 0.4s ease-out 0.2s both;
+		}
+
+		.splash-loader-bar {
+			width: 40%;
+			height: 100%;
+			border-radius: 2px;
+			background-color: rgba(255, 255, 255, 0.6);
+			animation: loading 1.2s ease-in-out infinite;
+		}
+
+		@keyframes fadeIn {
+			from {
+				opacity: 0;
+				transform: translateY(8px);
+			}
+			to {
+				opacity: 1;
+				transform: translateY(0);
+			}
+		}
+
+		@keyframes loading {
+			0% {
+				transform: translateX(-100%);
+			}
+			50% {
+				transform: translateX(150%);
+			}
+			100% {
+				transform: translateX(-100%);
+			}
+		}
+	</style>
+</head>
+<body>
+	<div class="splash-container">
+		<svg class="splash-logo" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+			<circle cx="48" cy="48" r="44" fill="#4A90D9"/>
+			<text x="48" y="60" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="40" font-weight="bold" fill="white">J</text>
+		</svg>
+		<div class="splash-title">JOPLIN</div>
+		<div class="splash-loader">
+			<div class="splash-loader-bar"></div>
+		</div>
+	</div>
+</body>
+</html>

--- a/packages/app-desktop/utils/shouldShowSplash.ts
+++ b/packages/app-desktop/utils/shouldShowSplash.ts
@@ -1,0 +1,20 @@
+import { join } from 'path';
+import { pathExistsSync, readFileSync } from 'fs-extra';
+
+// Determines whether the splash screen should be shown on startup.
+// Skips when the user has configured startMinimized + showTrayIcon,
+// since there's no point showing a splash they don't want to see.
+export default function shouldShowSplash(profilePath: string): boolean {
+	const settingsPath = join(profilePath, 'settings.json');
+	if (pathExistsSync(settingsPath)) {
+		try {
+			const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+			if (settings && settings.startMinimized && settings.showTrayIcon) {
+				return false;
+			}
+		} catch (_e) {
+			// Ignore — show splash on any parse error
+		}
+	}
+	return true;
+}

--- a/packages/app-desktop/utils/shouldShowSplash.ts
+++ b/packages/app-desktop/utils/shouldShowSplash.ts
@@ -9,7 +9,7 @@ export default function shouldShowSplash(profilePath: string): boolean {
 	if (pathExistsSync(settingsPath)) {
 		try {
 			const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
-			if (settings && settings.startMinimized && settings.showTrayIcon) {
+			if (settings && settings.startMinimized === true && settings.showTrayIcon === true) {
 				return false;
 			}
 		} catch (_e) {


### PR DESCRIPTION
AI disclosure 
Used it to write test and then also splash.html  and then a converation to refine my thinking process

fixes#7767

Description 
When Joplin starts, there's a noticeable delay before the main window appears — the user just stares at nothing. This adds a small splash screen with the Joplin logo and a loading indicator that shows immediately while the app initializes in the background.


Note : let say the app loads instantly then the splash screen never appear  it mainly for the device that are slower  

tested on both linux and windows 
windows ( slow ) the splash screen appear and run properly  and get destroys as soon as the main windows appear
linux ( faster os ) the splash screen never appears  because  the main windows starts instantly
 


[Screencast from 2026-03-08 07-10-33.webm](https://github.com/user-attachments/assets/f6aa523c-03a9-4c78-932d-160bdf81c876)
