### PR TITLE
Mobile: Fixes #14722: Fix incorrect sizing of the tag association screen when opening and dismissing the onscreen keyboard

### DIFF
--- a/packages/app-mobile/components/KeyboardAvoidingView.tsx
+++ b/packages/app-mobile/components/KeyboardAvoidingView.tsx
@@ -11,7 +11,9 @@ const KeyboardAvoidingView: React.FC<Props> = ({ enabled, children, ...forwarded
 		// When the floating keyboard is enabled, the KeyboardAvoidingView can have a very small
 		// height. Don't use the KeyboardAvoidingView when the floating keyboard is enabled.
 		// See https://github.com/facebook/react-native/issues/29473
-		!keyboardState.isFloatingKeyboard
+		// Also disable the keyboard avoiding view when the keyboard is not visible, to avoid sizing issues:
+		// https://github.com/laurent22/joplin/issues/14722
+		!keyboardState.isFloatingKeyboard && keyboardState.keyboardVisible
 	);
 
 	return <NativeKeyboardAvoidingView

--- a/packages/app-mobile/components/Modal.tsx
+++ b/packages/app-mobile/components/Modal.tsx
@@ -13,6 +13,7 @@ import useSafeAreaPadding from '../utils/hooks/useSafeAreaPadding';
 import { _ } from '@joplin/lib/locale';
 import KeyboardAvoidingView from './KeyboardAvoidingView';
 import Dialog from '@joplin/lib/components/Dialog';
+import useKeyboardState from '../utils/hooks/useKeyboardState';
 
 type OnClose = ()=> void;
 type OnShow = ()=> void;
@@ -42,8 +43,16 @@ export interface ModalElementProps {
 }
 
 const useStyles = (hasScrollView: boolean, backgroundColor: string|undefined) => {
-	const safeAreaPadding = useSafeAreaPadding();
+	const safeArea = useSafeAreaPadding();
+	const keyboardState = useKeyboardState();
 	return useMemo(() => {
+		const safeAreaPadding = {
+			paddingRight: safeArea.paddingRight,
+			paddingLeft: safeArea.paddingLeft,
+			paddingTop: safeArea.paddingTop,
+			paddingBottom: keyboardState.keyboardVisible ? 0 : safeArea.paddingBottom,
+		};
+
 		// On Android, the top-level container seems to need to be absolutely positioned
 		// to prevent it from being larger than the screen size:
 		const absoluteFill = {
@@ -90,7 +99,7 @@ const useStyles = (hasScrollView: boolean, backgroundColor: string|undefined) =>
 				zIndex: -1,
 			},
 		});
-	}, [hasScrollView, safeAreaPadding, backgroundColor]);
+	}, [hasScrollView, safeArea, keyboardState, backgroundColor]);
 };
 
 const useBackgroundTouchListeners = (onRequestClose: OnClose|null, backdropRef: RefObject<View>) => {


### PR DESCRIPTION
Since the React Native 0.81 upgrade, when opening an dismissing the onscreen keyboard on the tag association screen, the modal resizes incorrectly, leaving a variable gap between the top of the keyboard / bottom of the screen, depending on the Android version. This is due to change in the way the KeyboardAvoidingView behaves in the newer version of React Native. It is no longer necessary to include the bottom inset when the keyboard is visible and docked, as this is causing the gap when the on screen keyboard is open.

This PR addresses the issue by overriding the bottom inset to 0 for modals, when the keyboard is visible and docked. In addition, to fix the gap which occurs when dismissing the onscreen keyboard after it has already been opened, I have simply disabled the KeyboardAvoidingView the the keyboard is not visible.

This fixes: https://github.com/laurent22/joplin/issues/14722

### Testing

Testing on Android 16 with on screen keyboard and in hardware input mode:
https://github.com/user-attachments/assets/8c075395-60a3-4fc8-a398-843d96c2cc3c

Testing on Android 12 in hardware input mode with gesture navigation:
https://github.com/user-attachments/assets/8b7e80d4-3186-4782-9a3e-0831508f090a

Also tested on Android 10 on a real device, with an equivalent result, and also verified when the on screen keyboard is in floating mode, the model expands to the full screen height minus the insets