### PR TITLE
Mobile: Fix tag association screen gap after keyboard dismiss on Android

### DIFF
--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -24,7 +24,7 @@ const modalPropOverrides = {
 		keyboardShouldPersistTaps: true,
 	},
 	containerStyle: {
-		height: '100%',
+		flex: 1,
 	} as ViewStyle,
 };
 


### PR DESCRIPTION
#14740
AI Assistance Disclosure
- I used AI assistance (Claude) for drafting code.
- PR description was drafted with AI assistance and reviewed by me.

Problem
The gap on the bottom is present in the tag association of modal when opening/closing the on-screen keyboard.

Root Cause
The underlying cause was that the KeyboardAvoidingView style of the Modal.tsx file ( ...absoluteFill(position: absolute)) was on the KeyboardAvoidingView which prevented the KeyboardAvoidingView to resize correctly when the on-screen keyboard was closed.

Fix
The style of the keyBoardAvoidingView had the...absoluteFill taken out of it, giving it flex: 1, which will enable it to resize when the on-screen keyboard is closed.

Test Plan
Steps to reproduce the issue:
- Open a note on Android
- Open tag association screen
- Tick on search tags to access on-screen keyboard.
- Close on-screen keyboard
- Check to ensure that no gap is at the bottom of the screen.
Before Fix
and on closing the on-screen keyboard, a gap appears at the bottom of the tag association modal.
After Fix
1. Open a note
2. Open tag association screen
3. Tap Search tags input - keyboard opens
4. Dismiss keyboard
5. Verified no gap appears at bottom of modal