### PR TITLE
 Desktop(Windows): Fixes #14660 Text inputs are disabled after re-encrypt notes dialog journey

### DIFF
--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -62,7 +62,7 @@ export const enableEncryptionConfirmationMessages = (_masterKey: MasterKeyEntity
 };
 
 export const reencryptData = async () => {
-	const ok = confirm(_('Please confirm that you would like to re-encrypt your complete database.'));
+	const ok = await shim.showConfirmationDialog(_('Please confirm that you would like to re-encrypt your complete database.'));
 	if (!ok) return;
 
 	await BaseItem.forceSyncAll();

--- a/packages/lib/components/EncryptionConfigScreen/utils.ts
+++ b/packages/lib/components/EncryptionConfigScreen/utils.ts
@@ -9,6 +9,7 @@ import { masterKeyEnabled, setMasterKeyEnabled } from '../../services/synchroniz
 import MasterKey from '../../models/MasterKey';
 import { reg } from '../../registry';
 import Setting from '../../models/Setting';
+import { MessageBoxType } from '../../shim';
 const { useCallback, useEffect, useState } = shim.react();
 
 type PasswordChecks = Record<string, boolean>;
@@ -67,7 +68,7 @@ export const reencryptData = async () => {
 	await BaseItem.forceSyncAll();
 	void reg.waitForSyncFinishedThenSync();
 	Setting.setValue('encryption.shouldReencrypt', Setting.SHOULD_REENCRYPT_NO);
-	alert(_('Your data is going to be re-encrypted and synced again.'));
+	await shim.showMessageBox(_('Your data is going to be re-encrypted and synced again.'), { type: MessageBoxType.Info });
 };
 
 export const dontReencryptData = () => {


### PR DESCRIPTION
### Problem
In the following issue #14660 the text inputs would get disabled after re-encrypt notes alert dialog journey when using windows Desktop Application. The main cause of the issue was using alert(_'....') function in _**reencryptData**_ function in utils.ts , upon using the alert function the Text input fields would lose focus in Windows Desktop Applications.

### Solution
In order to solve this issue instead of using alert function in  _**reencryptData**_  a custom alert function was used by using shim.showMessageBox() to display the dialog. 

**Video**: 

https://github.com/user-attachments/assets/414d474a-5565-4564-acf9-58aead3fb523



### Test Plan
In order to test this , manual testing was performed using the following steps:
1. Go to Tools
2. Click on Options
3. Click on Encryption
4. Click on Show Advanced Settings
5. Click on Re-encrypt data 
6. Click on Ok during the re-encrypt data and go back to the main window.
7. Try Creating a a new Profile or try searching the notes the Input fields now do not lose focus.
