### PR TITLE
All: Sync: Fix notebook sharing can fail due to incorrect read-only share state

### DIFF
--- a/packages/lib/models/Folder.sharing.test.ts
+++ b/packages/lib/models/Folder.sharing.test.ts
@@ -181,6 +181,34 @@ describe('models/Folder.sharing', () => {
 		}
 	}));
 
+	it('should successfully clear the share ID of a no-longer-shared item in a readonly share', async () => {
+		const root = await Folder.save({
+			title: 'unshared root',
+			share_id: '',
+		});
+
+		const shareId = 'some-share-id-here';
+		const folder = await Folder.save({
+			title: 'Unshared, but still with an old share ID',
+			share_id: shareId,
+			parent_id: root.id,
+		});
+
+		const reset = simulateReadOnlyShareEnv([shareId]);
+		try {
+			await Folder.updateAllShareIds(
+				resourceService(),
+				Folder.syncShareCache.shares,
+			);
+		} finally {
+			reset();
+		}
+
+		expect(await Folder.load(folder.id)).toMatchObject({
+			share_id: '',
+		});
+	});
+
 	it('updating share IDs should not fail when a read-only resource is linked to a writeable note', async () => {
 		const root = await Folder.save({ title: 'read-only' });
 		let note = await Note.save({ title: 'Test', parent_id: root.id });

--- a/packages/lib/models/Folder.ts
+++ b/packages/lib/models/Folder.ts
@@ -548,7 +548,12 @@ export default class Folder extends BaseItem {
 				share_id: '',
 				updated_time: Date.now(),
 				parent_id: item.parent_id,
-			}, { autoTimestamp: false });
+			}, {
+				autoTimestamp: false,
+				// Required, to handle the case where the item's share_id points
+				// to a read-only share:
+				disableReadOnlyCheck: true,
+			});
 		}
 
 		logger.debug('updateFolderShareIds:', report);

--- a/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
+++ b/packages/lib/services/synchronizer/Synchronizer.basics.test.ts
@@ -283,6 +283,26 @@ describe('Synchronizer.basics', () => {
 		expect(conflictNote.id).not.toBe(note.id);
 	}));
 
+	it('should revert local changes to read-only folders', (async () => {
+		const folder = await Folder.save({ title: 'folder' });
+		await synchronizerStart();
+		await Folder.save({
+			id: folder.id,
+			title: 'folder (changed)',
+			share_id: 'some-incorrect-share-id',
+		});
+		synchronizer().testingHooks_ = ['itemIsReadOnly'];
+		await synchronizerStart();
+		synchronizer().testingHooks_ = [];
+
+		const reloadedFolder = await Folder.load(folder.id);
+		expect(reloadedFolder.title).toBe('folder');
+		expect(reloadedFolder.share_id).toBe('');
+
+		// Should not have created a conflict
+		expect(await Folder.all()).toHaveLength(1);
+	}));
+
 	it('should allow duplicate folder titles', (async () => {
 		await Folder.save({ title: 'folder' });
 


### PR DESCRIPTION
# Problem

If a Joplin client had a folder hierarchy similar to the following, notebook sharing would fail and errors would be logged during sync:

Suppose that a Joplin client has a `📂 Folder A` with empty `share_id`, which contains a `📂 Folder B` with a `share_id` that points to a read-only share:
```
📂 Folder A (share_id: '')
| 📂 Folder B (share_id: 'some-id-here')
```

Then, when `Folder.updateFolderShareIds` attempted to clear `📂 Folder B`'s `share_id`, a "Cannot change or delete a read-only item" exception would be thrown. This caused notebook sharing to fail and resulted in a warning ([caught here](https://github.com/laurent22/joplin/blob/c9dace8b4debd97c86e9f918b9272dd6b8b240dd/packages/lib/Synchronizer.ts#L477)) during sync.

See [the relevant forum post](https://discourse.joplinapp.org/t/problems-with-sync-and-sharing-notes-joplin-3-6-4-macos/49181).

# Solution

Disable the "is the item read-only" assertion in this case. If the change was incorrect, it should be later rejected by Joplin Server/Cloud during sync.

> [!NOTE]
>
> While this solution matches the behavior for non-read-only items (clearing the `share_id`), I'm not certain that this is the best solution. An alternative might be to keep the `share_id` as-is for read-only items.

# Testing

- This pull request includes an automated test that failed prior to the `disableReadOnlyCheck` change in `Folder.ts`.
- The sync fuzzer runs successfully for >= 130 steps.

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->