### PR TITLE
Desktop: Resolves #14791: Make it clear that importing a jex backup can duplicate your notes

### DIFF
--- a/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
+++ b/packages/app-desktop/gui/WindowCommandsAndDialogs/commands/importFrom.ts
@@ -76,12 +76,40 @@ const promptForSourcePath = async (module: ImportModule, sourceType: FileSystemI
 	}
 };
 
+const promptForJexImportWarning = async () => {
+	const settingKey = 'import.jexWarningShown';
+
+	if (Setting.value(settingKey)) return true;
+
+	const result = await bridge().showMessageBox(
+		_('Importing is intended for adding or restoring notes. After importing notes, if you enable sync with the same notes already on another device, duplicates will be created. To transfer notes between devices, please use sync instead. Do you want to continue with the import?'),
+		{
+			buttons: [_('Yes'), _('No')],
+			defaultId: 1,
+			cancelId: 1,
+		},
+	);
+
+	const shouldContinue = result === 0;
+
+	if (shouldContinue) {
+		Setting.setValue(settingKey, true);
+	}
+
+	return shouldContinue;
+};
+
 export const runtime = (control: WindowControl): CommandRuntime => {
 	return {
 		// Since this can be run from "go to anything", partialOptions needs to support being null or empty.
 		execute: async (context: CommandContext, options: ImportCommandOptions|undefined) => {
 			const importModule = await findImportModule(options, control);
 			if (!importModule) return null; // E.g. if cancelled
+
+			if (importModule.format === 'jex') {
+				const shouldContinue = await promptForJexImportWarning();
+				if (!shouldContinue) return null;
+			}
 
 			let sourcePath = options?.sourcePath ?? await promptForSourcePath(importModule, options?.sourceType);
 			if (Array.isArray(sourcePath)) {

--- a/packages/lib/models/settings/builtInMetadata.ts
+++ b/packages/lib/models/settings/builtInMetadata.ts
@@ -1175,6 +1175,14 @@ const builtInMetadata = (Setting: typeof SettingType) => {
 			appTypes: [AppType.Desktop],
 		},
 
+		'import.jexWarningShown': {
+			value: false,
+			type: SettingItemType.Bool,
+			public: false,
+			appTypes: [AppType.Desktop],
+			storage: SettingStorage.File,
+		},
+
 		startMinimized: { value: false, type: SettingItemType.Bool, storage: SettingStorage.File, isGlobal: true, section: 'application', public: true, appTypes: [AppType.Desktop], label: () => _('Start application minimised in the tray icon'), show: settings => !!settings['showTrayIcon'] },
 
 		collapsedFolderIds: { value: [] as string[], type: SettingItemType.Array, public: false },


### PR DESCRIPTION
## Problem

Users sometimes import a JEX backup expecting it to replace their existing notes. In practice, importing adds notes, so if sync is later enabled against the same dataset on another device, duplicate notes can be created. This can be difficult to clean up, especially for large note collections.

## Solution

Add a warning dialog before opening the file picker for **File > Import > JEX - Joplin Export File** on desktop.

The dialog warns that importing is intended for adding or restoring notes, and that enabling sync with the same notes already present on another device can create duplicates.

A private per-profile setting is used to control the warning so it is not shown repeatedly after the expected confirmation flow.

## Test Plan

1. Start with a profile where `import.jexWarningShown` is `false`.
2. Click **File > Import > JEX - Joplin Export File**.
3. Verify the warning dialog appears before the file picker opens.
4. Click **No** and verify the import is cancelled.
5. Click **File > Import > JEX - Joplin Export File** again and verify the warning behavior matches the intended implementation.
6. Click **Yes** and verify the file picker opens and the import flow continues.
7. Repeat the import action and verify the warning is no longer shown once the setting has been updated for the profile.
8. Verify that non-JEX import formats are unaffected.

## AI Disclosure

I used AI to help with understanding the drafting explanations, and reviewing wording for the PR. I manually implemented, writing code, tested, and verified the code changes myself.

video demonstration for above test cases.

https://github.com/user-attachments/assets/58f438ed-a9cb-42d7-bead-5aa58a6607c5

