### PR TITLE
Desktop, Mobile: Add a section to the synchronisation welcome note, explaining extra considerations on mobile

### DIFF
--- a/readme/welcome/3_synchronising_your_notes.md
+++ b/readme/welcome/3_synchronising_your_notes.md
@@ -23,3 +23,9 @@ OneDrive and WebDAV are also supported as synchronisation services. Please see [
 ## Using End-To-End Encryption
 
 Joplin supports end-to-end encryption (E2EE) on all the applications. E2EE is a system where only the owner of the data can read it. It prevents potential eavesdroppers - including telecom providers, internet providers, and even the developers of Joplin from being able to access the data. Please see the [End-To-End Encryption Tutorial](https://joplinapp.org/help/apps/sync/e2ee) for more information about this feature and how to enable it.
+
+## Synchronisation on mobile
+
+Because of limitations in the mobile app, synchronisation cannot run when the screen is off or when the Joplin app is in the background.
+
+When performing the initial sync on a new device, make sure Joplin is open and the screen stays on for the entire process. This requires temporarily disabling the screen timeout in your device's system settings. On Android, you may need to enable Developer Options to access this setting.


### PR DESCRIPTION
Currently, none of the official Joplin documentation mentions the lack of background sync on the mobile app. Users have to search the forum to find this out, and can [raise support requests](https://discourse.joplinapp.org/t/android-sync-only-receives-a-partial-dataset-after-repeated-clean-resets-server-changes-and-fresh/49138) thinking there is a problem, when they are seemingly unable to synchronize all of their notes on mobile because of this.

This PR makes a small addition to the 'Synchronising your notes' welcome note, which mentions this additional consideration when syncing on the mobile app. It deliberately does not give direct instructions for how to to disable screen timeout, as this varies from version to version of mobile OS'. But the aim is to inform the user of this limitation (for those that actually read the documentation), so that they can find out how to do it themselves if they are capable, or they can raise a more directed question on the forum if they are not.