### PR TITLE
Desktop: Fixes #14659: Reuse master password dialog when enabling E2EE

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -218,6 +218,8 @@ packages/app-desktop/gui/EditFolderDialog/Dialog.js
 packages/app-desktop/gui/EditFolderDialog/IconSelector.js
 packages/app-desktop/gui/EmojiBox.js
 packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.js
+packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.test.js
+packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.js
 packages/app-desktop/gui/ErrorBoundary.js
 packages/app-desktop/gui/ExtensionBadge.js
 packages/app-desktop/gui/FolderIconBox.js

--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,8 @@ packages/app-desktop/gui/EditFolderDialog/Dialog.js
 packages/app-desktop/gui/EditFolderDialog/IconSelector.js
 packages/app-desktop/gui/EmojiBox.js
 packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.js
+packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.test.js
+packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.js
 packages/app-desktop/gui/ErrorBoundary.js
 packages/app-desktop/gui/ExtensionBadge.js
 packages/app-desktop/gui/FolderIconBox.js

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -10,18 +10,21 @@ import { MasterKeyEntity } from '@joplin/lib/services/e2ee/types';
 import { getEncryptionEnabled, masterKeyEnabled, SyncInfo } from '@joplin/lib/services/synchronizer/syncInfoUtils';
 import { getDefaultMasterKey, getMasterPasswordStatusMessage, masterPasswordIsValid, toggleAndSetupEncryption } from '@joplin/lib/services/e2ee/utils';
 import Button, { ButtonLevel } from '../Button/Button';
