### PR TITLE
Improve error handling and clarify master password warning message

### DIFF
--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -81,7 +81,11 @@ export default function(props: Props) {
 				void reg.waitForSyncFinishedThenSync();
 				onClose();
 			} catch (error) {
-				void shim.showErrorDialog(error.message);
+				if (error instanceof Error) {
+					void shim.showErrorDialog(error.message);
+				} else {
+					void shim.showErrorDialog(String(error));
+				}
 			} finally {
 				setUpdatingPassword(false);
 			}
@@ -195,7 +199,11 @@ export default function(props: Props) {
 							</>
 						)}
 					</div>
-					<p className="bold">Please make sure you remember your password. For security reasons, it is not possible to recover it if it is lost.</p>
+					<p className="bold">
+  Please make sure you remember your master password. For security reasons,
+  it cannot be recovered if lost, and any data encrypted with it may become inaccessible.
+					</p>
+
 					{renderResetMasterPasswordLink()}
 				</div>
 			);


### PR DESCRIPTION
Fixes #14717

## Problem

The master password dialog currently displays a warning message about remembering the password, but the wording can be unclear for users. Additionally, the error handling in the catch block assumes that the thrown value is always an Error object, which may not always be the case.

## Solution

Improve the warning message to clearly explain that the master password cannot be recovered if lost and that encrypted data may become inaccessible.

Also update the catch block to safely handle both Error and non-Error exceptions by checking the type of the thrown value before displaying the error message.

## Test Plan

1. Run the desktop application.
2. Open the Master Password dialog.
3. Verify that the warning message clearly explains the consequences of losing the master password.
4. Trigger an error scenario (for example by entering an invalid current password).
5. Confirm that the error dialog still displays the correct message without crashing.

