### PR TITLE
Desktop:add password strength indicator to pc app

### DIFF
--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useCallback, useState, useEffect, useMemo } from 'react';
-import { getPasswordStrength, passwordStrengthLabels } from '@joplin/lib/services/e2ee/passwordStrength';
+import { getPasswordStrength } from '@joplin/lib/services/e2ee/passwordStrength';
+import { themeStyle } from '@joplin/lib/theme';
 import { _ } from '@joplin/lib/locale';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import DialogButtonRow, { ClickEvent } from '../DialogButtonRow';
@@ -171,20 +172,22 @@ export default function(props: Props) {
 		if (showPasswordForm) {
 			const enterPasswordLabel = [MasterPasswordStatus.Loaded, MasterPasswordStatus.Valid].includes(status) ? _('Enter new password') : _('Enter password');
 
+			const theme = themeStyle(props.themeId);
 			const strengthResult = getPasswordStrength(password1);
 			const strengthColors = ['#D32F2F', '#E64A19', '#FBC02D', '#7CB342', '#388E3C'];
 			const strengthColor = strengthColors[strengthResult.score];
 			const strengthPercent = password1 ? ((strengthResult.score + 1) / 5) * 100 : 0;
-			const strengthLabel = password1 ? passwordStrengthLabels[strengthResult.score] : '';
+			const strengthLabels = [_('Very Weak'), _('Weak'), _('Fair'), _('Strong'), _('Very Strong')];
+			const strengthLabel = password1 ? strengthLabels[strengthResult.score] : '';
 
 			const renderStrengthIndicator = () => {
 				if (!password1) return null;
 
 				return (
-					<div className="password-strength-indicator" style={{ marginTop: 8 }}>
+					<div style={{ marginTop: 8 }}>
 						<div style={{
 							height: 6,
-							backgroundColor: '#e0e0e0',
+							backgroundColor: theme.dividerColor,
 							borderRadius: 3,
 							overflow: 'hidden',
 							marginBottom: 4,
@@ -197,19 +200,17 @@ export default function(props: Props) {
 								transition: 'width 0.3s ease, background-color 0.3s ease',
 							}} />
 						</div>
-						<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-							<span style={{ fontSize: 12, fontWeight: 'bold', color: strengthColor }}>
-								{strengthLabel}
-							</span>
-						</div>
+						<span style={{ fontSize: theme.fontSize, fontWeight: 'bold', color: strengthColor }}>
+							{strengthLabel}
+						</span>
 						{strengthResult.feedback.warning && (
-							<p style={{ fontSize: 12, color: '#D32F2F', margin: '4px 0 0 0' }}>
+							<p style={{ fontSize: theme.fontSize, color: theme.colorError, margin: '4px 0 0 0' }}>
 								{strengthResult.feedback.warning}
 							</p>
 						)}
 						{strengthResult.feedback.suggestions.length > 0 && (
-							<ul style={{ fontSize: 12, margin: '4px 0 0 0', paddingLeft: 16, color: '#666' }}>
-								{strengthResult.feedback.suggestions.map((s, i) =>
+							<ul style={{ fontSize: theme.fontSize, margin: '4px 0 0 0', paddingLeft: 16, color: theme.colorFaded }}>
+								{strengthResult.feedback.suggestions.map((s: string, i: number) =>
 									<li key={i}>{s}</li>,
 								)}
 							</ul>

--- a/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
+++ b/packages/app-desktop/gui/MasterPasswordDialog/Dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useCallback, useState, useEffect, useMemo } from 'react';
+import { getPasswordStrength, passwordStrengthLabels } from '@joplin/lib/services/e2ee/passwordStrength';
 import { _ } from '@joplin/lib/locale';
 import useAsyncEffect, { AsyncEffectEvent } from '@joplin/lib/hooks/useAsyncEffect';
 import DialogButtonRow, { ClickEvent } from '../DialogButtonRow';
@@ -170,6 +171,53 @@ export default function(props: Props) {
 		if (showPasswordForm) {
 			const enterPasswordLabel = [MasterPasswordStatus.Loaded, MasterPasswordStatus.Valid].includes(status) ? _('Enter new password') : _('Enter password');
 
+			const strengthResult = getPasswordStrength(password1);
+			const strengthColors = ['#D32F2F', '#E64A19', '#FBC02D', '#7CB342', '#388E3C'];
+			const strengthColor = strengthColors[strengthResult.score];
+			const strengthPercent = password1 ? ((strengthResult.score + 1) / 5) * 100 : 0;
+			const strengthLabel = password1 ? passwordStrengthLabels[strengthResult.score] : '';
+
+			const renderStrengthIndicator = () => {
+				if (!password1) return null;
+
+				return (
+					<div className="password-strength-indicator" style={{ marginTop: 8 }}>
+						<div style={{
+							height: 6,
+							backgroundColor: '#e0e0e0',
+							borderRadius: 3,
+							overflow: 'hidden',
+							marginBottom: 4,
+						}}>
+							<div style={{
+								height: '100%',
+								width: `${strengthPercent}%`,
+								backgroundColor: strengthColor,
+								borderRadius: 3,
+								transition: 'width 0.3s ease, background-color 0.3s ease',
+							}} />
+						</div>
+						<div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+							<span style={{ fontSize: 12, fontWeight: 'bold', color: strengthColor }}>
+								{strengthLabel}
+							</span>
+						</div>
+						{strengthResult.feedback.warning && (
+							<p style={{ fontSize: 12, color: '#D32F2F', margin: '4px 0 0 0' }}>
+								{strengthResult.feedback.warning}
+							</p>
+						)}
+						{strengthResult.feedback.suggestions.length > 0 && (
+							<ul style={{ fontSize: 12, margin: '4px 0 0 0', paddingLeft: 16, color: '#666' }}>
+								{strengthResult.feedback.suggestions.map((s, i) =>
+									<li key={i}>{s}</li>,
+								)}
+							</ul>
+						)}
+					</div>
+				);
+			};
+
 			return (
 				<div>
 					<div className="form">
@@ -179,6 +227,7 @@ export default function(props: Props) {
 							value={password1}
 							onChange={onPasswordChange1}
 						/>
+						{renderStrengthIndicator()}
 
 						{needToRepeatPassword && (
 							<>

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -31,6 +31,7 @@
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.7",
     "@types/uuid": "10.0.0",
+    "@types/zxcvbn": "^4",
     "jest": "29.7.0",
     "jest-expect-message": "1.1.3",
     "jsdom": "26.1.0",
@@ -103,7 +104,8 @@
     "url-parse": "1.5.10",
     "uuid": "11.1.0",
     "word-wrap": "1.2.5",
-    "xml2js": "0.4.23"
+    "xml2js": "0.4.23",
+    "zxcvbn": "^4.4.2"
   },
   "gitHead": "05a29b450962bf05a8642bbd39446a1f679a96ba"
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -105,7 +105,7 @@
     "uuid": "11.1.0",
     "word-wrap": "1.2.5",
     "xml2js": "0.4.23",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "4.4.2"
   },
   "gitHead": "05a29b450962bf05a8642bbd39446a1f679a96ba"
 }

--- a/packages/lib/services/e2ee/passwordStrength.test.ts
+++ b/packages/lib/services/e2ee/passwordStrength.test.ts
@@ -1,0 +1,46 @@
+import { getPasswordStrength, passwordStrengthLabels } from './passwordStrength';
+
+describe('e2ee/passwordStrength', () => {
+
+	it('should return score 0 for an empty password', () => {
+		const result = getPasswordStrength('');
+		expect(result.score).toBe(0);
+		expect(result.feedback.warning).toBe('');
+		expect(result.feedback.suggestions).toEqual([]);
+	});
+
+	it('should return a low score for a very weak password', () => {
+		const result = getPasswordStrength('password');
+		expect(result.score).toBeLessThanOrEqual(1);
+	});
+
+	it('should return a low score for a short numeric password', () => {
+		const result = getPasswordStrength('1234');
+		expect(result.score).toBeLessThanOrEqual(1);
+	});
+
+	it('should return a higher score for a moderately complex password', () => {
+		const result = getPasswordStrength('MyP@ssw0rd!');
+		expect(result.score).toBeGreaterThanOrEqual(2);
+	});
+
+	it('should return a high score for a strong password', () => {
+		const result = getPasswordStrength('j8$Kq!2mZx@pL9&vR');
+		expect(result.score).toBeGreaterThanOrEqual(3);
+	});
+
+	it('should return feedback suggestions for weak passwords', () => {
+		const result = getPasswordStrength('aaa');
+		expect(result.feedback).toBeDefined();
+		expect(typeof result.feedback.warning).toBe('string');
+		expect(Array.isArray(result.feedback.suggestions)).toBe(true);
+	});
+
+	it('should have labels defined for all scores 0 through 4', () => {
+		for (let i = 0; i <= 4; i++) {
+			expect(passwordStrengthLabels[i]).toBeDefined();
+			expect(typeof passwordStrengthLabels[i]).toBe('string');
+		}
+	});
+
+});

--- a/packages/lib/services/e2ee/passwordStrength.ts
+++ b/packages/lib/services/e2ee/passwordStrength.ts
@@ -1,0 +1,38 @@
+import zxcvbn = require('zxcvbn');
+
+export interface PasswordStrengthResult {
+	score: 0 | 1 | 2 | 3 | 4;
+	feedback: {
+		warning: string;
+		suggestions: string[];
+	};
+}
+
+export const passwordStrengthLabels: Record<number, string> = {
+	0: 'Very Weak',
+	1: 'Weak',
+	2: 'Fair',
+	3: 'Strong',
+	4: 'Very Strong',
+};
+
+export const getPasswordStrength = (password: string): PasswordStrengthResult => {
+	if (!password) {
+		return {
+			score: 0,
+			feedback: {
+				warning: '',
+				suggestions: [],
+			},
+		};
+	}
+
+	const result = zxcvbn(password);
+	return {
+		score: result.score,
+		feedback: {
+			warning: result.feedback.warning || '',
+			suggestions: result.feedback.suggestions || [],
+		},
+	};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10892,6 +10892,7 @@ __metadata:
     "@types/react": "npm:19.1.10"
     "@types/react-dom": "npm:19.1.7"
     "@types/uuid": "npm:10.0.0"
+    "@types/zxcvbn": "npm:^4"
     adm-zip: "npm:0.5.16"
     async-mutex: "npm:0.5.0"
     base-64: "npm:1.0.0"
@@ -10951,6 +10952,7 @@ __metadata:
     uuid: "npm:11.1.0"
     word-wrap: "npm:1.2.5"
     xml2js: "npm:0.4.23"
+    zxcvbn: "npm:^4.4.2"
   languageName: unknown
   linkType: soft
 
@@ -17455,7 +17457,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/zxcvbn@npm:4.4.5":
+"@types/zxcvbn@npm:4.4.5, @types/zxcvbn@npm:^4":
   version: 4.4.5
   resolution: "@types/zxcvbn@npm:4.4.5"
   checksum: 10/279b0d43e21b8de48a9ef98b5753e343673fdb6cfdd2679e2afbb292410d610a0f01d7c1cb1dad1acbd0d35ee01e8a8dbe21cb034a2e2f3458492cf5fd3b44c3
@@ -54751,7 +54753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zxcvbn@npm:4.4.2":
+"zxcvbn@npm:4.4.2, zxcvbn@npm:^4.4.2":
   version: 4.4.2
   resolution: "zxcvbn@npm:4.4.2"
   checksum: 10/00c4636f10556174858bddd67758ef1e3046d005e9890a208fa5dd9296ec69a3e93ce8300a54d84cf72deea188503d8c5aa67c515daf79da40de378786832807

--- a/yarn.lock
+++ b/yarn.lock
@@ -10952,7 +10952,7 @@ __metadata:
     uuid: "npm:11.1.0"
     word-wrap: "npm:1.2.5"
     xml2js: "npm:0.4.23"
-    zxcvbn: "npm:^4.4.2"
+    zxcvbn: "npm:4.4.2"
   languageName: unknown
   linkType: soft
 
@@ -54753,7 +54753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zxcvbn@npm:4.4.2, zxcvbn@npm:^4.4.2":
+"zxcvbn@npm:4.4.2":
   version: 4.4.2
   resolution: "zxcvbn@npm:4.4.2"
   checksum: 10/00c4636f10556174858bddd67758ef1e3046d005e9890a208fa5dd9296ec69a3e93ce8300a54d84cf72deea188503d8c5aa67c515daf79da40de378786832807


### PR DESCRIPTION
### problem:
the gsoc issue highlighted the lack of a password strength check gui...i added it to the desktop one using zxcvbn
### solution:
- A color-coded bar that goes from red (weak) to green (strong)
- A label like "Very Weak", "Fair", or "Very Strong"
- Helpful tips like  for weaker passwords
### testing:
done manually to see if the strength check works well.




UI Image.
<img width="982" height="971" alt="image" src="https://github.com/user-attachments/assets/9ebc6f8a-0f73-4db1-a160-3af0e7db332f" />
