### PR TITLE
Desktop: Prevent duplicate plugin context menu entries

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -335,10 +335,17 @@ const useContextMenu = (props: ContextMenuProps) => {
 			}
 
 			// eslint-disable-next-line github/array-foreach, @typescript-eslint/no-explicit-any -- Old code before rule was applied, Old code before rule was applied
-			menuUtils.pluginContextMenuItems(props.plugins, MenuItemLocation.EditorContextMenu).forEach((item: any) => {
-				menu.append(new MenuItem(item));
-			});
+			const seenCommands = new Set<string>();
 
+			for (const item of menuUtils.pluginContextMenuItems(props.plugins, MenuItemLocation.EditorContextMenu)) {
+				const command = (item as { commandName?: string }).commandName;
+
+				if (command && seenCommands.has(command)) continue;
+
+				if (command) seenCommands.add(command);
+
+				menu.append(new MenuItem(item));
+			}
 			menu.popup({ window: targetWindow });
 		};
 


### PR DESCRIPTION
Fixes #14704

AI Disclosure:
Some assistance from AI tools was used while exploring possible approaches,
but the final code was reviewed, tested locally, and understood before submission.

Plugin context menu entries could appear twice when right-clicking
a resource link in the Markdown editor.

This happened because plugin context menu items were appended
multiple times when building the editor context menu.

The fix ensures plugin menu items are only added once by checking
existing command names before appending them.
Regression introduced in #14638.

Tested with plugin:
- Paste HTML as Markdown

Steps tested:
1. Insert image to create resource link
2. Select text including the resource link
3. Right-click the link

Before fix:
Plugin menu item appeared twice.

After fix:
Plugin menu item appears once.