### PR TITLE
Desktop: Fix Note properties dialog showing Completed date as a number

### DIFF
--- a/packages/app-desktop/gui/NotePropertiesDialog.tsx
+++ b/packages/app-desktop/gui/NotePropertiesDialog.tsx
@@ -45,7 +45,7 @@ interface State {
 const uniqueId = (key: string) => `note-properties-dialog-${key}`;
 
 const isPropertyDatetimeRelated = (key: string) => {
-	return key === 'user_created_time' || key === 'user_updated_time' || key === 'deleted_time';
+	return key === 'user_created_time' || key === 'user_updated_time' || key === 'deleted_time' || key === 'todo_completed';
 };
 
 class NotePropertiesDialog extends React.Component<Props, State> {


### PR DESCRIPTION
Fixes #14797

The `todo_completed` timestamp was not included in `isPropertyDatetimeRelated`, so it was formatted as a raw number. This PR adds it so it correctly displays and edits as a `datetime-local` field instead of a plain number.

(Disclosed: Co-authored by AI / Sigma)