-import { useCallback, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
-import { AppState } from '../../app.reducer';
+import { AppState, AppStateDialogName } from '../../app.reducer';
 import Setting from '@joplin/lib/models/Setting';
 import CommandService from '@joplin/lib/services/CommandService';
 import { PublicPrivateKeyPair } from '@joplin/lib/services/e2ee/ppk/ppk';
 import ToggleAdvancedSettingsButton from '../ConfigScreen/controls/ToggleAdvancedSettingsButton';
 import MacOSMissingPasswordHelpLink from '../ConfigScreen/controls/MissingPasswordHelpLink';
+import { Dispatch } from 'redux';
+import { shouldCancelPendingEnableAfterMasterPasswordDialog, shouldOpenMasterPasswordDialogForEnable, shouldResumeEnableAfterMasterPasswordDialog } from './enableFlow';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	themeId: any;
+	dispatch: Dispatch;
 	masterKeys: MasterKeyEntity[];
 	passwords: Record<string, string>;
 	notLoadedMasterKeys: string[];
@@ -30,10 +33,13 @@ interface Props {
 	activeMasterKeyId: string;
 	masterPassword: string;
 	ppk: PublicPrivateKeyPair;
+	masterPasswordDialogOpen: boolean;
 }
 
-const EncryptionConfigScreen = (props: Props) => {
+export const EncryptionConfigScreen = (props: Props) => {
 	const { inputPasswords, onInputPasswordChange } = useInputPasswords(props.passwords);
+	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
+	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
 
 	const theme = useMemo(() => {
 		return themeStyle(props.themeId);
@@ -43,6 +49,40 @@ const EncryptionConfigScreen = (props: Props) => {
 	const { passwordChecks, masterPasswordKeys, masterPasswordStatus } = usePasswordChecker(props.masterKeys, props.activeMasterKeyId, props.masterPassword, props.passwords);
 	const { showDisabledMasterKeys, toggleShowDisabledMasterKeys } = useToggleShowDisabledMasterKeys();
 	const needMasterPassword = useNeedMasterPassword(passwordChecks, props.masterKeys);
+
+	useEffect(() => {
+		const wasOpen = wasMasterPasswordDialogOpen.current;
+		wasMasterPasswordDialogOpen.current = props.masterPasswordDialogOpen;
+
+		if (shouldCancelPendingEnableAfterMasterPasswordDialog({
+			pendingEnableEncryption,
+			wasMasterPasswordDialogOpen: wasOpen,
+			masterPasswordDialogOpen: props.masterPasswordDialogOpen,
+			masterPassword: props.masterPassword,
+		})) {
+			setPendingEnableEncryption(false);
+			return;
+		}
+
+		if (!shouldResumeEnableAfterMasterPasswordDialog({
+			pendingEnableEncryption,
+			wasMasterPasswordDialogOpen: wasOpen,
+			masterPasswordDialogOpen: props.masterPasswordDialogOpen,
+			masterPassword: props.masterPassword,
+		})) return;
+
+		const masterKey = getDefaultMasterKey();
+
+		void (async () => {
+			try {
+				await toggleAndSetupEncryption(EncryptionService.instance(), true, masterKey, props.masterPassword);
+			} catch (error) {
+				await dialogs.alert(error.message);
+			} finally {
+				setPendingEnableEncryption(false);
+			}
+		})();
+	}, [pendingEnableEncryption, props.masterPasswordDialogOpen, props.masterPassword]);
 
 	const onUpgradeMasterKey = useCallback(async (mk: MasterKeyEntity) => {
 		const password = determineKeyPassword(mk.id, masterPasswordKeys, props.masterPassword, props.passwords);
@@ -200,6 +240,18 @@ const EncryptionConfigScreen = (props: Props) => {
 			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			if (!answer) return;
 		} else {
+			if (shouldOpenMasterPasswordDialogForEnable({
+				hasMasterPassword,
+				masterPasswordDialogOpen: props.masterPasswordDialogOpen,
+			})) {
+				setPendingEnableEncryption(true);
+				props.dispatch({
+					type: 'DIALOG_OPEN',
+					name: AppStateDialogName.MasterPassword,
+				});
+				return;
+			}
+
 			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
 			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
 		}
@@ -216,7 +268,7 @@ const EncryptionConfigScreen = (props: Props) => {
 		} catch (error) {
 			await dialogs.alert(error.message);
 		}
-	}, [props.masterPassword]);
+	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 
 	const renderEncryptionSection = () => {
 		const decryptedItemsInfo = <p>{decryptedStatText(stats)}</p>;
@@ -415,6 +467,7 @@ const mapStateToProps = (state: AppState) => {
 		notLoadedMasterKeys: state.notLoadedMasterKeys,
 		masterPassword: state.settings['encryption.masterPassword'],
 		ppk: syncInfo.ppk,
+		masterPasswordDialogOpen: !!state.dialogs.find(dialog => dialog.name === AppStateDialogName.MasterPassword),
 	};
 };
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -77,7 +77,8 @@ export const EncryptionConfigScreen = (props: Props) => {
 			try {
 				await toggleAndSetupEncryption(EncryptionService.instance(), true, masterKey, props.masterPassword);
 			} catch (error) {
-				await dialogs.alert(error.message);
+				const message = error instanceof Error ? error.message : String(error);
+				await dialogs.alert(message);
 			} finally {
 				setPendingEnableEncryption(false);
 			}

--- a/packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.test.ts
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.test.ts
@@ -1,0 +1,51 @@
+import { shouldCancelPendingEnableAfterMasterPasswordDialog, shouldOpenMasterPasswordDialogForEnable, shouldResumeEnableAfterMasterPasswordDialog } from './enableFlow';
+
+describe('enableFlow', () => {
+	test('opens the master password dialog when enabling encryption without a stored master password', () => {
+		expect(shouldOpenMasterPasswordDialogForEnable({
+			hasMasterPassword: false,
+			masterPasswordDialogOpen: false,
+		})).toBe(true);
+	});
+
+	test('does not reopen the master password dialog if it is already open', () => {
+		expect(shouldOpenMasterPasswordDialogForEnable({
+			hasMasterPassword: false,
+			masterPasswordDialogOpen: true,
+		})).toBe(false);
+	});
+
+	test('does not open the master password dialog when a master password already exists', () => {
+		expect(shouldOpenMasterPasswordDialogForEnable({
+			hasMasterPassword: true,
+			masterPasswordDialogOpen: false,
+		})).toBe(false);
+	});
+
+	test('resumes enabling encryption after the dialog closes with a saved password', () => {
+		expect(shouldResumeEnableAfterMasterPasswordDialog({
+			pendingEnableEncryption: true,
+			wasMasterPasswordDialogOpen: true,
+			masterPasswordDialogOpen: false,
+			masterPassword: 'new-password',
+		})).toBe(true);
+	});
+
+	test('cancels the pending enable flow if the dialog closes without a password', () => {
+		expect(shouldCancelPendingEnableAfterMasterPasswordDialog({
+			pendingEnableEncryption: true,
+			wasMasterPasswordDialogOpen: true,
+			masterPasswordDialogOpen: false,
+			masterPassword: '',
+		})).toBe(true);
+	});
+
+	test('does not resume while the dialog is still open', () => {
+		expect(shouldResumeEnableAfterMasterPasswordDialog({
+			pendingEnableEncryption: true,
+			wasMasterPasswordDialogOpen: true,
+			masterPasswordDialogOpen: true,
+			masterPassword: 'new-password',
+		})).toBe(false);
+	});
+});

--- a/packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.ts
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/enableFlow.ts
@@ -1,0 +1,23 @@
+interface OpenDialogInput {
+	hasMasterPassword: boolean;
+	masterPasswordDialogOpen: boolean;
+}
+
+interface ResumeEnableInput {
+	pendingEnableEncryption: boolean;
+	wasMasterPasswordDialogOpen: boolean;
+	masterPasswordDialogOpen: boolean;
+	masterPassword: string;
+}
+
+export const shouldOpenMasterPasswordDialogForEnable = ({ hasMasterPassword, masterPasswordDialogOpen }: OpenDialogInput) => {
+	return !hasMasterPassword && !masterPasswordDialogOpen;
+};
+
+export const shouldResumeEnableAfterMasterPasswordDialog = ({ pendingEnableEncryption, wasMasterPasswordDialogOpen, masterPasswordDialogOpen, masterPassword }: ResumeEnableInput) => {
+	return pendingEnableEncryption && wasMasterPasswordDialogOpen && !masterPasswordDialogOpen && !!masterPassword;
+};
+
+export const shouldCancelPendingEnableAfterMasterPasswordDialog = ({ pendingEnableEncryption, wasMasterPasswordDialogOpen, masterPasswordDialogOpen, masterPassword }: ResumeEnableInput) => {
+	return pendingEnableEncryption && wasMasterPasswordDialogOpen && !masterPasswordDialogOpen && !masterPassword;
+};


### PR DESCRIPTION
Ai disclosure 
test are written by ai 

Fixes : #14659



when Clicking “Enable encryption” now brings up the existing master-password dialog (with confirm + show/hide),
instead of the old one-field prompt, when no master password is stored
If you complete the dialog, encryption turns on immediately; if you cancel, nothing changes.
Pulled the enable-flow checks into a small helper and added targeted tests for the save and cancel paths.


https://github.com/user-attachments/assets/4904b2a2-f0cd-4c33-b44b-e87bc6e488be

