### PR TITLE
Chore: Desktop: Re-enable settings screen accessibility tests

### DIFF
--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from './util/test';
 import MainScreen from './models/MainScreen';
 import AxeBuilder from '@axe-core/playwright';
 import { Page } from '@playwright/test';
+import SettingsScreen from './models/SettingsScreen';
 
 const createScanner = (page: Page) => {
 	return new AxeBuilder({ page })
@@ -38,25 +39,24 @@ const expectNoViolations = async (page: Page) => {
 };
 
 test.describe('wcag', () => {
-	// Disabled due to random failure in CI:
-// for (const tabName of ['General', 'Plugins']) {
-// 	test(`should not detect significant issues in the settings screen ${tabName} tab`, async ({ electronApp, mainWindow }) => {
-// 		const mainScreen = await new MainScreen(mainWindow).setup();
-// 		await mainScreen.waitFor();
-//
-// 		await mainScreen.openSettings(electronApp);
-//
-// 		// Should be on the settings screen
-// 		const settingsScreen = new SettingsScreen(mainWindow);
-// 		await settingsScreen.waitFor();
-//
-// 		const tabLocator = settingsScreen.getTabLocator(tabName);
-// 		await tabLocator.click();
-// 		await expect(tabLocator).toBeFocused();
-//
-// 		await expectNoViolations(mainWindow);
-// 	});
-// }
+	for (const tabName of ['General', 'Plugins']) {
+		test(`should not detect significant issues in the settings screen ${tabName} tab`, async ({ electronApp, mainWindow }) => {
+			const mainScreen = await new MainScreen(mainWindow).setup();
+			await mainScreen.waitFor();
+
+			await mainScreen.openSettings(electronApp);
+
+			// Should be on the settings screen
+			const settingsScreen = new SettingsScreen(mainWindow);
+			await settingsScreen.waitFor();
+
+			const tabLocator = settingsScreen.getTabLocator(tabName);
+			await tabLocator.click();
+			await expect(tabLocator).toBeFocused();
+
+			await expectNoViolations(mainWindow);
+		});
+	}
 
 	test('should not detect significant issues in the main screen with an open note', async ({ mainWindow }) => {
 		const mainScreen = await new MainScreen(mainWindow).setup();


### PR DESCRIPTION
# Problem

There are a large number of recent pull requests that propose changes to the settings screen. Ideally, the automated accessibility tests should be run for these changes. However, the settings screen accessibility tests were previously disabled due to CI failures.

Since https://github.com/laurent22/joplin/pull/12415 has been merged, it should be safe to re-enable the settings screen accessibility tests.

# Solution

Re-enable the settings screen accessibility tests.

# Testing

The settings screen accessibility tests pass when run locally on Fedora 43 Linux (GNOME).

<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->