### PR TITLE
Fix/ctrl wheel zoom

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -527,6 +527,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useSyncDialogState.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.js
 packages/app-desktop/gui/dialogs.js
+packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.js
+packages/app-desktop/gui/hooks/useCtrlWheelZoom.js
 packages/app-desktop/gui/hooks/useEffectDebugger.js
 packages/app-desktop/gui/hooks/useElementHeight.js
 packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js

--- a/.gitignore
+++ b/.gitignore
@@ -500,6 +500,8 @@ packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useSyncDialogState.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowCommands.js
 packages/app-desktop/gui/WindowCommandsAndDialogs/utils/useWindowControl.js
 packages/app-desktop/gui/dialogs.js
+packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.js
+packages/app-desktop/gui/hooks/useCtrlWheelZoom.js
 packages/app-desktop/gui/hooks/useEffectDebugger.js
 packages/app-desktop/gui/hooks/useElementHeight.js
 packages/app-desktop/gui/hooks/useImperativeHandlerDebugger.js

--- a/packages/app-desktop/gui/Navigator.tsx
+++ b/packages/app-desktop/gui/Navigator.tsx
@@ -5,6 +5,7 @@ import { AppState, AppStateRoute } from '../app.reducer';
 import bridge from '../services/bridge';
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { WindowIdContext } from './NewWindowOrIFrame';
+import useCtrlWheelZoom from './hooks/useCtrlWheelZoom';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Partial refactor of code from before rule was applied
 type ScreenProps = any;
@@ -89,19 +90,6 @@ const useContainerSize = (container: HTMLElement|null) => {
 	}, [container]);
 
 	return size;
-};
-
-const useCtrlWheelZoom = () => {
-	useEffect(() => {
-		const handleWheel = (e: WheelEvent) => {
-			if (e.ctrlKey || e.metaKey) {
-				e.preventDefault();
-				Setting.incValue('windowContentZoomFactor', e.deltaY < 0 ? 10 : -10);
-			}
-		};
-		document.addEventListener('wheel', handleWheel, { passive: false });
-		return () => document.removeEventListener('wheel', handleWheel);
-	}, []);
 };
 
 const NavigatorComponent: React.FC<Props> = props => {

--- a/packages/app-desktop/gui/Navigator.tsx
+++ b/packages/app-desktop/gui/Navigator.tsx
@@ -91,6 +91,19 @@ const useContainerSize = (container: HTMLElement|null) => {
 	return size;
 };
 
+const useCtrlWheelZoom = () => {
+	useEffect(() => {
+		const handleWheel = (e: WheelEvent) => {
+			if (e.ctrlKey || e.metaKey) {
+				e.preventDefault();
+				Setting.incValue('windowContentZoomFactor', e.deltaY < 0 ? 10 : -10);
+			}
+		};
+		document.addEventListener('wheel', handleWheel, { passive: false });
+		return () => document.removeEventListener('wheel', handleWheel);
+	}, []);
+};
+
 const NavigatorComponent: React.FC<Props> = props => {
 	const route = props.route;
 	const screenInfo = props.screens[route?.routeName];
@@ -98,6 +111,7 @@ const NavigatorComponent: React.FC<Props> = props => {
 
 	useWindowTitleManager(screenInfo);
 	useWindowRefocusManager(route);
+	useCtrlWheelZoom();
 	const size = useContainerSize(container);
 
 	if (!route) throw new Error('Route must not be null');

--- a/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
+++ b/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
@@ -9,6 +9,10 @@ jest.mock('@joplin/lib/models/Setting', () => ({
 	},
 }));
 
+const dispatchWheel = (options: WheelEventInit) => {
+	document.dispatchEvent(new WheelEvent('wheel', { bubbles: true, ...options }));
+};
+
 describe('useCtrlWheelZoom', () => {
 
 	beforeEach(() => {
@@ -18,27 +22,24 @@ describe('useCtrlWheelZoom', () => {
 	test('should zoom on Ctrl/Meta+Wheel', () => {
 		renderHook(() => useCtrlWheelZoom());
 
-		// Ctrl+WheelUp → zoom in
-		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true }));
+		dispatchWheel({ deltaY: -100, ctrlKey: true });
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
 
 		jest.clearAllMocks();
 
-		// Ctrl+WheelDown → zoom out
-		document.dispatchEvent(new WheelEvent('wheel', { deltaY: 100, ctrlKey: true, bubbles: true }));
+		dispatchWheel({ deltaY: 100, ctrlKey: true });
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', -10);
 
 		jest.clearAllMocks();
 
-		// Meta+WheelUp → zoom in (macOS)
-		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, metaKey: true, bubbles: true }));
+		dispatchWheel({ deltaY: -100, metaKey: true });
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
 	});
 
 	test('should not zoom on wheel without modifier', () => {
 		renderHook(() => useCtrlWheelZoom());
 
-		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, bubbles: true }));
+		dispatchWheel({ deltaY: -100 });
 
 		expect(Setting.incValue).not.toHaveBeenCalled();
 	});

