### PR TITLE
All: Resolves #12037: Remove JSDOM from Turndown package

### DIFF
--- a/packages/turndown-plugin-gfm/src/tables.js
+++ b/packages/turndown-plugin-gfm/src/tables.js
@@ -119,7 +119,8 @@ rules.table = {
         }
       }
 
-      const captionContent = node.caption ? node.caption.textContent || '' : '';
+      const captionNode = node.querySelector ? node.querySelector('caption') : node.caption;
+      const captionContent = captionNode ? captionNode.textContent || '' : '';
       const caption = captionContent ? `${captionContent}\n\n` : '';
       const tableContent = `${emptyHeader}${content}`.trimStart();
       return `\n\n${caption}${tableContent}\n\n`;

--- a/packages/turndown-plugin-gfm/src/task-list-items.js
+++ b/packages/turndown-plugin-gfm/src/task-list-items.js
@@ -4,7 +4,7 @@ export default function taskListItems (turndownService) {
       const parent = node.parentNode;
       const grandparent = parent.parentNode;
       const grandparentIsListItem = !!grandparent && grandparent.nodeName === 'LI';
-      return (node.type === 'checkbox' || node.role === 'checkbox') && (
+      return (node.type === 'checkbox' || node.role === 'checkbox' || node.getAttribute('role') === 'checkbox') && (
         parent.nodeName === 'LI'
         // Handles the case where the label contains the checkbox. For example,
         // <label><input ...> ...label text...</label>

--- a/packages/turndown-plugin-gfm/src/task-list-items.js
+++ b/packages/turndown-plugin-gfm/src/task-list-items.js
@@ -4,7 +4,7 @@ export default function taskListItems (turndownService) {
       const parent = node.parentNode;
       const grandparent = parent.parentNode;
       const grandparentIsListItem = !!grandparent && grandparent.nodeName === 'LI';
-      return (node.type === 'checkbox' || node.role === 'checkbox' || node.getAttribute('role') === 'checkbox') && (
+      return (node.type === 'checkbox' || node.getAttribute('role') === 'checkbox') && (
         parent.nodeName === 'LI'
         // Handles the case where the label contains the checkbox. For example,
         // <label><input ...> ...label text...</label>

--- a/packages/turndown/config/rollup.config.mjs
+++ b/packages/turndown/config/rollup.config.mjs
@@ -9,7 +9,7 @@ export default function(config) {
 			name: 'TurndownService',
 			...config.output,
 		},
-		external: ['jsdom'],
+		external: ['@mixmark-io/domino'],
 		plugins: [
 			commonjs(),
 			replace({

--- a/packages/turndown/package.json
+++ b/packages/turndown/package.json
@@ -10,8 +10,8 @@
   "browser": "lib/turndown.browser.cjs.js",
   "dependencies": {
     "@adobe/css-tools": "4.4.4",
-    "html-entities": "1.4.0",
-    "jsdom": "26.1.0"
+    "@mixmark-io/domino": "2.2.0",
+    "html-entities": "1.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "28.0.9",

--- a/packages/turndown/src/html-parser.js
+++ b/packages/turndown/src/html-parser.js
@@ -47,9 +47,9 @@ function createHTMLParser () {
       }
     }
   } else {
-    var JSDOM = require('jsdom').JSDOM
+    var domino = require('@mixmark-io/domino')
     Parser.prototype.parseFromString = function (string) {
-      return new JSDOM(string).window.document
+      return domino.createDocument(string)
     }
   }
   return Parser

--- a/yarn.lock
+++ b/yarn.lock
@@ -11256,12 +11256,12 @@ __metadata:
   resolution: "@joplin/turndown@workspace:packages/turndown"
   dependencies:
     "@adobe/css-tools": "npm:4.4.4"
+    "@mixmark-io/domino": "npm:2.2.0"
     "@rollup/plugin-commonjs": "npm:28.0.9"
     "@rollup/plugin-node-resolve": "npm:16.0.3"
     "@rollup/plugin-replace": "npm:6.0.3"
     browserify: "npm:14.5.0"
     html-entities: "npm:1.4.0"
-    jsdom: "npm:26.1.0"
     rollup: "npm:4.2.0"
     standard: "npm:17.1.2"
     turndown-attendant: "npm:0.0.3"
@@ -12639,7 +12639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mixmark-io/domino@npm:^2.2.0":
+"@mixmark-io/domino@npm:2.2.0, @mixmark-io/domino@npm:^2.2.0":
   version: 2.2.0
   resolution: "@mixmark-io/domino@npm:2.2.0"
   checksum: 10/839624ba6baab655c4f7393e8b8561516849926651e02f40484729b9869436b1e077906810bcac0bba4762448512d3ebd2f6d9b463d8ab0d5f54d75ca5306519


### PR DESCRIPTION
Resolves #12037.

Problem 
JSDOM is way too heavy (~10MB) just to parse HTML for Markdown conversion. It spins up a full browser environment which is overkill for turndown.

Solution
Swap JSDOM for [@mixmark-io/domino](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (~100KB) — a fast, minimal DOM parser that covers everything turndown needs
 Added a [querySelector('caption')](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fallback in the GFM tables plugin since Domino doesn't have [HTMLTableElement.caption](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).