### PR TITLE
Desktop: Improve accessibility of drag cursor indicator in note list

### DIFF
--- a/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
+++ b/packages/app-desktop/gui/NoteListItem/NoteListItem.tsx
@@ -168,7 +168,11 @@ const NoteListItem = (props: NoteItemProps, ref: LegacyRef<HTMLDivElement>) => {
 		aria-setsize={props.noteCount}
 		role='option'
 	>
-		<div className="dragcursor" style={dragCursorStyle}></div>
+		<div
+				className="dragcursor"
+				style={dragCursorStyle}
+				aria-hidden="true"
+			></div>
 	</div>;
 };
 


### PR DESCRIPTION
## Description

Improves accessibility of the note list drag-and-drop functionality by hiding the decorative drag cursor indicator from screen readers.

## Problem
When dragging notes in the Joplin Desktop note list, a visual indicator (a thin line) appears to show where the note will be dropped. This visual element is purely decorative and serves only to provide visual feedback to sighted users. However, this element was not properly hidden from screen readers, which means users relying on assistive technologies would have this decorative element announced to them, creating unnecessary noise and confusion.

## Root Cause
The `dragcursor` div element in `NoteListItem.tsx` was missing the `aria-hidden="true"` attribute. This attribute tells assistive technologies (like screen readers) to ignore the element since it's purely visual and doesn't convey meaningful information to users who cannot see it.

## Solution
Added `aria-hidden="true"` to the dragcursor div element. This is a standard accessibility practice for decorative elements that should not be exposed to assistive technology users.

**File Changed:** `packages/app-desktop/gui/NoteListItem/NoteListItem.tsx`

**Change:**
```tsx
// Before
<div className="dragcursor" style={dragCursorStyle}></div>

// After
<div className="dragcursor" style={dragCursorStyle} aria-hidden="true"></div>
```

## Why This Matters
- **WCAG 2.1 Compliance**: Follows WCAG 2.1 Level A guidelines for hiding decorative elements from assistive technologies
- **Better User Experience**: Screen reader users will have a cleaner, less cluttered experience when dragging notes
- **Best Practice**: Using `aria-hidden` for purely visual elements is a standard accessibility pattern
- **No Breaking Changes**: Purely visual element, no functional impact

