### PR TITLE
Mobile: Fixes #13957: Fixed log screen auto-scroll loop during search

### DIFF
--- a/packages/app-mobile/components/screens/LogScreen.tsx
+++ b/packages/app-mobile/components/screens/LogScreen.tsx
@@ -73,7 +73,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 			if (this.refreshLogTimeout) {
 				clearTimeout(this.refreshLogTimeout);
 			}
-			setTimeout(() => {
+			this.refreshLogTimeout = setTimeout(() => {
 				this.refreshLogTimeout = null;
 				void this.refreshLogEntries();
 			}, 600);

--- a/packages/app-mobile/components/screens/LogScreen.tsx
+++ b/packages/app-mobile/components/screens/LogScreen.tsx
@@ -66,7 +66,6 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 	private refreshLogTimeout: any = null;
 	public override componentDidUpdate(_prevProps: Props, prevState: State) {
 		if ((prevState?.filter ?? '') !== (this.state.filter ?? '')) {
-			this.logListRef_.current?.scrollToOffset({ offset: 0, animated: false });
 
 			// We refresh the log only after a brief delay -- this prevents the log from updating
 			// with every keystroke in the filter input.

--- a/packages/app-mobile/components/screens/LogScreen.tsx
+++ b/packages/app-mobile/components/screens/LogScreen.tsx
@@ -35,6 +35,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 	private readonly menuOptions_: MenuOptionType[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	private styles_: any;
+	private readonly logListRef_ = React.createRef<FlatList>();
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	public static navigationOptions(): any {
@@ -65,6 +66,8 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 	private refreshLogTimeout: any = null;
 	public override componentDidUpdate(_prevProps: Props, prevState: State) {
 		if ((prevState?.filter ?? '') !== (this.state.filter ?? '')) {
+			this.logListRef_.current?.scrollToOffset({ offset: 0, animated: false });
+
 			// We refresh the log only after a brief delay -- this prevents the log from updating
 			// with every keystroke in the filter input.
 			if (this.refreshLogTimeout) {
@@ -165,6 +168,10 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 		this.setState({
 			logEntries: logEntries,
 			showErrorsOnly: showErrorsOnly,
+		}, () => {
+			if (this.state.filter !== undefined) {
+				this.logListRef_.current?.scrollToOffset({ offset: 0, animated: false });
+			}
 		});
 	}
 
@@ -218,6 +225,7 @@ class LogScreenComponent extends BaseScreenComponent<Props, State> {
 					onSearchButtonPress={this.onToggleFilterInput}/>
 				{this.state.filter !== undefined ? filterInput : null}
 				<FlatList
+					ref={this.logListRef_}
 					data={this.state.logEntries}
 					initialNumToRender={100}
 					renderItem={this.onRenderLogRow}


### PR DESCRIPTION
# AI Assistance Disclosure
Parts of this pull request were drafted with the help of an AI assistant. All code has been reviewed and verified manually.

Fixes #13957
# Problem
After scrolling down the log so that the loaded area has expanded, when using the search button to filter the log on the search screen, the filtered log automatically scrolls up and down quickly and repeatedly, and continues doing so after manually scrolling.

# Solution
Reset the FlatList scroll position after filtered data is applied.

Previously, the list could keep an unstable deep offset while the dataset changed due to filtering, which could trigger repeated scroll re-anchoring. Resetting after data application makes the filtered view start from a stable position and prevents the scroll loop.

# Test Plan
## Manual testing

In order to test this , manual testing was performed using the following steps:
1. Open mobile Log screen.
2. Scroll down several swipes.
3. Type any word in search


# Demo

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/134ed112-805d-4242-9e22-b372e5a02ea5" controls width="320"></video> | <video src="https://github.com/user-attachments/assets/fc05d53f-543b-43a2-a599-ffa8b9add31e" controls width="320"></video> |






