### PR TITLE
Desktop: Resolves #14797: Completed date/time is shown as a number

### DIFF
--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -45,7 +45,7 @@ interface State {
 const uniqueId = (key: string) => `note-properties-dialog-${key}`;
 
 const isPropertyDatetimeRelated = (key: string) => {
-	return key === 'user_created_time' || key === 'user_updated_time' || key === 'deleted_time';
+	return key === 'user_created_time' || key === 'user_updated_time' || key === 'deleted_time' || key === 'todo_completed';
 };
 
 class NotePropertiesDialog extends React.Component<Props, State> {


### PR DESCRIPTION
<!--

Before contributing, please read the contribution guidelines: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

If this is a Google Summer of Code pull request, please read the [GSoC pull request guidelines](https://github.com/joplin/gsoc/blob/master/pull_request_guidelines.md).

---

**Pull request title**: Please prefix the title with the platform you are targetting.

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

-->
## Problem
In the Note properties dialog, the Completed field for to-dos is shown as a raw number (e.g. 1773768308867) instead of a date/time. The Created and Updated fields are shown as formatted date/time.
## Solution
`todo_completed` is a Unix timestamp in ms (like user_created_time and user_updated_time) but was not treated as a datetime. The dialog uses `isPropertyDatetimeRelated()` to decide whether to format a value as date/time and whether to use a datetime-local input when editing.

**The fix**:
It is pretty simple actually, just add the `todo_completed` in the `isPropertyDatetimeRelated()`, and voila.

## Test Plan
- **Manual check:** Mark a to-do as completed, open Note properties, and confirm Completed shows a date/time (e.g. 17/03/2026 10:25) instead of a number. Click the edit icon and confirm the datetime picker opens and saving works.


<img width="444" height="398" alt="image" src="https://github.com/user-attachments/assets/72079ecc-b009-4209-ad64-ee4454d5df4c" />




fixes #14797
