### PR TITLE
Fix for navigation order mentioned in #14645.

### DIFF
--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -13,8 +13,8 @@
 			</div>
 			<div class="col-9 text-right d-none d-md-block">
 				{{> twitterLink}}
-				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
+				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>
 
@@ -59,8 +59,8 @@
 						</div>
 
 						<div class="text-center menu-mobile-top">
-							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
+							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>
 							<a href="{{forumUrl}}" class="fw500 mobile-menu-link">Forum</a>
 						</div>

--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -14,6 +14,7 @@
 			<div class="col-9 text-right d-none d-md-block">
 				{{> twitterLink}}
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
+				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>
 
@@ -59,6 +60,7 @@
 
 						<div class="text-center menu-mobile-top">
 							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
+							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>
 							<a href="{{forumUrl}}" class="fw500 mobile-menu-link">Forum</a>
 						</div>

--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -13,9 +13,13 @@
 			</div>
 			<div class="col-9 text-right d-none d-md-block">
 				{{> twitterLink}}
+<<<<<<< HEAD
+=======
 				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
+>>>>>>> d9055730a5f2a33bb9c74f6c2fc3390a16cd6823
 				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
+				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>
 
@@ -63,6 +67,7 @@
 							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
 							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
+							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>
 							<a href="{{forumUrl}}" class="fw500 mobile-menu-link">Forum</a>
 						</div>

--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -13,11 +13,6 @@
 			</div>
 			<div class="col-9 text-right d-none d-md-block">
 				{{> twitterLink}}
-<<<<<<< HEAD
-=======
-				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
-				<a href="{{baseUrl}}/news/" class="fw500">News</a>
->>>>>>> d9055730a5f2a33bb9c74f6c2fc3390a16cd6823
 				<a href="{{baseUrl}}/plugins/" class="fw500">Plugins</a>
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
@@ -64,8 +59,6 @@
 						</div>
 
 						<div class="text-center menu-mobile-top">
-							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
-							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/plugins/" class="fw500 mobile-menu-link">Plugins</a>
 							<a href="{{baseUrl}}/news/" class="fw500 mobile-menu-link">News</a>
 							<a href="{{baseUrl}}/help/" class="fw500 mobile-menu-link">Help</a>

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -208,6 +208,12 @@ const config = {
 						position: 'right',
 					},
 					{
+						to: process.env.WEBSITE_BASE_URL + '/plugins',
+						label: 'Plugins',
+						position: 'right',
+						target: '_self',
+					},
+					{
 						type: 'docSidebar',
 						sidebarId: 'helpSidebar',
 						position: 'right',

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -203,15 +203,15 @@ const config = {
 				},
 				items: [
 					{
-						to: '/news',
-						label: 'News',
-						position: 'right',
-					},
-					{
 						to: process.env.WEBSITE_BASE_URL + '/plugins',
 						label: 'Plugins',
 						position: 'right',
 						target: '_self',
+					},
+					{
+						to: '/news',
+						label: 'News',
+						position: 'right',
 					},
 					{
 						type: 'docSidebar',

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -214,17 +214,6 @@ const config = {
 						position: 'right',
 					},
 					{
-						to: process.env.WEBSITE_BASE_URL + '/plugins',
-						label: 'Plugins',
-						position: 'right',
-						target: '_self',
-					},
-					{
-						to: '/news',
-						label: 'News',
-						position: 'right',
-					},
-					{
 						type: 'docSidebar',
 						sidebarId: 'helpSidebar',
 						position: 'right',

--- a/packages/doc-builder/docusaurus.config.js
+++ b/packages/doc-builder/docusaurus.config.js
@@ -220,6 +220,11 @@ const config = {
 						target: '_self',
 					},
 					{
+						to: '/news',
+						label: 'News',
+						position: 'right',
+					},
+					{
 						type: 'docSidebar',
 						sidebarId: 'helpSidebar',
 						position: 'right',


### PR DESCRIPTION
**Problem**

The navigation order on the website and help documentation did not match the order used on the Plugins website. The Plugins website uses the order **Plugins / News / Help**, while the website and help documentation navigation were implemented as **News / Plugins / Help**.

This inconsistency results in different navigation structures across the Joplin websites, which can create confusion for users and makes the navigation less consistent.

**Solution**

This change updates the navigation order in the website navbar and the help documentation configuration so that the links follow the same order used on the Plugins website: **Plugins / News / Help**.

The change ensures that the navigation structure is consistent across the main website, help documentation, and the plugins website.

This change only affects the ordering of navigation links and does not modify any application logic or functionality.

**Test Plan**

Manual verification steps:

* Confirm the navigation order in `navbar.mustache` is **Plugins -> News -> Help** for the desktop navbar.
* Confirm the same order is reflected in the mobile navigation menu.
* Verify the documentation navbar configuration in `docusaurus.config.js` follows the same link order.
* Ensure the links still resolve correctly to `/plugins`, `/news`, and `/help`.

Since this change only modifies the order of navigation links, it should not affect other website functionality.



I have read the CLA Document and I hereby sign the CLA