### PR TITLE
Mobile: Disable auto correct, auto complete and auto capitalize for setting search field

### DIFF
--- a/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
+++ b/packages/app-mobile/components/screens/ConfigScreen/ConfigScreen.tsx
@@ -834,6 +834,9 @@ class ConfigScreenComponent extends BaseScreenComponent<ConfigScreenProps, Confi
 				placeholder={_('Search...')}
 				onChangeText={this.onSearchUpdate_}
 				autoFocus={true}
+				autoCapitalize='none'
+				autoComplete='off'
+				autoCorrect={false}
 			/>;
 
 			currentSection = (


### PR DESCRIPTION
This is an addition to https://github.com/laurent22/joplin/pull/14759

The setting search input uses auto correction / auto complete / auto capitalize when enabled on the input method. Logically a search input should not use those behaviours, as the input allows incomplete words or phrases by design, so should be excluded from those functions of the input method.

This PR disables auto correct, auto complete and auto capitalize for the setting search input in the app.

### Testing

**Behaviour before the change:**

https://github.com/user-attachments/assets/1c01b63e-65bf-4b8c-8740-25c56b4beb13

**Behaviour after the change:**

https://github.com/user-attachments/assets/13c31fa4-1c2f-42ca-b4e3-4c18bee68227