### PR TITLE
Revert "Desktop: Fix context menu missing cut/copy when selecting resource links in markdown editor"

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
+++ b/packages/app-desktop/gui/NoteEditor/NoteBody/CodeMirror/utils/useContextMenu.ts
@@ -244,26 +244,8 @@ const useContextMenu = (props: ContextMenuProps) => {
 			}
 
 			// Check if right-clicking on resource markup text (images or file attachments)
-			// When text is selected, CodeMirror's click position may fall slightly
-			// outside the resource markup. Prefer the actual click position first,
-			// then fall back to the selection start if hit-testing misses.
-			const editor = editorRef.current?.editor;
-			const hasSelectedText = !!editorRef.current?.getSelection();
-
-			let markupResourceInfo = getResourceInfoAtClickPos(params);
-
-			// When text is selected, CodeMirror can sometimes report a click
-			// position slightly outside the markup. If click detection fails,
-			// fall back to the selection start position.
-			if (!markupResourceInfo && hasSelectedText && editor?.state?.selection?.main) {
-				const pos = editor.state.selection.main.from;
-				const line = editor.state.doc.lineAt(pos);
-
-				markupResourceInfo = getResourceIdFromMarkup(line.text, pos - line.from);
-			}
-
-
-			if (markupResourceInfo && pointerInsideEditor(params) && !hasSelectedText) {
+			const markupResourceInfo = getResourceInfoAtClickPos(params);
+			if (markupResourceInfo && pointerInsideEditor(params)) {
 				event.preventDefault();
 				await showResourceContextMenu(markupResourceInfo.resourceId, markupResourceInfo.type);
 				return;
@@ -277,6 +259,7 @@ const useContextMenu = (props: ContextMenuProps) => {
 
 			const menu = new Menu();
 
+			const hasSelectedText = editorRef.current && !!editorRef.current.getSelection() ;
 
 			menu.append(
 				new MenuItem({
@@ -355,40 +338,7 @@ const useContextMenu = (props: ContextMenuProps) => {
 			menuUtils.pluginContextMenuItems(props.plugins, MenuItemLocation.EditorContextMenu).forEach((item: any) => {
 				menu.append(new MenuItem(item));
 			});
-			// If a resource link is selected, append resource actions
-			if (markupResourceInfo && hasSelectedText) {
-				const baseType = markupResourceInfo.type === 'image'
-					? ContextMenuItemType.Image
-					: ContextMenuItemType.Resource;
 
-				const itemType = await resolveContextMenuItemType(baseType, markupResourceInfo.resourceId);
-
-				const contextMenuOptions: ContextMenuOptions = {
-					itemType,
-					resourceId: markupResourceInfo.resourceId,
-					filename: null,
-					mime: null,
-					linkToCopy: null,
-					linkToOpen: null,
-					textToCopy: null,
-					htmlToCopy: null,
-					insertContent: () => { },
-					isReadOnly: true,
-					fireEditorEvent: () => { },
-					htmlToMd: null,
-					mdToHtml: null,
-				};
-
-				const resourceMenuItems = await buildMenuItems(menuItems(props.dispatch), contextMenuOptions);
-
-				if (resourceMenuItems.length) {
-					menu.append(new MenuItem({ type: 'separator' }));
-				}
-
-				for (const item of resourceMenuItems) {
-					menu.append(item);
-				}
-			}
 			menu.popup({ window: targetWindow });
 		};
 


### PR DESCRIPTION
Reverts laurent22/joplin#14638

Ref: https://github.com/laurent22/joplin/issues/14704