### PR TITLE
Desktop: Resolves #14143: Fixed scrolling behaviour in long lines for TinyMCE and CodeMirror

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
@@ -219,9 +219,20 @@ const translateLE_ = (codeMirror: any, percent: number, l2e: boolean) => {
 	let linInterp, result;
 	if (l2e) {
 		linInterp = percent * lineCount - lineU;
+		// eslint-disable-next-line no-console
+		console.log(`l2e ${ePercentU} + (${ePercentL} - ${ePercentU}) * ${linInterp}`);
 		result = ePercentU + (ePercentL - ePercentU) * linInterp;
 	} else {
-		linInterp = Math.max(0, Math.min(1, (percent - ePercentU) / (ePercentL - ePercentU))) || 0;
+		// eslint-disable-next-line no-console
+		console.log(`linInterp Max(0, Min(1, (${percent} - ${ePercentU}) / (${ePercentL} - ${ePercentU}))) || 0`);
+		const rawLinInterp = (percent - ePercentU) / (ePercentL - ePercentU);
+		if (!Number.isFinite(rawLinInterp)) {
+			linInterp = percent;
+		} else {
+			linInterp = Math.max(0, Math.min(1, rawLinInterp)) || 0;
+		}
+		// eslint-disable-next-line no-console
+		console.log(`e2l (${lineU} + ${linInterp}) / ${lineCount}`);
 		result = (lineU + linInterp) / lineCount;
 	}
 	return Math.max(0, Math.min(1, result));

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useScrollHandler.ts
@@ -219,20 +219,16 @@ const translateLE_ = (codeMirror: any, percent: number, l2e: boolean) => {
 	let linInterp, result;
 	if (l2e) {
 		linInterp = percent * lineCount - lineU;
-		// eslint-disable-next-line no-console
-		console.log(`l2e ${ePercentU} + (${ePercentL} - ${ePercentU}) * ${linInterp}`);
 		result = ePercentU + (ePercentL - ePercentU) * linInterp;
 	} else {
-		// eslint-disable-next-line no-console
-		console.log(`linInterp Max(0, Min(1, (${percent} - ${ePercentU}) / (${ePercentL} - ${ePercentU}))) || 0`);
 		const rawLinInterp = (percent - ePercentU) / (ePercentL - ePercentU);
-		if (!Number.isFinite(rawLinInterp)) {
+		if (ePercentL === ePercentU) {
+			// Prevents the Viewer from jumping to the bottom of
+			// the document when there is division by zero.
 			linInterp = percent;
 		} else {
 			linInterp = Math.max(0, Math.min(1, rawLinInterp)) || 0;
 		}
-		// eslint-disable-next-line no-console
-		console.log(`e2l (${lineU} + ${linInterp}) / ${lineCount}`);
 		result = (lineU + linInterp) / lineCount;
 	}
 	return Math.max(0, Math.min(1, result));

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -907,9 +907,6 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 						const win = editor.getWin();
 						const viewHeight = win.innerHeight;
 
-						// eslint-disable-next-line no-console
-						console.log('performing check', { rectTop: rect.top, rectBottom: rect.bottom, viewHeight: viewHeight, rect: rect });
-
 						if (rect.top < 0) {
 							win.scrollBy(0, rect.top);
 						} else if (rect.bottom > viewHeight) {

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/TinyMCE.tsx
@@ -896,6 +896,33 @@ const TinyMCE = (props: NoteBodyEditorProps, ref: Ref<NoteBodyEditorRef>) => {
 					editor.addShortcut('Meta+Shift+8', '', () => editor.execCommand('InsertUnorderedList'));
 					editor.addShortcut('Meta+Shift+9', '', () => editor.execCommand('InsertJoplinChecklist'));
 
+					// Override ScrollIntoView to scroll to the cursor's character position
+					// instead of the start of the paragraph.
+					// See: https://github.com/laurent22/joplin/issues/14143
+					editor.on('ScrollIntoView', (event) => {
+						const sel = editor.getDoc().getSelection();
+						if (!sel || sel.rangeCount === 0) return;
+
+						const rect = sel.getRangeAt(0).getBoundingClientRect();
+						const win = editor.getWin();
+						const viewHeight = win.innerHeight;
+
+						// eslint-disable-next-line no-console
+						console.log('performing check', { rectTop: rect.top, rectBottom: rect.bottom, viewHeight: viewHeight, rect: rect });
+
+						if (rect.top < 0) {
+							win.scrollBy(0, rect.top);
+						} else if (rect.bottom > viewHeight) {
+							win.scrollBy(0, rect.bottom - viewHeight);
+						} else if (rect.top === 0 && rect.height === 0) {
+							// Handles edge case where rect is not rendered
+							// See: https://stackoverflow.com/a/14384220/5757550
+							return;
+						}
+						event.preventDefault();
+						return;
+					});
+
 					// TODO: remove event on unmount?
 					editor.on('drop', (event) => {
 						// Prevent the message "Dropped file type is not supported" from showing up.

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.test.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.test.ts
@@ -210,4 +210,47 @@ describe('CodeMirror5Emulation', () => {
 			{ line: 0, ch: 5 },
 		)).toThrow(/is not an integer/i);
 	});
+
+	it('heightAtLine for a line past the document should be greater than for the last line', () => {
+		const codeMirror = makeCodeMirrorEmulation('line1\nline2\nline3');
+
+		// Mock lineBlockAt to return a block with non-zero height so that the
+		// distinction between top and top+height is observable in the test.
+		const mockLineBlock = { top: 900, bottom: 1000, height: 100, from: 0, to: 0 };
+		jest.spyOn(codeMirror.editor, 'lineBlockAt').mockReturnValue(mockLineBlock as never);
+
+		const lineCount = codeMirror.lineCount();
+
+		const heightAtLastLine = codeMirror.heightAtLine(lineCount - 1, 'local');
+		const heightPastEnd = codeMirror.heightAtLine(lineCount, 'local');
+
+		expect(heightPastEnd).toBeGreaterThan(heightAtLastLine);
+	});
+
+	it('heightAtLine for a line past the document should be greater than for the last line, given one long line', () => {
+		const singleLine = 'Very long line of text. '.repeat(400);
+		const codeMirror = makeCodeMirrorEmulation(`${singleLine}`);
+
+		// Mock lineBlockAt to return a block with non-zero height so that the
+		// distinction between top and top+height is observable in the test.
+		const mockLineBlock = { top: 900, bottom: 1000, height: 100, from: 0, to: 0 };
+		jest.spyOn(codeMirror.editor, 'lineBlockAt').mockReturnValue(mockLineBlock as never);
+
+		const lineCount = codeMirror.lineCount();
+
+		const heightAtLastLine = codeMirror.heightAtLine(lineCount - 1, 'local');
+		const heightPastEnd = codeMirror.heightAtLine(lineCount, 'local');
+
+		expect(heightPastEnd).toBeGreaterThan(heightAtLastLine);
+	});
+
+	it('heightAtLine should return a non-negative value for valid line numbers', () => {
+		const codeMirror = makeCodeMirrorEmulation('first\nsecond\nthird');
+		const lineCount = codeMirror.lineCount();
+
+		// Test all lines from top to bottom of document
+		for (let i = 0; i <= lineCount; i++) {
+			expect(codeMirror.heightAtLine(i, 'local')).toBeGreaterThanOrEqual(0);
+		}
+	});
 });

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -270,6 +270,9 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 
 		let height;
 		if (lineNumber >= doc.lines) {
+			// Handle case when lineNumber is at or below the last line
+			// This is necessary to prevent dividing by zero in translateLE_
+			// See: https://github.com/laurent22/joplin/issues/14143#issuecomment-3767793559
 			height = lineBlock.top + lineBlock.height;
 		} else {
 			height = lineBlock.top;

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -268,7 +268,12 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		const lineInfo = doc.line(Math.min(lineNumber + 1, doc.lines));
 		const lineBlock = this.editor.lineBlockAt(lineInfo.from);
 
-		const height = lineBlock.top;
+		let height;
+		if (lineNumber >= doc.lines) {
+			height = lineBlock.top + lineBlock.height;
+		} else {
+			height = lineBlock.top;
+		}
 		if (mode === 'local') {
 			const editorTop = this.editor.lineBlockAt(0).top;
 			return height - editorTop;

--- a/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
+++ b/packages/editor/CodeMirror/CodeMirror5Emulation/CodeMirror5Emulation.ts
@@ -271,7 +271,7 @@ export default class CodeMirror5Emulation extends BaseCodeMirror5Emulation {
 		let height;
 		if (lineNumber >= doc.lines) {
 			// Handle case when lineNumber is at or below the last line
-			// This is necessary to prevent dividing by zero in translateLE_
+			// This ensures ePercentL != ePercentU in translateLE_, which may cause linInterp to be infinity.
 			// See: https://github.com/laurent22/joplin/issues/14143#issuecomment-3767793559
 			height = lineBlock.top + lineBlock.height;
 		} else {


### PR DESCRIPTION
## Problem
In #14143, there are two different scenarios where making changes inside very long lines will cause the scroll position to jump or move incorrectly:
1. Problem 1 (additional bug, reported in a [comment](https://github.com/laurent22/joplin/issues/14143#issuecomment-3767793559)): In the Markdown Editor, making any changes to the very long line causes the scroll position in both the Editor and the Viewer to jump to the bottom of the document
2. Problem 2 (main bug, reported in original Issue post): In the Rich Text Editor, undoing/redoing any change to the very long line causes the scroll position to jump to the start of the line.

The expected behaviour on both Problem 1 & 2 is that the scroll position jumps to where the change occurred, so that it is visible inside the window to the user.

## Solution
1. Problem 1: Implement an `editor.on()` handler that overrides TinyMCE's handling of the `ScrollIntoView` event
2. Problem 2: Modify the `translateLE_()` calculation to prevent cases where `ePercentL === ePercentU`.

## Details
1. Problem 1 occurs because TinyMCE handles `ScrollIntoView` by creating a temporary "marker" element at the start of the line that it uses as a destination to scroll to. Unfortunately this marker is always created at the start of the line, even if the `ScrollIntoView` event was fired because of a change at the bottom of the line. Hence, the solution simply overrides this behaviour.
2. Problem 2 occurs because of an edge case inside `translateLE_()` where `ePercentL === ePercentU`.
	- In `l2e` translation,  the edge case above causes the following value `result = ePercentU + (ePercentL - ePercentU) * linInterp` to return a value equivalent to  `ePercentU` (which is the start of the line). This is the case documented for Problem 2 in the Issue.
	- In `e2l` translatiion, the following value (which I'll call raw linInterp) `(percent - ePercentU) / (ePercentL - ePercentU)` resolves to Infinity because it is divided by 0. However it is bounded by `Math.min(1,…)` which resolves to 1. As a result, it can also scroll to the bottom of the document.
	- Hence, the solution does two things:
		1. 2A: Checks if rawLinInterp is Infinity. If true, use `percent`.
		2. 2B: fixes `cm.heightAtLine()` to return "extra" height for lines beyond the document:
		```js
		const ePercentU = codeMirror.heightAtLine(lineU, 'local') / height;
		const ePercentL = codeMirror.heightAtLine(lineU + 1, 'local') / height;
		// existing behaviour: when lineU is the last line, height for lineU + 1 returned the same value as height for lineU.
		// with the fix: it should now return a larger value
## Manual Tests
I repeat these tests with two files: The initial [very long line text sample](https://github.com/laurent22/joplin/issues/14143#issuecomment-3766215253) from the Issue, and this [markdown sample file](https://gist.github.com/rt2zz/e0a1d6ab2682d2c47746950b84c0b6ee).
1. Erase word then Undo, with word inside the window
    1.  Select a word
    2.  Press backspace
    3.  Ensure scroll position does not move
    4.  Undo
    5.  Ensure scroll position does not move
2. Erase word then Undo, with word outside window
    1.  Select a word
    2.  Scroll until the word is not visible & well outside the window
    3.  Press backspace
    4.  Ensure scroll position jumps where the erased word was
    5.  Scroll again until word is well outside the window
    6.  Undo
    7.  Ensure scroll position jumps where the erased word is
3.  Enter text then Undo , with word inside the window
    1.  Type in text
    2.  Ensure scroll position does not move
    3.  Undo
    4.  Ensure scroll position does not move
4.  Enter text then Undo, with word outside the window
    1.  Scroll until cursor is not visible & well outside the window
    2.  Type in text
    3.  Ensure scroll position jumps where the new text is
    4.  Undo
    5.  Ensure scroll position jumps to where the new text was
  
## Demo

https://github.com/user-attachments/assets/a14a1b3d-e243-4687-b909-c913b9830f9d
