### PR TITLE
Desktop: Resolves #14801: Fix: Reach new notebook button via shift tab when scrolled down in the notebook list

### DIFF
--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -182,7 +182,8 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 			for (const itemIndex of this.props.alwaysRenderIndexes) {
 				const isVisible = itemIndex >= this.state.topItemIndex && itemIndex <= this.state.bottomItemIndex;
 				const isValidIndex = itemIndex >= 0 && itemIndex < items.length;
-				if (!isVisible && isValidIndex) {
+				const isAlreadySelected = this.props.selectedIndex === itemIndex;
+				if (!isVisible && isValidIndex && !isAlreadySelected) {
 					renderableBlocks.push({ from: itemIndex, to: itemIndex });
 				}
 			}

--- a/packages/app-desktop/gui/ItemList.tsx
+++ b/packages/app-desktop/gui/ItemList.tsx
@@ -16,6 +16,7 @@ interface Props<ItemType> {
 
 	selectedIndex?: number;
 	alwaysRenderSelection?: boolean;
+	alwaysRenderIndexes?: number[];
 
 	id?: string;
 	role?: string;
@@ -174,6 +175,16 @@ class ItemList<ItemType> extends React.Component<Props<ItemType>, State> {
 			const isValidSelection = this.props.selectedIndex >= 0 && this.props.selectedIndex < items.length;
 			if (!selectionVisible && isValidSelection) {
 				renderableBlocks.push({ from: this.props.selectedIndex, to: this.props.selectedIndex });
+			}
+		}
+
+		if (this.props.alwaysRenderIndexes?.length) {
+			for (const itemIndex of this.props.alwaysRenderIndexes) {
+				const isVisible = itemIndex >= this.state.topItemIndex && itemIndex <= this.state.bottomItemIndex;
+				const isValidIndex = itemIndex >= 0 && itemIndex < items.length;
+				if (!isVisible && isValidIndex) {
+					renderableBlocks.push({ from: itemIndex, to: itemIndex });
+				}
 			}
 		}
 

--- a/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
+++ b/packages/app-desktop/gui/Sidebar/FolderAndTagList.tsx
@@ -96,6 +96,9 @@ const FolderAndTagList: React.FC<Props> = props => {
 				// The selected item is the only item with tabindex=0. Always render it
 				// to allow the item list to be focused.
 				alwaysRenderSelection={true}
+				// Keep the notebooks header mounted even when offscreen so its action
+				// buttons remain reachable through keyboard tab order.
+				alwaysRenderIndexes={[0]}
 				selectedIndex={selectedIndex}
 
 				itemHeight={30}


### PR DESCRIPTION
**Fixes: #14801**

## Summary
When the notebook list is scrolled down, the "New notebook" button becomes unreachable via Shift+Tab because the header is unmounted by the virtualized list. This breaks keyboard navigation and accessibility.

## Fix
The fix ensures the header remains mounted so its buttons stay in the tab order:

- Added `alwaysRenderIndexes` to `ItemList` to allow specific items to always be rendered
- Used `alwaysRenderIndexes={[0]}` in `FolderAndTagList` to keep the header (index 0) mounted

## Changes made:

- **ItemList.tsx**  
  Added `alwaysRenderIndexes` prop to render specific indices even when offscreen.

- **FolderAndTagList.tsx**  
  Ensured the header (index 0) is always rendered so the "New notebook" button remains reachable via keyboard.

## Testing:
**I performed manual testing to check whether the fix works and recorded a demo video.**

https://github.com/user-attachments/assets/6a1627d5-a894-44d0-9636-b7d9eca27735


### Steps to test
- Create enough notebooks to make the sidebar scrollable
- Scroll down so the header is offscreen
- Press Shift+Tab from a notebook item
- Verify focus moves to the "New notebook" button and scrolls into view

## AI Disclosure:
- I used AI to help refine the PR description and explore possible solutions.