### PR TITLE
Mobile: Disable auto correct, auto complete and auto capitalize for search fields

### DIFF
--- a/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
@@ -51,8 +51,8 @@ const SearchBar: React.FC<Props> = ({ themeId, value, autoFocus, placeholder, on
 			<TextInput
 				style={styles.searchTextInput}
 				autoFocus={autoFocus}
-				autoCapitalize="none"
-				autoComplete="off"
+				autoCapitalize='none'
+				autoComplete='off'
 				autoCorrect={false}
 				underlineColorAndroid="#ffffff00"
 				onChangeText={onChangeText}

--- a/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
+++ b/packages/app-mobile/components/screens/SearchScreen/SearchBar.tsx
@@ -51,6 +51,9 @@ const SearchBar: React.FC<Props> = ({ themeId, value, autoFocus, placeholder, on
 			<TextInput
 				style={styles.searchTextInput}
 				autoFocus={autoFocus}
+				autoCapitalize="none"
+				autoComplete="off"
+				autoCorrect={false}
 				underlineColorAndroid="#ffffff00"
 				onChangeText={onChangeText}
 				onSubmitEditing={onSubmitEditing}


### PR DESCRIPTION
According to https://discourse.joplinapp.org/t/ios-now-corrects-search-string/48684/3, in recent versions of Joplin mobile, the note search input uses auto correction / auto complete, which causes difficulty entering and submitting search terms when using a keyboard to navigate the app. Logically a search input should not use auto correct, auto complete or auto capitalize, as the input allows incomplete words or phrases by design, so should be excluded from those functions of the input method.

This PR disables auto correct, auto complete and auto capitalize for both the note search and tag search inputs in the app.

### Testing

**Behaviour before change:**

https://github.com/user-attachments/assets/264c6ae8-da0c-4b5c-851b-738ef8cfed6f

**Behaviour after change:**

https://github.com/user-attachments/assets/910d01a7-5e88-42d6-a582-070fdd7845c1

