### PR TITLE
Mobile: Fixes #14747: Android new note/to-do autofocus keyboard regression

### DIFF
--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -458,26 +458,32 @@ describe('screens/Note', () => {
 			mockBlur.mockImplementation(() => {
 				isFocusedSpy.mockReturnValue(false);
 			});
+			let focusCalls = 0;
 			mockFocus.mockImplementation(() => {
+				focusCalls += 1;
 				isFocusedSpy.mockReturnValue(true);
-				act(() => {
-					store.dispatch({
-						type: 'KEYBOARD_VISIBLE_CHANGE',
-						visible: true,
+
+				if (focusCalls > 1) {
+					act(() => {
+						store.dispatch({
+							type: 'KEYBOARD_VISIBLE_CHANGE',
+							visible: true,
+						});
 					});
-				});
+				}
 			});
 
 			jest.advanceTimersByTime(200);
 			await waitFor(() => {
-				expect(mockFocus).toHaveBeenCalledTimes(1);
+				expect(mockBlur).toHaveBeenCalledTimes(1);
+				expect(mockFocus).toHaveBeenCalledTimes(2);
 				expect(mockFocus).toHaveBeenLastCalledWith('Note::focusUpdate::title', expect.anything());
 			});
 
 			const postAutofocusFocusCallCount = mockFocus.mock.calls.length;
 			fireEvent.changeText(provisionalTitleInput, 'T');
 			expect(mockFocus).toHaveBeenCalledTimes(postAutofocusFocusCallCount);
-			expect(mockBlur).not.toHaveBeenCalled();
+			expect(mockBlur).toHaveBeenCalledTimes(1);
 
 			provisionalScreen.unmount();
 		});

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -2,6 +2,12 @@ import * as React from 'react';
 
 import { describe, it, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../utils/testing/testingLibrary';
+import { LayoutChangeEvent, TextInput } from 'react-native';
+
+jest.mock('@joplin/lib/utils/focusHandler', () => ({
+	focus: jest.fn(),
+	blur: jest.fn(),
+}));
 
 import NoteScreen from './Note';
 import { setupDatabaseAndSynchronizer, switchClient, simulateReadOnlyShareEnv, supportDir, synchronizerStart, resourceFetcher, runWithFakeTimers } from '@joplin/lib/testing/test-utils';
@@ -18,7 +24,6 @@ import { ModelType } from '@joplin/lib/BaseModel';
 import ItemChange from '@joplin/lib/models/ItemChange';
 import { getDisplayParentId } from '@joplin/lib/services/trash';
 import { itemIsReadOnlySync, ItemSlice } from '@joplin/lib/models/utils/readOnly';
-import { LayoutChangeEvent } from 'react-native';
 import shim from '@joplin/lib/shim';
 import getWebViewWindowById from '../../../utils/testing/getWebViewWindowById';
 import CodeMirrorControl from '@joplin/editor/CodeMirror/CodeMirrorControl';
@@ -27,6 +32,7 @@ import Resource from '@joplin/lib/models/Resource';
 import TestProviderStack from '../../testing/TestProviderStack';
 import setupGlobalStore from '../../../utils/testing/setupGlobalStore';
 import CommandService from '@joplin/lib/services/CommandService';
+import { blur, focus } from '@joplin/lib/utils/focusHandler';
 
 jest.retryTimes(2);
 
@@ -34,6 +40,8 @@ interface WrapperProps {
 }
 
 let store: Store<AppState>;
+const mockFocus = focus as jest.MockedFunction<typeof focus>;
+const mockBlur = blur as jest.MockedFunction<typeof blur>;
 
 const mockNavigation = { state: { } };
 const WrappedNoteScreen: React.FC<WrapperProps> = _props => {
@@ -93,6 +101,16 @@ const openNewNote = async (noteProperties: NoteEntity) => {
 	await waitForNoteToMatch(note.id, { parent_id: note.parent_id, title: note.title, body: note.body });
 
 	return note.id;
+};
+
+const setNoteProvisional = async (noteId: string) => {
+	const note = await Note.load(noteId);
+
+	store.dispatch({
+		type: 'NOTE_UPDATE_ONE',
+		note: note,
+		provisional: true,
+	});
 };
 
 const openNoteActionsMenu = async () => {
@@ -422,6 +440,66 @@ describe('screens/Note', () => {
 		expect(titleInput).toBeVisible();
 		await expectToBeEditing(true);
 		unmount();
+	});
+
+	it('should autofocus provisional to-do titles without refocusing after title edits, and should not autofocus existing notes', async () => {
+		mockFocus.mockClear();
+		mockBlur.mockClear();
+		const isFocusedSpy = jest.spyOn(TextInput.prototype, 'isFocused');
+		isFocusedSpy.mockReturnValue(false);
+
+		const provisionalNoteId = await openNewNote({ title: '', body: '', is_todo: 1 });
+		await setNoteProvisional(provisionalNoteId);
+
+		await runWithFakeTimers(async () => {
+			const provisionalScreen = render(<WrappedNoteScreen />);
+			const provisionalTitleInput = await screen.findByPlaceholderText('Add title');
+			expect(provisionalTitleInput).toBeVisible();
+			mockBlur.mockImplementation(() => {
+				isFocusedSpy.mockReturnValue(false);
+			});
+			mockFocus.mockImplementation(() => {
+				isFocusedSpy.mockReturnValue(true);
+				act(() => {
+					store.dispatch({
+						type: 'KEYBOARD_VISIBLE_CHANGE',
+						visible: true,
+					});
+				});
+			});
+
+			jest.advanceTimersByTime(200);
+			await waitFor(() => {
+				expect(mockFocus).toHaveBeenCalledTimes(1);
+				expect(mockFocus).toHaveBeenLastCalledWith('Note::focusUpdate::title', expect.anything());
+			});
+
+			const postAutofocusFocusCallCount = mockFocus.mock.calls.length;
+			fireEvent.changeText(provisionalTitleInput, 'T');
+			expect(mockFocus).toHaveBeenCalledTimes(postAutofocusFocusCallCount);
+			expect(mockBlur).not.toHaveBeenCalled();
+
+			provisionalScreen.unmount();
+		});
+
+		mockFocus.mockClear();
+		mockBlur.mockClear();
+
+		await openNewNote({ title: 'Existing note', body: 'Test body', is_todo: 1 });
+		await runWithFakeTimers(async () => {
+			const existingScreen = render(<WrappedNoteScreen />);
+			const existingTitleInput = await screen.findByDisplayValue('Existing note');
+			expect(existingTitleInput).toBeVisible();
+
+			jest.advanceTimersByTime(200);
+			await Promise.resolve();
+
+			expect(mockFocus).not.toHaveBeenCalled();
+			expect(mockBlur).not.toHaveBeenCalled();
+			existingScreen.unmount();
+		});
+
+		isFocusedSpy.mockRestore();
 	});
 
 	it.each([

--- a/packages/app-mobile/components/screens/Note/Note.test.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { describe, it, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, screen, userEvent, waitFor } from '../../../utils/testing/testingLibrary';
-import { LayoutChangeEvent, TextInput } from 'react-native';
+import { LayoutChangeEvent, PermissionsAndroid, Platform, TextInput } from 'react-native';
 
 jest.mock('@joplin/lib/utils/focusHandler', () => ({
 	focus: jest.fn(),
@@ -447,65 +447,78 @@ describe('screens/Note', () => {
 		mockBlur.mockClear();
 		const isFocusedSpy = jest.spyOn(TextInput.prototype, 'isFocused');
 		isFocusedSpy.mockReturnValue(false);
+		const originalPlatformOsDescriptor = Object.getOwnPropertyDescriptor(Platform, 'OS');
+		const permissionsCheckSpy = jest.spyOn(PermissionsAndroid, 'check').mockResolvedValue(true);
 
-		const provisionalNoteId = await openNewNote({ title: '', body: '', is_todo: 1 });
-		await setNoteProvisional(provisionalNoteId);
+		Object.defineProperty(Platform, 'OS', {
+			configurable: true,
+			value: 'android',
+		});
 
-		await runWithFakeTimers(async () => {
-			const provisionalScreen = render(<WrappedNoteScreen />);
-			const provisionalTitleInput = await screen.findByPlaceholderText('Add title');
-			expect(provisionalTitleInput).toBeVisible();
-			mockBlur.mockImplementation(() => {
-				isFocusedSpy.mockReturnValue(false);
-			});
-			let focusCalls = 0;
-			mockFocus.mockImplementation(() => {
-				focusCalls += 1;
-				isFocusedSpy.mockReturnValue(true);
+		try {
+			const provisionalNoteId = await openNewNote({ title: '', body: '', is_todo: 1 });
+			await setNoteProvisional(provisionalNoteId);
 
-				if (focusCalls > 1) {
-					act(() => {
-						store.dispatch({
-							type: 'KEYBOARD_VISIBLE_CHANGE',
-							visible: true,
+			await runWithFakeTimers(async () => {
+				const provisionalScreen = render(<WrappedNoteScreen />);
+				const provisionalTitleInput = await screen.findByPlaceholderText('Add title');
+				expect(provisionalTitleInput).toBeVisible();
+				mockBlur.mockImplementation(() => {
+					isFocusedSpy.mockReturnValue(false);
+				});
+				let focusCalls = 0;
+				mockFocus.mockImplementation(() => {
+					focusCalls += 1;
+					isFocusedSpy.mockReturnValue(true);
+
+					if (focusCalls > 1) {
+						act(() => {
+							store.dispatch({
+								type: 'KEYBOARD_VISIBLE_CHANGE',
+								visible: true,
+							});
 						});
-					});
-				}
-			});
+					}
+				});
 
-			jest.advanceTimersByTime(200);
-			await waitFor(() => {
+				jest.advanceTimersByTime(200);
+				await waitFor(() => {
+					expect(mockBlur).toHaveBeenCalledTimes(1);
+					expect(mockFocus).toHaveBeenCalledTimes(2);
+					expect(mockFocus).toHaveBeenLastCalledWith('Note::focusUpdate::title', expect.anything());
+				});
+
+				const postAutofocusFocusCallCount = mockFocus.mock.calls.length;
+				fireEvent.changeText(provisionalTitleInput, 'T');
+				expect(mockFocus).toHaveBeenCalledTimes(postAutofocusFocusCallCount);
 				expect(mockBlur).toHaveBeenCalledTimes(1);
-				expect(mockFocus).toHaveBeenCalledTimes(2);
-				expect(mockFocus).toHaveBeenLastCalledWith('Note::focusUpdate::title', expect.anything());
+
+				provisionalScreen.unmount();
 			});
 
-			const postAutofocusFocusCallCount = mockFocus.mock.calls.length;
-			fireEvent.changeText(provisionalTitleInput, 'T');
-			expect(mockFocus).toHaveBeenCalledTimes(postAutofocusFocusCallCount);
-			expect(mockBlur).toHaveBeenCalledTimes(1);
+			mockFocus.mockClear();
+			mockBlur.mockClear();
 
-			provisionalScreen.unmount();
-		});
+			await openNewNote({ title: 'Existing note', body: 'Test body', is_todo: 1 });
+			await runWithFakeTimers(async () => {
+				const existingScreen = render(<WrappedNoteScreen />);
+				const existingTitleInput = await screen.findByDisplayValue('Existing note');
+				expect(existingTitleInput).toBeVisible();
 
-		mockFocus.mockClear();
-		mockBlur.mockClear();
+				jest.advanceTimersByTime(200);
+				await Promise.resolve();
 
-		await openNewNote({ title: 'Existing note', body: 'Test body', is_todo: 1 });
-		await runWithFakeTimers(async () => {
-			const existingScreen = render(<WrappedNoteScreen />);
-			const existingTitleInput = await screen.findByDisplayValue('Existing note');
-			expect(existingTitleInput).toBeVisible();
-
-			jest.advanceTimersByTime(200);
-			await Promise.resolve();
-
-			expect(mockFocus).not.toHaveBeenCalled();
-			expect(mockBlur).not.toHaveBeenCalled();
-			existingScreen.unmount();
-		});
-
-		isFocusedSpy.mockRestore();
+				expect(mockFocus).not.toHaveBeenCalled();
+				expect(mockBlur).not.toHaveBeenCalled();
+				existingScreen.unmount();
+			});
+		} finally {
+			if (originalPlatformOsDescriptor) {
+				Object.defineProperty(Platform, 'OS', originalPlatformOsDescriptor);
+			}
+			permissionsCheckSpy.mockRestore();
+			isFocusedSpy.mockRestore();
+		}
 	});
 
 	it.each([

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -104,7 +104,7 @@ interface Props extends BaseProps {
 	provisionalNoteIds: string[];
 	navigation: NoteNavigation;
 	dispatch: Dispatch;
-	noteId: string;
+	noteId: string | null;
 	keyboardVisible: boolean;
 	editorType: EditorType;
 	useEditorBeta: boolean;

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -48,7 +48,7 @@ import restoreItems from '@joplin/lib/services/trash/restoreItems';
 import { getDisplayParentTitle } from '@joplin/lib/services/trash';
 import { PluginHtmlContents, PluginStates, utils as pluginUtils } from '@joplin/lib/services/plugins/reducer';
 import debounce from '../../../utils/debounce';
-import { focus } from '@joplin/lib/utils/focusHandler';
+import { blur, focus } from '@joplin/lib/utils/focusHandler';
 import CommandService, { RegisteredRuntime } from '@joplin/lib/services/CommandService';
 import { ResourceInfo } from '../../NoteBodyViewer/hooks/useRerenderHandler';
 import getImageDimensions from '../../../utils/image/getImageDimensions';
@@ -105,6 +105,7 @@ interface Props extends BaseProps {
 	navigation: NoteNavigation;
 	dispatch: Dispatch;
 	noteId: string;
+	keyboardVisible: boolean;
 	editorType: EditorType;
 	useEditorBeta: boolean;
 	plugins: PluginStates;
@@ -193,6 +194,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	private focusUpdateIID_: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private folderPickerOptions_: any;
+	private titleKeyboardRefocusDone_ = false;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public dialogbox: any;
 	private commandRegistration_: RegisteredRuntime|null = null;
@@ -757,6 +759,8 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 		NavService.removeHandler(this.navHandler);
 
 		shared.uninstallResourceHandling(this.refreshResource);
+
+		if (this.focusUpdateIID_) shim.clearInterval(this.focusUpdateIID_);
 
 		void this.saveActionQueue(this.state.note.id).processAllNow();
 
@@ -1478,20 +1482,32 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 
 	public scheduleFocusUpdate() {
 		if (this.focusUpdateIID_) shim.clearInterval(this.focusUpdateIID_);
+		this.titleKeyboardRefocusDone_ = false;
 
 		const startTime = Date.now();
 
 		this.focusUpdateIID_ = shim.setInterval(() => {
-			if (!this.state.note) return;
+			// Wait for the actual note state before deciding which field should receive autofocus.
+			if (!this.state.note || this.state.isLoading || this.state.note.id !== this.props.noteId) return;
 
 			let fieldToFocus = this.state.note.is_todo ? 'title' : 'body';
 			if (this.state.mode === 'view') fieldToFocus = '';
 
 			let done = false;
+			const titleInputFocused = !!this.titleTextFieldRef.current?.isFocused?.();
+			const waitingForAndroidTitleKeyboard = Platform.OS === 'android' && fieldToFocus === 'title' && !this.props.keyboardVisible;
+			const titleFocusSettled = titleInputFocused && !waitingForAndroidTitleKeyboard;
 
 			if (fieldToFocus === 'title' && this.titleTextFieldRef?.current) {
-				done = true;
-				focus('Note::focusUpdate::title', this.titleTextFieldRef.current);
+				if (titleFocusSettled) {
+					done = true;
+				} else if (titleInputFocused && waitingForAndroidTitleKeyboard && !this.titleKeyboardRefocusDone_) {
+					// Recover from Android reporting the title as focused while the keyboard stays hidden.
+					this.titleKeyboardRefocusDone_ = true;
+					blur('Note::focusUpdate::titleBlur', this.titleTextFieldRef.current);
+				} else if (!titleInputFocused || !this.titleKeyboardRefocusDone_) {
+					focus('Note::focusUpdate::title', this.titleTextFieldRef.current);
+				}
 			} else if (fieldToFocus === 'body' && this.editorRef?.current) {
 				done = true;
 				focus('Note::focusUpdate::body', this.editorRef.current);
@@ -1935,6 +1951,7 @@ const NoteScreen = connect((state: AppState) => {
 		noteId: state.selectedNoteIds.length ? state.selectedNoteIds[0] : null,
 		noteHash: state.selectedNoteHash,
 		itemType: state.selectedItemType,
+		keyboardVisible: state.keyboardVisible,
 		folders: state.folders,
 		searchQuery: state.searchQuery,
 		themeId: state.settings.theme,

--- a/packages/app-mobile/components/screens/Note/Note.tsx
+++ b/packages/app-mobile/components/screens/Note/Note.tsx
@@ -195,6 +195,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private folderPickerOptions_: any;
 	private titleKeyboardRefocusDone_ = false;
+	private titleKeyboardRefocusPendingUntil_ = 0;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public dialogbox: any;
 	private commandRegistration_: RegisteredRuntime|null = null;
@@ -1483,6 +1484,7 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 	public scheduleFocusUpdate() {
 		if (this.focusUpdateIID_) shim.clearInterval(this.focusUpdateIID_);
 		this.titleKeyboardRefocusDone_ = false;
+		this.titleKeyboardRefocusPendingUntil_ = 0;
 
 		const startTime = Date.now();
 
@@ -1496,16 +1498,21 @@ class NoteScreenComponent extends BaseScreenComponent<ComponentProps, State> imp
 			let done = false;
 			const titleInputFocused = !!this.titleTextFieldRef.current?.isFocused?.();
 			const waitingForAndroidTitleKeyboard = Platform.OS === 'android' && fieldToFocus === 'title' && !this.props.keyboardVisible;
+			const readyForAndroidTitleRefocus = this.titleKeyboardRefocusPendingUntil_ > 0 && Date.now() >= this.titleKeyboardRefocusPendingUntil_;
 			const titleFocusSettled = titleInputFocused && !waitingForAndroidTitleKeyboard;
 
 			if (fieldToFocus === 'title' && this.titleTextFieldRef?.current) {
 				if (titleFocusSettled) {
 					done = true;
+				} else if (readyForAndroidTitleRefocus) {
+					this.titleKeyboardRefocusPendingUntil_ = 0;
+					this.titleKeyboardRefocusDone_ = true;
+					focus('Note::focusUpdate::title', this.titleTextFieldRef.current);
 				} else if (titleInputFocused && waitingForAndroidTitleKeyboard && !this.titleKeyboardRefocusDone_) {
 					// Recover from Android reporting the title as focused while the keyboard stays hidden.
-					this.titleKeyboardRefocusDone_ = true;
 					blur('Note::focusUpdate::titleBlur', this.titleTextFieldRef.current);
-				} else if (!titleInputFocused || !this.titleKeyboardRefocusDone_) {
+					this.titleKeyboardRefocusPendingUntil_ = Date.now() + 75;
+				} else if (!titleInputFocused && !this.titleKeyboardRefocusPendingUntil_) {
 					focus('Note::focusUpdate::title', this.titleTextFieldRef.current);
 				}
 			} else if (fieldToFocus === 'body' && this.editorRef?.current) {


### PR DESCRIPTION
Mobile: Fixes #14747: Android new note/to-do autofocus keyboard regression

## Summary
On Android, when creating a new to-do the title field could receive focus without the software keyboard opening. In some cases typing would then cause the keyboard to dismiss unexpectedly.

## Root cause
The mobile Note screen autofocus logic treated "input is focused" as a successful autofocus state.  
On Android it is possible for the title input to be focused while the software keyboard is still hidden, which caused the retry loop to stop too early.

## Fix
Update the autofocus logic so that Android title autofocus only completes when:

- the title input is focused
- the software keyboard is visible

Additional changes:
- clear any pending autofocus retry timer when the Note screen unmounts
- add regression test coverage for delayed keyboard visibility during provisional note autofocus

## Scope
Changes are limited to the mobile Note screen autofocus lifecycle and its related tests.

## Testing
Verified locally on Android:
- Creating a new to-do opens the keyboard automatically
- Typing in the title no longer causes keyboard dismissal
- Existing notes do not trigger autofocus

## FInal Output


https://github.com/user-attachments/assets/dd352b33-ee3a-4e1e-9db2-9f8d923729fb



## Dev Notes
Had multiple & significant while initial setup for mobile , had to refactor & go through different docs & learn how everything functions. It was super duper slow yet had fun , like a lot. I also have a minor yet crucial feature suggestion as well. This is my first PR for Joplin. Let's see how it goes.