### PR TITLE
Desktop: Fixes #14661 Disables the New Note and New To Do button until a notebook is created. 

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -98,7 +98,6 @@ function NoteListControls(props: Props) {
 	const newTodoButtonRef = useRef(null);
 	const noteControlsRef = useRef(null);
 	const searchAndSortRef = useRef(null);
-
 	const breakpoint = props.breakpoint;
 	const dynamicBreakpoints = props.dynamicBreakpoints;
 	const lineCount = props.lineCount;
@@ -164,6 +163,7 @@ function NoteListControls(props: Props) {
 		};
 	}, []);
 
+
 	function onNewTodoButtonClick() {
 		void CommandService.instance().execute('newTodo');
 	}
@@ -216,7 +216,6 @@ function NoteListControls(props: Props) {
 
 	function renderNewNoteButtons() {
 		if (!props.showNewNoteButtons) return null;
-
 		return (
 			<TopRow className="new-note-todo-buttons">
 				<StyledButton
@@ -284,11 +283,19 @@ interface ConnectProps {
 const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const whenClauseContext = stateToWhenClauseContext(state, { windowId: ownProps.windowId });
 	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
+	const hasSelectedNotebook = (windowState.selectedFolderIds?.length ?? 0) === 1;
+	const isActiveFolder = whenClauseContext.isActiveFolder;
+	const canCreateNote = hasSelectedNotebook &&
+        isActiveFolder &&
+        CommandService.instance().isEnabled('newNote', whenClauseContext);
+	const canCreateTodo = hasSelectedNotebook &&
+		isActiveFolder &&
+		CommandService.instance().isEnabled('newTodo', whenClauseContext);
 
 	return {
 		showNewNoteButtons: windowState.selectedFolderId !== getTrashFolderId(),
-		newNoteButtonEnabled: CommandService.instance().isEnabled('newNote', whenClauseContext),
-		newTodoButtonEnabled: CommandService.instance().isEnabled('newTodo', whenClauseContext),
+		newNoteButtonEnabled: canCreateNote,
+		newTodoButtonEnabled: canCreateTodo,
 		sortOrderButtonsVisible: state.settings['notes.sortOrder.buttonsVisible'],
 		sortOrderField: state.settings['notes.sortOrder.field'],
 		sortOrderReverse: state.settings['notes.sortOrder.reverse'],

--- a/packages/lib/services/commands/stateToWhenClauseContext.test.ts
+++ b/packages/lib/services/commands/stateToWhenClauseContext.test.ts
@@ -11,6 +11,7 @@ interface StateOptions {
 	selectedFolderIds: string[];
 	selectedNoteIds: string[];
 	notesParentType: string;
+	activeFolder: boolean;
 }
 const buildState = (options: Partial<StateOptions>) => {
 	return {
@@ -149,4 +150,130 @@ describe('stateToWhenClauseContext', () => {
 			stateToWhenClauseContext(applicationState, { commandFolderIds }),
 		).toHaveProperty('foldersAreDeleted', expectedDeletedState);
 	});
+
+
+
+
+	it('should set isActiveFolder to true when there is a valid active folder', () => {
+		const applicationState = buildState({
+			folders: [
+				{ id: 'folder1', deleted_time: 0, share_id: '', parent_id: '' },
+			],
+			selectedFolderId: 'folder1',
+			selectedFolderIds: ['folder1'],
+		});
+		applicationState.settings = {
+			...applicationState.settings,
+			activeFolderId: 'folder1',
+		};
+
+		const resultingState = stateToWhenClauseContext(applicationState);
+
+
+		expect(resultingState.isActiveFolder).toBeTruthy();
+	});
+
+	it('should set isActiveFolder to false when activeFolderId is not set', () => {
+		const applicationState = buildState({
+			folders: [
+				{ id: 'folder1', deleted_time: 0, share_id: '', parent_id: '' },
+			],
+			selectedFolderId: 'folder1',
+			selectedFolderIds: ['folder1'],
+		});
+		applicationState.settings = {
+			...applicationState.settings,
+			activeFolderId: '',
+		};
+
+		const resultingState = stateToWhenClauseContext(applicationState);
+
+		expect(resultingState.isActiveFolder).toBe(false);
+	});
+
+
+
+	it('should have required properties for button state when one notebook is selected', () => {
+		const applicationState = buildState({
+			folders: [
+				{ id: 'folder1', deleted_time: 0, share_id: '', parent_id: '' },
+			],
+			selectedFolderId: 'folder1',
+			selectedFolderIds: ['folder1'],
+		});
+
+		const whenClauseContext = stateToWhenClauseContext(applicationState);
+
+		// Properties needed for button enabled state
+		expect(whenClauseContext.oneFolderSelected).toBe(true);
+		expect(whenClauseContext).toHaveProperty('isActiveFolder');
+		expect(whenClauseContext.folderIsDeleted).toBe(false);
+		expect(whenClauseContext.folderIsTrash).toBe(false);
+	});
+
+	it('should allow button enabling when folder is valid (not deleted, not trash)', () => {
+		const applicationState = buildState({
+			folders: [
+				{ id: 'folder1', deleted_time: 0, share_id: '', parent_id: '' },
+			],
+			selectedFolderId: 'folder1',
+			selectedFolderIds: ['folder1'],
+			notesParentType: 'Folder',
+		});
+
+		const whenClauseContext = stateToWhenClauseContext(applicationState, { commandFolderId: 'folder1' });
+
+		// All conditions that should allow button to be enabled
+		expect(whenClauseContext.oneFolderSelected).toBe(true);
+		expect(whenClauseContext.folderIsDeleted).toBe(false);
+		expect(whenClauseContext.folderIsTrash).toBe(false);
+		expect(whenClauseContext.inTrash).toBe(false);
+	});
+
+	it('should prevent button enabling when in trash folder', () => {
+		const trashId = getTrashFolderId();
+		const applicationState = buildState({
+			folders: [],
+			selectedFolderId: trashId,
+			selectedFolderIds: [trashId],
+			notes: [
+				{ id: 'note1', deleted_time: 1722567036580 },
+			],
+			selectedNoteIds: ['note1'],
+		});
+
+		const whenClauseContext = stateToWhenClauseContext(applicationState);
+
+		// Buttons should be disabled in trash
+		expect(whenClauseContext.inTrash).toBe(true);
+	});
+
+	it('should handle multiple folders selected (buttons should be disabled)', () => {
+		const applicationState = buildState({
+			folders: [
+				{ id: 'folder1', deleted_time: 0, share_id: '', parent_id: '' },
+				{ id: 'folder2', deleted_time: 0, share_id: '', parent_id: '' },
+			],
+			selectedFolderIds: ['folder1', 'folder2'],
+		});
+
+		const whenClauseContext = stateToWhenClauseContext(applicationState);
+
+		// When multiple folders selected, oneFolderSelected is false
+		// which should disable new note/todo buttons
+		expect(whenClauseContext.oneFolderSelected).toBe(false);
+	});
+
+	it('should handle no folder selected (buttons should be disabled)', () => {
+		const applicationState = buildState({
+			folders: [],
+			selectedFolderIds: [],
+		});
+
+		const whenClauseContext = stateToWhenClauseContext(applicationState);
+
+		// When no folder selected, buttons should be disabled
+		expect(whenClauseContext.oneFolderSelected).toBe(false);
+	});
 });
+

--- a/packages/lib/services/commands/stateToWhenClauseContext.ts
+++ b/packages/lib/services/commands/stateToWhenClauseContext.ts
@@ -50,6 +50,7 @@ export interface WhenClauseContext {
 	someNotesSelected: boolean;
 	syncStarted: boolean;
 	hasActivePluginEditor: boolean;
+	isActiveFolder: boolean;
 }
 
 export default function stateToWhenClauseContext(state: State, options: WhenClauseContextOptions = null): WhenClauseContext {
@@ -68,10 +69,12 @@ export default function stateToWhenClauseContext(state: State, options: WhenClau
 	const commandFolderIds = state.notesParentType === 'Folder' ? (options.commandFolderIds || selectedFolderIds) : [];
 	const commandFolders = commandFolderIds.length ? BaseModel.modelsByIds(state.folders, commandFolderIds) : [];
 	const commandFolder = commandFolders.length ? commandFolders[0] : null;
-
 	const { editorPlugin } = state.pluginService ? getActivePluginEditorView(state.pluginService.plugins, windowState.windowId) : { editorPlugin: null };
-
 	const settings = state.settings || {};
+	const activeFolderId = settings?.activeFolderId;
+	const activeFolder = activeFolderId ? BaseModel.byId(state.folders, activeFolderId) : null;
+	const activeFolderIsValid = !!activeFolder && !activeFolder.deleted_time;
+	const isItActiveFolder = !!activeFolderId && activeFolderIsValid;
 
 	return {
 		// Application state
@@ -98,6 +101,7 @@ export default function stateToWhenClauseContext(state: State, options: WhenClau
 
 		// Folder selection
 		oneFolderSelected: selectedFolderIds.length === 1,
+		isActiveFolder: isItActiveFolder,
 
 		// Current note properties
 		noteIsTodo: selectedNote ? !!selectedNote.is_todo : false,


### PR DESCRIPTION
**Summary**
When opening a new profile with no notebooks, the "New note" and "New to-do" buttons are visible in the note list controls but on clicking them it does nothing as no notebook is created.

**AI Disclosure**
AI was used for suggestions and generating test cases for the stateToWhenClauseContext in stateToWhenClauseContext.test.ts 
Tests include:
Multiple folder selection disables buttons
No folder selection disables buttons

All generated tests were reviewed and validated. 

**Fix**
In order to enable/disable the button a property of isActiveFolder is created  
and the property is used with hasSelectedNotebook as a condition to enable the buttons. When both the conditions are true then the buttons are enabled.
To fix this the following files were changed.
1.NoteListControls.tsx
2.stateToWhenClauseContext.ts
Video:
[Screencast From 2026-03-10 13-40-06.webm](https://github.com/user-attachments/assets/bfed6c3d-49f9-43f0-b349-de86b71a1367)


**Testing:**
Few test cases are also added in the stateToWhenClauseContext.test.ts
for checking Property test of "isActiveFolder" and button enabling and disabling condition tests by checking valid folder state.

1. Creating a new profile.
2. Verifying whether the buttons are disabled or enabled when no notebook is created.
3. Creating a new notebook
4. Verifying whether the buttons are enabled or not.
5. Deleting the notebook and verifying the button are disabled again or not.







