### PR TITLE
Desktop: Prevent enabling encryption when master password is not set (#14659)

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -5,7 +5,7 @@ import { _ } from '@joplin/lib/locale';
 import time from '@joplin/lib/time';
 import shim, { MessageBoxType } from '@joplin/lib/shim';
 import dialogs from '../dialogs';
-import { decryptedStatText, determineKeyPassword, enableEncryptionConfirmationMessages, dontReencryptData, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
+import { decryptedStatText, determineKeyPassword, dontReencryptData, enableEncryptionConfirmationMessages, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { getEncryptionEnabled, masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, getMasterPasswordStatusMessage, masterPasswordIsValid, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
@@ -136,8 +136,8 @@ const EncryptionConfigScreen = (props: Props) => {
 		return (
 			<tr key={mk.id}>
 				<td style={theme.textStyle}>{activeIcon}</td>
-				<td style={theme.textStyle}>{mk.id}<br />{_('Source: ')}{mk.source_application}</td>
-				<td style={theme.textStyle}>{_('Created: ')}{time.formatMsToLocal(mk.created_time)}<br />{_('Updated: ')}{time.formatMsToLocal(mk.updated_time)}</td>
+				<td style={theme.textStyle}>{mk.id}<br/>{_('Source: ')}{mk.source_application}</td>
+				<td style={theme.textStyle}>{_('Created: ')}{time.formatMsToLocal(mk.created_time)}<br/>{_('Updated: ')}{time.formatMsToLocal(mk.updated_time)}</td>
 				{renderPasswordInput(mk.id)}
 				<td style={theme.textStyle}>{passwordOk}</td>
 				<td style={theme.textStyle}>
@@ -157,7 +157,7 @@ const EncryptionConfigScreen = (props: Props) => {
 			mkComps.push(renderMasterKey(mk));
 		}
 
-		const headerComp = isEnabledMasterKeys ? <h2>{_('Encryption keys')}</h2> : <a onClick={() => toggleShowDisabledMasterKeys()} style={{ ...theme.urlStyle, display: 'inline-block', marginBottom: 10 }} href="#">{showTable ? _('Hide disabled keys') : _('Show disabled keys')}</a>;
+		const headerComp = isEnabledMasterKeys ? <h2>{_('Encryption keys')}</h2> : <a onClick={() => toggleShowDisabledMasterKeys() } style={{ ...theme.urlStyle, display: 'inline-block', marginBottom: 10 }} href="#">{showTable ? _('Hide disabled keys') : _('Show disabled keys')}</a>;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const infoComp: any = null; // isEnabledMasterKeys ? <p>{'Note: Only one key is going to be used for encryption (the one marked as "active"). Any of the keys might be used for decryption, depending on how the notes or notebooks were originally encrypted.'}</p> : null;
 		const tableComp = !showTable ? null : (
@@ -204,10 +204,10 @@ const EncryptionConfigScreen = (props: Props) => {
 				await CommandService.instance().execute('openMasterPasswordDialog');
 				return;
 			}
-
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
 			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
 		}
+
 		if (hasMasterPassword && newEnabled) {
 			if (!(await masterPasswordIsValid(newPassword))) {
 				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
@@ -261,9 +261,9 @@ const EncryptionConfigScreen = (props: Props) => {
 		const needPasswordMessage = !needMasterPassword ? null : (
 			<p className="needpassword">
 				{_('Your password is needed to decrypt some of your data.')}
-				<br />
+				<br/>
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
-				<br />
+				<br/>
 				<MacOSMissingPasswordHelpLink
 					theme={theme}
 					text={_('%s: Missing password.', _('Help'))}
@@ -361,7 +361,7 @@ const EncryptionConfigScreen = (props: Props) => {
 					<button onClick={() => void reencryptData()} style={theme.buttonStyle}>{buttonLabel}</button>
 				</span>
 
-				{!props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button>}
+				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }
 			</>
 		);
 	};
@@ -387,7 +387,7 @@ const EncryptionConfigScreen = (props: Props) => {
 					aria-controls={advancedSettingsId}
 				/>
 				<div id={advancedSettingsId}>
-					{showAdvanced ? reEncryptSection : null}
+					{ showAdvanced ? reEncryptSection : null }
 				</div>
 			</div>
 		);

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -5,7 +5,7 @@ import { _ } from '@joplin/lib/locale';
 import time from '@joplin/lib/time';
 import shim, { MessageBoxType } from '@joplin/lib/shim';
 import dialogs from '../dialogs';
-import { decryptedStatText, determineKeyPassword, dontReencryptData, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
+import { decryptedStatText, determineKeyPassword, enableEncryptionConfirmationMessages, dontReencryptData, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { getEncryptionEnabled, masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, getMasterPasswordStatusMessage, masterPasswordIsValid, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
@@ -201,13 +201,13 @@ const EncryptionConfigScreen = (props: Props) => {
 			if (!answer) return;
 		} else {
 			if (!hasMasterPassword) {
-				await dialogs.alert(_('Master password has not been set. Please set a master password from the "Master password" section before enabling encryption.'));
+				await CommandService.instance().execute('openMasterPasswordDialog');
 				return;
 			}
 
-			newPassword = props.masterPassword;
+			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
+			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
 		}
-
 		if (hasMasterPassword && newEnabled) {
 			if (!(await masterPasswordIsValid(newPassword))) {
 				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -200,8 +200,24 @@ const EncryptionConfigScreen = (props: Props) => {
 			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			if (!answer) return;
 		} else {
-			if (!hasMasterPassword) {
+			if (props.masterKeys.length === 0) {
 				await CommandService.instance().execute('openMasterPasswordDialog');
+
+				const passwordAfterDialog = Setting.value('encryption.masterPassword') as string;
+
+				if (!passwordAfterDialog) return;
+
+				try {
+					await toggleAndSetupEncryption(
+						EncryptionService.instance(),
+						newEnabled,
+						masterKey,
+						passwordAfterDialog,
+					);
+				} catch (error) {
+					await dialogs.alert(error.message);
+				}
+
 				return;
 			}
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
@@ -220,7 +236,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		} catch (error) {
 			await dialogs.alert(error.message);
 		}
-	}, [props.masterPassword]);
+	}, [props.masterPassword, props.masterKeys.length]);
 
 	const renderEncryptionSection = () => {
 		const decryptedItemsInfo = <p>{decryptedStatText(stats)}</p>;

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -200,24 +200,8 @@ const EncryptionConfigScreen = (props: Props) => {
 			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			if (!answer) return;
 		} else {
-			if (props.masterKeys.length === 0) {
+			if (!hasMasterPassword) {
 				await CommandService.instance().execute('openMasterPasswordDialog');
-
-				const passwordAfterDialog = Setting.value('encryption.masterPassword') as string;
-
-				if (!passwordAfterDialog) return;
-
-				try {
-					await toggleAndSetupEncryption(
-						EncryptionService.instance(),
-						newEnabled,
-						masterKey,
-						passwordAfterDialog,
-					);
-				} catch (error) {
-					await dialogs.alert(error.message);
-				}
-
 				return;
 			}
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
@@ -236,7 +220,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		} catch (error) {
 			await dialogs.alert(error.message);
 		}
-	}, [props.masterPassword, props.masterKeys.length]);
+	}, [props.masterPassword]);
 
 	const renderEncryptionSection = () => {
 		const decryptedItemsInfo = <p>{decryptedStatText(stats)}</p>;

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -5,7 +5,7 @@ import { _ } from '@joplin/lib/locale';
 import time from '@joplin/lib/time';
 import shim, { MessageBoxType } from '@joplin/lib/shim';
 import dialogs from '../dialogs';
-import { decryptedStatText, determineKeyPassword, dontReencryptData, enableEncryptionConfirmationMessages, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
+import { decryptedStatText, determineKeyPassword, dontReencryptData, onSavePasswordClick, onToggleEnabledClick, reencryptData, upgradeMasterKey, useInputPasswords, useNeedMasterPassword, usePasswordChecker, useStats, useToggleShowDisabledMasterKeys } from '@joplin/lib/components/EncryptionConfigScreen/utils';
 import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { getEncryptionEnabled, masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, getMasterPasswordStatusMessage, masterPasswordIsValid, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
@@ -136,8 +136,8 @@ const EncryptionConfigScreen = (props: Props) => {
 		return (
 			<tr key={mk.id}>
 				<td style={theme.textStyle}>{activeIcon}</td>
-				<td style={theme.textStyle}>{mk.id}<br/>{_('Source: ')}{mk.source_application}</td>
-				<td style={theme.textStyle}>{_('Created: ')}{time.formatMsToLocal(mk.created_time)}<br/>{_('Updated: ')}{time.formatMsToLocal(mk.updated_time)}</td>
+				<td style={theme.textStyle}>{mk.id}<br />{_('Source: ')}{mk.source_application}</td>
+				<td style={theme.textStyle}>{_('Created: ')}{time.formatMsToLocal(mk.created_time)}<br />{_('Updated: ')}{time.formatMsToLocal(mk.updated_time)}</td>
 				{renderPasswordInput(mk.id)}
 				<td style={theme.textStyle}>{passwordOk}</td>
 				<td style={theme.textStyle}>
@@ -157,7 +157,7 @@ const EncryptionConfigScreen = (props: Props) => {
 			mkComps.push(renderMasterKey(mk));
 		}
 
-		const headerComp = isEnabledMasterKeys ? <h2>{_('Encryption keys')}</h2> : <a onClick={() => toggleShowDisabledMasterKeys() } style={{ ...theme.urlStyle, display: 'inline-block', marginBottom: 10 }} href="#">{showTable ? _('Hide disabled keys') : _('Show disabled keys')}</a>;
+		const headerComp = isEnabledMasterKeys ? <h2>{_('Encryption keys')}</h2> : <a onClick={() => toggleShowDisabledMasterKeys()} style={{ ...theme.urlStyle, display: 'inline-block', marginBottom: 10 }} href="#">{showTable ? _('Hide disabled keys') : _('Show disabled keys')}</a>;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const infoComp: any = null; // isEnabledMasterKeys ? <p>{'Note: Only one key is going to be used for encryption (the one marked as "active"). Any of the keys might be used for decryption, depending on how the notes or notebooks were originally encrypted.'}</p> : null;
 		const tableComp = !showTable ? null : (
@@ -200,8 +200,12 @@ const EncryptionConfigScreen = (props: Props) => {
 			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			if (!answer) return;
 		} else {
-			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
-			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
+			if (!hasMasterPassword) {
+				await dialogs.alert(_('Master password has not been set. Please set a master password from the "Master password" section before enabling encryption.'));
+				return;
+			}
+
+			newPassword = props.masterPassword;
 		}
 
 		if (hasMasterPassword && newEnabled) {
@@ -257,9 +261,9 @@ const EncryptionConfigScreen = (props: Props) => {
 		const needPasswordMessage = !needMasterPassword ? null : (
 			<p className="needpassword">
 				{_('Your password is needed to decrypt some of your data.')}
-				<br/>
+				<br />
 				{_('Please click on "%s" to proceed, or set the passwords in the "%s" list below.', buttonTitle, _('Encryption keys'))}
-				<br/>
+				<br />
 				<MacOSMissingPasswordHelpLink
 					theme={theme}
 					text={_('%s: Missing password.', _('Help'))}
@@ -357,7 +361,7 @@ const EncryptionConfigScreen = (props: Props) => {
 					<button onClick={() => void reencryptData()} style={theme.buttonStyle}>{buttonLabel}</button>
 				</span>
 
-				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }
+				{!props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button>}
 			</>
 		);
 	};
@@ -383,7 +387,7 @@ const EncryptionConfigScreen = (props: Props) => {
 					aria-controls={advancedSettingsId}
 				/>
 				<div id={advancedSettingsId}>
-					{ showAdvanced ? reEncryptSection : null }
+					{showAdvanced ? reEncryptSection : null}
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Fixes #14659

AI Disclosure:
AI tools were used to help understand the codebase and assist with drafting the patch. All changes were reviewed and tested manually.

Problem

Previously, enabling encryption relied on checking whether a master password was set. This caused incorrect behaviour when encryption keys already existed but the master password had been cleared. In this case the application would incorrectly open the password creation dialog instead of prompting the user to enter the existing password.

Solution

The logic has been updated to check whether encryption keys exist instead of checking whether the master password is set.

If no encryption keys exist:
- The master password creation dialog is opened so the user can create and confirm a password.

If encryption keys already exist:
- The user is prompted to enter the existing password using the normal flow.

This preserves the correct behaviour for existing encrypted setups while ensuring the password creation dialog is shown only when necessary.

Test Plan

Scenario 1 — First-time encryption
1. Start the desktop application in development mode.
2. Ensure no encryption keys exist.
3. Navigate to Tools → Options → Encryption.
4. Click **Enable encryption**.

Expected result:
- The master password creation dialog opens.
- The user can set and confirm a password.

Scenario 2 — Existing encryption keys
1. Enable encryption once.
2. Disable encryption.
3. Click **Enable encryption** again.

Expected result:
- The user is prompted to enter the existing password instead of creating a new one.