### PR TITLE
Desktop: Resolves #14788: Fix sync panel from jumping up and down

### DIFF
--- a/packages/app-desktop/gui/Sidebar/Sidebar.tsx
+++ b/packages/app-desktop/gui/Sidebar/Sidebar.tsx
@@ -16,14 +16,14 @@ import time from '@joplin/lib/time';
 
 
 interface Props {
-	themeId: number;
+	themeId?: number;
 	dispatch: Dispatch;
 	decryptionWorker: StateDecryptionWorker;
 	resourceFetcher: StateResourceFetcher;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 	syncReport: any;
 	syncStarted: boolean;
-	syncReportLogExpanded: boolean;
+	syncReportLogExpanded?: boolean;
 }
 
 const SidebarComponent = (props: Props) => {
@@ -44,7 +44,7 @@ const SidebarComponent = (props: Props) => {
 		);
 	};
 
-	const theme = themeStyle(props.themeId);
+	const theme = themeStyle(props.themeId ?? 1);
 
 	let decryptionReportText = '';
 	if (props.decryptionWorker && props.decryptionWorker.state !== 'idle' && props.decryptionWorker.itemCount) {
@@ -56,7 +56,7 @@ const SidebarComponent = (props: Props) => {
 		resourceFetcherText = _('Fetching resources: %d/%d', props.resourceFetcher.fetchingCount, props.resourceFetcher.toFetchCount);
 	}
 
-	const syncReportExpanded = props.syncReportLogExpanded;
+	const syncReportExpanded = props.syncReportLogExpanded ?? false;
 
 	const toggleSyncReport = useCallback(() => {
 		Setting.setValue('syncReportLogExpanded', !syncReportExpanded);
@@ -69,14 +69,13 @@ const SidebarComponent = (props: Props) => {
 	const completedTime = props.syncReport && props.syncReport.completedTime
 		? time.formatMsToLocal(props.syncReport.completedTime)
 		: null;
+	const lastSyncStatus = props.syncStarted ? _('In progress') : completedTime || '-';
+	const lastSyncText = _('Last sync: %s', lastSyncStatus);
 
 	const syncButton = renderSynchronizeButton(props.syncStarted ? 'cancel' : 'sync');
 
-	// Show toggle when there are log lines or a completed timestamp
-	const hasContent = lines.length > 0 || completedTime;
-
 	// Toggle to show/hide sync log output
-	const toggleButton = hasContent ? (
+	const toggleButton = (
 		<button
 			className="sidebar-sync-toggle"
 			onClick={toggleSyncReport}
@@ -84,10 +83,12 @@ const SidebarComponent = (props: Props) => {
 			aria-label={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 			title={syncReportExpanded ? _('Hide sync log') : _('Show sync log')}
 		>
-			<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
-			{!syncReportExpanded && completedTime ? <span className="timestamp">{_('Last sync: %s', completedTime)}</span> : ''}
+			<span className="toggle-icon" aria-hidden={true}>
+				<i className={`fas fa-caret-${syncReportExpanded ? 'down' : 'up'}`} />
+			</span>
+			<span className="timestamp">{lastSyncText}</span>
 		</button>
-	) : null;
+	);
 
 	// Sync log output, only visible when expanded
 	const syncReportComp = (syncReportExpanded && lines.length > 0) ? (

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
@@ -1,7 +1,7 @@
 .sidebar-sync-toggle {
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-start;
 	background: none;
 	border: none;
 	color: var(--joplin-color2);
@@ -9,6 +9,7 @@
 	cursor: pointer;
 	padding: 4px 0;
 	width: 100%;
+	min-height: calc(var(--joplin-font-size) * 1.6 + 8px);
 	font-size: calc(var(--joplin-font-size) * 1.6);
 	transition: opacity 0.2s;
 
@@ -16,8 +17,15 @@
 		opacity: 1;
 	}
 
+	>.toggle-icon {
+		width: 0.8em;
+		flex-shrink: 0;
+	}
+
 	>.timestamp {
+		display: block;
 		font-size: 0.6em;
 		margin-left: 6px;
+		line-height: 1.3;
 	}
 }

--- a/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
+++ b/packages/app-desktop/gui/Sidebar/styles/sidebar-sync-toggle.scss
@@ -5,7 +5,7 @@
 	background: none;
 	border: none;
 	color: var(--joplin-color2);
-	opacity: 0.5;
+	opacity: 0.6;
 	cursor: pointer;
 	padding: 4px 0;
 	width: 100%;


### PR DESCRIPTION
**FIxes: #14788**
### Summary

Fixes layout instability in the desktop sidebar sync panel by ensuring the toggle button, caret icon, and status text remain consistently visible across all sync states.

### Fixes

- Removed conditional rendering that caused elements to disappear during sync
- Ensured sync toggle button is always rendered
- Kept caret icon in a fixed-width container to prevent shifting
- Made status text always visible with dynamic content updates
- Stabilized layout using consistent height and alignment styles

https://github.com/user-attachments/assets/5ce86310-5ba0-441d-ac92-f83bfd9a29d6


### Testing

**Manually verified behavior in**:
- Collapsed + Idle
- Collapsed + Syncing
- Expanded + Syncing
- Expanded + Idle

### AI Disclosure:
- AI was used to improve the wording of the PR description.
- AI was used to understand the previous PR which caused this bug.