### PR TITLE
Desktop: Fixes #14704: Prevent duplicate plugin context menu items on resource links

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -385,8 +385,12 @@ const useContextMenu = (props: ContextMenuProps) => {
 					menu.append(new MenuItem({ type: 'separator' }));
 				}
 
+				const existingLabels = new Set(menu.items.map(i => i.label));
 				for (const item of resourceMenuItems) {
-					menu.append(item);
+					if (!existingLabels.has(item.label) || item.type === 'separator') {
+						menu.append(item);
+						if (item.label) existingLabels.add(item.label);
+					}
 				}
 			}
 			menu.popup({ window: targetWindow });


### PR DESCRIPTION
### Description

Fixes #14704

This PR fixes an issue where context menu items injected by plugins would appear duplicated when right-clicking on a resource link (with text selected) in the Markdown editor.

### Root Cause
The duplication occurred because the context menu building process was querying plugins for items twice during the same interaction:
1. First, during the initial construction of the standard text context menu.
2. Second, inside the [buildMenuItems](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/app-desktop/gui/NoteEditor/utils/contextMenuUtils.ts:199:0-243:2) helper when assembling resource-specific options for the clicked link.

Plugins indiscriminately added their items during both event emissions, resulting in duplicates on the final rendered menu.

### Solution
Updated the logic in [packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts](cci:7://file:///c:/Users/BIT/Desktop/joplin/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts:0:0-0:0) to de-duplicate the menu items before rendering. 

Instead of blindly appending the results of the second query (`resourceMenuItems`), the code now checks the `label` of each incoming item against a [Set](cci:1://file:///c:/Users/BIT/Desktop/joplin/packages/lib/services/e2ee/utils.ts:51:0-65:1) of labels already present in the menu. Only unique items (and structural separators) are appended, ensuring plugins can safely participate in both context queries without doubling up their UI entries.

### Testing
1. Install a plugin that adds a context menu item to the Markdown editor (e.g., Rich Markdown, Paste as Markdown).
2. Open the Markdown editor and type/select text that includes a resource link or image.
3. Right-click on the resource link.
4. Verify that the plugin's context menu options are only displayed once in the resulting menu.


