### PR TITLE
Desktop: Fixes #14663: Fix crash when rapidly closing secondary windows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -585,6 +585,7 @@ packages/app-desktop/integration-tests/util/setMessageBoxResponse.js
 packages/app-desktop/integration-tests/util/setSettingValue.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
+packages/app-desktop/integration-tests/util/waitForNextWindowMatching.js
 packages/app-desktop/integration-tests/wcag.spec.js
 packages/app-desktop/main-html.js
 packages/app-desktop/main.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -563,6 +563,7 @@ packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/NoteList.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
+packages/app-desktop/integration-tests/multiWindow.spec.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/pluginApi.spec.js
 packages/app-desktop/integration-tests/resizableLayout.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -536,6 +536,7 @@ packages/app-desktop/integration-tests/models/NoteEditorScreen.js
 packages/app-desktop/integration-tests/models/NoteList.js
 packages/app-desktop/integration-tests/models/SettingsScreen.js
 packages/app-desktop/integration-tests/models/Sidebar.js
+packages/app-desktop/integration-tests/multiWindow.spec.js
 packages/app-desktop/integration-tests/noteList.spec.js
 packages/app-desktop/integration-tests/pluginApi.spec.js
 packages/app-desktop/integration-tests/resizableLayout.spec.js

--- a/.gitignore
+++ b/.gitignore
@@ -558,6 +558,7 @@ packages/app-desktop/integration-tests/util/setMessageBoxResponse.js
 packages/app-desktop/integration-tests/util/setSettingValue.js
 packages/app-desktop/integration-tests/util/test.js
 packages/app-desktop/integration-tests/util/waitForNextOpenPath.js
+packages/app-desktop/integration-tests/util/waitForNextWindowMatching.js
 packages/app-desktop/integration-tests/wcag.spec.js
 packages/app-desktop/main-html.js
 packages/app-desktop/main.js

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -139,7 +139,7 @@ const NewWindowOrIFrame: React.FC<Props> = props => {
 		}
 	}, [doc, props.windowId]);
 
-	const parentNode = loaded ? doc?.body : null;
+	const parentNode = loaded && doc && !doc.defaultView.closed ? doc.body : null;
 	const wrappedChildren = <WindowIdContext.Provider value={props.windowId}>{props.children}</WindowIdContext.Provider>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Needed to allow adding the portal to the DOM

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -139,7 +139,7 @@ const NewWindowOrIFrame: React.FC<Props> = props => {
 		}
 	}, [doc, props.windowId]);
 
-	const parentNode = loaded && doc && !doc.defaultView.closed ? doc.body : null;
+	const parentNode = loaded && doc && !doc.defaultView?.closed ? doc.body : null;
 	const wrappedChildren = <WindowIdContext.Provider value={props.windowId}>{props.children}</WindowIdContext.Provider>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Needed to allow adding the portal to the DOM

--- a/packages/app-desktop/gui/NewWindowOrIFrame.tsx
+++ b/packages/app-desktop/gui/NewWindowOrIFrame.tsx
@@ -139,7 +139,7 @@ const NewWindowOrIFrame: React.FC<Props> = props => {
 		}
 	}, [doc, props.windowId]);
 
