### PR TITLE
CLI : Resolves #11631 Update command-sync.ts

### DIFF
--- a/packages/app-cli/app/command-sync.ts
+++ b/packages/app-cli/app/command-sync.ts
@@ -18,6 +18,7 @@ import { checkIfLoginWasSuccessful, generateApplicationConfirmUrl } from '@jopli
 import Logger from '@joplin/utils/Logger';
 import { uuidgen } from '@joplin/lib/uuid';
 import ShareService from '@joplin/lib/services/share/ShareService';
+import SearchEngine from '@joplin/lib/services/search/SearchEngine';
 
 const logger = Logger.create('command-sync');
 
@@ -261,6 +262,13 @@ class Command extends BaseCommand {
 				this.stdout(_('Downloading resources...'));
 				await ResourceFetcher.instance().fetchAll();
 				await ResourceFetcher.instance().waitForAllFinished();
+				// add searchengine index refresh for solving the issue ## 11631
+				try {
+					this.stdout(_('Updating search index...'));
+					await SearchEngine.instance().syncTables();
+				} catch (error) {
+					this.stderr(_('Search index update failed: %s', error.message));
+				}
 			}
 
 			const noPasswordMkIds = await masterKeysWithoutPassword();


### PR DESCRIPTION
// add searchengine index refresh for solving the issue ## 11631 of stale search result

https://github.com/laurent22/joplin/issues/11631

Problem: 
Searchengine index was not refreshing after the joplin sync command in CLI which was causing API to fail in searching newly added/modified notes after the sync.

Reason: 
If we were using TUI or GUI joplin, searchengine scheduler would have rebuilt index after sometime. However, CLI client executing "sync" command exits before the searchengine scheduler could be triggered to reindex notes. Hence, searchengine index in "REST API server Joplin" is stale and is unable to find newly added notes in search api call. 

Solution:
Therefore for the solution, we can call this function [public async syncTables()](https://github.com/laurent22/joplin/blob/27433ad2ef59758772d06d7c3fabd1f1d7dc3513/packages/lib/services/search/SearchEngine.ts#L341) after the sync is finished, it ensures that searchindex is refreshed. We will need to add this in Command_sync.ts present in app-cli.

I have added this function in command-sync.ts to be called when command is used in non-gui mode. therefore once the sync complete and data is syncronised, searchengine instance is asked to refresh its index.

Further we do not need to call for refreshing the searchengine index in case of changes made by REST API as was [suggested ](https://github.com/laurent22/joplin/issues/11631#issuecomment-2591416459) in the discussion of this issue. these changes will be handled by searchengine scheduler present in instance of Joplin which is receiving REST API calls.

Test : 
I have tested the following fix by adding syncTables() functions in packages/app-cli/app/command-sync.ts and is working fine to solve this issue as following are the response from rest API calls :

**pre-built joplin  :**
REST get query : curl "http://127.0.0.1:41184/notes/2cb8538b03d640439ba5adefa5084e71?token=..."
{
"id": "2cb8538b03d640439ba5adefa5084e71",
"parent_id": "9b536cd639e44d9b8353f8436c62fabf",
"title": "server reindexing",
"deleted_time": 0,
"type_": 1
}
REST search query: curl "http://127.0.0.1:41184/search?query=reindex&token=..."
{
"items": [],
"has_more": false
}


**local build :**

REST get query : curl "http://127.0.0.1:27583/notes/2cb8538b03d640439ba5adefa5084e71?token=..."
{
"id": "2cb8538b03d640439ba5adefa5084e71",
"parent_id": "9b536cd639e44d9b8353f8436c62fabf",
"title": "server reindexing",
"deleted_time": 0,
"type_": 1
}

REST search query: curl "http://127.0.0.1:27583/search?query=reindex&token=..."
{
"items": [
{
"id": "2cb8538b03d640439ba5adefa5084e71",
"parent_id": "9b536cd639e44d9b8353f8436c62fabf",
"title": "server reindexing",
"deleted_time": 0
}
],
"has_more": false
}


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->



AI disclosure:
A local LLM were used during the investigation and development process, specifically to help and analyse the issue logs and investigate the root cause related to URI encoding, it was also used to suggest test cases to validate the fix across different filename edge cases.

I have reviewed and understood all the changes, compiled the application locally, and tested the fix to confirm it works as intended.