### PR TITLE
Desktop: Fix context menu missing cut/copy when selecting resource links in markdown editor

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -102,7 +102,7 @@ interface ContextMenuProps {
 	editorPaste: ()=> void;
 	editorRef: RefObject<CodeMirrorControl>;
 	editorClassName: string;
-	containerRef: RefObject<HTMLDivElement|null>;
+	containerRef: RefObject<HTMLDivElement | null>;
 }
 
 const useContextMenu = (props: ContextMenuProps) => {
@@ -194,9 +194,9 @@ const useContextMenu = (props: ContextMenuProps) => {
 				linkToOpen: null,
 				textToCopy: null,
 				htmlToCopy: null,
-				insertContent: () => {},
+				insertContent: () => { },
 				isReadOnly: true,
-				fireEditorEvent: () => {},
+				fireEditorEvent: () => { },
 				htmlToMd: null,
 				mdToHtml: null,
 			};
@@ -244,9 +244,25 @@ const useContextMenu = (props: ContextMenuProps) => {
 			}
 
 			// Check if right-clicking on resource markup text (images or file attachments)
-			const markupResourceInfo = getResourceInfoAtClickPos(params);
+			// When text is selected, CodeMirror's click position may fall outside the
+			// resource markup. To ensure resource links are detected correctly, first
+			// check the selection start position. If no resource is found there,
+			// fall back to detecting the resource from the actual click position.
+			const editor = editorRef.current?.editor;
 
-			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
+			let markupResourceInfo: ResourceMarkupInfo | null = null;
+
+			if (editor) {
+				const pos = editor.state.selection.main.from;
+				const line = editor.state.doc.lineAt(pos);
+
+				markupResourceInfo = getResourceIdFromMarkup(line.text, pos - line.from);
+			}
+
+			if (!markupResourceInfo) {
+				markupResourceInfo = getResourceInfoAtClickPos(params);
+			}
+			const hasSelectedText = !!editorRef.current?.getSelection();
 
 			if (markupResourceInfo && pointerInsideEditor(params) && !hasSelectedText) {
 				event.preventDefault();
@@ -340,7 +356,40 @@ const useContextMenu = (props: ContextMenuProps) => {
 			menuUtils.pluginContextMenuItems(props.plugins, MenuItemLocation.EditorContextMenu).forEach((item: any) => {
 				menu.append(new MenuItem(item));
 			});
+			// If a resource link is selected, append resource actions
+			if (markupResourceInfo && hasSelectedText) {
+				const baseType = markupResourceInfo.type === 'image'
+					? ContextMenuItemType.Image
+					: ContextMenuItemType.Resource;
 
+				const itemType = await resolveContextMenuItemType(baseType, markupResourceInfo.resourceId);
+
+				const contextMenuOptions: ContextMenuOptions = {
+					itemType,
+					resourceId: markupResourceInfo.resourceId,
+					filename: null,
+					mime: null,
+					linkToCopy: null,
+					linkToOpen: null,
+					textToCopy: null,
+					htmlToCopy: null,
+					insertContent: () => { },
+					isReadOnly: true,
+					fireEditorEvent: () => { },
+					htmlToMd: null,
+					mdToHtml: null,
+				};
+
+				const resourceMenuItems = await buildMenuItems(menuItems(props.dispatch), contextMenuOptions);
+
+				if (resourceMenuItems.length) {
+					menu.append(new MenuItem({ type: 'separator' }));
+				}
+
+				for (const item of resourceMenuItems) {
+					menu.append(item);
+				}
+			}
 			menu.popup({ window: targetWindow });
 		};
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -251,20 +251,19 @@ const useContextMenu = (props: ContextMenuProps) => {
 			const editor = editorRef.current?.editor;
 			const hasSelectedText = !!editorRef.current?.getSelection();
 
-			let markupResourceInfo: ResourceMarkupInfo | null = null;
+			let markupResourceInfo = getResourceInfoAtClickPos(params);
 
-			// If text is selected, detect resource from the selection start
-			if (hasSelectedText && editor?.state?.selection?.main) {
+			// When text is selected, CodeMirror can sometimes report a click
+			// position slightly outside the markup. If click detection fails,
+			// fall back to the selection start position.
+			if (!markupResourceInfo && hasSelectedText && editor?.state?.selection?.main) {
 				const pos = editor.state.selection.main.from;
 				const line = editor.state.doc.lineAt(pos);
 
 				markupResourceInfo = getResourceIdFromMarkup(line.text, pos - line.from);
 			}
 
-			// Otherwise detect resource from the click position
-			if (!markupResourceInfo) {
-				markupResourceInfo = getResourceInfoAtClickPos(params);
-			}
+
 			if (markupResourceInfo && pointerInsideEditor(params) && !hasSelectedText) {
 				event.preventDefault();
 				await showResourceContextMenu(markupResourceInfo.resourceId, markupResourceInfo.type);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -244,10 +244,9 @@ const useContextMenu = (props: ContextMenuProps) => {
 			}
 
 			// Check if right-clicking on resource markup text (images or file attachments)
-			// When text is selected, CodeMirror's click position may fall outside the
-			// resource markup. To ensure resource links are detected correctly, first
-			// check the selection start position. If no resource is found there,
-			// fall back to detecting the resource from the actual click position.
+			// When text is selected, CodeMirror's click position may fall slightly
+			// outside the resource markup. Prefer the actual click position first,
+			// then fall back to the selection start if hit-testing misses.
 			const editor = editorRef.current?.editor;
 			const hasSelectedText = !!editorRef.current?.getSelection();
 

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -102,7 +102,7 @@ interface ContextMenuProps {
 	editorPaste: ()=> void;
 	editorRef: RefObject<CodeMirrorControl>;
 	editorClassName: string;
-	containerRef: RefObject<HTMLDivElement | null>;
+	containerRef: RefObject<HTMLDivElement|null>;
 }
 
 const useContextMenu = (props: ContextMenuProps) => {
@@ -194,9 +194,9 @@ const useContextMenu = (props: ContextMenuProps) => {
 				linkToOpen: null,
 				textToCopy: null,
 				htmlToCopy: null,
-				insertContent: () => { },
+				insertContent: () => {},
 				isReadOnly: true,
-				fireEditorEvent: () => { },
+				fireEditorEvent: () => {},
 				htmlToMd: null,
 				mdToHtml: null,
 			};

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -249,21 +249,22 @@ const useContextMenu = (props: ContextMenuProps) => {
 			// check the selection start position. If no resource is found there,
 			// fall back to detecting the resource from the actual click position.
 			const editor = editorRef.current?.editor;
+			const hasSelectedText = !!editorRef.current?.getSelection();
 
 			let markupResourceInfo: ResourceMarkupInfo | null = null;
 
-			if (editor) {
+			// If text is selected, detect resource from the selection start
+			if (hasSelectedText && editor?.state?.selection?.main) {
 				const pos = editor.state.selection.main.from;
 				const line = editor.state.doc.lineAt(pos);
 
 				markupResourceInfo = getResourceIdFromMarkup(line.text, pos - line.from);
 			}
 
+			// Otherwise detect resource from the click position
 			if (!markupResourceInfo) {
 				markupResourceInfo = getResourceInfoAtClickPos(params);
 			}
-			const hasSelectedText = !!editorRef.current?.getSelection();
-
 			if (markupResourceInfo && pointerInsideEditor(params) && !hasSelectedText) {
 				event.preventDefault();
 				await showResourceContextMenu(markupResourceInfo.resourceId, markupResourceInfo.type);

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -245,7 +245,10 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 			// Check if right-clicking on resource markup text (images or file attachments)
 			const markupResourceInfo = getResourceInfoAtClickPos(params);
-			if (markupResourceInfo && pointerInsideEditor(params)) {
+
+			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
+
+			if (markupResourceInfo && pointerInsideEditor(params) && !hasSelectedText) {
 				event.preventDefault();
 				await showResourceContextMenu(markupResourceInfo.resourceId, markupResourceInfo.type);
 				return;
@@ -259,7 +262,6 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 			const menu = new Menu();
 
-			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
 
 			menu.append(
 				new MenuItem({


### PR DESCRIPTION
Fixes #14637

Previously, when right-clicking a selected resource link in the Markdown editor,
the resource context menu would always appear, preventing access to normal
text editing actions like Cut and Copy.

This change ensures that the resource context menu is only shown when no text
is selected. When text is selected, the standard editor context menu is shown
instead.

Tested locally by selecting resource links and verifying that the correct
context menu appears.
<img width="483" height="194" alt="Screenshot 2026-03-08 114604" src="https://github.com/user-attachments/assets/2f69340c-aecb-4a2a-8ab6-3e0d6319b7c9" />
