### PR TITLE
Mobile: Fixes #14771: Show confirmation dialog before closing tags dialog with unsaved changes

### DIFF
--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -10,6 +10,7 @@ import { _ } from '@joplin/lib/locale';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import { ViewStyle } from 'react-native';
+import shim from '@joplin/lib/shim';
 
 interface Props {
 	themeId: number;
@@ -32,6 +33,7 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 	const [noteId, setNoteId] = useState(props.noteId);
 	const [savingTags, setSavingTags] = useState(false);
 	const [noteTags, setNoteTags] = useState<string[]>([]);
+	const [originalTags, setOriginalTags] = useState<string[]>([]);
 
 	useEffect(() => {
 		if (props.noteId) setNoteId(props.noteId);
@@ -53,18 +55,37 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 		props.onCloseRequested?.();
 	}, [props.onCloseRequested]);
 
+	const hasUnsavedChanges = useMemo(() => {
+		return () => {
+			if (noteTags.length !== originalTags.length) return true;
+			return noteTags.some(tag => !originalTags.includes(tag)) ||
+				originalTags.some(tag => !noteTags.includes(tag));
+		};
+	}, [noteTags, originalTags]);
+
+	const onModalClose = useCallback(async () => {
+		if (hasUnsavedChanges()) {
+			const shouldDiscard = await shim.showConfirmationDialog(
+				_('You have unsaved tag changes. Discard them?'),
+			);
+			if (!shouldDiscard) return;
+		}
+		onCancelPress();
+	}, [onCancelPress, hasUnsavedChanges]);
+
 	const modalProps = useMemo(() => {
 		return {
 			...modalPropOverrides,
-			onClose: onCancelPress,
+			onClose: onModalClose,
 		};
-	}, [onCancelPress]);
+	}, [onModalClose]);
 
 	useAsyncEffect(async (event) => {
 		const tags = await Tag.tagsByNoteId(noteId);
 		const noteTags = tags.map(t => t.title);
 		if (!event.cancelled) {
 			setNoteTags(noteTags);
+			setOriginalTags(noteTags);
 		}
 	}, [noteId]);
 

--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -7,7 +7,7 @@ import { AppState } from '../../utils/types';
 import { TagEntity } from '@joplin/lib/services/database/types';
 import TagEditor, { TagEditorMode } from '../TagEditor';
 import { _ } from '@joplin/lib/locale';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useAsyncEffect from '@joplin/lib/hooks/useAsyncEffect';
 import { ViewStyle } from 'react-native';
 
@@ -53,6 +53,13 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 		props.onCloseRequested?.();
 	}, [props.onCloseRequested]);
 
+	const modalProps = useMemo(() => {
+		return {
+			...modalPropOverrides,
+			onClose: onCancelPress,
+		};
+	}, [onCancelPress]);
+
 	useAsyncEffect(async (event) => {
 		const tags = await Tag.tagsByNoteId(noteId);
 		const noteTags = tags.map(t => t.title);
@@ -68,7 +75,7 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 		buttonBarEnabled={!savingTags}
 		okTitle={_('Apply')}
 		cancelTitle={_('Cancel')}
-		modalProps={modalPropOverrides}
+		modalProps={modalProps}
 	>
 		<TagEditor
 			themeId={props.themeId}

--- a/packages/app-mobile/components/screens/NoteTagsDialog.tsx
+++ b/packages/app-mobile/components/screens/NoteTagsDialog.tsx
@@ -55,12 +55,10 @@ const NoteTagsDialogComponent: React.FC<Props> = props => {
 		props.onCloseRequested?.();
 	}, [props.onCloseRequested]);
 
-	const hasUnsavedChanges = useMemo(() => {
-		return () => {
-			if (noteTags.length !== originalTags.length) return true;
-			return noteTags.some(tag => !originalTags.includes(tag)) ||
-				originalTags.some(tag => !noteTags.includes(tag));
-		};
+	const hasUnsavedChanges = useCallback(() => {
+		if (noteTags.length !== originalTags.length) return true;
+		return noteTags.some(tag => !originalTags.includes(tag)) ||
+			originalTags.some(tag => !noteTags.includes(tag));
 	}, [noteTags, originalTags]);
 
 	const onModalClose = useCallback(async () => {


### PR DESCRIPTION
### **Description:**
**AI Assistance Disclosure**
I used AI to help identify the issue and fix some linting errors. I first wrote part of the code myself and tried to solve the problem. Then I used AI assistance to help refine the solution and remove some errors. I carefully reviewed all the code, tested the implementation on an Android device

**Problem**
Users cannot close the note tags dialog using the Android Back button or Escape key. When they press these keys, the dialog remains open. Only the Cancel button allows dismissal without saving changes, creating an inconsistent user experience and making it impossible to dismiss the dialog in certain situations.

**Solution**
I updated the NoteTagsDialog component to:

Detect when the dialog is closed using Back/Escape

Show a confirmation dialog if there are unsaved changes

Let users either discard the changes or stay and continue editing

Close the dialog normally if no changes were made

Test Plan
Manual testing on Android device:

Open a note and access the tags dialog
Make tag changes (add/remove tags)
Press Android Back button → confirmation dialog should appear
Tap "Cancel" → dialog stays open with changes intact
Press Back again and tap "OK" → dialog closes, changes discarded
### Video:


https://github.com/user-attachments/assets/e175306e-2685-471f-a465-b9f0371572b2