--- a/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
+++ b/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react';
+import Setting from '@joplin/lib/models/Setting';
+import useCtrlWheelZoom from './useCtrlWheelZoom';
+
+jest.mock('@joplin/lib/models/Setting', () => ({
+	__esModule: true,
+	default: {
+		incValue: jest.fn(),
+	},
+}));
+
+describe('useCtrlWheelZoom', () => {
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should zoom in on Ctrl+WheelUp', () => {
+		renderHook(() => useCtrlWheelZoom());
+
+		const event = new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true });
+		const preventSpy = jest.spyOn(event, 'preventDefault');
+		document.dispatchEvent(event);
+
+		expect(preventSpy).toHaveBeenCalled();
+		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
+	});
+
+	test('should zoom out on Ctrl+WheelDown', () => {
+		renderHook(() => useCtrlWheelZoom());
+
+		const event = new WheelEvent('wheel', { deltaY: 100, ctrlKey: true, bubbles: true });
+		const preventSpy = jest.spyOn(event, 'preventDefault');
+		document.dispatchEvent(event);
+
+		expect(preventSpy).toHaveBeenCalled();
+		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', -10);
+	});
+
+	test('should zoom on Meta+Wheel (macOS)', () => {
+		renderHook(() => useCtrlWheelZoom());
+
+		const event = new WheelEvent('wheel', { deltaY: -100, metaKey: true, bubbles: true });
+		document.dispatchEvent(event);
+
+		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
+	});
+
+	test('should not zoom on wheel without modifier', () => {
+		renderHook(() => useCtrlWheelZoom());
+
+		const event = new WheelEvent('wheel', { deltaY: -100, bubbles: true });
+		const preventSpy = jest.spyOn(event, 'preventDefault');
+		document.dispatchEvent(event);
+
+		expect(preventSpy).not.toHaveBeenCalled();
+		expect(Setting.incValue).not.toHaveBeenCalled();
+	});
+
+	test('should remove listener on unmount', () => {
+		const removeSpy = jest.spyOn(document, 'removeEventListener');
+		const { unmount } = renderHook(() => useCtrlWheelZoom());
+
+		unmount();
+
+		expect(removeSpy).toHaveBeenCalledWith('wheel', expect.any(Function));
+		removeSpy.mockRestore();
+	});
+});

--- a/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
+++ b/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
@@ -41,8 +41,10 @@ describe('useCtrlWheelZoom', () => {
 		renderHook(() => useCtrlWheelZoom());
 
 		const event = new WheelEvent('wheel', { deltaY: -100, metaKey: true, bubbles: true });
+		const preventSpy = jest.spyOn(event, 'preventDefault');
 		document.dispatchEvent(event);
 
+		expect(preventSpy).toHaveBeenCalled();
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
 	});
 

--- a/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
+++ b/packages/app-desktop/gui/hooks/useCtrlWheelZoom.test.ts
@@ -15,57 +15,31 @@ describe('useCtrlWheelZoom', () => {
 		jest.clearAllMocks();
 	});
 
