### PR TITLE
Locked notes: add params and types scaffolding

### DIFF
--- a/packages/lib/services/lockedNotes/params.ts
+++ b/packages/lib/services/lockedNotes/params.ts
@@ -1,0 +1,19 @@
+export const LOCKED_NOTES_MAGIC = 'JLN';
+export const LOCKED_NOTES_VERSION = 1 as const;
+
+/**
+ * Algorithm ID for v1:
+ * PBKDF2 (SHA-512) + AES-256-GCM, random salt + random IV per chunk.
+ */
+export const LOCKED_NOTES_ALGORITHM_ID_V1 = 1 as const;
+
+export const DEFAULT_PBKDF2_ITERATIONS = 220_000;
+export const DEFAULT_SALT_BYTES = 16; // per chunk
+export const DEFAULT_AUTH_TAG_LENGTH_BYTES = 16; // AES-GCM tag length
+export const DEFAULT_KEY_LENGTH_BYTES = 32; // AES-256
+export const DEFAULT_FILE_CHUNK_SIZE = 512 * 1024; // 512 KiB
+
+export const LOCKED_NOTES_STRING_PREFIX = 'JLN1:';
+
+export const DEFAULT_DIGEST_ALGORITHM = 'SHA-512';
+export const DEFAULT_CIPHER_ALGORITHM = 'AES-256-GCM';

--- a/packages/lib/services/lockedNotes/types.ts
+++ b/packages/lib/services/lockedNotes/types.ts
@@ -1,0 +1,44 @@
+
+import type { EncryptionResult } from '../e2ee/types';
+
+export type LockedNotesAlgorithmId = 1;
+
+export interface LockedNotesHeaderV1 {
+	version: 1;
+	algorithm: LockedNotesAlgorithmId;
+	masterKeyId: string; // 32 hex chars (lowercase)
+	iterationCount: number;
+	saltLength: number; // bytes
+	authTagLength: number; // bytes
+	flags: number; // reserved (0 for now)
+}
+
+export type LockedNotesChunk = EncryptionResult;
+
+export interface LockedNotesEncryptOptions {
+	masterKeyId: string;
+	/**
+	 * Decrypted master key material (password) used with PBKDF2.
+	 * (Wire-up to the actual master key retrieval happens later.)
+	 */
+	encryptionKey: string;
+
+	iterationCount?: number;
+	saltLength?: number;
+	authTagLength?: number;
+	fileChunkSize?: number;
+}
+
+export interface LockedNotesDecryptOptions {
+	encryptionKey: string;
+}
+
+
+export interface AsyncChunkReader {
+
+	read(maxBytes: number): Promise<Buffer | null>;
+}
+
+export interface AsyncChunkWriter {
+	write(data: Buffer): Promise<void>;
+}


### PR DESCRIPTION
Hi , I've been recently working on the GSoC 2026 project idea "Encrypted notes (locked notes)" and I'm working on the related issues. The aim of this is to support notes that will be stored/synced in encrypted form and "unlocked" locally with the user's encryption keys.
 implementation plan:
In order to limit the scope of each PR and allow focused changes, I'm planning on working on the project in two branches:
 Cryptography / format layer (in packages/lib): define the locked notes container format + header/AAD binding, implement string and chunked-file encryption/decryption using existing E2EE crypto primitives.
 Integration layer: wiring in models/sync and the Desktop/Mobile UI/UX (lock/unlock flow, errors, back-compatibility etc.).
What this PR includes (Part 1 - only cryptography scaffolding):
 This PR will only provide initial scaffolding files for the cryptography/format layer:
  - packages/lib/services/lockedNotes/params.ts - will define constants and default parameters (magic/version, algorithm IDs, default PBKDF2/AES-GCM parameters, chunk sizes, etc).
  - packages/lib/services/lockedNotes/types.ts - will define share TS types/interfaces for the locked-notes header/records, along with minimal reader/writer interfaces that will be used by file crypto.
  
 There will be no behavior changes in this PR. Follow-up PRs will implement header encoding/decoding and tests, then string encryption and tests, then file encryption and tests and finally exports and integration wiring.
Testing:
 There are no new tests included in this PR (just constants and types). It will not break existing tests.

Feedback requested:

Could you please review this PR structure/splitting approach (scaffolding → header/tests → string crypto/tests → file crypto/tests → exports → integration) and confirm it’s a good incremental way to land the locked-notes work?

 I’m working on the  issues in the repo  now, and if this approach is approved, I’ll continue implementing the remaining parts in follow-up PRs.