### PR TITLE
Fixes #12507: Allow renaming a tag to the title of an orphaned tag

### DIFF
--- a/packages/lib/models/Tag.test.ts
+++ b/packages/lib/models/Tag.test.ts
@@ -212,6 +212,25 @@ describe('models/Tag', () => {
 		expect(commonTagIds.includes(tagc.id)).toBe(true);
 	});
 
+	it('should allow renaming a tag to the name of an orphaned tag', async () => {
+		const folder1 = await Folder.save({ title: 'folder1' });
+		const note1 = await Note.save({ title: 'note1', parent_id: folder1.id });
+		const note2 = await Note.save({ title: 'note2', parent_id: folder1.id });
+
+		await Tag.setNoteTagsByTitles(note1.id, ['un']);
+		await Tag.setNoteTagsByTitles(note2.id, ['deux']);
+
+		await Note.delete(note1.id, { toTrash: true });
+		await Note.delete(note1.id, { toTrash: false });
+
+		const tagDeux = await Tag.loadByTitle('deux');
+		const hasThrown = await checkThrowAsync(async () => await Tag.save({ id: tagDeux.id, title: 'un' }, { userSideValidation: true }));
+		expect(hasThrown).toBe(false);
+
+		const renamedTag = await Tag.load(tagDeux.id);
+		expect(renamedTag.title).toBe('un');
+	});
+
 	it('should allow finding tags when case does not match, for standard ASCII characters', async () => {
 		const note1 = await Note.save({});
 		await Tag.setNoteTagsByTitles(note1.id, ['Hello']);

--- a/packages/lib/models/Tag.ts
+++ b/packages/lib/models/Tag.ts
@@ -233,7 +233,14 @@ export default class Tag extends BaseItem {
 				o.title = o.title.trim();
 
 				const existingTag = await Tag.loadByTitle(o.title);
-				if (existingTag && existingTag.id !== o.id) throw new Error(_('The tag "%s" already exists. Please choose a different name.', o.title));
+				if (existingTag && existingTag.id !== o.id) {
+					const noteIds = await Tag.noteIds(existingTag.id);
+					if (noteIds.length === 0) {
+						await Tag.untagAll(existingTag.id);
+					} else {
+						throw new Error(_('The tag "%s" already exists. Please choose a different name.', o.title));
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
When a note with an exclusive tag is permanently deleted, the tag record remains in the database but becomes invisible in the UI (no active notes reference it). Attempting to rename another tag to this orphaned tag's name fails with "The tag already exists", even though the user cannot see or interact with the orphaned tag.

This fix checks whether the conflicting tag is an orphan (has no associated active notes) during rename validation. If so, it removes the orphaned tag and its stale note_tags records, allowing the rename to proceed. If the conflicting tag is still in use, the existing error is thrown as before.

Previous PRs (#13628, #14616) were closed due to concerns about sync complexity. #13628 cleaned up note_tags during permanent deletion; #14616 both cleaned up orphaned tags during deletion and handled rename conflicts. This PR takes a narrower approach — it only handles the rename conflict case without modifying the deletion flow, minimizing the impact on sync behavior.

A test case has been added to verify that renaming to an orphaned tag name succeeds.
