### PR TITLE
Desktop (macOS): Fixes: Enable Cmd+C copy shortcut in view mode

### DIFF
--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.test.ts
@@ -6,6 +6,7 @@ const baseContext: Record<string, any> = {
 	modalDialogVisible: false,
 	gotoAnythingVisible: false,
 	markdownEditorPaneVisible: true,
+	markdownViewerPaneVisible: false,
 	oneNoteSelected: true,
 	noteIsMarkdown: true,
 	noteIsReadOnly: false,
@@ -98,9 +99,38 @@ describe('editorCommandDeclarations', () => {
 			{
 				textBold: false,
 				textPaste: false,
-
-				// TODO: textCopy should be enabled in read-only notes:
-				// textCopy: false,
+				// textCopy should remain enabled even when the note is read-only
+				textCopy: true,
+			},
+		],
+		[
+			// Viewer-only mode (no editor pane visible, only the rendered viewer)
+			{
+				markdownEditorPaneVisible: false,
+				richTextEditorVisible: false,
+				markdownViewerPaneVisible: true,
+			},
+			{
+				// textCopy should be enabled so users can copy selected text from the viewer
+				textCopy: true,
+				// editing commands should remain disabled in viewer mode
+				textCut: false,
+				textPaste: false,
+				textBold: false,
+			},
+		],
+		[
+			// Viewer-only mode with a read-only note
+			{
+				markdownEditorPaneVisible: false,
+				richTextEditorVisible: false,
+				markdownViewerPaneVisible: true,
+				noteIsReadOnly: true,
+			},
+			{
+				textCopy: true,
+				textCut: false,
+				textPaste: false,
 			},
 		],
 	])('should correctly determine whether command is enabled (case %#)', (context, expectedStates) => {

--- a/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
+++ b/packages/app-desktop/gui/NoteEditor/editorCommandDeclarations.ts
@@ -10,18 +10,38 @@ const workWithHtmlNotes = [
 	'textSelectAll',
 ];
 
+// Commands that should remain enabled when only the viewer pane is visible (no editor pane).
+// Copy should work in viewer mode so users can copy selected text from the rendered note.
+const worksInViewerMode = [
+	'textCopy',
+];
+
+// Commands that should remain enabled even when the note is read-only.
+// Copy should work on read-only notes so users can still copy text from them.
+const worksInReadOnlyMode = [
+	'textCopy',
+];
+
 export const enabledCondition = (commandName: string) => {
 	const markdownEditorOnly = !Object.keys(joplinCommandToTinyMceCommands).includes(commandName);
 	const noteMustBeMarkdown = !workWithHtmlNotes.includes(commandName);
+	const allowInViewer = worksInViewerMode.includes(commandName);
+	const allowInReadOnly = worksInReadOnlyMode.includes(commandName);
+
+	const editorPaneCondition = markdownEditorOnly
+		? 'markdownEditorPaneVisible'
+		: allowInViewer
+			? '(markdownEditorPaneVisible || richTextEditorVisible || markdownViewerPaneVisible)'
+			: '(markdownEditorPaneVisible || richTextEditorVisible)';
 
 	const output = [
 		// gotoAnythingVisible: Enable if the command palette (which is a modal dialog) is visible
 		'(!modalDialogVisible || gotoAnythingVisible)',
 
-		markdownEditorOnly ? 'markdownEditorPaneVisible' : '(markdownEditorPaneVisible || richTextEditorVisible)',
+		editorPaneCondition,
 		'oneNoteSelected',
 		noteMustBeMarkdown ? 'noteIsMarkdown' : '',
-		'!noteIsReadOnly',
+		allowInReadOnly ? '' : '!noteIsReadOnly',
 	];
 
 	return output.filter(c => !!c).join(' && ');


### PR DESCRIPTION
The current version of Joplin disables the "Copy" command from the edit menu when in view mode. While this may not be a major issue on other platforms, on macOS the Cmd+C shortcut relies on the presence of the "Copy" item in the menu. As a result, this behavior prevents users from using the Cmd+C shortcut to copy in view mode on macOS. This PR fixes the issue.