### PR TITLE
Desktop: Fixes #14661: hide new note/todo buttons when no notebook exists

### DIFF
--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -286,7 +286,7 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
 
 	return {
-		showNewNoteButtons: windowState.selectedFolderId !== getTrashFolderId(),
+		showNewNoteButtons: !!windowState.selectedFolderId && windowState.selectedFolderId !== getTrashFolderId(),
 		newNoteButtonEnabled: CommandService.instance().isEnabled('newNote', whenClauseContext),
 		newTodoButtonEnabled: CommandService.instance().isEnabled('newTodo', whenClauseContext),
 		sortOrderButtonsVisible: state.settings['notes.sortOrder.buttonsVisible'],

--- a/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
+++ b/packages/app-desktop/gui/NoteListControls/NoteListControls.tsx
@@ -284,9 +284,11 @@ interface ConnectProps {
 const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const whenClauseContext = stateToWhenClauseContext(state, { windowId: ownProps.windowId });
 	const windowState = stateUtils.windowStateById(state, ownProps.windowId);
+	const hasFolderForNewNotes = whenClauseContext.selectedFolderIsValid
+		&& windowState.selectedFolderId !== getTrashFolderId();
 
 	return {
-		showNewNoteButtons: !!windowState.selectedFolderId && windowState.selectedFolderId !== getTrashFolderId(),
+		showNewNoteButtons: hasFolderForNewNotes,
 		newNoteButtonEnabled: CommandService.instance().isEnabled('newNote', whenClauseContext),
 		newTodoButtonEnabled: CommandService.instance().isEnabled('newTodo', whenClauseContext),
 		sortOrderButtonsVisible: state.settings['notes.sortOrder.buttonsVisible'],

--- a/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
+++ b/packages/app-desktop/gui/NoteListWrapper/NoteListWrapper.tsx
@@ -60,7 +60,7 @@ const useNoteListControlsBreakpoints = (width: number, newNoteButtonElement: Ele
 	const [dynamicBreakpoints, setDynamicBreakpoints] = useState<Breakpoints>({ Sm: BaseBreakpoint.Sm, Md: BaseBreakpoint.Md, Lg: BaseBreakpoint.Lg, Xl: BaseBreakpoint.Xl });
 	const previousWidth = usePrevious(width);
 	const widthHasChanged = width !== previousWidth;
-	const showNewNoteButton = selectedFolderId !== getTrashFolderId();
+	const showNewNoteButton = !!selectedFolderId && selectedFolderId !== getTrashFolderId();
 
 	// Initialize language-specific breakpoints
 	useEffect(() => {

--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/newNote.ts
@@ -3,7 +3,7 @@ import { _ } from '@joplin/lib/locale';
 import Note from '@joplin/lib/models/Note';
 import Folder from '@joplin/lib/models/Folder';
 
-export const newNoteEnabledConditions = 'oneFolderSelected && !inConflictFolder && !folderIsReadOnly && !folderIsTrash';
+export const newNoteEnabledConditions = 'oneFolderSelected && selectedFolderIsValid && !inConflictFolder && !folderIsReadOnly && !folderIsTrash';
 
 export const declaration: CommandDeclaration = {
 	name: 'newNote',

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -34,13 +34,14 @@ export default class MainScreen {
 	}
 
 	public async waitFor() {
-		await this.newNoteButton.waitFor();
 		await this.noteList.waitFor();
 	}
 
 	// Follows the steps a user would use to create a new note.
 	public async createNewNote(title: string) {
 		await this.waitFor();
+		// The new note button is only visible when a folder is selected -- wait for it explicitly.
+		await this.newNoteButton.waitFor();
 
 		// Create the new note. Retry this -- creating new notes can sometimes fail if done just after
 		// application startup.

--- a/packages/lib/services/commands/stateToWhenClauseContext.test.ts
+++ b/packages/lib/services/commands/stateToWhenClauseContext.test.ts
@@ -149,4 +149,47 @@ describe('stateToWhenClauseContext', () => {
 			stateToWhenClauseContext(applicationState, { commandFolderIds }),
 		).toHaveProperty('foldersAreDeleted', expectedDeletedState);
 	});
+
+	it.each([
+		{
+			label: 'should be false when no folders exist (new profile)',
+			selectedFolderId: 'non-existent-folder',
+			folders: [],
+			expected: false,
+		},
+		{
+			label: 'should be false when selectedFolderId is null',
+			selectedFolderId: null,
+			folders: [{ id: '1', deleted_time: 0, share_id: '', parent_id: '' }],
+			expected: false,
+		},
+		{
+			label: 'should be false when selected folder has been deleted',
+			selectedFolderId: '1',
+			folders: [{ id: '1', deleted_time: 1000, share_id: '', parent_id: '' }],
+			expected: false,
+		},
+		{
+			label: 'should be true when selected folder exists and is not deleted',
+			selectedFolderId: '1',
+			folders: [{ id: '1', deleted_time: 0, share_id: '', parent_id: '' }],
+			expected: true,
+		},
+		{
+			label: 'should be false when selectedFolderId does not match any folder',
+			selectedFolderId: 'stale-id',
+			folders: [{ id: '1', deleted_time: 0, share_id: '', parent_id: '' }],
+			expected: false,
+		},
+	])('should set selectedFolderIsValid correctly: $label', ({ selectedFolderId, folders, expected }) => {
+		const applicationState = buildState({
+			selectedFolderId,
+			folders,
+			notes: [],
+		});
+
+		expect(
+			stateToWhenClauseContext(applicationState),
+		).toHaveProperty('selectedFolderIsValid', expected);
+	});
 });

--- a/packages/lib/services/commands/stateToWhenClauseContext.ts
+++ b/packages/lib/services/commands/stateToWhenClauseContext.ts
@@ -47,6 +47,7 @@ export interface WhenClauseContext {
 	noteTodoCompleted: boolean;
 	oneFolderSelected: boolean;
 	oneNoteSelected: boolean;
+	selectedFolderIsValid: boolean;
 	someNotesSelected: boolean;
 	syncStarted: boolean;
 	hasActivePluginEditor: boolean;
@@ -73,6 +74,14 @@ export default function stateToWhenClauseContext(state: State, options: WhenClau
 
 	const settings = state.settings || {};
 
+	// Check whether the window's selected folder actually exists and is not
+	// deleted. This resolves the case where selectedFolderId is stale (e.g.
+	// new profile with no notebooks) or points to a deleted folder.
+	const selectedFolder = windowState.selectedFolderId
+		? BaseModel.byId(state.folders, windowState.selectedFolderId)
+		: null;
+	const selectedFolderIsValid = !!selectedFolder && !selectedFolder.deleted_time;
+
 	return {
 		// Application state
 		notesAreBeingSaved: stateUtils.hasNotesBeingSaved(state),
@@ -98,6 +107,7 @@ export default function stateToWhenClauseContext(state: State, options: WhenClau
 
 		// Folder selection
 		oneFolderSelected: selectedFolderIds.length === 1,
+		selectedFolderIsValid,
 
 		// Current note properties
 		noteIsTodo: selectedNote ? !!selectedNote.is_todo : false,


### PR DESCRIPTION
Fixes: #14661

### Summary
When creating a new profile with no notebooks, the new note and new todo buttons were enabled but non-functional, since there was no folder to create notes in. This fix hides the buttons completely when no valid notebook exists—matching the behavior that occurs after a folder is deleted while viewing notes.

### Fix:
The fix adds `selectedFolderIsValid` to the when clause context, which verifies that the window's `selectedFolderId` references an actual, non-deleted folder in the app state.

Changes made:

- `stateToWhenClauseContext.ts`— Added `selectedFolderIsValid` property that checks if `selectedFolderId` points to a real, non-deleted folder. This is computed per-window to handle multi-window scenarios correctly.

- `newNote.ts`— Added `selectedFolderIsValid` to the `enabledCondition`, so the `newNote` and newTodo commands are disabled everywhere they're used (menus, keyboard shortcuts, command palette) when no valid folder exists.

- `NoteListControls.tsx`— Updated the `showNewNoteButtons`logic to use `whenClauseContext.selectedFolderIsValid`, ensuring buttons are completely hidden (not just disabled) when there's no valid notebook to create in.

https://github.com/user-attachments/assets/d402bdf6-3e92-4b28-98b7-4f23522b7f5b

### Testing:
Steps to test the fix
1. Create a new profile via File > Switch profile > Add new profile.
2. Switch to it and verify the "New note" and "New to-do" buttons are not visible (consistent with having no notebooks)
4. Create a notebook and verify the buttons appear
5. Delete the notebook (moves to Trash) and verify the buttons disappear again (existing behavior unchanged)
- I added test cases related to the fix in `stateToWhenClauseContext.test.ts`.
- All old and new tests pass successfully.

### AI Disclosure:
- I used AI to improve wordings in the PR description.
- AI was used to test different approaches to resolve this issue.