### PR TITLE
Server: Fix delta API can return changes in wrong order

### DIFF
--- a/packages/server/src/models/ChangeModel.test.ts
+++ b/packages/server/src/models/ChangeModel.test.ts
@@ -51,17 +51,17 @@ describe('ChangeModel', () => {
 		expect(allUncompressedChanges.length).toBe(8);
 
 		{
-			// When we get all the changes, we get DELETE 1, CREATE 2, and CREATE 3:
+			// When we get all the changes, we get CREATE 2, DELETE 1, and CREATE 3:
 			// - We don't get CREATE 1 since CREATE 1 -> DELETE 1 was compressed to
 			//   DELETE 1.
 			// - We don't get any UPDATE event since they've been compressed
 			//   down to the CREATE events.
 			const changes = (await changeModel.delta(user.id)).items;
 			expect(changes.length).toBe(3);
-			expect(changes[0].item_id).toBe(item1.id);
-			expect(changes[0].type).toBe(ChangeType.Delete);
-			expect(changes[1].item_id).toBe(item2.id);
-			expect(changes[1].type).toBe(ChangeType.Create);
+			expect(changes[0].item_id).toBe(item2.id);
+			expect(changes[0].type).toBe(ChangeType.Create);
+			expect(changes[1].item_id).toBe(item1.id);
+			expect(changes[1].type).toBe(ChangeType.Delete);
 			expect(changes[2].item_id).toBe(item3.id);
 			expect(changes[2].type).toBe(ChangeType.Create);
 		}

--- a/packages/server/src/models/ChangeModel.ts
+++ b/packages/server/src/models/ChangeModel.ts
@@ -282,10 +282,6 @@ export default class ChangeModel extends BaseModel<Change> {
 		// returns the rows directly;
 		const output: Change[] = results.rows ? results.rows : results;
 
-		// This property is present only for the purpose of ordering the results
-		// and can be removed afterwards.
-		for (const change of output) delete change.counter;
-
 		return output;
 	}
 
@@ -323,6 +319,10 @@ export default class ChangeModel extends BaseModel<Change> {
 			};
 			return deltaChange;
 		});
+
+		// This property is present only for the purpose of ordering the results
+		// and can be removed afterwards.
+		for (const change of finalChanges) delete change.counter;
 
 		return {
 			items: finalChanges,


### PR DESCRIPTION
# Problem

The `delta` API call could return changes in an incorrect order.

Since `change.counter` is deleted [on this line](https://github.com/laurent22/joplin/blob/2e3daad78e99a6c32490b711b68521f90b40d393/packages/server/src/models/ChangeModel.ts#L287), `ChangeModel.compressChanges_` is not provided changes with a `counter`. As a result, changes were sorted based on `undefined`:
https://github.com/laurent22/joplin/blob/2e3daad78e99a6c32490b711b68521f90b40d393/packages/server/src/models/ChangeModel.ts#L462

This prevented `ChangeModel.compressChanges_` from correctly restoring the original order of the changes it compressed. Since JavaScript's `sort` function [is stable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#:~:text=Stable%3A%20The%20comparator%20returns%20the%20same%20result%20with%20the%20same%20pair%20of%20input), results were returned in the order in which the output array was created.

In particular, for each item, creates and deletes should be in the correct order (along with the first update), but:
- Changes for different items may appear in a different order relative to each other.
- Subsequent updates will be included immediately after the first ([code](https://github.com/laurent22/joplin/blob/2e3daad78e99a6c32490b711b68521f90b40d393/packages/server/src/models/ChangeModel.ts#L454)).

# Solution

Preserve `change.counter` until after change compression step has run.

# Notes

- This does not appear to be a regression (or at least, not a recent one). Change counter deletion has existed since [commit](https://github.com/laurent22/joplin/commit/5986710fc08ec34a4632943763ff4ea4640000fa). The `counter`-based sorting logic has been a part of `compressChanges` since [commit](https://github.com/laurent22/joplin/commit/41684a64ef7cac06977704982a8ec3ae85745693).
- The issue was [reported here](https://github.com/laurent22/joplin/pull/14712#discussion_r2921556803) during the `coderabbitai` review of #14712.

# Testing

- Fixed an existing test, which had incorrect expected state.
  - The test does the following actions:
    `CREATE 1`, `UPDATE 1`, `UPDATE 1`, `CREATE 2`, `UPDATE 2`, `DELETE 1`, `UPDATE 2`, `CREATE 3`
    However, it expected the first page of results to be `DELETE 1`, `CREATE 2`, `CREATE 3` (with the `DELETE 1` before the `CREATE 2`).
- Ran the sync fuzzer with the PostgreSQL server backend and otherwise default settings.
  - Fuzzing ran successfully for >110 steps before being manually stopped.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->