### PR TITLE
Mobile: Fixes #14685: Restrict sidebar gestures to notebook list

### DIFF
--- a/packages/app-mobile/root.tsx
+++ b/packages/app-mobile/root.tsx
@@ -715,13 +715,15 @@ class AppComponent extends React.Component<AppComponentProps, AppComponentState>
 
 		let sideMenuContent: ReactNode = null;
 		let menuPosition = SideMenuPosition.Left;
-		let disableSideMenuGestures = this.props.disableSideMenuGestures;
+		let disableSideMenuGestures = true;
 
 		if (this.props.routeName === 'Note') {
 			sideMenuContent = <SideMenuContentNote options={this.props.noteSideMenuOptions}/>;
 			menuPosition = SideMenuPosition.Right;
-		} else if (this.props.routeName === 'Config') {
-			disableSideMenuGestures = true;
+			disableSideMenuGestures = this.props.disableSideMenuGestures;
+		} else if (this.props.routeName === 'Notes') {
+			sideMenuContent = <SideMenuContent/>;
+			disableSideMenuGestures = false;
 		} else {
 			sideMenuContent = <SideMenuContent/>;
 		}


### PR DESCRIPTION
Fixes #14685

The left notebook sidebar could be opened by swiping on screens where it shouldn't be available (e.g. Profiles, Log, Sync Status, Note History). Previously, gestures were enabled by default and only explicitly disabled on the Config screen.

This changes the approach - gestures are now disabled by default and only enabled on:
- `Notes` screen (left notebook sidebar)
- `Note` screen (right-side note options, still respects image editor override)

Tested on Android.

**Log screen**
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/d6a75e14-082a-499c-8fad-f02d06765cd9" width="150"> | <img src="https://github.com/user-attachments/assets/0fd70bd6-f0f2-4f71-ab77-6dda2442bdd6" width="150"> |

**Sync Status screen**
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/6ae19edc-e69e-40c5-8e06-9ead8cae8731" width="150"> | <img src="https://github.com/user-attachments/assets/f04a436c-2d34-4084-b16b-9a264567defb" width="150"> |