### PR TITLE
Desktop: Fixes #14661: hide new note/todo buttons when no notebook exists

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -286,7 +286,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
 
 	return {
-		showNewNoteButtons: windowState.selectedFolderId !== getTrashFolderId(),
+		showNewNoteButtons: !!windowState.selectedFolderId && windowState.selectedFolderId !== getTrashFolderId(),
 		newNoteButtonEnabled: CommandService.instance().isEnabled('newNote', whenClauseContext),
 		newTodoButtonEnabled: CommandService.instance().isEnabled('newTodo', whenClauseContext),
 		sortOrderButtonsVisible: state.settings['notes.sortOrder.buttonsVisible'],

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -60,7 +60,7 @@ const useNoteListControlsBreakpoints = (width: number, newNoteButtonElement: Ele
 	const [dynamicBreakpoints, setDynamicBreakpoints] = useState<Breakpoints>({ Sm: BaseBreakpoint.Sm, Md: BaseBreakpoint.Md, Lg: BaseBreakpoint.Lg, Xl: BaseBreakpoint.Xl });
 	const previousWidth = usePrevious(width);
 	const widthHasChanged = width !== previousWidth;
-	const showNewNoteButton = selectedFolderId !== getTrashFolderId();
+	const showNewNoteButton = !!selectedFolderId && selectedFolderId !== getTrashFolderId();
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -34,13 +34,14 @@ export default class MainScreen {
 	}
 
 	public async waitFor() {
-		await this.newNoteButton.waitFor();
 		await this.noteList.waitFor();
 	}
 
 	// Follows the steps a user would use to create a new note.
 	public async createNewNote(title: string) {
 		await this.waitFor();
+		// The new note button is only visible when a folder is selected -- wait for it explicitly.
+		await this.newNoteButton.waitFor();
 
 		// Create the new note. Retry this -- creating new notes can sometimes fail if done just after
 		// application startup.


### PR DESCRIPTION
Fixes: #14661

### Summary
When opening a new profile with no notebooks, the "New note" and "New to-do" buttons were visible in the note list controls but non-functional clicking them did nothing because there was no notebook to create a note in.

### Fix:
The condition controlling button visibility was:
`selectedFolderId !== getTrashFolderId()`
On a brand new profile, `selectedFolderId` is null. Since `null !== trashFolderId` evaluates to true, the buttons were shown. This was inconsistent with the correct behavior seen when all notebooks are deleted (which auto-selects the Trash folder, making the condition false and hiding the buttons).

To fix this I have added a truthiness check before the trash comparison in two places:
1. `NoteListControls.tsx`
2. `NoteListWrapper.tsx`

https://github.com/user-attachments/assets/d402bdf6-3e92-4b28-98b7-4f23522b7f5b

### Testing:
1. Create a new profile via File > Switch profile > Add new profile.
2. Switch to it and verify the "New note" and "New to-do" buttons are not visible (consistent with having no notebooks)
4. Create a notebook and verify the buttons appear
5. Delete the notebook (moves to Trash) and verify the buttons disappear again (existing behavior unchanged)