### PR TITLE
Desktop: Accessibility: Fix accessibility issues flagged by automated tools in the note properties dialog

### DIFF
--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -317,7 +317,7 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 		const styles = this.styles(this.props.themeId);
 		const theme = themeStyle(this.props.themeId);
 		const labelText = this.formatLabel(key);
-		const labelComp = <label htmlFor={uniqueId(key)} role='rowheader' style={{ ...theme.textStyle, ...theme.controlBoxLabel }}>{labelText}</label>;
+		const labelComp = <label htmlFor={uniqueId(key)} style={{ ...theme.textStyle, ...theme.controlBoxLabel }}>{labelText}</label>;
 		let controlComp = null;
 		let editComp = null;
 		let editCompHandler = null;
@@ -422,11 +422,11 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 					textOverflow: 'ellipsis',
 					display: 'inline-block',
 				};
-				controlComp = (
+				controlComp = displayedValue ? (
 					<a href="#" onClick={() => bridge().openExternal(url)} style={urlStyle}>
 						{displayedValue}
 					</a>
-				);
+				) : null;
 			} else if (key === 'revisionsLink') {
 				controlComp = (
 					<a href="#" onClick={this.revisionsLink_click} style={theme.urlStyle}>
@@ -468,10 +468,10 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 		}
 
 		return (
-			<div role='row' key={key} style={theme.controlBox} className="note-property-box">
-				{labelComp}
-				<span role='cell'>{controlComp} {editComp}</span>
-			</div>
+			<tr key={key} style={theme.controlBox} className="note-property-box">
+				<th>{labelComp}</th>
+				<td>{controlComp} {editComp}</td>
+			</tr>
 		);
 	}
 
@@ -497,10 +497,12 @@ class NotePropertiesDialog extends React.Component<Props, State> {
 
 		return (
 			<Dialog onCancel={this.props.onClose}>
-				<div style={theme.dialogTitle} id='note-properties-dialog-title'>{_('Note properties')}</div>
-				<div role='table' aria-labelledby='note-properties-dialog-title'>
-					{noteComps}
-				</div>
+				<h1 style={theme.dialogTitle} id='note-properties-dialog-title'>{_('Note properties')}</h1>
+				<table aria-labelledby='note-properties-dialog-title'>
+					<tbody>
+						{noteComps}
+					</tbody>
+				</table>
 				<DialogButtonRow
 					themeId={this.props.themeId}
 					okButtonShow={!this.isReadOnly()}

--- a/packages/app-desktop/gui/styles/index.scss
+++ b/packages/app-desktop/gui/styles/index.scss
@@ -3,6 +3,7 @@
 @use './base-button.scss';
 @use './dialog-modal-layer.scss';
 @use './user-webview-dialog.scss';
+@use './note-property-box.scss';
 @use './prompt-dialog.scss';
 @use './flat-button.scss';
 @use './link-button.scss';

--- a/packages/app-desktop/gui/styles/note-property-box.scss
+++ b/packages/app-desktop/gui/styles/note-property-box.scss
@@ -1,0 +1,11 @@
+
+.note-property-box {
+	> th, > td {
+		border: none;
+		padding: 0;
+	}
+
+	.rdt {
+		display: inline-block;
+	}
+}

--- a/packages/app-desktop/gui/styles/note-property-box.scss
+++ b/packages/app-desktop/gui/styles/note-property-box.scss
@@ -1,4 +1,3 @@
-
 .note-property-box {
 	> th, > td {
 		border: none;

--- a/packages/app-desktop/integration-tests/wcag.spec.ts
+++ b/packages/app-desktop/integration-tests/wcag.spec.ts
@@ -82,6 +82,17 @@ test.describe('wcag', () => {
 		await expectNoViolations(mainWindow);
 	});
 
+	test('should not detect significant issues in the note properties screen', async ({ mainWindow, electronApp }) => {
+		const mainScreen = await new MainScreen(mainWindow).setup();
+		await mainScreen.createNewNote('Test');
+		await mainScreen.goToAnything.runCommand(electronApp, 'showNoteProperties');
+
+		const header = mainScreen.dialog.locator('h1');
+		await expect(header).toBeVisible();
+
+		await expectNoViolations(mainWindow);
+	});
+
 	test('should not detect significant issues in the change app layout screen', async ({ mainWindow, electronApp }) => {
 		const mainScreen = await new MainScreen(mainWindow).setup();
 		await mainScreen.changeLayoutScreen.open(electronApp);

--- a/packages/app-desktop/main.scss
+++ b/packages/app-desktop/main.scss
@@ -106,10 +106,6 @@ a {
 	font-family: sans-serif;
 }
 
-.note-property-box .rdt {
-	display: inline-block;
-}
-
 .help-tooltip {
 	font-family: sans-serif;
 	max-width: 200px;

--- a/packages/lib/theme.ts
+++ b/packages/lib/theme.ts
@@ -332,7 +332,7 @@ export function extraStyles(theme: ThemeAndDerivedColors) {
 			padding: 10,
 			fontSize: baseFontSize,
 		},
-		dialogTitle: { ...h1Style, marginBottom: '1.2em' },
+		dialogTitle: { ...h1Style, marginBottom: '1.2em', marginTop: '0' },
 		dropdownList: { ...inputStyle },
 		colorHover: theme.color,
 		backgroundHover: `${theme.selectedColor2}44`,


### PR DESCRIPTION
# Problem

- The automated accessibility scanner wasn't set up to test the accessibility of the note properties dialog.
- When the "URL" field is empty, the "URL" link was focusable, but had an empty label.
   - On Linux, this was read by Orca as "index, link".
- `role='rowheader'` was present on a `<label>`, which is not permitted by the spec, when the `label` is associated with an element through `for`:
  >  If a label element is implicitly or explicitly associated with a labelable element then no role
  > — https://www.w3.org/TR/html-aria/#el-label

# Solution

- Run the automated accessibility scanner for the note properties dialog.
- Hide the "URL" field when there is no URL.
- Use `<table>`/`<tr>`/etc. instead of `role=` roles.
  - [MDN recommends using `<table>`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/rowheader_role#best_practices), `<tr>`, `<th>`, etc. where possible.

# Testing

Automated testing: Enables the accessibility scanner for the "note properties" dialog.

With the Orca screen reader on Linux,
- The table is still described as "note properties, table with 8 rows 2 columns".
- The "URL" input can still be edited, by activating the "edit" button. As before, the input is still described as "URL, entry" (after the screen reader reads "URL, rowheader").

Visually, the dialog looks the same:
| Before | After |
|--------|-------|
| <img width="869" height="842" alt="screenshot: note properties dialog" src="https://github.com/user-attachments/assets/6131d188-65cd-44be-8b4e-38a5a373bcd9" /> | <img width="869" height="842" alt="screenshot: note properties dialog" src="https://github.com/user-attachments/assets/3189ba9d-9699-47e5-abe8-6006e1a85ade" /> |


<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->