### PR TITLE
Desktop: Fixes #14660: Text inputs disabled after re-encrypt notes dialog

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -354,7 +354,7 @@ const EncryptionConfigScreen = (props: Props) => {
 				<h2>{_('Re-encryption')}</h2>
 				<p style={theme.textStyle} dangerouslySetInnerHTML={{ __html: t }}></p>
 				<span style={{ marginRight: 10 }}>
-					<button onClick={() => void reencryptData()} style={theme.buttonStyle}>{buttonLabel}</button>
+					<button onClick={() => void reencryptData(msg => dialogs.confirm(msg), msg => dialogs.alert(msg))} style={theme.buttonStyle}>{buttonLabel}</button>
 				</span>
 
 				{ !props.shouldReencrypt ? null : <button onClick={() => dontReencryptData()} style={theme.buttonStyle}>{_('Ignore')}</button> }

--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -60,14 +60,14 @@ export const enableEncryptionConfirmationMessages = (_masterKey: MasterKeyEntity
 	return msg;
 };
 
-export const reencryptData = async () => {
-	const ok = confirm(_('Please confirm that you would like to re-encrypt your complete database.'));
+export const reencryptData = async (onConfirm: (msg: string) => Promise<boolean>, onAlert: (msg: string) => Promise<void>) => {
+	const ok = await onConfirm(_('Please confirm that you would like to re-encrypt your complete database.'));
 	if (!ok) return;
 
 	await BaseItem.forceSyncAll();
 	void reg.waitForSyncFinishedThenSync();
 	Setting.setValue('encryption.shouldReencrypt', Setting.SHOULD_REENCRYPT_NO);
-	alert(_('Your data is going to be re-encrypted and synced again.'));
+	await onAlert(_('Your data is going to be re-encrypted and synced again.'));
 };
 
 export const dontReencryptData = () => {

--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -60,7 +60,7 @@ export const enableEncryptionConfirmationMessages = (_masterKey: MasterKeyEntity
 	return msg;
 };
 
-export const reencryptData = async (onConfirm: (msg: string) => Promise<boolean>, onAlert: (msg: string) => Promise<void>) => {
+export const reencryptData = async (onConfirm: (msg: string)=> Promise<boolean>, onAlert: (msg: string)=> Promise<void>) => {
 	const ok = await onConfirm(_('Please confirm that you would like to re-encrypt your complete database.'));
 	if (!ok) return;
 


### PR DESCRIPTION
### Description

Fixes #14660

This PR resolves an issue where focus was lost and text inputs became unresponsive in the Desktop application after the "Re-encrypt data" journey.

**Root Cause:**
The [reencryptData](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/lib/components/EncryptionConfigScreen/utils.ts:62:0-70:2) function in the library was using native browser [confirm()](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/app-desktop/gui/dialogs.ts:35:1-44:2) and [alert()](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/app-desktop/gui/dialogs.ts:5:1-5:56) calls. In Electron (specifically on Windows), native synchronous dialogs block the renderer's event loop and can cause the window to lose its internal focus state. This resulted in text inputs appearing "disabled" until the user manually toggled the window focus (e.g., ALT+TAB).

**Changes:**
- Refactored [reencryptData](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/lib/components/EncryptionConfigScreen/utils.ts:62:0-70:2) in [packages/lib/components/EncryptionConfigScreen/utils.ts](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/lib/components/EncryptionConfigScreen/utils.ts:0:0-0:0) to accept [onConfirm](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/lib/components/EncryptionConfigScreen/utils.ts:48:0-60:2) and `onAlert` callbacks instead of using native blocking functions.
- Updated [packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx:0:0-0:0) to pass Joplin's custom `dialogs.confirm` and `dialogs.alert` methods to the re-encryption logic.
- These custom dialogs are asynchronous HTML overlays that do not block the renderer, thereby preserving the focus chain and solving the reported issue.

### Validation
- Verified that the "Re-encrypt data" flow still functions with the correct confirmation and notification steps.
- Confirmed that text inputs remain focusable and active immediately after the dialogs are dismissed.
- Ensured no impact on the mobile platform as the function is not utilized there.
