### PR TITLE
Mobile: Fixes #14727: Fix OneDrive auth code double-encoding on mobile

### DIFF
--- a/packages/app-mobile/components/screens/onedrive-login.js
+++ b/packages/app-mobile/components/screens/onedrive-login.js
@@ -8,9 +8,17 @@ const { ScreenHeader } = require('../ScreenHeader');
 const { reg } = require('@joplin/lib/registry');
 const { _ } = require('@joplin/lib/locale');
 const { BaseScreenComponent } = require('../base-screen');
-const parseUri = require('@joplin/lib/parseUri');
 const { themeStyle } = require('../global-style');
 const shim = require('@joplin/lib/shim').default;
+
+const authCodeFromUrl = (url) => {
+	if (!url) return null;
+	try {
+		return new URL(url).searchParams.get('code');
+	} catch (error) {
+		return null;
+	}
+};
 
 class OneDriveLoginScreenComponent extends BaseScreenComponent {
 	static navigationOptions() {
@@ -58,10 +66,10 @@ class OneDriveLoginScreenComponent extends BaseScreenComponent {
 		// doesn't exist, use this for now. The whole component is completely undocumented
 		// at the moment so it's likely to change.
 		const url = noIdeaWhatThisIs.url;
-		const parsedUrl = parseUri(url);
+		const authCode = authCodeFromUrl(url);
 
-		if (!this.authCode_ && parsedUrl && parsedUrl.queryKey && parsedUrl.queryKey.code) {
-			this.authCode_ = parsedUrl.queryKey.code;
+		if (!this.authCode_ && authCode) {
+			this.authCode_ = authCode;
 
 			try {
 				await reg


### PR DESCRIPTION
**Problem**

OneDrive authentication was broken on mobile for new devices/profiles. After completing the Microsoft login flow in the WebView, the app would show a "Could not login to OneDrive" error with `400 invalid_grant / AADSTS70000: The provided value for the 'code' parameter is not valid`.

**Solution**
Fixes #14727 

The old code used `parseUri` to extract the auth code from the callback URL. `parseUri` returns raw URL-encoded values without decoding them (e.g. `abc%24xyz` stays as `abc%24xyz`). When this was then passed to `objectToQueryString`, which calls `encodeURIComponent`, the value got double-encoded (`%24` -> `%2524`), making the token request invalid.

Replaced `parseUri` with the standard `URL.searchParams.get('code')` which correctly decodes the auth code before it's used in the token exchange. This is safe across all platforms - the desktop OAuth flow uses a localhost server and never touches this code path.


**Test Plan**

<table>
<tr>
<td>

**Android** – fresh profile, OneDrive login -> sync started 

<img width="360" src="https://github.com/user-attachments/assets/9e1ec658-adda-4872-8b3d-3ecfbbd9d2a2" />

</td>
<td>

**Desktop** – OneDrive auth unaffected 

<img width="280" src="https://github.com/user-attachments/assets/1124a348-cce9-4fd4-89f8-12d5b5668322" />

</td>
</tr>
</table>

**AI assistance disclosure**
Used AI assistance for understanding and debugging only.