### PR TITLE
All: Fixes #14540: Handles duplicate tags conflict by overwriting local with remote during sync

### DIFF
--- a/packages/lib/Synchronizer.ts
+++ b/packages/lib/Synchronizer.ts
@@ -1,5 +1,10 @@
 import Logger from '@joplin/utils/Logger';
-import LockHandler, { appTypeToLockType, hasActiveLock, LockClientType, LockType } from './services/synchronizer/LockHandler';
+import LockHandler, {
+	appTypeToLockType,
+	hasActiveLock,
+	LockClientType,
+	LockType,
+} from './services/synchronizer/LockHandler';
 import Setting, { AppType } from './models/Setting';
 import shim from './shim';
 import MigrationHandler from './services/synchronizer/MigrationHandler';
@@ -20,10 +25,33 @@ import JoplinError from './JoplinError';
 import ShareService from './services/share/ShareService';
 import TaskQueue from './TaskQueue';
 import ItemUploader from './services/synchronizer/ItemUploader';
-import { FileApi, getSupportsDeltaWithItems, isLocalServer, PaginatedList, RemoteItem, enableEnhancedBasicDeltaAlgorithm } from './file-api';
+import {
+	FileApi,
+	getSupportsDeltaWithItems,
+	isLocalServer,
+	PaginatedList,
+	RemoteItem,
+	enableEnhancedBasicDeltaAlgorithm,
+} from './file-api';
 import JoplinDatabase from './JoplinDatabase';
-import { checkIfCanSync, fetchSyncInfo, checkSyncTargetIsValid, getActiveMasterKey, localSyncInfo, mergeSyncInfos, saveLocalSyncInfo, setMasterKeyHasBeenUsed, SyncInfo, syncInfoEquals, uploadSyncInfo } from './services/synchronizer/syncInfoUtils';
-import { getMasterPassword, setupAndDisableEncryption, setupAndEnableEncryption } from './services/e2ee/utils';
+import {
+	checkIfCanSync,
+	fetchSyncInfo,
+	checkSyncTargetIsValid,
+	getActiveMasterKey,
+	localSyncInfo,
+	mergeSyncInfos,
+	saveLocalSyncInfo,
+	setMasterKeyHasBeenUsed,
+	SyncInfo,
+	syncInfoEquals,
+	uploadSyncInfo,
+} from './services/synchronizer/syncInfoUtils';
+import {
+	getMasterPassword,
+	setupAndDisableEncryption,
+	setupAndEnableEncryption,
+} from './services/e2ee/utils';
 import { generateKeyPair } from './services/e2ee/ppk/ppk';
 import syncDebugLog from './services/synchronizer/syncDebugLog';
 import handleConflictAction from './services/synchronizer/utils/handleConflictAction';
@@ -34,6 +62,8 @@ import { SyncAction } from './services/synchronizer/utils/types';
 import checkDisabledSyncItemsNotification from './services/synchronizer/utils/checkDisabledSyncItemsNotification';
 import { reg } from './registry';
 import SyncTargetRegistry from './SyncTargetRegistry';
+import Tag from './models/Tag';
+import { TagEntity } from './services/database/types';
 const { sprintf } = require('sprintf-js');
 const { Dirnames } = require('./services/synchronizer/utils/types');
 
