### PR TITLE
Desktop, Mobile: Fixes #14647: Fix inconsistent note order upon note creation, when custom order is set

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -485,6 +485,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newFolder.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newSubFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newTodo.js

--- a/.gitignore
+++ b/.gitignore
@@ -458,6 +458,7 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/commands/index.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/linkToNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/moveToFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newFolder.js
+packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.test.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newSubFolder.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newTodo.js

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.test.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.test.ts
@@ -1,4 +1,3 @@
-import NavService from '@joplin/lib/services/NavService';
 import { runtime } from './newNote';
 import { setupDatabaseAndSynchronizer, switchClient } from '@joplin/lib/testing/test-utils';
 import Note from '@joplin/lib/models/Note';
@@ -14,10 +13,7 @@ describe('newNote', () => {
 		[null, null],
 		['order', true],
 		['order', false],
-	])('should create and navigate to a new note', async (sortOrderField: string, sortOrderReverse: boolean) => {
-		const dispatchMock = jest.fn();
-		NavService.dispatch = dispatchMock;
-
+	])('should create a new note', async (sortOrderField: string, sortOrderReverse: boolean) => {
 		// The command needs an active folder ID.
 		const activeFolder = await Folder.save({ title: 'folder' });
 		const initialNote = await Note.save({ title: 'test', parent_id: activeFolder.id });
@@ -26,11 +22,9 @@ describe('newNote', () => {
 		Setting.setValue('notes.sortOrder.reverse', sortOrderReverse);
 
 		await runtime().execute(null, 'test note', true);
-		expect(dispatchMock).toHaveBeenCalledTimes(1);
 
 		// Correct note should have been created
-		const noteId = dispatchMock.mock.lastCall[0].noteId;
-		const newNote = await Note.load(noteId);
+		const newNote = (await Note.loadByField('body', 'test note'));
 		expect(newNote.body).toEqual('test note');
 		expect(newNote.parent_id).toEqual(activeFolder.id);
 		if (sortOrderField === 'order' && !!sortOrderReverse) {
@@ -38,12 +32,7 @@ describe('newNote', () => {
 		} else if (sortOrderField === 'order' && !sortOrderReverse) {
 			expect(newNote.order).toBeLessThanOrEqual(initialNote.order - Note.defaultIntevalBetweenNotes);
 		} else {
-			expect(newNote.order).toBeLessThan(initialNote.order + Note.defaultIntevalBetweenNotes);
+			expect(newNote.order).toEqual(0);
 		}
-
-		// Should have tried to navigate to the note.
-		expect(dispatchMock.mock.lastCall).toMatchObject([
-			{ noteId: noteId, noteHash: '' },
-		]);
 	});
 });

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
@@ -2,6 +2,7 @@ import { utils, CommandRuntime, CommandDeclaration, CommandContext } from '@jopl
 import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
+import Setting from '@joplin/lib/models/Setting';
 
 export const newNoteEnabledConditions = 'oneFolderSelected && !inConflictFolder && !folderIsReadOnly && !folderIsTrash';
 
@@ -19,9 +20,17 @@ export const runtime = (): CommandRuntime => {
 
 			const defaultValues = Note.previewFieldsWithDefaultValues({ includeTimestamps: false });
 
-			let newNote = { ...defaultValues, parent_id: folder.id,
+			let order;
+			if (Setting.value('notes.sortOrder.field') === 'order') {
+				order = await Note.getNextOrderValue(folder.id);
+			}
+
+			let newNote = {
+				...defaultValues, parent_id: folder.id,
 				is_todo: isTodo ? 1 : 0,
-				body: body };
+				body: body,
+				...(order ? { order } : {}),
+			};
 
 			newNote = await Note.save(newNote, { provisional: true });
 

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
@@ -29,7 +29,7 @@ export const runtime = (): CommandRuntime => {
 				...defaultValues, parent_id: folder.id,
 				is_todo: isTodo ? 1 : 0,
 				body: body,
-				...(order ? { order } : {}),
+				...(order !== undefined ? { order } : {}),
 			};
 
 			newNote = await Note.save(newNote, { provisional: true });

--- a/packages/app-mobile/commands/newNote.ts
+++ b/packages/app-mobile/commands/newNote.ts
@@ -3,6 +3,7 @@ import Logger from '@joplin/utils/Logger';
 import goToNote, { GotoNoteOptions } from './util/goToNote';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
+import Setting from '@joplin/lib/models/Setting';
 
 const logger = Logger.create('newNoteCommand');
 
@@ -19,10 +20,16 @@ export const runtime = (): CommandRuntime => {
 				return;
 			}
 
+			let order;
+			if (Setting.value('notes.sortOrder.field') === 'order') {
+				order = await Note.getNextOrderValue(folder.id);
+			}
+
 			const note = await Note.save({
 				body,
 				parent_id: folder.id,
 				is_todo: todo ? 1 : 0,
+				...(order ? { order } : {}),
 			}, { provisional: true });
 
 			logger.info(`Navigating to note ${note.id}`);

--- a/packages/app-mobile/commands/newNote.ts
+++ b/packages/app-mobile/commands/newNote.ts
@@ -29,7 +29,7 @@ export const runtime = (): CommandRuntime => {
 				body,
 				parent_id: folder.id,
 				is_todo: todo ? 1 : 0,
-				...(order ? { order } : {}),
+				...(order !== undefined ? { order } : {}),
 			}, { provisional: true });
 
 			logger.info(`Navigating to note ${note.id}`);

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -52,6 +52,7 @@ export default class Note extends BaseItem {
 	private static geolocationCache_: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static dueDateObjects_: any;
+	private static defaultIntevalBetweenNotes = 60 * 60 * 1000;
 
 	public static tableName() {
 		return 'notes';
@@ -1125,19 +1126,18 @@ export default class Note extends BaseItem {
 			// and the increment between the order values of each inserted notes.
 			let newOrder = 0;
 			let intervalBetweenNotes = 0;
-			const defaultIntevalBetweenNotes = 60 * 60 * 1000;
 
 			if (!relevantExistingNoteCount) { // If there's no (relevant) notes in the target notebook
 				newOrder = Date.now();
-				intervalBetweenNotes = defaultIntevalBetweenNotes;
+				intervalBetweenNotes = this.defaultIntevalBetweenNotes;
 			} else if (index > lastRelevantNoteIndex) { // Insert at the end (of relevant group)
 				intervalBetweenNotes = notes[lastRelevantNoteIndex].order / (noteIds.length + 1);
 				newOrder = notes[lastRelevantNoteIndex].order - intervalBetweenNotes;
 			} else if (index <= firstRelevantNoteIndex) { // Insert at the beginning (of relevant group)
 				const firstNoteOrder = notes[firstRelevantNoteIndex].order;
 				if (firstNoteOrder >= Date.now()) {
-					intervalBetweenNotes = defaultIntevalBetweenNotes;
-					newOrder = firstNoteOrder + defaultIntevalBetweenNotes;
+					intervalBetweenNotes = this.defaultIntevalBetweenNotes;
+					newOrder = firstNoteOrder + this.defaultIntevalBetweenNotes;
 				} else {
 					intervalBetweenNotes = (Date.now() - firstNoteOrder) / (noteIds.length + 1);
 					newOrder = firstNoteOrder + intervalBetweenNotes * noteIds.length;
@@ -1151,7 +1151,7 @@ export default class Note extends BaseItem {
 					for (let i = index; i >= 0; i--) {
 						const n = notes[i];
 						if (n.order <= previousOrder) {
-							const o = previousOrder + defaultIntevalBetweenNotes;
+							const o = previousOrder + this.defaultIntevalBetweenNotes;
 							const updatedNote = await this.updateNoteOrder_(n, o);
 							notes[i] = { ...n, ...updatedNote };
 							previousOrder = o;
@@ -1202,5 +1202,16 @@ export default class Note extends BaseItem {
 		conflictNote.is_conflict = 1;
 		conflictNote.conflict_original_id = sourceNote.id;
 		return await Note.save(conflictNote, { autoTimestamp: false, changeSource: changeSource });
+	}
+
+	public static async getNextOrderValue(folderId: string) {
+		const reverse = Setting.value('notes.sortOrder.reverse');
+		if (reverse) {
+			const folder = await this.modelSelectOne('SELECT MAX(`order`) as `order` FROM notes WHERE parent_id = ?', [folderId]);
+			return Number(folder.order ?? 0) + this.defaultIntevalBetweenNotes;
+		} else {
+			const folder = await this.modelSelectOne('SELECT MIN(`order`) as `order` FROM notes WHERE parent_id = ?', [folderId]);
+			return Number(folder.order ?? 0) - this.defaultIntevalBetweenNotes;
+		}
 	}
 }

--- a/packages/lib/models/Note.ts
+++ b/packages/lib/models/Note.ts
@@ -46,13 +46,13 @@ export interface PreviewsOptions {
 
 export default class Note extends BaseItem {
 
+	public static defaultIntevalBetweenNotes = 60 * 60 * 1000;
 	public static updateGeolocationEnabled_ = true;
 	private static geolocationUpdating_ = false;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static geolocationCache_: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private static dueDateObjects_: any;
-	private static defaultIntevalBetweenNotes = 60 * 60 * 1000;
 
 	public static tableName() {
 		return 'notes';


### PR DESCRIPTION
### Background

When custom ordering is set, Joplin provides the ability to reorder notes within the notebook. This is managed by the Notes.insertNotesAt function and the order field on the note entity. When creating a new note, currently the desktop and mobile app behaves differently with regards to what default value is set for the order field. The desktop app always sets it to 0 (due to using Note.previewFieldsWithDefaultValues in the newNote command), while the mobile app sets it to the current time. This creates a discrepancy in behaviour as noted in https://github.com/laurent22/joplin/issues/14647.

Regardless of this difference however, reordering notes can result in notes being created with an order value in the future (in increments of 1 hour, as per Notes.insertNotesAt). This means that after notes have been re-arranged, this results in notes created shortly after, being created at neither the start or the end of the note list. See videos demonstrating this on both the desktop and mobile app (note I am using the changes in https://github.com/laurent22/joplin/pull/14610 on mobile, in order to reorder notes on the mobile app):

https://github.com/user-attachments/assets/e8856d74-545c-47d1-b53d-476217893f46
https://github.com/user-attachments/assets/8ef942d1-c3f7-49ae-a06a-36ca8cb72710

### Solution

In order to remedy this issue, I have implemented logic which, when the sort field is set to custom on the current notebook (with per notebook sorting, or global sorting), will create new notes with a sort order which is 1 hour earlier or later than the note with the earliest or latest order value in the active notebook, depending on the value of the reverse sort order setting. The reverse sort order setting is currently not applicable for custom sort order. However, users may wish to choose whether they want new notes / todos to be created at the top or the bottom of the note list, and therefore altering the position to insert new notes depending on this setting offers users the flexibility to choose. If preferred, I can change the logic to ignore this setting and always insert at the bottom of the list.

If the user decides to change the notebook after creating the note, where custom sort is relevant for the new destination, this will result in an inconsistent sort order for the item (also applicable to when the all notes notebook is selected), but this should be a minor compromise for gaining the ability to have a consistent insertion order for the currently selected notebook. Inconsistent sort order is also an existing issue in general, if moving notes between custom sorted notebooks.

This fixes https://github.com/laurent22/joplin/issues/14647 and the additional issues described in this PR.

### Testing

See videos demonstrating behaviour working correctly on desktop and mobile, with reverse sort order both enabled and disabled and showing that when the uncompleted todos at top setting is set to true, the note list is still be segmented by this restriction, and notes are created at the boundaries of the relevant section instead of the full list:

https://github.com/user-attachments/assets/e264af8d-a52a-4e15-9c6c-f414ebe444c7
https://github.com/user-attachments/assets/6afc703e-023b-42c0-8218-8af2ab0d3e7f

I have also tested the note insertion with custom sort enabled using own sort order on and notebook, and included unit tests for new note creation which verify the new behaviour