### PR TITLE
Add Plugins link to website navigation

### DIFF
--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -14,6 +14,7 @@
 			<div class="col-9 text-right d-none d-md-block">
 				{{> twitterLink}}
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
+				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>
 
@@ -59,6 +60,7 @@
 
 						<div class="text-center menu-mobile-top">
 							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
+							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>
 							<a href="{{forumUrl}}" class="fw500 mobile-menu-link">Forum</a>
 						</div>

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -208,6 +208,12 @@ const config = {
 						position: 'right',
 					},
 					{
+						to: process.env.WEBSITE_BASE_URL + '/plugins',
+						label: 'Plugins',
+						position: 'right',
+						target: '_self',
+					},
+					{
 						type: 'docSidebar',
 						sidebarId: 'helpSidebar',
 						position: 'right',


### PR DESCRIPTION
**Problem**

The Joplin website navigation does not provide a direct link to the Plugins page. As a result, users browsing the website cannot easily discover the plugins section from the main navigation menu. Users may need to manually navigate to the plugins page or rely on external links, which makes plugin discovery less intuitive.

**Solution**

This change adds a **Plugins** link to the website navigation menu so that the Plugins page can be accessed directly from the top navbar. The link was added to both the desktop navbar and the mobile navigation menu to ensure consistent navigation across devices. The documentation site configuration was also updated so that the Plugins page appears in the help/docs navigation.

This change only affects the website navigation UI and does not alter any application logic.

**Test Plan**

Manual verification steps:

1. Confirm the **Plugins** link was added to the desktop navbar in `navbar.mustache`.
2. Confirm the **Plugins** link was added to the mobile navigation section in `navbar.mustache`.
3. Verify that a Plugins entry exists in the documentation site navbar configuration in `docusaurus.config.js`.
4. Ensure the link points to `/plugins`, matching the URL pattern used by other navigation items.

This change only adds a navigation entry and should not affect other website functionality.
