### PR TITLE
Desktop: fixes #101111: ENEX import no longer breaks bullet items with a line break into separate paragraphs

### DIFF
--- a/packages/app-cli/tests/enex_to_md/list_with_br.html
+++ b/packages/app-cli/tests/enex_to_md/list_with_br.html
@@ -1,4 +1,7 @@
 <ul>
 	<li>First line<br/>Second line</li>
 	<li>Normal item</li>
+	<li>With sub-list<ul>
+		<li>Sub-list<br/>Paragraph<br/>Also another line</li>
+	</ul></li>
 </ul>

--- a/packages/app-cli/tests/enex_to_md/list_with_br.html
+++ b/packages/app-cli/tests/enex_to_md/list_with_br.html
@@ -1,0 +1,4 @@
+<ul>
+	<li>First line<br/>Second line</li>
+	<li>Normal item</li>
+</ul>

--- a/packages/app-cli/tests/enex_to_md/list_with_br.md
+++ b/packages/app-cli/tests/enex_to_md/list_with_br.md
@@ -1,2 +1,4 @@
-- First line Second line
+- First line
+  Second line
+
 - Normal item

--- a/packages/app-cli/tests/enex_to_md/list_with_br.md
+++ b/packages/app-cli/tests/enex_to_md/list_with_br.md
@@ -2,3 +2,7 @@
   Second line
 
 - Normal item
+- With sub-list
+    - Sub-list
+      Paragraph
+      Also another line

--- a/packages/app-cli/tests/enex_to_md/list_with_br.md
+++ b/packages/app-cli/tests/enex_to_md/list_with_br.md
@@ -1,0 +1,2 @@
+- First line Second line
+- Normal item

--- a/packages/lib/import-enex-md-gen.ts
+++ b/packages/lib/import-enex-md-gen.ts
@@ -897,7 +897,7 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[], tasks: Extra
 				section.lines.push(BLOCK_OPEN);
 				state.inPre = true;
 			} else if (n === 'br') {
-				section.lines.push(NEWLINE);
+				section.lines.push(state.lists.length ? SPACE : NEWLINE);
 			} else if (n === 'en-media') {
 				const hash = nodeAttributes.hash;
 

--- a/packages/lib/import-enex-md-gen.ts
+++ b/packages/lib/import-enex-md-gen.ts
@@ -233,6 +233,10 @@ const isListItem = function(line: string) {
 	return line && line.trim().indexOf('- ') === 0;
 };
 
+const isListContinuation = function(line: string) {
+	return line && line.startsWith('  ') && !isListItem(line);
+};
+
 const isCodeLine = function(line: string) {
 	return line && line.indexOf('\t') === 0;
 };
@@ -262,7 +266,7 @@ function formatMdLayout(lines: string[]) {
 		const line = lines[i];
 
 		// Add a new line at the end of a list of items
-		if (isListItem(previous) && line && !isListItem(line)) {
+		if (isListItem(previous) && line && !isListItem(line) && !isListContinuation(line)) {
 			newLines.push('');
 
 			// Add a new line at the beginning of a list of items
@@ -897,7 +901,13 @@ function enexXmlToMdArray(stream: any, resources: ResourceEntity[], tasks: Extra
 				section.lines.push(BLOCK_OPEN);
 				state.inPre = true;
 			} else if (n === 'br') {
-				section.lines.push(state.lists.length ? SPACE : NEWLINE);
+				if (state.lists.length) {
+					const indent = '    '.repeat(state.lists.length - 1);
+					section.lines.push(NEWLINE);
+					section.lines.push(`${indent}  `);
+				} else {
+					section.lines.push(NEWLINE);
+				}
 			} else if (n === 'en-media') {
 				const hash = nodeAttributes.hash;
 


### PR DESCRIPTION
Fixes a bug where importing an ENEX file with a bullet point containing a line break `<br>` would incorrectly split the text into a separate paragraph below the list item.

The fix: when `<br>` appears inside a list item, a newline is emitted followed by a 2-space indent prefix for the continuation text (I searched abit and this is standard Markdown list continuation syntax). A new isListContinuation helper detects these lines and the blank-line rule in formatMdLayout skips them so no extra paragraph is added. `<br>` outside a list is unchanged.

Closes #10111
### Before: 
<img width="878" height="481" alt="Screenshot 2026-03-08 162814" src="https://github.com/user-attachments/assets/dcbd8875-a63a-4cd2-94bf-4dc9c91ad872" />

### After:
<img width="871" height="377" alt="image" src="https://github.com/user-attachments/assets/885a0bff-dead-4157-bcc3-d9900ee026e7" />

