### PR TITLE
Mobile: fix openFolder x-callback-url link on Android

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -651,6 +651,7 @@ packages/app-mobile/commands/newNote.js
 packages/app-mobile/commands/openItem.js
 packages/app-mobile/commands/openNote.js
 packages/app-mobile/commands/scrollToHash.js
+packages/app-mobile/commands/util/goToFolder.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/commands/util/showResource.js
 packages/app-mobile/components/BetaChip.js

--- a/.gitignore
+++ b/.gitignore
@@ -624,6 +624,7 @@ packages/app-mobile/commands/newNote.js
 packages/app-mobile/commands/openItem.js
 packages/app-mobile/commands/openNote.js
 packages/app-mobile/commands/scrollToHash.js
+packages/app-mobile/commands/util/goToFolder.js
 packages/app-mobile/commands/util/goToNote.js
 packages/app-mobile/commands/util/showResource.js
 packages/app-mobile/components/BetaChip.js

--- a/packages/app-mobile/commands/openItem.ts
+++ b/packages/app-mobile/commands/openItem.ts
@@ -9,6 +9,7 @@ import { BaseItemEntity } from '@joplin/lib/services/database/types';
 import { ModelType } from '@joplin/lib/BaseModel';
 import showResource from './util/showResource';
 import { isCallbackUrl, parseCallbackUrl } from '@joplin/lib/callbackUrlUtils';
+import goToFolder from './util/goToFolder';
 
 const logger = Logger.create('openItemCommand');
 
@@ -20,10 +21,16 @@ const openItemById = async (itemId: string, hash?: string) => {
 	logger.info(`Navigating to item ${itemId}`);
 	const item: BaseItemEntity = await BaseItem.loadItemById(itemId);
 
+	if (!item) {
+		throw new Error(`Item not found: ${itemId}`);
+	}
+
 	if (item.type_ === ModelType.Note) {
 		await goToNote(itemId, hash);
 	} else if (item.type_ === ModelType.Resource) {
 		await showResource(item);
+	} else if (item.type_ === ModelType.Folder) {
+		await goToFolder(item.id);
 	} else {
 		throw new Error(`Unsupported item type for links: ${item.type_}`);
 	}

--- a/packages/app-mobile/commands/util/goToFolder.ts
+++ b/packages/app-mobile/commands/util/goToFolder.ts
@@ -1,0 +1,11 @@
+import Folder from '@joplin/lib/models/Folder';
+import NavService from '@joplin/lib/services/NavService';
+
+const goToFolder = async (id: string) => {
+	if (!(await Folder.load(id))) {
+		throw new Error(`No folder with id ${id}`);
+	}
+	return NavService.go('Notes', { folderId: id });
+};
+
+export default goToFolder;


### PR DESCRIPTION
Fixes #14286

## Summary
Fixes `joplin://x-callback-url/openFolder?id=<id>` links not working on Android.

## Problem
On Android, clicking a `joplin://x-callback-url/openFolder` link resulted in the error:

Unsupported item type for links: 2

The deep-link handler did not correctly support folder targets, causing the app to fail when attempting to open a notebook via an external link.

## Solution
Update the Android deep-link handling logic so that folder links are recognized and the application navigates to the corresponding notebook instead of treating the link as an unsupported item type.

## Testing
Tested on an Android emulator (Pixel 6, API 34):

1. Created a notebook in Joplin
2. Copied its external link
3. Triggered the link using:

adb shell am start -a android.intent.action.VIEW -d "joplin://x-callback-url/openFolder?id=<folderId>"

Result:
- Joplin opens and navigates to the correct notebook.
- Verified that `openNote` links still work as expected (no regression).

**Result**

https://github.com/user-attachments/assets/4d254dcf-ff82-46ff-ad5b-c15d7ea492b9


