### PR TITLE
Desktop: Fix note list losing focus after moving note to trash

### DIFF
--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -31,6 +31,7 @@ import { stateUtils } from '@joplin/lib/reducer';
 import { connect } from 'react-redux';
 import useOnNoteDoubleClick from './utils/useOnNoteDoubleClick';
 import useAutoScroll from './utils/useAutoScroll';
+import useRefocusOnDeletion from './utils/useRefocusOnDeletion';
 
 const commands = {
 	focusElementNoteList,
@@ -74,6 +75,7 @@ const NoteList = (props: Props) => {
 
 	const { activeNoteId, setActiveNoteId } = useActiveDescendantId(props.selectedFolderId, props.selectedNoteIds);
 	const focusNote = useFocusNote(listRef, props.notes, makeItemIndexVisible, setActiveNoteId);
+	useRefocusOnDeletion(props.notes.length, props.selectedNoteIds, props.focusedField, focusNote);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,

--- a/packages/app-desktop/gui/NoteList/NoteList2.tsx
+++ b/packages/app-desktop/gui/NoteList/NoteList2.tsx
@@ -75,7 +75,7 @@ const NoteList = (props: Props) => {
 
 	const { activeNoteId, setActiveNoteId } = useActiveDescendantId(props.selectedFolderId, props.selectedNoteIds);
 	const focusNote = useFocusNote(listRef, props.notes, makeItemIndexVisible, setActiveNoteId);
-	useRefocusOnDeletion(props.notes.length, props.selectedNoteIds, props.focusedField, focusNote);
+	useRefocusOnDeletion(props.notes.length, props.selectedNoteIds, props.focusedField, props.selectedFolderId, focusNote);
 
 	const moveNote = useMoveNote(
 		props.notesParentType,

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import useRefocusOnDeletion from './useRefocusOnDeletion';
+
+describe('useRefocusOnDeletion', () => {
+	it('should call focusNote when a note is removed and note list has focus', () => {
+		const focusNote = jest.fn();
+
+		const { rerender } = renderHook(
+			({ noteCount }: { noteCount: number }) =>
+				useRefocusOnDeletion(noteCount, ['note-2'], '', focusNote),
+			{ initialProps: { noteCount: 3 } },
+		);
+
+		rerender({ noteCount: 2 });
+
+		expect(focusNote).toHaveBeenCalledWith('note-2');
+	});
+
+	it('should not call focusNote when another field has focus', () => {
+		const focusNote = jest.fn();
+
+		const { rerender } = renderHook(
+			({ noteCount }: { noteCount: number }) =>
+				useRefocusOnDeletion(noteCount, ['note-2'], 'editor', focusNote),
+			{ initialProps: { noteCount: 3 } },
+		);
+
+		rerender({ noteCount: 2 });
+
+		expect(focusNote).not.toHaveBeenCalled();
+	});
+
+	it('should not call focusNote when note count increases', () => {
+		const focusNote = jest.fn();
+
+		const { rerender } = renderHook(
+			({ noteCount }: { noteCount: number }) =>
+				useRefocusOnDeletion(noteCount, ['note-1'], '', focusNote),
+			{ initialProps: { noteCount: 2 } },
+		);
+
+		rerender({ noteCount: 3 });
+
+		expect(focusNote).not.toHaveBeenCalled();
+	});
+
+	it('should not call focusNote when multiple notes are selected', () => {
+		const focusNote = jest.fn();
+
+		const { rerender } = renderHook(
+			({ noteCount }: { noteCount: number }) =>
+				useRefocusOnDeletion(noteCount, ['note-1', 'note-2'], '', focusNote),
+			{ initialProps: { noteCount: 3 } },
+		);
+
+		rerender({ noteCount: 2 });
+
+		expect(focusNote).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -4,57 +4,56 @@ import useRefocusOnDeletion from './useRefocusOnDeletion';
 describe('useRefocusOnDeletion', () => {
 	it('should call focusNote when a note is removed and note list has focus', () => {
 		const focusNote = jest.fn();
-
 		const { rerender } = renderHook(
 			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-2'], '', focusNote),
+				useRefocusOnDeletion(noteCount, ['note-2'], '', 'folder-1', focusNote),
 			{ initialProps: { noteCount: 3 } },
 		);
-
 		rerender({ noteCount: 2 });
-
 		expect(focusNote).toHaveBeenCalledWith('note-2');
 	});
 
 	it('should not call focusNote when another field has focus', () => {
 		const focusNote = jest.fn();
-
 		const { rerender } = renderHook(
 			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-2'], 'editor', focusNote),
+				useRefocusOnDeletion(noteCount, ['note-2'], 'editor', 'folder-1', focusNote),
 			{ initialProps: { noteCount: 3 } },
 		);
-
 		rerender({ noteCount: 2 });
-
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 
 	it('should not call focusNote when note count increases', () => {
 		const focusNote = jest.fn();
-
 		const { rerender } = renderHook(
 			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-1'], '', focusNote),
+				useRefocusOnDeletion(noteCount, ['note-1'], '', 'folder-1', focusNote),
 			{ initialProps: { noteCount: 2 } },
 		);
-
 		rerender({ noteCount: 3 });
-
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 
 	it('should not call focusNote when multiple notes are selected', () => {
 		const focusNote = jest.fn();
-
 		const { rerender } = renderHook(
 			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-1', 'note-2'], '', focusNote),
+				useRefocusOnDeletion(noteCount, ['note-1', 'note-2'], '', 'folder-1', focusNote),
 			{ initialProps: { noteCount: 3 } },
 		);
-
 		rerender({ noteCount: 2 });
+		expect(focusNote).not.toHaveBeenCalled();
+	});
 
+	it('should not call focusNote when switching to a folder with fewer notes', () => {
+		const focusNote = jest.fn();
+		const { rerender } = renderHook(
+			({ noteCount, selectedFolderId }: { noteCount: number; selectedFolderId: string }) =>
+				useRefocusOnDeletion(noteCount, ['note-1'], '', selectedFolderId, focusNote),
+			{ initialProps: { noteCount: 3, selectedFolderId: 'folder-1' } },
+		);
+		rerender({ noteCount: 2, selectedFolderId: 'folder-2' });
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 });

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.test.ts
@@ -2,58 +2,40 @@ import { renderHook } from '@testing-library/react';
 import useRefocusOnDeletion from './useRefocusOnDeletion';
 
 describe('useRefocusOnDeletion', () => {
-	it('should call focusNote when a note is removed and note list has focus', () => {
-		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-2'], '', 'folder-1', focusNote),
-			{ initialProps: { noteCount: 3 } },
-		);
-		rerender({ noteCount: 2 });
-		expect(focusNote).toHaveBeenCalledWith('note-2');
-	});
-
-	it('should not call focusNote when another field has focus', () => {
-		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-2'], 'editor', 'folder-1', focusNote),
-			{ initialProps: { noteCount: 3 } },
-		);
-		rerender({ noteCount: 2 });
-		expect(focusNote).not.toHaveBeenCalled();
-	});
-
-	it('should not call focusNote when note count increases', () => {
+	it('should refocus when a note is deleted in the same folder', () => {
 		const focusNote = jest.fn();
 		const { rerender } = renderHook(
 			({ noteCount }: { noteCount: number }) =>
 				useRefocusOnDeletion(noteCount, ['note-1'], '', 'folder-1', focusNote),
-			{ initialProps: { noteCount: 2 } },
-		);
-		rerender({ noteCount: 3 });
-		expect(focusNote).not.toHaveBeenCalled();
-	});
-
-	it('should not call focusNote when multiple notes are selected', () => {
-		const focusNote = jest.fn();
-		const { rerender } = renderHook(
-			({ noteCount }: { noteCount: number }) =>
-				useRefocusOnDeletion(noteCount, ['note-1', 'note-2'], '', 'folder-1', focusNote),
 			{ initialProps: { noteCount: 3 } },
 		);
 		rerender({ noteCount: 2 });
+		expect(focusNote).toHaveBeenCalledWith('note-1');
+	});
+
+	test.each([
+		['note count increases', 2, 3, '', ['note-1']],
+		['another field has focus', 3, 2, 'editor', ['note-1']],
+		['multiple notes are selected', 3, 2, '', ['note-1', 'note-2']],
+	])('should not refocus when %s', (_label, initialCount, newCount, focusedField, noteIds) => {
+		const focusNote = jest.fn();
+		const { rerender } = renderHook(
+			({ noteCount }: { noteCount: number }) =>
+				useRefocusOnDeletion(noteCount, noteIds, focusedField, 'folder-1', focusNote),
+			{ initialProps: { noteCount: initialCount } },
+		);
+		rerender({ noteCount: newCount });
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 
-	it('should not call focusNote when switching to a folder with fewer notes', () => {
+	it('should not refocus when switching to a folder with fewer notes', () => {
 		const focusNote = jest.fn();
 		const { rerender } = renderHook(
-			({ noteCount, selectedFolderId }: { noteCount: number; selectedFolderId: string }) =>
-				useRefocusOnDeletion(noteCount, ['note-1'], '', selectedFolderId, focusNote),
-			{ initialProps: { noteCount: 3, selectedFolderId: 'folder-1' } },
+			({ noteCount, folderId }: { noteCount: number; folderId: string }) =>
+				useRefocusOnDeletion(noteCount, ['note-1'], '', folderId, focusNote),
+			{ initialProps: { noteCount: 3, folderId: 'folder-1' } },
 		);
-		rerender({ noteCount: 2, selectedFolderId: 'folder-2' });
+		rerender({ noteCount: 2, folderId: 'folder-2' });
 		expect(focusNote).not.toHaveBeenCalled();
 	});
 });

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import usePrevious from '@joplin/lib/hooks/usePrevious';
+
+const useRefocusOnDeletion = (
+	noteCount: number,
+	selectedNoteIds: string[],
+	focusedField: string,
+	focusNote: (noteId: string) => void,
+) => {
+	const previousNoteCount = usePrevious(noteCount, 0);
+
+	useEffect(() => {
+		const noteWasRemoved = noteCount < previousNoteCount;
+		if (noteWasRemoved && selectedNoteIds.length === 1 && !focusedField) {
+			focusNote(selectedNoteIds[0]);
+		}
+	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, focusNote]);
+};
+
+export default useRefocusOnDeletion;

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -1,20 +1,20 @@
 import { useEffect } from 'react';
 import usePrevious from '@joplin/lib/hooks/usePrevious';
-
 const useRefocusOnDeletion = (
 	noteCount: number,
 	selectedNoteIds: string[],
 	focusedField: string,
+	selectedFolderId: string,
 	focusNote: (noteId: string)=> void,
 ) => {
 	const previousNoteCount = usePrevious(noteCount, 0);
-
+	const previousFolderId = usePrevious(selectedFolderId, '');
 	useEffect(() => {
 		const noteWasRemoved = noteCount < previousNoteCount;
-		if (noteWasRemoved && selectedNoteIds.length === 1 && !focusedField) {
+		const folderDidNotChange = selectedFolderId === previousFolderId;
+		if (noteWasRemoved && folderDidNotChange && selectedNoteIds.length === 1 && !focusedField) {
 			focusNote(selectedNoteIds[0]);
 		}
-	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, focusNote]);
+	}, [noteCount, previousNoteCount, selectedNoteIds, focusedField, selectedFolderId, previousFolderId, focusNote]);
 };
-
 export default useRefocusOnDeletion;

--- a/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
+++ b/packages/app-desktop/gui/NoteList/utils/useRefocusOnDeletion.ts
@@ -5,7 +5,7 @@ const useRefocusOnDeletion = (
 	noteCount: number,
 	selectedNoteIds: string[],
 	focusedField: string,
-	focusNote: (noteId: string) => void,
+	focusNote: (noteId: string)=> void,
 ) => {
 	const previousNoteCount = usePrevious(noteCount, 0);
 


### PR DESCRIPTION
**AI Assistance Disclosure** - Used an AI tool to help navigate the codebase and understand the focus 
management pattern in NoteList2.tsx. The fix approach, code, and tests were written by me. I have reviewed everything carefully and fully understand each line.

When a note is deleted, the next note becomes visually selected but keyboard focus is lost - arrow keys stop working.

The fix adds a `useRefocusOnDeletion` hook that detects when the note count drops and calls `focusNote` on the newly selected note, using the existing `usePrevious` hook.

https://github.com/user-attachments/assets/8193b241-dc2c-4ccc-b770-872b99e91297

Fixes #10753

**Test plan**
Manual: create a few notes, delete one, press arrow keys - focus moves correctly to the next note. Also verified that focus is not stolen when the editor or title field is active.

Automated: added unit tests in `useRefocusOnDeletion.test.ts` covering deletion, no-op on addition, multi-select, and the focusedField guard.