### PR TITLE
Desktop: Fixes #11823: Fixed cancel behavior labels when switching config screens

### DIFF
--- a/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-desktop/gui/ConfigScreen/ConfigScreen.tsx
@@ -19,7 +19,7 @@ import shouldShowMissingPasswordWarning from '@joplin/lib/components/shared/conf
 import MacOSMissingPasswordHelpLink from './controls/MissingPasswordHelpLink';
 const { KeymapConfigScreen } = require('../KeymapConfig/KeymapConfigScreen');
 import SettingComponent, { UpdateSettingValueEvent } from './controls/SettingComponent';
-import shim from '@joplin/lib/shim';
+import shim, { MessageBoxType } from '@joplin/lib/shim';
 
 
 interface Font {
@@ -145,8 +145,16 @@ class ConfigScreenComponent extends React.Component<any, any> {
 			screenName = section.name;
 
 			if (this.hasChanges()) {
-				const ok = await shim.showConfirmationDialog(_('This will open a new screen. Save your current changes?'));
-				if (ok) {
+				const answer = await shim.showMessageBox(
+					_('This will open a new screen. Save your current changes?'),
+					{
+						type: MessageBoxType.Confirm,
+						buttons: [_('Save changes'), _('Discard changes')],
+						defaultId: 0,
+						cancelId: 1,
+					},
+				);
+				if (answer === 0) {
 					await shared.saveSettings(this);
 				}
 			}


### PR DESCRIPTION
### Problem
When a user has unsaved changes in the Configuration screen and tries to switch to another screen (like "Keyboard Shortcuts"), a confirmation dialog appears. Previously, the buttons were "OK" and "Cancel", which was highly misleading as discussed in issue #11823.

### Solution
I replaced `shim.showConfirmationDialog` with `shim.showMessageBox` in `ConfigScreen.tsx`. This allows the use of custom button labels. The buttons are now explicitly labeled "Save changes" and "Discard changes", making the UI much clearer and resolving the confusion. 

### Test Plan
Manual verification steps:
1. Open Joplin Desktop.
2. Go to Settings/Configuration.
3. Change any setting (e.g., toggle an option in Note History).
4. Do not click "Apply" or "OK".
5. Click on a different section (like "Keyboard Shortcuts") on the left menu.
6. The dialog successfully appears with the new "Save changes" and "Discard changes" buttons.

Here is the screenshot of the new UI:

https://github.com/user-attachments/assets/f8a2c9e2-b5f8-4ec9-b7af-1d3949af9524

