### PR TITLE
Desktop: Fixes #14628: prevent renderer crash when closing secondary window on Windows

### DIFF
--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -470,10 +470,8 @@ export default class ElectronAppWrapper {
 			window.webContents.setZoomFactor(this.mainWindow().webContents.getZoomFactor());
 
 			window.once('close', () => {
-				// Notify the main renderer immediately so it can unmount the React Portal
-				// before the secondary window's frame is disposed. Without this, there is a
-				// ~2s polling gap during which React renders into a destroyed document,
-				// crashing the shared renderer process on Windows.
+				// Immediately notify the main renderer to unmount the Portal before the
+				// frame is disposed — avoids a ~2s gap that crashes the renderer on Windows.
 				if (this.win_ && !this.win_.isDestroyed() && !this.win_.webContents.isDestroyed()) {
 					this.win_.webContents.send('secondary-window-closing', windowId);
 				}

--- a/packages/app-desktop/ElectronAppWrapper.ts
+++ b/packages/app-desktop/ElectronAppWrapper.ts
@@ -470,6 +470,14 @@ export default class ElectronAppWrapper {
 			window.webContents.setZoomFactor(this.mainWindow().webContents.getZoomFactor());
 
 			window.once('close', () => {
+				// Notify the main renderer immediately so it can unmount the React Portal
+				// before the secondary window's frame is disposed. Without this, there is a
+				// ~2s polling gap during which React renders into a destroyed document,
+				// crashing the shared renderer process on Windows.
+				if (this.win_ && !this.win_.isDestroyed() && !this.win_.webContents.isDestroyed()) {
+					this.win_.webContents.send('secondary-window-closing', windowId);
+				}
+
 				this.secondaryWindows_.delete(windowId);
 
 				const allSecondaryWindowsClosed = this.secondaryWindows_.size === 0;

--- a/packages/app-desktop/app.ts
+++ b/packages/app-desktop/app.ts
@@ -733,6 +733,10 @@ class Application extends BaseApplication {
 					});
 				}
 			});
+
+			ipcRenderer.on('secondary-window-closing', (_event, windowId: string) => {
+				this.dispatch({ type: 'WINDOW_CLOSE', windowId });
+			});
 		});
 
 		addTask('app/initPluginService', () => this.initPluginService());

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -55,11 +55,12 @@ const useDocument = (
 						shim.setTimeout(() => resolve(), 2000);
 					});
 
+					// Re-check after sleep to avoid duplicate WINDOW_CLOSE if IPC already fired.
+					if (unmounted) break;
+
 					if (openedWindow?.closed) {
-						// Null out the doc before dispatching WINDOW_CLOSE so React stops
-						// rendering the Portal into the now-destroyed document. Without this,
-						// React 19's stricter Portal cleanup crashes the main renderer process
-						// when the secondary window is closed on Windows.
+						// Null out doc first so React stops rendering into the destroyed window
+						// before WINDOW_CLOSE triggers unmounting (prevents renderer crash on Windows).
 						setDoc(null);
 						onCloseRef.current?.();
 						openedWindow = null;

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -40,7 +40,7 @@ const useDocument = (
 
 	useEffect(() => {
 		let openedWindow: Window|null = null;
-		const unmounted = false;
+		let unmounted = false;
 		if (iframeElement) {
 			setDoc(iframeElement?.contentWindow?.document);
 		} else if (mode === WindowMode.NewWindow) {
@@ -56,6 +56,11 @@ const useDocument = (
 					});
 
 					if (openedWindow?.closed) {
+						// Null out the doc before dispatching WINDOW_CLOSE so React stops
+						// rendering the Portal into the now-destroyed document. Without this,
+						// React 19's stricter Portal cleanup crashes the main renderer process
+						// when the secondary window is closed on Windows.
+						setDoc(null);
 						onCloseRef.current?.();
 						openedWindow = null;
 						break;
@@ -65,6 +70,7 @@ const useDocument = (
 		}
 
 		return () => {
+			unmounted = true;
 			// Delay: Closing immediately causes Electron to crash
 			setTimeout(() => {
 				if (!openedWindow?.closed) {


### PR DESCRIPTION
Fixes #14628 

## Summary

Closing a note opened in a new window caused the main window's renderer process to crash (white screen) on Windows.

## Root Cause
The secondary window content is rendered via a React Portal from the main window's renderer process. When the secondary window is closed, Joplin polls every 2 seconds to detect it. During that window, React keeps trying to render into an already-destroyed document — crashing the shared renderer process.

## Fix
3 small changes:
1. **Immediate notification** (`ElectronAppWrapper.ts` + `app.ts`) — When Electron detects the secondary window closing, it immediately notifies the main renderer to unmount the Portal instead of waiting for the 2-second poll.
2. **Clear document first** (`NewWindowOrIFrame.tsx`) — On window-closed, set `doc = null` so React stops rendering the Portal before dispatching the close event.
3. **Fix polling loop** (`NewWindowOrIFrame.tsx`) — `const unmounted` was a bug (can never change), changed to `let unmounted` so the loop actually stops when the component unmounts.

## Testing
1. Right-click a note in the note list → Open in new window
2. Close the new window
3. Verify the main window remains stable — no white screen or renderer crash

## Notes
- Windows only, not reproducible on Linux
- Regression introduced in v3.6.3, likely related to React 19 upgrade (#14327)

## Demo

https://github.com/user-attachments/assets/5536100b-a6d1-4a2d-a1bb-de53063cd3ed

