### PR TITLE
Desktop: Fixes #13107: html to markdown conversion sometimes converting links to plaintext with <ins> tags

### DIFF
--- a/packages/app-cli/tests/html_to_md/anchor_underlined_fragment.html
+++ b/packages/app-cli/tests/html_to_md/anchor_underlined_fragment.html
@@ -1,0 +1,1 @@
+<a href="#section" style="text-decoration: underline">Section Link</a>

--- a/packages/app-cli/tests/html_to_md/anchor_underlined_fragment.md
+++ b/packages/app-cli/tests/html_to_md/anchor_underlined_fragment.md
@@ -1,0 +1,1 @@
+[Section Link](#section)

--- a/packages/turndown/src/commonmark-rules.js
+++ b/packages/turndown/src/commonmark-rules.js
@@ -115,6 +115,11 @@ rules.insert = {
     //
     // https://github.com/laurent22/joplin/issues/5480
     if (node.nodeName === 'INS') return true;
+    if (node.nodeName === 'A' && (
+      node.getAttribute('href') ||
+      node.getAttribute('name') ||
+      node.getAttribute('id')
+    )) return false;
     return getStyleProp(node, 'text-decoration') === 'underline';
   },
 


### PR DESCRIPTION
Fixes #13107

# Problem

In `commonmark-rules.js`, Joplin's turndown fork has an insert rule that treats any element with `style="text-decoration: underline` as inserted text and converts it to `<ins>...</ins>`. This was added to preserve underline formatting from TinyMCE shortcuts.

This rule is broad enough to match underlined `<a>` tags too. Turndown picks the first matching rule for a node, and insert is defined before the link rules. So for this input:

`<a href="#section" style="text-decoration: underline">Section Link</a>`

the `<a>` node matches rules.insert first, gets converted to:

`<ins>Section Link</ins>`

and never reaches the normal link rule that would have produced a markdown link.

When pasting text from sites like github, this often leads to many links being converted to `<ins>link title</ins>` instead of an actual markdown link (impacting both the rich text editor paste and the new paste as markdown feature in the markdown editor).

# Solution

This PR modifies the insert rule to opt out of anchors so that the later turndown link rule can convert them to markdown links.

# Test plan

## Paste as Markdown and TinyMCE editor
- [x] Test pasting HTML links styled with `text-decoration: underline` and verify they are converted to markdown links
- [x] Test pasting regular text (non-link) text styled with `text-decoration: underline` and verify that its converted to `<ins>text</ins>`

## TinyMCE editor
- [x] Test for regressions with underlining text, test both the toolbar button and keyboard shortcuts to underline text, and verify that the `<ins>` tags are inserted as expected. Tested underlining plain text, text with inline styling, and links (this still inserts the `<ins>` tags as expected, but realistically a user probably wouldn't try to underline a link which is already styled with an underline).

> [!NOTE]
> Pasting plain text styled with `text-decoration: underline` works when pasting it on its own, but if I paste both a link + plain text styled with `text-decoration: underline` _at the same time_ (see the below example), the link is converted as expected, but the plain text example doesn't get the `<ins>` tags. This is pre-existing behavior that happens in the current 3.6.4 version.

```html
<p style="text-decoration: underline">Section Link</p>

<a href="#section" style="text-decoration: underline">Section Link</a>
```

## Prosemirror editor
- [x] Test pasting HTML links styled with `text-decoration: underline` in the rich text editor, verify they are converted to markdown links, however I don't believe the prosemirror editor uses Turndown for the html to markdown conversion.

> [!NOTE]
> Pasting `<p style="text-decoration: underline">Section Link</p>` into the prosemirror editor gets converted to `<span style="color: rgb(0, 0, 0);">Section Link</span>` (no `<ins>` tags), but this is pre-existing behavior that can be re-created on the production web app at https://app.joplincloud.com/)

## Before/After example

https://github.com/user-attachments/assets/e362fb4f-f200-464a-81e2-1ce048c9efbc

https://github.com/user-attachments/assets/012dfcd6-655f-4e59-9c20-dbca93219645






