### PR TITLE
Desktop: Fixes #14676: Prevent 'Open With' prompt when toggling check…

### DIFF
--- a/packages/app-desktop/gui/NoteRevisionViewer.tsx
+++ b/packages/app-desktop/gui/NoteRevisionViewer.tsx
@@ -52,7 +52,7 @@ const useNoteContent = (
 
 	const markupToHtml = useMarkupToHtml({
 		themeId,
-		customCss,
+		customCss: `${customCss}\n .joplin-checkbox { pointer-events: none; opacity: 0.5; }`,
 		plugins: {},
 		whiteBackgroundNoteRendering: false,
 		scrollbarSize,
@@ -155,6 +155,10 @@ const NoteRevisionViewerComponent: React.FC<Props> = ({ themeId, noteId, onBack,
 		// const args = event.args;
 
 		// if (msg !== 'percentScroll') console.info(`Got ipc-message: ${msg}`, args);
+
+		if (msg.indexOf('checkboxclick:') === 0 || msg === 'noteRenderComplete') {
+			return;
+		}
 
 		try {
 			if (msg.indexOf('joplin://') === 0) {


### PR DESCRIPTION
This PR fixes a bug where clicking a checkbox in the Note History window would cause an annoying "Open With" popup (or "No application found" on Mac) to appear.

Basically the History window did not know what to do when a checkbox was clicked. Because it did not have instructions for that click it was accidentally passing the message to the computer's operating system as if it were a website link. This caused the system to ask the user which app they wanted to use to open the "link"

I solved this in two simple ways:-
1. **Disabled the click:** I added a bit of CSS to the History view so the checkboxes are now greyed out and don't respond to clicks. This makes it clear to the user that they can not edit old versions of a note.
2. **Blocked the message:** I updated the code to make sure that even if someone manages to click the box, the app just ignores it instead of trying to open it as an external link.

I tested this on my machine and confirmed that:
- The checkboxes look disabled in the history view.
- Clicking them does absolutely nothing now no more popups and no more error warnings in the console.