### PR TITLE
Desktop: Wrap hardcoded strings in MasterPasswordDialog with _() for i18n

### DIFF
--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -164,11 +164,11 @@ export default function(props: Props) {
 		const renderResetMasterPasswordLink = () => {
 			if (mode === Mode.Reset) return null;
 			if (status === MasterPasswordStatus.Valid) return null;
-			return <p><a href="#" onClick={onToggleMode}>Reset master password</a></p>;
+			return <p><a href="#" onClick={onToggleMode}>{_('Reset master password')}</a></p>;
 		};
 
 		if (showPasswordForm) {
-			const enterPasswordLabel = [MasterPasswordStatus.Loaded, MasterPasswordStatus.Valid].includes(status) ? 'Enter new password' : 'Enter password';
+			const enterPasswordLabel = [MasterPasswordStatus.Loaded, MasterPasswordStatus.Valid].includes(status) ? _('Enter new password') : _('Enter password');
 
 			return (
 				<div>
@@ -197,14 +197,14 @@ export default function(props: Props) {
 							</>
 						)}
 					</div>
-					<p className="bold">Please make sure you remember your password. For security reasons, it is not possible to recover it if it is lost.</p>
+					<p className="bold">{_('Please make sure you remember your password. For security reasons, it is not possible to recover it if it is lost.')}</p>
 					{renderResetMasterPasswordLink()}
 				</div>
 			);
 		} else {
 			return (
 				<p>
-					<a onClick={onShowPasswordForm} href="#">Change master password</a>
+					<a onClick={onShowPasswordForm} href="#">{_('Change master password')}</a>
 				</p>
 			);
 		}
@@ -214,16 +214,16 @@ export default function(props: Props) {
 		if (mode === Mode.Reset) {
 			return (
 				<div className="dialog-content">
-					<p>Attention: After resetting your password it will no longer be possible to decrypt any data encrypted with your current password. All encrypted shared notebooks will also be unshared, so please ask the notebook owner to share it again with you.</p>
+					<p>{_('Attention: After resetting your password it will no longer be possible to decrypt any data encrypted with your current password. All encrypted shared notebooks will also be unshared, so please ask the notebook owner to share it again with you.')}</p>
 					{renderPasswordForm()}
 				</div>
 			);
 		} else {
 			return (
 				<div className="dialog-content">
-					<p>Your master password is used to protect sensitive information. In particular, it is used to encrypt your notes when end-to-end encryption (E2EE) is enabled, or to share and encrypt notes with someone who has E2EE enabled.</p>
+					<p>{_('Your master password is used to protect sensitive information. In particular, it is used to encrypt your notes when end-to-end encryption (E2EE) is enabled, or to share and encrypt notes with someone who has E2EE enabled.')}</p>
 					<p>
-						<span>{'Master password status:'}</span> <span className="bold">{getMasterPasswordStatusMessage(status)}</span>
+						<span>{_('Master password status:')}</span> <span className="bold">{getMasterPasswordStatusMessage(status)}</span>
 					</p>
 					{renderPasswordForm()}
 				</div>


### PR DESCRIPTION
### Problem

The Master Password dialog is partially untranslatable for non-English Joplin users. Seven user-facing strings — including password entry labels, security warnings, and action links — are hardcoded in English rather than wrapped in the `_()` translation function. This means users who run Joplin in other languages see a mix of translated and untranslated text in this critical security dialog, which degrades the user experience and can cause confusion when managing encryption passwords.

The affected strings are:
- "Enter password" / "Enter new password" labels
- "Reset master password" and "Change master password" link text
- The security warning about remembering passwords
- The reset mode warning about data loss
- The description explaining what the master password is used for
- "Master password status:" label

### Solution

Wrapped all 7 hardcoded strings with `_()` from `@joplin/lib/locale`, which is already imported and used for other strings in the same file (e.g., "Current password", "Re-enter password", dialog titles). This registers the strings for extraction by Joplin's translation tooling, enabling community translators to provide localized versions.

This is a text-only change with no functional impact — the English strings remain identical, and no control flow or logic is modified.

### Test Plan

1. Open **Tools → Manage master password**
2. Verify all labels, warnings, and descriptions render correctly in English (identical to current behaviour)
3. Click "Reset master password" link — verify reset mode text also renders correctly
4. Switch Joplin locale to a non-English language — verify the strings are now available for translation (they appear in English until translations are contributed, but `_()` ensures they are picked up by the translation extraction tooling)