### PR TITLE
All: Fixes #14412: Skip share consistency check when not using Joplin Server/Cloud

### DIFF
--- a/packages/lib/services/share/ShareService.test.ts
+++ b/packages/lib/services/share/ShareService.test.ts
@@ -323,6 +323,10 @@ describe('ShareService', () => {
 		// in tests.
 		const previousLogLevel = Logger.globalLogger.setLevel(LogLevel.Error);
 
+		// checkShareConsistency only runs when the sync target supports
+		// sharing (Joplin Server/Cloud).
+		Setting.setValue('sync.target', 9);
+
 		const service = testShareFolderService({
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			'GET api/shares': async (_query: Record<string, any>, _body: any): Promise<any> => {
@@ -338,6 +342,31 @@ describe('ShareService', () => {
 		expect(await Folder.load(folder.id)).toBeFalsy();
 
 		Logger.globalLogger.setLevel(previousLogLevel);
+	});
+
+	it('should skip share consistency check when not using a share-compatible sync target', async () => {
+		// Simulate a non-Joplin Server sync target (e.g. WebDAV = 6).
+		// This reproduces the scenario where a user previously used Joplin
+		// Server (which set share_id on folders), then switched to WebDAV.
+		// checkShareConsistency() should not attempt to call the Joplin
+		// Server API since we are no longer on a share-capable sync target.
+		Setting.setValue('sync.target', 6);
+
+		const service = mockShareService({
+			onExec: async () => {
+				throw new Error('Should not call the API when share is not enabled');
+			},
+		});
+
+		// Create a folder with a stale share_id leftover from Joplin Server
+		const folder = await Folder.save({ share_id: 'stale_share_id' });
+
+		// This should not throw or attempt any API calls
+		await service.checkShareConsistency();
+
+		// The folder should still exist since we cannot verify shares
+		// without a Joplin Server API connection
+		expect(await Folder.load(folder.id)).toBeTruthy();
 	});
 
 	it('should leave a shared folder', async () => {

--- a/packages/lib/services/share/ShareService.ts
+++ b/packages/lib/services/share/ShareService.ts
@@ -247,6 +247,12 @@ export default class ShareService {
 	// necessary otherwise sync will try to update items that are not longer
 	// accessible and will throw the error "Could not find share with ID: xxxx")
 	public async checkShareConsistency() {
+		// Sharing is only supported on Joplin Server/Cloud. If the user is
+		// using a different sync target, there is no share API to query and
+		// any share_id values on folders are stale leftovers from a previous
+		// sync target configuration.
+		if (!this.enabled) return;
+
 		const rootSharedFolders = await Folder.rootSharedFolders(this.shares);
 		let hasRefreshedShares = false;
 		let shares = this.shares;


### PR DESCRIPTION
Fixes https://github.com/laurent22/joplin/issues/14412

When a user switches from Joplin Server to WebDAV/Nextcloud, leftover `share_id` values on folders cause `ShareService.checkShareConsistency()` to call the Joplin Server API with the current (non-server) sync target settings, crashing with `Unknown key: sync.6.apiKey`.

The fix adds an early return in `checkShareConsistency()` when the current sync target does not support sharing, matching the existing guard in `maintenance()`.

### Testing

- Added a test that sets the sync target to WebDAV, creates a folder with a stale `share_id`, and verifies `checkShareConsistency()` returns without attempting any API calls.
- Updated the existing `checkShareConsistency` test to explicitly set `sync.target` to Joplin Server (9), since the method now requires a share-capable sync target.