### PR TITLE
Desktop: Fixes #14637: Add Cut and Copy options to link context menu

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -281,14 +281,14 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 				handleCopyToClipboard(options);
 				options.insertContent('');
 			},
-			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy),
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy)),
 		},
 		copy: {
 			label: _('Copy'),
 			onAction: async (options: ContextMenuOptions) => {
 				handleCopyToClipboard(options);
 			},
-			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !!options.textToCopy || !!options.htmlToCopy,
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy)),
 		},
 		paste: {
 			label: _('Paste'),

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -261,18 +261,14 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 			onAction: async () => {
 				bridge().activeWindow().webContents.cut();
 			},
-			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
-				return itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink || !!options.textToCopy;
-			},
+			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink,
 		},
 		linkCopy: {
 			label: _('Copy'),
 			onAction: async () => {
 				bridge().activeWindow().webContents.copy();
 			},
-			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
-				return itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink || !!options.textToCopy;
-			},
+			isActive: (itemType: ContextMenuItemType) => itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink,
 		},
 		separator4: makeSeparator(),
 		cut: {
@@ -288,7 +284,7 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 			onAction: async (options: ContextMenuOptions) => {
 				handleCopyToClipboard(options);
 			},
-			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy)),
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!!options.textToCopy || !!options.htmlToCopy),
 		},
 		paste: {
 			label: _('Paste'),

--- a/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/contextMenu.ts
@@ -256,6 +256,24 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 			},
 			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType === ContextMenuItemType.Link || !!options.linkToCopy,
 		},
+		linkCut: {
+			label: _('Cut'),
+			onAction: async () => {
+				bridge().activeWindow().webContents.cut();
+			},
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
+				return itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink || !!options.textToCopy;
+			},
+		},
+		linkCopy: {
+			label: _('Copy'),
+			onAction: async () => {
+				bridge().activeWindow().webContents.copy();
+			},
+			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => {
+				return itemType === ContextMenuItemType.Link || itemType === ContextMenuItemType.NoteLink || !!options.textToCopy;
+			},
+		},
 		separator4: makeSeparator(),
 		cut: {
 			label: _('Cut'),
@@ -263,14 +281,14 @@ export function menuItems(dispatch: Function): ContextMenuItems {
 				handleCopyToClipboard(options);
 				options.insertContent('');
 			},
-			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy)),
+			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !options.isReadOnly && (!!options.textToCopy || !!options.htmlToCopy),
 		},
 		copy: {
 			label: _('Copy'),
 			onAction: async (options: ContextMenuOptions) => {
 				handleCopyToClipboard(options);
 			},
-			isActive: (itemType: ContextMenuItemType, options: ContextMenuOptions) => itemType !== ContextMenuItemType.Image && (!!options.textToCopy || !!options.htmlToCopy),
+			isActive: (_itemType: ContextMenuItemType, options: ContextMenuOptions) => !!options.textToCopy || !!options.htmlToCopy,
 		},
 		paste: {
 			label: _('Paste'),


### PR DESCRIPTION
This PR addresses issue #14637. I noticed the "Cut" and "Copy" actions were missing from the context menu whenever a user right-clicked directly on a link or an internal NoteLink in the Desktop Markdown editor.

To resolve this, I updated `contextMenu.ts` to properly handle these elements. The menu's active state now checks if the target is a standard Link, an internal NoteLink, or if there is actively selected text. 

For the clipboard functionality itself, the actions leverage the native Electron `bridge().activeWindow().webContents.cut()` and `copy()` methods. This guarantees the actions stay perfectly synced with the editor's native selection buffer and the OS clipboard.

Screenshots

Before:
<img width="1278" height="310" alt="Before Change" src="https://github.com/user-attachments/assets/9df3c38e-87bb-4945-9a76-0c4b582e54e8" />

After:
<img width="1024" height="358" alt="After change" src="https://github.com/user-attachments/assets/1cc6dd92-7457-4393-849b-0dd086699301" />

Testing done:
* Confirmed the actions remain hidden when right-clicking empty space.
* Verified they correctly appear on standard web links and internal Joplin note links.
* Checked that the Cut action successfully removes the text and updates the clipboard.
* Checked that the Copy action successfully copies the text to the OS clipboard.