-	const parentNode = loaded && doc && !doc.defaultView?.closed ? doc.body : null;
+	const parentNode = loaded ? doc?.body : null;
 	const wrappedChildren = <WindowIdContext.Provider value={props.windowId}>{props.children}</WindowIdContext.Provider>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Needed to allow adding the portal to the DOM

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -113,6 +113,9 @@ const useContextMenu = (props: ContextMenuProps) => {
 	// It might be buggy, refer to the below issue
 	// https://github.com/laurent22/joplin/pull/3974#issuecomment-718936703
 	useEffect(() => {
+		const targetWindow = bridge().windowById(windowId);
+		if (!targetWindow) return ()=> {};
+
 		const isAncestorOfCodeMirrorEditor = (elem: Element) => {
 			for (; elem.parentElement; elem = elem.parentElement) {
 				if (elem.classList.contains(props.editorClassName)) {
@@ -178,8 +181,6 @@ const useContextMenu = (props: ContextMenuProps) => {
 			const line = editor.state.doc.lineAt(clickPos);
 			return getResourceIdFromMarkup(line.text, clickPos - line.from);
 		};
-
-		const targetWindow = bridge().windowById(windowId);
 
 		const showResourceContextMenu = async (resourceId: string, type: ResourceMarkupType) => {
 			const menu = new Menu();

--- a/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/TinyMCE/utils/useContextMenu.ts
@@ -35,8 +35,10 @@ export default function(editor: Editor, plugins: PluginStates, dispatch: Dispatc
 	useEffect(() => {
 		if (!editor) return () => {};
 
-		const contextMenuItems = menuItems(dispatch);
 		const targetWindow = bridge().windowById(windowId);
+		if (!targetWindow) return () => {};
+
+		const contextMenuItems = menuItems(dispatch);
 
 		const makeMainMenuItems = async (element: Element) => {
 			let itemType: ContextMenuItemType = ContextMenuItemType.None;

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -66,7 +66,7 @@ export default class MainScreen {
 	}
 
 	public async openNewWindow(electronApp: ElectronApplication) {
-		const pagePromise = waitForNextWindowMatching(/^Joplin - /, electronApp);
+		const pagePromise = waitForNextWindowMatching(/^Joplin -/, electronApp);
 
 		await activateMainMenuItem(electronApp, 'Open in new window');
 		return pagePromise;

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -7,6 +7,7 @@ import setFilePickerResponse from '../util/setFilePickerResponse';
 import NoteList from './NoteList';
 import { expect } from '../util/test';
 import ChangeAppLayoutScreen from './ChangeAppLayoutScreen';
+import { Second } from '@joplin/utils/time';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
@@ -62,6 +63,34 @@ export default class MainScreen {
 	public async openSettings(electronApp: ElectronApplication) {
 		// Check both labels so this works on MacOS
 		await activateMainMenuItem(electronApp, /^(Preferences\.\.\.|Options)$/);
+	}
+
+	public async openNewWindow(electronApp: ElectronApplication) {
+		return new Promise<Page>((resolve, reject) => {
+			let resolved = false;
+			const offWindowAdded = () => electronApp.off('window', onWindowAdded);
+			const onWindowAdded = async (page: Page) => {
+				if ((await page.title()).startsWith('Joplin -')) {
+					offWindowAdded();
+
+					resolved = true;
+					resolve(page);
+				}
+			};
+			electronApp.on('window', onWindowAdded);
+
+			setTimeout(async () => {
+				if (resolved) return;
+
+				offWindowAdded();
+
+				const windows = electronApp.windows();
+				const titles = await Promise.all(windows.map(w => w.title()));
+				reject(new Error(`Opening a window timed out. Open window titles: ${JSON.stringify(titles)}.`));
+			}, 30 * Second);
+
+			void activateMainMenuItem(electronApp, 'Open in new window');
+		});
 	}
 
 	public async search(text: string) {

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -67,22 +67,26 @@ export default class MainScreen {
 
 	public async openNewWindow(electronApp: ElectronApplication) {
 		return new Promise<Page>((resolve, reject) => {
-			let resolved = false;
-			const offWindowAdded = () => electronApp.off('window', onWindowAdded);
+			let timeout: NodeJS.Timeout|null = null;
+			const clearListenersAndTimeouts = () => {
+				if (timeout) {
+					clearTimeout(timeout);
+					timeout = null;
+				}
+				electronApp.off('window', onWindowAdded);
+			};
+
 			const onWindowAdded = async (page: Page) => {
 				if ((await page.title()).startsWith('Joplin -')) {
-					offWindowAdded();
-
-					resolved = true;
+					clearListenersAndTimeouts();
 					resolve(page);
 				}
 			};
 			electronApp.on('window', onWindowAdded);
 
-			setTimeout(async () => {
-				if (resolved) return;
-
-				offWindowAdded();
+			timeout = setTimeout(async () => {
+				timeout = null;
+				clearListenersAndTimeouts();
 
 				const windows = electronApp.windows();
 				const titles = await Promise.all(windows.map(w => w.title()));

--- a/packages/app-desktop/integration-tests/models/MainScreen.ts
+++ b/packages/app-desktop/integration-tests/models/MainScreen.ts
@@ -7,7 +7,7 @@ import setFilePickerResponse from '../util/setFilePickerResponse';
 import NoteList from './NoteList';
 import { expect } from '../util/test';
 import ChangeAppLayoutScreen from './ChangeAppLayoutScreen';
-import { Second } from '@joplin/utils/time';
+import waitForNextWindowMatching from '../util/waitForNextWindowMatching';
 
 export default class MainScreen {
 	public readonly newNoteButton: Locator;
@@ -66,35 +66,10 @@ export default class MainScreen {
 	}
 
 	public async openNewWindow(electronApp: ElectronApplication) {
-		return new Promise<Page>((resolve, reject) => {
-			let timeout: NodeJS.Timeout|null = null;
-			const clearListenersAndTimeouts = () => {
-				if (timeout) {
-					clearTimeout(timeout);
-					timeout = null;
-				}
-				electronApp.off('window', onWindowAdded);
-			};
+		const pagePromise = waitForNextWindowMatching(/^Joplin - /, electronApp);
 
-			const onWindowAdded = async (page: Page) => {
-				if ((await page.title()).startsWith('Joplin -')) {
-					clearListenersAndTimeouts();
-					resolve(page);
-				}
-			};
-			electronApp.on('window', onWindowAdded);
-
-			timeout = setTimeout(async () => {
-				timeout = null;
-				clearListenersAndTimeouts();
-
-				const windows = electronApp.windows();
-				const titles = await Promise.all(windows.map(w => w.title()));
-				reject(new Error(`Opening a window timed out. Open window titles: ${JSON.stringify(titles)}.`));
-			}, 30 * Second);
-
-			void activateMainMenuItem(electronApp, 'Open in new window');
-		});
+		await activateMainMenuItem(electronApp, 'Open in new window');
+		return pagePromise;
 	}
 
 	public async search(text: string) {

--- a/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
+++ b/packages/app-desktop/integration-tests/models/NoteEditorScreen.ts
@@ -4,7 +4,7 @@ import activateMainMenuItem from '../util/activateMainMenuItem';
 import EditorCodeDialog from './EditorCodeDialog';
 import setSettingValue from '../util/setSettingValue';
 
-export default class NoteEditorPage {
+export default class NoteEditorScreen {
 	public readonly codeMirrorEditor: Locator;
 	public readonly noteViewerContainer: Locator;
 	public readonly editorPluginFrame: Locator;
@@ -26,7 +26,8 @@ export default class NoteEditorPage {
 	private readonly containerLocator: Locator;
 
 	public constructor(private page_: Page) {
-		this.containerLocator = page_.locator('.rli-editor');
+		// .rli-editor is used in the main window, .note-editor-wrapper in secondary windows
+		this.containerLocator = page_.locator('.rli-editor, .note-editor-wrapper');
 		this.codeMirrorEditor = this.containerLocator.locator('.cm-editor');
 		this.richTextEditor = this.containerLocator.locator('iframe[title="Rich Text Area"]');
 		this.editorPluginFrame = this.containerLocator.locator('iframe[id^="plugin-view-"]');

--- a/packages/app-desktop/integration-tests/multiWindow.spec.ts
+++ b/packages/app-desktop/integration-tests/multiWindow.spec.ts
@@ -3,13 +3,13 @@ import MainScreen from './models/MainScreen';
 import NoteEditorScreen from './models/NoteEditorScreen';
 
 test.describe('multiWindow', () => {
-	// Disabled: This test usually hangs when closing secondary windows (see https://github.com/laurent22/joplin/issues/14628):
+	// Disabled: This test often hangs when closing secondary windows (see https://github.com/laurent22/joplin/issues/14628):
 	test.fixme('should support quickly creating, then closing secondary windows', async ({ mainWindow, electronApp }) => {
 		const mainPage = await new MainScreen(mainWindow).setup();
 		await mainPage.createNewNote('Test');
 
 		const windows = [];
-		for (let i = 0; i < 12; i++) {
+		for (let i = 0; i < 4; i++) {
 			const window = await mainPage.openNewWindow(electronApp);
 
 			// Should load successfully
@@ -20,7 +20,9 @@ test.describe('multiWindow', () => {
 		}
 
 		// Close them all, very quickly.
-		await Promise.all(windows.map(window => window.close()));
+		for (const window of windows) {
+			await window.close();
+		}
 
 		// Should not have crashed
 		await expect(await mainPage.noteEditor.contentLocator()).toBeVisible();

--- a/packages/app-desktop/integration-tests/multiWindow.spec.ts
+++ b/packages/app-desktop/integration-tests/multiWindow.spec.ts
@@ -8,7 +8,7 @@ test.describe('multiWindow', () => {
 		await mainPage.createNewNote('Test');
 
 		const windows = [];
-		for (let i = 0; i < 4; i++) {
+		for (let i = 0; i < 8; i++) {
 			const window = await mainPage.openNewWindow(electronApp);
 
 			// Should load successfully

--- a/packages/app-desktop/integration-tests/multiWindow.spec.ts
+++ b/packages/app-desktop/integration-tests/multiWindow.spec.ts
@@ -3,12 +3,13 @@ import MainScreen from './models/MainScreen';
 import NoteEditorScreen from './models/NoteEditorScreen';
 
 test.describe('multiWindow', () => {
-	test('should support quickly creating, then closing secondary windows', async ({ mainWindow, electronApp }) => {
+	// Disabled: This test usually hangs when closing secondary windows (see https://github.com/laurent22/joplin/issues/14628):
+	test.fixme('should support quickly creating, then closing secondary windows', async ({ mainWindow, electronApp }) => {
 		const mainPage = await new MainScreen(mainWindow).setup();
 		await mainPage.createNewNote('Test');
 
 		const windows = [];
-		for (let i = 0; i < 8; i++) {
+		for (let i = 0; i < 12; i++) {
 			const window = await mainPage.openNewWindow(electronApp);
 
 			// Should load successfully
@@ -19,9 +20,7 @@ test.describe('multiWindow', () => {
 		}
 
 		// Close them all, very quickly.
-		for (const window of windows) {
-			await window.close();
-		}
+		await Promise.all(windows.map(window => window.close()));
 
 		// Should not have crashed
 		await expect(await mainPage.noteEditor.contentLocator()).toBeVisible();

--- a/packages/app-desktop/integration-tests/multiWindow.spec.ts
+++ b/packages/app-desktop/integration-tests/multiWindow.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from './util/test';
+import MainScreen from './models/MainScreen';
+import NoteEditorScreen from './models/NoteEditorScreen';
+
+test.describe('multiWindow', () => {
+	test('should support quickly creating, then closing secondary windows', async ({ mainWindow, electronApp }) => {
+		const mainPage = await new MainScreen(mainWindow).setup();
+		await mainPage.createNewNote('Test');
+
+		const windows = [];
+		for (let i = 0; i < 4; i++) {
+			const window = await mainPage.openNewWindow(electronApp);
+
+			// Should load successfully
+			const screen = new NoteEditorScreen(window);
+			await screen.waitFor();
+
+			windows.push(window);
+		}
+
+		// Close them all, very quickly.
+		for (const window of windows) {
+			await window.close();
+		}
+
+		// Should not have crashed
+		await expect(await mainPage.noteEditor.contentLocator()).toBeVisible();
+	});
+});
+

--- a/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
+++ b/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
@@ -1,0 +1,34 @@
+import { Second } from '@joplin/utils/time';
+import { ElectronApplication, Page } from '@playwright/test';
+
+const waitForNextWindowMatching = (titlePattern: RegExp, electronApp: ElectronApplication) => {
+	return new Promise<Page>((resolve, reject) => {
+		let timeout: NodeJS.Timeout|null = null;
+		const clearListenersAndTimeouts = () => {
+			if (timeout) {
+				clearTimeout(timeout);
+				timeout = null;
+			}
+			electronApp.off('window', onWindowAdded);
+		};
+
+		const onWindowAdded = async (page: Page) => {
+			if ((await page.title()).match(titlePattern)) {
+				clearListenersAndTimeouts();
+				resolve(page);
+			}
+		};
+		electronApp.on('window', onWindowAdded);
+
+		timeout = setTimeout(async () => {
+			timeout = null;
+			clearListenersAndTimeouts();
+
+			const windows = electronApp.windows();
+			const titles = await Promise.all(windows.map(w => w.title()));
+			reject(new Error(`Opening a window timed out. Open window titles: ${JSON.stringify(titles)}.`));
+		}, 30 * Second);
+	});
+};
+
+export default waitForNextWindowMatching;

--- a/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
+++ b/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
@@ -13,7 +13,8 @@ const waitForNextWindowMatching = (titlePattern: RegExp, electronApp: ElectronAp
 		};
 
 		const onWindowAdded = async (page: Page) => {
-			if ((await page.title()).match(titlePattern)) {
+			const title = await page.title();
+			if (title.match(titlePattern)) {
 				clearListenersAndTimeouts();
 				resolve(page);
 			}

--- a/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
+++ b/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
@@ -24,11 +24,21 @@ const waitForNextWindowMatching = (titlePattern: RegExp, electronApp: ElectronAp
 			timeout = null;
 			clearListenersAndTimeouts();
 
-			const windows = electronApp.windows();
-			const titles = await Promise.all(windows.map(w => w.title()));
-			reject(new Error(`Opening a window timed out. Open window titles: ${JSON.stringify(titles)}.`));
+			const windowTitles = await getOpenWindowTitles(electronApp);
+			reject(new Error(`Opening a window timed out. Open window titles: ${JSON.stringify(windowTitles)}.`));
 		}, 30 * Second);
 	});
 };
 
 export default waitForNextWindowMatching;
+
+const getOpenWindowTitles = (electronApp: ElectronApplication) => {
+	const windows = electronApp.windows();
+	return Promise.all(windows.map(async w => {
+		try {
+			return await w.title();
+		} catch (error) {
+			return `(Error: ${error})`;
+		}
+	}));
+};

--- a/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
+++ b/packages/app-desktop/integration-tests/util/waitForNextWindowMatching.ts
@@ -10,6 +10,7 @@ const waitForNextWindowMatching = (titlePattern: RegExp, electronApp: ElectronAp
 				timeout = null;
 			}
 			electronApp.off('window', onWindowAdded);
+			electronApp.off('close', onClose);
 		};
 
 		const onWindowAdded = async (page: Page) => {
@@ -19,7 +20,13 @@ const waitForNextWindowMatching = (titlePattern: RegExp, electronApp: ElectronAp
 				resolve(page);
 			}
 		};
+		const onClose = () => {
+			clearListenersAndTimeouts();
+			reject(new Error('Target application closed.'));
+		};
+
 		electronApp.on('window', onWindowAdded);
+		electronApp.on('close', onClose);
 
 		timeout = setTimeout(async () => {
 			timeout = null;


### PR DESCRIPTION
# Problem

A crash could occur when closing secondary app windows.

`useContextMenu` attempted to register an event listener on a null `targetWindow` if its `useEffect` ran **after** the window had been closed.

# Solution

Guards against a `null` target window in `useContextMenu.ts`.


Fixes #14663 (regression from https://github.com/laurent22/joplin/commit/02dfef11aa0551896eea8d7476d886cb4c2fbb30).

> [!IMPORTANT]
>
> While this fixes the issue identified by the stack trace in #14663, this **does not fix** the "renderer process gone" error when closing secondary windows in some cases (see [comment](https://github.com/laurent22/joplin/pull/14640#issuecomment-4019808146)).

# Test plan

## Manual testing

Manual regression testing has been done with the Rich Text Editor.

[Screencast from 2026-03-11 09-51-37.webm](https://github.com/user-attachments/assets/019da575-42a8-4550-ae9f-39a706ef5878)

## Automated testing

Disabled test: `should support quickly creating, then closing secondary windows`:
- The test opens, then closes several secondary windows (CodeMirror editor). This test failed prior to the changes to `useContextMenu.ts` either with an error overlay or a hang.
- With the changes in this pull request, the test no longer fails with an error overlay and seems to usually pass when run locally.
- This test is currently disabled, since it can still fail due to a freeze/hang when closing windows (see [comment](https://github.com/laurent22/joplin/pull/14640#issuecomment-4019808146)).
  - This freeze seems to be a different issue from #14663, despite having similar symptoms.


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->