### PR TITLE
Add automated security analysis command for plugins 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1809,6 +1809,7 @@ packages/pdf-viewer/types.js
 packages/pdf-viewer/ui/GotoPage.js
 packages/pdf-viewer/ui/IconButtons.js
 packages/pdf-viewer/ui/ZoomControls.js
+packages/plugin-repo-cli/commands/analyzePlugin.js
 packages/plugin-repo-cli/commands/updateRelease.js
 packages/plugin-repo-cli/index.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.js

--- a/.gitignore
+++ b/.gitignore
@@ -1782,6 +1782,7 @@ packages/pdf-viewer/types.js
 packages/pdf-viewer/ui/GotoPage.js
 packages/pdf-viewer/ui/IconButtons.js
 packages/pdf-viewer/ui/ZoomControls.js
+packages/plugin-repo-cli/commands/analyzePlugin.js
 packages/plugin-repo-cli/commands/updateRelease.js
 packages/plugin-repo-cli/index.js
 packages/plugin-repo-cli/lib/checkIfPluginCanBeAdded.test.js

--- a/packages/plugin-repo-cli/commands/analyzePlugin.ts
+++ b/packages/plugin-repo-cli/commands/analyzePlugin.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+
+import { execCommand } from '@joplin/utils';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+export default async function(args: any) {
+    const pluginId = args.pluginId;
+    const repoDir = args.pluginRepoDir;
+    const pluginPath = path.resolve(repoDir, 'plugins', pluginId);
+
+    if (!(await fs.pathExists(pluginPath))) {
+        throw new Error(`Plugin not found at ${pluginPath}`);
+    }
+
+    console.info(`Analysing plugin with Docker: ${pluginId}...`);
+
+    try {
+        // running semgrep via docker
+        const output = await execCommand([
+            'docker', 'run', '--rm',
+            '-v', `${pluginPath}:/src`,
+            'returntocorp/semgrep',
+            'semgrep',
+            '--config', 'p/security-audit',
+            '--config', 'p/typescript',
+            '--error', 
+            '/src'
+        ]);
+        console.info('No critical security issues found.');
+        console.log(output);
+    } catch (error) {
+        if (error.message.includes('docker: command not found')) {
+            console.error('Docker is not installed or running. Please ensure Docker is available.');
+        } else {
+            console.error('Security issues identified:');
+            console.error(error.message);
+        }
+    }
+}

--- a/packages/plugin-repo-cli/commands/analyzePlugin.ts
+++ b/packages/plugin-repo-cli/commands/analyzePlugin.ts
@@ -23,7 +23,9 @@ export default async function(args: any) {
             '-v', `${pluginPath}:/src`,
             'returntocorp/semgrep',
             'semgrep',
+            '--config', 'p/default',
             '--config', 'p/security-audit',
+            '--config', 'p/javascript',
             '--config', 'p/typescript',
             '--error', 
             '/src'

--- a/packages/plugin-repo-cli/index.ts
+++ b/packages/plugin-repo-cli/index.ts
@@ -17,6 +17,8 @@ import { applyManifestOverrides, getObsoleteManifests, getSupersededPackages, re
 import { execCommand } from '@joplin/utils';
 import validateUntrustedManifest from './lib/validateUntrustedManifest';
 import searchPlugins, { PackageInfo } from './lib/searchPlugins';
+import commandAnalyzePlugin from './commands/analyzePlugin';
+
 
 function pluginInfoFromSearchResults(results: PackageInfo[]): NpmPackage[] {
 	const output: NpmPackage[] = [];
@@ -290,6 +292,7 @@ async function main() {
 		build: commandBuild,
 		version: commandVersion,
 		updateRelease: commandUpdateRelease,
+		analyzePlugin: commandAnalyzePlugin,
 	};
 
 	let selectedCommand = '';
@@ -320,6 +323,15 @@ async function main() {
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		.command('update-release <plugin-repo-dir>', 'Update GitHub release', () => {}, (args: any) => setSelectedCommand('updateRelease', args))
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		.command('analyze-plugin <plugin-repo-dir> <plugin-id>', 'Analyze a plugin for security issues', (yargs: any) => {
+			yargs.positional('plugin-id', {
+				type: 'string',
+				describe: 'The id of the plugin to analyze',
+			});
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		}, (args: any) => setSelectedCommand('analyzePlugin', args))
 
 		.help()
 		.argv;

--- a/packages/tools/cspell/dictionary1.txt
+++ b/packages/tools/cspell/dictionary1.txt
@@ -367,6 +367,8 @@ Grønland
 grouptoolbarbutton
 Gruber
 gsoc
+semgrep
+returntocorp
 gttest
 Guåhån
 guarentee


### PR DESCRIPTION
This PR implements the automated security review command for plugins as requested in issue #12369. It introduces a new analyze-plugin command to the plugin-repo-cli that utilizes Semgrep executed via Docker. This ensures a consistent, zero-dependency environment for identifying vulnerabilities like unsafe eval calls or insecure network dependencies during the plugin vetting process.

## Key File Changes:
- packages/plugin-repo-cli/commands/analyzePlugin.ts
: Implemented new command logic for Dockerized Semgrep analysis.
- packages/plugin-repo-cli/index.ts
: Registered the analyze-plugin command in the CLI.
- packages/tools/cspell/dictionary1.txt
: Added semgrep and returntocorp to the project dictionary to pass pre-commit checks.
- packages/tools/cspell/dictionary1.txt
: Added semgrep and returntocorp to the project dictionary to pass pre-commit checks.

## Manual Testing of working
<img width="1428" height="813" alt="image" src="https://github.com/user-attachments/assets/c9abc05f-3577-42b2-805d-aed9fe4d7cb4" />
<img width="1389" height="861" alt="image" src="https://github.com/user-attachments/assets/02a19a8a-374a-42e1-8b77-42b3e8ed83be" />

## Testing done with following code

```copy
// this is a mock Joplin plugin for security testing
// It intentionally contains a vulnerability to test the semgrep scanner

function doSomethingInsecure(userInput) {
    // sec risk: 'eval' is dangerous and should be flagged by the scanner
    eval(userInput);
}

const joplin = require('joplin');

joplin.plugins.register({
    onStart: async function() {
        console.info('Security test plugin started');
    }
});
```

