### PR TITLE
Desktop: Fixes #14676: ignore revision-view checkbox IPC messages

### DIFF
--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -157,7 +157,10 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 		// if (msg !== 'percentScroll') console.info(`Got ipc-message: ${msg}`, args);
 
 		try {
-			if (msg.indexOf('joplin://') === 0) {
+			if (msg.indexOf('checkboxclick:') === 0) {
+				// Revision previews are read-only. Ignore checkbox toggle IPC messages so they
+				// don't fall through to URL handling (`checkboxclick:` looks like a protocol).
+			} else if (msg.indexOf('joplin://') === 0) {
 				throw new Error(_('Unsupported link or message: %s', msg));
 			} else if (urlUtils.urlProtocol(msg)) {
 				await bridge().openExternal(msg);


### PR DESCRIPTION
## Problem / Impact
- In note history view, clicking rendered checkboxes can emit `checkboxclick:` IPC messages.
- Those messages were not explicitly ignored and could fall through URL handling, triggering unintended external navigation behavior on Windows.

## Solution
- Add an early guard in `NoteRevisionViewer` to ignore `checkboxclick:` IPC messages.
- Keep existing `joplin://` routing behavior unchanged for real internal links.
- Scope is intentionally minimal to message-routing logic in one file.

## Testing
- Validation attempted: `yarn eslint --resolve-plugins-relative-to . --quiet --ext .ts,.tsx packages/app-desktop/gui/NoteRevisionViewer.tsx`
- Local dependency install state is unavailable in this environment (`Couldn't find the node_modules state file`), so full lint/test execution could not complete here.
- Manual verification rationale: this patch only changes IPC message filtering, with no broader behavior changes.

## Related
Fixes #14676