### PR TITLE
Desktop: Fixes #14613: JPEG images cannot be pasted from clipboard on Linux

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -51,8 +51,11 @@ jest.mock('../../../services/bridge', () => ({
 const getResourceHandling = () => require('./resourceHandling');
 
 describe('resourceHandling', () => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const clipboard = (): any => require('electron').clipboard;
+	type MockClipboard = {
+		has: jest.Mock<boolean, [format: string]>;
+		readBuffer: jest.Mock<Buffer, [format: string]>;
+	};
+	const clipboard = (): MockClipboard => require('electron').clipboard as MockClipboard;
 
 	let processPastedHtml: typeof import('./resourceHandling').processPastedHtml;
 	let getResourcesFromPasteEvent: typeof import('./resourceHandling').getResourcesFromPasteEvent;

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.test.ts
@@ -1,5 +1,4 @@
 import Setting from '@joplin/lib/models/Setting';
-import { processPastedHtml } from './resourceHandling';
 import markupLanguageUtils from '@joplin/lib/markupLanguageUtils';
 import HtmlToMd from '@joplin/lib/HtmlToMd';
 import { HtmlToMarkdownHandler, MarkupToHtmlHandler } from './types';
@@ -21,7 +20,55 @@ const createTestMarkupConverters = () => {
 	return { markupToHtml, htmlToMd };
 };
 
+jest.mock('electron', () => ({
+	clipboard: {
+		has: jest.fn(),
+		readBuffer: jest.fn(),
+	},
+}), { virtual: true });
+
+const mockFsDriver = {
+	writeFile: jest.fn().mockResolvedValue(undefined),
+	remove: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('@joplin/lib/shim', () => ({
+	__esModule: true,
+	default: {
+		attachFileToNoteBody: jest.fn().mockResolvedValue('![](:/fakeResourceId)'),
+		fsDriver: () => mockFsDriver,
+	},
+}));
+
+jest.mock('../../../services/bridge', () => ({
+	__esModule: true,
+	default: () => ({
+		showErrorMessageBox: jest.fn(),
+		showOpenDialog: jest.fn(),
+	}),
+}));
+
+const getResourceHandling = () => require('./resourceHandling');
+
 describe('resourceHandling', () => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const clipboard = (): any => require('electron').clipboard;
+
+	let processPastedHtml: typeof import('./resourceHandling').processPastedHtml;
+	let getResourcesFromPasteEvent: typeof import('./resourceHandling').getResourcesFromPasteEvent;
+
+	beforeAll(() => {
+		const rh = getResourceHandling();
+		processPastedHtml = rh.processPastedHtml;
+		getResourcesFromPasteEvent = rh.getResourcesFromPasteEvent;
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockFsDriver.writeFile.mockResolvedValue(undefined);
+		mockFsDriver.remove.mockResolvedValue(undefined);
+	});
+
 	it('should sanitize pasted HTML', async () => {
 		Setting.setConstant('resourceDir', '/home/.config/joplin/resources');
 
@@ -30,7 +77,7 @@ describe('resourceHandling', () => {
 			['<a href="javascript: alert()">test</a>', '<a href="#">test</a>'],
 			['<a href="file:///home/.config/joplin/resources/test.pdf">test</a>', '<a href="file:///home/.config/joplin/resources/test.pdf">test</a>'],
 			['<a href="file:///etc/passwd">evil.pdf</a>', '<a href="#">evil.pdf</a>'],
-			['<script >evil()</script>', ''],
+			['<script >evil()</script>', ''],
 			['<script>evil()</script>', ''],
 			[
 				'<img onload="document.body.innerHTML = evil;" src="data:image/svg+xml;base64,=="/>',
@@ -59,8 +106,32 @@ describe('resourceHandling', () => {
 	it('should preserve images pasted from the resource directory', async () => {
 		const { markupToHtml, htmlToMd } = createTestMarkupConverters();
 
-		// All images in the resource directory should be preserved.
 		const html = `<img src="file://${encodeURI(Setting.value('resourceDir'))}/resource.png" alt="test"/>`;
 		expect(await processPastedHtml(html, htmlToMd, markupToHtml)).toBe(html);
+	});
+
+	it('should return empty when clipboard has no image', async () => {
+		clipboard().has.mockReturnValue(false);
+		expect(await getResourcesFromPasteEvent(null)).toEqual([]);
+	});
+
+	it('should return empty when readBuffer returns no data', async () => {
+		clipboard().has.mockImplementation((fmt: string) => fmt === 'image/jpeg');
+		clipboard().readBuffer.mockReturnValue(Buffer.alloc(0));
+		expect(await getResourcesFromPasteEvent(null)).toEqual([]);
+	});
+
+	it('should return a resource and call preventDefault when JPEG is in clipboard', async () => {
+		Setting.setConstant('tempDir', '/tmp/test');
+
+		const mockJpegBuffer = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]);
+		clipboard().has.mockImplementation((fmt: string) => fmt === 'image/jpeg');
+		clipboard().readBuffer.mockReturnValue(mockJpegBuffer);
+
+		const mockEvent = { preventDefault: jest.fn() };
+		const result = await getResourcesFromPasteEvent(mockEvent);
+
+		expect(result.length).toBeGreaterThan(0);
+		expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/resourceHandling.ts
@@ -92,33 +92,42 @@ export function resourcesStatus(resourceInfos: any) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 export async function getResourcesFromPasteEvent(event: any) {
 	const output = [];
-	const formats = clipboard.availableFormats();
-	for (let i = 0; i < formats.length; i++) {
-		const format = formats[i].toLowerCase();
-		const formatType = format.split('/')[0];
 
-		if (formatType === 'image') {
-			// writeImageToFile can process only image/jpeg, image/jpg or image/png mime types
-			if (['image/png', 'image/jpg', 'image/jpeg'].indexOf(format) < 0) {
-				continue;
+	// On Linux, clipboard.availableFormats() doesn't report 'image/jpeg' even
+	// when a JPEG is present, due to an Electron/Chromium limitation. Using
+	// clipboard.has() and clipboard.readBuffer() works correctly instead.
+	// See: https://github.com/laurent22/joplin/issues/14613
+	const supportedFormats = ['image/png', 'image/jpeg', 'image/jpg'];
+
+	for (const format of supportedFormats) {
+		if (!clipboard.has(format)) continue;
+
+		const data = clipboard.readBuffer(format);
+		if (!data || data.length === 0) continue;
+
+		const fileExt = mimeUtils.toFileExtension(format);
+		const filePath = `${Setting.value('tempDir')}/${md5(Date.now() + Math.random())}.${fileExt}`;
+
+		let md = null;
+		try {
+			await shim.fsDriver().writeFile(filePath, data, 'buffer');
+			md = await commandAttachFileToBody('', [filePath]);
+		} finally {
+			try {
+				await shim.fsDriver().remove(filePath);
+			} catch (e) {
+				logger.warn(`Failed to remove temp file: ${filePath}`, e);
 			}
+		}
+
+		if (md) {
 			if (event) event.preventDefault();
-
-			const image = clipboard.readImage();
-
-			const fileExt = mimeUtils.toFileExtension(format);
-			const filePath = `${Setting.value('tempDir')}/${md5(Date.now())}.${fileExt}`;
-
-			await shim.writeImageToFile(image, format, filePath);
-			const md = await commandAttachFileToBody('', [filePath]);
-			await shim.fsDriver().remove(filePath);
-
-			if (md) output.push(md);
+			output.push(md);
+			break;
 		}
 	}
 	return output;
 }
-
 
 const processImagesInPastedHtml = async (html: string) => {
 	const allImageUrls: string[] = [];


### PR DESCRIPTION
### Problem

On Linux, pasting a JPEG image from the clipboard into a note does nothing. PNG images paste correctly. The issue is specific to Linux.

### Solution

`clipboard.availableFormats()` in Electron does not report `image/jpeg` on Linux even when a JPEG is present (Electron/Chromium limitation: https://github.com/electron/electron/issues/32490). The previous code iterated over `availableFormats()` so JPEG was silently skipped. Additionally, `clipboard.readImage()` returns an empty NativeImage for JPEG on Linux.

The fix replaces `clipboard.availableFormats()` with explicit `clipboard.has(format)` checks, and uses `clipboard.readBuffer(format)`
instead of `clipboard.readImage()`. `event.preventDefault()` is called only after confirming usable data exists. This is low risk — PNG behaviour is unchanged.

### Test Plan

Added unit tests in `resourceHandling.test.ts` mocking the Linux clipboard behaviour. All 5 tests pass.

### AI Disclosure

I used AI assistance to help understand the Electron clipboard limitation and to structure the PR description.