### PR TITLE
 Desktop: Fixes 14695: Validate password on re-enable encryption after master password cleared

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -204,7 +204,7 @@ const EncryptionConfigScreen = (props: Props) => {
 			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
 		}
 
-		if (hasMasterPassword && newEnabled) {
+		if ((hasMasterPassword || !!masterKey) && newEnabled) {
 			if (!(await masterPasswordIsValid(newPassword))) {
 				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
 				return;

--- a/packages/lib/services/e2ee/utils.test.ts
+++ b/packages/lib/services/e2ee/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterAllCleanUp, setupDatabaseAndSynchronizer, switchClient, encryptionService, expectNotThrow, expectThrow, kvStore, msleep } from '../../testing/test-utils';
 import MasterKey from '../../models/MasterKey';
-import { activeMasterKeySanityCheck, migrateMasterPassword, migratePpk, resetMasterPassword, showMissingMasterKeyMessage, updateMasterPassword } from './utils';
+import { activeMasterKeySanityCheck, masterPasswordIsValid, migrateMasterPassword, migratePpk, resetMasterPassword, showMissingMasterKeyMessage, updateMasterPassword } from './utils';
 import { localSyncInfo, masterKeyById, masterKeyEnabled, saveLocalSyncInfo, setActiveMasterKeyId, setMasterKeyEnabled, setPpk } from '../synchronizer/syncInfoUtils';
 import Setting from '../../models/Setting';
 import { generateKeyPair, generateKeyPairWithAlgorithm, getPpkAlgorithm, ppkPasswordIsValid, testing__setPpkMigrations_ } from './ppk/ppk';
@@ -215,6 +215,18 @@ describe('e2ee/utils', () => {
 
 		const syncInfo = localSyncInfo();
 		expect(syncInfo.activeMasterKeyId).toBe(mk1.id);
+	});
+
+	it('should reject wrong password against master key when encryption.masterPassword is cleared', async () => {
+		const password = '111111';
+		const wrongPassword = 'wrong-password';
+
+		const mk = await MasterKey.save(await encryptionService().generateMasterKey(password));
+		setActiveMasterKeyId(mk.id);
+		Setting.setValue('encryption.masterPassword', '');
+
+		expect(await masterPasswordIsValid(password)).toBe(true);
+		expect(await masterPasswordIsValid(wrongPassword)).toBe(false);
 	});
 
 });


### PR DESCRIPTION
Fixes #14695

Fix: Extend the condition to also validate when an existing master key is present.
Test: Added a test confirming masterPasswordIsValid correctly rejects wrong passwords in this state.


https://github.com/user-attachments/assets/505f7352-815b-4418-9ec0-a4b0cc3d6b15