-	test('should zoom in on Ctrl+WheelUp', () => {
+	test('should zoom on Ctrl/Meta+Wheel', () => {
 		renderHook(() => useCtrlWheelZoom());
 
-		const event = new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true });
-		const preventSpy = jest.spyOn(event, 'preventDefault');
-		document.dispatchEvent(event);
-
-		expect(preventSpy).toHaveBeenCalled();
+		// Ctrl+WheelUp → zoom in
+		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, ctrlKey: true, bubbles: true }));
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
-	});
 
-	test('should zoom out on Ctrl+WheelDown', () => {
-		renderHook(() => useCtrlWheelZoom());
+		jest.clearAllMocks();
 
-		const event = new WheelEvent('wheel', { deltaY: 100, ctrlKey: true, bubbles: true });
-		const preventSpy = jest.spyOn(event, 'preventDefault');
-		document.dispatchEvent(event);
-
-		expect(preventSpy).toHaveBeenCalled();
+		// Ctrl+WheelDown → zoom out
+		document.dispatchEvent(new WheelEvent('wheel', { deltaY: 100, ctrlKey: true, bubbles: true }));
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', -10);
-	});
 
-	test('should zoom on Meta+Wheel (macOS)', () => {
-		renderHook(() => useCtrlWheelZoom());
+		jest.clearAllMocks();
 
-		const event = new WheelEvent('wheel', { deltaY: -100, metaKey: true, bubbles: true });
-		const preventSpy = jest.spyOn(event, 'preventDefault');
-		document.dispatchEvent(event);
-
-		expect(preventSpy).toHaveBeenCalled();
+		// Meta+WheelUp → zoom in (macOS)
+		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, metaKey: true, bubbles: true }));
 		expect(Setting.incValue).toHaveBeenCalledWith('windowContentZoomFactor', 10);
 	});
 
 	test('should not zoom on wheel without modifier', () => {
 		renderHook(() => useCtrlWheelZoom());
 
-		const event = new WheelEvent('wheel', { deltaY: -100, bubbles: true });
-		const preventSpy = jest.spyOn(event, 'preventDefault');
-		document.dispatchEvent(event);
+		document.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, bubbles: true }));
 
-		expect(preventSpy).not.toHaveBeenCalled();
 		expect(Setting.incValue).not.toHaveBeenCalled();
-	});
-
-	test('should remove listener on unmount', () => {
-		const removeSpy = jest.spyOn(document, 'removeEventListener');
-		const { unmount } = renderHook(() => useCtrlWheelZoom());
-
-		unmount();
-
-		expect(removeSpy).toHaveBeenCalledWith('wheel', expect.any(Function));
-		removeSpy.mockRestore();
 	});
 });

--- a/packages/app-desktop/gui/hooks/useCtrlWheelZoom.ts
+++ b/packages/app-desktop/gui/hooks/useCtrlWheelZoom.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import Setting from '@joplin/lib/models/Setting';
+
+const useCtrlWheelZoom = () => {
+	useEffect(() => {
+		const handleWheel = (e: WheelEvent) => {
+			if (e.ctrlKey || e.metaKey) {
+				e.preventDefault();
+				Setting.incValue('windowContentZoomFactor', e.deltaY < 0 ? 10 : -10);
+			}
+		};
+		document.addEventListener('wheel', handleWheel, { passive: false });
+		return () => document.removeEventListener('wheel', handleWheel);
+	}, []);
+};
+
+export default useCtrlWheelZoom;


### PR DESCRIPTION
Ai disclosure
used it to write test

fixes: #7914
Problem
Joplin Desktop supports zooming via keyboard shortcuts (Ctrl+Plus, Ctrl+Minus, Ctrl+0) but doesn't support the standard Ctrl+Wheel (or Cmd+Wheel on macOS) zoom gesture that most desktop applications support.

Solution
Added a useCtrlWheelZoom React hook that listens for wheel events with Ctrl/Cmd held and adjusts the windowContentZoomFactor setting accordingly.
the hook reuses the same Setting.incValue('windowContentZoomFactor', ±10) API used by the existing keyboard zoom in 
MenuBar.tsx.Zoom is bounded between 30% and 300% by the setting's minimum/maximum constraints.

https://github.com/user-attachments/assets/9256f007-b8b1-412d-9c3e-f2c6d11d95b4

