### PR TITLE
Desktop: Fixes #14658: Always require password confirmation when changing master password after encryption

### DIFF
--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -5,7 +5,7 @@ import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffe
 import DialogButtonRow, { ClickEvent } from '../DialogButtonRow';
 import Dialog from '@joplin/lib/components/Dialog';
 import DialogTitle from '../DialogTitle';
-import { getMasterPasswordStatus, getMasterPasswordStatusMessage, checkHasMasterPasswordEncryptedData, masterPasswordIsValid, MasterPasswordStatus, resetMasterPassword, updateMasterPassword, getMasterPassword } from '@joplin/lib/services/e2ee/utils';
+import { getMasterPasswordStatus, getMasterPasswordStatusMessage, masterPasswordIsValid, MasterPasswordStatus, resetMasterPassword, updateMasterPassword, getMasterPassword } from '@joplin/lib/services/e2ee/utils';
 import { reg } from '@joplin/lib/registry';
 import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import KvStore from '@joplin/lib/services/KvStore';
@@ -26,7 +26,6 @@ enum Mode {
 
 export default function(props: Props) {
 	const [status, setStatus] = useState(MasterPasswordStatus.NotSet);
-	const [hasMasterPasswordEncryptedData, setHasMasterPasswordEncryptedData] = useState(true);
 	const [currentPassword, setCurrentPassword] = useState('');
 	const [currentPasswordIsValid, setCurrentPasswordIsValid] = useState(false);
 	const [password1, setPassword1] = useState('');
@@ -56,10 +55,8 @@ export default function(props: Props) {
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		const newStatus = await getMasterPasswordStatus();
-		const hasIt = await checkHasMasterPasswordEncryptedData();
 		if (event.cancelled) return;
 		setStatus(newStatus);
-		setHasMasterPasswordEncryptedData(hasIt);
 	}, []);
 
 	const onButtonRowClick = useCallback(async (event: ClickEvent) => {
@@ -90,10 +87,8 @@ export default function(props: Props) {
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [currentPassword, password1, onClose, mode]);
 
-	const needToRepeatPassword = useMemo(() => {
-		if (mode === Mode.Reset) return true;
-		return !hasMasterPasswordEncryptedData;
-	}, [hasMasterPasswordEncryptedData, mode]);
+	// Always require the user to confirm the new password
+	const needToRepeatPassword = true;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const onCurrentPasswordChange = useCallback((event: any) => {
@@ -124,8 +119,8 @@ export default function(props: Props) {
 	}, []);
 
 	useEffect(() => {
-		setSaveButtonDisabled(updatingPassword || (!password1 || (needToRepeatPassword && password1 !== password2)));
-	}, [password1, password2, updatingPassword, needToRepeatPassword]);
+		setSaveButtonDisabled(updatingPassword || !password1 || password1 !== password2);
+	}, [password1, password2, updatingPassword]);
 
 	useEffect(() => {
 		setShowPasswordForm([MasterPasswordStatus.NotSet, MasterPasswordStatus.Invalid].includes(status));

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -5,7 +5,7 @@ import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffe
 import DialogButtonRow, { ClickEvent } from '../DialogButtonRow';
 import Dialog from '@joplin/lib/components/Dialog';
 import DialogTitle from '../DialogTitle';
-import { getMasterPasswordStatus, getMasterPasswordStatusMessage, masterPasswordIsValid, MasterPasswordStatus, resetMasterPassword, updateMasterPassword, getMasterPassword } from '@joplin/lib/services/e2ee/utils';
+import { getMasterPasswordStatus, getMasterPasswordStatusMessage, checkHasMasterPasswordEncryptedData, masterPasswordIsValid, MasterPasswordStatus, resetMasterPassword, updateMasterPassword, getMasterPassword } from '@joplin/lib/services/e2ee/utils';
 import { reg } from '@joplin/lib/registry';
 import EncryptionService from '@joplin/lib/services/e2ee/EncryptionService';
 import KvStore from '@joplin/lib/services/KvStore';
@@ -26,6 +26,7 @@ enum Mode {
 
 export default function(props: Props) {
 	const [status, setStatus] = useState(MasterPasswordStatus.NotSet);
+	const [hasMasterPasswordEncryptedData, setHasMasterPasswordEncryptedData] = useState(true);
 	const [currentPassword, setCurrentPassword] = useState('');
 	const [currentPasswordIsValid, setCurrentPasswordIsValid] = useState(false);
 	const [password1, setPassword1] = useState('');
@@ -55,8 +56,10 @@ export default function(props: Props) {
 
 	useAsyncEffect(async (event: AsyncEffectEvent) => {
 		const newStatus = await getMasterPasswordStatus();
+		const hasIt = await checkHasMasterPasswordEncryptedData();
 		if (event.cancelled) return;
 		setStatus(newStatus);
+		setHasMasterPasswordEncryptedData(hasIt);
 	}, []);
 
 	const onButtonRowClick = useCallback(async (event: ClickEvent) => {
@@ -87,8 +90,12 @@ export default function(props: Props) {
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
 	}, [currentPassword, password1, onClose, mode]);
 
-	// Always require the user to confirm the new password
-	const needToRepeatPassword = true;
+	// Show the "Re-enter password" confirmation field
+	const needToRepeatPassword = useMemo(() => {
+		if (mode === Mode.Reset) return true;
+		if (showCurrentPassword) return true;
+		return !hasMasterPasswordEncryptedData;
+	}, [mode, showCurrentPassword, hasMasterPasswordEncryptedData]);
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	const onCurrentPasswordChange = useCallback((event: any) => {
@@ -119,8 +126,8 @@ export default function(props: Props) {
 	}, []);
 
 	useEffect(() => {
-		setSaveButtonDisabled(updatingPassword || !password1 || password1 !== password2);
-	}, [password1, password2, updatingPassword]);
+		setSaveButtonDisabled(updatingPassword || (!password1 || (needToRepeatPassword && password1 !== password2)));
+	}, [password1, password2, updatingPassword, needToRepeatPassword]);
 
 	useEffect(() => {
 		setShowPasswordForm([MasterPasswordStatus.NotSet, MasterPasswordStatus.Invalid].includes(status));

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -41,7 +41,7 @@ export default function(props: Props) {
 		if (mode === Mode.Reset) return false;
 		return true;
 		// eslint-disable-next-line @seiyab/react-hooks/exhaustive-deps -- Old code before rule was applied
-	}, [status]);
+	}, [status, mode]);
 
 	const onClose = useCallback(() => {
 		props.dispatch({


### PR DESCRIPTION
**FIxes: #14658**

## Summary:
This PR fixes abug where the "Re-enter password" confirmation field was missing from the Change Master Password dialog after encryption was enabled. Previously, users could change their master password without confirmation, creating a risk of data loss due to typos.

## Fix:

#### The logic in `Dialog.tsx`  was changed so that the `needToRepeatPassword` variable is always true.

- **Before** : The confirmation field was only shown if there was no encrypted data `(!hasMasterPasswordEncryptedData)`.
- **After** : The confirmation field is always shown, both during initial setup and when changing the master password.

#### Removed dead code:

- The `hasMasterPasswordEncryptedData` state and the call to `checkHasMasterPasswordEncryptedData` were removed, as they are no longer needed.
- The save button validation and related effects were simplified to always require matching passwords.

https://github.com/user-attachments/assets/a2a92b5e-1193-44fd-bbf2-b1a61015125c


## Testing:
**1. Initial encryption setup:**

- Go to Tools -> Options -> Encryption and enable encryption.
- Verify that the form shows "New password" and "Re-enter password" fields.

**2. Change master password:**

- With encryption enabled, go to Tools -> Options -> Encryption -> Change master password.
- Verify that the form now shows "Current password", "New password", and "Re-enter password" fields (the missing field is now present).
- Try entering mismatched passwords; the save button should remain disabled.
- Enter matching passwords; the save button should enable.

- All present tests pass.
<img width="1118" height="340" alt="image" src="https://github.com/user-attachments/assets/400880a9-6af9-41d2-9e06-c90cfaaa1d2c" />


## AI Disclosure:
- I used AI to improve the wording of the PR description.
- Ai was used to locate the exact function and file which carried the bug.