### PR TITLE
Desktop: Replace smalltalk with React Dialog to add password visibility in encryption setup

### DIFF
--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -45,7 +45,8 @@ export const EncryptionConfigScreen = (props: Props) => {
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
 	const [enableEncryptionPromptVisible, setEnableEncryptionPromptVisible] = useState(false);
 	const [enableEncryptionPassword, setEnableEncryptionPassword] = useState('');
-	const [enableEncryptionError, setEnableEncryptionError] = useState('');
+	const promptPromiseRef = useRef<(password: string | null)=> void>(null);
+
 	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
 
 	const theme = useMemo(() => {
@@ -237,69 +238,52 @@ export const EncryptionConfigScreen = (props: Props) => {
 		return null;
 	};
 
-	const onEnableEncryptionConfirm = useCallback(async (newPassword: string) => {
-		setEnableEncryptionError('');
-
-		if (!newPassword) {
-			setEnableEncryptionPromptVisible(false);
-			return; // cancelled
-		}
-
-		const masterKey = getDefaultMasterKey();
-		const hasMasterPassword = !!props.masterPassword;
-
-		if (hasMasterPassword) {
-			if (!(await masterPasswordIsValid(newPassword))) {
-				setEnableEncryptionError(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'));
-				return;
-			}
-		}
-
-		try {
-			await toggleAndSetupEncryption(EncryptionService.instance(), true, masterKey, newPassword);
-			setEnableEncryptionPromptVisible(false);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			setEnableEncryptionError(message);
-		}
-	}, [props.masterPassword]);
-
 	const onToggleButtonClick = useCallback(async () => {
 		const isEnabled = getEncryptionEnabled();
 		const newEnabled = !isEnabled;
 		const masterKey = getDefaultMasterKey();
 		const hasMasterPassword = !!props.masterPassword;
+		let newPassword: string | null = '';
 
-		// Disabling encryption logic
 		if (isEnabled) {
 			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
 			if (!answer) return;
-
-			// Perform disable request directly as password is not needed
-			try {
-				await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, '');
-			} catch (error) {
-				await dialogs.alert(error.message);
+		} else {
+			if (shouldOpenMasterPasswordDialogForEnable({
+				hasMasterPassword,
+				masterPasswordDialogOpen: props.masterPasswordDialogOpen,
+			})) {
+				setPendingEnableEncryption(true);
+				props.dispatch({
+					type: 'DIALOG_OPEN',
+					name: AppStateDialogName.MasterPassword,
+				});
+				return;
 			}
-			return;
-		}
 
-		if (shouldOpenMasterPasswordDialogForEnable({
-			hasMasterPassword,
-			masterPasswordDialogOpen: props.masterPasswordDialogOpen,
-		})) {
-			setPendingEnableEncryption(true);
-			props.dispatch({
-				type: 'DIALOG_OPEN',
-				name: AppStateDialogName.MasterPassword,
+			// Wait for the custom React Dialog to resolve
+			setEnableEncryptionPassword('');
+			setEnableEncryptionPromptVisible(true);
+			newPassword = await new Promise<string | null>((resolve) => {
+				promptPromiseRef.current = resolve;
 			});
-			return;
+
+			if (newPassword === null) return; // User cancelled
 		}
 
-		// Trigger inner logic for asking password via custom dialog
-		setEnableEncryptionPassword('');
-		setEnableEncryptionError('');
-		setEnableEncryptionPromptVisible(true);
+		if (hasMasterPassword && newEnabled) {
+			if (!(await masterPasswordIsValid(newPassword))) {
+				await dialogs.alert(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'));
+				return;
+			}
+		}
+
+		try {
+			await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, newPassword);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			await dialogs.alert(message);
+		}
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 
 	const renderEnableEncryptionDialog = () => {
@@ -313,6 +297,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 		const onClose = () => {
 			setEnableEncryptionPromptVisible(false);
+			if (promptPromiseRef.current) promptPromiseRef.current(null);
 		};
 
 		const onDialogButtonRowClick = (event: { buttonName: string }) => {
@@ -321,13 +306,13 @@ export const EncryptionConfigScreen = (props: Props) => {
 				return;
 			}
 			if (event.buttonName === 'ok') {
-				void onEnableEncryptionConfirm(enableEncryptionPassword);
+				setEnableEncryptionPromptVisible(false);
+				if (promptPromiseRef.current) promptPromiseRef.current(enableEncryptionPassword);
 			}
 		};
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required because PasswordInput's ChangeEventHandler type is incorrect
 		const onPasswordInputChange = (event: any) => {
-			setEnableEncryptionError('');
 			setEnableEncryptionPassword(event.target.value);
 		};
 
@@ -346,11 +331,6 @@ export const EncryptionConfigScreen = (props: Props) => {
 								value={enableEncryptionPassword}
 								onChange={onPasswordInputChange}
 							/>
-							{enableEncryptionError && (
-								<div style={{ ...theme.textStyle, color: theme.colorError, marginTop: 10, marginBottom: 10 }}>
-									{enableEncryptionError}
-								</div>
-							)}
 						</div>
 					</div>
 					<DialogButtonRow

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -281,7 +281,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 		try {
 			await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, newPassword);
 		} catch (error) {
-		    await dialogs.alert(error.message);
+			await dialogs.alert(error.message);
 		}
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -24,6 +24,7 @@ import Dialog from '@joplin/lib/components/Dialog';
 import DialogButtonRow from '../DialogButtonRow';
 import DialogTitle from '../DialogTitle';
 import PasswordInput from '../PasswordInput/PasswordInput';
+import { ChangeEvent } from '../PasswordInput/types';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -311,8 +312,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 			}
 		};
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required because PasswordInput's ChangeEventHandler type is incorrect
-		const onPasswordInputChange = (event: any) => {
+		const onPasswordInputChange = (event: ChangeEvent) => {
 			setEnableEncryptionPassword(event.target.value);
 		};
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -24,7 +24,6 @@ import Dialog from '@joplin/lib/components/Dialog';
 import DialogButtonRow from '../DialogButtonRow';
 import DialogTitle from '../DialogTitle';
 import PasswordInput from '../PasswordInput/PasswordInput';
-import { ChangeEvent } from '../PasswordInput/types';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -274,16 +273,15 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 		if (hasMasterPassword && newEnabled) {
 			if (!(await masterPasswordIsValid(newPassword))) {
-				await dialogs.alert(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'));
+				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
 				return;
 			}
 		}
 
 		try {
 			await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, newPassword);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			await dialogs.alert(message);
+		} catch (error: any) {
+			await dialogs.alert(error.message);
 		}
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 
@@ -312,7 +310,8 @@ export const EncryptionConfigScreen = (props: Props) => {
 			}
 		};
 
-		const onPasswordInputChange = (event: ChangeEvent) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required because PasswordInput's ChangeEventHandler type is incorrect
+		const onPasswordInputChange = (event: any) => {
 			setEnableEncryptionPassword(event.target.value);
 		};
 

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -317,7 +317,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 		};
 
 		return (
-			<Dialog onCancel={onClose}>
+			<Dialog onCancel={onClose} className="enable-encryption-dialog">
 				<div className="dialog-root">
 					<DialogTitle title={_('Enable encryption')}/>
 					<div className="dialog-content">

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -45,6 +45,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
 	const [enableEncryptionPromptVisible, setEnableEncryptionPromptVisible] = useState(false);
 	const [enableEncryptionPassword, setEnableEncryptionPassword] = useState('');
+	const [enableEncryptionError, setEnableEncryptionError] = useState('');
 	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
 
 	const theme = useMemo(() => {
@@ -237,23 +238,29 @@ export const EncryptionConfigScreen = (props: Props) => {
 	};
 
 	const onEnableEncryptionConfirm = useCallback(async (newPassword: string) => {
-		setEnableEncryptionPromptVisible(false);
-		if (!newPassword) return; // cancelled
+		setEnableEncryptionError('');
+
+		if (!newPassword) {
+			setEnableEncryptionPromptVisible(false);
+			return; // cancelled
+		}
 
 		const masterKey = getDefaultMasterKey();
 		const hasMasterPassword = !!props.masterPassword;
 
 		if (hasMasterPassword) {
 			if (!(await masterPasswordIsValid(newPassword))) {
-				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
+				setEnableEncryptionError(_('Invalid password. Please try again. If you have forgotten your password you will need to reset it.'));
 				return;
 			}
 		}
 
 		try {
 			await toggleAndSetupEncryption(EncryptionService.instance(), true, masterKey, newPassword);
+			setEnableEncryptionPromptVisible(false);
 		} catch (error) {
-			await dialogs.alert(error.message);
+			const message = error instanceof Error ? error.message : String(error);
+			setEnableEncryptionError(message);
 		}
 	}, [props.masterPassword]);
 
@@ -291,6 +298,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 		// Trigger inner logic for asking password via custom dialog
 		setEnableEncryptionPassword('');
+		setEnableEncryptionError('');
 		setEnableEncryptionPromptVisible(true);
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 
@@ -317,6 +325,12 @@ export const EncryptionConfigScreen = (props: Props) => {
 			}
 		};
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Required because PasswordInput's ChangeEventHandler type is incorrect
+		const onPasswordInputChange = (event: any) => {
+			setEnableEncryptionError('');
+			setEnableEncryptionPassword(event.target.value);
+		};
+
 		return (
 			<Dialog onCancel={onClose}>
 				<div className="dialog-root">
@@ -330,8 +344,13 @@ export const EncryptionConfigScreen = (props: Props) => {
 							<PasswordInput
 								inputId="enable-encryption-password"
 								value={enableEncryptionPassword}
-								onChange={(event) => setEnableEncryptionPassword(event.value)}
+								onChange={onPasswordInputChange}
 							/>
+							{enableEncryptionError && (
+								<div style={{ ...theme.textStyle, color: theme.colorError, marginTop: 10, marginBottom: 10 }}>
+									{enableEncryptionError}
+								</div>
+							)}
 						</div>
 					</div>
 					<DialogButtonRow

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -20,6 +20,10 @@ import ToggleAdvancedSettingsButton from '../ConfigScreen/controls/ToggleAdvance
 import MacOSMissingPasswordHelpLink from '../ConfigScreen/controls/MissingPasswordHelpLink';
 import { Dispatch } from 'redux';
 import { shouldCancelPendingEnableAfterMasterPasswordDialog, shouldOpenMasterPasswordDialogForEnable, shouldResumeEnableAfterMasterPasswordDialog } from './enableFlow';
+import Dialog from '@joplin/lib/components/Dialog';
+import DialogButtonRow from '../DialogButtonRow';
+import DialogTitle from '../DialogTitle';
+import PasswordInput from '../PasswordInput/PasswordInput';
 
 interface Props {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -39,6 +43,8 @@ interface Props {
 export const EncryptionConfigScreen = (props: Props) => {
 	const { inputPasswords, onInputPasswordChange } = useInputPasswords(props.passwords);
 	const [pendingEnableEncryption, setPendingEnableEncryption] = useState(false);
+	const [enableEncryptionPromptVisible, setEnableEncryptionPromptVisible] = useState(false);
+	const [enableEncryptionPassword, setEnableEncryptionPassword] = useState('');
 	const wasMasterPasswordDialogOpen = useRef(props.masterPasswordDialogOpen);
 
 	const theme = useMemo(() => {
@@ -230,34 +236,14 @@ export const EncryptionConfigScreen = (props: Props) => {
 		return null;
 	};
 
-	const onToggleButtonClick = useCallback(async () => {
-		const isEnabled = getEncryptionEnabled();
-		const newEnabled = !isEnabled;
+	const onEnableEncryptionConfirm = useCallback(async (newPassword: string) => {
+		setEnableEncryptionPromptVisible(false);
+		if (!newPassword) return; // cancelled
+
 		const masterKey = getDefaultMasterKey();
 		const hasMasterPassword = !!props.masterPassword;
-		let newPassword = '';
 
-		if (isEnabled) {
-			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
-			if (!answer) return;
-		} else {
-			if (shouldOpenMasterPasswordDialogForEnable({
-				hasMasterPassword,
-				masterPasswordDialogOpen: props.masterPasswordDialogOpen,
-			})) {
-				setPendingEnableEncryption(true);
-				props.dispatch({
-					type: 'DIALOG_OPEN',
-					name: AppStateDialogName.MasterPassword,
-				});
-				return;
-			}
-
-			const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
-			newPassword = await dialogs.prompt(msg.join('\n\n'), '', '', { type: 'password' });
-		}
-
-		if (hasMasterPassword && newEnabled) {
+		if (hasMasterPassword) {
 			if (!(await masterPasswordIsValid(newPassword))) {
 				await dialogs.alert('Invalid password. Please try again. If you have forgotten your password you will need to reset it.');
 				return;
@@ -265,11 +251,98 @@ export const EncryptionConfigScreen = (props: Props) => {
 		}
 
 		try {
-			await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, newPassword);
+			await toggleAndSetupEncryption(EncryptionService.instance(), true, masterKey, newPassword);
 		} catch (error) {
 			await dialogs.alert(error.message);
 		}
+	}, [props.masterPassword]);
+
+	const onToggleButtonClick = useCallback(async () => {
+		const isEnabled = getEncryptionEnabled();
+		const newEnabled = !isEnabled;
+		const masterKey = getDefaultMasterKey();
+		const hasMasterPassword = !!props.masterPassword;
+
+		// Disabling encryption logic
+		if (isEnabled) {
+			const answer = await dialogs.confirm(_('Disabling encryption means *all* your notes and attachments are going to be re-synchronised and sent unencrypted to the sync target. Do you wish to continue?'));
+			if (!answer) return;
+
+			// Perform disable request directly as password is not needed
+			try {
+				await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, '');
+			} catch (error) {
+				await dialogs.alert(error.message);
+			}
+			return;
+		}
+
+		if (shouldOpenMasterPasswordDialogForEnable({
+			hasMasterPassword,
+			masterPasswordDialogOpen: props.masterPasswordDialogOpen,
+		})) {
+			setPendingEnableEncryption(true);
+			props.dispatch({
+				type: 'DIALOG_OPEN',
+				name: AppStateDialogName.MasterPassword,
+			});
+			return;
+		}
+
+		// Trigger inner logic for asking password via custom dialog
+		setEnableEncryptionPassword('');
+		setEnableEncryptionPromptVisible(true);
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
+
+	const renderEnableEncryptionDialog = () => {
+		if (!enableEncryptionPromptVisible) return null;
+
+		const masterKey = getDefaultMasterKey();
+		const hasMasterPassword = !!props.masterPassword;
+
+		const msg = enableEncryptionConfirmationMessages(masterKey, hasMasterPassword);
+		const messageComps = msg.map((m, index) => <p key={index} style={theme.textStyle}>{m}</p>);
+
+		const onClose = () => {
+			setEnableEncryptionPromptVisible(false);
+		};
+
+		const onDialogButtonRowClick = (event: { buttonName: string }) => {
+			if (event.buttonName === 'cancel') {
+				onClose();
+				return;
+			}
+			if (event.buttonName === 'ok') {
+				void onEnableEncryptionConfirm(enableEncryptionPassword);
+			}
+		};
+
+		return (
+			<Dialog onCancel={onClose}>
+				<div className="dialog-root">
+					<DialogTitle title={_('Enable encryption')}/>
+					<div className="dialog-content">
+						<div style={{ marginBottom: 16 }}>
+							{messageComps}
+						</div>
+						<div style={{ marginBottom: 16 }}>
+							<label style={{ ...theme.textStyle, marginBottom: 5, display: 'block' }} htmlFor="enable-encryption-password">{_('Password:')}</label>
+							<PasswordInput
+								inputId="enable-encryption-password"
+								value={enableEncryptionPassword}
+								onChange={(event) => setEnableEncryptionPassword(event.value)}
+							/>
+						</div>
+					</div>
+					<DialogButtonRow
+						themeId={props.themeId}
+						onClick={onDialogButtonRowClick}
+						okButtonDisabled={!enableEncryptionPassword}
+					/>
+				</div>
+			</Dialog>
+		);
+	};
 
 	const renderEncryptionSection = () => {
 		const decryptedItemsInfo = <p>{decryptedStatText(stats)}</p>;
@@ -451,6 +524,7 @@ export const EncryptionConfigScreen = (props: Props) => {
 			{renderMasterKeySection(props.masterKeys.filter(mk => !masterKeyEnabled(mk)), false)}
 			{renderNonExistingMasterKeysSection()}
 			{renderAdvancedSection()}
+			{renderEnableEncryptionDialog()}
 		</div>
 	);
 };

--- a/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
+++ b/packages/app-desktop/gui/EncryptionConfigScreen/EncryptionConfigScreen.tsx
@@ -280,8 +280,8 @@ export const EncryptionConfigScreen = (props: Props) => {
 
 		try {
 			await toggleAndSetupEncryption(EncryptionService.instance(), newEnabled, masterKey, newPassword);
-		} catch (error: any) {
-			await dialogs.alert(error.message);
+		} catch (error) {
+		    await dialogs.alert(error.message);
 		}
 	}, [props.dispatch, props.masterPassword, props.masterPasswordDialogOpen]);
 

--- a/packages/app-desktop/gui/PasswordInput/types.ts
+++ b/packages/app-desktop/gui/PasswordInput/types.ts
@@ -1,5 +1,5 @@
 export interface ChangeEvent {
-    value: string;
+	value: string;
 }
 
 export type ChangeEventHandler = (event: ChangeEvent)=> void;

--- a/packages/app-desktop/gui/PasswordInput/types.ts
+++ b/packages/app-desktop/gui/PasswordInput/types.ts
@@ -1,3 +1,4 @@
+
 export interface ChangeEvent {
 	value: string;
 }

--- a/packages/app-desktop/gui/PasswordInput/types.ts
+++ b/packages/app-desktop/gui/PasswordInput/types.ts
@@ -1,4 +1,5 @@
-import { ChangeEvent as ReactChangeEvent } from 'react';
+export interface ChangeEvent {
+    value: string;
+}
 
-export type ChangeEvent = ReactChangeEvent<HTMLInputElement>;
 export type ChangeEventHandler = (event: ChangeEvent)=> void;

--- a/packages/app-desktop/gui/PasswordInput/types.ts
+++ b/packages/app-desktop/gui/PasswordInput/types.ts
@@ -1,6 +1,4 @@
+import { ChangeEvent as ReactChangeEvent } from 'react';
 
-export interface ChangeEvent {
-	value: string;
-}
-
+export type ChangeEvent = ReactChangeEvent<HTMLInputElement>;
 export type ChangeEventHandler = (event: ChangeEvent)=> void;

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -290,18 +290,18 @@ Component-specific classes
 	padding-bottom: 20px;
 }
 
-.master-password-dialog .dialog-root {
+.master-password-dialog .dialog-root, .enable-encryption-dialog .dialog-root {
 	min-width: 500px;
 	max-width: 600px;
 }
 
-.master-password-dialog .dialog-content {
+.master-password-dialog .dialog-content, .enable-encryption-dialog .dialog-content {
 	background-color: var(--joplin-background-color3);
 	padding: 1em;
 	padding-bottom: 1px;
 }
 
-.master-password-dialog .current-password-wrapper {
+.master-password-dialog .current-password-wrapper, .enable-encryption-dialog .current-password-wrapper {
 	display: flex;
 	flex-direction: row;
 	align-items: center;


### PR DESCRIPTION
### Description
Currently, when a user clicks "Enable encryption", the app asks for their password but masks the input entirely. Since this password is going to be used to encrypt their entire database, making a typo here can cause a lot of stress. 

This PR adds a "show password" (eye icon) toggle to that prompt so users can easily view and verify their password while typing.

### Technical details & Implementation
Initially, I looked into just adding an HTML button to the existing prompt, but I noticed we were using the `dialogs.prompt()` method there, which relies under the hood on the legacy `smalltalk` library. Because `smalltalk` generates its DOM outside of our React tree, we can't cleanly inject custom components or buttons into it.

To solve this and give the user the right to view their password, I completely replaced the legacy `smalltalk` prompt with our native, already-built React `<Dialog>` and `<PasswordInput>` components. 

**Here is exactly how I refactored the flow:**
* **State Management:** I introduced two new state variables (`enableEncryptionPromptVisible` and `enableEncryptionPassword`). 
* **The Flow:** Instead of halting javascript execution with an `await dialogs.prompt(...)` call, clicking the "Enable encryption" button now just sets `enableEncryptionPromptVisible` to `true`. This opens our custom React Dialog.
* **The Logic:** When the user clicks "OK" in the new dialog, it passes the typed password directly to the exact same `toggleAndSetupEncryption(...)` function as before. 

### Why is this better?
1. **Safety:** Absolutely no logical or encryption-related code was touched, only the frontend UI triggering it. 
2. **Consistency:** Using the pre-built `<PasswordInput>` gives us the show/hide eye toggle for free, and using `<Dialog>` ensures this popup natively respects Joplin's existing CSS system (like the `dialog-root` and `dialog-content` wrappers for dark/light themes). 

### Testing
- [x] Clicked "Enable encryption" and verified the customized React modal opens.
- [x] Typed a password and clicked the eye icon to verify it toggles text visibility properly.
- [x] Verified that hitting "Cancel" cleanly closes the modal by resetting the state, without triggering encryption.
- [x] Verified that confirming with a valid password successfully triggers the encryption background setup.


### Before:
<img width="429" height="248" alt="Screenshot From 2026-03-14 22-17-16 (Edited)" src="https://github.com/user-attachments/assets/09122e54-0db3-4e51-8090-ceecfb688e97" />


### After:
<img width="765" height="308" alt="image" src="https://github.com/user-attachments/assets/5aeabee9-5274-41ba-8fb3-2d2c7ccae5b9" />

### After all alterations(both light and dark mode):
<img width="767" height="387" alt="Screenshot From 2026-03-23 21-00-44" src="https://github.com/user-attachments/assets/c86e756c-36fc-4d90-9283-f02ffc5f6008" />
<img width="767" height="387" alt="Screenshot From 2026-03-23 21-01-09" src="https://github.com/user-attachments/assets/5d8d2895-d788-4392-a15a-890fb1724fc7" />