@@ -42,7 +72,7 @@ const logger = Logger.create('Synchronizer');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 function isCannotSyncError(error: any): boolean {
 	if (!error) return false;
-	if (['rejectedByTarget', 'fileNotFound'].indexOf(error.code) >= 0) return true;
+	if (['rejectedByTarget', 'fileNotFound'].indexOf(error.code) >= 0) { return true; }
 
 	// If the request times out we give up too because sometimes it's due to the
 	// file being large or some other connection issues, and we don't want that
@@ -51,13 +81,15 @@ function isCannotSyncError(error: any): boolean {
 	// message: "network timeout at: .....
 	// name: "FetchError"
 	// type: "request-timeout"
-	if (error.type === 'request-timeout' || error.message.includes('network timeout')) return true;
+	if (
+		error.type === 'request-timeout' ||
+    error.message.includes('network timeout')
+	) { return true; }
 
 	return false;
 }
 
 export default class Synchronizer {
-
 	public static verboseMode = true;
 	public static partialSyncSteps = ['update_remote', 'delete_remote'];
 
@@ -145,7 +177,13 @@ export default class Synchronizer {
 
 	public migrationHandler() {
 		if (this.migrationHandler_) return this.migrationHandler_;
-		this.migrationHandler_ = new MigrationHandler(this.api(), this.db(), this.lockHandler(), this.lockClientType(), this.clientId_);
+		this.migrationHandler_ = new MigrationHandler(
+			this.api(),
+			this.db(),
+			this.lockHandler(),
+			this.lockClientType(),
+			this.clientId_,
+		);
 		return this.migrationHandler_;
 	}
 
@@ -199,22 +237,58 @@ export default class Synchronizer {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static reportToLines(report: any) {
 		const lines = [];
-		if (report.createLocal) lines.push(_('Created local items: %d.', report.createLocal));
-		if (report.updateLocal) lines.push(_('Updated local items: %d.', report.updateLocal));
-		if (report.createRemote) lines.push(_('Created remote items: %d.', report.createRemote));
-		if (report.updateRemote) lines.push(_('Updated remote items: %d.', report.updateRemote));
-		if (report.deleteLocal) lines.push(_('Deleted local items: %d.', report.deleteLocal));
-		if (report.deleteRemote) lines.push(_('Deleted remote items: %d.', report.deleteRemote));
-		if (report.fetchingTotal && report.fetchingProcessed) lines.push(_('Fetched items: %d/%d.', report.fetchingProcessed, report.fetchingTotal));
-		if (report.cancelling && !report.completedTime) lines.push(_('Cancelling...'));
-		if (report.completedTime) lines.push(_('Completed: %s (%s)', time.formatMsToLocal(report.completedTime), this.completionTime(report)));
-		if (this.reportHasErrors(report)) lines.push(_('Last error: %s', report.errors[report.errors.length - 1].toString().substr(0, 500)));
+		if (report.createLocal) { lines.push(_('Created local items: %d.', report.createLocal)); }
+		if (report.updateLocal) { lines.push(_('Updated local items: %d.', report.updateLocal)); }
+		if (report.createRemote) { lines.push(_('Created remote items: %d.', report.createRemote)); }
+		if (report.updateRemote) { lines.push(_('Updated remote items: %d.', report.updateRemote)); }
+		if (report.deleteLocal) { lines.push(_('Deleted local items: %d.', report.deleteLocal)); }
+		if (report.deleteRemote) { lines.push(_('Deleted remote items: %d.', report.deleteRemote)); }
+		if (report.fetchingTotal && report.fetchingProcessed) {
+			lines.push(
+				_(
+					'Fetched items: %d/%d.',
+					report.fetchingProcessed,
+					report.fetchingTotal,
+				),
+			);
+		}
+		if (report.cancelling && !report.completedTime) { lines.push(_('Cancelling...')); }
+		if (report.completedTime) {
+			lines.push(
+				_(
+					'Completed: %s (%s)',
+					time.formatMsToLocal(report.completedTime),
+					this.completionTime(report),
+				),
+			);
+		}
+		if (this.reportHasErrors(report)) {
+			lines.push(
+				_(
+					'Last error: %s',
+					report.errors[report.errors.length - 1].toString().substr(0, 500),
+				),
+			);
+		}
 
 		return lines;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-	public logSyncOperation(action: SyncAction | 'cancelling' | 'starting' | 'fetchingTotal' | 'fetchingProcessed' | 'finished', local: any = null, remote: RemoteItem = null, message: string = null, actionCount = 1) {
+	public logSyncOperation(
+		action:
+      | SyncAction
+      | 'cancelling'
+      | 'starting'
+      | 'fetchingTotal'
+      | 'fetchingProcessed'
+      | 'finished',
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+		local: any = null,
+		remote: RemoteItem = null,
+		message: string = null,
+		actionCount = 1,
+	) {
 		const line = ['Sync'];
 		line.push(action);
 		if (message) line.push(message);
@@ -242,7 +316,7 @@ export default class Synchronizer {
 			logger.debug(line.join(': '));
 		}
 
-		if (!['fetchingProcessed', 'fetchingTotal'].includes(action)) syncDebugLog.info(line.join(': '));
+		if (!['fetchingProcessed', 'fetchingTotal'].includes(action)) { syncDebugLog.info(line.join(': ')); }
 
 		if (!this.progressReport_[action]) this.progressReport_[action] = 0;
 		this.progressReport_[action] += actionCount;
@@ -254,8 +328,8 @@ export default class Synchronizer {
 		// for this but for now this simple fix will do.
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const reportCopy: any = {};
-		for (const n in this.progressReport_) reportCopy[n] = this.progressReport_[n];
-		if (reportCopy.errors) reportCopy.errors = this.progressReport_.errors.slice();
+		for (const n in this.progressReport_) { reportCopy[n] = this.progressReport_[n]; }
+		if (reportCopy.errors) { reportCopy.errors = this.progressReport_.errors.slice(); }
 		this.dispatch({ type: 'SYNC_REPORT_UPDATE', report: reportCopy });
 	}
 
@@ -330,18 +404,34 @@ export default class Synchronizer {
 	}
 
 	public isFullSync(steps: string[]) {
-		return steps.includes('update_remote') && steps.includes('delete_remote') && steps.includes('delta');
+		return (
+			steps.includes('update_remote') &&
+      steps.includes('delete_remote') &&
+      steps.includes('delta')
+		);
 	}
 
 	private async lockErrorStatus_() {
 		const locks = await this.lockHandler().locks();
 		const currentDate = await this.lockHandler().currentDate();
 
-		const hasActiveExclusiveLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Exclusive);
+		const hasActiveExclusiveLock = await hasActiveLock(
+			locks,
+			currentDate,
+			this.lockHandler().lockTtl,
+			LockType.Exclusive,
+		);
 		if (hasActiveExclusiveLock) return 'hasExclusiveLock';
 
 		if (this.lockHandler().enabled) {
-			const hasActiveSyncLock = await hasActiveLock(locks, currentDate, this.lockHandler().lockTtl, LockType.Sync, this.lockClientType(), this.clientId_);
+			const hasActiveSyncLock = await hasActiveLock(
+				locks,
+				currentDate,
+				this.lockHandler().lockTtl,
+				LockType.Sync,
+				this.lockClientType(),
+				this.clientId_,
+			);
 			if (!hasActiveSyncLock) return 'syncLockGone';
 		}
 
@@ -365,7 +455,12 @@ export default class Synchronizer {
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private async apiCall(fnName: string, ...args: any[]) {
-		if (this.syncTargetIsLocked_) throw new JoplinError('Sync target is locked - aborting API call', 'lockError');
+		if (this.syncTargetIsLocked_) {
+			throw new JoplinError(
+				'Sync target is locked - aborting API call',
+				'lockError',
+			);
+		}
 
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
@@ -377,7 +472,10 @@ export default class Synchronizer {
 			// does not do special processing on the original error. For example, if a resource could not be downloaded,
 			// don't mark it as a "cannotSyncItem" since we don't know that.
 			if (lockStatus) {
-				throw new JoplinError(`Sync target lock error: ${lockStatus}. Original error was: ${error.message}`, 'lockError');
+				throw new JoplinError(
+					`Sync target lock error: ${lockStatus}. Original error was: ${error.message}`,
+					'lockError',
+				);
 			} else {
 				throw error;
 			}
@@ -391,11 +489,129 @@ export default class Synchronizer {
 	// 3. DELTA: Find on the sync target the items that have been modified or deleted and apply the changes locally.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public async start(options: any = null) {
+		const fetchDelta = (() => {
+			interface DeltaResultPage {
+				listResult: PaginatedList;
+				supportsDeltaWithItems: boolean;
+				remotesIndex: Map<string, { result: RemoteItem; content?: RemoteItem | null }>;
+				remotesQueuedForDownloadIndex: Set<string>;
+			}
+
+			const deltaPages: DeltaResultPage[] = [];
+			let hasRun = false;
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			return async (context: any = null, syncTargetId: any, downloadQueue: any, options: any = {}) => {
+				if ('preferCache' in options && options.preferCache) {
+					if (hasRun) {
+						return deltaPages;
+					}
+				}
+
+				hasRun = true;
+				deltaPages.length = 0;
+
+				// let context = null;
+				// if (lastContext.delta) context = lastContext.delta;
+				while (true) {
+					if (this.cancelling()) break;
+					const listResult: PaginatedList = await this.apiCall('delta', '', {
+						context: context,
+						// allItemIdsHandler() provides a way for drivers that don't have a delta API to
+						// still provide delta functionality by comparing the items they have to the items
+						// the client has. Very inefficient but that's the only possible workaround.
+						// It's a function so that it is only called if the driver needs these IDs. For
+						// drivers with a delta functionality it's a noop.
+						allItemIdsHandler: async () => {
+							return BaseItem.syncedItemIds(syncTargetId);
+						},
+						// This is only used by the basic delta
+						allItemMetadataHandler: async () => {
+							return BaseItem.remoteItemMetadata(syncTargetId);
+						},
+						wipeOutFailSafe: Setting.value('sync.wipeOutFailSafe'),
+						logger: logger,
+					});
+					// Ensure that if the sync target directory has changed, lost access, or has been purged by some external process while the sync is running, that a failsafe error is triggered where info.json and .sync/version.txt can no longer be found
+					// This check is more reliable than checking the count of items alone, as it is possible for sync items become segmented between 2 directories, possibly by the target directory changing during sync
+					// This scenario is possible with OneDrive sync, see https://github.com/laurent22/joplin/issues/11489
+					// This check while the sync is running is only necessary for the delta step of the sync, as this is where local deletions are calculated by comparing the local database and the sync target. These deletions are driven by the listResult field to determine which remote items exist
+					// As long as we check that info.json still exists after each time the listResult field is repopulated, there should not be a risk of unwanted deletions when failsafe is enabled, unless the target directory is directly manipulated by the user
+					await checkSyncTargetIsValid(this.api());
+					const supportsDeltaWithItems = getSupportsDeltaWithItems(listResult);
+					logger.info('supportsDeltaWithItems = ', supportsDeltaWithItems);
+					this.logSyncOperation(
+						'fetchingTotal',
+						null,
+						null,
+						'Fetching delta items from sync target',
+						listResult.items.length,
+					);
+					// Index listResult by path so we can triage efficiently.
+					// We might as well also store the result's content.
+					// If content needs to be downloaded,
+					// then push to the downloaded queue for now.
+					// We'll then add the downloaded content to our index
+					// once all downloads have completed.
+					const remotesIndex = new Map<string, { result: RemoteItem; content?: RemoteItem | null }>();
+					const remotesQueuedForDownloadIndex = new Set<string>();
+					const remoteIds = listResult.items.map((r: RemoteItem) =>
+						BaseItem.pathToId(r.path),
+					);
+					const locals = await BaseItem.loadItemsByIds(remoteIds);
+
+					for (const result of listResult.items) {
+						if (!BaseItem.isSystemPath(result.path)) continue;
+						let needsToDownload = true;
+						if (result.isDeleted) {
+							needsToDownload = false;
+							remotesIndex.set(result.path, { result });
+							continue;
+						}
+						if (this.api().supportsAccurateTimestamp) {
+							const local = locals.find(
+								(l) => l.id === BaseItem.pathToId(result.path),
+							);
+							if (local && local.updated_time === result.jop_updated_time) { needsToDownload = false; }
+						}
+						if (supportsDeltaWithItems) {
+							needsToDownload = false;
+						}
+						if (needsToDownload) {
+							downloadQueue.push(result.path, async () => {
+								return this.apiCall('get', result.path);
+							});
+							remotesIndex.set(result.path, { result });
+						} else {
+							remotesIndex.set(result.path, { result, content: result.jopItem });
+						}
+					}
+
+					deltaPages.push({
+						listResult,
+						supportsDeltaWithItems,
+						remotesIndex,
+						remotesQueuedForDownloadIndex,
+					});
+
+					context = listResult.context;
+
+					if (!listResult.hasMore) break;
+				}
+				return deltaPages;
+			};
+		})();
+
 		if (!options) options = {};
 
 		if (this.state() !== 'idle') {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-			const error: any = new Error(sprintf('Synchronisation is already in progress. State: %s', this.state()));
+			const error: any = new Error(
+				sprintf(
+					'Synchronisation is already in progress. State: %s',
+					this.state(),
+				),
+			);
 			error.code = 'alreadyStarted';
 			throw error;
 		}
@@ -407,7 +623,9 @@ export default class Synchronizer {
 
 		const lastContext = options.context ? options.context : {};
 
-		const syncSteps = options.syncSteps ? options.syncSteps : ['update_remote', 'delete_remote', 'delta'];
+		const syncSteps = options.syncSteps
+			? options.syncSteps
+			: ['update_remote', 'delete_remote', 'delta'];
 
 		// The default is to log errors, but when testing it's convenient to be able to catch and verify errors
 		const throwOnError = options.throwOnError === true;
@@ -426,11 +644,34 @@ export default class Synchronizer {
 		this.dispatch({ type: 'SYNC_STARTED' });
 		eventManager.emit(EventName.SyncStart);
 
-		this.logSyncOperation('starting', null, null, `Starting synchronisation to target ${syncTargetId}... supportsAccurateTimestamp = ${this.api().supportsAccurateTimestamp}; supportsMultiPut = ${this.api().supportsMultiPut}} [${synchronizationId}]`);
+		this.logSyncOperation(
+			'starting',
+			null,
+			null,
+			`Starting synchronisation to target ${syncTargetId}... supportsAccurateTimestamp = ${
+				this.api().supportsAccurateTimestamp
+			}; supportsMultiPut = ${
+				this.api().supportsMultiPut
+			}} [${synchronizationId}]`,
+		);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		const handleCannotSyncItem = async (ItemClass: typeof BaseItem, syncTargetId: any, item: any, cannotSyncReason: string, itemLocation: any = null) => {
-			await ItemClass.saveSyncDisabled(syncTargetId, item, cannotSyncReason, itemLocation);
+		const handleCannotSyncItem = async (
+			ItemClass: typeof BaseItem,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			syncTargetId: any,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			item: any,
+			cannotSyncReason: string,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+			itemLocation: any = null,
+		) => {
+			await ItemClass.saveSyncDisabled(
+				syncTargetId,
+				item,
+				cannotSyncReason,
+				itemLocation,
+			);
 		};
 
 		// We index resources before sync mostly to flag any potential orphan
@@ -466,15 +707,21 @@ export default class Synchronizer {
 			// Before synchronising make sure all share_id properties are set
 			// correctly so as to share/unshare the right items.
 			try {
-				await Folder.updateAllShareIds(this.resourceService(), this.shareService_ ? this.shareService_.shares : []);
-				if (this.shareService_) await this.shareService_.checkShareConsistency();
+				await Folder.updateAllShareIds(
+					this.resourceService(),
+					this.shareService_ ? this.shareService_.shares : [],
+				);
+				if (this.shareService_) { await this.shareService_.checkShareConsistency(); }
 			} catch (error) {
 				if (error && error.code === ErrorCode.IsReadOnly) {
 					// We ignore it because the functions above tried to modify a
 					// read-only item and failed. Normally it shouldn't happen since
 					// the UI should prevent, but if there's a bug in the UI or some
 					// other issue we don't want sync to fail because of this.
-					logger.error('Could not update share because an item is readonly:', error);
+					logger.error(
+						'Could not update share because an item is readonly:',
+						error,
+					);
 				} else {
 					throw error;
 				}
@@ -512,7 +759,10 @@ export default class Synchronizer {
 				localInfo = await this.setPpkIfNotExist(localInfo, remoteInfo);
 
 				if (syncTargetIsNew && localInfo.activeMasterKeyId) {
-					localInfo = setMasterKeyHasBeenUsed(localInfo, localInfo.activeMasterKeyId);
+					localInfo = setMasterKeyHasBeenUsed(
+						localInfo,
+						localInfo.activeMasterKeyId,
+					);
 				}
 
 				// console.info('LOCAL', localInfo);
@@ -520,22 +770,49 @@ export default class Synchronizer {
 
 				if (!syncInfoEquals(localInfo, remoteInfo)) {
 					let newInfo = mergeSyncInfos(localInfo, remoteInfo);
-					if (newInfo.activeMasterKeyId) newInfo = setMasterKeyHasBeenUsed(newInfo, newInfo.activeMasterKeyId);
+					if (newInfo.activeMasterKeyId) {
+						newInfo = setMasterKeyHasBeenUsed(
+							newInfo,
+							newInfo.activeMasterKeyId,
+						);
+					}
 					const previousE2EE = localInfo.e2ee;
-					logger.info('Sync target info differs between local and remote - merging infos: ', newInfo.toObject());
+					logger.info(
+						'Sync target info differs between local and remote - merging infos: ',
+						newInfo.toObject(),
+					);
 
-					await this.lockHandler().acquireLock(LockType.Exclusive, this.lockClientType(), this.clientId_, { clearExistingSyncLocksFromTheSameClient: true });
+					await this.lockHandler().acquireLock(
+						LockType.Exclusive,
+						this.lockClientType(),
+						this.clientId_,
+						{ clearExistingSyncLocksFromTheSameClient: true },
+					);
 					await uploadSyncInfo(this.api(), newInfo);
 					await saveLocalSyncInfo(newInfo);
-					await this.lockHandler().releaseLock(LockType.Exclusive, this.lockClientType(), this.clientId_);
+					await this.lockHandler().releaseLock(
+						LockType.Exclusive,
+						this.lockClientType(),
+						this.clientId_,
+					);
 
 					// console.info('NEW', newInfo);
 
-					if (newInfo.revisionServiceEnabled !== localInfo.revisionServiceEnabled) {
-						Setting.setValue('revisionService.enabled', newInfo.revisionServiceEnabled);
+					if (
+						newInfo.revisionServiceEnabled !== localInfo.revisionServiceEnabled
+					) {
+						Setting.setValue(
+							'revisionService.enabled',
+							newInfo.revisionServiceEnabled,
+						);
 					}
-					if (newInfo.revisionServiceTtlDays !== localInfo.revisionServiceTtlDays) {
-						Setting.setValue('revisionService.ttlDays', newInfo.revisionServiceTtlDays);
+					if (
+						newInfo.revisionServiceTtlDays !== localInfo.revisionServiceTtlDays
+					) {
+						Setting.setValue(
+							'revisionService.ttlDays',
+							newInfo.revisionServiceTtlDays,
+						);
 					}
 
 					if (newInfo.e2ee !== previousE2EE) {
@@ -556,16 +833,26 @@ export default class Synchronizer {
 					this.dispatch({ type: 'MUST_AUTHENTICATE', value: true });
 				}
 				if (error.code === 'outdatedSyncTarget') {
-					Setting.setValue('sync.upgradeState', Setting.SYNC_UPGRADE_STATE_SHOULD_DO);
+					Setting.setValue(
+						'sync.upgradeState',
+						Setting.SYNC_UPGRADE_STATE_SHOULD_DO,
+					);
 				}
 				throw error;
 			}
 
-			syncLock = await this.lockHandler().acquireLock(LockType.Sync, this.lockClientType(), this.clientId_);
+			syncLock = await this.lockHandler().acquireLock(
+				LockType.Sync,
+				this.lockClientType(),
+				this.clientId_,
+			);
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 			this.lockHandler().startAutoLockRefresh(syncLock, (error: any) => {
-				logger.warn('Could not refresh lock - cancelling sync. Error was:', error);
+				logger.warn(
+					'Could not refresh lock - cancelling sync. Error was:',
+					error,
+				);
 				this.syncTargetIsLocked_ = true;
 				void this.cancel();
 			});
@@ -581,12 +868,20 @@ export default class Synchronizer {
 					syncTargetId,
 					this.cancelling(),
 					(action, local, logSyncOperation, message, actionCount) => {
-						this.logSyncOperation(action, local, logSyncOperation, message, actionCount);
+						this.logSyncOperation(
+							action,
+							local,
+							logSyncOperation,
+							message,
+							actionCount,
+						);
 					},
 					(fnName, ...args) => {
 						return this.apiCall(fnName, ...args);
 					},
-					action => { return this.dispatch(action); },
+					(action) => {
+						return this.dispatch(action);
+					},
 				);
 			} // DELETE_REMOTE STEP
 
@@ -596,8 +891,49 @@ export default class Synchronizer {
 			// First, find all the items that have been changed since the
 			// last sync and apply the changes to remote.
 			// ========================================================================
-
 			if (syncSteps.indexOf('update_remote') >= 0) {
+				// We need to fetch delta in this step as well
+				// in order to identify which of our local tags
+				// are duplicates of of the remote tags.
+				if (this.downloadQueue_) await this.downloadQueue_.stop();
+				this.downloadQueue_ = new TaskQueue('syncDownload');
+				this.downloadQueue_.logger_ = logger;
+				let context = null;
+				if (lastContext.delta) context = lastContext.delta;
+				const deltaPages = await fetchDelta(context, syncTargetId, this.downloadQueue_);
+				// Wait for downloads to finish then add them to our remotes index
+				const taskResults = await this.downloadQueue_.waitForAllResults();
+				for (const path in taskResults) {
+					const task = taskResults[path];
+					if (task.error) throw task.error;
+					const content = task.result
+						? await BaseItem.unserialize(task.result)
+						: null;
+					for (const page of deltaPages) {
+						if (!page.remotesIndex.has(path)) continue;
+						const remote = page.remotesIndex.get(path);
+						remote.content = content;
+					}
+				}
+				// Index remote tags by title. We'll use it to check for conflicts by title.
+				const remoteTagsIndex = new Map<string, RemoteItem[]>();
+				for (const page of deltaPages) {
+					for (const { content } of page.remotesIndex.values()) {
+						if (!content) continue;
+						if (content.type_ === ModelType.Tag) {
+							const tag = content as TagEntity;
+							if (!remoteTagsIndex.has(tag.title)) {
+								remoteTagsIndex.set(tag.title, [content]);
+							} else {
+								const val = remoteTagsIndex.get(tag.title);
+								val.push(content);
+							}
+						}
+					}
+				}
+				// We need this to keep track of which tags have been synced.
+				const alreadySyncedTagIds = new Map();
+
 				const donePaths: string[] = [];
 
 				const completeItemProcessing = (path: string) => {
@@ -611,7 +947,12 @@ export default class Synchronizer {
 					const locals = result.items;
 
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-					await itemUploader.preUploadItems(result.items.filter((it: any) => result.neverSyncedItemIds.includes(it.id)));
+					await itemUploader.preUploadItems(
+						result.items.filter((it) =>
+							result.neverSyncedItemIds.includes(it.id),
+						),
+					);
+
 
 					for (let i = 0; i < locals.length; i++) {
 						if (this.cancelling()) break;
@@ -632,17 +973,41 @@ export default class Synchronizer {
 						//   and will see a conflict. There's currently no automatic fix for this - the remote item on the sync target must be fixed manually
 						//   (by setting an updated_time less than current time).
 						if (donePaths.indexOf(path) >= 0) {
-							const syncItem = await BaseItem.syncItem(syncTargetId, local.id, { fields: ['force_sync'] });
+							const syncItem = await BaseItem.syncItem(syncTargetId, local.id, {
+								fields: ['force_sync'],
+							});
 							if (local.updated_time > time.unixMs()) {
-								throw new JoplinError(sprintf('Processing a path that has already been done: %s. Remote item has an updated_time in the future', path), 'processingPathTwice');
+								throw new JoplinError(
+									sprintf(
+										'Processing a path that has already been done: %s. Remote item has an updated_time in the future',
+										path,
+									),
+									'processingPathTwice',
+								);
 							} else if (syncItem.force_sync) {
-								throw new JoplinError(sprintf('Processing a path that has already been done: %s. Item was marked for sync using force_sync', path), 'processingPathTwice');
+								throw new JoplinError(
+									sprintf(
+										'Processing a path that has already been done: %s. Item was marked for sync using force_sync',
+										path,
+									),
+									'processingPathTwice',
+								);
 							} else {
-								throw new JoplinError(sprintf('Processing a path that has already been done: %s. The user is making changes while the sync is in progress', path), 'changedDuringSync');
+								throw new JoplinError(
+									sprintf(
+										'Processing a path that has already been done: %s. The user is making changes while the sync is in progress',
+										path,
+									),
+									'changedDuringSync',
+								);
 							}
 						}
 
-						const remote: RemoteItem = result.neverSyncedItemIds.includes(local.id) ? null : await this.apiCall('stat', path);
+						let remote: RemoteItem = result.neverSyncedItemIds.includes(
+							local.id,
+						)
+							? null
+							: await this.apiCall('stat', path);
 						let action: SyncAction = null;
 						let itemIsReadOnly = false;
 						let reason = '';
@@ -650,15 +1015,47 @@ export default class Synchronizer {
 
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 						const getConflictType = (conflictedItem: any) => {
-							if (conflictedItem.type_ === BaseModel.TYPE_NOTE) return SyncAction.NoteConflict;
-							if (conflictedItem.type_ === BaseModel.TYPE_RESOURCE) return SyncAction.ResourceConflict;
+							if (conflictedItem.type_ === BaseModel.TYPE_NOTE) { return SyncAction.NoteConflict; }
+							if (conflictedItem.type_ === BaseModel.TYPE_RESOURCE) { return SyncAction.ResourceConflict; }
 							return SyncAction.ItemConflict;
 						};
 
 						if (!remote) {
 							if (!local.sync_time) {
-								action = SyncAction.CreateRemote;
-								reason = 'remote does not exist, and local is new and has never been synced';
+								if (local.type_ === ModelType.Tag || local.type_ === ModelType.NoteTag) {
+									// If local is a tag or note tag, extract the tag id
+									// and look through remoteTagsIndex to find out
+									// if we have a duplicate tag (by title).
+									const localItem = await BaseItem.loadItemByTypeAndId(local.type_, local.id);
+									let tagId: string;
+									if (localItem.type_ === ModelType.Tag) {
+										tagId = local.id;
+									} else if (localItem.type_ === ModelType.NoteTag) {
+										const noteTag = await BaseItem.loadItemByTypeAndId(local.type_, local.id);
+										tagId = noteTag.tag_id;
+									}
+									if (!alreadySyncedTagIds.has(tagId)) {
+										const tagsByTitle = remoteTagsIndex.get(localItem.title);
+										const conflictedTag = tagsByTitle
+											?.find((remote) => remote.id !== tagId);
+										if (!conflictedTag) {
+											action = SyncAction.CreateRemote;
+											reason =
+												'remote does not exist, and local is new and has never been synced';
+										} else {
+											remote = conflictedTag;
+											action = SyncAction.ResolveDuplicateTag;
+											reason = 'both remote and local exist, but local is a duplicate';
+											alreadySyncedTagIds.set(tagId, tagId);
+										}
+									} else {
+										reason = 'already synced';
+									}
+								} else {
+									action = SyncAction.CreateRemote;
+									reason =
+											'remote does not exist, and local is new and has never been synced';
+								}
 							} else {
 								// Note or item was modified after having been deleted remotely
 								// "itemConflict" is for all the items except the notes, which are dealt with in a special way
@@ -692,7 +1089,11 @@ export default class Synchronizer {
 									throw error;
 								}
 							}
-							if (!remoteContent) throw new Error(`Got metadata for path but could not fetch content: ${path}`);
+							if (!remoteContent) {
+								throw new Error(
+									`Got metadata for path but could not fetch content: ${path}`,
+								);
+							}
 							remoteContent = await BaseItem.unserialize(remoteContent);
 
 							if (remoteContent.updated_time > local.sync_time) {
@@ -715,7 +1116,50 @@ export default class Synchronizer {
 
 						this.logSyncOperation(action, local, remote, reason);
 
-						if (local.type_ === BaseModel.TYPE_RESOURCE && (action === SyncAction.CreateRemote || action === SyncAction.UpdateRemote)) {
+						if (action === SyncAction.ResolveDuplicateTag) {
+							// In a duplicate tag situation, we treat remote as the original
+							// and local as the duplicate.
+							// Regardless of whether the local item is a Tag or NoteTag,
+							// we make sure to reconcile ALL Tags AND NoteTags
+							// related to the conflict.
+							const localItem = await BaseItem.loadItemByTypeAndId(local.type_, local.id);
+							let localTagId: string;
+							if (localItem.type_ === ModelType.Tag) {
+								localTagId = local.id;
+							} else if (localItem.type_ === ModelType.NoteTag) {
+								localTagId = localItem.tag_id;
+							}
+							const syncTimeQueries = BaseItem.updateSyncTimeQueries(
+								syncTargetId,
+								remote,
+								BaseItem.remoteItemSyncTime(remote.updated_time),
+								remote.updated_time,
+							);
+							// Untag all notes previously tagged with local tag
+							// and tag them with remote tag.
+							const taggedNotes = await Tag.noteIds(localTagId);
+							await Tag.untagAll(localTagId);
+							await Tag.save(remote, {
+								autoTimestamp: false,
+								changeSource: ItemChange.SOURCE_SYNC,
+								nextQueries: syncTimeQueries,
+							});
+							for (const noteId of taggedNotes) {
+								await Tag.addNote(remote.id, noteId);
+							}
+							// Make sure we go through another upload iteration to create
+							// remote items for the note tags we've added locally.
+							result.hasMore = true;
+							// Sometimes a scheduled sync may omit the delta step, but if
+							// we've had to resolve a duplicate tag conflict, then we might
+							// as well go through it since we've made the call delta already.
+							syncSteps.push('delta');
+						}
+						if (
+							local.type_ === BaseModel.TYPE_RESOURCE &&
+              (action === SyncAction.CreateRemote ||
+                action === SyncAction.UpdateRemote)
+						) {
 							const localState = await Resource.localState(local.id);
 							if (localState.fetch_status !== Resource.FETCH_STATUS_DONE) {
 								// This condition normally shouldn't happen
@@ -750,8 +1194,15 @@ export default class Synchronizer {
 								// already been done" on the next loop, and sync
 								// will never finish because we'll always end up
 								// here.
-								logger.info(`Need to upload a resource, but blob is not present: ${path}`);
-								await handleCannotSyncItem(ItemClass, syncTargetId, local, 'Trying to upload resource, but only metadata is present.');
+								logger.info(
+									`Need to upload a resource, but blob is not present: ${path}`,
+								);
+								await handleCannotSyncItem(
+									ItemClass,
+									syncTargetId,
+									local,
+									'Trying to upload resource, but only metadata is present.',
+								);
 								action = null;
 							} else {
 								try {
@@ -763,7 +1214,9 @@ export default class Synchronizer {
 									const localResourceContentPath = result.path;
 
 									if (resource.size >= 10 * 1000 * 1000) {
-										logger.warn(`Uploading a large resource (resourceId: ${local.id}, size:${resource.size} bytes) which may tie up the sync process.`);
+										logger.warn(
+											`Uploading a large resource (resourceId: ${local.id}, size:${resource.size} bytes) which may tie up the sync process.`,
+										);
 									}
 
 									// We skip updating the blob if it hasn't
@@ -771,18 +1224,38 @@ export default class Synchronizer {
 									// that case, it means the resource metadata
 									// (title, filename, etc.) has been changed,
 									// but not the data blob.
-									const syncItem = await BaseItem.syncItem(syncTargetId, resource.id, { fields: ['sync_time', 'force_sync'] });
-									if (!syncItem || syncItem.sync_time < resource.blob_updated_time || syncItem.force_sync) {
-										await this.apiCall('put', remoteContentPath, null, { path: localResourceContentPath, source: 'file', shareId: resource.share_id });
+									const syncItem = await BaseItem.syncItem(
+										syncTargetId,
+										resource.id,
+										{ fields: ['sync_time', 'force_sync'] },
+									);
+									if (
+										!syncItem ||
+                    syncItem.sync_time < resource.blob_updated_time ||
+                    syncItem.force_sync
+									) {
+										await this.apiCall('put', remoteContentPath, null, {
+											path: localResourceContentPath,
+											source: 'file',
+											shareId: resource.share_id,
+										});
 									}
 								} catch (error) {
 									if (isCannotSyncError(error)) {
-										await handleCannotSyncItem(ItemClass, syncTargetId, local, error.message);
+										await handleCannotSyncItem(
+											ItemClass,
+											syncTargetId,
+											local,
+											error.message,
+										);
 										action = null;
 									} else if (error && error.code === ErrorCode.IsReadOnly) {
 										action = getConflictType(local);
 										itemIsReadOnly = true;
-										logger.info('Resource is readonly and cannot be modified - handling it as a conflict:', local);
+										logger.info(
+											'Resource is readonly and cannot be modified - handling it as a conflict:',
+											local,
+										);
 									} else {
 										throw error;
 									}
@@ -790,15 +1263,40 @@ export default class Synchronizer {
 							}
 						}
 
-						if (action === SyncAction.CreateRemote || action === SyncAction.UpdateRemote) {
+						if (
+							action === SyncAction.CreateRemote ||
+              action === SyncAction.UpdateRemote
+						) {
 							let canSync = true;
 							try {
-								if (this.testingHooks_.indexOf('notesRejectedByTarget') >= 0 && local.type_ === BaseModel.TYPE_NOTE) throw new JoplinError('Testing rejectedByTarget', 'rejectedByTarget');
-								if (this.testingHooks_.indexOf('itemIsReadOnly') >= 0) throw new JoplinError('Testing isReadOnly', ErrorCode.IsReadOnly);
-								await itemUploader.serializeAndUploadItem(ItemClass, path, local);
+								if (
+									this.testingHooks_.indexOf('notesRejectedByTarget') >= 0 &&
+                  local.type_ === BaseModel.TYPE_NOTE
+								) {
+									throw new JoplinError(
+										'Testing rejectedByTarget',
+										'rejectedByTarget',
+									);
+								}
+								if (this.testingHooks_.indexOf('itemIsReadOnly') >= 0) {
+									throw new JoplinError(
+										'Testing isReadOnly',
+										ErrorCode.IsReadOnly,
+									);
+								}
+								await itemUploader.serializeAndUploadItem(
+									ItemClass,
+									path,
+									local,
+								);
 							} catch (error) {
 								if (error && error.code === 'rejectedByTarget') {
-									await handleCannotSyncItem(ItemClass, syncTargetId, local, error.message);
+									await handleCannotSyncItem(
+										ItemClass,
+										syncTargetId,
+										local,
+										error.message,
+									);
 									canSync = false;
 								} else if (error && error.code === ErrorCode.IsReadOnly) {
 									action = getConflictType(local);
@@ -838,7 +1336,11 @@ export default class Synchronizer {
 								// uploading. So we can leave it unspecified and then on the next run of the delta step, it will
 								// get set there
 
-								await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time);
+								await ItemClass.saveSyncTime(
+									syncTargetId,
+									local,
+									local.updated_time,
+								);
 							}
 						}
 
@@ -867,99 +1369,71 @@ export default class Synchronizer {
 			// Loop through all the remote items, find those that
 			// have been created or updated, and apply the changes to local.
 			// ------------------------------------------------------------------------
-
-			if (this.downloadQueue_) await this.downloadQueue_.stop();
-			this.downloadQueue_ = new TaskQueue('syncDownload');
-			this.downloadQueue_.logger_ = logger;
-
 			if (syncSteps.indexOf('delta') >= 0) {
 				// At this point all the local items that have changed have been pushed to remote
 				// or handled as conflicts, so no conflict is possible after this.
+				if (this.downloadQueue_) await this.downloadQueue_.stop();
+				this.downloadQueue_ = new TaskQueue('syncDownload');
+				this.downloadQueue_.logger_ = logger;
 
 				let context = null;
+				if (lastContext.delta) context = lastContext.delta;
+				// Prefer cache when fetching delta just in case
+				// we have already made the call in the UPLOAD step.
+				const deltaPages = await fetchDelta(context, syncTargetId, this.downloadQueue_, { preferCache: true });
+
 				let newDeltaContext = null;
 				const localFoldersToDelete = new Set<string>();
 				let hasCancelled = false;
-				if (lastContext.delta) context = lastContext.delta;
+				const pageNum = 0;
 
 				while (true) {
 					if (this.cancelling() || hasCancelled) break;
 
-					const listResult: PaginatedList = await this.apiCall('delta', '', {
-						context: context,
-
-						// allItemIdsHandler() provides a way for drivers that don't have a delta API to
-						// still provide delta functionality by comparing the items they have to the items
-						// the client has. Very inefficient but that's the only possible workaround.
-						// It's a function so that it is only called if the driver needs these IDs. For
-						// drivers with a delta functionality it's a noop.
-						allItemIdsHandler: async () => {
-							return BaseItem.syncedItemIds(syncTargetId);
-						},
-
-						// This is only used by the basic delta
-						allItemMetadataHandler: async () => {
-							return BaseItem.remoteItemMetadata(syncTargetId);
-						},
-
-						wipeOutFailSafe: Setting.value('sync.wipeOutFailSafe'),
-
-						logger: logger,
-					});
-
-					// Ensure that if the sync target directory has changed, lost access, or has been purged by some external process while the sync is running, that a failsafe error is triggered where info.json and .sync/version.txt can no longer be found
-					// This check is more reliable than checking the count of items alone, as it is possible for sync items become segmented between 2 directories, possibly by the target directory changing during sync
-					// This scenario is possible with OneDrive sync, see https://github.com/laurent22/joplin/issues/11489
-					// This check while the sync is running is only necessary for the delta step of the sync, as this is where local deletions are calculated by comparing the local database and the sync target. These deletions are driven by the listResult field to determine which remote items exist
-					// As long as we check that info.json still exists after each time the listResult field is repopulated, there should not be a risk of unwanted deletions when failsafe is enabled, unless the target directory is directly manipulated by the user
-					await checkSyncTargetIsValid(this.api());
+					if (deltaPages.length === 0) break;
+					const currPage = deltaPages[pageNum];
+					const listResult = currPage.listResult;
+					const remotes = Array.from(currPage.remotesIndex.values());
 
 					const supportsDeltaWithItems = getSupportsDeltaWithItems(listResult);
-
 					logger.info('supportsDeltaWithItems = ', supportsDeltaWithItems);
 
-					const remotes = listResult.items;
+					this.logSyncOperation(
+						'fetchingTotal',
+						null,
+						null,
+						'Fetching delta items from sync target',
+						remotes.length,
+					);
 
-					this.logSyncOperation('fetchingTotal', null, null, 'Fetching delta items from sync target', remotes.length);
-
-					const remoteIds = remotes.map(r => BaseItem.pathToId(r.path));
+					const remoteIds = remotes.map(({ result }) =>
+						BaseItem.pathToId(result.path),
+					);
 					const locals = await BaseItem.loadItemsByIds(remoteIds);
 
-					for (const remote of remotes) {
-						if (this.cancelling()) break;
-
-						let needsToDownload = true;
-						if (this.api().supportsAccurateTimestamp) {
-							const local = locals.find(l => l.id === BaseItem.pathToId(remote.path));
-							if (local && local.updated_time === remote.jop_updated_time) needsToDownload = false;
-						}
-
-						if (supportsDeltaWithItems) {
-							needsToDownload = false;
-						}
-
-						if (needsToDownload) {
-							this.downloadQueue_.push(remote.path, async () => {
-								return this.apiCall('get', remote.path);
-							});
-						}
-					}
-
 					for (let i = 0; i < remotes.length; i++) {
-						if (this.cancelling() || this.testingHooks_.indexOf('cancelDeltaLoop2') >= 0) {
+						if (
+							this.cancelling() ||
+              this.testingHooks_.indexOf('cancelDeltaLoop2') >= 0
+						) {
 							hasCancelled = true;
 							break;
 						}
 
-						this.logSyncOperation('fetchingProcessed', null, null, 'Processing fetched item');
+						this.logSyncOperation(
+							'fetchingProcessed',
+							null,
+							null,
+							'Processing fetched item',
+						);
 
-						const remote = remotes[i];
+						const remote = remotes[i].result;
 						if (!BaseItem.isSystemPath(remote.path)) continue; // The delta API might return things like the .sync, .resource or the root folder
 
 						const loadContent = async () => {
 							if (supportsDeltaWithItems) return remote.jopItem;
 
-							const task = await this.downloadQueue_.waitForResult(path);
+							const task = await this.downloadQueue_.waitForResult(remote.path);
 							if (task.error) throw task.error;
 							if (!task.result) return null;
 							return await BaseItem.unserialize(task.result);
@@ -969,7 +1443,7 @@ export default class Synchronizer {
 						const remoteId = BaseItem.pathToId(path);
 						let action: SyncAction = null;
 						let reason = '';
-						let local = locals.find(l => l.id === remoteId);
+						let local = locals.find((l) => l.id === remoteId);
 						let ItemClass = null;
 						let content = null;
 
@@ -978,7 +1452,7 @@ export default class Synchronizer {
 								if (remote.isDeleted !== true) {
 									action = SyncAction.CreateLocal;
 									reason = 'remote exists but local does not';
-									content = await loadContent();
+									content = 'content' in remotes[i] ? remotes[i].content : await loadContent();
 									ItemClass = content ? BaseItem.itemClass(content) : null;
 								} else {
 									reason = 'skipping: the item was deleted';
@@ -991,14 +1465,24 @@ export default class Synchronizer {
 									reason = 'remote has been deleted';
 								} else {
 									if (localFoldersToDelete.has(remoteId)) {
-										logger.debug('Removing a scheduled folder deletion (', remoteId, '). It was recreated by sync.');
+										logger.debug(
+											'Removing a scheduled folder deletion (',
+											remoteId,
+											'). It was recreated by sync.',
+										);
 										localFoldersToDelete.delete(remoteId);
 									}
 
-									if (this.api().supportsAccurateTimestamp && remote.jop_updated_time === local.updated_time) {
+									if (
+										this.api().supportsAccurateTimestamp &&
+                    remote.jop_updated_time === local.updated_time
+									) {
 										// Nothing to do, and no need to fetch the content
 									} else {
-										content = await loadContent();
+										// Check our remotesIndex for the content prop. If it exists,
+										// then the content has already been downloaded.
+										// Otherwise we can load the content right here.
+										content = 'content' in remotes[i] ? remotes[i].content : await loadContent();
 										if (content && content.updated_time > local.updated_time) {
 											action = SyncAction.UpdateLocal;
 											reason = 'remote is more recent than local';
@@ -1006,7 +1490,12 @@ export default class Synchronizer {
 											// When the enhanced basic delta algorithm is first used, all items are rescanned and we need to persist the remoteItemUpdatedTime
 											// to set up the initial synced state. This also catches the case if content.updated_time < local.updated_time due to manual manipulation
 											// of the md files, to prevent these items being continually fetched on every sync
-											await ItemClass.saveSyncTime(syncTargetId, local, local.updated_time, remote.updated_time);
+											await ItemClass.saveSyncTime(
+												syncTargetId,
+												local,
+												local.updated_time,
+												remote.updated_time,
+											);
 										}
 									}
 								}
@@ -1022,15 +1511,24 @@ export default class Synchronizer {
 							}
 						}
 
-						if (this.testingHooks_.indexOf('skipRevisions') >= 0 && content && content.type_ === BaseModel.TYPE_REVISION) action = null;
+						if (
+							this.testingHooks_.indexOf('skipRevisions') >= 0 &&
+              content &&
+              content.type_ === BaseModel.TYPE_REVISION
+						) { action = null; }
 
 						if (!action) continue;
 
 						this.logSyncOperation(action, local, remote, reason);
 
-						if (action === SyncAction.CreateLocal || action === SyncAction.UpdateLocal) {
+						if (
+							action === SyncAction.CreateLocal ||
+              action === SyncAction.UpdateLocal
+						) {
 							if (content === null) {
-								logger.warn(`Remote has been deleted between now and the delta() call? In that case it will be handled during the next sync: ${path}`);
+								logger.warn(
+									`Remote has been deleted between now and the delta() call? In that case it will be handled during the next sync: ${path}`,
+								);
 								continue;
 							}
 							content = ItemClass.filter(content);
@@ -1040,27 +1538,46 @@ export default class Synchronizer {
 							// will not have these properties and, since they are required, it would cause a problem. So this check
 							// if they are present and, if not, set them to a reasonable default.
 							// Let's leave these two lines for 6 months, by which time all the clients should have been synced.
-							if (!content.user_updated_time) content.user_updated_time = content.updated_time;
-							if (!content.user_created_time) content.user_created_time = content.created_time;
+							if (!content.user_updated_time) { content.user_updated_time = content.updated_time; }
+							if (!content.user_created_time) { content.user_created_time = content.created_time; }
 
 							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 							const options: any = {
 								autoTimestamp: false,
-								nextQueries: BaseItem.updateSyncTimeQueries(syncTargetId, content, BaseItem.remoteItemSyncTime(content.updated_time), remote.updated_time),
+								nextQueries: BaseItem.updateSyncTimeQueries(
+									syncTargetId,
+									content,
+									BaseItem.remoteItemSyncTime(content.updated_time),
+									remote.updated_time,
+								),
 								changeSource: ItemChange.SOURCE_SYNC,
 							};
 							if (action === SyncAction.CreateLocal) options.isNew = true;
 							if (action === SyncAction.UpdateLocal) options.oldItem = local;
 
-							const creatingOrUpdatingResource = content.type_ === BaseModel.TYPE_RESOURCE && (action === SyncAction.CreateLocal || action === SyncAction.UpdateLocal);
+							const creatingOrUpdatingResource =
+                content.type_ === BaseModel.TYPE_RESOURCE &&
+                (action === SyncAction.CreateLocal ||
+                  action === SyncAction.UpdateLocal);
 
 							if (creatingOrUpdatingResource) {
 								if (content.size >= this.maxResourceSize()) {
-									await handleCannotSyncItem(ItemClass, syncTargetId, content, `File "${content.title}" is larger than allowed ${this.maxResourceSize()} bytes. Beyond this limit, the mobile app would crash.`, BaseItem.SYNC_ITEM_LOCATION_REMOTE);
+									await handleCannotSyncItem(
+										ItemClass,
+										syncTargetId,
+										content,
+										`File "${
+											content.title
+										}" is larger than allowed ${this.maxResourceSize()} bytes. Beyond this limit, the mobile app would crash.`,
+										BaseItem.SYNC_ITEM_LOCATION_REMOTE,
+									);
 									continue;
 								}
 
-								await ResourceLocalState.save({ resource_id: content.id, fetch_status: Resource.FETCH_STATUS_IDLE });
+								await ResourceLocalState.save({
+									resource_id: content.id,
+									fetch_status: Resource.FETCH_STATUS_IDLE,
+								});
 							}
 
 							if (content.type_ === ModelType.MasterKey) {
@@ -1077,7 +1594,9 @@ export default class Synchronizer {
 								// should always be in info.json now.
 								const existingMasterKey = await MasterKey.load(content.id);
 								if (!existingMasterKey) {
-									logger.info(`Downloaded a master key that was not in info.json - adding it to the store. ID: ${content.id}`);
+									logger.info(
+										`Downloaded a master key that was not in info.json - adding it to the store. ID: ${content.id}`,
+									);
 									await MasterKey.save(content);
 								}
 							} else {
@@ -1089,7 +1608,12 @@ export default class Synchronizer {
 								}
 							}
 
-							if (creatingOrUpdatingResource) this.dispatch({ type: 'SYNC_CREATED_OR_UPDATED_RESOURCE', id: content.id });
+							if (creatingOrUpdatingResource) {
+								this.dispatch({
+									type: 'SYNC_CREATED_OR_UPDATED_RESOURCE',
+									id: content.id,
+								});
+							}
 
 							// if (!hasAutoEnabledEncryption && content.type_ === BaseModel.TYPE_MASTER_KEY && !masterKeysBefore) {
 							// 	hasAutoEnabledEncryption = true;
@@ -1100,7 +1624,7 @@ export default class Synchronizer {
 							// 	logger.info('Encryption has been enabled with downloaded master key as active key. However, note that no password was initially supplied. It will need to be provided by user.');
 							// }
 
-							if (content.encryption_applied) this.dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' });
+							if (content.encryption_applied) { this.dispatch({ type: 'SYNC_GOT_ENCRYPTED_ITEM' }); }
 						} else if (action === SyncAction.DeleteLocal) {
 							if (local.type_ === BaseModel.TYPE_FOLDER) {
 								localFoldersToDelete.add(local.id);
@@ -1108,14 +1632,11 @@ export default class Synchronizer {
 							}
 
 							const ItemClass = BaseItem.itemClass(local.type_);
-							await ItemClass.delete(
-								local.id,
-								{
-									trackDeleted: false,
-									changeSource: ItemChange.SOURCE_SYNC,
-									sourceDescription: 'sync: deleteLocal',
-								},
-							);
+							await ItemClass.delete(local.id, {
+								trackDeleted: false,
+								changeSource: ItemChange.SOURCE_SYNC,
+								sourceDescription: 'sync: deleteLocal',
+							});
 						}
 					}
 
@@ -1138,11 +1659,13 @@ export default class Synchronizer {
 							newDeltaContext = listResult.context;
 							break;
 						}
-						context = listResult.context;
+						// context = listResult.context;
 					}
 				}
 
-				outputContext.delta = newDeltaContext ? newDeltaContext : lastContext.delta;
+				outputContext.delta = newDeltaContext
+					? newDeltaContext
+					: lastContext.delta;
 
 				// ------------------------------------------------------------------------
 				// Delete the folders that have been collected in the loop above.
@@ -1156,7 +1679,12 @@ export default class Synchronizer {
 					for (const folderId of localFoldersToDelete) {
 						const noteIds = await Folder.noteIds(folderId);
 						if (noteIds.length) {
-							logger.warn('Conflict: Folder to be deleted', folderId, 'still contains notes', noteIds);
+							logger.warn(
+								'Conflict: Folder to be deleted',
+								folderId,
+								'still contains notes',
+								noteIds,
+							);
 							// CONFLICT
 							await Folder.markNotesAsConflict(folderId);
 						}
@@ -1187,7 +1715,17 @@ export default class Synchronizer {
 
 			if (throwOnError) {
 				errorToThrow = error;
-			} else if (error && ['cannotEncryptEncrypted', 'noActiveMasterKey', 'processingPathTwice', 'failSafe', 'lockError', 'outdatedSyncTarget'].indexOf(error.code) >= 0) {
+			} else if (
+				error &&
+					[
+						'cannotEncryptEncrypted',
+						'noActiveMasterKey',
+						'processingPathTwice',
+						'failSafe',
+						'lockError',
+						'outdatedSyncTarget',
+					].indexOf(error.code) >= 0
+			) {
 				// Only log an info statement for this since this is a common condition that is reported
 				// in the application, and needs to be resolved by the user.
 				// Or it's a temporary issue that will be resolved on next sync.
@@ -1195,11 +1733,15 @@ export default class Synchronizer {
 
 				if (error.code === 'failSafe' || error.code === 'lockError') {
 					// Get the message to display on UI, but not in testing to avoid polluting stdout
-					if (!shim.isTestingEnv()) this.progressReport_.errors.push(error.message);
+					if (!shim.isTestingEnv()) { this.progressReport_.errors.push(error.message); }
 					this.logLastRequests();
 				}
 			} else if (error.code === 'unknownItemType') {
-				this.progressReport_.errors.push(_('Unknown item type downloaded - please upgrade Joplin to the latest version'));
+				this.progressReport_.errors.push(
+					_(
+						'Unknown item type downloaded - please upgrade Joplin to the latest version',
+					),
+				);
 				logger.error(error);
 			} else if (error.code === 'changedDuringSync') {
 				// We want to re-trigger the sync in this scenario
@@ -1209,7 +1751,10 @@ export default class Synchronizer {
 				logger.error(error);
 				if (error.details) logger.error('Details:', error.details);
 
-				const isLocalWebDavServer = Setting.value('sync.target') === SyncTargetRegistry.nameToId('webdav') && isLocalServer(Setting.value('sync.6.path'));
+				const isLocalWebDavServer =
+          Setting.value('sync.target') ===
+            SyncTargetRegistry.nameToId('webdav') &&
+          isLocalServer(Setting.value('sync.6.path'));
 
 				// Don't save to the report errors that are due to things like temporary network errors or timeout, except if using a local WebDAV server, in which
 				// case timeout errors can occur when the server is actually down. Those type of errors happen consistently when a local server is down when using
@@ -1224,7 +1769,11 @@ export default class Synchronizer {
 
 		if (syncLock) {
 			this.lockHandler().stopAutoLockRefresh(syncLock);
-			await this.lockHandler().releaseLock(LockType.Sync, this.lockClientType(), this.clientId_);
+			await this.lockHandler().releaseLock(
+				LockType.Sync,
+				this.lockClientType(),
+				this.clientId_,
+			);
 		}
 
 		this.syncTargetIsLocked_ = false;
@@ -1239,7 +1788,12 @@ export default class Synchronizer {
 
 		this.progressReport_.completedTime = time.unixMs();
 
-		this.logSyncOperation('finished', null, null, `Synchronisation finished [${synchronizationId}]`);
+		this.logSyncOperation(
+			'finished',
+			null,
+			null,
+			`Synchronisation finished [${synchronizationId}]`,
+		);
 
 		await this.logSyncSummary(this.progressReport_);
 
@@ -1250,12 +1804,17 @@ export default class Synchronizer {
 		});
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
-		await checkDisabledSyncItemsNotification((action: any) => this.dispatch(action));
+		await checkDisabledSyncItemsNotification((action: any) =>
+			this.dispatch(action),
+		);
 
 		this.onProgress_ = function() {};
 		this.progressReport_ = {};
 
-		this.dispatch({ type: 'SYNC_COMPLETED', isFullSync: this.isFullSync(syncSteps) });
+		this.dispatch({
+			type: 'SYNC_COMPLETED',
+			isFullSync: this.isFullSync(syncSteps),
+		});
 
 		this.state_ = 'idle';
 
@@ -1265,17 +1824,24 @@ export default class Synchronizer {
 		// If there are any un-synced outgoing changes made up to the point just before the sync completes, then trigger the sync again to reduce the likelihood
 		// that the user will close or minimise the app when there are un-synced changes, because the sync is reported as completed.
 		// IMPORTANT: This must be the very last step in the sync, to avoid any window to allow an un-synced change to get missed
-		if (!hasErrors && !hasCaughtError && !cancelledBeforeClearedState && !this.cancelling()) {
+		if (
+			!hasErrors &&
+      !hasCaughtError &&
+      !cancelledBeforeClearedState &&
+      !this.cancelling()
+		) {
 			const result = await BaseItem.itemsThatNeedSync(syncTargetId);
 
 			if (result.items.length > 0) {
-				logger.info('There are more outgoing changes to sync, schedule the sync again');
+				logger.info(
+					'There are more outgoing changes to sync, schedule the sync again',
+				);
 				void reg.scheduleSync(reg.syncAsYouTypeInterval(), { syncSteps }, true);
 				hasOutgoingChanges = true;
 			}
 		}
 
-		if (!hasOutgoingChanges) this.dispatch({ type: 'SYNC_PENDING_UPDATE', value: false });
+		if (!hasOutgoingChanges) { this.dispatch({ type: 'SYNC_PENDING_UPDATE', value: false }); }
 
 		return outputContext;
 	}

--- a/packages/lib/TaskQueue.ts
+++ b/packages/lib/TaskQueue.ts
@@ -143,6 +143,17 @@ export default class TaskQueue {
 		});
 	}
 
+	public async waitForAllResults() {
+		return new Promise((resolve) => {
+			const checkIID = setInterval(() => {
+				if (this.waitingTasks_.length) return;
+				if (Object.keys(this.processingTasks_).length) return;
+				clearInterval(checkIID);
+				resolve(this.results_);
+			}, 100);
+		});
+	}
+
 	public async waitForOneSlot() {
 		return new Promise((resolve) => {
 			const checkIID = setInterval(() => {

--- a/packages/lib/services/synchronizer/Synchronizer.tags.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.tags.test.ts
@@ -4,6 +4,7 @@ import Note from '../../models/Note';
 import Tag from '../../models/Tag';
 import MasterKey from '../../models/MasterKey';
 import { setEncryptionEnabled } from '../synchronizer/syncInfoUtils';
+import NoteTag from '../../models/NoteTag';
 
 describe('Synchronizer.tags', () => {
 
@@ -70,4 +71,66 @@ describe('Synchronizer.tags', () => {
 		await shouldSyncTagTest(true);
 	}));
 
+	it('should replace a local tag with its remote counterpart when they both have the same title but different ids',
+		async () => {
+			const n1 = await Note.save({ title: 'mynote' });
+			const localTag = await Tag.save({ title: 'mytag' });
+			await Tag.addNote(localTag.id, n1.id);
+			let noteIds = await Tag.noteIds(localTag.id);
+			expect(noteIds).toContain(n1.id);
+			await synchronizerStart();
+
+			await switchClient(2);
+
+			const n2 = await Note.save({ title: 'mynote2' });
+			const remoteTag = await Tag.save({ title: 'mytag' });
+			await Tag.addNote(remoteTag.id, n2.id);
+			noteIds = await Tag.noteIds(remoteTag.id);
+			expect(noteIds).toContain(n2.id);
+
+			expect(!!localTag).toBe(true);
+			expect(!!remoteTag).toBe(true);
+			expect(localTag.id).not.toBe(remoteTag.id);
+			expect(localTag.title).toBe(remoteTag.title);
+
+			await synchronizerStart();
+
+			const localTagAfterSync = await Tag.load(localTag.id);
+			const remoteTagAfterSync = await Tag.load(remoteTag.id);
+			expect(localTagAfterSync.id).toBe(localTag.id);
+			expect(remoteTagAfterSync).not.toBeDefined();
+		},
+	);
+
+	it('should update the tag_id of note tags when when local tag is a duplicate of a remote tag with the same title',
+		async () => {
+			const n1 = await Note.save({ title: 'mynote' });
+			const localTag = await Tag.save({ title: 'mytag' });
+			await Tag.addNote(localTag.id, n1.id);
+			let noteIds = await Tag.noteIds(localTag.id);
+			expect(noteIds).toContain(n1.id);
+			await synchronizerStart();
+
+			await switchClient(2);
+
+			const n2 = await Note.save({ title: 'mynote2' });
+			const remoteTag = await Tag.save({ title: 'mytag' });
+			await Tag.addNote(remoteTag.id, n2.id);
+			noteIds = await Tag.noteIds(remoteTag.id);
+			expect(noteIds).toContain(n2.id);
+
+			expect(!!localTag).toBe(true);
+			expect(!!remoteTag).toBe(true);
+			expect(localTag.id).not.toBe(remoteTag.id);
+			expect(localTag.title).toBe(remoteTag.title);
+
+			await synchronizerStart();
+
+			const noteTags = await NoteTag.byNoteIds([n1.id, n2.id]);
+			expect(noteTags).toHaveLength(2);
+			const [nt1, nt2] = noteTags;
+			expect(nt1).toHaveProperty('tag_id', localTag.id);
+			expect(nt2).toHaveProperty('tag_id', localTag.id);
+		},
+	);
 });

--- a/packages/lib/services/synchronizer/utils/types.ts
+++ b/packages/lib/services/synchronizer/utils/types.ts
@@ -16,6 +16,7 @@ export enum SyncAction {
 	CreateLocal = 'createLocal',
 	UpdateLocal = 'updateLocal',
 	DeleteLocal = 'deleteLocal',
+	ResolveDuplicateTag = 'resolveDuplicateTag',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied


### PR DESCRIPTION
## Problem

Say we have two clients, `A` and `B`. If `B` creates a new tag that already exists in `A` but not in `B`, then the next sync will result in duplicate tags on both clients. 

The problem arises due to the fact that when `B` creates a new tag, it has no knowledge that a tag with the same title already exists in `A`. Thus, it proceeds to create the tag with a fresh new id. When `B` syncs, both the local and remote tags are considered to be distinct from each other since they have different ids despite having the same title. And so we end up with duplicate tags in `B`. When `A` syncs, it also gets duplicate tags.

## Solution

On sync, identify which remote tags have a duplicate local counterpart during the upload step. Handle the conflict by 

1. Overwriting the local tag with the remote tag.
2. Untagging all local notes previously tagged with the local tag and re-tagging them the remote tag.

### Reasoning

If a tag is present in `A` but not in `B` then it must appear in the delta results called from `B`. This is why we can reliably compare our never synced local tags to delta to check for duplicates.

### Performance

**Upload step**

The API call to delta is now also called at the beginning of the upload step and indexed. All queued downloads are awaited and also indexed. This is done to enable lookup of remote tags in O(1) to check for duplicates.

**Delta step**

To prevent an additional API call in the delta step, we cache the result if it was previously called during the upload step.

**Overall overhead**

- **When the sync steps include delta**: this approach is just as efficient, except possibly when we await for the entire download queue to finish in the upload step. 

- **When the sync steps include delete and upload, but not delta**: we may incur overhead from both the call to delta and awaiting the download queue in the upload step.

## Testing

**Manual**

The change was verified manually by attempting to reproduce the error as discussed under issue #14540.

- **Client 1**: Joplin CLI app
- **Client 2**: Joplin desktop app (on Linux: Debian)

1. Setup 2 Joplin clients with the default notes
2. Make sure both clients are in sync
3. On client 1, create the tag 'meetings', then click sync
4. On client 2, before the client has a chance to sync again, create the tag 'meetings', then click sync

On sync completion, rather than ending up with 2 tags that each have the same title `meetings` with a count of 1, we get one tag `meetings` that has a count of 2. If we proceed to sync client 1 again, we get the same result.

**Automated**

Two unit tests have been implemented to verify that the change works as intended. Particularly we check that

1. The local tag has been overwritten with the remote tag.
2. All related note tags have been amended to reflect the change in (1).





